### PR TITLE
PIM-6806: Update product completenesses whenever a family is updated …

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -818,7 +818,7 @@
 
 - Change `Pim\Component\Catalog\Model\FamilyInterface` to add `setAttributeAsImage` and `getAttributeAsImage`
 - Remove method `addMissingProductValues` of `Pim\Component\Catalog\Builder\ProductBuilderInterface` (this method is now handled by `Pim\Component\Catalog\ValuesFiller\ProductValuesFiller::fillMissingValues`)
-- Remove method `getFamilyFromJobParameters` of `Pim\Component\Catalog\Model\ProductInterface`
+- Remove method `getFamily` of `Pim\Component\Catalog\Model\ProductInterface`
 - PIM-6732: Remove `AddProductToVariantGroupProcessor` from `Pim\Component\Catalog\Repository\ProductRepositoryInterface`
 
 ### Type hint

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -10,6 +10,7 @@
 ## Better manage products with variants!
 
 - PIM-6773: Add the missing required attributes filter in the product model edit form
+- PIM-6806: Update product completenesses whenever the attribute requirements of a family are updated
 
 ## BC breaks
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -817,7 +817,7 @@
 
 - Change `Pim\Component\Catalog\Model\FamilyInterface` to add `setAttributeAsImage` and `getAttributeAsImage`
 - Remove method `addMissingProductValues` of `Pim\Component\Catalog\Builder\ProductBuilderInterface` (this method is now handled by `Pim\Component\Catalog\ValuesFiller\ProductValuesFiller::fillMissingValues`)
-- Remove method `getFamily` of `Pim\Component\Catalog\Model\ProductInterface`
+- Remove method `getFamilyFromJobParameters` of `Pim\Component\Catalog\Model\ProductInterface`
 - PIM-6732: Remove `AddProductToVariantGroupProcessor` from `Pim\Component\Catalog\Repository\ProductRepositoryInterface`
 
 ### Type hint

--- a/features/Context/catalog/apparel/jobs.yml
+++ b/features/Context/catalog/apparel/jobs.yml
@@ -283,3 +283,8 @@ jobs:
         alias:     compute_product_models_descendants
         label:     Compute product models descendants
         type:      compute_product_models_descendants
+    compute_completeness_of_products_family:
+        connector: internal
+        alias:     compute_completeness_of_products_family
+        label:     compute completeness of products family
+        type:      compute_completeness_of_products_family

--- a/features/Context/catalog/catalog_modeling/jobs.yml
+++ b/features/Context/catalog/catalog_modeling/jobs.yml
@@ -217,3 +217,8 @@ jobs:
         alias:     compute_product_models_descendants
         label:     Compute product models descendants
         type:      compute_product_models_descendants
+    compute_completeness_of_products_family:
+        connector: internal
+        alias:     compute_completeness_of_products_family
+        label:     compute completeness of products family
+        type:      compute_completeness_of_products_family

--- a/features/Context/catalog/default/jobs.yml
+++ b/features/Context/catalog/default/jobs.yml
@@ -72,3 +72,8 @@ jobs:
         alias:     compute_product_models_descendants
         label:     Compute product models descendants
         type:      compute_product_models_descendants
+    compute_completeness_of_products_family:
+        connector: internal
+        alias:     compute_completeness_of_products_family
+        label:     compute completeness of products family
+        type:      compute_completeness_of_products_family

--- a/features/Context/catalog/footwear/jobs.yml
+++ b/features/Context/catalog/footwear/jobs.yml
@@ -534,3 +534,8 @@ jobs:
         alias:     compute_product_models_descendants
         label:     Compute product models descendants
         type:      compute_product_models_descendants
+    compute_completeness_of_products_family:
+        connector: internal
+        alias:     compute_completeness_of_products_family
+        label:     compute completeness of products family
+        type:      compute_completeness_of_products_family

--- a/features/product/completeness/remove_completeness.feature
+++ b/features/product/completeness/remove_completeness.feature
@@ -22,44 +22,6 @@ Feature: Display the completeness of a product
     And I am logged in as "Julia"
     And I launched the completeness calculator
 
-  Scenario: Remove completeness from grid when family requirements changed
-    Given I am on the "sneakers" family page
-    And I visit the "Attributes" tab
-    And I switch the attribute "rating" requirement in channel "mobile"
-    And I save the family
-    And I should not see the text "There are unsaved changes."
-    And I am on the products grid
-    And I switch the locale to "en_US"
-    When I switch the scope to "Mobile"
-    Then the row "sneakers" should contain:
-     | column   | value |
-     | complete | -     |
-    And the row "sandals" should contain:
-     | column   | value |
-     | complete | 40%   |
-    When I switch the scope to "Tablet"
-    Then the row "sneakers" should contain:
-     | column   | value |
-     | complete | -     |
-    And the row "sandals" should contain:
-     | column   | value |
-     | complete | 25%   |
-    When I switch the locale to "fr_FR"
-    And I switch the scope to "Mobile"
-    Then the row "sneakers" should contain:
-     | column   | value |
-     | complete | -     |
-    And the row "sandals" should contain:
-     | column   | value |
-     | complete | 60%   |
-    When I switch the scope to "Tablet"
-    Then the row "sneakers" should contain:
-     | column   | value |
-     | complete | -     |
-    And the row "sandals" should contain:
-     | column   | value |
-     | complete | 50%   |
-
   Scenario: Remove completeness when locales of a channel are deleted
     Given I am on the "tablet" channel page
     When I change the "Locales" to "French (France)"

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/FamilySaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/FamilySaver.php
@@ -58,8 +58,6 @@ class FamilySaver implements SaverInterface, BulkSaverInterface
 
         $this->objectManager->persist($family);
 
-        $this->completenessManager->scheduleForFamily($family);
-
         $this->objectManager->flush();
 
         $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($family, $options));

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/FamilySaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/FamilySaver.php
@@ -32,7 +32,8 @@ class FamilySaver implements SaverInterface, BulkSaverInterface
 
     /**
      * @param ObjectManager                  $objectManager
-     * @param CompletenessManager            $completenessManager
+     * @param CompletenessManager            $completenessManager (@deprecated will be removed in 2.1
+     *                                                            {@see \Pim\Bundle\CatalogBundle\EventSubscriber\ComputeCompletenessOnFamilyUpdateSubscriber})
      * @param EventDispatcherInterface       $eventDispatcher
      */
     public function __construct(
@@ -82,8 +83,6 @@ class FamilySaver implements SaverInterface, BulkSaverInterface
             $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($family, $options));
 
             $this->objectManager->persist($family);
-
-            $this->completenessManager->scheduleForFamily($family);
         }
 
         $this->objectManager->flush();

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriber.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Bundle\BatchBundle\Launcher\JobLauncherInterface;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Runs a job whenever a family is updated.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ComputeCompletenessOnFamilyUpdateSubscriber implements EventSubscriberInterface
+{
+    /** @var TokenStorageInterface */
+    private $tokenStorage;
+
+    /** @var JobLauncherInterface */
+    private $jobLauncher;
+
+    /** @var IdentifiableObjectRepositoryInterface */
+    private $jobInstanceRepository;
+
+    /** @var string */
+    private $jobName;
+
+    /**
+     * @param TokenStorageInterface                 $tokenStorage
+     * @param JobLauncherInterface                  $jobLauncher
+     * @param IdentifiableObjectRepositoryInterface $jobInstanceRepository
+     * @param string                                $jobName
+     */
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        JobLauncherInterface $jobLauncher,
+        IdentifiableObjectRepositoryInterface $jobInstanceRepository,
+        string $jobName
+    ) {
+        $this->tokenStorage = $tokenStorage;
+        $this->jobLauncher = $jobLauncher;
+        $this->jobInstanceRepository = $jobInstanceRepository;
+        $this->jobName = $jobName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [StorageEvents::POST_SAVE => 'computeCompletenessOfProductsFamily'];
+    }
+
+    /**
+     * @param GenericEvent $event
+     */
+    public function computeCompletenessOfProductsFamily(GenericEvent $event)
+    {
+        $subject = $event->getSubject();
+
+        if (!$subject instanceof FamilyInterface) {
+            return;
+        }
+
+        if (!$event->hasArgument('unitary') || false === $event->getArgument('unitary')) {
+            return;
+        }
+
+        $user = $this->tokenStorage->getToken()->getUser();
+        $jobInstance = $this->jobInstanceRepository->findOneByIdentifier($this->jobName);
+
+        $this->jobLauncher->launch($jobInstance, $user, ['family_code' => $subject->getCode()]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriber.php
@@ -91,12 +91,8 @@ class ComputeCompletenessOnFamilyUpdateSubscriber implements EventSubscriberInte
             return;
         }
 
-        if (!$event->hasArgument('unitary') || false === $event->getArgument('unitary')) {
-            return;
-        }
-
         if (null === $subject->getId()) {
-            $this->areAttributeRequirementsUpdatedForFamilies[$subject->getCode()] = false;
+            $this->areAttributeRequirementsUpdatedForFamilies = false;
 
             return;
         }
@@ -118,14 +114,6 @@ class ComputeCompletenessOnFamilyUpdateSubscriber implements EventSubscriberInte
         $subject = $event->getSubject();
 
         if (!$subject instanceof FamilyInterface) {
-            return;
-        }
-
-        if (!$event->hasArgument('unitary') || false === $event->getArgument('unitary')) {
-            return;
-        }
-
-        if (null === $subject->getId()) {
             return;
         }
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriber.php
@@ -65,7 +65,7 @@ class ComputeCompletenessOnFamilyUpdateSubscriber implements EventSubscriberInte
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             StorageEvents::PRE_SAVE  => 'areAttributeRequirementsUpdated',
@@ -76,7 +76,7 @@ class ComputeCompletenessOnFamilyUpdateSubscriber implements EventSubscriberInte
     /**
      * @param GenericEvent $event
      */
-    public function areAttributeRequirementsUpdated(GenericEvent $event)
+    public function areAttributeRequirementsUpdated(GenericEvent $event): void
     {
         $subject = $event->getSubject();
 
@@ -100,7 +100,7 @@ class ComputeCompletenessOnFamilyUpdateSubscriber implements EventSubscriberInte
     /**
      * @param GenericEvent $event
      */
-    public function computeCompletenessOfProductsFamily(GenericEvent $event)
+    public function computeCompletenessOfProductsFamily(GenericEvent $event): void
     {
         $subject = $event->getSubject();
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriber.php
@@ -104,8 +104,10 @@ class ComputeCompletenessOnFamilyUpdateSubscriber implements EventSubscriberInte
         $oldAttributeRequirementsKeys = $this->getOldAttributeRequirementKeys($subject);
         $newAttributeRequirementsKeys = array_keys($subject->getAttributeRequirements());
 
-        $this->areAttributeRequirementsUpdatedForFamilies[$subject->getCode()] =
-            $this->areAttributeRequirementsListsDifferent($oldAttributeRequirementsKeys, $newAttributeRequirementsKeys);
+        $this->areAttributeRequirementsUpdatedForFamilies = $this->areAttributeRequirementsListsDifferent(
+            $oldAttributeRequirementsKeys,
+            $newAttributeRequirementsKeys
+        );
     }
 
     /**
@@ -123,13 +125,15 @@ class ComputeCompletenessOnFamilyUpdateSubscriber implements EventSubscriberInte
             return;
         }
 
-        if ($this->areAttributeRequirementsUpdatedForFamilies[$subject->getCode()]) {
+        if (null === $subject->getId()) {
+            return;
+        }
+
+        if ($this->areAttributeRequirementsUpdatedForFamilies) {
             $user = $this->tokenStorage->getToken()->getUser();
             $jobInstance = $this->jobInstanceRepository->findOneByIdentifier($this->jobName);
             $this->jobLauncher->launch($jobInstance, $user, ['family_code' => $subject->getCode()]);
         }
-
-        unset($this->areAttributeRequirementsUpdatedForFamilies[$subject->getCode()]);
     }
 
     /**
@@ -143,8 +147,8 @@ class ComputeCompletenessOnFamilyUpdateSubscriber implements EventSubscriberInte
 
         $oldAttributeRequirements = $this->attributeRequirementRepository->findRequiredAttributesCodesByFamily($family);
         foreach ($oldAttributeRequirements as $oldAttributeRequirement) {
-            $oldAttributeRequirementsKeys[] =
-                $oldAttributeRequirement['attribute'] . '_' . $oldAttributeRequirement['channel'];
+            $oldAttributeRequirementsKeys[] = $oldAttributeRequirement['attribute'] . '_' .
+                $oldAttributeRequirement['channel'];
         }
 
         return $oldAttributeRequirementsKeys;

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -119,7 +119,7 @@ services:
         class: '%pim_catalog.event_subscriber.compute_completeness_on_family_update.class%'
         arguments:
             - '@security.token_storage'
-            - '@akeneo_batch.launcher.simple_job_launcher'
+            - '@akeneo_batch_queue.launcher.queue_job_launcher'
             - '@akeneo_batch.job.job_instance_repository'
             - '@pim_catalog.repository.attribute_requirement'
             - '%pim_catalog.compute_completeness_of_products_family.job_name%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -13,6 +13,7 @@ parameters:
     pim_catalog.event_subscriber.index_product_models.class: Pim\Bundle\CatalogBundle\EventSubscriber\IndexProductModelsSubscriber
     pim_catalog.event_subscriber.compute_product_model_descendants.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeProductModelDescendantsSubscriber
     pim_catalog.event_subscriber.add_unique_attributes_to_variant_product_attribute_set.class: Pim\Bundle\CatalogBundle\EventSubscriber\AddUniqueAttributesToVariantProductAttributeSetSubscriber
+    pim_catalog.event_subscriber.compute_completeness_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeCompletenessOnFamilyUpdateSubscriber
 
 services:
     # Subscribers
@@ -111,5 +112,15 @@ services:
         class: '%pim_catalog.event_subscriber.add_unique_attributes_to_variant_product_attribute_set.class%'
         arguments:
             - '@pim_catalog.family_variant.add_unique_attributes'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    pim_catalog.event_subscriber.compute_completeness_on_family_update_subscriber:
+        class: '%pim_catalog.event_subscriber.compute_completeness_on_family_update.class%'
+        arguments:
+            - '@security.token_storage'
+            - '@akeneo_batch.launcher.simple_job_launcher'
+            - '@akeneo_batch.job.job_instance_repository'
+            - '%pim_catalog.compute_completeness_of_products_family.job_name%'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -121,6 +121,7 @@ services:
             - '@security.token_storage'
             - '@akeneo_batch.launcher.simple_job_launcher'
             - '@akeneo_batch.job.job_instance_repository'
+            - '@pim_catalog.repository.attribute_requirement'
             - '%pim_catalog.compute_completeness_of_products_family.job_name%'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/job_constraints.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/job_constraints.yml
@@ -1,10 +1,18 @@
 parameters:
     pim_catalog.job.job_parameters.constraint_collection_provider.compute_product_models_descendants.class: Pim\Component\Catalog\Job\JobParameters\ConstraintCollectionProvider\ComputeProductModelsDescendants
+    pim_catalog.job.job_parameters.constraint_collection_provider.compute_completeness_of_products_family.class: Pim\Component\Catalog\Job\JobParameters\ConstraintCollectionProvider\ComputeCompletenessOfProductsFamily
 
 services:
     pim_catalog.job.job_parameters.constraint_collection_provider.compute_product_models_descendants:
         class: '%pim_catalog.job.job_parameters.constraint_collection_provider.compute_product_models_descendants.class%'
         arguments:
             - ['compute_product_models_descendants']
+        tags:
+            - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
+
+    pim_catalog.job.job_parameters.constraint_collection_provider.compute_completeness_of_products_family:
+        class: '%pim_catalog.job.job_parameters.constraint_collection_provider.compute_completeness_of_products_family.class%'
+        arguments:
+            - ['compute_completeness_of_products_family']
         tags:
             - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/job_constraints.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/job_constraints.yml
@@ -12,7 +12,5 @@ services:
 
     pim_catalog.job.job_parameters.constraint_collection_provider.compute_completeness_of_products_family:
         class: '%pim_catalog.job.job_parameters.constraint_collection_provider.compute_completeness_of_products_family.class%'
-        arguments:
-            - ['compute_completeness_of_products_family']
         tags:
             - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/job_defaults.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/job_defaults.yml
@@ -6,3 +6,11 @@ services:
                 - '%pim_catalog.compute_product_models_descendants.job_name%'
         tags:
             - { name: akeneo_batch.job.job_parameters.default_values_provider }
+
+    pim_catalog.job.job_parameters.default_values_provider.compute_completeness_of_products_family:
+        class: '%akeneo_batch.job.job_parameters.empty_values_provider.class%'
+        arguments:
+            -
+                - '%pim_catalog.compute_completeness_of_products_family.job_name%'
+        tags:
+            - { name: akeneo_batch.job.job_parameters.default_values_provider }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
@@ -23,8 +23,11 @@ services:
     pim_catalog.tasklet.compute_completeness_of_products_family:
         class: '%pim_catalog.tasklet.compute_completeness_of_products_family.class%'
         arguments:
+            - '@pim_catalog.repository.family'
+            - '@pim_catalog.manager.completeness'
             - '@pim_catalog.query.product_query_builder_factory'
             - '@pim_catalog.saver.product'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
         public: false
 
     pim_catalog.step.compute_product_models_descendants:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
@@ -1,6 +1,6 @@
 parameters:
     pim_catalog.tasklet.compute_product_models_descendants.class: Pim\Component\Catalog\Job\ComputeProductModelsDescendantsTasklet
-    pim_catalog.tasklet.compute_completeness_of_products_family.class: Pim\Component\Catalog\Job\ComputeCompletenessOfProductsFamily
+    pim_catalog.tasklet.compute_completeness_of_products_family.class: Pim\Component\Catalog\Job\ComputeCompletenessOfProductsFamilyTasklet
 
     pim_catalog.compute_product_models_descendants.job_type: 'compute_product_models_descendants'
     pim_catalog.compute_product_models_descendants.job_name: 'compute_product_models_descendants'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
@@ -24,7 +24,6 @@ services:
         class: '%pim_catalog.tasklet.compute_completeness_of_products_family.class%'
         arguments:
             - '@pim_catalog.repository.family'
-            - '@pim_catalog.manager.completeness'
             - '@pim_catalog.query.product_query_builder_factory'
             - '@pim_catalog.saver.product'
             - '@akeneo_storage_utils.doctrine.object_detacher'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
@@ -1,10 +1,16 @@
 parameters:
     pim_catalog.tasklet.compute_product_models_descendants.class: Pim\Component\Catalog\Job\ComputeProductModelsDescendantsTasklet
+    pim_catalog.tasklet.compute_completeness_of_products_family.class: Pim\Component\Catalog\Job\ComputeCompletenessOfProductsFamily
 
     pim_catalog.compute_product_models_descendants.job_type: 'compute_product_models_descendants'
     pim_catalog.compute_product_models_descendants.job_name: 'compute_product_models_descendants'
     pim_catalog.compute_product_models_descendants.tasklet_name: 'compute_product_models_descendants'
     pim_catalog.compute_descendants.connector_name: 'compute descendants completeness'
+
+    pim_catalog.compute_completeness_of_products_family.job_type: 'compute_completeness_of_products_family'
+    pim_catalog.compute_completeness_of_products_family.job_name: 'compute_completeness_of_products_family'
+    pim_catalog.compute_completeness_of_products_family.tasklet_name: 'compute_completeness_of_products_family'
+    pim_catalog.compute_completeness_of_products_family.connector_name: 'compute completeness of products family'
 
 services:
     pim_catalog.tasklet.compute_product_models_descendants:
@@ -14,6 +20,13 @@ services:
             - '@pim_catalog.saver.product_model_descendants'
         public: false
 
+    pim_catalog.tasklet.compute_completeness_of_products_family:
+        class: '%pim_catalog.tasklet.compute_completeness_of_products_family.class%'
+        arguments:
+            - '@pim_catalog.query.product_query_builder_factory'
+            - '@pim_catalog.saver.product'
+        public: false
+
     pim_catalog.step.compute_product_models_descendants:
         class: '%pim_connector.step.tasklet.class%'
         arguments:
@@ -21,6 +34,15 @@ services:
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
             - '@pim_catalog.tasklet.compute_product_models_descendants'
+        public: false
+
+    pim_catalog.step.compute_completeness_of_products_family:
+        class: '%pim_connector.step.tasklet.class%'
+        arguments:
+            - '%pim_catalog.compute_completeness_of_products_family.tasklet_name%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_catalog.tasklet.compute_completeness_of_products_family'
         public: false
 
     pim_catalog.job.compute_product_models_descendants:
@@ -37,3 +59,18 @@ services:
                 name: akeneo_batch.job
                 connector: '%pim_catalog.compute_descendants.connector_name%'
                 type: '%pim_catalog.compute_product_models_descendants.job_type%'
+
+    pim_catalog.job.compute_completeness_of_products_family:
+        class: '%pim_connector.job.simple_job.class%'
+        arguments:
+            - '%pim_catalog.compute_completeness_of_products_family.job_name%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            -
+                - '@pim_catalog.step.compute_completeness_of_products_family'
+        public: false
+        tags:
+            -
+                name: akeneo_batch.job
+                connector: '%pim_catalog.compute_completeness_of_products_family.connector_name%'
+                type: '%pim_catalog.compute_completeness_of_products_family.job_type%'

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/FamilySaverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/FamilySaverSpec.php
@@ -39,7 +39,6 @@ class FamilySaverSpec extends ObjectBehavior
     }
 
     function it_saves_multiple_family(
-        $completenessManager,
         $objectManager,
         $eventDispatcher,
         FamilyInterface $family1,
@@ -50,9 +49,6 @@ class FamilySaverSpec extends ObjectBehavior
 
         $objectManager->persist($family1)->shouldBeCalled();
         $objectManager->persist($family2)->shouldBeCalled();
-
-//        $completenessManager->scheduleForFamily($family1)->shouldBeCalled($family1);
-//        $completenessManager->scheduleForFamily($family2)->shouldBeCalled($family2);
 
         $objectManager->flush()->shouldBeCalled();
 

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriberSpec.php
@@ -54,8 +54,6 @@ class ComputeCompletenessOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         UserInterface $user
     ) {
         $event->getSubject()->willReturn($family);
-        $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(true);
 
         $family->getId()->willReturn(152);
 
@@ -97,8 +95,6 @@ class ComputeCompletenessOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         AttributeRequirementInterface $attributeRequirement2
     ) {
         $event->getSubject()->willReturn($family);
-        $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(true);
 
         $family->getId()->willReturn(152);
 
@@ -122,7 +118,6 @@ class ComputeCompletenessOnFamilyUpdateSubscriberSpec extends ObjectBehavior
             ]
         );
 
-        $family->getCode()->willReturn('accessories');
         $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
 
         $this->areAttributeRequirementsUpdated($event);
@@ -134,88 +129,12 @@ class ComputeCompletenessOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         GenericEvent $event,
         FamilyInterface $family
     ) {
-        $event->getSubject()->willReturn($family);
-        $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(true);
-
         $family->getId()->willReturn(null);
-        $family->getCode()->willReturn('accessories');
+        $event->getSubject()->willReturn($family);
         $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
 
         $this->areAttributeRequirementsUpdated($event);
         $this->computeCompletenessOfProductsFamily($event);
-    }
-
-    function it_handles_conccurent_pre_and_post_save_for_different_families(
-        $attributeRequirementRepository,
-        $tokenStorage,
-        $jobInstanceRepository,
-        $jobLauncher,
-        GenericEvent $event1,
-        GenericEvent $event2,
-        FamilyInterface $family1,
-        FamilyInterface $family2,
-        AttributeRequirementInterface $attributeRequirement1,
-        JobInstance $jobInstance,
-        TokenInterface $token,
-        UserInterface $user
-    ) {
-        $event1->getSubject()->willReturn($family1);
-        $event1->hasArgument('unitary')->willReturn(true);
-        $event1->getArgument('unitary')->willReturn(true);
-        $family1->getId()->willReturn(152);
-        $family1->getCode()->willReturn('accessories');
-        $attributeRequirementRepository->findRequiredAttributesCodesByFamily($family1)->willReturn(
-            [
-                [
-                    'attribute' => 'price',
-                    'channel'   => 'ecommerce',
-                ],
-                [
-                    'attribute' => 'text',
-                    'channel'   => 'ecommerce',
-                ],
-            ]
-        );
-        $family1->getAttributeRequirements()->willReturn(
-            [
-                'price_ecommerce' => $attributeRequirement1
-            ]
-        );
-
-        $event2->getSubject()->willReturn($family2);
-        $event2->hasArgument('unitary')->willReturn(true);
-        $event2->getArgument('unitary')->willReturn(true);
-        $family2->getId()->willReturn(93);
-        $family2->getCode()->willReturn('shorts');
-        $attributeRequirementRepository->findRequiredAttributesCodesByFamily($family2)->willReturn(
-            [
-                [
-                    'attribute' => 'price',
-                    'channel'   => 'ecommerce',
-                ],
-                [
-                    'attribute' => 'text',
-                    'channel'   => 'ecommerce',
-                ],
-            ]
-        );
-        $family2->getAttributeRequirements()->willReturn(
-            [
-                'price_ecommerce' => $attributeRequirement1
-            ]
-        );
-
-        $tokenStorage->getToken()->willReturn($token);
-        $token->getUser()->willReturn($user);
-        $jobInstanceRepository->findOneByIdentifier('my_job_name')->willReturn($jobInstance);
-        $jobLauncher->launch($jobInstance, $user, ['family_code' => 'accessories'])->shouldBeCalled();
-        $jobLauncher->launch($jobInstance, $user, ['family_code' => 'shorts'])->shouldBeCalled();
-
-        $this->areAttributeRequirementsUpdated($event1);
-        $this->areAttributeRequirementsUpdated($event2);
-        $this->computeCompletenessOfProductsFamily($event1);
-        $this->computeCompletenessOfProductsFamily($event2);
     }
 
     function it_only_handles_family_objects(
@@ -223,80 +142,6 @@ class ComputeCompletenessOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         GenericEvent $event
     ) {
         $event->getSubject()->willReturn(new \StdClass());
-        $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(true);
-
-        $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
-
-        $this->areAttributeRequirementsUpdated($event);
-        $this->computeCompletenessOfProductsFamily($event);
-    }
-
-    function it_only_handles_events_having_a_unitary_argument_at_pre_and_post_save(
-        $jobLauncher,
-        $attributeRequirementRepository,
-        AttributeRequirementInterface $attributeRequirement1,
-        GenericEvent $event,
-        FamilyInterface $family
-    ) {
-        $event->getSubject()->willReturn($family);
-        $event->hasArgument('unitary')->willReturn(false);
-
-        $family->getId()->willReturn(152);
-        $family->getAttributeRequirements()->willReturn(
-            [
-                'price_ecommerce' => $attributeRequirement1
-            ]
-        );
-
-        $attributeRequirementRepository->findRequiredAttributesCodesByFamily($family)->willReturn(
-            [
-                [
-                    'attribute' => 'price',
-                    'channel'   => 'ecommerce',
-                ],
-                [
-                    'attribute' => 'text',
-                    'channel'   => 'ecommerce',
-                ],
-            ]
-        );
-
-        $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
-
-        $this->areAttributeRequirementsUpdated($event);
-        $this->computeCompletenessOfProductsFamily($event);
-    }
-
-    function it_only_handles_unitary_updates_at_pre_and_post_save(
-        $jobLauncher,
-        $attributeRequirementRepository,
-        AttributeRequirementInterface $attributeRequirement1,
-        GenericEvent $event,
-        FamilyInterface $family
-    ) {
-        $event->getSubject()->willReturn($family);
-        $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(false);
-
-        $family->getId()->willReturn(152);
-        $family->getAttributeRequirements()->willReturn(
-            [
-                'price_ecommerce' => $attributeRequirement1
-            ]
-        );
-        $attributeRequirementRepository->findRequiredAttributesCodesByFamily($family)->willReturn(
-            [
-                [
-                    'attribute' => 'price',
-                    'channel'   => 'ecommerce',
-                ],
-                [
-                    'attribute' => 'text',
-                    'channel'   => 'ecommerce',
-                ],
-            ]
-        );
 
         $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
 

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriberSpec.php
@@ -217,4 +217,90 @@ class ComputeCompletenessOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $this->computeCompletenessOfProductsFamily($event1);
         $this->computeCompletenessOfProductsFamily($event2);
     }
+
+    function it_only_handles_family_objects(
+        $jobLauncher,
+        GenericEvent $event
+    ) {
+        $event->getSubject()->willReturn(new \StdClass());
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
+
+        $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
+
+        $this->areAttributeRequirementsUpdated($event);
+        $this->computeCompletenessOfProductsFamily($event);
+    }
+
+    function it_only_handles_events_having_a_unitary_argument_at_pre_and_post_save(
+        $jobLauncher,
+        $attributeRequirementRepository,
+        AttributeRequirementInterface $attributeRequirement1,
+        GenericEvent $event,
+        FamilyInterface $family
+    ) {
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(false);
+
+        $family->getId()->willReturn(152);
+        $family->getAttributeRequirements()->willReturn(
+            [
+                'price_ecommerce' => $attributeRequirement1
+            ]
+        );
+
+        $attributeRequirementRepository->findRequiredAttributesCodesByFamily($family)->willReturn(
+            [
+                [
+                    'attribute' => 'price',
+                    'channel'   => 'ecommerce',
+                ],
+                [
+                    'attribute' => 'text',
+                    'channel'   => 'ecommerce',
+                ],
+            ]
+        );
+
+        $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
+
+        $this->areAttributeRequirementsUpdated($event);
+        $this->computeCompletenessOfProductsFamily($event);
+    }
+
+    function it_only_handles_unitary_updates_at_pre_and_post_save(
+        $jobLauncher,
+        $attributeRequirementRepository,
+        AttributeRequirementInterface $attributeRequirement1,
+        GenericEvent $event,
+        FamilyInterface $family
+    ) {
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(false);
+
+        $family->getId()->willReturn(152);
+        $family->getAttributeRequirements()->willReturn(
+            [
+                'price_ecommerce' => $attributeRequirement1
+            ]
+        );
+        $attributeRequirementRepository->findRequiredAttributesCodesByFamily($family)->willReturn(
+            [
+                [
+                    'attribute' => 'price',
+                    'channel'   => 'ecommerce',
+                ],
+                [
+                    'attribute' => 'text',
+                    'channel'   => 'ecommerce',
+                ],
+            ]
+        );
+
+        $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
+
+        $this->areAttributeRequirementsUpdated($event);
+        $this->computeCompletenessOfProductsFamily($event);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriberSpec.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Bundle\BatchBundle\Launcher\JobLauncherInterface;
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\EventSubscriber\ComputeCompletenessOnFamilyUpdateSubscriber;
+use Pim\Bundle\UserBundle\Entity\UserInterface;
+use Pim\Component\Catalog\Model\AttributeRequirementInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Repository\AttributeRequirementRepositoryInterface;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class ComputeCompletenessOnFamilyUpdateSubscriberSpec extends ObjectBehavior
+{
+    function let(
+        TokenStorageInterface $tokenStorage,
+        JobLauncherInterface $jobLauncher,
+        IdentifiableObjectRepositoryInterface $jobInstanceRepository,
+        AttributeRequirementRepositoryInterface $attributeRequirementRepository
+    ) {
+      $this->beConstructedWith($tokenStorage, $jobLauncher, $jobInstanceRepository, $attributeRequirementRepository, 'my_job_name');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ComputeCompletenessOnFamilyUpdateSubscriber::class);
+    }
+
+    function it_subsribes_to_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn([
+            StorageEvents::PRE_SAVE  => 'areAttributeRequirementsUpdated',
+            StorageEvents::POST_SAVE => 'computeCompletenessOfProductsFamily',
+        ]);
+    }
+
+    function it_detects_that_the_attribute_requirements_of_the_family_changed_on_pre_save_and_run_job_on_post_save(
+        $attributeRequirementRepository,
+        $tokenStorage,
+        $jobInstanceRepository,
+        $jobLauncher,
+        GenericEvent $event,
+        FamilyInterface $family,
+        AttributeRequirementInterface $attributeRequirement1,
+        JobInstance $jobInstance,
+        TokenInterface $token,
+        UserInterface $user
+    ) {
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
+
+        $family->getId()->willReturn(152);
+
+        $attributeRequirementRepository->findRequiredAttributesCodesByFamily($family)->willReturn(
+            [
+                [
+                    'attribute' => 'price',
+                    'channel'   => 'ecommerce',
+                ],
+                [
+                    'attribute' => 'text',
+                    'channel'   => 'ecommerce',
+                ],
+            ]
+        );
+
+        $family->getAttributeRequirements()->willReturn(
+            [
+                'price_ecommerce' => $attributeRequirement1
+            ]
+        );
+
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
+        $jobInstanceRepository->findOneByIdentifier('my_job_name')->willReturn($jobInstance);
+        $family->getCode()->willReturn('accessories');
+        $jobLauncher->launch($jobInstance, $user, ['family_code' => 'accessories'])->shouldBeCalled();
+
+        $this->areAttributeRequirementsUpdated($event);
+        $this->computeCompletenessOfProductsFamily($event);
+    }
+
+    function it_detects_that_the_attribute_requirements_of_the_family_has_not_changed_on_pre_save_and_do_not_run_job_on_post_save(
+        $attributeRequirementRepository,
+        $jobLauncher,
+        GenericEvent $event,
+        FamilyInterface $family,
+        AttributeRequirementInterface $attributeRequirement1,
+        AttributeRequirementInterface $attributeRequirement2
+    ) {
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
+
+        $family->getId()->willReturn(152);
+
+        $attributeRequirementRepository->findRequiredAttributesCodesByFamily($family)->willReturn(
+            [
+                [
+                    'attribute' => 'price',
+                    'channel'   => 'ecommerce',
+                ],
+                [
+                    'attribute' => 'text',
+                    'channel'   => 'ecommerce',
+                ],
+            ]
+        );
+
+        $family->getAttributeRequirements()->willReturn(
+            [
+                'price_ecommerce' => $attributeRequirement1,
+                'text_ecommerce' => $attributeRequirement2
+            ]
+        );
+
+        $family->getCode()->willReturn('accessories');
+        $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
+
+        $this->areAttributeRequirementsUpdated($event);
+        $this->computeCompletenessOfProductsFamily($event);
+    }
+
+    function it_does_not_run_the_job_for_new_families(
+        $jobLauncher,
+        GenericEvent $event,
+        FamilyInterface $family
+    ) {
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
+
+        $family->getId()->willReturn(null);
+        $family->getCode()->willReturn('accessories');
+        $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
+
+        $this->areAttributeRequirementsUpdated($event);
+        $this->computeCompletenessOfProductsFamily($event);
+    }
+
+    function it_handles_conccurent_pre_and_post_save_for_different_families(
+        $attributeRequirementRepository,
+        $tokenStorage,
+        $jobInstanceRepository,
+        $jobLauncher,
+        GenericEvent $event1,
+        GenericEvent $event2,
+        FamilyInterface $family1,
+        FamilyInterface $family2,
+        AttributeRequirementInterface $attributeRequirement1,
+        JobInstance $jobInstance,
+        TokenInterface $token,
+        UserInterface $user
+    ) {
+        $event1->getSubject()->willReturn($family1);
+        $event1->hasArgument('unitary')->willReturn(true);
+        $event1->getArgument('unitary')->willReturn(true);
+        $family1->getId()->willReturn(152);
+        $family1->getCode()->willReturn('accessories');
+        $attributeRequirementRepository->findRequiredAttributesCodesByFamily($family1)->willReturn(
+            [
+                [
+                    'attribute' => 'price',
+                    'channel'   => 'ecommerce',
+                ],
+                [
+                    'attribute' => 'text',
+                    'channel'   => 'ecommerce',
+                ],
+            ]
+        );
+        $family1->getAttributeRequirements()->willReturn(
+            [
+                'price_ecommerce' => $attributeRequirement1
+            ]
+        );
+
+        $event2->getSubject()->willReturn($family2);
+        $event2->hasArgument('unitary')->willReturn(true);
+        $event2->getArgument('unitary')->willReturn(true);
+        $family2->getId()->willReturn(93);
+        $family2->getCode()->willReturn('shorts');
+        $attributeRequirementRepository->findRequiredAttributesCodesByFamily($family2)->willReturn(
+            [
+                [
+                    'attribute' => 'price',
+                    'channel'   => 'ecommerce',
+                ],
+                [
+                    'attribute' => 'text',
+                    'channel'   => 'ecommerce',
+                ],
+            ]
+        );
+        $family2->getAttributeRequirements()->willReturn(
+            [
+                'price_ecommerce' => $attributeRequirement1
+            ]
+        );
+
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
+        $jobInstanceRepository->findOneByIdentifier('my_job_name')->willReturn($jobInstance);
+        $jobLauncher->launch($jobInstance, $user, ['family_code' => 'accessories'])->shouldBeCalled();
+        $jobLauncher->launch($jobInstance, $user, ['family_code' => 'shorts'])->shouldBeCalled();
+
+        $this->areAttributeRequirementsUpdated($event1);
+        $this->areAttributeRequirementsUpdated($event2);
+        $this->computeCompletenessOfProductsFamily($event1);
+        $this->computeCompletenessOfProductsFamily($event2);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
@@ -115,12 +115,12 @@ abstract class AbstractCompletenessTestCase extends TestCase
     }
 
     /**
-     * @param string $familyCode
-     * @param string $channelCode
-     * @param string $attributeCode
-     * @param string $attributeType
-     * @param bool $localisable
-     * @param bool $scopable
+     * @param string            $familyCode
+     * @param string            $channelCode
+     * @param string            $attributeCode
+     * @param string            $attributeType
+     * @param bool              $localisable
+     * @param bool              $scopable
      * @param LocaleInterface[] $localesSpecific
      *
      * @return FamilyInterface
@@ -171,14 +171,12 @@ abstract class AbstractCompletenessTestCase extends TestCase
         return $family;
     }
 
-    protected function removeFamilyRequirement($familyCode, $channelCode, $attributeCode)
+    protected function removeFamilyRequirement($familyCode, $channelCode, $attributeCode): void
     {
         $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier($familyCode);
         $attributeRequirementToRemove = $this->getAttributeRequirement($family, $channelCode, $attributeCode);
         $family->removeAttributeRequirement($attributeRequirementToRemove);
         $this->get('pim_catalog.saver.family')->save($family);
-
-        return $family;
     }
 
     /**
@@ -199,8 +197,8 @@ abstract class AbstractCompletenessTestCase extends TestCase
 
     /**
      * @param FamilyInterface $family
-     * @param string $channelCode
-     * @param string $attributeCode
+     * @param string          $channelCode
+     * @param string          $attributeCode
      *
      * @return null|AttributeRequirementInterface
      */

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
@@ -2,9 +2,9 @@
 
 namespace Pim\Bundle\CatalogBundle\tests\integration\Completeness;
 
-use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\AttributeRequirementInterface;
 use Pim\Component\Catalog\Model\CompletenessInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
@@ -171,6 +171,16 @@ abstract class AbstractCompletenessTestCase extends TestCase
         return $family;
     }
 
+    protected function removeFamilyRequirement($familyCode, $channelCode, $attributeCode)
+    {
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier($familyCode);
+        $attributeRequirementToRemove = $this->getAttributeRequirement($family, $channelCode, $attributeCode);
+        $family->removeAttributeRequirement($attributeRequirementToRemove);
+        $this->get('pim_catalog.saver.family')->save($family);
+
+        return $family;
+    }
+
     /**
      * @param string $code
      *
@@ -185,5 +195,32 @@ abstract class AbstractCompletenessTestCase extends TestCase
         }
 
         return $family;
+    }
+
+    /**
+     * @param FamilyInterface $family
+     * @param string $channelCode
+     * @param string $attributeCode
+     *
+     * @return null|AttributeRequirementInterface
+     */
+    private function getAttributeRequirement(
+        FamilyInterface $family,
+        string $channelCode,
+        string $attributeCode
+    ): ?AttributeRequirementInterface {
+        $attributeRequirementToRemove = null;
+
+        $attributeRequirements = $family->getAttributeRequirements();
+        foreach ($attributeRequirements as $attributeRequirement) {
+            if ($channelCode === $attributeRequirement->getChannelCode() &&
+                $attributeCode === $attributeRequirement->getAttributeCode()
+            ) {
+                $attributeRequirementToRemove = $attributeRequirement;
+                break;
+            }
+        }
+
+        return $attributeRequirementToRemove;
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
@@ -221,6 +221,7 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
      */
     private function assertJobWasExecutedTimes(string $jobName, int $times): void
     {
+        $this->get('doctrine.orm.default_entity_manager')->clear();
         $jobInstance = $this->get('pim_enrich.repository.job_instance')->findOneBy(['code' => $jobName]);
         $jobExecutionsCount = $jobInstance->getJobExecutions()->count();
         $this->assertEquals(

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace tests\integration\Pim\Bundle\CatalogBundle\Completeness;
 
-use Akeneo\Component\Batch\Job\BatchStatus;
 use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessTestCase;
 use Pim\Component\Catalog\AttributeTypes;

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace tests\integration\Pim\Bundle\CatalogBundle\Completeness;
 
+use Akeneo\Component\Batch\Job\BatchStatus;
 use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
 use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessTestCase;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\CompletenessInterface;
@@ -14,21 +16,25 @@ use Pim\Component\Catalog\Model\ProductInterface;
  * Checks the completeness is computed whenever the required attributes of a family is changed.
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
- * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenessTestCase
 {
+    /** @var JobLauncher */
+    protected $jobLauncher;
+
     public function testComputeCompletenessesForProductWhenUpdatingAttributeRequirements()
     {
         $this->assertJobWasExecutedTimes('compute_completeness_of_products_family', 0);
         $this->assertCompleteness('watch', 'ecommerce', 'fr_FR', 20);
         $this->assertCompleteness('braided-hat-xxxl', 'ecommerce', 'fr_FR', 80);
         $this->addFamilyRequirement('accessories', 'ecommerce', 'composition');
-        $this->waitForJobExecutionsToEnd('compute_completeness_of_products_family');
+        $this->LaunchTimesAndWaitForJobExecutionsToEnd(1, 'compute_completeness_of_products_family');
         $this->assertJobWasExecutedTimes('compute_completeness_of_products_family', 1);
-        $this->assertJobWasExecutedWithJobParameters(
+        $this->assertJobWasExecutedWithStatusAndJobParameters(
             'compute_completeness_of_products_family',
+            BatchStatus::COMPLETED,
             ['family_code' => 'accessories']
         );
         $this->assertCompleteness('watch', 'ecommerce', 'fr_FR', 16);
@@ -59,8 +65,7 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
     }
 
     /**
-     * This case checks that running family updates concurrently does not break the computation of the completeness.
-     * - Both family updates should trigger completeness recomputations
+     * Test update two families.
      */
     public function testComputeCompletenessesOfTwoSubsquentDifferentFamiliesUpdates()
     {
@@ -69,14 +74,16 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
         $this->assertCompleteness('tshirt-unique-size-navy-blue', 'ecommerce', 'fr_FR', 54);
         $this->addFamilyRequirement('accessories', 'ecommerce', 'composition');
         $this->addFamilyRequirement('clothing', 'ecommerce', 'price');
-        $this->waitForJobExecutionsToEnd('compute_completeness_of_products_family');
+        $this->LaunchTimesAndWaitForJobExecutionsToEnd(2, 'compute_completeness_of_products_family');
         $this->assertJobWasExecutedTimes('compute_completeness_of_products_family', 2);
-        $this->assertJobWasExecutedWithJobParameters(
+        $this->assertJobWasExecutedWithStatusAndJobParameters(
             'compute_completeness_of_products_family',
+            BatchStatus::COMPLETED,
             ['family_code' => 'accessories']
         );
-        $this->assertJobWasExecutedWithJobParameters(
+        $this->assertJobWasExecutedWithStatusAndJobParameters(
             'compute_completeness_of_products_family',
+            BatchStatus::COMPLETED,
             ['family_code' => 'clothing']
         );
         $this->assertCompleteness('watch', 'ecommerce', 'fr_FR', 16);
@@ -84,8 +91,7 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
     }
 
     /**
-     * This case checks that running family updates concurrently does not break the computation of the completeness.
-     * - One out of the two families should trigger the recomputations
+     * Test update two families only updates the one needed.
      */
     public function testComputeCompletenessesOnceForTwoSubsquentDifferentFamiliesUpdates()
     {
@@ -94,10 +100,11 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
         $this->assertCompleteness('tshirt-unique-size-navy-blue', 'ecommerce', 'fr_FR', 54);
         $this->addFamilyRequirement('accessories', 'ecommerce', 'composition');
         $this->updateFamilyPropertiesNotTriggeringCompletenessRecomputation('clothing');
-        $this->waitForJobExecutionsToEnd('compute_completeness_of_products_family');
+        $this->LaunchTimesAndWaitForJobExecutionsToEnd(1,'compute_completeness_of_products_family');
         $this->assertJobWasExecutedTimes('compute_completeness_of_products_family', 1);
-        $this->assertJobWasExecutedWithJobParameters(
+        $this->assertJobWasExecutedWithStatusAndJobParameters(
             'compute_completeness_of_products_family',
+            BatchStatus::COMPLETED,
             ['family_code' => 'accessories']
         );
         $this->assertCompleteness('watch', 'ecommerce', 'fr_FR', 16);
@@ -120,6 +127,7 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
         parent::setUp();
 
         $this->purgeJobExecutions('compute_completeness_of_products_family');
+        $this->jobLauncher = new JobLauncher(static::$kernel);
     }
 
     /**
@@ -224,10 +232,13 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
 
     /**
      * @param string $jobName
-     * @param array $jobParameters
+     * @param int    $batchStatus
+     * @param array  $jobParameters
      */
-    private function assertJobWasExecutedWithJobParameters(string $jobName, array $jobParameters = [])
+    private function assertJobWasExecutedWithStatusAndJobParameters(string $jobName, int $batchStatus, array $jobParameters = [])
     {
+        $this->get('doctrine.orm.default_entity_manager')->clear();
+
         $found = false;
         $jobInstance = $this->get('pim_enrich.repository.job_instance')->findOneBy(['code' => $jobName]);
         foreach ($jobInstance->getJobExecutions() as $jobExecution) {
@@ -237,22 +248,29 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
                 array_diff($jobParameters, $executedJobParameters)
             );
 
-            if (0 === count($diff)) {
+            if (0 === count($diff) &&
+                $jobExecution->getStatus()->getValue() === $batchStatus
+            ) {
                 $found = true;
                 break;
             }
         }
 
-        $this->assertTrue($found, 'Job execution with job parameters given not found.');
+        $this->assertTrue($found, 'Job execution with job parameters and status given not found.');
     }
 
     /**
-     * Wait for all the job executions of the given jobName to finnish within a given timeout.
+     * Launches the  Wait for all the job executions of the given jobName to finnish within a given timeout.
      *
+     * @param int    $times
      * @param string $jobName
      */
-    private function waitForJobExecutionsToEnd(string $jobName)
+    private function LaunchTimesAndWaitForJobExecutionsToEnd(int $times, string $jobName)
     {
+        for ($i = 0; $i < $times; $i++) {
+            $this->jobLauncher->launchConsumerOnce();
+        }
+
         $maxRetry = 30;
         for ($retry = 0; $retry < $maxRetry; $retry++) {
             sleep(1);

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
@@ -39,6 +39,14 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
     /**
      * {@inheritdoc}
      */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function setUp()
     {
         parent::setUp();
@@ -61,14 +69,6 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
         }
 
         $this->get('akeneo_batch.saver.job_instance')->save($jobInstance);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getConfiguration(): Configuration
-    {
-        return $this->catalog->useFunctionalCatalog('catalog_modeling');
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\integration\Pim\Bundle\CatalogBundle\Completeness;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\CatalogBundle\tests\integration\Completeness\AbstractCompletenessTestCase;
+use Pim\Component\Catalog\Model\CompletenessInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * Checks the completeness is computed whenever the required attributes of a family is changed.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenessTestCase
+{
+    public function testComputeCompletenessForProductWhenUpdatingAttributeRequirements()
+    {
+        $this->assertCompleteness('watch', 'ecommerce', 'fr_FR', 20);
+        $this->addFamilyRequirement('accessories', 'ecommerce', 'color');
+        $this->assertCompleteness('watch', 'ecommerce', 'fr_FR', 33);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return new Configuration([Configuration::getFunctionalCatalogPath('catalog_modeling')]);
+    }
+
+    /**
+     * @param $productIdentifier
+     * @param $channelCode
+     * @param $localeCode
+     * @param $ratio
+     */
+    private function assertCompleteness($productIdentifier, $channelCode, $localeCode, $ratio): void
+    {
+        $this->get('doctrine.orm.default_entity_manager')->clear();
+
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier($productIdentifier);
+        $completeness = $this->getCompletenesses($product, $channelCode, $localeCode);
+
+        $this->assertNotNull($completeness);
+        $this->assertEquals($ratio, $completeness->getRatio());
+    }
+
+    /**
+     * Return the completeness of a product for a channel and a locale.
+     *
+     * @param ProductInterface $product
+     * @param string           $channelCode
+     * @param string           $localeCode
+     *
+     * @return CompletenessInterface
+     */
+    private function getCompletenesses(
+        ProductInterface $product,
+        string $channelCode,
+        string $localeCode
+    ): ?CompletenessInterface {
+        $completenesses = $product->getCompletenesses();
+
+        foreach ($completenesses as $completeness) {
+            if ($channelCode === $completeness->getChannel()->getCode() &&
+                $localeCode === $completeness->getLocale()->getCode()) {
+                return $completeness;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/role.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/role.js
@@ -1,11 +1,13 @@
 'use strict';
 
 define([
+        'jquery',
         'pim/controller/form',
         'pim/security-context',
         'pim/form-config-provider',
         'pim/router'
     ], function (
+        $,
         FormController,
         securityContext,
         configProvider,

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -633,3 +633,8 @@ jobs:
         alias:     compute_product_models_descendants
         label:     Compute product models descendants
         type:      compute_product_models_descendants
+    compute_completeness_of_products_family:
+        connector: internal
+        alias:     compute_completeness_of_products_family
+        label:     compute completeness of products family
+        type:      compute_completeness_of_products_family

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/minimal/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/minimal/jobs.yml
@@ -71,3 +71,8 @@ jobs:
         alias:     compute_product_models_descendants
         label:     Compute product models descendants
         type:      compute_product_models_descendants
+    compute_completeness_of_products_family:
+        connector: internal
+        alias:     compute_completeness_of_products_family
+        label:     compute completeness of products family
+        type:      compute_completeness_of_products_family

--- a/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamily.php
+++ b/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamily.php
@@ -78,9 +78,7 @@ class ComputeCompletenessOfProductsFamily implements TaskletInterface
      */
     public function execute(): void
     {
-        $jobParameters = $this->stepExecution->getJobParameters();
-        $familyCode = $jobParameters->get('family_code');
-
+        $familyCode = $this->stepExecution->getJobParameters()->get('family_code');
         $this->resetCompletenessOfProductsForFamily($familyCode);
         $this->computeCompletenesses($familyCode);
     }
@@ -129,7 +127,7 @@ class ComputeCompletenessOfProductsFamily implements TaskletInterface
     private function findProductsForFamily(string $familyCode): CursorInterface
     {
         $pqb = $this->productQueryBuilderFactory->create();
-        $pqb->addFilter('family', Operators::IN_LIST, [$familyCode]);
+        $pqb->addFilter('family', Operators::EQUALS, $familyCode);
 
         return $pqb->execute();
     }

--- a/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamily.php
+++ b/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamily.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Job;
+
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Connector\Step\TaskletInterface;
+
+/**
+ * Triggers the computation of the completeness for all products belonging to a family that has been updated by calling
+ * save on them.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ComputeCompletenessOfProductsFamily implements TaskletInterface
+{
+    /** @var StepExecution */
+    private $stepExecution;
+
+    /** @var SaverInterface */
+    private $productSaver;
+
+    /** @var ProductQueryBuilderFactoryInterface */
+    private $productQueryBuilderFactory;
+
+    /**
+     * @param ProductQueryBuilderFactoryInterface $productQueryBuilderFactory
+     * @param SaverInterface                      $productSaver
+     */
+    public function __construct(
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        SaverInterface $productSaver
+    ) {
+        $this->productQueryBuilderFactory = $productQueryBuilderFactory;
+        $this->productSaver = $productSaver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStepExecution(StepExecution $stepExecution): void
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(): void
+    {
+        $jobParameters = $this->stepExecution->getJobParameters();
+        $familyCode = $jobParameters->get('family_code');
+
+        $products = $this->findProductsForFamily($familyCode);
+        foreach ($products as $product) {
+            $this->productSaver->save($product);
+        }
+    }
+
+    /**
+     * @param string $familyCode
+     *
+     * @return CursorInterface
+     */
+    private function findProductsForFamily(string $familyCode): CursorInterface
+    {
+        $pqb = $this->productQueryBuilderFactory->create();
+        $pqb->addFilter('family', Operators::IN_LIST, [$familyCode]);
+
+        return $pqb->execute();
+    }
+}

--- a/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamily.php
+++ b/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamily.php
@@ -6,7 +6,10 @@ namespace Pim\Component\Catalog\Job;
 
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
-use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use Pim\Component\Catalog\Manager\CompletenessManager;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Component\Connector\Step\TaskletInterface;
@@ -21,25 +24,45 @@ use Pim\Component\Connector\Step\TaskletInterface;
  */
 class ComputeCompletenessOfProductsFamily implements TaskletInterface
 {
+    private const BATCH_SIZE = 100;
+
     /** @var StepExecution */
     private $stepExecution;
 
-    /** @var SaverInterface */
-    private $productSaver;
+    /** @var IdentifiableObjectRepositoryInterface */
+    private $familyRepository;
+
+    /** @var CompletenessManager */
+    private $completenessManager;
 
     /** @var ProductQueryBuilderFactoryInterface */
     private $productQueryBuilderFactory;
 
+    /** @var BulkObjectDetacherInterface */
+    private $bulkObjectDetacher;
+
+    /** @var BulkSaverInterface */
+    private $bulkProductSaver;
+
     /**
-     * @param ProductQueryBuilderFactoryInterface $productQueryBuilderFactory
-     * @param SaverInterface                      $productSaver
+     * @param IdentifiableObjectRepositoryInterface $familyRepository
+     * @param CompletenessManager                   $completenessManager
+     * @param ProductQueryBuilderFactoryInterface   $productQueryBuilderFactory
+     * @param BulkObjectDetacherInterface           $bulkObjectDetacher
+     * @param BulkSaverInterface                    $bulkProductSaver
      */
     public function __construct(
+        IdentifiableObjectRepositoryInterface $familyRepository,
+        CompletenessManager $completenessManager,
         ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
-        SaverInterface $productSaver
+        BulkSaverInterface $bulkProductSaver,
+        BulkObjectDetacherInterface $bulkObjectDetacher
     ) {
+        $this->familyRepository = $familyRepository;
+        $this->completenessManager = $completenessManager;
         $this->productQueryBuilderFactory = $productQueryBuilderFactory;
-        $this->productSaver = $productSaver;
+        $this->bulkProductSaver = $bulkProductSaver;
+        $this->bulkObjectDetacher = $bulkObjectDetacher;
     }
 
     /**
@@ -58,10 +81,44 @@ class ComputeCompletenessOfProductsFamily implements TaskletInterface
         $jobParameters = $this->stepExecution->getJobParameters();
         $familyCode = $jobParameters->get('family_code');
 
-        $products = $this->findProductsForFamily($familyCode);
-        foreach ($products as $product) {
-            $this->productSaver->save($product);
+        $this->resetCompletenessOfProductsForFamily($familyCode);
+        $this->computeCompletenesses($familyCode);
+    }
+
+    /**
+     * Resets the completeness of products belonging to the family.
+     *
+     * @param string $familyCode
+     */
+    private function resetCompletenessOfProductsForFamily(string $familyCode): void
+    {
+        $family = $this->familyRepository->findOneByIdentifier($familyCode);
+        $this->completenessManager->scheduleForFamily($family);
+    }
+
+    /**
+     * Recompute the completenesses of all products belonging to the family by calling 'save' on them.
+     *
+     * @param string $familyCode
+     */
+    private function computeCompletenesses(string $familyCode): void
+    {
+        $productToSave = $this->findProductsForFamily($familyCode);
+
+        $productBatch = [];
+        foreach ($productToSave as $product) {
+            $productBatch[] = $product;
+
+            if (self::BATCH_SIZE === $productBatch) {
+                $this->bulkProductSaver->saveAll($productBatch);
+                $this->bulkObjectDetacher->detachAll($productBatch);
+
+                $productBatch = [];
+            }
         }
+
+        $this->bulkProductSaver->saveAll($productBatch);
+        $this->bulkObjectDetacher->detachAll($productBatch);
     }
 
     /**

--- a/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamilyTasklet.php
+++ b/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamilyTasklet.php
@@ -24,7 +24,7 @@ use Pim\Component\Connector\Step\TaskletInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class ComputeCompletenessOfProductsFamily implements TaskletInterface
+class ComputeCompletenessOfProductsFamilyTasklet implements TaskletInterface
 {
     private const BATCH_SIZE = 100;
 

--- a/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamilyTasklet.php
+++ b/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamilyTasklet.php
@@ -82,7 +82,7 @@ class ComputeCompletenessOfProductsFamilyTasklet implements TaskletInterface
     /**
      * Get the family instance from the job parameters or null.
      *
-     * @return null|FamilyInterface
+     * @return FamilyInterface
      *
      * @throws UndefinedJobParameterException
      * @throws \InvalidArgumentException

--- a/src/Pim/Component/Catalog/Job/JobParameters/ConstraintCollectionProvider/ComputeCompletenessOfProductsFamily.php
+++ b/src/Pim/Component/Catalog/Job/JobParameters/ConstraintCollectionProvider/ComputeCompletenessOfProductsFamily.php
@@ -21,13 +21,7 @@ class ComputeCompletenessOfProductsFamily implements ConstraintCollectionProvide
      */
     public function getConstraintCollection(): Collection
     {
-        return new Collection(
-            [
-                'fields' => [
-                    'family_code' => new NotBlank(),
-                ],
-            ]
-        );
+        return new Collection(['fields' => ['family_code' => new NotBlank()]]);
     }
 
     /**

--- a/src/Pim/Component/Catalog/Job/JobParameters/ConstraintCollectionProvider/ComputeCompletenessOfProductsFamily.php
+++ b/src/Pim/Component/Catalog/Job/JobParameters/ConstraintCollectionProvider/ComputeCompletenessOfProductsFamily.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Job\JobParameters\ConstraintCollectionProvider;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface;
+use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * @author    Samir Boulil <samir.boulil@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ComputeCompletenessOfProductsFamily implements ConstraintCollectionProviderInterface
+{
+    /** @var array */
+    protected $supportedJobNames;
+
+    /**
+     * @param array $supportedJobNames
+     */
+    public function __construct(array $supportedJobNames)
+    {
+        $this->supportedJobNames = $supportedJobNames;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConstraintCollection(): Collection
+    {
+        return new Collection(
+            [
+                'fields' => [
+                    'family_code' => new NotBlank(),
+                ],
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(JobInterface $job): bool
+    {
+        return in_array($job->getName(), $this->supportedJobNames);
+    }
+}

--- a/src/Pim/Component/Catalog/Job/JobParameters/ConstraintCollectionProvider/ComputeCompletenessOfProductsFamily.php
+++ b/src/Pim/Component/Catalog/Job/JobParameters/ConstraintCollectionProvider/ComputeCompletenessOfProductsFamily.php
@@ -16,17 +16,6 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 class ComputeCompletenessOfProductsFamily implements ConstraintCollectionProviderInterface
 {
-    /** @var array */
-    protected $supportedJobNames;
-
-    /**
-     * @param array $supportedJobNames
-     */
-    public function __construct(array $supportedJobNames)
-    {
-        $this->supportedJobNames = $supportedJobNames;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -46,6 +35,6 @@ class ComputeCompletenessOfProductsFamily implements ConstraintCollectionProvide
      */
     public function supports(JobInterface $job): bool
     {
-        return in_array($job->getName(), $this->supportedJobNames);
+        return 'compute_completeness_of_products_family' === $job->getName();
     }
 }

--- a/src/Pim/Component/Catalog/spec/Job/ComputeCompletenessOfProductsFamilySpec.php
+++ b/src/Pim/Component/Catalog/spec/Job/ComputeCompletenessOfProductsFamilySpec.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Job;
+
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Job\ComputeCompletenessOfProductsFamily;
+use Pim\Component\Catalog\Manager\CompletenessManager;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+
+class ComputeCompletenessOfProductsFamilySpec extends ObjectBehavior
+{
+    function let(
+        IdentifiableObjectRepositoryInterface $familyRepository,
+        CompletenessManager $completenessManager,
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        BulkSaverInterface $bulkProductSaver,
+        BulkObjectDetacherInterface $bulkObjectDetacher
+    ) {
+        $this->beConstructedWith(
+            $familyRepository,
+            $completenessManager,
+            $productQueryBuilderFactory,
+            $bulkProductSaver,
+            $bulkObjectDetacher
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ComputeCompletenessOfProductsFamily::class);
+    }
+
+    function it_calls_recomputes_the_completeness_of_all_the_products_belonging_the_given_family(
+        $familyRepository,
+        $completenessManager,
+        $productQueryBuilderFactory,
+        $bulkProductSaver,
+        $bulkObjectDetacher,
+        StepExecution $stepExecution,
+        JobParameters $jobParameters,
+        FamilyInterface $family,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $cursor,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3
+    ) {
+        $jobParameters->get('family_code')->willReturn('accessories');
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $familyRepository->findOneByIdentifier('accessories')->willReturn($family);
+
+        $completenessManager->scheduleForFamily($family)->shouldBeCalled();
+
+        $productQueryBuilderFactory->create()->willReturn($pqb);
+        $family->getCode()->willReturn('accessories');
+        $pqb->addFilter('family', Operators::IN_LIST, ['accessories'])->shouldBeCalled();
+        $pqb->execute()->willReturn($cursor);
+
+        $cursor->valid()->willReturn(true, true, true, false);
+        $cursor->current()->willReturn($product1, $product2, $product3);
+        $cursor->next()->shouldBeCalled();
+        $cursor->rewind()->shouldBeCalled();
+
+        $bulkProductSaver->saveAll([$product1, $product2, $product3])->shouldBeCalled();
+        $bulkObjectDetacher->detachAll([$product1, $product2, $product3])->shouldBeCalled();
+
+        $this->setStepExecution($stepExecution);
+        $this->execute();
+    }
+
+    function it_does_not_recompute_if_the_given_family_code_is_invalid(
+        $familyRepository,
+        $completenessManager,
+        $bulkProductSaver,
+        $bulkObjectDetacher,
+        StepExecution $stepExecution,
+        JobParameters $jobParameters
+    ) {
+        $jobParameters->get('family_code')->willReturn('unknown_family');
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $familyRepository->findOneByIdentifier('unknown_family')->willReturn(null);
+
+        $completenessManager->scheduleForFamily()->shouldNotBeCalled();
+        $bulkProductSaver->saveAll()->shouldNotBeCalled();
+        $bulkObjectDetacher->detachAll()->shouldNotBeCalled();
+
+        $this->setStepExecution($stepExecution);
+        $this->execute();
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
+++ b/src/Pim/Component/Catalog/spec/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
@@ -9,7 +9,7 @@ use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Job\ComputeCompletenessOfProductsFamily;
+use Pim\Component\Catalog\Job\ComputeCompletenessOfProductsFamilyTasklet;
 use Pim\Component\Catalog\Manager\CompletenessManager;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -17,7 +17,7 @@ use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
 
-class ComputeCompletenessOfProductsFamilySpec extends ObjectBehavior
+class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
 {
     function let(
         IdentifiableObjectRepositoryInterface $familyRepository,
@@ -37,7 +37,7 @@ class ComputeCompletenessOfProductsFamilySpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType(ComputeCompletenessOfProductsFamily::class);
+        $this->shouldHaveType(ComputeCompletenessOfProductsFamilyTasklet::class);
     }
 
     function it_calls_recomputes_the_completeness_of_all_the_products_belonging_the_given_family(

--- a/src/Pim/Component/Catalog/spec/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
+++ b/src/Pim/Component/Catalog/spec/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
@@ -10,25 +10,23 @@ use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterfa
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Job\ComputeCompletenessOfProductsFamilyTasklet;
-use Pim\Component\Catalog\Manager\CompletenessManager;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+use Pim\Component\Connector\Step\TaskletInterface;
 
 class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
 {
     function let(
         IdentifiableObjectRepositoryInterface $familyRepository,
-        CompletenessManager $completenessManager,
         ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
         BulkSaverInterface $bulkProductSaver,
         BulkObjectDetacherInterface $bulkObjectDetacher
     ) {
         $this->beConstructedWith(
             $familyRepository,
-            $completenessManager,
             $productQueryBuilderFactory,
             $bulkProductSaver,
             $bulkObjectDetacher
@@ -40,9 +38,13 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
         $this->shouldHaveType(ComputeCompletenessOfProductsFamilyTasklet::class);
     }
 
-    function it_calls_recomputes_the_completeness_of_all_the_products_belonging_the_given_family(
+    function it_is_a_tasklet()
+    {
+        $this->shouldImplement(TaskletInterface::class);
+    }
+
+    function it_recomputes_the_completeness_of_all_the_products_belonging_the_given_family(
         $familyRepository,
-        $completenessManager,
         $productQueryBuilderFactory,
         $bulkProductSaver,
         $bulkObjectDetacher,
@@ -58,8 +60,6 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
         $jobParameters->get('family_code')->willReturn('accessories');
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $familyRepository->findOneByIdentifier('accessories')->willReturn($family);
-
-        $completenessManager->scheduleForFamily($family)->shouldBeCalled();
 
         $productQueryBuilderFactory->create()->willReturn($pqb);
         $family->getCode()->willReturn('accessories');
@@ -80,7 +80,6 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
 
     function it_does_not_recompute_if_the_given_family_code_is_invalid(
         $familyRepository,
-        $completenessManager,
         $bulkProductSaver,
         $bulkObjectDetacher,
         StepExecution $stepExecution,
@@ -90,11 +89,11 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $familyRepository->findOneByIdentifier('unknown_family')->willReturn(null);
 
-        $completenessManager->scheduleForFamily()->shouldNotBeCalled();
         $bulkProductSaver->saveAll()->shouldNotBeCalled();
         $bulkObjectDetacher->detachAll()->shouldNotBeCalled();
 
         $this->setStepExecution($stepExecution);
-        $this->execute();
+        $this->shouldThrow(new \InvalidArgumentException('Family not found, "unknown_family" given'))
+            ->during('execute');
     }
 }

--- a/tests/catalog/technical/jobs.yml
+++ b/tests/catalog/technical/jobs.yml
@@ -117,3 +117,8 @@ jobs:
         alias:     compute_product_models_descendants
         label:     Compute product models descendants
         type:      compute_product_models_descendants
+    compute_completeness_of_products_family:
+        connector: internal
+        alias:     compute_completeness_of_products_family
+        label:     compute completeness of products family
+        type:      compute_completeness_of_products_family


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Update all the products belonging to a family whenever its family requirements are updated.

This PR introduces:
1.  a new Subscriber `ComputeCompletenessOnFamilyUpdateSubscriber` which listen to PRE_SAVE event on families is reponsible to check wether the attribute requirements of this family has been updated and keep this information for the POST_SAVE (This is a stateful class).
 
2. `ComputeCompletenessOnFamilyUpdateSubscriber` which also listens to POST_SAVE events on families and triggers a job to update the products completenesses if the attribute requirements are updated (calculated in the PRE_SAVE).

3. the job `compute_completeness_of_products_family` takes a family code as a job argument. It searches for all the products belonging to the family and  save them to compute the new completeness.

- [x] Detects wether an attribute requirement has been updated to trigger the recomputation of the completeness.
- [x] BulkSave products instead of save

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | Upcoming PR
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
