### PR TITLE
SDS-1772: Removes query cache

### DIFF
--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/Cursor/Cursor.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/Cursor/Cursor.php
@@ -122,7 +122,12 @@ class Cursor extends AbstractCursor
                 ->from($from->getFrom(), $from->getAlias(), $rootIdExpr)
                 ->groupBy($rootIdExpr);
 
-            $results = $this->queryBuilder->getQuery()->getArrayResult();
+            $query = $this->queryBuilder->getQuery();
+            $query->useQueryCache(false);
+            //$query->setQueryCacheDriver(null);
+            //$query->useResultCache(false);
+
+            $results = $query->getArrayResult();
             $this->entitiesIds = array_keys($results);
         }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -171,7 +171,12 @@ class ProductRepository extends EntityRepository implements
         );
         $qb->setParameter(':product_ids', $productIds);
 
-        return $qb->getQuery()->execute();
+        $query = $qb->getQuery();
+        $query->useQueryCache(false);
+        //$query->setQueryCacheDriver(null);
+        //$query->useResultCache(false);
+
+        return $query->execute();
     }
 
     /**
@@ -391,7 +396,13 @@ class ProductRepository extends EntityRepository implements
         $qb = $pqb->getQueryBuilder();
         $attribute = $this->getIdentifierAttribute();
         $pqb->addFilter($attribute->getCode(), Operators::EQUALS, $identifier);
-        $result = $qb->getQuery()->execute();
+
+        $query = $qb->getQuery();
+        $query->useQueryCache(false);
+        //$query->useResultCache(false);
+        //$query->setQueryCacheDriver(null);
+
+        $result = $query->execute();
 
         if (empty($result)) {
             return null;


### PR DESCRIPTION
Import creates some memory leak due to doctrine. I saw that every entity is well cleared but some doctrine objects are staying in doctrine cache (SingleSelectExecutor, ParserResult, ResultSetMapping).

**How it works?!**
Doctrine uses cache on DQL to avoid to transform many times the same thing.
That's why a good practice is to use named parameters instead of directly inject values.

**Now, where is the problem?!**
When we are using the pqb, we use uniqid() to join tables. It is working pretty well (as it creates a new uniq SQL join). Just it creates a memory leak on the DQL part (as each query is a new DQL and each one creates a cache)
Here is a query example:
```SELECT o FROM Pim\Component\Catalog\Model\Product o INNER JOIN o.values filteridentifier_product59e4a6351dfd2 WITH filteridentifier_product59e4a6351dfd2.attribute = 1 AND filteridentifier_product59e4a6351dfd2.varchar LIKE '101181'```

This DQL will be used as hash for cache. As you see it won't be unique for two reasons.
First because the like clause uses a value instead of a parameter. So each time the LIKE condition will be different, it will create a new cache entry.
Second reason, because the `uniqid` creates a random id on the join clause. As the PQB is reinitialize for each query, it means a new join will be created and the cache won't be reuse.

In the perfect world, DQL query should be like that:
```SELECT o FROM Pim\Component\Catalog\Model\Product o INNER JOIN o.values filteridentifier_product WITH filteridentifier_product.attribute = 1 AND filteridentifier_product.varchar LIKE ':identifier'```

**Solutions**
I found two ways to fix it:
- Clear doctrine query cache (I don't know the performance impacts)
- Rework this part using attribute codes + auto-increment instead of uniqid.

I tried first with the second solution because it seems cleaner. Unfortunately, there was too much impacts and I cannot burn anything on a patch. Impacts exist on all the filters attribute, fields, but are also dispatched multi join tables (multi options, multi ref data, metrics, prices, medias). It also needs some fixes on the sorters. And it does resolve the named parameter problem that are created in a lower stack (CriteriaCondition).
Last but not least, the same problem could happen on published products so it also needs changes and tests at this level.

Seeing that, I preferred to fix the problem in a simple way deactivating query cache. As it cannot be used today, it should not impact anything on the current performances.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
