### PR TITLE
SDS-1772: Fix memory leak on product import

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 PIM-6939: fix sort order on export
+SDS-1772: Removes query cache use on PQB to avoid memory leak
 
 # 1.7.11 (2017-10-16)
 

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/Cursor/Cursor.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/Cursor/Cursor.php
@@ -122,7 +122,10 @@ class Cursor extends AbstractCursor
                 ->from($from->getFrom(), $from->getAlias(), $rootIdExpr)
                 ->groupBy($rootIdExpr);
 
-            $results = $this->queryBuilder->getQuery()->getArrayResult();
+            $query = $this->queryBuilder->getQuery();
+            $query->useQueryCache(false);
+
+            $results = $query->getArrayResult();
             $this->entitiesIds = array_keys($results);
         }
 

--- a/src/Akeneo/Bundle/StorageUtilsBundle/spec/Doctrine/ORM/Cursor/CursorFactorySpec.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/spec/Doctrine/ORM/Cursor/CursorFactorySpec.php
@@ -28,7 +28,7 @@ class CursorFactorySpec extends ObjectBehavior
         $this->shouldImplement('Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface');
     }
 
-    function it_creates_a_cursor(QueryBuilder $queryBuilder, AbstractQuery $query, From $from)
+    function it_creates_a_cursor(QueryBuilder $queryBuilder, QueryWithCache $query, From $from)
     {
         $queryBuilder->getRootAliases()->willReturn(['a']);
         $queryBuilder->getDQLPart('from')->willReturn([$from]);
@@ -37,9 +37,15 @@ class CursorFactorySpec extends ObjectBehavior
         $queryBuilder->from(Argument::any(), Argument::any(), 'a.id')->willReturn($queryBuilder);
         $queryBuilder->groupBy('a.id')->willReturn($queryBuilder);
         $queryBuilder->getQuery()->willReturn($query);
+        $query->useQueryCache(false)->shouldBeCalled();
         $query->getArrayResult()->willReturn([]);
 
         $cursor = $this->createCursor($queryBuilder);
         $cursor->shouldBeAnInstanceOf('Akeneo\Component\StorageUtils\Cursor\CursorInterface');
     }
+}
+
+abstract class QueryWithCache extends AbstractQuery
+{
+    public abstract function useQueryCache($bool);
 }

--- a/src/Akeneo/Bundle/StorageUtilsBundle/spec/Doctrine/ORM/Cursor/CursorSpec.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/spec/Doctrine/ORM/Cursor/CursorSpec.php
@@ -18,7 +18,7 @@ class CursorSpec extends ObjectBehavior
     function let(
         QueryBuilder $queryBuilder,
         EntityManager $entityManager,
-        AbstractQuery $query,
+        Query $query,
         From $from
     ) {
         $rootIdExpr = 'o.id';
@@ -44,8 +44,9 @@ class CursorSpec extends ObjectBehavior
         $this->shouldImplement('Akeneo\Component\StorageUtils\Cursor\CursorInterface');
     }
 
-    function it_is_countable($entityManager, CursorableRepositoryInterface $repository)
+    function it_is_countable($entityManager, $query, CursorableRepositoryInterface $repository)
     {
+        $query->useQueryCache(false)->shouldBeCalled();
         $entityManager->getRepository(Argument::any())->willReturn($repository);
         $repository->findByIds(Argument::any())->willReturn(Argument::any());
 
@@ -55,8 +56,8 @@ class CursorSpec extends ObjectBehavior
 
     function it_is_iterable(
         $queryBuilder,
+        $query,
         EntityManager $entityManager,
-        AbstractQuery $query,
         From $from,
         CursorableRepositoryInterface $repository
     ) {
@@ -90,6 +91,8 @@ class CursorSpec extends ObjectBehavior
         $queryBuilder->from(Argument::any(), Argument::any(), $rootIdExpr)->willReturn($queryBuilder);
         $queryBuilder->groupBy($rootIdExpr)->willReturn($queryBuilder);
         $queryBuilder->getQuery()->willReturn($query);
+
+        $query->useQueryCache(false)->shouldBeCalled();
 
         $query->getArrayResult()->willReturn([
             10 => 10,
@@ -160,6 +163,8 @@ class CursorSpec extends ObjectBehavior
             2 => 12,
             4 => 14
         ];
+
+        $query->useQueryCache(false)->shouldBeCalled();
         $query->getArrayResult()->willReturn($ids);
 
         $entityManager->getRepository($entityClass)->willReturn($repository);
@@ -204,6 +209,8 @@ class CursorSpec extends ObjectBehavior
             2 => 12,
             4 => 14
         ];
+
+        $query->useQueryCache(false)->shouldBeCalled();
         $query->getArrayResult()->willReturn($ids);
 
         $entityManager->getRepository($entityClass)->willReturn($repository);
@@ -238,4 +245,9 @@ class Entity
     {
         return $this->id;
     }
+}
+
+abstract class Query extends AbstractQuery
+{
+    public abstract function useQueryCache($bool);
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -171,7 +171,10 @@ class ProductRepository extends EntityRepository implements
         );
         $qb->setParameter(':product_ids', $productIds);
 
-        return $qb->getQuery()->execute();
+        $query = $qb->getQuery();
+        $query->useQueryCache(false);
+
+        return $query->execute();
     }
 
     /**
@@ -391,7 +394,11 @@ class ProductRepository extends EntityRepository implements
         $qb = $pqb->getQueryBuilder();
         $attribute = $this->getIdentifierAttribute();
         $pqb->addFilter($attribute->getCode(), Operators::EQUALS, $identifier);
-        $result = $qb->getQuery()->execute();
+
+        $query = $qb->getQuery();
+        $query->useQueryCache(false);
+
+        $result = $query->execute();
 
         if (empty($result)) {
             return null;


### PR DESCRIPTION
Import creates some memory leak due to doctrine. I saw that every entity is well cleared but some doctrine objects are staying in doctrine cache (SingleSelectExecutor, ParserResult, ResultSetMapping).

**How it works?!**
Doctrine uses cache on DQL to avoid to transform many times the same thing.
That's why a good practice is to use named parameters instead of directly inject values.

**Now, where is the problem?!**
When we are using the pqb, we use uniqid() to join tables. It is working pretty well (as it creates a new uniq SQL join). Just it creates a memory leak on the DQL part (as each query is a new DQL and each one creates a cache)
Here is a query example:
```SELECT o FROM Pim\Component\Catalog\Model\Product o INNER JOIN o.values filteridentifier_product59e4a6351dfd2 WITH filteridentifier_product59e4a6351dfd2.attribute = 1 AND filteridentifier_product59e4a6351dfd2.varchar LIKE '101181'```

This DQL will be used as hash for cache. As you see it won't be unique for two reasons.
First because the like clause uses a value instead of a parameter. So each time the LIKE condition will be different, it will create a new cache entry.
Second reason, because the `uniqid` creates a random id on the join clause. As the PQB is reinitialize for each query, it means a new join will be created and the cache won't be reuse.

In the perfect world, DQL query should be like that:
```SELECT o FROM Pim\Component\Catalog\Model\Product o INNER JOIN o.values filteridentifier_product WITH filteridentifier_product.attribute = 1 AND filteridentifier_product.varchar LIKE ':identifier'```

**Solutions**
I found two ways to fix it:
- Clear doctrine query cache (I don't know the performance impacts)
- Rework this part using attribute codes + auto-increment instead of uniqid.

I tried first with the second solution because it seems cleaner. Unfortunately, there was too much impacts and I cannot burn anything on a patch. Impacts exist on all the filters attribute, fields, but are also dispatched multi join tables (multi options, multi ref data, metrics, prices, medias). It also needs some fixes on the sorters. And it does resolve the named parameter problem that are created in a lower stack (CriteriaCondition).
Last but not least, the same problem could happen on published products so it also needs changes and tests at this level.

Seeing that, I preferred to fix the problem in a simple way deactivating query cache. As it cannot be used today, it should not impact anything on the current performances.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
