### PR TITLE
 PIM-6918: fix not empty filter on boolean attribute deletion

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - PIM-6898: Fixes some data can break ES index and crashes new products indexing
 - PIM-6891: Keep the tab context between product and product model forms
+- PIM-6918: Fix error when deleteing boolean attribute linked to a published product
 
 ## Better UI\UX!
 

--- a/features/attribute/delete_attribute.feature
+++ b/features/attribute/delete_attribute.feature
@@ -38,10 +38,3 @@ Feature: Delete an attribute
     And I should be able to use the following filters:
       | filter | operator | value          | result |
       | name   | contains | My caterpillar |        |
-
-  @jira https://akeneo.atlassian.net/browse/PIM-6918
-  Scenario: Successfully delete an attribute
-    Given I am on the attributes page
-    When I click on the "delete" action of the row which contains "Handmade"
-    And I confirm the deletion
-    Then I should not see the text "Handmade"

--- a/features/attribute/delete_attribute.feature
+++ b/features/attribute/delete_attribute.feature
@@ -38,3 +38,10 @@ Feature: Delete an attribute
     And I should be able to use the following filters:
       | filter | operator | value          | result |
       | name   | contains | My caterpillar |        |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6918
+  Scenario: Successfully delete an attribute
+    Given I am on the attributes page
+    When I click on the "delete" action of the row which contains "Handmade"
+    And I confirm the deletion
+    Then I should not see the text "Handmade"

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/BooleanFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/BooleanFilter.php
@@ -79,6 +79,16 @@ class BooleanFilter extends AbstractAttributeFilter implements AttributeFilterIn
                 $this->searchQueryBuilder->addFilter($filterClause);
                 break;
 
+            case Operators::IS_NOT_EMPTY:
+                $filterClause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+
+                $this->searchQueryBuilder->addFilter($filterClause);
+                break;
+
             default:
                 throw InvalidOperatorException::notSupported($operator, static::class);
         }
@@ -94,7 +104,7 @@ class BooleanFilter extends AbstractAttributeFilter implements AttributeFilterIn
      */
     protected function checkValue(AttributeInterface $attribute, $value)
     {
-        if (!is_bool($value)) {
+        if (!(is_bool($value) || '' === $value)) {
             throw InvalidPropertyTypeException::booleanExpected($attribute->getCode(), static::class, $value);
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -210,7 +210,7 @@ services:
         arguments:
             - '@pim_catalog.validator.helper.attribute'
             - ['pim_catalog_boolean']
-            - ['=', '!=']
+            - ['=', '!=', 'NOT EMPTY']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.filter', priority: 30 }
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/BooleanFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Boolean/BooleanFilterIntegration.php
@@ -30,6 +30,8 @@ class BooleanFilterIntegration extends AbstractProductQueryBuilderTestCase
                 'a_yes_no' => [['data' => false, 'locale' => null, 'scope' => null]]
             ]
         ]);
+
+        $this->createProduct('empty', []);
     }
 
     public function testOperatorEquals()
@@ -48,6 +50,12 @@ class BooleanFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $result = $this->executeFilter([['a_yes_no', Operators::NOT_EQUAL, false]]);
         $this->assert($result, ['yes']);
+    }
+
+    public function testOperatorNotEmpty()
+    {
+        $result = $this->executeFilter([['a_yes_no', Operators::IS_NOT_EMPTY, '']]);
+        $this->assert($result, ['yes', 'no']);
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

See https://github.com/akeneo/pim-community-dev/pull/7005

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
