### PR TITLE
Add a "webpack-dev" command

### DIFF
--- a/bin/docker/pim-front.sh
+++ b/bin/docker/pim-front.sh
@@ -7,4 +7,4 @@ docker-compose exec fpm bin/console --env=test cache:clear --no-warmup
 
 docker-compose exec fpm bin/console --env=prod pim:installer:assets --symlink --clean
 
-docker-compose run --rm node yarn run webpack
+docker-compose run --rm node yarn run webpack-dev

--- a/bin/docker/pim-initialize.sh
+++ b/bin/docker/pim-initialize.sh
@@ -8,4 +8,4 @@ docker-compose exec fpm bin/console --env=test cache:clear --no-warmup
 docker-compose exec fpm bin/console --env=prod pim:install --force --symlink --clean
 docker-compose exec fpm bin/console --env=behat pim:installer:db
 
-docker-compose run --rm node yarn run webpack
+docker-compose run --rm node yarn run webpack-dev

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "http://www.akeneo.com",
   "scripts": {
     "webpack": "webpack --config webpack.config.js --env=prod",
+    "webpack-dev": "webpack --config webpack.config.js",
     "webpack-watch": "webpack --progress --config webpack.config.js --watch",
     "lint": "node ./node_modules/eslint/bin/eslint 'src/**/*.js' --ignore-path .eslintignore --quiet",
     "lint-fix": "node ./node_modules/eslint/bin/eslint 'src/**/*.js' --ignore-path .eslintignore --quiet --fix"


### PR DESCRIPTION
## Description

Currently, we have two commands to build our assets with webpack:
- `webpack` which run in production environment, and so minify the code
- `webpack-watch` which build in development environment and then keep running, watching the code and building it again at each modification (which is cool!).

This PR introduces a third command: `webpack-dev`, which does a simple build like `webpack`, but in development environment, so the code will not be minified.

This would be usefull to build the assets when developping with Docker, as there is some stability issues with `webpack-watch`, and provide a development alternative anyway.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
