### PR TITLE
[PIM-6892] Add locked categories for product models

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -13,6 +13,7 @@
 - API-399: Create a product model
 - PIM-6903: Adds compare/translate functionality for product models
 - API-404: Update partially a single product model
+- PIM-6892: Forbids users to unselect categories of parent product models
 
 ## Better UI\UX!
 

--- a/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
+++ b/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
@@ -55,6 +55,7 @@ class PimEnrichExtension extends Extension
         $loader->load('mass_actions.yml');
         $loader->load('normalizers.yml');
         $loader->load('providers.yml');
+        $loader->load('queries.yml');
         $loader->load('query_builder.yml');
         $loader->load('query_builders.yml');
         $loader->load('readers.yml');

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/AscendantCategories.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/AscendantCategories.php
@@ -50,8 +50,7 @@ class AscendantCategories implements AscendantCategoriesInterface
             $result = array_map(function ($id) {
                 return intval($id['id']);
             }, $queryBuilder->getQuery()->getResult());
-        }
-        else if ($entity instanceof VariantProductInterface) {
+        } elseif ($entity instanceof VariantProductInterface) {
             $queryBuilder
                 ->select('category.id AS id, parent_category.id AS parent_id')
                 ->from(VariantProductInterface::class, 'variant_product')

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/AscendantCategories.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/AscendantCategories.php
@@ -62,7 +62,7 @@ class AscendantCategories implements AscendantCategoriesInterface
                 ->setParameter(':id', $entity->getId());
 
             foreach ($queryBuilder->getQuery()->getResult() as $resultItem) {
-                if (null !== $resultItem['id'] && !in_array(intval($resultItem['id']), $result)) {
+                if (!in_array(intval($resultItem['id']), $result)) {
                     $result[] = intval($resultItem['id']);
                 }
                 if (null !== $resultItem['parent_id'] && !in_array(intval($resultItem['parent_id']), $result)) {

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/AscendantCategories.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/AscendantCategories.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\Doctrine\ORM\Query;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Pim\Component\Catalog\Model\CategoryInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Pim\Component\Enrich\Query\AscendantCategoriesInterface;
+
+/**
+ * Query data to get the ascendant categories of entities with family variant
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AscendantCategories implements AscendantCategoriesInterface
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /**
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCategoryIds(EntityWithFamilyVariantInterface $entity): array
+    {
+        $result = [];
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+
+        if ($entity instanceof ProductModelInterface) {
+            $queryBuilder
+                ->select('DISTINCT(category.id) AS id')
+                ->from(ProductModelInterface::class, 'product_model')
+                ->innerJoin('product_model.parent', 'parent_product_model')
+                ->innerJoin('parent_product_model.categories', 'category')
+                ->where('product_model.id = :id')
+                ->setParameter(':id', $entity->getId());
+
+            $result = array_map(function ($id) {
+                return intval($id['id']);
+            }, $queryBuilder->getQuery()->getResult());
+        }
+        else if ($entity instanceof VariantProductInterface) {
+            $queryBuilder
+                ->select('category.id AS id, parent_category.id AS parent_id')
+                ->from(VariantProductInterface::class, 'variant_product')
+                ->innerJoin('variant_product.parent', 'product_model')
+                ->leftJoin('product_model.parent', 'parent_product_model')
+                ->leftJoin('product_model.categories', 'category')
+                ->leftJoin('parent_product_model.categories', 'parent_category')
+                ->where('variant_product.id = :id')
+                ->setParameter(':id', $entity->getId());
+
+            foreach ($queryBuilder->getQuery()->getResult() as $resultItem) {
+                if (null !== $resultItem['id'] && !in_array(intval($resultItem['id']), $result)) {
+                    $result[] = intval($resultItem['id']);
+                }
+                if (null !== $resultItem['parent_id'] && !in_array(intval($resultItem['parent_id']), $result)) {
+                    $result[] = intval($resultItem['parent_id']);
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -161,7 +161,7 @@ class ProductModelNormalizer implements NormalizerInterface
                 'attributes_axes'           => $axesAttributes,
                 'image'                     => $this->normalizeImage($closestImage, $format, $context),
                 'variant_navigation'        => $this->navigationNormalizer->normalize($productModel, $format, $context),
-                'locked_category_ids'       => $this->lockedCategoryIds($productModel)
+                'ascendant_category_ids'    => $this->AscendantCategoryIds($productModel)
             ] + $this->getLabels($productModel);
 
         return $normalizedProductModel;
@@ -214,7 +214,7 @@ class ProductModelNormalizer implements NormalizerInterface
      *
      * @return integer[]
      */
-    private function lockedCategoryIds(ProductModelInterface $productModel): array
+    private function AscendantCategoryIds(ProductModelInterface $productModel): array
     {
         $result = [];
 

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -161,6 +161,7 @@ class ProductModelNormalizer implements NormalizerInterface
                 'attributes_axes'           => $axesAttributes,
                 'image'                     => $this->normalizeImage($closestImage, $format, $context),
                 'variant_navigation'        => $this->navigationNormalizer->normalize($productModel, $format, $context),
+                'locked_category_ids'       => $this->lockedCategoryIds($productModel)
             ] + $this->getLabels($productModel);
 
         return $normalizedProductModel;
@@ -204,5 +205,26 @@ class ProductModelNormalizer implements NormalizerInterface
         }
 
         return $this->fileNormalizer->normalize($data->getData(), $format, $context);
+    }
+
+    /**
+     * Returns the category ids inherited from parent product model
+     *
+     * @param ProductModelInterface $productModel
+     *
+     * @return integer[]
+     */
+    private function lockedCategoryIds(ProductModelInterface $productModel): array
+    {
+        $result = [];
+
+        $parent = $productModel->getParent();
+        if (null !== $parent) {
+            foreach ($parent->getCategories() as $category) {
+                $result[] = $category->getId();
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -13,6 +13,7 @@ use Pim\Component\Catalog\Completeness\CompletenessCalculatorInterface;
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
 use Pim\Component\Catalog\Manager\CompletenessManager;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Model\VariantProductInterface;
@@ -188,18 +189,19 @@ class ProductNormalizer implements NormalizerInterface
         $updated = null !== $newestLog ? $this->versionNormalizer->normalize($newestLog, 'internal_api') : null;
 
         $normalizedProduct['meta'] = [
-            'form'                   => $this->formProvider->getForm($product),
-            'id'                     => $product->getId(),
-            'created'                => $created,
-            'updated'                => $updated,
-            'model_type'             => 'product',
-            'structure_version'      => $this->structureVersionProvider->getStructureVersion(),
-            'completenesses'         => $this->getNormalizedCompletenesses($product),
-            'image'                  => $this->normalizeImage($product->getImage(), $format, $context),
+            'form'              => $this->formProvider->getForm($product),
+            'id'                => $product->getId(),
+            'created'           => $created,
+            'updated'           => $updated,
+            'model_type'        => 'product',
+            'structure_version' => $this->structureVersionProvider->getStructureVersion(),
+            'completenesses'    => $this->getNormalizedCompletenesses($product),
+            'image'             => $this->normalizeImage($product->getImage(), $format, $context),
         ] + $this->getLabels($product) + $this->getAssociationMeta($product);
 
         // TODO Refactor this condition in 2.1 to remove default null parameter.
-        $normalizedProduct['meta']['ascendant_category_ids'] = (null !== $this->ascendantCategoriesQuery)
+        $normalizedProduct['meta']['ascendant_category_ids'] =
+            (null !== $this->ascendantCategoriesQuery) && ($product instanceof EntityWithFamilyVariantInterface)
             ? $this->ascendantCategoriesQuery->getCategoryIds($product)
             : [];
 

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -182,15 +182,15 @@ class ProductNormalizer implements NormalizerInterface
         $updated = null !== $newestLog ? $this->versionNormalizer->normalize($newestLog, 'internal_api') : null;
 
         $normalizedProduct['meta'] = [
-            'form'                => $this->formProvider->getForm($product),
-            'id'                  => $product->getId(),
-            'created'             => $created,
-            'updated'             => $updated,
-            'model_type'          => 'product',
-            'structure_version'   => $this->structureVersionProvider->getStructureVersion(),
-            'completenesses'      => $this->getNormalizedCompletenesses($product),
-            'image'               => $this->normalizeImage($product->getImage(), $format, $context),
-            'locked_category_ids' => $this->lockedCategoryIds($product),
+            'form'                   => $this->formProvider->getForm($product),
+            'id'                     => $product->getId(),
+            'created'                => $created,
+            'updated'                => $updated,
+            'model_type'             => 'product',
+            'structure_version'      => $this->structureVersionProvider->getStructureVersion(),
+            'completenesses'         => $this->getNormalizedCompletenesses($product),
+            'image'                  => $this->normalizeImage($product->getImage(), $format, $context),
+            'ascendant_category_ids' => $this->AscendantCategoryIds($product),
         ] + $this->getLabels($product) + $this->getAssociationMeta($product);
 
         $normalizedProduct['meta'] += $this->getMetaForVariantProduct($product, $format, $context);
@@ -333,7 +333,7 @@ class ProductNormalizer implements NormalizerInterface
      *
      * @return integer[]
      */
-    private function lockedCategoryIds(ProductInterface $product): array
+    private function AscendantCategoryIds(ProductInterface $product): array
     {
         $result = [];
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -70,6 +70,7 @@ services:
             - '@pim_catalog.values_filler.product'
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
             - '@pim_enrich.normalizer.variant_navigation'
+            - '@pim_enrich.doctrine.query.ascendant_categories'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 
@@ -89,6 +90,7 @@ services:
             - '@pim_enrich.normalizer.variant_navigation'
             - '@pim_catalog.doctrine.query.find_variant_product_completeness'
             - '@pim_catalog.product_models.image_as_label'
+            - '@pim_enrich.doctrine.query.ascendant_categories'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/queries.yml
@@ -1,0 +1,8 @@
+parameters:
+    pim_enrich.doctrine.query.ascendant_categories.class: 'Pim\Bundle\EnrichBundle\Doctrine\ORM\Query\AscendantCategories'
+
+services:
+    pim_enrich.doctrine.query.ascendant_categories:
+        class: '%pim_enrich.doctrine.query.ascendant_categories.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -1034,6 +1034,7 @@ config:
         pim/template/product/tab/attribute/validation-error: pimenrich/templates/product/tab/attributes/validation-error.html
         pim/template/product/tab/associations:               pimenrich/templates/product/tab/associations.html
         pim/template/product/tab/association-panes:          pimenrich/templates/product/tab/association-panes.html
+        pim/template/product/tab/jstree-locked-item:         pimenrich/templates/product/tab/jstree-locked-item.html
         pim/template/product/completeness:                   pimenrich/templates/product/completeness.html
         pim/template/product/history:                        pimenrich/templates/product/history.html
         pim/template/product/comments:                       pimenrich/templates/product/comments.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
@@ -142,8 +142,7 @@ define(
              * Locks a set of categories
              */
             lockCategories: function() {
-                const lockedCategoryIds = this.getFormData().meta.locked_category_ids;
-                console.log(lockedCategoryIds);
+                const lockedCategoryIds = this.getFormData().meta.ascendant_category_ids;
                 lockedCategoryIds.forEach((categoryId) => {
                     const node = $('#node_' + categoryId);
                     node.find('> a').replaceWith(this.lockedTemplate({

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
@@ -51,6 +51,7 @@ define(
             treeAssociate: null,
             cache: {},
             trees: [],
+            loadedEvent: null,
 
             /**
              * Associates the tree code to the number of selected categories
@@ -118,21 +119,37 @@ define(
 
                     this.delegateEvents();
 
-                    mediator.on('jstree:loaded', () => {
-                        const lockedCategoryIds = this.getFormData().meta.locked_category_ids;
-                        lockedCategoryIds.forEach((categoryId) => {
-                            const node = $('#node_' + categoryId);
-                            node.find('a').replaceWith(this.lockedTemplate({
-                                label: node.text().trim()
-                            }));
-                        });
-                    });
+                    this.loadedEvent = this.lockCategories.bind(this);
+                    mediator.on('jstree:loaded', this.loadedEvent);
 
                     this.initCategoryCount();
                     this.renderCategorySwitcher();
                 }.bind(this));
 
                 return this;
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            shutdown: function () {
+                mediator.off('jstree:loaded', this.loadedEvent);
+
+                BaseForm.prototype.shutdown.apply(this, arguments);
+            },
+
+            /**
+             * Locks a set of categories
+             */
+            lockCategories: function() {
+                const lockedCategoryIds = this.getFormData().meta.locked_category_ids;
+                console.log(lockedCategoryIds);
+                lockedCategoryIds.forEach((categoryId) => {
+                    const node = $('#node_' + categoryId);
+                    node.find('> a').replaceWith(this.lockedTemplate({
+                        label: node.find('> a').text().trim()
+                    }));
+                });
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
@@ -51,7 +51,7 @@ define(
             treeAssociate: null,
             cache: {},
             trees: [],
-            loadedEvent: null,
+            onLoadedEvent: null,
 
             /**
              * Associates the tree code to the number of selected categories
@@ -119,8 +119,8 @@ define(
 
                     this.delegateEvents();
 
-                    this.loadedEvent = this.lockCategories.bind(this);
-                    mediator.on('jstree:loaded', this.loadedEvent);
+                    this.onLoadedEvent = this.lockCategories.bind(this);
+                    mediator.on('jstree:loaded', this.onLoadedEvent);
 
                     this.initCategoryCount();
                     this.renderCategorySwitcher();
@@ -133,7 +133,7 @@ define(
              * {@inheritdoc}
              */
             shutdown: function () {
-                mediator.off('jstree:loaded', this.loadedEvent);
+                mediator.off('jstree:loaded', this.onLoadedEvent);
 
                 BaseForm.prototype.shutdown.apply(this, arguments);
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
@@ -16,6 +16,7 @@ define(
         'pim/form',
         'pim/template/product/tab/categories',
         'pim/template/product/tab/catalog-switcher',
+        'pim/template/product/tab/jstree-locked-item',
         'pim/user-context',
         'routing',
         'pim/tree/associate',
@@ -29,6 +30,7 @@ define(
         BaseForm,
         formTemplate,
         switcherTemplate,
+        lockedTemplate,
         UserContext,
         Routing,
         TreeAssociate,
@@ -37,6 +39,7 @@ define(
         return BaseForm.extend({
             template: _.template(formTemplate),
             switcherTemplate: _.template(switcherTemplate),
+            lockedTemplate: _.template(lockedTemplate),
             className: 'tab-pane active',
             id: 'product-categories',
             treeLinkSelector: 'tree-link-',
@@ -114,6 +117,16 @@ define(
                     });
 
                     this.delegateEvents();
+
+                    mediator.on('jstree:loaded', () => {
+                        const lockedCategoryIds = this.getFormData().meta.locked_category_ids;
+                        lockedCategoryIds.forEach((categoryId) => {
+                            const node = $('#node_' + categoryId);
+                            node.find('a').replaceWith(this.lockedTemplate({
+                                label: node.text().trim()
+                            }));
+                        });
+                    });
 
                     this.initCategoryCount();
                     this.renderCategorySwitcher();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/tree-associate.jstree.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/tree-associate.jstree.js
@@ -134,6 +134,10 @@ define(
                 var $tree = $('#tree-' + treeId);
                 $tree.jstree(self.config);
 
+                $tree.bind('loaded.jstree', function () {
+                    mediator.trigger('jstree:loaded');
+                });
+
                 $tree.bind('check_node.jstree', function (e, d) {
                     if (d.inst.get_checked() && $(d.rslt.obj[0]).hasClass('jstree-root') === false) {
                         var selected = this.parseHiddenCategories();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/jstree-locked-item.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/jstree-locked-item.html
@@ -1,0 +1,5 @@
+<div class="jstree-lockeditem">
+    <div class="AknSelectButton AknSelectButton--disabled"></div>
+    <div class="jstree-lockedicon"></div>
+    <%- label %>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -19,6 +19,7 @@ use Pim\Component\Catalog\ProductModel\Query\CompleteVariantProducts;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 use Pim\Component\Enrich\Converter\ConverterInterface;
+use Pim\Component\Enrich\Query\AscendantCategoriesInterface;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -37,7 +38,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
         VariantNavigationNormalizer $navigationNormalizer,
         VariantProductRatioInterface $findVariantProductCompleteness,
-        ImageAsLabel $imageAsLabel
+        ImageAsLabel $imageAsLabel,
+        AscendantCategoriesInterface $ascendantCategories
     ) {
         $this->beConstructedWith(
             $normalizer,
@@ -52,7 +54,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             $attributesProvider,
             $navigationNormalizer,
             $findVariantProductCompleteness,
-            $imageAsLabel
+            $imageAsLabel,
+            $ascendantCategories
         );
     }
 
@@ -74,6 +77,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $navigationNormalizer,
         $findVariantProductCompleteness,
         $imageAsLabel,
+        $ascendantCategories,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -171,6 +175,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             'total' => 10,
         ]);
 
+        $ascendantCategories->getCategoryIds($productModel)->willReturn([42]);
+
         $this->normalize($productModel, 'internal_api', $options)->shouldReturn(
             [
                 'code'           => 'tshirt_blue',
@@ -196,7 +202,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                     'label'          => [
                         'en_US' => 'Tshirt blue',
                         'fr_FR' => 'Tshirt bleu',
-                    ]
+                    ],
+                    'ascendant_category_ids' => [42],
                 ]
             ]
         );
@@ -215,6 +222,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $navigationNormalizer,
         $findVariantProductCompleteness,
         $imageAsLabel,
+        $ascendantCategories,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -299,6 +307,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             'total' => 10,
         ]);
 
+        $ascendantCategories->getCategoryIds($productModel)->willReturn([42]);
+
         $this->normalize($productModel, 'internal_api', $options)->shouldReturn(
             [
                 'code'           => 'tshirt_blue',
@@ -324,7 +334,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                     'label'          => [
                         'en_US' => 'Tshirt blue',
                         'fr_FR' => 'Tshirt bleu',
-                    ]
+                    ],
+                    'ascendant_category_ids' => [42],
                 ]
             ]
         );
@@ -343,6 +354,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $navigationNormalizer,
         $findVariantProductCompleteness,
         $imageAsLabel,
+        $ascendantCategories,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -440,6 +452,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             'total' => 10,
         ]);
 
+        $ascendantCategories->getCategoryIds($productModel)->willReturn([42]);
+
         $this->normalize($productModel, 'internal_api', $options)->shouldReturn(
             [
                 'code'           => 'tshirt_blue',
@@ -465,7 +479,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                     'label'          => [
                         'en_US' => 'Tshirt blue',
                         'fr_FR' => 'Tshirt bleu',
-                    ]
+                    ],
+                    'ascendant_category_ids' => [42],
                 ]
             ]
         );

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
+use Pim\Bundle\EnrichBundle\Doctrine\ORM\Query\AscendantCategories;
 use Pim\Bundle\EnrichBundle\Normalizer\FileNormalizer;
 use Pim\Bundle\EnrichBundle\Normalizer\VariantNavigationNormalizer;
 use Pim\Bundle\EnrichBundle\Provider\Form\FormProviderInterface;
@@ -31,6 +32,7 @@ use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Pim\Component\Catalog\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 use Pim\Component\Enrich\Converter\ConverterInterface;
+use Pim\Component\Enrich\Query\AscendantCategoriesInterface;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -56,7 +58,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         ProductBuilderInterface $productBuilder,
         EntityWithFamilyValuesFillerInterface $productValuesFiller,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
-        VariantNavigationNormalizer $navigationNormalizer
+        VariantNavigationNormalizer $navigationNormalizer,
+        AscendantCategoriesInterface $ascendantCategories
     ) {
         $this->beConstructedWith(
             $normalizer,
@@ -78,7 +81,8 @@ class ProductNormalizerSpec extends ObjectBehavior
             $productBuilder,
             $productValuesFiller,
             $attributesProvider,
-            $navigationNormalizer
+            $navigationNormalizer,
+            $ascendantCategories
         );
     }
 
@@ -214,11 +218,12 @@ class ProductNormalizerSpec extends ObjectBehavior
                     'associations'      => [
                         'group' => ['groupIds' => [12]]
                     ],
+                    'ascendant_category_ids'    => [],
                     'variant_navigation'        => [],
                     'attributes_for_this_level' => [],
                     'attributes_axes'           => [],
                     'parent_attributes'         => [],
-                    'family_variant'            => null
+                    'family_variant'            => null,
                 ]
             ]
         );
@@ -241,6 +246,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $productValuesFiller,
         $navigationNormalizer,
         $attributesProvider,
+        $ascendantCategories,
         VariantProductInterface $mug,
         AssociationInterface $upsell,
         AssociationTypeInterface $groupType,
@@ -351,6 +357,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         $size->getCode()->willReturn('size');
         $description->getCode()->willReturn('description');
 
+        $ascendantCategories->getCategoryIds($mug)->willReturn([42]);
+
         $this->normalize($mug, 'internal_api', $options)->shouldReturn(
             [
                 'enabled'    => true,
@@ -376,6 +384,7 @@ class ProductNormalizerSpec extends ObjectBehavior
                     'associations'      => [
                         'group' => ['groupIds' => [12]]
                     ],
+                    'ascendant_category_ids'    => [42],
                     'variant_navigation' => ['NAVIGATION NORMALIZED'],
                     'attributes_for_this_level' => ['size'],
                     'attributes_axes'           => ['size'],

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/SelectButton.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/SelectButton.less
@@ -27,4 +27,14 @@
     background-position: center;
     background-size: @AknCheckboxSize @AknCheckboxSize - 1px;
   }
+
+  &--disabled {
+    cursor: not-allowed;
+    border-color: lighten(@AknSlateGrey, 10%);
+    background-color: lighten(@AknSlateGrey, 10%);
+    background-image: url("../../../images/icon-checkwhite.svg");
+    background-repeat: no-repeat;
+    background-position: 0 0;
+    background-size: @AknCheckboxSize - 1px;
+  }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
@@ -181,6 +181,27 @@
       float: none;
     }
   }
+
+  .jstree-lockeditem {
+    height: 35px;
+    font-size: 14px;
+    padding: 0 0 0 27px;
+    color: @AknDarkBlue !important;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: ~"calc(100% - 32px)";
+    overflow: hidden;
+    cursor: not-allowed;
+    font-weight: bold;
+  }
+
+  .jstree-lockedicon {
+    background: url("../../images/jstree/icon-folderfull.svg") no-repeat center 0;
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    margin: 0 4px 0 8px;
+  }
 }
 
 .root-unselectable .jstree-root > a > .jstree-checkbox {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
@@ -184,8 +184,9 @@
 
   .jstree-lockeditem {
     height: 35px;
+    display: inline-block;
     font-size: 14px;
-    padding: 0 0 0 27px;
+    padding: 0;
     color: @AknDarkBlue !important;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/src/Pim/Component/Enrich/Query/AscendantCategoriesInterface.php
+++ b/src/Pim/Component/Enrich/Query/AscendantCategoriesInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Component\Enrich\Query;
+
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+
+/**
+ * Query data to get the ascendant categories of entities with family variant
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface AscendantCategoriesInterface
+{
+    /**
+     * Returns the ids of categories of all ascendant
+     *
+     * @param EntityWithFamilyVariantInterface $entity
+     *
+     * @return integer[]
+     */
+    public function getCategoryIds(EntityWithFamilyVariantInterface $entity): array;
+}


### PR DESCRIPTION
This PR disable jstree items if they belongs to parent of grandparent product model.
If you find the front crappy, ask me IRL because I didn't found any solution and can list all the tested ones.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | y
| Micro Demo to the PO (Story only) | y
| Migration script                  | -
| Tech Doc                          | -

