### PR TITLE
PIM-5817: move datepicker above field instead of under

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,7 @@
 - PIM-6898: Fixes some data can break ES index and crashes new products indexing
 - PIM-6891: Keep the tab context between product and product model forms
 - PIM-6918: Fix error when deleteing boolean attribute linked to a published product
+- PIM-5817: move datepicker above field instead of under
 
 ## Better UI\UX!
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/lib/bootstrap-datetimepicker/js/bootstrap-datetimepicker.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/lib/bootstrap-datetimepicker/js/bootstrap-datetimepicker.js
@@ -266,16 +266,16 @@
       offset.top = offset.top + this.height;
 
       var $window = $(window);
-      
+
       if ( this.options.width != undefined ) {
         this.widget.width( this.options.width );
       }
-      
+
       if ( this.options.orientation == 'left' ) {
         this.widget.addClass( 'left-oriented' );
         offset.left   = offset.left - this.widget.width() + 20;
       }
-      
+
       if (this._isInFixed()) {
         position = 'fixed';
         offset.top -= $window.scrollTop();
@@ -293,7 +293,8 @@
 
       this.widget.css({
         position: position,
-        top: offset.top,
+        top: offset.top - this.widget.outerHeight() -
+          (this.component ? this.component.outerHeight() : this.$element.outerHeight()),
         left: offset.left,
         right: offset.right
       });
@@ -851,7 +852,7 @@
           else return 'AM';
 	} else if (property === 'UTCYear') {
           rv = d.getUTCFullYear();
-          rv = rv.toString().substr(2);   
+          rv = rv.toString().substr(2);
         } else {
           methodName = 'get' + property;
           rv = d[methodName]();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR only moves the datepickers to upper position instead of down. 
**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added Behats                      | NA
| Added integration tests           | NA
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
