### PR TITLE
API-407: Fix too many error messages

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -23,6 +23,7 @@
 - PIM-6898: Fixes some data can break ES index and crashes new products indexing
 - PIM-6918: Fix error when deleteing boolean attribute linked to a published product
 - PIM-5817: move datepicker above field instead of under
+- API-407: Fix too many error messages when trying to create a product model that extends a product model with a parent
 
 ## Better manage products with variants!
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
@@ -323,67 +323,66 @@ JSON;
         $this->assertSameProductModels($expectedProductModel, 'root_product_model');
     }
 
-    //TODO: to be fixed in API-407
-//    public function testSubProductModelCreationThatSetsASubProductModelAsParent()
-//    {
-//        $this->createProductModel(
-//            [
-//                'code'           => 'tshirt_sub_product_model',
-//                'family_variant' => 'familyVariantA1',
-//                'parent'         => 'tshirt',
-//                'values'         => [
-//                    'a_simple_select' => [
-//                        [
-//                            'scope'  => null,
-//                            'locale' => null,
-//                            'data'   => "optionB",
-//                        ],
-//                    ],
-//                ],
-//            ]
-//        );
-//
-//        $client = $this->createAuthenticatedClient();
-//
-//        $data =
-//            <<<JSON
-//    {
-//        "code": "sub_product_model",
-//        "parent": "tshirt_sub_product_model",
-//        "family_variant": "familyVariantA1",
-//        "values": {
-//          "a_simple_select": [
-//            {
-//              "locale": null,
-//              "scope": null,
-//              "data": "optionB"
-//            }
-//          ]
-//        }
-//    }
-//JSON;
-//
-//        $client->request('POST', 'api/rest/v1/product-models', [], [], [], $data);
-//
-//        $expectedContent =
-//            <<<JSON
-//{
-//  "code": 422,
-//  "message": "Validation failed.",
-//  "errors": [
-//    {
-//      "property": "parent",
-//      "message": "The product model \"sub_product_model\" cannot have the product model \"tshirt_sub_product_model\" as parent"
-//    }
-//  ]
-//}
-//JSON;
-//
-//        $response = $client->getResponse();
-//
-//        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
-//        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
-//    }
+    public function testSubProductModelCreationThatSetsASubProductModelAsParent()
+    {
+        $this->createProductModel(
+            [
+                'code'           => 'tshirt_sub_product_model',
+                'family_variant' => 'familyVariantA1',
+                'parent'         => 'tshirt',
+                'values'         => [
+                    'a_simple_select' => [
+                        [
+                            'scope'  => null,
+                            'locale' => null,
+                            'data'   => "optionB",
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+            <<<JSON
+    {
+        "code": "sub_product_model",
+        "parent": "tshirt_sub_product_model",
+        "family_variant": "familyVariantA1",
+        "values": {
+          "a_simple_select": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "optionB"
+            }
+          ]
+        }
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/product-models', [], [], [], $data);
+
+        $expectedContent =
+            <<<JSON
+{
+  "code": 422,
+  "message": "Validation failed.",
+  "errors": [
+    {
+      "property": "parent",
+      "message": "The product model \"sub_product_model\" cannot have the product model \"tshirt_sub_product_model\" as parent"
+    }
+  ]
+}
+JSON;
+
+        $response = $client->getResponse();
+
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
 
     public function testSubProductModelCreationWithAlreadyExistingAxes()
     {

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
@@ -124,6 +124,49 @@ JSON;
         $this->assertSame($standardizedProduct['values']['a_text'][0]['data'], 'My awesome text');
     }
 
+    public function testCreateSubProductModelWithSubProductModelAsParent()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "family_variant": "familyVariantA1",
+        "parent": "sub_sweat",
+        "values": {
+          "a_text": [
+            {
+              "locale": null,
+              "scope": null,
+              "data": "My awesome text"
+            }
+          ]
+        }
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/product-models/new_sub_sweat', [], [], [], $data);
+
+        $expectedContent =
+            <<<JSON
+{
+  "code": 422,
+  "message": "Validation failed.",
+  "errors": [
+    {
+      "property": "parent",
+      "message": "The product model \"new_sub_sweat\" cannot have the product model \"sub_sweat\" as parent"
+    }
+  ]
+}
+JSON;
+
+        $response = $client->getResponse();
+
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
     public function testUpdateAxisSubProductModel()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
@@ -1005,6 +1005,59 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
+    public function testCreateASubProductModelWithAFamilyWithOnlyOneLevelOfVariation()
+    {
+        $this->createProductModel(
+            [
+                'code' => 'root_product_model',
+                'family_variant' => 'familyVariantA2',
+                'values'  => [
+                    'a_number_float'  => [['data' => '12.5', 'locale' => null, 'scope' => null]],
+                ]
+            ]
+        );
+
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "code": "sub_product",
+        "parent": "root_product_model",
+        "values": {
+            "a_simple_select":[
+                {
+                    "locale":null,
+                    "scope":null,
+                    "data":"optionB"
+                }
+            ]
+        }
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/product-models/sub_product', [], [], [], $data);
+
+        $expectedContent =
+            <<<JSON
+{
+  "code": 422,
+  "message": "Validation failed.",
+  "errors": [
+    {
+      "property": "",
+      "message": "The product model \"sub_product\" cannot have a parent"
+    }
+  ]
+}
+JSON;
+
+        $response = $client->getResponse();
+
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
     public function testUpdateRootProductModelWithANewFamily()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
@@ -1045,7 +1045,7 @@ JSON;
   "message": "Validation failed.",
   "errors": [
     {
-      "property": "",
+      "property": "parent",
       "message": "The product model \"sub_product\" cannot have a parent"
     }
   ]

--- a/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
@@ -49,7 +49,7 @@ class NotEmptyVariantAxesValidator extends ConstraintValidator
         // be on the 3 level sub_product_model_2 -> sub_product_model_1 -> root_product_model) and will return the axes
         // on the 3 level.
         if ($entity instanceof ProductModelInterface && null !== $entity->getParent()) {
-            if (null !== $entity->getParent()->getParent()) {
+            if (null !== $entity->getParent()->getParent() || 1 === (int) $entity->getParent()->getFamilyVariant()->getNumberOfLevel()) {
                 return;
             }
         }

--- a/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
@@ -4,6 +4,7 @@ namespace Pim\Component\Catalog\Validator\Constraints;
 
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -41,6 +42,16 @@ class NotEmptyVariantAxesValidator extends ConstraintValidator
 
         if (null === $entity->getFamilyVariant()) {
             return;
+        }
+
+        // This fix prevent the empty variant axes to return a wrong error message when we try to create a sub product
+        // model that extends another sub product model. Else the validator thinks it's a variant product (as it will
+        // be on the 3 level sub_product_model_2 -> sub_product_model_1 -> root_product_model) and will return the axes
+        // on the 3 level.
+        if ($entity instanceof ProductModelInterface && null !== $entity->getParent()) {
+            if (null !== $entity->getParent()->getParent()) {
+                return;
+            }
         }
 
         $axes = $this->axesProvider->getAxes($entity);

--- a/src/Pim/Component/Catalog/Validator/Constraints/ProductModelPositionInTheVariantTreeValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/ProductModelPositionInTheVariantTreeValidator.php
@@ -57,7 +57,7 @@ class ProductModelPositionInTheVariantTreeValidator extends ConstraintValidator
                 [
                     '%product_model%' => $productModel->getCode(),
                 ]
-            )->addViolation();
+            )->atPath('parent')->addViolation();
         }
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This fix prevent the empty variant axes to return a wrong error message when we try to create a sub product model that extends another sub product model. Else the validator thinks it's a variant product (as it will be on the 3 level sub_product_model_2 -> sub_product_model_1 -> root_product_model) and will return the axes on the 3 level.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | Yes
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo
