### PR TITLE
[Bugfix 2.0] Add use class alias for proper form parent indication

### DIFF
--- a/src/Pim/Bundle/LocalizationBundle/Form/Type/LocaleType.php
+++ b/src/Pim/Bundle/LocalizationBundle/Form/Type/LocaleType.php
@@ -4,7 +4,7 @@ namespace Pim\Bundle\LocalizationBundle\Form\Type;
 
 use Akeneo\Component\Localization\Provider\LocaleProviderInterface;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\LocaleType;
+use Symfony\Component\Form\Extension\Core\Type\LocaleType as SymfonyLocaleType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class LocaleType extends AbstractType
@@ -34,7 +34,7 @@ class LocaleType extends AbstractType
      */
     public function getParent()
     {
-        return LocaleType::class;
+        return SymfonyLocaleType::class;
     }
 
     /**


### PR DESCRIPTION
This is a backport of fix #7011 to 2.0 branch