### PR TITLE
PIM-6933: fix menu display in case of acl restriction

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,8 @@
 
 - GITHUB-7035: Change class alias for proper LocaleType form parent indication, cheers @mkilmanas!
 - PIM-6567: Fix attributes filter to not remove axes
+- PIM-6933: Fix menu display in case of acl restriction
+- PIM-6922: fix sort order on attribute groups
 
 ## Better manage products with variants!
 
@@ -11,7 +13,7 @@
 
 ## BC breaks
 
-- Change the constructor of `Pim\Component\Catalog\Completeness\CompletenessCalculator`. Remove `Pim\Component\Catalog\Factory\ValueFactory` and both `Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface`. Add `Pim\Component\Catalog\EntityWithFamily\IncompleteValueCollectionFactory` and `Pim\Component\Catalog\EntityWithFamily\RequiredValueCollectionFactory`. 
+- Change the constructor of `Pim\Component\Catalog\Completeness\CompletenessCalculator`. Remove `Pim\Component\Catalog\Factory\ValueFactory` and both `Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface`. Add `Pim\Component\Catalog\EntityWithFamily\IncompleteValueCollectionFactory` and `Pim\Component\Catalog\EntityWithFamily\RequiredValueCollectionFactory`.
 - Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductModelNormalizer` to add `Symfony\Component\Serializer\Normalizer\NormalizerInterface`.
 
 # 2.0.4 (2017-10-19)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/role.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/role.js
@@ -3,13 +3,32 @@
 define([
         'pim/controller/form',
         'pim/security-context',
-        'pim/form-config-provider'
+        'pim/form-config-provider',
+        'pim/router'
     ], function (
         FormController,
         securityContext,
-        configProvider
+        configProvider,
+        router
     ) {
         return FormController.extend({
+            /**
+             * {@inheritdoc}
+             */
+            renderRoute: function (route, path) {
+                return securityContext.initialize().then(() => {
+                    if (!securityContext.isGranted('pim_user_role_edit')) {
+                        router.redirectToRoute('pim_dashboard_index');
+
+                        return;
+                    }
+
+                    return $.get(path)
+                        .then(this.renderTemplate.bind(this))
+                        .promise();
+                })
+            },
+
             /**
              * {@inheritdoc}
              */
@@ -18,6 +37,10 @@ define([
                 configProvider.clear();
 
                 FormController.prototype.afterSubmit.apply(this, arguments);
+
+                if (!this.$('#entity-updated span').is(':visible')) {
+                    location.reload();
+                }
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/column-tabs-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/column-tabs-navigation.js
@@ -1,4 +1,5 @@
 'use strict';
+
 /**
  * Display navigation links in column for the tab display
  *

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/menu.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/menu.js
@@ -29,6 +29,20 @@ define(
                 this.$el.empty().append(this.template());
 
                 return BaseForm.prototype.render.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            renderExtension: function (extension) {
+                if (!_.isEmpty(extension.options.config) &&
+                    !extension.options.config.to &&
+                    _.isFunction(extension.hasChildren) &&
+                    !extension.hasChildren()) {
+                    return;
+                }
+
+                BaseForm.prototype.renderExtension.apply(this, arguments);
             }
         });
     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/tab.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/tab.js
@@ -63,7 +63,13 @@ define(
              * {@inheritdoc}
              */
             render: function () {
-                this.$el.empty().append(this.template({
+                this.$el.empty();
+
+                if (!this.config.to && !this.hasChildren()) {
+                    return this;
+                }
+
+                this.$el.append(this.template({
                     active: this.active,
                     title: this.getLabel(),
                     url: Routing.generateHash(this.getRoute(), this.getRouteParams()),
@@ -154,6 +160,15 @@ define(
                 if (event.target === this.code) {
                     this.items.push(event);
                 }
+            },
+
+            /**
+             * Does this tab have children elements
+             *
+             * @return {Boolean}
+             */
+            hasChildren: function () {
+                return 0 < this.items.length;
             }
         });
     });


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix render of menu item displaying even if they don't have sub items. Before this fix, if no subsection were visible by the user, the menu was crashing. Now, You need to be able to see at least one section to see the menu item.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added Behats                      | Todo
| Added integration tests           | NA
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
