### PR TITLE
 PIM-6567: Fix attributes filter to not remove axes

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - GITHUB-7035: Change class alias for proper LocaleType form parent indication, cheers @mkilmanas!
+- PIM-6567: Fix attributes filter to not remove axes
 
 # 2.0.4 (2017-10-19)
 

--- a/src/Pim/Component/Catalog/spec/ProductModel/Filter/ProductAttributeFilterSpec.php
+++ b/src/Pim/Component/Catalog/spec/ProductModel/Filter/ProductAttributeFilterSpec.php
@@ -5,13 +5,12 @@ namespace spec\Pim\Component\Catalog\ProductModel\Filter;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
-use Pim\Component\Catalog\ProductModel\Filter\AttributeFilterInterface;
-use Pim\Component\Catalog\ProductModel\Filter\ProductAttributeFilter;
 use Prophecy\Argument;
 
 class ProductAttributeFilterSpec extends ObjectBehavior
@@ -39,13 +38,36 @@ class ProductAttributeFilterSpec extends ObjectBehavior
         $productRepository,
         FamilyInterface $family,
         ProductInterface $product,
-        Collection $attribute
+        Collection $familyAttributes,
+        Collection $familyAttributeCodes
     ) {
         $familyRepository->findOneByIdentifier('Summer Tshirt')->willReturn($family);
-        $family->getAttributes()->willReturn($attribute);
-        $attribute->exists(Argument::any())->shouldBeCalledTimes(3);
+        $family->getAttributes()->willReturn($familyAttributes);
+        $familyAttributes->map(Argument::any())->willReturn($familyAttributeCodes);
+        $familyAttributeCodes->toArray()->willReturn(['sku', 'description']);
 
         $productRepository->findOneByIdentifier('tshirt')->willReturn($product);
+
+        $expected = [
+            'identifier' => 'tshirt',
+            'family' => 'Summer Tshirt',
+            'values' => [
+                'sku' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'tshirt',
+                    ],
+                ],
+                'description' => [
+                    [
+                        'locale' => 'en_US',
+                        'scope' => 'mobile',
+                        'data' => 'My awesome description',
+                    ],
+                ],
+            ],
+        ];
 
         $this->filter(
             [
@@ -75,7 +97,7 @@ class ProductAttributeFilterSpec extends ObjectBehavior
                     ],
                 ],
             ]
-        );
+        )->shouldReturn($expected);
     }
 
     function it_filters_the_attributes_that_does_not_belong_to_a_family_variant(
@@ -85,7 +107,12 @@ class ProductAttributeFilterSpec extends ObjectBehavior
         ProductInterface $product,
         FamilyVariantInterface $familyVariant,
         VariantAttributeSetInterface $variantAttributeSet,
-        Collection $attribute
+        Collection $attributes,
+        Collection $axes,
+        AttributeInterface $sku,
+        AttributeInterface $weight,
+        AttributeInterface $description,
+        AttributeInterface $color
     ) {
         $productModelRepository->findOneByIdentifier('parent-code')->willReturn($productModel);
         $productModel->getFamilyVariant()->willreturn($familyVariant);
@@ -94,8 +121,53 @@ class ProductAttributeFilterSpec extends ObjectBehavior
         $productRepository->findOneByIdentifier('tshirt')->willReturn($product);
 
         $familyVariant->getVariantAttributeSet(2)->willReturn($variantAttributeSet);
-        $variantAttributeSet->getAttributes()->willReturn($attribute);
-        $attribute->exists(Argument::any())->shouldBeCalledTimes(3);
+        $variantAttributeSet->getAttributes()->willReturn($attributes);
+        $variantAttributeSet->getAxes()->willReturn($axes);
+        $attributes->toArray()->willReturn([$sku, $weight, $description]);
+        $axes->toArray()->willReturn([$color]);
+
+        $sku->getCode()->willReturn('sku');
+        $weight->getCode()->willReturn('weight');
+        $description->getCode()->willReturn('description');
+        $color->getCode()->willReturn('color');
+
+        $expected = [
+            'identifier' => 'tshirt',
+            'parent' => 'parent-code',
+            'values' => [
+                'sku' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'tshirt',
+                    ],
+                ],
+                'weight' => [
+                    [
+                        'locale' => 'en_US',
+                        'scope' => 'mobile',
+                        'data' => [
+                            'unit' => 'GRAM',
+                            'amount' => '30'
+                        ]
+                    ],
+                ],
+                'description' => [
+                    [
+                        'locale' => 'en_US',
+                        'scope' => 'mobile',
+                        'data' => 'My awesome description',
+                    ],
+                ],
+                'color' => [
+                    [
+                        'locale' => 'en_US',
+                        'scope' => 'mobile',
+                        'data' => '[blue]',
+                    ],
+                ],
+            ],
+        ];
 
         $this->filter(
             [
@@ -116,6 +188,16 @@ class ProductAttributeFilterSpec extends ObjectBehavior
                             'data' => 'My very awesome T-shirt',
                         ],
                     ],
+                    'weight' => [
+                        [
+                            'locale' => 'en_US',
+                            'scope' => 'mobile',
+                            'data' => [
+                                'unit' => 'GRAM',
+                                'amount' => '30'
+                            ]
+                        ],
+                    ],
                     'description' => [
                         [
                             'locale' => 'en_US',
@@ -123,8 +205,15 @@ class ProductAttributeFilterSpec extends ObjectBehavior
                             'data' => 'My awesome description',
                         ],
                     ],
+                    'color' => [
+                        [
+                            'locale' => 'en_US',
+                            'scope' => 'mobile',
+                            'data' => '[blue]',
+                        ],
+                    ],
                 ],
             ]
-        );
+        )->shouldReturn($expected);
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/ProductModel/Filter/ProductAttributeFilterIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/ProductModel/Filter/ProductAttributeFilterIntegration.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Pim\Component\Catalog\tests\integration\ProductModel\Filter;
+
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProductAttributeFilterIntegration extends TestCase
+{
+    protected function getConfiguration()
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    public function testFilterAttributesNotComingFromFamily()
+    {
+        $expected = [
+            'identifier' => 'shoes',
+            'parent' => 'brooksblue',
+            'family' => 'shoes',
+            'values' => [],
+        ];
+
+        $product = [
+            'identifier' => 'shoes',
+            'parent' => 'brooksblue',
+            'family' => 'shoes',
+            'values' => [
+                'wash_temperature' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'HOT',
+                    ]
+                ]
+            ]
+        ];
+
+        $filteredProduct = $this
+            ->get('pim_connector.processor.attribute_filter.product')
+            ->filter($product);
+
+        $this->assertSame($expected, $filteredProduct);
+    }
+
+    public function testFilterAttributesNotComingFromFamilyVariant()
+    {
+        $expected = [
+            'identifier' => 'shoes',
+            'parent' => 'brooksblue',
+            'family' => 'shoes',
+            'values' => [],
+        ];
+
+        $product = [
+            'identifier' => 'shoes',
+            'parent' => 'brooksblue',
+            'family' => 'shoes',
+            'values' => [
+                'brand' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'Mike',
+                    ],
+                ],
+            ]
+        ];
+
+        $filteredProduct = $this
+            ->get('pim_connector.processor.attribute_filter.product')
+            ->filter($product);
+
+        $this->assertSame($expected, $filteredProduct);
+    }
+
+    public function testKeepAttributeAndAxesComingFromFamilyVariant()
+    {
+        $expected = [
+            'identifier' => 'shoes',
+            'parent' => 'brooksblue',
+            'family' => 'shoes',
+            'values' => [
+                'sku' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'shoes',
+                    ],
+                ],
+                'eu_shoes_size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => '43',
+                    ]
+                ],
+                'weight' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => [
+                            'amount' => '600.0000',
+                            'unit'   => 'GRAM'
+                        ]
+                    ]
+                ]
+            ],
+        ];
+
+        $product = [
+            'identifier' => 'shoes',
+            'parent' => 'brooksblue',
+            'family' => 'shoes',
+            'values' => [
+                'sku' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'shoes',
+                    ],
+                ],
+                'eu_shoes_size' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => '43',
+                    ]
+                ],
+                'weight' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => [
+                            'amount' => '600.0000',
+                            'unit'   => 'GRAM'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $filteredProduct = $this
+            ->get('pim_connector.processor.attribute_filter.product')
+            ->filter($product);
+
+        $this->assertSame($expected, $filteredProduct);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When creating a new variant product, the attribute filter was removing values for axes.
The fix takes into account axes too now, to keep their values.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | N
| Added integration tests           | Y
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
