### PR TITLE
PIM-6460: Attributes removed from family are removed from family variant as well

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -6,6 +6,7 @@
 - PIM-6838: Display completeness panel after Attributes in the PEF
 - PIM-6891: On the grid, execute the ES query only once, not twice
 - PIM-6967: Allow category panels to be resized
+- PIM-6460: Preventing from deleting attributes used as axis from the family and remove the deleted attributes from the family variants.
 
 # 2.0.6 (2017-11-03)
 

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1803,6 +1803,24 @@ class WebUser extends PimContext
     }
 
     /**
+     * @param string $buttonLabel
+     *
+     * @Given /^I press the cancel button in the popin$/
+     */
+    public function iPressTheCancelButtonInThePopin()
+    {
+        $buttonElement = $this->spin(function () {
+            return $this
+                ->getCurrentPage()
+                ->find('css', '.modal-full-body .AknButtonList > .AknFullPage-cancel');
+        }, 'Cannot find cancel button label in modal');
+
+        $buttonElement->click();
+
+        $this->wait();
+    }
+
+    /**
      * @param string $item
      * @param string $button
      *

--- a/features/family/remove_attribute_from_a_family.feature
+++ b/features/family/remove_attribute_from_a_family.feature
@@ -18,7 +18,7 @@ Feature: Remove attribute from a family
     When I am on the "1111111292" product page
     Then I should not see the text "Material"
 
-  Scenario: Successfully remove an attribute from a family and it does not appear in the variant product edit page
+  Scenario: Successfully remove an attribute from a family and it does not appear in the variant product product model edit pages
     Given I am on the "accessories" family page
     And I visit the "Attributes" tab
     When I remove the "material" attribute
@@ -26,7 +26,10 @@ Feature: Remove attribute from a family
     And I should not see the text "There are unsaved changes."
     Then I should see the flash message "Attribute successfully removed from the family"
     When I am on the "model-braided-hat" product model page
-    Then I should not see the text "Material"
+    And I should see the text "Supplier"
+    And I should not see the text "Material"
+    And I am on the "braided-hat-m" product page
+    And I should not see the text "Material"
 
   Scenario: Impossible to remove some attributes from a family (used as label, used as image, used as axis)
     Given I am on the "shoes" family page
@@ -40,7 +43,7 @@ Feature: Remove attribute from a family
     Then I should see the flash message "Cannot remove this attribute used as a variant axis in a family variant"
     And I should see the text "size"
 
-  Scenario: Sucessfully remove an attribute from a family removes it from the family variants.
+  Scenario: Successfully remove an attribute from a family removes it from the family variants.
     Given I am on the "shoes" family page
     And I visit the "Variants" tab
     When I click on the "Shoes by size and color" row
@@ -59,43 +62,3 @@ Feature: Remove attribute from a family
     And I should not see the text "Weight"
     And I should see the text "Variation picture"
     And I should not see the text "Model picture"
-
-  @skip
-  Scenario: Successfully update product completeness when removing a required attribute from a family
-    Given I am on the "Bags" family page
-    And I visit the "Attributes" tab
-    And I switch the attribute "manufacturer" requirement in channel "ecommerce"
-    And I switch the attribute "manufacturer" requirement in channel "mobile"
-    And I save the family
-    Then I should not see the text "There are unsaved changes."
-    When I launched the completeness calculator
-    And I am on the "bag-noname" product page
-    And I visit the "Completeness" column tab
-    Then I should see the completeness:
-      | channel    | locale                  | state    | message         | ratio |
-      | e-commerce | English (United States) | warning  | 1 missing value | 50%   |
-      | e-commerce | French (France)         | warning  | 1 missing value | 50%   |
-      | mobile     | English (United States) | disabled | none            | none  |
-      | mobile     | French (France)         | warning  | 1 missing value | 50%   |
-    When I am on the "Bags" family page
-    And I visit the "Attributes" tab
-    And I remove the "manufacturer" attribute
-    And I save the family
-    Then I should not see the text "There are unsaved changes."
-    When I am on the "bag-noname" product page
-    And I visit the "Completeness" column tab
-    Then I should see the completeness:
-      | channel    | locale                  | state    | message            | ratio |
-      | e-commerce | English (United States) |          | Not yet calculated |       |
-      | e-commerce | French (France)         |          | Not yet calculated |       |
-      | mobile     | English (United States) | disabled | none               | none  |
-      | mobile     | French (France)         |          | Not yet calculated |       |
-    When I launched the completeness calculator
-    And I am on the "bag-noname" product page
-    And I visit the "Completeness" column tab
-    Then I should see the completeness:
-      | channel    | locale                  | state    | message  | ratio |
-      | e-commerce | English (United States) | success  | Complete | 100%  |
-      | e-commerce | French (France)         | success  | Complete | 100%  |
-      | mobile     | English (United States) | disabled | none     | none  |
-      | mobile     | French (France)         | success  | Complete | 100%  |

--- a/features/family/remove_attribute_from_a_family.feature
+++ b/features/family/remove_attribute_from_a_family.feature
@@ -5,30 +5,60 @@ Feature: Remove attribute from a family
   I need to be able to remove an attribute from a family
 
   Background:
-    Given the "default" catalog configuration
-    And the following attributes:
-      | label-en_US      | group | type             | code            |
-      | Long Description | other | pim_catalog_text | longDescription |
-      | Manufacturer     | other | pim_catalog_text | manufacturer    |
-    And the following family:
-      | code | attributes                   |
-      | Bags | longDescription,manufacturer |
-    And the following product:
-      | sku            | family | longDescription | manufacturer |
-      | bag-dolce-vita | Bags   | my description  | dolce        |
-      | bag-noname     | Bags   | some random bag |              |
+    Given the "catalog_modeling" catalog configuration
     And I am logged in as "Peter"
 
   Scenario: Successfully remove an attribute from a family and display it as removable from product
-    Given I am on the "Bags" family page
+    Given I am on the "accessories" family page
     And I visit the "Attributes" tab
-    When I remove the "manufacturer" attribute
+    When I remove the "material" attribute
     And I save the family
     And I should not see the text "There are unsaved changes."
     Then I should see the flash message "Attribute successfully removed from the family"
-    And I should see attribute "Long Description" in group "Other"
-    When I am on the "bag-dolce-vita" product page
-    Then I should see a remove link next to the "Manufacturer" field
+    When I am on the "1111111292" product page
+    Then I should not see the text "Material"
+
+  Scenario: Successfully remove an attribute from a family and it does not appear in the variant product edit page
+    Given I am on the "accessories" family page
+    And I visit the "Attributes" tab
+    When I remove the "material" attribute
+    And I save the family
+    And I should not see the text "There are unsaved changes."
+    Then I should see the flash message "Attribute successfully removed from the family"
+    When I am on the "model-braided-hat" product model page
+    Then I should not see the text "Material"
+
+  Scenario: Impossible to remove some attributes from a family (used as label, used as image, used as axis)
+    Given I am on the "shoes" family page
+    And I visit the "Attributes" tab
+    And I scroll down
+    When I remove the "variation_name" attribute
+    Then I should see the flash message "Cannot remove attribute used as label"
+    When I remove the "variation_image" attribute
+    Then I should see the flash message "Cannot remove used as the main picture"
+    When I remove the "size" attribute
+    Then I should see the flash message "Cannot remove this attribute used as a variant axis in a family variant"
+    And I should see the text "size"
+
+  Scenario: Sucessfully remove an attribute from a family removes it from the family variants.
+    Given I am on the "shoes" family page
+    And I visit the "Variants" tab
+    When I click on the "Shoes by size and color" row
+    Then I should see the text "EU Shoes Size"
+    Then I should see the text "Weight"
+    And I should see the text "Variation picture"
+    And I should see the text "Model picture"
+    When I press the cancel button in the popin
+    And I visit the "Attributes" tab
+    And I remove the "weight" attribute
+    And I remove the "image" attribute
+    And I save the family
+    And I visit the "Variants" tab
+    And I click on the "Shoes by size and color" row
+    Then I should see the text "EU Shoes Size"
+    And I should not see the text "Weight"
+    And I should see the text "Variation picture"
+    And I should not see the text "Model picture"
 
   @skip
   Scenario: Successfully update product completeness when removing a required attribute from a family

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Family/PartialUpdateFamilyIntegration.php
@@ -385,11 +385,11 @@ JSON;
     }
 JSON;
 
-        $client->request('PATCH', 'api/rest/v1/families/familyA', [], [], [], $data);
+        $client->request('PATCH', 'api/rest/v1/families/familyA1', [], [], [], $data);
 
-        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('familyA');
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('familyA1');
         $familyStandard = [
-            'code'                   => 'familyA',
+            'code'                   => 'familyA1',
             'attributes'             => [ 'sku' ],
             'attribute_as_label'     => 'sku',
             'attribute_as_image'     => null,
@@ -399,8 +399,7 @@ JSON;
                 'tablet'             => [ 'sku' ],
             ],
             'labels'                 => [
-                'fr_FR' => 'Une famille A',
-                'en_US' => 'A family A'
+                'en_US' => 'A family A1'
             ],
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.family');

--- a/src/Pim/Bundle/CatalogBundle/Entity/Family.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Family.php
@@ -166,6 +166,8 @@ class Family implements FamilyInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException
      */
     public function removeAttribute(AttributeInterface $attribute)
     {

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Whenever an attribute is removed from a family, we need to ensure this attribute is removed from every family
+ * variants belonging to this family.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber implements EventSubscriberInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            StorageEvents::PRE_SAVE => 'removeDeletedAttributeFromFamilyVariants',
+        ];
+    }
+
+    /**
+     * Removes the removed attributes from family from the family variants belonging to this family.
+     *
+     * @param GenericEvent $event
+     */
+    public function removeDeletedAttributeFromFamilyVariants(GenericEvent $event): void
+    {
+        $subject = $event->getSubject();
+
+        if (!$subject instanceof FamilyInterface) {
+            return;
+        }
+
+        $familyAttributeCodes = $subject->getAttributeCodes();
+        foreach ($subject->getFamilyVariants() as $familyVariant) {
+            $familyVariantsAttributeCodes = $this->getFamilyVariantsAttributeCodes($familyVariant);
+            $toRemoveAttributes = $this->getExtraAttributesOfFamilyVariant(
+                $familyAttributeCodes,
+                $familyVariantsAttributeCodes
+            );
+
+            if (!empty($toRemoveAttributes)) {
+                $this->removeAttributeFromFamilyVariantsAttributeSet($familyVariant, $toRemoveAttributes);
+            }
+        }
+    }
+
+    /**
+     * @param FamilyVariantInterface $familyVariant
+     *
+     * @return array
+     */
+    private function getFamilyVariantsAttributeCodes(FamilyVariantInterface $familyVariant): array
+    {
+        $getAttributeCodeFunction = function (AttributeInterface $attribute) {
+            return $attribute->getCode();
+        };
+        $familyVariantAttributesCodes = array_merge(
+            $familyVariant->getAttributes()->map($getAttributeCodeFunction)->toArray(),
+            $familyVariant->getAxes()->map($getAttributeCodeFunction)->toArray()
+        );
+
+        return $familyVariantAttributesCodes;
+    }
+
+    /**
+     * Returns the attribute codes that exists in the family variant and that does not exist in the family.
+     *
+     * The returned attributes should be removed from the family variant attribute sets.
+     *
+     * @param array $familyAttributeCodes
+     * @param array $familyVariantsAttributeCodes
+     *
+     * @return array
+     */
+    private function getExtraAttributesOfFamilyVariant(
+        array $familyAttributeCodes,
+        array $familyVariantsAttributeCodes
+    ): array {
+        return array_diff($familyVariantsAttributeCodes, $familyAttributeCodes);
+    }
+
+    /**
+     * Removes the attribute in the given array from the variant attribute set of the given family variant.
+     *
+     * @param FamilyVariantInterface $familyVariant
+     * @param array                  $toRemoveAttributes
+     */
+    private function removeAttributeFromFamilyVariantsAttributeSet(
+        FamilyVariantInterface $familyVariant,
+        array $toRemoveAttributes
+    ): void {
+        foreach ($familyVariant->getVariantAttributeSets() as $variantAttributeSet) {
+            $attributesToKeep = [];
+            foreach ($variantAttributeSet->getAttributes() as $attribute) {
+                if (!in_array($attribute->getCode(), $toRemoveAttributes)) {
+                    $attributesToKeep[] = $attribute;
+                }
+            }
+            $variantAttributeSet->setAttributes($attributesToKeep);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriber.php
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber implements EventSubscriberInterface
+class RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriber implements EventSubscriberInterface
 {
     /**
      * {@inheritdoc}
@@ -27,7 +27,7 @@ class RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber implements Event
     public static function getSubscribedEvents(): array
     {
         return [
-            StorageEvents::PRE_SAVE => 'removeDeletedAttributeFromFamilyVariants',
+            StorageEvents::PRE_SAVE => 'removeDeletedAttributesFromFamilyVariants',
         ];
     }
 
@@ -36,7 +36,7 @@ class RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber implements Event
      *
      * @param GenericEvent $event
      */
-    public function removeDeletedAttributeFromFamilyVariants(GenericEvent $event): void
+    public function removeDeletedAttributesFromFamilyVariants(GenericEvent $event): void
     {
         $subject = $event->getSubject();
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Validates and saves the family variants belonging to a family whenever it is updated.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterface
+{
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /** @var BulkSaverInterface */
+    private $familyVariantSaver;
+
+    /**
+     * @param ValidatorInterface $validator
+     * @param BulkSaverInterface $familyVariantSaver
+     */
+    public function __construct(ValidatorInterface $validator, BulkSaverInterface $familyVariantSaver)
+    {
+        $this->validator = $validator;
+        $this->familyVariantSaver = $familyVariantSaver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            StorageEvents::POST_SAVE => 'validateAndSaveFamilyVariants',
+        ];
+    }
+
+    /**
+     * Validates and saves the family variants belonging to a family whenever it is updated.
+     *
+     * @param GenericEvent $event
+     */
+    public function validateAndSaveFamilyVariants(GenericEvent $event)
+    {
+        $subject = $event->getSubject();
+        if (!$subject instanceof FamilyInterface) {
+            return;
+        }
+
+        $validfamilyVariants = [];
+        $allViolations = [];
+
+        foreach ($subject->getFamilyVariants() as $familyVariant) {
+            $violations = $this->validator->validate($familyVariant);
+
+            if (0 === $violations->count()) {
+                $validfamilyVariants[] = $familyVariant;
+            } else {
+                $allViolations[$familyVariant->getCode()] = $violations;
+            }
+        }
+
+        $this->familyVariantSaver->saveAll($validfamilyVariants);
+
+        if (!empty($allViolations)) {
+            $errorMessage = $this->getErrorMessage($allViolations);
+            throw new \LogicException($errorMessage);
+        }
+    }
+
+    /**
+     * Formats an error message with all the given ConstraintViolationLists
+     *
+     * @param array $allViolations
+     *
+     * @return string
+     */
+    private function getErrorMessage(array $allViolations): string
+    {
+        $errorMessage = 'One or more errors occured while updating the following family variants:\n';
+        foreach ($allViolations as $familyVariantCode => $constraintViolationList) {
+            $errorMessage .= sprintf('%s:\n', $familyVariantCode);
+            foreach ($constraintViolationList as $violation) {
+                $errorMessage .= sprintf('- %s\n', $violation->getMessage());
+            }
+        }
+
+        return $errorMessage;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -50,8 +50,10 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
      * Validates and saves the family variants belonging to a family whenever it is updated.
      *
      * @param GenericEvent $event
+     *
+     * @throws \LogicException
      */
-    public function validateAndSaveFamilyVariants(GenericEvent $event)
+    public function validateAndSaveFamilyVariants(GenericEvent $event): void
     {
         $subject = $event->getSubject();
         if (!$subject instanceof FamilyInterface) {

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -60,20 +60,20 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
             return;
         }
 
-        $validfamilyVariants = [];
+        $validFamilyVariants = [];
         $allViolations = [];
 
         foreach ($subject->getFamilyVariants() as $familyVariant) {
             $violations = $this->validator->validate($familyVariant);
 
             if (0 === $violations->count()) {
-                $validfamilyVariants[] = $familyVariant;
+                $validFamilyVariants[] = $familyVariant;
             } else {
                 $allViolations[$familyVariant->getCode()] = $violations;
             }
         }
 
-        $this->familyVariantSaver->saveAll($validfamilyVariants);
+        $this->familyVariantSaver->saveAll($validFamilyVariants);
 
         if (!empty($allViolations)) {
             $errorMessage = $this->getErrorMessage($allViolations);

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Family.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Family.orm.yml
@@ -41,8 +41,6 @@ Pim\Bundle\CatalogBundle\Entity\Family:
         familyVariants:
             targetEntity: Pim\Component\Catalog\Model\FamilyVariantInterface
             mappedBy: family
-            cascade:
-                - persist
         translations:
             targetEntity: Pim\Component\Catalog\Model\FamilyTranslationInterface
             mappedBy: foreignKey

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -17,6 +17,7 @@ parameters:
     pim_catalog.event_subscriber.compute_product_models_descendants.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeProductModelDescendantsSubscriber
     pim_catalog.event_subscriber.compute_family_variant_structure_changes.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeFamilyVariantStructureChangesSubscriber
     pim_catalog.event_subscriber.remove_attribute_from_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber
+    pim_catalog.event_subscriber.save_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber
 
 services:
     # Subscribers
@@ -137,6 +138,7 @@ services:
             - '@pim_catalog.family_variant.add_unique_attributes'
         tags:
             - { name: kernel.event_subscriber }
+
     pim_catalog.event_subscriber.index_product_model_completedata:
         class: '%pim_catalog.event_subscriber.index_product_model_complete.class%'
         arguments:
@@ -157,8 +159,13 @@ services:
 
     pim_catalog.event_subscriber.remove_attribute_from_family_variants_on_family_update:
         class: '%pim_catalog.event_subscriber.remove_attribute_from_family_variants_on_family_update.class%'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    pim_catalog.event_subscriber.save_family_variants_on_family_update:
+        class: '%pim_catalog.event_subscriber.save_family_variants_on_family_update.class%'
         arguments:
-            - '@pim_catalog.updater.family_variant'
             - '@validator'
+            - '@pim_catalog.saver.family_variant'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -16,7 +16,7 @@ parameters:
     pim_catalog.event_subscriber.compute_completeness_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeCompletenessOnFamilyUpdateSubscriber
     pim_catalog.event_subscriber.compute_product_models_descendants.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeProductModelDescendantsSubscriber
     pim_catalog.event_subscriber.compute_family_variant_structure_changes.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeFamilyVariantStructureChangesSubscriber
-    pim_catalog.event_subscriber.remove_attribute_from_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber
+    pim_catalog.event_subscriber.remove_attributes_from_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriber
     pim_catalog.event_subscriber.save_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber
 
 services:
@@ -157,8 +157,8 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
-    pim_catalog.event_subscriber.remove_attribute_from_family_variants_on_family_update:
-        class: '%pim_catalog.event_subscriber.remove_attribute_from_family_variants_on_family_update.class%'
+    pim_catalog.event_subscriber.remove_attributes_from_family_variants_on_family_update:
+        class: '%pim_catalog.event_subscriber.remove_attributes_from_family_variants_on_family_update.class%'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -16,6 +16,7 @@ parameters:
     pim_catalog.event_subscriber.compute_completeness_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeCompletenessOnFamilyUpdateSubscriber
     pim_catalog.event_subscriber.compute_product_models_descendants.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeProductModelDescendantsSubscriber
     pim_catalog.event_subscriber.compute_family_variant_structure_changes.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeFamilyVariantStructureChangesSubscriber
+    pim_catalog.event_subscriber.remove_attribute_from_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber
 
 services:
     # Subscribers
@@ -151,5 +152,13 @@ services:
             - '@akeneo_batch.job.job_instance_repository'
             - '@pim_catalog.repository.attribute_requirement'
             - '%pim_catalog.compute_completeness_of_products_family.job_name%'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    pim_catalog.event_subscriber.remove_attribute_from_family_variants_on_family_update:
+        class: '%pim_catalog.event_subscriber.remove_attribute_from_family_variants_on_family_update.class%'
+        arguments:
+            - '@pim_catalog.updater.family_variant'
+            - '@validator'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/family.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/family.yml
@@ -7,6 +7,7 @@ Pim\Bundle\CatalogBundle\Entity\Family:
         - Pim\Component\Catalog\Validator\Constraints\FamilyRequirements: ~
         - Pim\Component\Catalog\Validator\Constraints\FamilyAttributeAsLabel: ~
         - Pim\Component\Catalog\Validator\Constraints\FamilyAttributeAsImage: ~
+        - Pim\Component\Catalog\Validator\Constraints\FamilyAttributeUsedAsAxis: ~
     properties:
         code:
             - NotBlank: ~

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -51,6 +51,7 @@ parameters:
     pim_catalog.validator.constraint.not_empty_family.class: Pim\Component\Catalog\Validator\Constraints\NotEmptyFamilyValidator
     pim_catalog.validator.constraint.invalid_variant_product_parent.class: Pim\Component\Catalog\Validator\Constraints\VariantProductParentValidator
     pim_catalog.validator.constraint.immutable_variant_axis_values.class:  Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxesValuesValidator
+    pim_catalog.validator.constraint.family_attribute_used_as_axis.class:  Pim\Component\Catalog\Validator\Constraints\FamilyAttributeUsedAsAxisValidator
 
 services:
     # Helpers
@@ -394,3 +395,8 @@ services:
         class: '%pim_catalog.validator.constraint.not_empty_family.class%'
         tags:
             - { name: validator.constraint_validator, alias: pim_family_not_empty }
+
+    pim_catalog.validator.constraint.family_attribute_used_as_axis:
+        class: '%pim_catalog.validator.constraint.family_attribute_used_as_axis.class%'
+        tags:
+            - { name: validator.constraint_validator, alias: pim_family_attribute_used_as_axis }

--- a/src/Pim/Bundle/CatalogBundle/spec/Entity/FamilySpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Entity/FamilySpec.php
@@ -3,10 +3,16 @@
 namespace spec\Pim\Bundle\CatalogBundle\Entity;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Entity\Family;
 use Pim\Component\Catalog\Model\AttributeInterface;
 
 class FamilySpec extends ObjectBehavior
 {
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(Family::class);
+    }
+
     function it_contains_attributes(AttributeInterface $sku, AttributeInterface $name)
     {
         $this->addAttribute($sku)->shouldReturn($this);

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriberSpec.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\EventSubscriber\RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriberSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber::class);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldImplement(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn([
+            StorageEvents::PRE_SAVE => 'removeDeletedAttributeFromFamilyVariants',
+        ]);
+    }
+
+    function it_does_not_process_non_family_objects(GenericEvent $event, \StdClass $notFamilyObject)
+    {
+        $event->getSubject()->willReturn($notFamilyObject);
+        $this->removeDeletedAttributeFromFamilyVariants($event);
+    }
+
+    function it_removes_attributes_from_a_family_variant_when_it_has_been_removed_from_the_family(
+        GenericEvent $event,
+        FamilyInterface $family,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantsIterator,
+        FamilyVariantInterface $familyVariant,
+        Collection $familyVariantAttributes,
+        Collection $variantAttributeSets,
+        \ArrayIterator $variantAttributeSetsIterator,
+        Collection $variantAxes,
+        VariantAttributeSetInterface $variantAttributeSet1,
+        VariantAttributeSetInterface $variantAttributeSet2,
+        Collection $familyVariantAttributes1,
+        \ArrayIterator $familyVariantAttributesIterator1,
+        Collection $familyVariantAttributes2,
+        \ArrayIterator $familyVariantAttributesIterator2,
+        AttributeInterface $attribute1,
+        AttributeInterface $attribute2,
+        AttributeInterface $attribute3,
+        AttributeInterface $attribute4,
+        AttributeInterface $axis1,
+        AttributeInterface $axis2,
+        AttributeInterface $toRemoveAttribute
+    ) {
+        $event->getSubject()->willReturn($family);
+
+        $family->getFamilyVariants()->willReturn($familyVariants);
+        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
+        $familyVariantsIterator->valid()->willReturn(true, false);
+        $familyVariantsIterator->current()->willReturn($familyVariant);
+        $familyVariantsIterator->rewind()->shouldBeCalled();
+        $familyVariantsIterator->next()->shouldBeCalled();
+
+        $familyVariant->getAttributes()->willReturn($familyVariantAttributes);
+        $familyVariantAttributes->map(Argument::cetera())->willReturn($familyVariantAttributes);
+        $familyVariantAttributes->toArray()->willReturn([
+            'attribute_1',
+            'attribute_2',
+            'attribute_3',
+            'attribute_4',
+            'axis_1',
+            'axis_2',
+            'attribute_removed_from_family'
+        ]);
+
+        $familyVariant->getAxes()->willReturn($variantAxes);
+        $variantAxes->map(Argument::cetera())->willReturn($variantAxes);
+        $variantAxes->toArray()->willReturn(['axis_1', 'axis_2']);
+
+        $toRemoveAttribute->getCode()->willReturn('attribute_removed_from_family');
+
+        $family->getAttributeCodes()->willReturn([
+            'attribute_1',
+            'attribute_2',
+            'attribute_3',
+            'attribute_4',
+            'axis_1',
+            'axis_2'
+        ]);
+
+        $familyVariant->getVariantAttributeSets()->willReturn($variantAttributeSets);
+        $variantAttributeSets->getIterator()->willReturn($variantAttributeSetsIterator);
+        $variantAttributeSetsIterator->current()->willReturn($variantAttributeSet1, $variantAttributeSet2);
+        $variantAttributeSetsIterator->valid()->willReturn(true, true, false);
+        $variantAttributeSetsIterator->rewind()->shouldBeCalled();
+        $variantAttributeSetsIterator->next()->shouldBeCalled();
+
+        $variantAttributeSet1->getAttributes()->willReturn($familyVariantAttributes1);
+        $familyVariantAttributes1->getIterator()->willReturn($familyVariantAttributesIterator1);
+        $familyVariantAttributesIterator1->current()->willReturn($attribute1, $attribute2, $axis1, $toRemoveAttribute);
+        $familyVariantAttributesIterator1->valid()->willReturn(true, true, true, true, false);
+        $familyVariantAttributesIterator1->next()->shouldBeCalled();
+        $familyVariantAttributesIterator1->rewind()->shouldBeCalled();
+
+        $variantAttributeSet2->getAttributes()->willReturn($familyVariantAttributes2);
+        $familyVariantAttributes2->getIterator()->willReturn($familyVariantAttributesIterator2);
+        $familyVariantAttributesIterator2->current()->willReturn($attribute3, $attribute4, $axis2);
+        $familyVariantAttributesIterator2->valid()->willReturn(true, true, true, false);
+        $familyVariantAttributesIterator2->next()->shouldBeCalled();
+        $familyVariantAttributesIterator2->rewind()->shouldBeCalled();
+
+        $attribute1->getCode()->willReturn('attribute_1');
+        $attribute2->getCode()->willReturn('attribute_2');
+        $attribute3->getCode()->willReturn('attribute_3');
+        $attribute4->getCode()->willReturn('attribute_4');
+        $axis1->getCode()->willReturn('axis_1');
+        $axis2->getCode()->willReturn('axis_2');
+
+        $variantAttributeSet1->setAttributes([$attribute1, $attribute2, $axis1])->shouldBeCalled();
+        $variantAttributeSet2->setAttributes([$attribute3, $attribute4, $axis2])->shouldBeCalled();
+
+        $this->removeDeletedAttributeFromFamilyVariants($event);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriberSpec.php
@@ -5,7 +5,7 @@ namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
 use Akeneo\Component\StorageUtils\StorageEvents;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\CatalogBundle\EventSubscriber\RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber;
+use Pim\Bundle\CatalogBundle\EventSubscriber\RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriber;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
@@ -14,11 +14,11 @@ use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
-class RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriberSpec extends ObjectBehavior
+class RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType(RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriber::class);
+        $this->shouldHaveType(RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriber::class);
     }
 
     function it_is_an_event_subscriber()
@@ -29,14 +29,14 @@ class RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriberSpec extends Obje
     function it_subscribes_to_events()
     {
         $this->getSubscribedEvents()->shouldReturn([
-            StorageEvents::PRE_SAVE => 'removeDeletedAttributeFromFamilyVariants',
+            StorageEvents::PRE_SAVE => 'removeDeletedAttributesFromFamilyVariants',
         ]);
     }
 
     function it_does_not_process_non_family_objects(GenericEvent $event, \StdClass $notFamilyObject)
     {
         $event->getSubject()->willReturn($notFamilyObject);
-        $this->removeDeletedAttributeFromFamilyVariants($event);
+        $this->removeDeletedAttributesFromFamilyVariants($event);
     }
 
     function it_removes_attributes_from_a_family_variant_when_it_has_been_removed_from_the_family(
@@ -130,6 +130,6 @@ class RemoveAttributeFromFamilyVariantsOnFamilyUpdateSubscriberSpec extends Obje
         $variantAttributeSet1->setAttributes([$attribute1, $attribute2, $axis1])->shouldBeCalled();
         $variantAttributeSet2->setAttributes([$attribute3, $attribute4, $axis2])->shouldBeCalled();
 
-        $this->removeDeletedAttributeFromFamilyVariants($event);
+        $this->removeDeletedAttributesFromFamilyVariants($event);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
+{
+    function let(ValidatorInterface $validator, BulkSaverInterface $familyVariantSaver)
+    {
+        $this->beConstructedWith($validator, $familyVariantSaver);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(SaveFamilyVariantOnFamilyUpdateSubscriber::class);
+    }
+
+    function it_subscribes_to_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn([
+            StorageEvents::POST_SAVE => 'validateAndSaveFamilyVariants',
+        ]);
+    }
+
+    function it_only_supports_families_object(
+        $validator,
+        $familyVariantSaver,
+        GenericEvent $event,
+        \stdClass $object
+    ) {
+        $validator->validate()->shouldNotBeCalled();
+        $familyVariantSaver->saveAll()->shouldNotBeCalled();
+
+        $event->getSubject()->willReturn($object);
+        $this->validateAndSaveFamilyVariants($event);
+    }
+
+    function it_validates_and_saves_family_variants_on_family_update(
+        $validator,
+        $familyVariantSaver,
+        GenericEvent $event,
+        FamilyInterface $family,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantsIterator,
+        FamilyVariantInterface $familyVariants1,
+        FamilyVariantInterface $familyVariants2,
+        ConstraintViolationList $constraintViolationList
+    ) {
+        $family->getFamilyVariants()->willReturn($familyVariants);
+
+        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
+        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2);
+        $familyVariantsIterator->valid()->willReturn(true, true, false);
+        $familyVariantsIterator->rewind()->shouldBeCalled();
+        $familyVariantsIterator->next()->shouldBeCalled();
+
+        $validator->validate($familyVariants1)->willReturn($constraintViolationList);
+        $constraintViolationList->count()->willReturn(0);
+        $validator->validate($familyVariants2)->willReturn($constraintViolationList);
+        $constraintViolationList->count()->willReturn(0);
+
+        $familyVariantSaver->saveAll([$familyVariants1, $familyVariants2])->shouldBeCalled();
+
+        $event->getSubject()->willReturn($family);
+        $this->validateAndSaveFamilyVariants($event);
+    }
+
+    function it_throws_an_exception_when_family_variants_are_invalid_and_saves_the_valid_ones(
+        $validator,
+        $familyVariantSaver,
+        GenericEvent $event,
+        FamilyInterface $family,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantsIterator,
+        FamilyVariantInterface $familyVariants1,
+        FamilyVariantInterface $familyVariants2,
+        FamilyVariantInterface $familyVariants3
+    ) {
+        $family->getFamilyVariants()->willReturn($familyVariants);
+
+        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
+        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2, $familyVariants3);
+        $familyVariantsIterator->valid()->willReturn(true, true, true, false);
+        $familyVariantsIterator->rewind()->shouldBeCalled();
+        $familyVariantsIterator->next()->shouldBeCalled();
+
+        $familyVariants1->getCode()->willReturn('family_variant_1');
+        $familyVariants2->getCode()->willReturn('family_variant_2');
+
+        $constraintViolation1 = new ConstraintViolation('Error 1 with family variant', '', [], '', '', '10,45');
+        $constraintViolation2 = new ConstraintViolation('Error 2 with family variant', '', [], '', '', '10,45');
+
+        $constraintViolationList1 = new ConstraintViolationList([$constraintViolation1, $constraintViolation2]);
+        $constraintViolationList2 = new ConstraintViolationList([$constraintViolation1]);
+        $constraintViolationList3 = new ConstraintViolationList();
+
+        $validator->validate($familyVariants1)->willReturn($constraintViolationList1);
+        $validator->validate($familyVariants2)->willReturn($constraintViolationList2);
+        $validator->validate($familyVariants3)->willReturn($constraintViolationList3);
+
+        $familyVariantSaver->saveAll([$familyVariants3])->shouldBeCalled();
+
+        $event->getSubject()->willReturn($family);
+        $errorMessage = 'One or more errors occured while updating the following family variants:\n' .
+            'family_variant_1:\n- Error 1 with family variant\n- Error 2 with family variant\n' .
+            'family_variant_2:\n- Error 1 with family variant\n';
+        $this->shouldThrow(new \LogicException($errorMessage))->during('validateAndSaveFamilyVariants', [$event]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AbstractCompletenessTestCase.php
@@ -159,12 +159,13 @@ abstract class AbstractCompletenessTestCase extends TestCase
     {
         $channel = $this->get('pim_catalog.repository.channel')->findOneByIdentifier($channelCode);
         $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier($attributeCode);
-
         $requirement = $this->get('pim_catalog.factory.attribute_requirement')
             ->createAttributeRequirement($attribute, $channel, true);
 
         $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier($familyCode);
-        $family->addAttribute($attribute);
+        if (!$family->hasAttributeCode($attributeCode)) {
+            $family->addAttribute($attribute);
+        }
         $family->addAttributeRequirement($requirement);
         $this->get('pim_catalog.saver.family')->save($family);
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessOnFamilyUpdateIntegration.php
@@ -65,32 +65,6 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
     }
 
     /**
-     * Test update two families.
-     */
-    public function testComputeCompletenessesOfTwoSubsquentDifferentFamiliesUpdates()
-    {
-        $this->assertJobWasExecutedTimes('compute_completeness_of_products_family', 0);
-        $this->assertCompleteness('watch', 'ecommerce', 'fr_FR', 20);
-        $this->assertCompleteness('tshirt-unique-size-navy-blue', 'ecommerce', 'fr_FR', 54);
-        $this->addFamilyRequirement('accessories', 'ecommerce', 'composition');
-        $this->addFamilyRequirement('clothing', 'ecommerce', 'price');
-        $this->LaunchTimesAndWaitForJobExecutionsToEnd(2, 'compute_completeness_of_products_family');
-        $this->assertJobWasExecutedTimes('compute_completeness_of_products_family', 2);
-        $this->assertJobWasExecutedWithStatusAndJobParameters(
-            'compute_completeness_of_products_family',
-            BatchStatus::COMPLETED,
-            ['family_code' => 'accessories']
-        );
-        $this->assertJobWasExecutedWithStatusAndJobParameters(
-            'compute_completeness_of_products_family',
-            BatchStatus::COMPLETED,
-            ['family_code' => 'clothing']
-        );
-        $this->assertCompleteness('watch', 'ecommerce', 'fr_FR', 16);
-        $this->assertCompleteness('tshirt-unique-size-navy-blue', 'ecommerce', 'fr_FR', 50);
-    }
-
-    /**
      * Test update two families only updates the one needed.
      */
     public function testComputeCompletenessesOnceForTwoSubsquentDifferentFamiliesUpdates()
@@ -100,7 +74,7 @@ class CalculateCompletenessOnFamilyUpdateIntegration extends AbstractCompletenes
         $this->assertCompleteness('tshirt-unique-size-navy-blue', 'ecommerce', 'fr_FR', 54);
         $this->addFamilyRequirement('accessories', 'ecommerce', 'composition');
         $this->updateFamilyPropertiesNotTriggeringCompletenessRecomputation('clothing');
-        $this->LaunchTimesAndWaitForJobExecutionsToEnd(1,'compute_completeness_of_products_family');
+        $this->LaunchTimesAndWaitForJobExecutionsToEnd(1, 'compute_completeness_of_products_family');
         $this->assertJobWasExecutedTimes('compute_completeness_of_products_family', 1);
         $this->assertJobWasExecutedWithStatusAndJobParameters(
             'compute_completeness_of_products_family',

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/UpdateFamilyIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/UpdateFamilyIntegration.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\integration\Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Validator\Constraints\FamilyAttributeAsLabel;
+use Pim\Component\Catalog\Validator\Constraints\FamilyAttributeUsedAsAxis;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * Tries to update family attributes.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UpdateFamilyIntegration extends TestCase
+{
+    public function testRemovingSimpleAttributeFromFamilyIsAllowed()
+    {
+        $violations = $this->removeAttributeFromFamily('shoes', ['material']);
+        $this->assertEquals(0, $violations->count());
+    }
+
+    public function testRemovingAttributeUsedAsLabelIsNotAllowed()
+    {
+        $violations = $this->removeAttributeFromFamily('shoes', ['variation_name']);
+        $this->assertEquals(1, $violations->count());
+        $violation = $violations->getIterator()->current();
+        $this->assertEquals(FamilyAttributeAsLabel::class, get_class($violation->getConstraint()));
+        $this->assertEquals(
+            'Property "attribute_as_label" must belong to the family',
+            $violation->getMessage()
+        );
+    }
+
+    public function testRemovingAxisAttributeOfAFamilyVariantFromFamilyIsNotAllowed()
+    {
+        $violations = $this->removeAttributeFromFamily('shoes', ['size']);
+        $this->assertEquals(1, $violations->count());
+        $violation = $violations->getIterator()->current();
+        $this->assertEquals(FamilyAttributeUsedAsAxis::class, get_class($violation->getConstraint()));
+        $this->assertEquals(
+            'Attribute "size" is an axis in "shoes_size_color" family variant. It must belong to the family.',
+            $violation->getMessage()
+        );
+    }
+
+    public function testRemovingAttributeFromAFamilyAlsoRemovesItFromTheFamilyVariants()
+    {
+        $errors = $this->removeAttributeFromFamily('shoes', ['weight']);
+        $this->assertEquals(0, $errors->count());
+        $this->assertAttributeMissingFromFamilyVariants('weight', 'shoes');
+    }
+
+    public function testRemovingMultipleAttributesFromAFamilyAlsoRemovesItFromTheFamilyVariants()
+    {
+        $errors = $this->removeAttributeFromFamily('shoes', ['weight', 'composition']);
+        $this->assertEquals(0, $errors->count());
+        $this->assertAttributeMissingFromFamilyVariants('weight', 'shoes');
+        $this->assertAttributeMissingFromFamilyVariants('composition', 'shoes');
+    }
+
+    /**
+     * @return Configuration
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    /**
+     * @param string $familyCode
+     * @param array  $attributeCodes
+     *
+     * @return ConstraintViolationListInterface
+     */
+    private function removeAttributeFromFamily(
+        string $familyCode,
+        array $attributeCodes
+    ): ConstraintViolationListInterface {
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier($familyCode);
+        foreach ($attributeCodes as $attributeCode) {
+            $attribute = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier($attributeCode);
+            $family->removeAttribute($attribute);
+        }
+
+        $violations = $this->get('validator')->validate($family);
+
+        if ($violations->count() === 0) {
+            $this->get('pim_catalog.saver.family')->save($family);
+        }
+
+        return $violations;
+    }
+
+    /**
+     * Asserts that the given attribute code does not belong to any variant attribute set related to the given family
+     * code
+     *
+     * @param string $attributeCode
+     * @param string $familyCode
+     */
+    private function assertAttributeMissingFromFamilyVariants(string $attributeCode, string $familyCode): void
+    {
+        $this->get('doctrine.orm.default_entity_manager')->clear();
+        $family = $this->testKernel->getContainer()->get('pim_catalog.repository.family')->findOneByIdentifier(
+            $familyCode
+        );
+        foreach ($family->getFamilyVariants() as $familyVariant) {
+            $familyVariantAttributeCodes = $this->getVariantFamilyAttributeCodes($familyVariant);
+            $isAttributeFound = in_array($attributeCode, $familyVariantAttributeCodes);
+            $this->assertFalse(
+                $isAttributeFound,
+                sprintf(
+                    'Attribute "%s" found in an attribute set of the family variant "%s"',
+                    $attributeCode,
+                    $familyVariant->getCode()
+                )
+            );
+        }
+    }
+
+    /**
+     * @param FamilyVariantInterface $familyVariant
+     *
+     * @return array
+     */
+    private function getVariantFamilyAttributeCodes(FamilyVariantInterface $familyVariant): array
+    {
+        return $familyVariant->getAttributes()->map(function (AttributeInterface $attribute) {
+            return $attribute->getCode();
+        })->toArray();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/UpdateFamilyIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/UpdateFamilyIntegration.php
@@ -37,6 +37,7 @@ class UpdateFamilyIntegration extends TestCase
             'Property "attribute_as_label" must belong to the family',
             $violation->getMessage()
         );
+        $this->assertEquals('attribute_as_label', $violation->getPropertyPath());
     }
 
     public function testRemovingAxisAttributeOfAFamilyVariantFromFamilyIsNotAllowed()
@@ -49,6 +50,7 @@ class UpdateFamilyIntegration extends TestCase
             'Attribute "size" is an axis in "shoes_size_color" family variant. It must belong to the family.',
             $violation->getMessage()
         );
+        $this->assertEquals('attributes', $violation->getPropertyPath());
     }
 
     public function testRemovingAttributeFromAFamilyAlsoRemovesItFromTheFamilyVariants()

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/FamilyVariantNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/FamilyVariantNormalizer.php
@@ -46,7 +46,8 @@ class FamilyVariantNormalizer implements NormalizerInterface
         $result['meta'] = [
             'structure_version' => $this->structureVersionProvider->getStructureVersion(),
             'form'              => 'pim-family-variant-edit-form',
-            'id'                => $object->getId()
+            'id'                => $object->getId(),
+            'model_type'        => 'family_variant',
         ];
 
         return $result;

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/GroupTypeNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/GroupTypeNormalizer.php
@@ -45,7 +45,8 @@ class GroupTypeNormalizer implements NormalizerInterface
 
         $result['meta'] = [
             'structure_version' => $this->structureVersionProvider->getStructureVersion(),
-            'id'                => $object->getId()
+            'id'                => $object->getId(),
+            'model_type'        => 'group_type',
         ];
 
         return $result;

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
@@ -206,6 +206,11 @@ extensions:
         position: 190
         config:
             label: pim_enrich.form.family.tab.attributes.label_label
+            confirmation:
+                title: pim_enrich.confirmation.remove_item
+                subTitle: pim_menu.item.attribute
+                message: pim_enrich.confirmation.delete.attribute_from_family
+                buttonText: pim_enrich.confirmation.remove
 
     pim-family-edit-form-variant:
         module: pim/family-edit-form/family-variant

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/edit.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/edit.js
@@ -25,11 +25,6 @@ define([
     ) {
         return BaseEdit.extend({
             template: _.template(template),
-            events: {
-                'click .cancel': () => {
-                    this.trigger('cancel');
-                }
-            },
 
             /**
              * {@inheritdoc}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -41,7 +41,7 @@ define([
             attributeNotRequiredIconClass: 'AknAcl-icon icon-circle non-required',
             requiredLabel: __('pim_enrich.form.family.tab.attributes.required_label'),
             notRequiredLabel: __('pim_enrich.form.family.tab.attributes.not_required_label'),
-            identifierAttribute: 'pim_catalog_identifier',
+            identifierAttributeType: 'pim_catalog_identifier',
             template: _.template(template),
             errors: [],
             catalogLocale: UserContext.get('catalogLocale'),
@@ -69,11 +69,11 @@ define([
                     'pim_enrich:form:entity:post_fetch',
                     this.render
                 );
-                this.listenTo(this.getRoot(), 'pim_enrich:form:update_read_only', function (readOnly) {
+                this.listenTo(this.getRoot(), 'pim_enrich:form:update_read_only', (readOnly) => {
                     this.readOnly = readOnly;
 
                     this.render();
-                }.bind(this));
+                });
 
                 this.listenTo(
                     this.getRoot(),
@@ -110,13 +110,13 @@ define([
                             'apply_filters': false
                         }
                     )
-                ).then(function (channels, attributeGroups) {
+                ).then((channels, attributeGroups) => {
                     this.channels = channels;
                     var groupedAttributes = _.groupBy(data.attributes, 'group');
 
-                    _.sortBy(groupedAttributes, function (attributes, group) {
+                    _.sortBy(groupedAttributes, (attributes, group) => {
                         return _.findWhere(attributeGroups, {code: group}).sort_order;
-                    }.bind(this));
+                    });
 
                     _.each(groupedAttributes, function (attributes, group) {
                         attributes = _.sortBy(attributes, function (attribute) {
@@ -136,7 +136,7 @@ define([
                         attributeGroups: attributeGroups,
                         colspan: (this.channels.length + 2),
                         i18n: i18n,
-                        identifierAttribute: this.identifierAttribute,
+                        identifierAttributeType: this.identifierAttributeType,
                         catalogLocale: this.catalogLocale,
                         readOnly: this.readOnly
                     }));
@@ -145,7 +145,7 @@ define([
 
                     this.delegateEvents();
                     this.renderExtensions();
-                }.bind(this));
+                });
             },
 
             /**
@@ -202,7 +202,7 @@ define([
              * @returns {boolean}
              */
             isAttributeEditable: function (type) {
-                return this.identifierAttribute !== type;
+                return this.identifierAttributeType !== type;
             },
 
             /**
@@ -236,23 +236,26 @@ define([
             },
 
             /**
-             * Removes attribute from family
+             * Removes attribute from family upon user confirmation
              *
              * Checks if user has rights to remove attributes
              * Checks if attribute is not used as label
+             * Checks if attribute is not used as image
+             * Checks if attribute is not used as axis in a family variant
              *
              * @param {Object} event
              */
             onRemoveAttribute: function (event) {
                 event.preventDefault();
-                var attributeAsLabel = this.getFormData().attribute_as_label;
-                var attributeAsImage = this.getFormData().attribute_as_image;
+                const attributeAsLabel = this.getFormData().attribute_as_label;
+                const attributeAsImage = this.getFormData().attribute_as_image;
+                const attributesUsedAsAxis = this.getFormData().meta.attributes_used_as_axis;
 
                 if (!SecurityContext.isGranted('pim_enrich_family_edit_attributes')) {
                     return false;
                 }
 
-                var attributeToRemove = event.currentTarget.dataset.attribute;
+                const attributeToRemove = event.currentTarget.dataset.attribute;
 
                 if (attributeAsLabel === attributeToRemove) {
                     Messenger.notify(
@@ -261,6 +264,7 @@ define([
                     );
 
                     return false;
+
                 } else if (attributeAsImage === attributeToRemove) {
                     Messenger.notify(
                         'error',
@@ -268,9 +272,16 @@ define([
                     );
 
                     return false;
+                } else if (_.contains(attributesUsedAsAxis, attributeToRemove)) {
+                    Messenger.notify(
+                        'error',
+                        __('pim_enrich.entity.family.info.cant_remove_attribute_as_used_as_axis')
+                    );
+
+                    return false;
                 }
 
-                return this.removeAttribute(attributeToRemove);
+                this.removeAttribute(attributeToRemove);
             },
 
             /**
@@ -291,13 +302,13 @@ define([
                 $.when(
                     FetcherRegistry.getFetcher('attribute')
                         .search(options)
-                ).then(function (attributes) {
-                    _.each(attributes, function (attribute) {
+                ).then((attributes) => {
+                    _.each(attributes, (attribute) => {
                         this.addAttribute(attribute);
-                    }.bind(this));
+                    });
 
                     this.render();
-                }.bind(this)).always(function () {
+                }).always(function () {
                     loadingMask.hide().$el.remove();
                 });
             },
@@ -320,7 +331,7 @@ define([
                             }
                         }),
                     FetcherRegistry.getFetcher('attribute').getIdentifierAttribute()
-                ).then(function (attributeGroups, identifier) {
+                ).then((attributeGroups, identifier) => {
                     var existingAttributes = _.pluck(this.getFormData().attributes, 'code');
                     var groupsAttributes = [].concat.apply(
                         [],
@@ -338,13 +349,13 @@ define([
                                 limit: attributesToAdd.length
                             }
                         });
-                }.bind(this)).then(function (attributes) {
-                    _.each(attributes, function (attribute) {
+                }).then((attributes) => {
+                    _.each(attributes, (attribute) => {
                         this.addAttribute(attribute);
-                    }.bind(this));
+                    });
 
                     this.render();
-                }.bind(this)).always(function () {
+                }).always(function () {
                     loadingMask.hide().$el.remove();
                 });
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -275,7 +275,7 @@ define([
                 } else if (_.contains(attributesUsedAsAxis, attributeToRemove)) {
                     Messenger.notify(
                         'error',
-                        __('pim_enrich.entity.family.info.cant_remove_attribute_as_used_as_axis')
+                        __('pim_enrich.entity.family.info.cant_remove_attribute_used_as_axis')
                     );
 
                     return false;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/cache-invalidator.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/cache-invalidator.js
@@ -13,7 +13,7 @@ define([
              */
             configure: function () {
                 _.each(__moduleConfig.events, function (event) {
-                    this.listenTo(mediator, event, this.checkStructureVersion);
+                    this.listenTo(this.getRoot(), event, this.checkStructureVersion);
                 }.bind(this));
 
                 this.listenTo(this.getRoot(), 'pim_enrich:form:cache:clear', this.clearCache);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family/tab/attributes/attributes.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family/tab/attributes/attributes.html
@@ -46,7 +46,7 @@
                 </td>
                 <% }) %><!-- end each channel -->
                 <td class="AknGrid-bodyCell AknGrid-bodyCell--right">
-                    <% if (identifierAttribute !== attribute.type && !readOnly) { %>
+                    <% if (identifierAttributeType !== attribute.type && !readOnly) { %>
                     <span class="AknIconButton AknIconButton--small AknIconButton--trash remove-attribute" data-attribute="<%- attribute.code %>"></span>
                     <% } %>
                 </td>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -334,6 +334,7 @@ pim_enrich:
                 cant_remove_attribute_as_label: Cannot remove attribute used as label
                 cant_remove_attribute_as_image: Cannot remove attribute used as the main picture
                 attribute_edit_permission_is_not_granted: You have no rights to edit family's attributes
+                cant_remove_attribute_used_as_axis: Cannot remove this attribute used as a variant axis in a family variant
             meta:
                 created: Created
                 created_by: Created by

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/AssociationType/edit.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/AssociationType/edit.html.twig
@@ -33,7 +33,7 @@
                                                 FormBuilder.build(associationType.meta.form)
                                                     .then(function (form) {
                                                         form.setData(associationType);
-                                                        mediator.trigger('pim_enrich:form:entity:post_fetch', associationType);
+                                                        form.trigger('pim_enrich:form:entity:post_fetch', associationType);
                                                         form.setElement('#association-type-edit-form').render();
                                                     });
                                             }).fail(function(response, textStatus, errorThrown) {

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/FamilyNormalizerSpec.php
@@ -2,14 +2,14 @@
 
 namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
 
+use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
 use Pim\Bundle\VersioningBundle\Manager\VersionManager;
-use Pim\Component\Catalog\Model\AttributeGroupInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
-use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class FamilyNormalizerSpec extends ObjectBehavior
@@ -49,19 +49,24 @@ class FamilyNormalizerSpec extends ObjectBehavior
             ->shouldReturn(false);
     }
 
-    function it_normalizes_family(
+    function it_normalizes_family_without_attributes_used_as_axis(
         $familyNormalizer,
         $attributeNormalizer,
         $collectionFilter,
         AttributeRepositoryInterface $attributeRepository,
-        AttributeGroupInterface $marketingAttributeGroup,
         FamilyInterface $family,
+        Collection $emptyCollection,
+        \ArrayIterator $emptyCollectionIterator,
         VersionManager $versionManager,
         AttributeInterface $name,
         AttributeInterface $description,
         AttributeInterface $price
     ) {
         $family->getId()->willReturn(1);
+        $family->getFamilyVariants()->willReturn($emptyCollection);
+        $emptyCollection->getIterator()->willReturn($emptyCollectionIterator);
+        $emptyCollectionIterator->valid()->willReturn(false);
+        $emptyCollectionIterator->rewind()->shouldBeCalled();
 
         $normalizedFamily = [
             'code'       => 'tshirts',
@@ -87,7 +92,6 @@ class FamilyNormalizerSpec extends ObjectBehavior
         $familyNormalizer->normalize($family, 'standard', [])
             ->shouldBeCalled()
             ->willReturn($normalizedFamily);
-
 
         $attributeRepository->findAttributesByFamily($family)->willReturn([$name, $price]);
         $collectionFilter->filterCollection([$name, $description, $price], 'pim.internal_api.attribute.view')
@@ -157,6 +161,168 @@ class FamilyNormalizerSpec extends ObjectBehavior
                     'form'    => 'pim-family-edit-form',
                     'created' => null,
                     'updated' => null,
+                    'attributes_used_as_axis' => []
+                ]
+            ]
+        );
+    }
+
+    function it_normalizes_family_with_attributes_used_as_axis_from_multiple_family_variants(
+        $familyNormalizer,
+        $attributeNormalizer,
+        $collectionFilter,
+        AttributeRepositoryInterface $attributeRepository,
+        FamilyInterface $family,
+        Collection $emptyCollection,
+        \ArrayIterator $emptyCollectionIterator,
+        FamilyVariantInterface $familyVariant1,
+        Collection $familyVariantAxes1,
+        FamilyVariantInterface $familyVariant2,
+        Collection $familyVariantAxes2,
+        VersionManager $versionManager,
+        AttributeInterface $name,
+        AttributeInterface $description,
+        AttributeInterface $price,
+        AttributeInterface $attributeUsedInTwoFamilyVariantsAsAxis,
+        AttributeInterface $axis1,
+        AttributeInterface $axis2,
+        AttributeInterface $axis3,
+        AttributeInterface $axis4
+    ) {
+        $family->getId()->willReturn(1);
+        $family->getFamilyVariants()->willReturn($emptyCollection);
+        $emptyCollection->getIterator()->willReturn($emptyCollectionIterator);
+        $emptyCollectionIterator->current()->willReturn($familyVariant1, $familyVariant2);
+        $emptyCollectionIterator->valid()->willReturn(true, true, false);
+        $emptyCollectionIterator->next()->shouldBeCalled();
+        $emptyCollectionIterator->rewind()->shouldBeCalled();
+
+        $familyVariant1->getAxes()->willReturn($familyVariantAxes1);
+        $familyVariantAxes1->toArray()->willReturn(
+            [
+                $attributeUsedInTwoFamilyVariantsAsAxis,
+                $axis1,
+                $axis3
+            ]
+        );
+
+        $familyVariant2->getAxes()->willReturn($familyVariantAxes2);
+        $familyVariantAxes2->toArray()->willReturn(
+            [
+                $attributeUsedInTwoFamilyVariantsAsAxis,
+                $axis2,
+                $axis4,
+            ]
+        );
+
+        $attributeUsedInTwoFamilyVariantsAsAxis->getCode()->willReturn(
+            'attribute_used_in_two_family_variants'
+        );
+        $axis1->getCode()->willReturn('axis1');
+        $axis2->getCode()->willReturn('axis2');
+        $axis3->getCode()->willReturn('axis3');
+        $axis4->getCode()->willReturn('axis4');
+
+        $normalizedFamily = [
+            'code'       => 'tshirts',
+            'attributes' => [
+                'name',
+                'description',
+                'price',
+            ],
+            'attribute_as_label'     => 'name',
+            'attribute_requirements' => [
+                'ecommerce' => ['name', 'price'],
+                'mobile'    => ['name', 'price'],
+            ],
+            'labels' => [],
+            'meta'   => [
+                'id'      => 1,
+                'form'    => 'pim-family-edit-form',
+                'created' => null,
+                'updated' => null,
+            ]
+        ];
+
+        $familyNormalizer->normalize($family, 'standard', [])
+            ->shouldBeCalled()
+            ->willReturn($normalizedFamily);
+
+        $attributeRepository->findAttributesByFamily($family)->willReturn([$name, $price]);
+        $collectionFilter->filterCollection([$name, $description, $price], 'pim.internal_api.attribute.view')
+            ->willReturn([$name, $price]);
+
+        $attributeRepository->findBy(['code' => ['name', 'price']])
+            ->willReturn([$name, $price]);
+        $collectionFilter->filterCollection([$name, $price], 'pim.internal_api.attribute.view')
+            ->willReturn([$name, $price]);
+
+        $name->getCode()->willReturn('name');
+        $price->getCode()->willReturn('price');
+
+        $attributeNormalizer->normalize($name, 'internal_api', [])->willReturn(
+            [
+                'code'       => 'name',
+                'type'       => 'pim_catalog_text',
+                'group'      => 'marketing',
+                'labels'     => [],
+                'sort_order' => 1,
+            ]
+        );
+
+        $attributeNormalizer->normalize($price, 'internal_api', [])->willReturn(
+            [
+                'code'       => 'price',
+                'type'       => 'pim_catalog_price_collection',
+                'group'      => 'marketing',
+                'labels'     => [],
+                'sort_order' => 3,
+            ]
+        );
+
+        $family->getCode()->willReturn('tshirts');
+        $family->getAttributeAsLabel()->willReturn($name);
+
+        $versionManager->getOldestLogEntry($family)->shouldBeCalled();
+        $versionManager->getNewestLogEntry($family)->shouldBeCalled();
+
+        $this->normalize($family)->shouldReturn(
+            [
+                'code'       => 'tshirts',
+                'attributes' => [
+                    [
+                        'code'       => 'name',
+                        'type'       => 'pim_catalog_text',
+                        'group'      => 'marketing',
+                        'labels'     => [],
+                        'sort_order' => 1,
+                    ],
+                    [
+                        'code'       => 'price',
+                        'type'       => 'pim_catalog_price_collection',
+                        'group'      => 'marketing',
+                        'labels'     => [],
+                        'sort_order' => 3,
+                    ]
+                ],
+                'attribute_as_label'     => 'name',
+                'attribute_requirements' => [
+                    'ecommerce' => ['name', 'price'],
+                    'mobile'    => ['name', 'price'],
+                ],
+                'labels' => [],
+                'meta' => [
+                    'id'      => 1,
+                    'form'    => 'pim-family-edit-form',
+                    'created' => null,
+                    'updated' => null,
+                    'attributes_used_as_axis' => [
+                        'attribute_used_in_two_family_variants',
+                        'axis1',
+                        'axis3',
+                        'axis2',
+                        'axis4',
+                    ]
                 ]
             ]
         );

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsImage.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsImage.php
@@ -24,7 +24,6 @@ class FamilyAttributeAsImage extends Constraint
     public $messageAttributeGlobal = 'Property "attribute_as_image" must not be scopable nor localizable '.
         'for this family';
 
-
     /** @var string */
     public $propertyPath = 'attribute_as_image';
 

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeUsedAsAxis.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeUsedAsAxis.php
@@ -7,6 +7,7 @@ namespace Pim\Component\Catalog\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 
 /**
+ * Family attribute_used_as_axis constraint
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -17,10 +18,13 @@ class FamilyAttributeUsedAsAxis extends Constraint
     /** @var string */
     public $messageAttribute = 'Attribute "%attribute%" is an axis in "%family_variant%" family variant. It must belong to the family.';
 
+    /** @var string */
+    public $propertyPath = 'attributes';
+
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'pim_family_attribute_used_as_axis';
     }
@@ -28,7 +32,7 @@ class FamilyAttributeUsedAsAxis extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function getTargets()
+    public function getTargets(): string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeUsedAsAxis.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeUsedAsAxis.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyAttributeUsedAsAxis extends Constraint
+{
+    /** @var string */
+    public $messageAttribute = 'Attribute "%attribute%" is an axis in "%family_variant%" family variant. It must belong to the family.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return 'pim_family_attribute_used_as_axis';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeUsedAsAxisValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeUsedAsAxisValidator.php
@@ -11,7 +11,9 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
- *  Family attribute_used_as_axis constraint
+ * Family attribute_used_as_axis constraint.
+ *
+ * Checks that all attributes used as axis are also attributes of the family.
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -22,7 +24,7 @@ class FamilyAttributeUsedAsAxisValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($family, Constraint $constraint)
+    public function validate($family, Constraint $constraint): void
     {
         if (!$family instanceof FamilyInterface) {
             return;
@@ -79,6 +81,7 @@ class FamilyAttributeUsedAsAxisValidator extends ConstraintValidator
                     '%attribute%'      => $missingAttributeUsedAsAxis,
                     '%family_variant%' => $familyVariant->getCode(),
                 ])
+                ->atPath($constraint->propertyPath)
                 ->addViolation();
         }
     }

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeUsedAsAxisValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeUsedAsAxisValidator.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Validator\Constraints;
+
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ *  Family attribute_used_as_axis constraint
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyAttributeUsedAsAxisValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($family, Constraint $constraint)
+    {
+        if (!$family instanceof FamilyInterface) {
+            return;
+        }
+
+        if (!$constraint instanceof FamilyAttributeUsedAsAxis) {
+            return;
+        }
+
+        foreach ($family->getFamilyVariants() as $familyVariant) {
+            $missingAttributesUsedAsAxis = $this->getMissingAttributeCodesUsedAsAxis($family, $familyVariant);
+            if (!empty($missingAttributesUsedAsAxis)) {
+                $this->buildViolationsForMissingAttributesUsedAsAxis(
+                    $constraint,
+                    $familyVariant,
+                    $missingAttributesUsedAsAxis
+                );
+            }
+        }
+    }
+
+    /**
+     * @param FamilyInterface        $family
+     * @param FamilyVariantInterface $familyVariant
+     *
+     * @return string[]
+     */
+    private function getMissingAttributeCodesUsedAsAxis(
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant
+    ): array {
+        $attributeCodesUsedAsAxis = $familyVariant->getAxes()->map(
+            function (AttributeInterface $attribute) {
+                return $attribute->getCode();
+            }
+        )->toArray();
+
+        return array_diff($attributeCodesUsedAsAxis, $family->getAttributeCodes());
+    }
+
+    /**
+     * @param Constraint             $constraint
+     * @param FamilyVariantInterface $familyVariant
+     * @param AttributeInterface[]   $missingAttributeCodesUsedAsAxis
+     */
+    private function buildViolationsForMissingAttributesUsedAsAxis(
+        Constraint $constraint,
+        FamilyVariantInterface $familyVariant,
+        array $missingAttributeCodesUsedAsAxis
+    ): void {
+        foreach ($missingAttributeCodesUsedAsAxis as $missingAttributeUsedAsAxis) {
+            $this->context
+                ->buildViolation($constraint->messageAttribute, [
+                    '%attribute%'      => $missingAttributeUsedAsAxis,
+                    '%family_variant%' => $familyVariant->getCode(),
+                ])
+                ->addViolation();
+        }
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyAttributeUsedAsAxisValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyAttributeUsedAsAxisValidatorSpec.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Validator\Constraints\FamilyAttributeUsedAsAxis;
+use Pim\Component\Catalog\Validator\Constraints\FamilyAttributeUsedAsAxisValidator;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class FamilyAttributeUsedAsAxisValidatorSpec extends ObjectBehavior
+{
+    function let(ExecutionContextInterface $context)
+    {
+        $this->initialize($context);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(FamilyAttributeUsedAsAxisValidator::class);
+    }
+
+    function it_only_supports_constraint_family_attributes_used_as_axis(
+        $context,
+        FamilyAttributeUsedAsAxis $familyAttributesUsedAsAxisConstraint,
+        FamilyInterface $family,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantIterator
+    ) {
+        $family->getFamilyVariants()->willReturn($familyVariants);
+        $familyVariants->getIterator()->willReturn($familyVariantIterator);
+        $familyVariantIterator->rewind()->shouldBeCalled();
+        $familyVariantIterator->next()->shouldNotBeCalled();
+        $familyVariantIterator->valid()->willReturn(false);
+
+        $this->validate($family, $familyAttributesUsedAsAxisConstraint);
+    }
+
+    function it_does_not_support_other_constraint_family_attributes_used_as_axis_constraint(
+        Constraint $otherConstraint,
+        FamilyInterface $family
+    ) {
+        $family->getFamilyVariants()->shouldNotBeCalled();
+
+        $this->validate($family, $otherConstraint);
+    }
+
+    function it_builds_violation_for_an_attribute_used_as_axis_in_one_family_variant(
+        $context,
+        ConstraintViolationBuilderInterface $violationBuilder,
+        FamilyAttributeUsedAsAxis $familyAttributesUsedAsAxisConstraint,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantIterator,
+        Collection $axisAttributes
+    ) {
+        $family->getAttributeCodes()->willReturn(['common_attribute_1', 'common_attribute_2']);
+
+        $family->getFamilyVariants()->willReturn($familyVariants);
+        $familyVariants->getIterator()->willReturn($familyVariantIterator);
+        $familyVariantIterator->current()->willReturn($familyVariant);
+        $familyVariantIterator->valid()->willReturn(true, false);
+        $familyVariantIterator->rewind()->shouldBeCalled();
+        $familyVariantIterator->next()->shouldBeCalled();
+
+        $familyVariant->getCode()->willReturn('my_family_variant');
+        $familyVariant->getAxes()->willReturn($axisAttributes);
+        $axisAttributes->map(Argument::cetera())->willReturn($axisAttributes);
+        $axisAttributes->toArray()->willReturn(['attribute_used_as_axis_code']);
+
+        $context->buildViolation(
+            $familyAttributesUsedAsAxisConstraint->messageAttribute,
+            [
+                '%attribute%'      => 'attribute_used_as_axis_code',
+                '%family_variant%' => 'my_family_variant',
+            ]
+        )->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($family, $familyAttributesUsedAsAxisConstraint);
+    }
+
+    function it_builds_violations_for_an_attribute_used_as_axis_in_multiple_family_variants(
+        $context,
+        ConstraintViolationBuilderInterface $violationBuilder,
+        FamilyAttributeUsedAsAxis $familyAttributesUsedAsAxisConstraint,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant1,
+        FamilyVariantInterface $familyVariant2,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantIterator,
+        Collection $axisAttributes1,
+        Collection $axisAttributes2
+    ) {
+        $family->getAttributeCodes()->willReturn(['common_attribute_1', 'common_attribute_2', 'axis_attribute']);
+
+        $family->getFamilyVariants()->willReturn($familyVariants);
+        $familyVariants->getIterator()->willReturn($familyVariantIterator);
+        $familyVariantIterator->current()->willReturn($familyVariant1, $familyVariant2);
+        $familyVariantIterator->valid()->willReturn(true, false);
+        $familyVariantIterator->rewind()->shouldBeCalled();
+        $familyVariantIterator->next()->shouldBeCalled();
+
+        $familyVariant1->getCode()->willReturn('my_family_variant_1');
+        $familyVariant1->getAxes()->willReturn($axisAttributes1);
+        $axisAttributes1->map(Argument::cetera())->willReturn($axisAttributes1);
+        $axisAttributes1->toArray()->willReturn(['attribute_used_as_axis_code_1', 'axis_attribute']);
+
+        $familyVariant2->getCode()->willReturn('my_family_variant_2');
+        $familyVariant2->getAxes()->willReturn($axisAttributes2);
+        $axisAttributes2->map(Argument::cetera())->willReturn($axisAttributes2);
+        $axisAttributes2->toArray()->willReturn(['axis_attribute', 'attribute_used_as_axis_code_2']);
+
+        $context->buildViolation(
+            $familyAttributesUsedAsAxisConstraint->messageAttribute,
+            [
+                '%attribute%'      => 'attribute_used_as_axis_code_1',
+                '%family_variant%' => 'my_family_variant_1',
+            ]
+        )->willReturn($violationBuilder);
+        $context->buildViolation(
+            $familyAttributesUsedAsAxisConstraint->messageAttribute,
+            [
+                '%attribute%'      => 'attribute_used_as_axis_code_2',
+                '%family_variant%' => 'my_family_variant_2',
+            ]
+        )->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($family, $familyAttributesUsedAsAxisConstraint);
+    }
+
+    function it_builds_violations_for_multiple_attributes_used_as_axis_one_family_variant(
+        $context,
+        ConstraintViolationBuilderInterface $violationBuilder,
+        FamilyAttributeUsedAsAxis $familyAttributesUsedAsAxisConstraint,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantIterator,
+        Collection $axisAttributes
+    ) {
+        $family->getAttributeCodes()->willReturn(['common_attribute_1', 'common_attribute_2']);
+
+        $family->getFamilyVariants()->willReturn($familyVariants);
+        $familyVariants->getIterator()->willReturn($familyVariantIterator);
+        $familyVariantIterator->current()->willReturn($familyVariant);
+        $familyVariantIterator->valid()->willReturn(true, false);
+        $familyVariantIterator->rewind()->shouldBeCalled();
+        $familyVariantIterator->next()->shouldBeCalled();
+
+        $familyVariant->getCode()->willReturn('my_family_variant');
+        $familyVariant->getAxes()->willReturn($axisAttributes);
+        $axisAttributes->map(Argument::cetera())->willReturn($axisAttributes);
+        $axisAttributes->toArray()->willReturn(['attribute_used_as_axis_code_1', 'attribute_used_as_axis_code_2']);
+
+        $context->buildViolation(
+            $familyAttributesUsedAsAxisConstraint->messageAttribute,
+            [
+                '%attribute%'      => 'attribute_used_as_axis_code_1',
+                '%family_variant%' => 'my_family_variant',
+            ]
+        )->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
+
+        $context->buildViolation(
+            $familyAttributesUsedAsAxisConstraint->messageAttribute,
+            [
+                '%attribute%'      => 'attribute_used_as_axis_code_2',
+                '%family_variant%' => 'my_family_variant',
+            ]
+        )->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($family, $familyAttributesUsedAsAxisConstraint);
+    }
+
+    function it_builds_violations_for_multiple_attributes_used_as_axis_in_multiple_family_variants(
+        $context,
+        ConstraintViolationBuilderInterface $violationBuilder,
+        FamilyAttributeUsedAsAxis $familyAttributesUsedAsAxisConstraint,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant1,
+        FamilyVariantInterface $familyVariant2,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantIterator,
+        Collection $axisAttributes1,
+        Collection $axisAttributes2
+    ) {
+        $family->getAttributeCodes()->willReturn(['common_attribute_1', 'common_attribute_2']);
+
+        $family->getFamilyVariants()->willReturn($familyVariants);
+        $familyVariants->getIterator()->willReturn($familyVariantIterator);
+        $familyVariantIterator->current()->willReturn($familyVariant1, $familyVariant2);
+        $familyVariantIterator->valid()->willReturn(true, false);
+        $familyVariantIterator->rewind()->shouldBeCalled();
+        $familyVariantIterator->next()->shouldBeCalled();
+
+        $familyVariant1->getCode()->willReturn('my_family_variant_1');
+        $familyVariant1->getAxes()->willReturn($axisAttributes1);
+        $axisAttributes1->map(Argument::cetera())->willReturn($axisAttributes1);
+        $axisAttributes1->toArray()->willReturn(['attribute_used_as_axis_code_1', 'attribute_used_as_axis_code_2']);
+
+        $familyVariant2->getCode()->willReturn('my_family_variant_2');
+        $familyVariant2->getAxes()->willReturn($axisAttributes2);
+        $axisAttributes2->map(Argument::cetera())->willReturn($axisAttributes2);
+        $axisAttributes2->toArray()->willReturn(['attribute_used_as_axis_code_1', 'attribute_used_as_axis_code_2']);
+
+        $context->buildViolation(
+            $familyAttributesUsedAsAxisConstraint->messageAttribute,
+            [
+                '%attribute%'      => 'attribute_used_as_axis_code_1',
+                '%family_variant%' => 'my_family_variant_1',
+            ]
+        )->willReturn($violationBuilder);
+        $context->buildViolation(
+            $familyAttributesUsedAsAxisConstraint->messageAttribute,
+            [
+                '%attribute%'      => 'attribute_used_as_axis_code_2',
+                '%family_variant%' => 'my_family_variant_1',
+            ]
+        )->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
+
+        $context->buildViolation(
+            $familyAttributesUsedAsAxisConstraint->messageAttribute,
+            [
+                '%attribute%'      => 'attribute_used_as_axis_code_1',
+                '%family_variant%' => 'my_family_variant_2',
+            ]
+        )->willReturn($violationBuilder);
+        $context->buildViolation(
+            $familyAttributesUsedAsAxisConstraint->messageAttribute,
+            [
+                '%attribute%'      => 'attribute_used_as_axis_code_2',
+                '%family_variant%' => 'my_family_variant_2',
+            ]
+        )->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($family, $familyAttributesUsedAsAxisConstraint);
+    }
+
+    function it_does_not_build_any_violation(
+        $context,
+        FamilyAttributeUsedAsAxis $familyAttributesUsedAsAxisConstraint,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant1,
+        FamilyVariantInterface $familyVariant2,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantIterator,
+        Collection $axisAttributes1,
+        Collection $axisAttributes2
+    ) {
+        $family->getAttributeCodes()->willReturn([
+            'common_attribute_1',
+            'common_attribute_2',
+            'attribute_used_as_axis_code_1',
+            'attribute_used_as_axis_code_2',
+            'common_attributes_3',
+            'common_attributes_4',
+        ]);
+
+        $family->getFamilyVariants()->willReturn($familyVariants);
+        $familyVariants->getIterator()->willReturn($familyVariantIterator);
+        $familyVariantIterator->current()->willReturn($familyVariant1, $familyVariant2);
+        $familyVariantIterator->valid()->willReturn(true, false);
+        $familyVariantIterator->rewind()->shouldBeCalled();
+        $familyVariantIterator->next()->shouldBeCalled();
+
+        $familyVariant1->getCode()->willReturn('my_family_variant_1');
+        $familyVariant1->getAxes()->willReturn($axisAttributes1);
+        $axisAttributes1->map(Argument::cetera())->willReturn($axisAttributes1);
+        $axisAttributes1->toArray()->willReturn(['attribute_used_as_axis_code_1', 'attribute_used_as_axis_code_2']);
+
+        $familyVariant2->getCode()->willReturn('my_family_variant_2');
+        $familyVariant2->getAxes()->willReturn($axisAttributes2);
+        $axisAttributes2->map(Argument::cetera())->willReturn($axisAttributes2);
+        $axisAttributes2->toArray()->willReturn(['attribute_used_as_axis_code_1', 'attribute_used_as_axis_code_2']);
+
+        $context->buildViolation()->shouldNotBeCalled();
+
+        $this->validate($family, $familyAttributesUsedAsAxisConstraint);
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyAttributeUsedAsAxisValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyAttributeUsedAsAxisValidatorSpec.php
@@ -81,6 +81,7 @@ class FamilyAttributeUsedAsAxisValidatorSpec extends ObjectBehavior
                 '%family_variant%' => 'my_family_variant',
             ]
         )->willReturn($violationBuilder);
+        $violationBuilder->atPath('attributes')->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($family, $familyAttributesUsedAsAxisConstraint);
@@ -131,6 +132,7 @@ class FamilyAttributeUsedAsAxisValidatorSpec extends ObjectBehavior
                 '%family_variant%' => 'my_family_variant_2',
             ]
         )->willReturn($violationBuilder);
+        $violationBuilder->atPath('attributes')->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($family, $familyAttributesUsedAsAxisConstraint);
@@ -176,6 +178,7 @@ class FamilyAttributeUsedAsAxisValidatorSpec extends ObjectBehavior
                 '%family_variant%' => 'my_family_variant',
             ]
         )->willReturn($violationBuilder);
+        $violationBuilder->atPath('attributes')->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($family, $familyAttributesUsedAsAxisConstraint);
@@ -226,8 +229,6 @@ class FamilyAttributeUsedAsAxisValidatorSpec extends ObjectBehavior
                 '%family_variant%' => 'my_family_variant_1',
             ]
         )->willReturn($violationBuilder);
-        $violationBuilder->addViolation()->shouldBeCalled();
-
         $context->buildViolation(
             $familyAttributesUsedAsAxisConstraint->messageAttribute,
             [
@@ -242,6 +243,7 @@ class FamilyAttributeUsedAsAxisValidatorSpec extends ObjectBehavior
                 '%family_variant%' => 'my_family_variant_2',
             ]
         )->willReturn($violationBuilder);
+        $violationBuilder->atPath('attributes')->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($family, $familyAttributesUsedAsAxisConstraint);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- Prevents a user from deleting attributes Attributes used as axis in family variants of a family.
- When an attribute is removed from a family, it should be removed from all family variant's attributeSet belonging to this family.
- It should also not appear in the product/product model edit forms.
- Replaced a cascade persist (persist family -> persist family variants) by a dedicated subscriber

----------------
**Reviewable commit by commit**

----------------

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | Ok
| Added integration tests           | Ok
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| CI  | Ok 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
