### PR TITLE
PIM-6939: fix sort order on export

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug Fixes
+
+PIM-6939: fix sort order on export
+
 # 1.7.11 (2017-10-16)
 
 ## Bug Fixes

--- a/features/export/product-export-builder/export_products_with_attributes.feature
+++ b/features/export/product-export-builder/export_products_with_attributes.feature
@@ -9,6 +9,7 @@ Feature: Export products with only selected attributes
     And the following attributes:
       | code                 | label-en_US          | type                     | group  |
       | high_heel_color      | High heel color      | pim_catalog_simpleselect | colors |
+      | lace                 | Lace                 | pim_catalog_text         | colors |
       | high_heel_color_sole | High heel color sole | pim_catalog_simpleselect | colors |
     And the following "high_heel_color" attribute options: Red, Blue
     And the following "high_heel_color_sole" attribute options: Green, Orange
@@ -149,4 +150,24 @@ Feature: Export products with only selected attributes
     sku;categories;enabled;family;groups;high_heel_color;high_heel_color_sole
     HEEL-1;2014_collection;1;high_heels;;Red;Green
     HEEL-2;2014_collection;1;high_heels;;Blue;Orange
+    """
+
+  @jira https://akeneo.atlassian.net/browse/PIM-5994
+  Scenario: Export products by selecting multiple attribute with similar code using the UI in a specific order
+    Given the following products:
+      | sku    | family | name-en_US | weather_conditions | categories      | lace |
+      | BOOT-3 | boots  | The boot 3 |                    | 2014_collection | 2L   |
+    And the following job "csv_footwear_product_export" configuration:
+      | filePath | %tmp%/product_export/product_export.csv |
+    When I am on the "csv_footwear_product_export" export job edit page
+    And I visit the "Content" tab
+    And I filter by "completeness" with operator "No condition on completeness" and value ""
+    And I select the following attributes to export lace, weather_conditions and lace_color
+    And I press the "Save" button
+    Then I should not see the text "There are unsaved changes"
+    When I launch the export job
+    And I wait for the "csv_footwear_product_export" job to finish
+    Then exported file of "csv_footwear_product_export" should contains the following headers:
+    """
+    sku;categories;enabled;family;groups;lace;weather_conditions;lace_color
     """

--- a/src/Pim/Component/Connector/Writer/File/ProductColumnSorter.php
+++ b/src/Pim/Component/Connector/Writer/File/ProductColumnSorter.php
@@ -61,7 +61,7 @@ class ProductColumnSorter extends DefaultColumnSorter implements ColumnSorterInt
             $sortedColumns = [];
             foreach ($rawColumns as $columnCode) {
                 $sortedColumns = array_merge($sortedColumns, array_filter($columns, function ($columnCandidate) use ($columnCode) {
-                    return 0 !== preg_match(sprintf('/^%s(-.*)*/', $columnCode), $columnCandidate);
+                    return 0 !== preg_match(sprintf('/^%s(-.*)*$/', $columnCode), $columnCandidate);
                 }));
             }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix sort order for export in case of same base attributes

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added Behats                      | Y
| Added integration tests           | NA
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
