### PR TITLE
API-411: Fix missing case when no values are provided

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - GITHUB-7035: Change class alias for proper LocaleType form parent indication, cheers @mkilmanas!
 - PIM-6567: Fix attributes filter to not remove axes
+- API-411: Fix error 500 when product model has no values
 - PIM-6933: Fix menu display in case of acl restriction
 - PIM-6922: fix sort order on attribute groups
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
@@ -488,7 +488,7 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
-    public function testTOTO()
+    public function testCreateASubProductModelOfASubProductModelWithNoValuesAndInvalidFamilyVariant()
     {
         $this->createProductModel(
             [

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
@@ -488,6 +488,57 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
+    public function testTOTO()
+    {
+        $this->createProductModel(
+            [
+                'code'           => 'sub_product_model',
+                'family_variant' => 'familyVariantA1',
+                'parent'         => 'sweat',
+                'values'         => [
+                    'a_simple_select' => [
+                        [
+                            'scope'  => null,
+                            'locale' => null,
+                            'data'   => "optionB",
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+            <<<JSON
+    {
+        "code": "sub_sub_product_model",
+        "family_variant": "familyVariantA2",
+        "parent": "sub_product_model"
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/product-models', [], [], [], $data);
+
+        $expectedContent =
+            <<<JSON
+{
+  "code": 422,
+  "message": "The parent is not a product model of the family variant \"familyVariantA2\" but belongs to the family \"familyVariantA1\". Check the standard format documentation.",
+  "_links": {
+    "documentation": {
+      "href": "http://api.akeneo.com/api-reference.html#post_product_model"
+    }
+  }
+}
+JSON;
+
+        $response = $client->getResponse();
+
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
     public function testSubProductModelCreationWithNoValuesForTheAxeDefinedInParent()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Component/Catalog/ProductModel/Filter/ProductModelAttributeFilter.php
+++ b/src/Pim/Component/Catalog/ProductModel/Filter/ProductModelAttributeFilter.php
@@ -81,6 +81,10 @@ class ProductModelAttributeFilter implements AttributeFilterInterface
 
         $variantAttributeSet = $familyVariant->getVariantAttributeSet($parentProductModel->getVariationLevel() + 1);
 
+        if (null === $variantAttributeSet) {
+            return $standardProductModel;
+        }
+
         return $this->keepOnlyAttributes($standardProductModel, $variantAttributeSet->getAttributes());
     }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When no values are provided via the API it raises a 500 in the ProductModelAttributeFilter as the variantAttribtueSet variable will be null. This PR aims to fix it.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | Yes
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
