### PR TITLE
PIM-6923: fix search filter on datagrid

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,7 +5,8 @@
 - GITHUB-7035: Change class alias for proper LocaleType form parent indication, cheers @mkilmanas!
 - PIM-6567: Fix attributes filter to not remove axes
 - PIM-6933: Fix menu display in case of acl restriction
-- PIM-6922: fix sort order on attribute groups
+- PIM-6922: Fix sort order on attribute groups
+- PIM-6923: Fix search on all grids when returning on it
 
 ## Better manage products with variants!
 

--- a/features/attribute/browse/view.feature
+++ b/features/attribute/browse/view.feature
@@ -15,3 +15,18 @@ Feature: View attributes
     And I should see the columns Label, Type, Group, Scopable, Localizable
     And I should see attributes SKU, Name, Manufacturer, Volume, Description, Price, Rating, Side view, Top view, Size, Color, Lace color, Length, Number in stock, Heel color, Sole color, Sole fabric, Lace fabric, Cap color, Rate of sale, Rear view and Attribute 123
     And the rows should be sorted ascending by Label
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6923
+  Scenario: Successfully search attributes and empty field
+    Then the grid should contain 25 elements
+    When I search "me"
+    Then I should see attributes Name, Comment and Volume
+    And the grid should contain 3 elements
+    When I click on the "Name" row
+    And I should see the text "Label translations"
+    And I am on the attributes page
+    Then the grid should contain 3 elements
+    And I should see attributes Name, Comment and Volume
+    When I search ""
+    Then the grid should contain 25 elements
+    And I should see attributes SKU, Name, Manufacturer, Volume, Description, Price, Rating, Side view, Top view, Size, Color, Lace color, Length, Number in stock, Heel color, Sole color, Sole fabric, Lace fabric, Cap color, Rate of sale, Rear view and Attribute 123

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/pageable-collection.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/pageable-collection.js
@@ -170,6 +170,9 @@ function(_, Backbone, BackbonePageableCollection, app) {
                 prefix = this.inputName + '[_filter]'
             }
 
+            if (this.inputName && data[this.inputName]) {
+                data[this.inputName]._filter = {};
+            }
             if (state.filters) {
                 _.extend(
                     data,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/role.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/role.js
@@ -1,11 +1,13 @@
 'use strict';
 
 define([
+        'jquery',
         'pim/controller/form',
         'pim/security-context',
         'pim/form-config-provider',
         'pim/router'
     ], function (
+        $,
         FormController,
         securityContext,
         configProvider,


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Remove filter state coming from url and repopulate it with the proper filter from the actual filters

The fix is not really a real fix but more a "rustine". The problem is that the filters coming from the locale storage are not override by the actual DOM filters. So the fix is to remove the filters coming from the locale storage after the first load. That way the state is well applied after a reload but you can filter after it. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added Behats                      | Todo
| Added integration tests           | NA
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
