### PR TITLE
Fix form error's 'message' index

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
@@ -175,7 +175,7 @@ class AttributeOptionController
         try {
             $this->optionRemover->remove($attributeOption);
         } catch (\Exception $e) {
-            return new JsonResponse(['message' => $e->getMessage()], $e->getCode());
+            return new JsonResponse(['code' => $e->getMessage()], $e->getCode());
         }
 
         return new JsonResponse();


### PR DESCRIPTION
The expected message array key index is actually 'code' and not 'message'. The 'message' is not used for any purposes