### PR TITLE
PIM-6878: Make attribute creation icons extensible 

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -8,6 +8,7 @@
 - PIM-6933: Fix menu display in case of acl restriction
 - PIM-6922: Fix sort order on attribute groups
 - PIM-6923: Fix search on all grids when returning on it
+- PIM-6878: Fix attribute creation popin not extensible
 
 ## Better manage products with variants!
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/create-modal-content.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/create-modal-content.html
@@ -12,7 +12,7 @@
       <div class="AknWidget-content AknWidget-content--withPadding">
           <div class="AknSquareList">
               <% _.each(attributeTypes, function(attributeType){ %>
-                  <span class="AknSquareList-item  AknButton--withIcon attribute-choice"
+                  <span class="AknSquareList-item attribute-choice"
                       data-route="<%- generateRoute('pim_enrich_attribute_create', { attribute_type: attributeType.code }) %>">
                       <i class="AknButton-squareIcon AknButton-squareIcon--<%- iconsMap[attributeType.code] %>"></i>
                       <div><%- attributeType.label %></div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/create-modal-content.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/create-modal-content.html
@@ -12,10 +12,9 @@
       <div class="AknWidget-content AknWidget-content--withPadding">
           <div class="AknSquareList">
               <% _.each(attributeTypes, function(attributeType){ %>
-                  <span class="AknSquareList-item attribute-choice"
+                  <span class="AknSquareList-item  AknButton--withIcon attribute-choice"
                       data-route="<%- generateRoute('pim_enrich_attribute_create', { attribute_type: attributeType.code }) %>">
-                      <img src="/bundles/pimui/images/attribute/icon-<%- iconsMap[attributeType.code] %>.svg" class="AknSquareList-icon">
-                      <img src="/bundles/pimui/images/attribute/icon-<%- iconsMap[attributeType.code] %>.svg" class="AknSquareList-icon AknSquareList-icon--selected">
+                      <i class="AknButton-squareIcon AknButton-squareIcon--<%- iconsMap[attributeType.code] %>"></i>
                       <div><%- attributeType.label %></div>
                   </span>
               <% }); %>

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/Button.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/Button.less
@@ -261,13 +261,5 @@
     &--metric {
       background-image: url("../../../images/attribute/icon-metric.svg");
     }
-
-    &--multiselect {
-      background-image: url("../../../images/attribute/icon-multiselect.svg");
-    }
-
-    &--select {
-      background-image: url("../../../images/attribute/icon-select.svg");
-    }
   }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/Button.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/Button.less
@@ -261,5 +261,9 @@
     &--metric {
       background-image: url("../../../images/attribute/icon-metric.svg");
     }
+
+    &--assetCollection {
+      background-image: url("../../../images/attribute/icon-assetCollection.svg");
+    }
   }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/Button.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/Button.less
@@ -206,4 +206,68 @@
     background-size: 20px;
     padding-right: 34px;
   }
+
+  &-squareIcon {
+    width: 54px;
+    height: 54px;
+    display: flex;
+    background-size: 100%;
+    margin: 5px auto 10px;
+
+    &--id {
+      background-image: url("../../../images/attribute/icon-id.svg");
+    }
+
+    &--text {
+      background-image: url("../../../images/attribute/icon-text.svg");
+    }
+
+    &--textarea {
+      background-image: url("../../../images/attribute/icon-textarea.svg");
+    }
+
+    &--number {
+      background-image: url("../../../images/attribute/icon-number.svg");
+    }
+
+    &--price {
+      background-image: url("../../../images/attribute/icon-price.svg");
+    }
+
+    &--multiselect {
+      background-image: url("../../../images/attribute/icon-multiselect.svg");
+    }
+
+    &--select {
+      background-image: url("../../../images/attribute/icon-select.svg");
+    }
+
+    &--file {
+      background-image: url("../../../images/attribute/icon-file.svg");
+    }
+
+    &--asset {
+      background-image: url("../../../images/attribute/icon-asset.svg");
+    }
+
+    &--switch {
+      background-image: url("../../../images/attribute/icon-switch.svg");
+    }
+
+    &--date {
+      background-image: url("../../../images/attribute/icon-date.svg");
+    }
+
+    &--metric {
+      background-image: url("../../../images/attribute/icon-metric.svg");
+    }
+
+    &--multiselect {
+      background-image: url("../../../images/attribute/icon-multiselect.svg");
+    }
+
+    &--select {
+      background-image: url("../../../images/attribute/icon-select.svg");
+    }
+  }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR moves the images for the create attribute popin icons to CSS so that they can be overridden 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
