### PR TITLE
TIP-819 Remove wait refresh for indexing commands

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -8,6 +8,9 @@
 - PIM-6933: Fix menu display in case of acl restriction
 - PIM-6922: fix sort order on attribute groups
 
+# Improvements
+ - TIP-819: 3x indexing performance on command by not waiting for index refresh (Product, ProductModel and PublishedProduct indexing commands)
+
 ## Better manage products with variants!
 
 - PIM-6773: Add the missing required attributes filter in the product model edit form
@@ -17,6 +20,7 @@
 
 ## BC breaks
 
+- `Refresh::disabled()` rename to `Refresh::disable()`, to make it homogeneous with `Refresh::enable()` and `Refresh::waitFor()`
 - Change the constructor of `Pim\Component\Catalog\Completeness\CompletenessCalculator`. Remove `Pim\Component\Catalog\Factory\ValueFactory` and both `Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface`. Add `Pim\Component\Catalog\EntityWithFamily\IncompleteValueCollectionFactory` and `Pim\Component\Catalog\EntityWithFamily\RequiredValueCollectionFactory`.
 - Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductModelNormalizer` to add `Symfony\Component\Serializer\Normalizer\NormalizerInterface`.
 - Move `Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\CompletenessFilter` to `Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\CompletenessFilter`

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Refresh.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Refresh.php
@@ -41,6 +41,16 @@ final class Refresh
      */
     public static function disabled()
     {
+        @trigger_error('The '.__FUNCTION__.' function is deprecated and will be removed in a future version.', E_USER_DEPRECATED);
+
+        return self::disable();
+    }
+
+    /**
+     * @return Refresh
+     */
+    public static function disable()
+    {
         return new self(Refresh::DISABLE);
     }
 

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/RefreshSpec.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/RefreshSpec.php
@@ -15,7 +15,7 @@ class RefreshSpec extends ObjectBehavior
 
     function it_creates_a_disable_refresh_param()
     {
-        $this->beConstructedThrough('disabled');
+        $this->beConstructedThrough('disable');
         $this->getType()->shouldReturn(Refresh::DISABLE);
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Command/IndexProductCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/IndexProductCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pim\Bundle\CatalogBundle\Command;
 
+use Akeneo\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
@@ -109,7 +110,7 @@ class IndexProductCommand extends ContainerAwareCommand
 
             $products = $this->productRepository->findAllWithOffsetAndSize($offset, self::BULK_SIZE);
 
-            $this->bulkProductIndexer->indexAll($products);
+            $this->bulkProductIndexer->indexAll($products, ['index_refresh' => Refresh::disable()]);
             $this->bulkProductDetacher->detachAll($products);
         }
 
@@ -153,7 +154,7 @@ class IndexProductCommand extends ContainerAwareCommand
             $i++;
 
             if (0 === $i % self::BULK_SIZE) {
-                $this->bulkProductIndexer->indexAll($productBulk);
+                $this->bulkProductIndexer->indexAll($productBulk, ['index_refresh' => Refresh::disable()]);
                 $this->bulkProductDetacher->detachAll($productBulk);
 
                 $productBulk = [];
@@ -169,7 +170,7 @@ class IndexProductCommand extends ContainerAwareCommand
         }
 
         if (!empty($productBulk)) {
-            $this->bulkProductIndexer->indexAll($productBulk);
+            $this->bulkProductIndexer->indexAll($productBulk, ['index_refresh' => Refresh::disable()]);
             $this->bulkProductDetacher->detachAll($productBulk);
 
             $totalProductsIndexed += count($productBulk);

--- a/src/Pim/Bundle/CatalogBundle/Command/IndexProductModelCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/IndexProductModelCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pim\Bundle\CatalogBundle\Command;
 
+use Akeneo\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
@@ -119,7 +120,7 @@ class IndexProductModelCommand extends ContainerAwareCommand
                 self::BULK_SIZE
             );
 
-            $this->bulkProductModelIndexer->indexAll($rootProductModels);
+            $this->bulkProductModelIndexer->indexAll($rootProductModels, ['index_refresh' => Refresh::disable()]);
             $this->bulkProductModelDescendantsIndexer->indexAll($rootProductModels);
             $this->bulkProductModelDetacher->detachAll($rootProductModels);
         }
@@ -165,8 +166,8 @@ class IndexProductModelCommand extends ContainerAwareCommand
             $i++;
 
             if (0 === $i % self::BULK_SIZE) {
-                $this->bulkProductModelIndexer->indexAll($productModelBulk);
-                $this->bulkProductModelDescendantsIndexer->indexAll($productModelBulk);
+                $this->bulkProductModelIndexer->indexAll($productModelBulk, ['index_refresh' => Refresh::disable()]);
+                $this->bulkProductModelDescendantsIndexer->indexAll($productModelBulk, ['index_refresh' => Refresh::disable()]);
                 $this->bulkProductModelDetacher->detachAll($productModelBulk);
 
                 $productModelBulk = [];
@@ -182,8 +183,8 @@ class IndexProductModelCommand extends ContainerAwareCommand
         }
 
         if (!empty($productModelBulk)) {
-            $this->bulkProductModelIndexer->indexAll($productModelBulk);
-            $this->bulkProductModelDescendantsIndexer->indexAll($productModelBulk);
+            $this->bulkProductModelIndexer->indexAll($productModelBulk, ['index_refresh' => Refresh::disable()]);
+            $this->bulkProductModelDescendantsIndexer->indexAll($productModelBulk, ['index_refresh' => Refresh::disable()]);
             $this->bulkProductModelDetacher->detachAll($productModelBulk);
 
             $totalProductModelsIndexed += count($productModelBulk);

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Indexer/ProductIndexer.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Indexer/ProductIndexer.php
@@ -77,6 +77,9 @@ class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverI
     /**
      * Indexes a product in both the product index and the product and product model index.
      *
+     * If the index_refresh is provided, it uses the refresh strategy defined.
+     * Otherwise the waitFor strategy is by default.
+     *
      * {@inheritdoc}
      */
     public function indexAll(array $objects, array $options = []) : void
@@ -84,6 +87,8 @@ class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverI
         if (empty($objects)) {
             return;
         }
+
+        $indexRefresh = $options['index_refresh'] ?? Refresh::waitFor();
 
         $normalizedProducts = [];
         $normalizedProductModels = [];
@@ -103,12 +108,12 @@ class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverI
             $normalizedProductModels[] = $normalizedProductModel;
         }
 
-        $this->productClient->bulkIndexes($this->indexType, $normalizedProducts, 'id', Refresh::waitFor());
+        $this->productClient->bulkIndexes($this->indexType, $normalizedProducts, 'id', $indexRefresh);
         $this->productAndProductModelClient->bulkIndexes(
             $this->indexType,
             $normalizedProductModels,
             'id',
-            Refresh::waitFor()
+            $indexRefresh
         );
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Indexer/ProductModelDescendantsIndexer.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Indexer/ProductModelDescendantsIndexer.php
@@ -93,7 +93,7 @@ class ProductModelDescendantsIndexer implements
         }
 
         foreach ($objects as $object) {
-            $this->index($object);
+            $this->index($object, $options);
         }
     }
 
@@ -142,24 +142,25 @@ class ProductModelDescendantsIndexer implements
      * (products or product models).
      *
      * @param Collection $productModelChildren
+     * @param array      $options
      */
-    private function indexProductModelChildren(Collection $productModelChildren) : void
+    private function indexProductModelChildren(Collection $productModelChildren, array $options = []) : void
     {
         if ($productModelChildren->isEmpty()) {
             return;
         }
 
         if ($productModelChildren->first() instanceof VariantProductInterface) {
-            $this->productIndexer->indexAll($productModelChildren->toArray());
+            $this->productIndexer->indexAll($productModelChildren->toArray(), $options);
 
             return;
         }
 
-        $this->productModelIndexer->indexAll($productModelChildren->toArray());
+        $this->productModelIndexer->indexAll($productModelChildren->toArray(), $options);
 
         foreach ($productModelChildren as $productModelChild) {
-            $this->indexProductModelChildren($productModelChild->getProductModels());
-            $this->indexProductModelChildren($productModelChild->getProducts());
+            $this->indexProductModelChildren($productModelChild->getProductModels(), $options);
+            $this->indexProductModelChildren($productModelChild->getProducts(), $options);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Indexer/ProductModelIndexer.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Indexer/ProductModelIndexer.php
@@ -79,6 +79,9 @@ class ProductModelIndexer implements IndexerInterface, BulkIndexerInterface, Rem
     /**
      * Indexes a product in both the product model index and the product and product model index.
      *
+     * If the index_refresh is provided, it uses the refresh strategy defined.
+     * Otherwise the waitFor strategy is by default.
+     *
      * {@inheritdoc}
      */
     public function indexAll(array $objects, array $options = []) : void
@@ -86,6 +89,8 @@ class ProductModelIndexer implements IndexerInterface, BulkIndexerInterface, Rem
         if (empty($objects)) {
             return;
         }
+
+        $indexRefresh = $options['index_refresh'] ?? Refresh::waitFor();
 
         $normalizedObjects = [];
         foreach ($objects as $object) {
@@ -101,7 +106,7 @@ class ProductModelIndexer implements IndexerInterface, BulkIndexerInterface, Rem
             $this->indexType,
             $normalizedObjects,
             'id',
-            Refresh::waitFor()
+            $indexRefresh
         );
 
         $normalizedObjects = [];
@@ -118,7 +123,7 @@ class ProductModelIndexer implements IndexerInterface, BulkIndexerInterface, Rem
             $this->indexType,
             $normalizedObjects,
             'id',
-            Refresh::waitFor()
+            $indexRefresh
         );
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductCommandSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductCommandSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Command;
 
+use Akeneo\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
@@ -59,7 +60,7 @@ class IndexProductCommandSpec extends ObjectBehavior
         $productRepository->countAll()->willReturn(2);
         $productRepository->findAllWithOffsetAndSize(0, 100)->willReturn([$product1, $product2]);
 
-        $productIndexer->indexAll([$product1, $product2])->shouldBeCalled();
+        $productIndexer->indexAll([$product1, $product2], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
 
         $productDetacher->detachAll([$product1, $product2])->shouldBeCalled();
 
@@ -108,7 +109,7 @@ class IndexProductCommandSpec extends ObjectBehavior
 
         $productRepository->findBy(['identifier' => ['product_identifier_to_index']])->willReturn([$productToIndex]);
 
-        $productIndexer->indexAll([$productToIndex])->shouldBeCalled();
+        $productIndexer->indexAll([$productToIndex], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
         $productDetacher->detachAll([$productToIndex])->shouldBeCalled();
 
         $output->writeln('<info>1 products found for indexing</info>')->shouldBeCalled();
@@ -157,7 +158,7 @@ class IndexProductCommandSpec extends ObjectBehavior
 
         $productRepository->findBy(['identifier' => ['product_1', 'product_2']])->willReturn([$product1, $product2]);
 
-        $productIndexer->indexAll([$product1, $product2])->shouldBeCalled();
+        $productIndexer->indexAll([$product1, $product2], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
         $productDetacher->detachAll([$product1, $product2])->shouldBeCalled();
 
         $output->writeln('<info>2 products found for indexing</info>')->shouldBeCalled();
@@ -207,7 +208,7 @@ class IndexProductCommandSpec extends ObjectBehavior
 
         $productToIndex->getIdentifier()->willReturn('product_1');
 
-        $productIndexer->indexAll([$productToIndex])->shouldBeCalled();
+        $productIndexer->indexAll([$productToIndex], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
         $productDetacher->detachAll([$productToIndex])->shouldBeCalled();
 
         $output->writeln('<error>Some products were not found for the given identifiers: wrong_product</error>')->shouldBeCalled();

--- a/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductModelCommandSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductModelCommandSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Command;
 
+use Akeneo\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
@@ -64,7 +65,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
             ->findRootProductModelsWithOffsetAndSize(0, 100)
             ->willReturn([$productModel1, $productModel2]);
 
-        $productModelIndexer->indexAll([$productModel1, $productModel2])->shouldBeCalled();
+        $productModelIndexer->indexAll([$productModel1, $productModel2], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
 
         $productModelDetacher->detachAll([$productModel1, $productModel2])->shouldBeCalled();
 
@@ -117,7 +118,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
 
         $productModelRepository->findBy(['code' => ['product_model_code_to_index']])->willReturn([$productModelToIndex]);
 
-        $productModelIndexer->indexAll([$productModelToIndex])->shouldBeCalled();
+        $productModelIndexer->indexAll([$productModelToIndex], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
         $productModelDetacher->detachAll([$productModelToIndex])->shouldBeCalled();
 
         $output->writeln('<info>1 product models found for indexing</info>')->shouldBeCalled();
@@ -174,7 +175,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         $productModel1->getCode()->willReturn('product_model_1');
         $productModel2->getCode()->willReturn('product_model_2');
 
-        $productModelIndexer->indexAll([$productModel1, $productModel2])->shouldBeCalled();
+        $productModelIndexer->indexAll([$productModel1, $productModel2], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
         $productModelDetacher->detachAll([$productModel1, $productModel2])->shouldBeCalled();
 
         $output->writeln('<info>2 product models found for indexing</info>')->shouldBeCalled();
@@ -231,7 +232,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         $productModel1->getCode()->willReturn('product_model_1');
         $productModel2->getCode()->willReturn('product_model_2');
 
-        $productModelIndexer->indexAll([$productModel1, $productModel2])->shouldBeCalled();
+        $productModelIndexer->indexAll([$productModel1, $productModel2], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
         $productModelDetacher->detachAll([$productModel1, $productModel2])->shouldBeCalled();
 
         $output->writeln('<error>Some product models were not found for the given codes: wrong_product_model</error>')->shouldBeCalled();

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Indexer/ProductIndexerSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Indexer/ProductIndexerSpec.php
@@ -18,9 +18,9 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class ProductIndexerSpec extends ObjectBehavior
 {
-    function let(NormalizerInterface $normalizer, Client $productIndexer, Client $productModelIndexer)
+    function let(NormalizerInterface $normalizer, Client $productIndexClient, Client $productModelIndexClient)
     {
-        $this->beConstructedWith($normalizer, $productIndexer, $productModelIndexer, 'an_index_type_for_test_purpose');
+        $this->beConstructedWith($normalizer, $productIndexClient, $productModelIndexClient, 'an_index_type_for_test_purpose');
     }
 
     function it_is_initializable()
@@ -42,24 +42,24 @@ class ProductIndexerSpec extends ObjectBehavior
 
     function it_throws_an_exception_when_attempting_to_index_a_product_without_id(
         $normalizer,
-        $productIndexer,
-        $productModelIndexer,
+        $productIndexClient,
+        $productModelIndexClient,
         \stdClass $aWrongProduct
     ) {
         $normalizer->normalize($aWrongProduct, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)->willReturn([]);
-        $productIndexer->index(Argument::cetera())->shouldNotBeCalled();
+        $productIndexClient->index(Argument::cetera())->shouldNotBeCalled();
 
         $normalizer->normalize($aWrongProduct, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->shouldNotBeCalled([]);
-        $productModelIndexer->index(Argument::cetera())->shouldNotBeCalled();
+        $productModelIndexClient->index(Argument::cetera())->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)->during('index', [$aWrongProduct]);
     }
 
     function it_throws_an_exception_when_attempting_to_bulk_index_a_product_without_an_id(
         $normalizer,
-        $productIndexer,
-        $productModelIndexer,
+        $productIndexClient,
+        $productModelIndexClient,
         ProductInterface $product,
         \stdClass $aWrongProduct
     ) {
@@ -73,22 +73,22 @@ class ProductIndexerSpec extends ObjectBehavior
         $normalizer->normalize($aWrongProduct, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->shouldNotBeCalled();
 
-        $productIndexer->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
-        $productModelIndexer->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
+        $productIndexClient->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
+        $productModelIndexClient->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)->during('indexAll', [[$product, $aWrongProduct]]);
     }
 
-    function it_indexes_a_single_product($normalizer, $productIndexer, $productModelIndexer, ProductInterface $product)
+    function it_indexes_a_single_product($normalizer, $productIndexClient, $productModelIndexClient, ProductInterface $product)
     {
         $normalizer->normalize($product, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
             ->willReturn(['id' => 'foobar', 'a key' => 'a value']);
-        $productIndexer->index('an_index_type_for_test_purpose', 'foobar', ['id' => 'foobar', 'a key' => 'a value'])
+        $productIndexClient->index('an_index_type_for_test_purpose', 'foobar', ['id' => 'foobar', 'a key' => 'a value'])
             ->shouldBeCalled();
 
         $normalizer->normalize($product, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(['id' => 'foobar', 'a key' => 'a value']);
-        $productModelIndexer->index('an_index_type_for_test_purpose', 'foobar', ['id' => 'foobar', 'a key' => 'a value'])
+        $productModelIndexClient->index('an_index_type_for_test_purpose', 'foobar', ['id' => 'foobar', 'a key' => 'a value'])
             ->shouldBeCalled();
 
         $this->index($product);
@@ -96,8 +96,8 @@ class ProductIndexerSpec extends ObjectBehavior
 
     function it_bulk_indexes_products(
         $normalizer,
-        $productIndexer,
-        $productModelIndexer,
+        $productIndexClient,
+        $productModelIndexClient,
         ProductInterface $product1,
         ProductInterface $product2
     ) {
@@ -106,7 +106,7 @@ class ProductIndexerSpec extends ObjectBehavior
         $normalizer->normalize($product2, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
             ->willReturn(['id' => 'bar', 'a key' => 'another value']);
 
-        $productIndexer->bulkIndexes('an_index_type_for_test_purpose', [
+        $productIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
         ], 'id', Refresh::waitFor())->shouldBeCalled();
@@ -116,7 +116,7 @@ class ProductIndexerSpec extends ObjectBehavior
         $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(['id' => 'bar', 'a key' => 'another value']);
 
-        $productModelIndexer->bulkIndexes('an_index_type_for_test_purpose', [
+        $productModelIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
         ], 'id', Refresh::waitFor())->shouldBeCalled();
@@ -124,28 +124,121 @@ class ProductIndexerSpec extends ObjectBehavior
         $this->indexAll([$product1, $product2]);
     }
 
-    function it_does_not_bulk_index_empty_arrays_of_products($normalizer, $productIndexer, $productModelIndexer)
+    function it_does_not_bulk_index_empty_arrays_of_products($normalizer, $productIndexClient, $productModelIndexClient)
     {
         $normalizer->normalize(Argument::cetera())->shouldNotBeCalled();
-        $productIndexer->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
-        $productModelIndexer->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
+        $productIndexClient->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
+        $productModelIndexClient->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
 
         $this->indexAll([]);
     }
 
-    function it_deletes_products_from_elasticsearch_index($productIndexer, $productModelIndexer)
+    function it_deletes_products_from_elasticsearch_index($productIndexClient, $productModelIndexClient)
     {
-        $productIndexer->delete('an_index_type_for_test_purpose', 40)->shouldBeCalled();
-        $productModelIndexer->delete('an_index_type_for_test_purpose', 'product_40')->shouldBeCalled();
+        $productIndexClient->delete('an_index_type_for_test_purpose', 40)->shouldBeCalled();
+        $productModelIndexClient->delete('an_index_type_for_test_purpose', 'product_40')->shouldBeCalled();
 
         $this->remove(40)->shouldReturn(null);
     }
 
-    function it_bulk_deletes_products_from_elasticsearch_index($productIndexer, $productModelIndexer)
+    function it_bulk_deletes_products_from_elasticsearch_index($productIndexClient, $productModelIndexClient)
     {
-        $productIndexer->bulkDelete('an_index_type_for_test_purpose', [40, 33])->shouldBeCalled();
-        $productModelIndexer->bulkDelete('an_index_type_for_test_purpose', ['product_40', 'product_33'])->shouldBeCalled();
+        $productIndexClient->bulkDelete('an_index_type_for_test_purpose', [40, 33])->shouldBeCalled();
+        $productModelIndexClient->bulkDelete('an_index_type_for_test_purpose', ['product_40', 'product_33'])->shouldBeCalled();
 
         $this->removeAll([40, 33])->shouldReturn(null);
+    }
+
+    function it_indexes_products_and_wait_for_index_refresh_by_default(
+        ProductInterface $product1,
+        ProductInterface $product2,
+        $normalizer,
+        $productIndexClient,
+        $productModelIndexClient
+        ) {
+
+        $normalizer->normalize($product1, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($product2, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $normalizer->normalize($product1, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $productIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::waitFor())->shouldBeCalled();
+
+        $productModelIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::waitFor())->shouldBeCalled();
+
+        $this->indexAll([$product1, $product2]);
+    }
+
+    function it_indexes_products_and_disable_index_refresh(
+        ProductInterface $product1,
+        ProductInterface $product2,
+        $normalizer,
+        $productIndexClient,
+        $productModelIndexClient
+        ) {
+
+        $normalizer->normalize($product1, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($product2, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $normalizer->normalize($product1, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $productIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::disable())->shouldBeCalled();
+
+        $productModelIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::disable())->shouldBeCalled();
+
+        $this->indexAll([$product1, $product2], ['index_refresh' => Refresh::disable()]);
+    }
+
+    function it_indexes_products_and_enable_index_refresh_without_waiting_for_it(
+        ProductInterface $product1,
+        ProductInterface $product2,
+        $normalizer,
+        $productIndexClient,
+        $productModelIndexClient
+        ) {
+
+        $normalizer->normalize($product1, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($product2, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $normalizer->normalize($product1, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $productIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::enable())->shouldBeCalled();
+
+        $productModelIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::enable())->shouldBeCalled();
+
+        $this->indexAll([$product1, $product2], ['index_refresh' => Refresh::enable()]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Indexer/ProductModelDescendantsIndexerSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Indexer/ProductModelDescendantsIndexerSpec.php
@@ -54,7 +54,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productChildren->isEmpty()->willReturn(false);
         $productChildren->first()->willReturn($childProduct1);
         $productChildren->toArray()->willReturn([$childProduct1, $childProduct2]);
-        $productIndexer->indexAll([$childProduct1, $childProduct2])->shouldBeCalled();
+        $productIndexer->indexAll([$childProduct1, $childProduct2], [])->shouldBeCalled();
 
         $productModel->getProductModels()->willReturn($productModelChildren);
         $productModelChildren->isEmpty()->willReturn(true);
@@ -113,7 +113,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productVariantsChildren->first()->willReturn($childVariantProduct1);
         $productVariantsChildren->toArray()->willReturn([$childVariantProduct1, $childVariantProduct2]);
 
-        $productIndexer->indexAll([$childVariantProduct1, $childVariantProduct2])->shouldBeCalled();
+        $productIndexer->indexAll([$childVariantProduct1, $childVariantProduct2], [])->shouldBeCalled();
 
         $this->index($rootProductModel);
     }
@@ -147,7 +147,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productChildren1->isEmpty()->willReturn(false);
         $productChildren1->first()->willReturn($childProduct1);
         $productChildren1->toArray()->willReturn([$childProduct1, $childProduct2]);
-        $productIndexer->indexAll([$childProduct1, $childProduct2])->shouldBeCalled();
+        $productIndexer->indexAll([$childProduct1, $childProduct2], [])->shouldBeCalled();
 
         $productModel1->getProductModels()->willReturn($productModelChildren1);
         $productModelChildren1->isEmpty()->willReturn(true);
@@ -157,7 +157,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productChildren2->isEmpty()->willReturn(false);
         $productChildren2->first()->willReturn($childProduct3);
         $productChildren2->toArray()->willReturn([$childProduct3, $childProduct4]);
-        $productIndexer->indexAll([$childProduct3, $childProduct4])->shouldBeCalled();
+        $productIndexer->indexAll([$childProduct3, $childProduct4], [])->shouldBeCalled();
 
         $productModel2->getProductModels()->willReturn($productModelChildren2);
         $productModelChildren2->isEmpty()->willReturn(true);

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Indexer/ProductModelIndexerSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Indexer/ProductModelIndexerSpec.php
@@ -148,4 +148,94 @@ class ProductModelIndexerSpec extends ObjectBehavior
 
         $this->removeAll([40, 33])->shouldReturn(null);
     }
+
+    function it_indexes_product_models_and_wait_for_index_refresh_by_default(
+        $normalizer,
+        $productModelClient,
+        $productAndProductModelClient,
+        ProductModelInterface $productModel1,
+        ProductModelInterface $productModel2
+    ) {
+        $normalizer->normalize($productModel1, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($productModel2, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $productModelClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::waitFor())->shouldBeCalled();
+
+        $normalizer->normalize($productModel1, ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($productModel2, ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $productAndProductModelClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::waitFor())->shouldBeCalled();
+
+        $this->indexAll([$productModel1, $productModel2]);
+    }
+
+    function it_indexes_product_models_and_disable_index_refresh(
+        $normalizer,
+        $productModelClient,
+        $productAndProductModelClient,
+        ProductModelInterface $productModel1,
+        ProductModelInterface $productModel2
+    ) {
+        $normalizer->normalize($productModel1, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($productModel2, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $productModelClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::disable())->shouldBeCalled();
+
+        $normalizer->normalize($productModel1, ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($productModel2, ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $productAndProductModelClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::disable())->shouldBeCalled();
+
+        $this->indexAll([$productModel1, $productModel2], ['index_refresh' => Refresh::disable()]);
+    }
+
+    function it_indexes_product_models_and_enable_index_refresh_without_waiting_for_it(
+        $normalizer,
+        $productModelClient,
+        $productAndProductModelClient,
+        ProductModelInterface $productModel1,
+        ProductModelInterface $productModel2
+    ) {
+        $normalizer->normalize($productModel1, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($productModel2, ProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $productModelClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::disable())->shouldBeCalled();
+
+        $normalizer->normalize($productModel1, ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'foo', 'a key' => 'a value']);
+        $normalizer->normalize($productModel2, ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => 'bar', 'a key' => 'another value']);
+
+        $productAndProductModelClient->bulkIndexes('an_index_type_for_test_purpose', [
+            ['id' => 'foo', 'a key' => 'a value'],
+            ['id' => 'bar', 'a key' => 'another value'],
+        ], 'id', Refresh::disable())->shouldBeCalled();
+
+        $this->indexAll([$productModel1, $productModel2], ['index_refresh' => Refresh::disable()]);
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Remove the waiting time between each batch of 100 items when indexing products and products model from the command lines.
The refresh strategy is now at disable, relying on the standard refreshing feature of Elasticsearch without waiting for it to take effect.
More details here:
https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html

Reindexing icecat_demo_dev results:
 - before: 28s
 - after: 9s

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
