### PR TITLE
PIM-6806: Add new job instance in the changelog

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -17,6 +17,10 @@
 - Change the constructor of `Pim\Component\Catalog\Completeness\CompletenessCalculator`. Remove `Pim\Component\Catalog\Factory\ValueFactory` and both `Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface`. Add `Pim\Component\Catalog\EntityWithFamily\IncompleteValueCollectionFactory` and `Pim\Component\Catalog\EntityWithFamily\RequiredValueCollectionFactory`.
 - Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductModelNormalizer` to add `Symfony\Component\Serializer\Normalizer\NormalizerInterface`.
 
+## New jobs
+IMPORTANT: In order for your PIM to work properly, you will need to run the following commands to add the missing job instances.
+- Add the job instance `compute_completeness_of_products_family`: `bin/console akeneo:batch:create-job "internal" "compute_completeness_of_products_family" "compute_completeness_of_products_family" "compute_completeness_of_products_family" '{"family_code":"null"}' "compute completeness of products family" --env=prod`
+
 # 2.0.4 (2017-10-19)
 
 # 2.0.3 (2017-10-19)


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Introducing features in patches sometimes induces adding new jobs. We use to do doctrine migration for new jobs but as discussed with @nidup for minor versions we prefer to document this change in the changelog.

A new internal job as been introduced here https://github.com/akeneo/pim-community-dev/pull/7006. 

This PR documents it in the changelog. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
