### PR TITLE
PIM-6567: fix "values for variation" for entities with family variant

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Model/ProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Model/ProductModelIntegration.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Model;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\ValueInterface;
+
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProductModelIntegration extends TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    public function testGetValuesForVariationForRootProductModel()
+    {
+        $rootProductModel = $this->getFromTestContainer('pim_catalog.repository.product_model')
+            ->findOneByIdentifier('brooksblue');
+
+        $this->getFromTestContainer('pim_catalog.updater.product_model')
+            ->update($rootProductModel, [
+                'values' => [
+                    'sku' => [
+                        [
+                            'scope' => null,
+                            'locale' => null,
+                            'data' => 'testsku'
+                        ]
+                    ]
+                ]
+            ]);
+
+        $variationValues = $rootProductModel->getValuesForVariation();
+
+        $this->assertNull($variationValues->getByCodes('sku'));
+        $this->assertInstanceOf(ValueInterface::class, $variationValues->getByCodes('variation_name', null, 'en_US'));
+    }
+
+    public function testGetValuesForVariationForSubProductModel()
+    {
+        $rootProductModel = $this->getFromTestContainer('pim_catalog.repository.product_model')
+            ->findOneByIdentifier('model-running-shoes-m');
+
+        $this->getFromTestContainer('pim_catalog.updater.product_model')
+            ->update($rootProductModel, [
+                'values' => [
+                    'sku' => [
+                        [
+                            'scope' => null,
+                            'locale' => null,
+                            'data' => 'testsku'
+                        ]
+                    ],
+                    'description' => [
+                        [
+                            'scope' => 'ecommerce',
+                            'locale' => 'en_US',
+                            'data' => 'A new description'
+                        ]
+                    ]
+                ]
+            ]);
+
+        $variationValues = $rootProductModel->getValuesForVariation();
+
+        $this->assertNull($variationValues->getByCodes('sku'));
+        $this->assertNull($variationValues->getByCodes('description'));
+        $this->assertInstanceOf(ValueInterface::class, $variationValues->getByCodes('variation_name', null, 'en_US'));
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Model/VariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Model/VariantProductIntegration.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Model;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\ValueInterface;
+
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class VariantProductIntegration extends TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    public function testGetValuesForVariation()
+    {
+        $variantProduct = $this->getFromTestContainer('pim_catalog.repository.variant_product')
+            ->findOneByIdentifier('1111111287');
+
+        $this->getFromTestContainer('pim_catalog.updater.product')
+            ->update($variantProduct, [
+                'values' => [
+                    'supplier' => [
+                        [
+                            'scope' => null,
+                            'locale' => null,
+                            'data' => 'zaro'
+                        ]
+                    ]
+                ]
+            ]);
+
+        $variationValues = $variantProduct->getValuesForVariation();
+
+        $this->assertNull($variationValues->getByCodes('supplier'));
+        $this->assertInstanceOf(ValueInterface::class, $variationValues->getByCodes('sku'));
+    }
+}

--- a/src/Pim/Component/Catalog/Model/ProductModel.php
+++ b/src/Pim/Component/Catalog/Model/ProductModel.php
@@ -130,7 +130,26 @@ class ProductModel implements ProductModelInterface
      */
     public function getValuesForVariation(): ValueCollectionInterface
     {
-        return $this->values;
+        $variationLevel = $this->getVariationLevel();
+
+        if (ProductModel::ROOT_VARIATION_LEVEL === $variationLevel) {
+            $allowedAttributes = $this->getFamilyVariant()->getCommonAttributes()->toArray();
+        } else {
+            $attributeSet = $this->getFamilyVariant()->getVariantAttributeSet($variationLevel);
+            $allowedAttributes = array_merge(
+                $attributeSet->getAttributes()->toArray(),
+                $attributeSet->getAxes()->toArray()
+            );
+        }
+
+        $valuesForVariation = new ValueCollection();
+        foreach ($this->values as $value) {
+            if (in_array($value->getAttribute(), $allowedAttributes)) {
+                $valuesForVariation->add($value);
+            }
+        }
+
+        return $valuesForVariation;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Model/VariantProduct.php
+++ b/src/Pim/Component/Catalog/Model/VariantProduct.php
@@ -67,7 +67,23 @@ class VariantProduct extends AbstractProduct implements VariantProductInterface
      */
     public function getValuesForVariation(): ValueCollectionInterface
     {
-        return $this->values;
+        $attributeSet = $this->getFamilyVariant()->getVariantAttributeSet(
+            $this->getVariationLevel()
+        );
+
+        $allowedAttributes = array_merge(
+            $attributeSet->getAttributes()->toArray(),
+            $attributeSet->getAxes()->toArray()
+        );
+
+        $valuesForVariation = new ValueCollection();
+        foreach ($this->values as $value) {
+            if (in_array($value->getAttribute(), $allowedAttributes)) {
+                $valuesForVariation->add($value);
+            }
+        }
+
+        return $valuesForVariation;
     }
 
     /**

--- a/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
@@ -4,7 +4,6 @@ namespace spec\Pim\Component\Catalog\Model;
 
 use Akeneo\Component\Classification\CategoryAwareInterface;
 use Akeneo\Component\Versioning\Model\VersionableInterface;
-use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\CategoryInterface;
@@ -14,10 +13,8 @@ use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModel;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\TimestampableInterface;
-use Pim\Component\Catalog\Model\ValueCollection;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
-use Pim\Component\Connector\ArrayConverter\FlatToStandard\Value;
 
 class ProductModelSpec extends ObjectBehavior
 {
@@ -260,12 +257,6 @@ class ProductModelSpec extends ObjectBehavior
         $this->setValues($values);
 
         $this->getImage()->shouldReturn(null);
-    }
-
-    function it_has_the_values_of_the_variation(ValueCollectionInterface $valueCollection)
-    {
-        $this->setValues($valueCollection);
-        $this->getValuesForVariation()->shouldReturn($valueCollection);
     }
 
     function it_has_values(

--- a/src/Pim/Component/Catalog/spec/Model/VariantProductSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/VariantProductSpec.php
@@ -147,14 +147,6 @@ class VariantProductSpec extends ObjectBehavior
         $this->isAttributeRemovable($attribute)->shouldReturn(true);
     }
 
-    function it_has_the_values_of_the_variation(
-        ValueCollectionInterface $valueCollection
-    ) {
-        $this->setValues($valueCollection);
-
-        $this->getValuesForVariation()->shouldBeLike($valueCollection);
-    }
-
     function it_has_values(
         ValueCollectionInterface $valueCollection,
         ProductModelInterface $productModel,


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The current way to retrieve values for variation (for the level of the entity) is not resilient to any update of the product or any weird data from the database.
This PR tries to bring a solution by filtering the data in the method `getValuesForVariation()` to be sure to always have the real values of the variation. 

> Note: I made unit test with phpunit this time, the spec was waaaay too verbose and unreadable. But if you want me to still do the spec, I can.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Added integration tests           | Y (unit test)
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo