### PR TITLE
PIM-6960: fix association type deletion on pef

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 - PIM-6904: Product Grid - Horizontal scrollbar should be at the bottom of the screen instead to be at the end of the grid
+- PIM-6960: fix association type deletion when it's the first item of the list
 
 # 1.7.12 (2017-10-25)
 

--- a/features/product/associate_product.feature
+++ b/features/product/associate_product.feature
@@ -220,3 +220,26 @@ Feature: Associate a product
     When I select the "Substitution" association
     Then I should see the text "0 products and 0 groups"
     And the row "caterpillar_boots" should not be checked
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6960
+  Scenario: Don't make the pef fail after current association type removal
+    Given I am on the association types page
+    And I create a new association type
+    Then I should see the Code field
+    When I fill in the following information in the popin:
+      | Code | social_sell |
+    And I press the "Save" button
+    When I edit the "charcoal-boots" product
+    When I visit the "Associations" tab
+    And I select the "social_sell" association
+    And I check the row "shoelaces"
+    And I save the product
+    Then I should see the text "1 products and 0 groups"
+    When I am on the association types page
+    Then I should see association type social_sell
+    When I click on the "Delete" action of the row which contains "social_sell"
+    And I confirm the deletion
+    Then I should not see association type social_sell
+    When I edit the "charcoal-boots" product
+    And I visit the "Associations" tab
+    Then I should see the text "black-boots"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -131,7 +131,9 @@ define(
                 ).then(function (associationTypes, identifierAttribute) {
                     var currentAssociationType = associationTypes.length ? _.first(associationTypes).code : null;
 
-                    if (null === this.getCurrentAssociationType()) {
+                    if (null === this.getCurrentAssociationType() ||
+                        _.isUndefined(_.findWhere(associationTypes, {code: this.getCurrentAssociationType()}))
+                    ) {
                         this.setCurrentAssociationType(currentAssociationType);
                     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fixes the association removal when going back to the pef

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added Behats                      | Y
| Added integration tests           | NA
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
