### PR TITLE
PIM-6914: Fix Default UI locale shown for new user

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -14,6 +14,10 @@
 
 IMPORTANT: In order to use the new quick exports, please execute `bin/console doctrine:migrations:migrate` to migrate your configurations.
 
+## Bug fixes
+
+- PIM-6914: Default UI locale for a new user is en_US but fix display of saved UI locale for user
+
 # 2.0.5 (2017-10-26)
 
 ## Bug fixes

--- a/features/user/edit_my_account.feature
+++ b/features/user/edit_my_account.feature
@@ -39,3 +39,20 @@ Feature: Change my profile
     When I logout
     And I am logged in as "Peter" with password Peter{}()/\@:
     Then I am on the dashboard page
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6914
+  Scenario: Successfully display the UI locale of the user
+    Given I edit the "Peter" user
+    When I visit the "Interfaces" tab
+    And I fill in the following information:
+      | UI locale (required) | French (France) |
+    And I save the user
+    Then I should not see the text "There are unsaved changes"
+    And I should see the text "français (France)"
+    Given I edit the "Mary" user
+    When I visit the "Interfaces" tab
+    And I fill in the following information:
+      | Langue de l'interface (obligatoire) | français (France) |
+    And I save the user
+    Then I should not see the text "There are unsaved changes"
+    And I should see the text "français (France)"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

en_US was always the displayed UI locale on the user edit interfaces edition.
Now we correctly displayed the saved UI locale and if it's a user creation, we put the en_US as default locale.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | Y
| Added integration tests           | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo