### PR TITLE
Fix product standard format documentation

### DIFF
--- a/STANDARD_FORMAT.md
+++ b/STANDARD_FORMAT.md
@@ -413,8 +413,6 @@ Its standard format would be the following:
         array:10 [
           "identifier" => "bar"
           "family" => "familyA"
-          "family_variant" => null,
-          "parent" => null,
           "groups" => array:2 [
             0 => "groupA"
             1 => "groupB"
@@ -514,8 +512,6 @@ Its standard format would be the following:
         array:10 [
           "identifier" => "foo"
           "family" => "familyA"
-          "family_variant" => null
-          "parent" => null
           "groups" => array:2 [
             0 => "groupA"
             1 => "groupB"
@@ -795,8 +791,7 @@ Its standard format would be the following:
         array:10 [
           "identifier" => "baz"
           "family" => "familyA"
-          "family_variant" => "familyVariantA",
-          "parent" => "fooProductModel",
+          "parent" => "fooProductModel"
           "groups" => array:0 []
           "categories" => array:0 []
           "enabled" => false
@@ -841,10 +836,6 @@ Its standard format would be the following:
           "family" => "familyA"
           "family_variant" => "familyVariantA1"
           "parent" => "fooProductModel"
-          "groups" => array:2 [
-            0 => "groupA"
-            1 => "groupB"
-          ]
           "categories" => array:2 [
             0 => "categoryA"
             1 => "categoryB"
@@ -883,10 +874,6 @@ Its standard format would be the following:
           "family" => "familyA"
           "family_variant" => "familyVariantA1"
           "parent" => null
-          "groups" => array:2 [
-            0 => "groupA"
-            1 => "groupB"
-          ]
           "categories" => array:2 [
             0 => "categoryA1"
             1 => "categoryB"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix some errors in the standard documentation :
- Products don't have any parent neither family variant.
- Variant products don't have any family variant.
- Product models don't have any groups.