### PR TITLE
PIM-6904: Horizontal scrollbar should be at the bottom of the screen instead to be at the end of the grid

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug Fixes
+
+- PIM-6904: Product Grid - Horizontal scrollbar should be at the bottom of the screen instead to be at the end of the grid
+
 # 1.7.12 (2017-10-25)
 
 ## Bug Fixes

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/GridContainer.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/GridContainer.less
@@ -1,5 +1,4 @@
 .AknGridContainer {
   position: relative;
   padding: 10px 20px;
-  overflow-x: auto;
 }


### PR DESCRIPTION
**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Added integration tests           | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo