### PR TITLE
PIM-6948 Uses search after instead of offset limit

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,11 +4,16 @@
 
 - PIM-6354: Adds product models during quick exports
 
+## Bug fixes
+- PIM-6948: Use search after method for products and product models indexing instead of offset limit
+
 ## BC breaks
 
 - Rename `Pim\Bundle\EnrichBundle\Connector\Job\JobParameters\ConstraintCollectionProvider\ProductQuickExport` to `ProductAndProductModelQuickExport`
 - Rename `Pim\Bundle\EnrichBundle\Connector\Processor\QuickExport\ProductProcessor` to `ProductAndProductModelProcessor`
 - Updates quick export configurations to remove `filePath` and add `filePathProduct` and `filePathProductModel`.
+- Adds `Pim\Component\Catalog\Repository\ProductRepositoryInterface.php::searchAfter()` and `Pim\Component\Catalog\Repository\ProductModelRepositoryInterface::searchAfter()` methods
+- Deletes `Pim\Component\Catalog\Repository\ProductRepositoryInterface.php::findAllWithOffsetAndSize()` and `Pim\Component\Catalog\Repository\ProductModelRepositoryInterface::findRootProductModelsWithOffsetAndSize()` methods.
 
 ## Update jobs
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductModelRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductModelRepository.php
@@ -79,19 +79,6 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
     /**
      * {@inheritdoc}
      */
-    public function findRootProductModelsWithOffsetAndSize($offset = 0, $size = 100): array
-    {
-        $queryBuilder = $this->createQueryBuilder('pm')
-            ->andWhere('pm.parent IS NULL')
-            ->setFirstResult($offset)
-            ->setMaxResults($size);
-
-        return $queryBuilder->getQuery()->getResult();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function findChildrenProductModels(ProductModelInterface $productModel): array
     {
         $qb = $this
@@ -140,6 +127,25 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
             ->from(VariantProduct::class, 'p')
             ->where('p.parent = :parent')
             ->setParameter('parent', $productModel);
+
+        return $qb->getQuery()->execute();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function searchRootProductModelsAfter(?ProductModelInterface $productModel, int $limit): array
+    {
+        $qb = $this->createQueryBuilder('pm')
+            ->andWhere('pm.parent IS NULL')
+            ->orderBy('pm.id', 'ASC')
+            ->setMaxResults($limit);
+        ;
+
+        if (null !== $productModel) {
+            $qb->andWhere('pm.id > :productModelId')
+                ->setParameter(':productModelId', $productModel->getId());
+        }
 
         return $qb->getQuery()->execute();
     }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -145,18 +145,6 @@ class ProductRepository extends EntityRepository implements
     /**
      * {@inheritdoc}
      */
-    public function findAllWithOffsetAndSize($offset = 0, $size = 100)
-    {
-        $queryBuilder = $this->createQueryBuilder('p')
-            ->setFirstResult($offset)
-            ->setMaxResults($size);
-
-        return $queryBuilder->getQuery()->getResult();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getAssociatedProductIds(ProductInterface $product)
     {
         $qb = $this->createQueryBuilder('p')
@@ -170,6 +158,24 @@ class ProductRepository extends EntityRepository implements
             ->innerJoin('a.products', 'pa')
             ->where('p.id = :productId')
             ->setParameter(':productId', $product->getId());
+
+        return $qb->getQuery()->execute();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function searchAfter(?ProductInterface $product, int $limit): array
+    {
+        $qb = $this->createQueryBuilder('p')
+            ->orderBy('p.id', 'ASC')
+            ->setMaxResults($limit);
+        ;
+
+        if (null !== $product) {
+            $qb->where('p.id > :productId')
+                ->setParameter(':productId', $product->getId());
+        }
 
         return $qb->getQuery()->execute();
     }

--- a/src/Pim/Component/Catalog/Repository/ProductModelRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/ProductModelRepositoryInterface.php
@@ -36,14 +36,6 @@ interface ProductModelRepositoryInterface extends
     public function countRootProductModels(): int;
 
     /**
-     * @param int $offset
-     * @param int $size
-     *
-     * @return array
-     */
-    public function findRootProductModelsWithOffsetAndSize($offset = 0, $size = 100): array;
-
-    /**
      * Find product models which are the direct children of the given $productModel
      *
      * @param ProductModelInterface $productModel
@@ -78,4 +70,12 @@ interface ProductModelRepositoryInterface extends
      * @return array
      */
     public function findChildrenProducts(ProductModelInterface $productModel): array;
+
+    /**
+     * Get root products models after the one provided. Mainly used to iterate
+     * through a large collecion.
+     *
+     * The limit parameter defines the number of products to return.
+     */
+    public function searchRootProductModelsAfter(?ProductModelInterface $product, int $limit): array;
 }

--- a/src/Pim/Component/Catalog/Repository/ProductRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/ProductRepositoryInterface.php
@@ -65,14 +65,6 @@ interface ProductRepositoryInterface extends ObjectRepository
     public function hasAttributeInFamily($productId, $attributeCode);
 
     /**
-     * @param int $offset
-     * @param int $size
-     *
-     * @return array
-     */
-    public function findAllWithOffsetAndSize($offset = 0, $size = 100);
-
-    /**
      * Get all associated products ids
      *
      * @param ProductInterface $product
@@ -80,4 +72,12 @@ interface ProductRepositoryInterface extends ObjectRepository
      * @return string[]
      */
     public function getAssociatedProductIds(ProductInterface $product);
+
+    /**
+     * Get products after the one provided. Mainly used to iterate through
+     * a large collecion.
+     *
+     * The limit parameter defines the number of products to return.
+     */
+    public function searchAfter(?ProductInterface $product, int $limit): array;
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
The offset-limit method cannot handle consequent volume of data because it has an exponential response time. The search after method provides a linear response time.

See https://www.eversql.com/faster-pagination-in-mysql-why-order-by-with-limit-and-offset-is-slow/ for some detals.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | WIP
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -