### PR TITLE
TIP-824 Reduce indexing time by around 20%

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -7,6 +7,9 @@
 ## Bug fixes
 - PIM-6948: Use search after method for products and product models indexing instead of offset limit
 
+## Improvements
+- TIP-824: Increase CLI products indexing performance by 20%
+
 ## BC breaks
 
 - Rename `Pim\Bundle\EnrichBundle\Connector\Job\JobParameters\ConstraintCollectionProvider\ProductQuickExport` to `ProductAndProductModelQuickExport`

--- a/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductCommandSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductCommandSpec.php
@@ -4,8 +4,8 @@ namespace spec\Pim\Bundle\CatalogBundle\Command;
 
 use Akeneo\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Bundle\ElasticsearchBundle\Client;
-use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
+use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
@@ -44,7 +44,7 @@ class IndexProductCommandSpec extends ObjectBehavior
         $container,
         ProductRepositoryInterface $productRepository,
         BulkIndexerInterface $productIndexer,
-        BulkObjectDetacherInterface $productDetacher,
+        ObjectManager $objectManager,
         InputInterface $input,
         OutputInterface $output,
         Application $application,
@@ -58,7 +58,7 @@ class IndexProductCommandSpec extends ObjectBehavior
     ) {
         $container->get('pim_catalog.repository.product')->willReturn($productRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
-        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productDetacher);
+        $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
 
         $productRepository->countAll()->willReturn(5);
         $productRepository->searchAfter(null, 100)->willReturn([$product1, $product2]);
@@ -70,9 +70,7 @@ class IndexProductCommandSpec extends ObjectBehavior
         $productIndexer->indexAll([$product3, $product4], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
         $productIndexer->indexAll([$product5], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
 
-        $productDetacher->detachAll([$product1, $product2])->shouldBeCalled();
-        $productDetacher->detachAll([$product3, $product4])->shouldBeCalled();
-        $productDetacher->detachAll([$product5])->shouldBeCalled();
+        $objectManager->clear()->shouldBeCalledTimes(3);
 
         $output->writeln('<info>5 products to index</info>')->shouldBeCalled();
         $output->writeln('Indexing products 1 to 2')->shouldBeCalled();
@@ -107,7 +105,7 @@ class IndexProductCommandSpec extends ObjectBehavior
         $container,
         ProductRepositoryInterface $productRepository,
         BulkIndexerInterface $productIndexer,
-        BulkObjectDetacherInterface $productDetacher,
+        ObjectManager $objectManager,
         InputInterface $input,
         OutputInterface $output,
         Application $application,
@@ -117,12 +115,12 @@ class IndexProductCommandSpec extends ObjectBehavior
     ) {
         $container->get('pim_catalog.repository.product')->willReturn($productRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
-        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productDetacher);
+        $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
 
         $productRepository->findBy(['identifier' => ['product_identifier_to_index']])->willReturn([$productToIndex]);
 
         $productIndexer->indexAll([$productToIndex], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
-        $productDetacher->detachAll([$productToIndex])->shouldBeCalled();
+        $objectManager->clear()->shouldBeCalled();
 
         $output->writeln('<info>1 products found for indexing</info>')->shouldBeCalled();
         $output->writeln('<info>1 products indexed</info>')->shouldBeCalled();
@@ -155,7 +153,7 @@ class IndexProductCommandSpec extends ObjectBehavior
         $container,
         ProductRepositoryInterface $productRepository,
         BulkIndexerInterface $productIndexer,
-        BulkObjectDetacherInterface $productDetacher,
+        ObjectManager $objectManager,
         InputInterface $input,
         OutputInterface $output,
         Application $application,
@@ -166,12 +164,12 @@ class IndexProductCommandSpec extends ObjectBehavior
     ) {
         $container->get('pim_catalog.repository.product')->willReturn($productRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
-        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productDetacher);
+        $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
 
         $productRepository->findBy(['identifier' => ['product_1', 'product_2']])->willReturn([$product1, $product2]);
 
         $productIndexer->indexAll([$product1, $product2], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
-        $productDetacher->detachAll([$product1, $product2])->shouldBeCalled();
+        $objectManager->clear()->shouldBeCalled();
 
         $output->writeln('<info>2 products found for indexing</info>')->shouldBeCalled();
         $output->writeln('<info>2 products indexed</info>')->shouldBeCalled();
@@ -204,7 +202,7 @@ class IndexProductCommandSpec extends ObjectBehavior
         $container,
         ProductRepositoryInterface $productRepository,
         BulkIndexerInterface $productIndexer,
-        BulkObjectDetacherInterface $productDetacher,
+        ObjectManager $objectManager,
         InputInterface $input,
         OutputInterface $output,
         Application $application,
@@ -214,14 +212,14 @@ class IndexProductCommandSpec extends ObjectBehavior
     ) {
         $container->get('pim_catalog.repository.product')->willReturn($productRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
-        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productDetacher);
+        $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
 
         $productRepository->findBy(['identifier' => ['product_1', 'wrong_product']])->willReturn([$productToIndex]);
 
         $productToIndex->getIdentifier()->willReturn('product_1');
 
         $productIndexer->indexAll([$productToIndex], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
-        $productDetacher->detachAll([$productToIndex])->shouldBeCalled();
+        $objectManager->clear()->shouldBeCalled();
 
         $output->writeln('<error>Some products were not found for the given identifiers: wrong_product</error>')->shouldBeCalled();
         $output->writeln('<info>1 products found for indexing</info>')->shouldBeCalled();
@@ -255,7 +253,7 @@ class IndexProductCommandSpec extends ObjectBehavior
         $container,
         ProductRepositoryInterface $productRepository,
         BulkIndexerInterface $productIndexer,
-        BulkObjectDetacherInterface $productDetacher,
+        ObjectManager $objectManager,
         InputInterface $input,
         OutputInterface $output,
         Application $application,
@@ -264,7 +262,7 @@ class IndexProductCommandSpec extends ObjectBehavior
     ) {
         $container->get('pim_catalog.repository.product')->willReturn($productRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
-        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productDetacher);
+        $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
 
         $output->writeln('<error>Please specify a list of product identifiers to index or use the flag --all to index all products</error>')
             ->shouldBeCalled();

--- a/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductModelCommandSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Command/IndexProductModelCommandSpec.php
@@ -4,8 +4,8 @@ namespace spec\Pim\Bundle\CatalogBundle\Command;
 
 use Akeneo\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Bundle\ElasticsearchBundle\Client;
-use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
+use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
@@ -45,7 +45,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         ProductModelRepositoryInterface $productModelRepository,
         BulkIndexerInterface $productModelIndexer,
         BulkIndexerInterface $productModelDescendantsIndexer,
-        BulkObjectDetacherInterface $productModelDetacher,
+        ObjectManager $objectManager,
         InputInterface $input,
         OutputInterface $output,
         Application $application,
@@ -58,10 +58,10 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         ProductModelInterface $productModel5
     ) {
         $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
-        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productModelDetacher);
         $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
         $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
             ->willReturn($productModelDescendantsIndexer);
+        $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
 
         $productModelRepository->countRootProductModels()->willReturn(5);
         $productModelRepository->searchRootProductModelsAfter(null, 100)->willReturn([$productModel1, $productModel2]);
@@ -73,9 +73,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         $productModelIndexer->indexAll([$productModel3, $productModel4], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
         $productModelIndexer->indexAll([$productModel5], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
 
-        $productModelDetacher->detachAll([$productModel1, $productModel2])->shouldBeCalled();
-        $productModelDetacher->detachAll([$productModel3, $productModel4])->shouldBeCalled();
-        $productModelDetacher->detachAll([$productModel5])->shouldBeCalled();
+        $objectManager->clear()->shouldBeCalledTimes(3);
 
         $output->writeln('<info>5 product models to index</info>')->shouldBeCalled();
         $output->writeln('Indexing product models 1 to 2')->shouldBeCalled();
@@ -112,7 +110,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         ProductModelRepositoryInterface $productModelRepository,
         BulkIndexerInterface $productModelIndexer,
         BulkIndexerInterface $productModelDescendantsIndexer,
-        BulkObjectDetacherInterface $productModelDetacher,
+        ObjectManager $objectManager,
         InputInterface $input,
         OutputInterface $output,
         Application $application,
@@ -121,15 +119,15 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         ProductModelInterface $productModelToIndex
     ) {
         $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
-        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productModelDetacher);
         $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
         $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
             ->willReturn($productModelDescendantsIndexer);
+        $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
 
         $productModelRepository->findBy(['code' => ['product_model_code_to_index']])->willReturn([$productModelToIndex]);
 
         $productModelIndexer->indexAll([$productModelToIndex], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
-        $productModelDetacher->detachAll([$productModelToIndex])->shouldBeCalled();
+        $objectManager->clear()->shouldBeCalled();
 
         $output->writeln('<info>1 product models found for indexing</info>')->shouldBeCalled();
         $output->writeln('<info>1 product models indexed</info>')->shouldBeCalled();
@@ -164,7 +162,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         ProductModelRepositoryInterface $productModelRepository,
         BulkIndexerInterface $productModelIndexer,
         BulkIndexerInterface $productModelDescendantsIndexer,
-        BulkObjectDetacherInterface $productModelDetacher,
+        ObjectManager $objectManager,
         InputInterface $input,
         OutputInterface $output,
         Application $application,
@@ -174,10 +172,10 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         ProductModelInterface $productModel2
     ) {
         $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
-        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productModelDetacher);
         $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
         $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
             ->willReturn($productModelDescendantsIndexer);
+        $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
 
         $productModelRepository->findBy(['code' => ['product_model_1', 'product_model_2']])
             ->willReturn([$productModel1, $productModel2]);
@@ -186,7 +184,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         $productModel2->getCode()->willReturn('product_model_2');
 
         $productModelIndexer->indexAll([$productModel1, $productModel2], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
-        $productModelDetacher->detachAll([$productModel1, $productModel2])->shouldBeCalled();
+        $objectManager->clear()->shouldBeCalled();
 
         $output->writeln('<info>2 product models found for indexing</info>')->shouldBeCalled();
         $output->writeln('<info>2 product models indexed</info>')->shouldBeCalled();
@@ -221,7 +219,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         ProductModelRepositoryInterface $productModelRepository,
         BulkIndexerInterface $productModelIndexer,
         BulkIndexerInterface $productModelDescendantsIndexer,
-        BulkObjectDetacherInterface $productModelDetacher,
+        ObjectManager $objectManager,
         InputInterface $input,
         OutputInterface $output,
         Application $application,
@@ -231,10 +229,10 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         ProductModelInterface $productModel2
     ) {
         $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
-        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productModelDetacher);
         $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
         $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
             ->willReturn($productModelDescendantsIndexer);
+        $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
 
         $productModelRepository->findBy(['code' => ['product_model_1', 'product_model_2', 'wrong_product_model']])
             ->willReturn([$productModel1, $productModel2]);
@@ -243,7 +241,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         $productModel2->getCode()->willReturn('product_model_2');
 
         $productModelIndexer->indexAll([$productModel1, $productModel2], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
-        $productModelDetacher->detachAll([$productModel1, $productModel2])->shouldBeCalled();
+        $objectManager->clear()->shouldBeCalled();
 
         $output->writeln('<error>Some product models were not found for the given codes: wrong_product_model</error>')->shouldBeCalled();
         $output->writeln('<info>2 product models found for indexing</info>')->shouldBeCalled();
@@ -279,7 +277,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         ProductModelRepositoryInterface $productModelRepository,
         BulkIndexerInterface $productModelIndexer,
         BulkIndexerInterface $productModelDescendantsIndexer,
-        BulkObjectDetacherInterface $productModelDetacher,
+        ObjectManager $objectManager,
         InputInterface $input,
         OutputInterface $output,
         Application $application,
@@ -287,10 +285,10 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         InputDefinition $definition
     ) {
         $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
-        $container->get('akeneo_storage_utils.doctrine.object_detacher')->willReturn($productModelDetacher);
         $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
         $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
             ->willReturn($productModelDescendantsIndexer);
+        $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
 
         $output->writeln('<error>Please specify a list of product model codes to index or use the flag --all to index all product models</error>')
             ->shouldBeCalled();

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/FamilyNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/FamilyNormalizer.php
@@ -3,6 +3,7 @@
 namespace Pim\Component\Catalog\Normalizer\Indexing;
 
 use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\Product\ProductNormalizer;
 use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
 use Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
@@ -24,6 +25,9 @@ class FamilyNormalizer implements NormalizerInterface
     /** @var LocaleRepositoryInterface */
     protected $localeRepository;
 
+    /** @var LocaleInterface[] */
+    protected $activatedLocales;
+
     /**
      * @param NormalizerInterface       $translationNormalizer
      * @param LocaleRepositoryInterface $localeRepository
@@ -41,8 +45,12 @@ class FamilyNormalizer implements NormalizerInterface
      */
     public function normalize($object, $format = null, array $context = [])
     {
+        if (null === $this->activatedLocales) {
+            $this->activatedLocales = $this->localeRepository->getActivatedLocaleCodes();
+        }
+
         $context = array_merge($context, [
-            'locales' => $this->localeRepository->getActivatedLocaleCodes(),
+            'locales' => $this->activatedLocales,
         ]);
 
         return [


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This is the last obvious batch of perf optimization for products indexing. The next step could be to totally short circuit Doctrine and object hydration by working with arrays, but that would only provides a performance increase about to 2x, maybe 3x top.

This is not bad, but that would the cost in maintainability would be quite high (no objects, very different way of manipulating data compared to the rest of the program, etc...). 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | WIP
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

