### PR TITLE
Delete cache on acl between integration tests of the API

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -90,6 +90,9 @@ abstract class ApiTestCase extends WebTestCase
         $client = static::createClient($options, $server);
         $client->setServerParameter('HTTP_AUTHORIZATION', 'Bearer '.$accessToken);
 
+        $aclManager = $this->get('oro_security.acl.manager');
+        $aclManager->clearCache();
+
         if (!isset($server['CONTENT_TYPE'])) {
             $client->setServerParameter('CONTENT_TYPE', 'application/json');
         }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix the CI failing since 9 days.
A cache on ACL is responsible of this error. This cache is kept between the tests.
When you are loading different catalogs, it can fail, because the ACL are not the same for the users.

This cache stores user and associated role. So, it's a cache on data (probably a problem for horizontal scalability..).


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
