### PR TITLE
PIM-6567: Fix VariantAttributeSet setters (axis, attributes)

### DIFF
--- a/features/export/export_family_variants.feature
+++ b/features/export/export_family_variants.feature
@@ -17,7 +17,7 @@ Feature: Export family variants in CSV
     And exported file of "csv_catalog_modeling_family_variant_export" should contain:
       """
       code;family;label-de_DE;label-en_US;label-fr_FR;variant-axes_1;variant-axes_2;variant-attributes_1;variant-attributes_2
-      clothing_color_size;clothing;"Kleidung nach Farbe und Größe";"Clothing by color and size";"Vêtements par couleur et taille";color;size;variation_name,variation_image,composition,color,material;sku,weight,size,ean
+      clothing_color_size;clothing;"Kleidung nach Farbe und Größe";"Clothing by color and size";"Vêtements par couleur et taille";color;size;variation_name,variation_image,composition,material;sku,weight,ean
       shoes_size;shoes;"Schuhe nach Größe";"Shoes by size";"Chaussures par taille";eu_shoes_size;;sku,weight,size,ean;
       clothing_colorsize;clothing;"Kleidung nach Farbe/Größe";"Clothing by color/size";"Vêtements par couleur/taille";color,size;;sku,variation_name,variation_image,composition,ean;
       clothing_size;clothing;"Kleidung nach Größe";"Clothing by size";"Vêtements par taille";size;;sku,weight,size,ean;

--- a/features/import/family_variant/csv/create_family_variant.feature
+++ b/features/import/family_variant/csv/create_family_variant.feature
@@ -20,8 +20,8 @@ Feature: Create variants of family through CSV import
     And I launch the import job
     And I wait for the "csv_catalog_modeling_family_variant_import" job to finish
     Then there should be the following family variants:
-      | code                        | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                         | variant-attributes_2 |
-      | another_clothing_color_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color          | size           | color,name,image,variation_image,composition | size,ean,sku,weight  |
+      | code                        | family   | label-de_DE                   | label-en_US                | label-fr_FR                     | variant-axes_1 | variant-axes_2 | variant-attributes_1                   | variant-attributes_2 |
+      | another_clothing_color_size | clothing | Kleidung nach Farbe und Größe | Clothing by color and size | Vêtements par couleur et taille | color          | size           | name,image,variation_image,composition | ean,sku,weight       |
 
   Scenario: I successfully import a variant by size with one level of variation for the family shoes
     Given the following CSV file to import:

--- a/src/Pim/Component/Catalog/Model/VariantAttributeSet.php
+++ b/src/Pim/Component/Catalog/Model/VariantAttributeSet.php
@@ -51,7 +51,11 @@ class VariantAttributeSet implements VariantAttributeSetInterface
      */
     public function hasAttribute(AttributeInterface $attribute): bool
     {
-        return $this->attributes->contains($attribute);
+        $attributeCodes = $this->attributes->map(function (AttributeInterface $attribute) {
+            return $attribute->getCode();
+        })->toArray();
+
+        return in_array($attribute->getCode(), $attributeCodes, true);
     }
 
     /**
@@ -69,14 +73,14 @@ class VariantAttributeSet implements VariantAttributeSetInterface
      */
     public function setAttributes(array $attributes): void
     {
-        $attributesWithoutAxis = [];
+        $attributesWithoutAxes = [];
         foreach ($attributes as $attribute) {
-            if (!$this->axes->contains($attributes)) {
-                $attributesWithoutAxis[] = $attribute;
+            if (!$this->isAxis($attribute)) {
+                $attributesWithoutAxes[] = $attribute;
             }
         }
 
-        $this->attributes = new ArrayCollection($attributesWithoutAxis);
+        $this->attributes = new ArrayCollection($attributesWithoutAxes);
     }
 
     /**
@@ -93,10 +97,10 @@ class VariantAttributeSet implements VariantAttributeSetInterface
     public function setAxes(array $axes): void
     {
         foreach ($axes as $axis) {
-            if (!$this->axes->contains($axis)) {
+            if (!$this->isAxis($axis)) {
                 $this->axes->add($axis);
             }
-            if ($this->attributes->contains($axis)) {
+            if ($this->hasAttribute($axis)) {
                 $this->attributes->removeElement($axis);
             }
         }
@@ -131,5 +135,21 @@ class VariantAttributeSet implements VariantAttributeSetInterface
         }
 
         return $labels;
+    }
+
+    /**
+     * Checks whether an attribute is defined as Axis
+     *
+     * @param AttributeInterface $attribute
+     *
+     * @return bool
+     */
+    private function isAxis(AttributeInterface $attribute): bool
+    {
+        $axesCodes = $this->axes->map(function (AttributeInterface $attribute) {
+            return $attribute->getCode();
+        })->toArray();
+
+        return in_array($attribute->getCode(), $axesCodes, true);
     }
 }

--- a/src/Pim/Component/Catalog/Model/VariantAttributeSet.php
+++ b/src/Pim/Component/Catalog/Model/VariantAttributeSet.php
@@ -69,7 +69,14 @@ class VariantAttributeSet implements VariantAttributeSetInterface
      */
     public function setAttributes(array $attributes): void
     {
-        $this->attributes = new ArrayCollection($attributes);
+        $attributesWithoutAxis = [];
+        foreach ($attributes as $attribute) {
+            if (!$this->axes->contains($attributes)) {
+                $attributesWithoutAxis[] = $attribute;
+            }
+        }
+
+        $this->attributes = new ArrayCollection($attributesWithoutAxis);
     }
 
     /**
@@ -89,8 +96,8 @@ class VariantAttributeSet implements VariantAttributeSetInterface
             if (!$this->axes->contains($axis)) {
                 $this->axes->add($axis);
             }
-            if (!$this->attributes->contains($axis)) {
-                $this->attributes->add($axis);
+            if ($this->attributes->contains($axis)) {
+                $this->attributes->removeElement($axis);
             }
         }
     }

--- a/src/Pim/Component/Catalog/spec/Model/VariantAttributeSetSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/VariantAttributeSetSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Model;
 
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\VariantAttributeSet;
 use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
 use PhpSpec\ObjectBehavior;
@@ -16,5 +17,81 @@ class VariantAttributeSetSpec extends ObjectBehavior
     function it_is_a_family_variant()
     {
         $this->shouldImplement(VariantAttributeSetInterface::class);
+    }
+
+    function it_cannot_set_the_same_attribute_multiple_times(
+        AttributeInterface $attribute1,
+        AttributeInterface $attribute2
+    ) {
+        $this->setAttributes([$attribute1, $attribute2]);
+        $this->setAttributes([$attribute1, $attribute2]);
+
+        $attributes = $this->getAttributes();
+        $attributes->count()->shouldReturn(2);
+        $attributes->contains($attribute1)->shouldReturn(true);
+        $attributes->contains($attribute2)->shouldReturn(true);
+    }
+
+    function it_cannot_set_the_same_axis_multiple_times(
+        AttributeInterface $attribute1,
+        AttributeInterface $attribute2
+    ) {
+        $this->setAxes([$attribute1, $attribute2]);
+        $this->setAxes([$attribute1, $attribute2]);
+
+        $axis = $this->getAxes();
+        $axis->count()->shouldReturn(2);
+        $axis->contains($attribute1)->shouldReturn(true);
+        $axis->contains($attribute2)->shouldReturn(true);
+    }
+
+    function it_sets_axes_with_no_attributes(
+        AttributeInterface $attribute1,
+        AttributeInterface $attribute2,
+        AttributeInterface $attribute3
+    ) {
+        $this->setAxes([$attribute1, $attribute2, $attribute3]);
+        $axes = $this->getAxes();
+        $axes->count()->shouldReturn(3);
+        $axes->contains($attribute1)->shouldReturn(true);
+        $axes->contains($attribute2)->shouldReturn(true);
+        $axes->contains($attribute3)->shouldReturn(true);
+    }
+
+    function it_removes_attributes_used_as_axis_from_the_attribute_list(
+        AttributeInterface $attribute1,
+        AttributeInterface $attribute2,
+        AttributeInterface $attribute3
+    ) {
+        $this->setAttributes([$attribute1, $attribute2, $attribute3]);
+
+        $this->setAxes([$attribute1, $attribute2]);
+        $axes = $this->getAxes();
+        $axes->count()->shouldReturn(2);
+        $axes->contains($attribute1)->shouldReturn(true);
+        $axes->contains($attribute2)->shouldReturn(true);
+        $axes->contains($attribute3)->shouldReturn(false);
+
+        $attributes = $this->getAttributes();
+        $attributes->count()->shouldReturn(1);
+        $attributes->contains($attribute1)->shouldReturn(false);
+        $attributes->contains($attribute2)->shouldReturn(false);
+        $attributes->contains($attribute3)->shouldReturn(true);
+    }
+
+    function it_returns_the_label_of_the_axis_with_given_locale_code(
+        AttributeInterface $attribute1,
+        AttributeInterface $attribute2
+    ) {
+        $attribute1->setLocale('en_US')->shouldBeCalled();
+        $attribute1->getLabel()->willReturn('Attribute 1 label');
+        $attribute2->setLocale('en_US')->shouldBeCalled();
+        $attribute2->getLabel()->willReturn('Attribute 2 label');
+
+        $this->setAxes([$attribute1, $attribute2]);
+        $this->getAxesLabels('en_US')->shouldReturn([
+            'Attribute 1 label',
+            'Attribute 2 label'
+        ]);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

    Before:
    Whenever you would set an attribute as an axis within a
    VariantAttributeSet you could also put it as attribute within this same
    VariantAttributeSet.

    The appearance of the axis within this list was implicit and optionnal.

    Problem:
    This was a in regarding the import/export formats regarding the
    variant-attributes column as sometimes the axis would figure in the list
    of attributes and sometimes it won't depending on how it would have been
    saved.

    Fix:
    When setting an axis, we check if it exists in the attributes list if
    it's case we remove it.
    When setting an attribute, we check if it is not in the axes list, if it
    is we do not add it to the attribute list.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
