### PR TITLE
API-216: add application/x-www-form-urlencoded as allowed Content-Typ…

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -4,6 +4,7 @@
 
 - PIM-6904: Product Grid - Horizontal scrollbar should be at the bottom of the screen instead to be at the end of the grid
 - PIM-6960: fix association type deletion when it's the first item of the list
+- API-216: add application/x-www-form-urlencoded as allowed Content-Type when getting a token with the API
 
 # 1.7.12 (2017-10-25)
 

--- a/src/Pim/Bundle/ApiBundle/Resources/config/api.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/api.yml
@@ -9,5 +9,6 @@ pim_api:
         rules:
             - { path: '^/api/rest/v\d+/media-files', methods: ['POST'], content_types:['multipart/form-data']}
             - { path: '^/api/rest/v\d+/(products|families|categories|attributes)$', methods: ['PATCH'], content_types:['application/vnd.akeneo.collection+json'] }
+            - { path: '^/api/oauth/v\d+/token', content_types:['application/json', 'application/x-www-form-urlencoded'] }
             - { path: '^/api', content_types:['application/json'] }
             - { path: '', stop: true }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/RefreshTokenIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Token/RefreshTokenIntegration.php
@@ -47,6 +47,46 @@ class RefreshTokenIntegration extends ApiTestCase
         $this->assertArrayHasKey('refresh_token', $responseBody);
     }
 
+    public function testRefreshTokenWithFormUrlEncodedContentType()
+    {
+        list($clientId, $secret) = $this->createOAuthClient();
+        list($accessToken, $refreshToken) = $this->authenticate($clientId, $secret, self::USERNAME, self::PASSWORD);
+
+        $client = $this->createAuthenticatedClient(
+            [],
+            [],
+            $clientId,
+            $secret,
+            self::USERNAME,
+            self::PASSWORD,
+            $accessToken,
+            $refreshToken
+        );
+
+        $client->request('POST', 'api/oauth/v1/token',
+            [
+                'grant_type'    => 'refresh_token',
+                'refresh_token' => $refreshToken,
+            ],
+            [],
+            [
+                'PHP_AUTH_USER' => $clientId,
+                'PHP_AUTH_PW'   => $secret,
+                'CONTENT_TYPE'  => 'application/x-www-form-urlencoded',
+            ]
+        );
+
+        $response = $client->getResponse();
+        $responseBody = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertArrayHasKey('access_token', $responseBody);
+        $this->assertArrayHasKey('expires_in', $responseBody);
+        $this->assertArrayHasKey('token_type', $responseBody);
+        $this->assertArrayHasKey('scope', $responseBody);
+        $this->assertArrayHasKey('refresh_token', $responseBody);
+    }
+
     public function testMissingRefreshToken()
     {
         list($clientId, $secret) = $this->createOAuthClient();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The standard way to authenticate with Oauth 2.0 is the with the Content-Type application/x-www-form-urlencoded, not application/json.
Source : https://tools.ietf.org/html/rfc6749#section-2.3.1
Actually, it's important to support that because a lot of librairies use `application/x-www-form-urlencoded` and usage `application/json` implies some customisation on the client side.

We decided to fix it as a bug.


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
