### PR TITLE
PIM-6838: Reorder completeness tab in PEF

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Improvements
 
 - IM-825: allow concurrent AJAX requests by closing the session in a listener
+- PIM-6838: Display completeness panel after Attributes in the PEF
 
 # 2.0.6 (2017-11-03)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -198,12 +198,18 @@ extensions:
             tabTitle: pim_enrich.form.product.tab.attributes.title
             deletionFailed: pim_enrich.form.product.flash.attribute_deletion_error
 
+    pim-product-edit-form-completeness:
+        module: pim/product-edit-form/completeness
+        parent: pim-product-edit-form-column-tabs
+        targetZone: container
+        position: 100
+
     pim-product-edit-form-categories:
         module: pim/product-edit-form/categories
         parent: pim-product-edit-form-column-tabs
         targetZone: container
         aclResourceId: pim_enrich_product_categories_view
-        position: 100
+        position: 120
         config:
             itemCategoryListRoute: pim_enrich_product_listcategories
             itemCategoryTreeRoute: pim_enrich_product_category_rest_list
@@ -213,7 +219,7 @@ extensions:
         parent: pim-product-edit-form-column-tabs
         targetZone: container
         aclResourceId: pim_enrich_associations_view
-        position: 110
+        position: 130
 
     pim-product-edit-form-attribute-group-selector:
         module: pim/form/common/attributes/attribute-group-selector
@@ -295,25 +301,19 @@ extensions:
         targetZone: self
         position: 90
 
-    pim-product-edit-form-completeness:
-        module: pim/product-edit-form/completeness
-        parent: pim-product-edit-form-column-tabs
-        targetZone: container
-        position: 120
-
     pim-product-edit-form-comments:
         module: pim/product-edit-form/comments
         parent: pim-product-edit-form-column-tabs
         targetZone: container
         aclResourceId: pim_enrich_product_comment
-        position: 130
+        position: 140
 
     pim-product-edit-form-history:
         module: pim/product-edit-form/history
         parent: pim-product-edit-form-column-tabs
         targetZone: container
         aclResourceId: pim_enrich_product_history
-        position: 140
+        position: 150
 
     pim-product-edit-form-copy-scope-switcher:
         module: pim/product-edit-form/scope-switcher


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR moves the 'Completeness' tab link in the product edit form under 'Attributes'

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
