### PR TITLE
PIM-6967: Allow category panels to be resized

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,7 @@
 - IM-825: allow concurrent AJAX requests by closing the session in a listener
 - PIM-6838: Display completeness panel after Attributes in the PEF
 - PIM-6891: On the grid, execute the ES query only once, not twice
+- PIM-6967: Allow category panels to be resized
 
 # 2.0.6 (2017-11-03)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -893,6 +893,7 @@ config:
         pim/menu/tab:                                        pimenrich/js/menu/tab
         pim/menu/item:                                       pimenrich/js/menu/item
         pim/menu/navigation-block:                           pimenrich/js/menu/navigation-block
+        pim/menu/resizable:                                  pimenrich/js/menu/resizable
         pim/menu/user-navigation:                            pimenrich/js/menu/user-navigation
         pim/menu/logo:                                       pimenrich/js/menu/logo
         pim/menu/column:                                     pimenrich/js/menu/column

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/simple-view.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/simple-view.js
@@ -75,7 +75,11 @@ define([
          */
         toggleThirdColumn() {
             const thirdColumn = this.$el.find('.AknDefault-thirdColumnContainer');
+            const thirdColumnContent = this.$el.find('.AknDefault-thirdColumn');
+            const width = thirdColumnContent.outerWidth() || 300;
+
             if (null !== thirdColumn) {
+                thirdColumn.css({marginLeft: -width, marginRight: width });
                 thirdColumn.toggleClass('AknDefault-thirdColumnContainer--open');
             }
         }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/resizable.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/resizable.js
@@ -1,0 +1,72 @@
+/**
+ * Adds behavior to allow a div to be resized
+ * Stores and restores the resized width
+ *
+ * @author    Tamara Robichet <tamara.robichet@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(['jquery'], function($) {
+    const Resizable = {
+        options: {
+            maxWidth: null,
+            minWidth: null,
+            container: null,
+            storageKey: null
+        },
+
+        /**
+         * Set the div with the provided container as resizable
+         * with jQuery UI.
+         *
+         * @param {Object} options
+         */
+        set(options = {}) {
+            this.options = Object.assign(this.options, options);
+
+            const { maxWidth, minWidth, container } = this.options;
+
+            if (null === container) {
+                throw new Error('You must specify the container');
+            }
+
+            $(container).resizable({
+                maxWidth,
+                minWidth,
+                handles: 'e',
+                create: this.restoreWidth.bind(this),
+                stop: this.storeWidth.bind(this)
+            });
+        },
+
+        /**
+         * Destroy the resizable and handler events
+         */
+        destroy() {
+            $(this.options.container).resizable('destroy');
+        },
+
+        /**
+         * Store the last resized width of the element in localStorage
+         * @param  {jQuery.Event} event The jQuery event when the resize dragging stops
+         * @param  {Object} ui The object containing the data for the div
+         */
+        storeWidth(event, ui) {
+            const { minWidth, storageKey } = this.options;
+            const containerWidth = ui.size.width || minWidth;
+            localStorage.setItem(`resizable-${storageKey}`, containerWidth);
+        },
+
+        /**
+         * Get the stored width from localStorage and set it on the div.
+         * If there is no previously stored width, use the minWidth
+         */
+        restoreWidth() {
+            const { storageKey, container, minWidth } = this.options;
+            const width = localStorage.getItem(`resizable-${storageKey}`);
+            $(container).outerWidth(width || minWidth);
+        }
+    };
+
+    return Resizable;
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/resizable.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/resizable.js
@@ -7,7 +7,13 @@
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 define(['jquery'], function($) {
-    const Resizable = {
+    return {
+        /**
+         * @property {Number} maxWidth The maximum width of the panel in pixels
+         * @property {Number} minWidth The minimum width of the panel in pixels
+         * @property {String|HTMLElement} container A selector or element that will be resizable
+         * @property {String} storageKey The name of the localStorage key to store the width
+         */
         options: {
             maxWidth: null,
             minWidth: null,
@@ -27,7 +33,7 @@ define(['jquery'], function($) {
             const { maxWidth, minWidth, container } = this.options;
 
             if (null === container) {
-                throw new Error('You must specify the container');
+                throw new Error('You must specify the container as an element or CSS selector');
             }
 
             $(container).resizable({
@@ -43,13 +49,18 @@ define(['jquery'], function($) {
          * Destroy the resizable and handler events
          */
         destroy() {
-            $(this.options.container).resizable('destroy');
+            const container = $(this.options.container);
+            const resizableInstance = container.resizable('instance');
+
+            if (undefined !== resizableInstance) {
+                container.resizable('destroy');
+            }
         },
 
         /**
          * Store the last resized width of the element in localStorage
          * @param  {jQuery.Event} event The jQuery event when the resize dragging stops
-         * @param  {Object} ui The object containing the data for the div
+         * @param  {Object} ui The data for the resizable element
          */
         storeWidth(event, ui) {
             const { minWidth, storageKey } = this.options;
@@ -67,6 +78,4 @@ define(['jquery'], function($) {
             $(container).outerWidth(width || minWidth);
         }
     };
-
-    return Resizable;
 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
@@ -11,14 +11,16 @@ define(
         'underscore',
         'oro/translator',
         'pim/form',
-        'pim/template/product/grid/category-switcher'
+        'pim/template/product/grid/category-switcher',
+        'pim/menu/resizable'
     ],
     function(
         $,
         _,
         __,
         BaseForm,
-        template
+        template,
+        Resizable
     ) {
         return BaseForm.extend({
             template: _.template(template),
@@ -45,11 +47,6 @@ define(
              * {@inheritdoc}
              */
             render() {
-                $('.AknDefault-thirdColumn').addClass('AknDefault-thirdColumn--resizable').resizable({
-                    maxWidth: 500,
-                    minWidth: 300
-                });
-
                 this.$el.html(this.template({
                     label: __('pim_enrich.entity.product.category'),
                     isOpen: this.isOpen,
@@ -60,8 +57,11 @@ define(
                 this.renderExtensions();
             },
 
+            /**
+             * {@inheritdoc}
+             */
             shutdown() {
-                $('.AknDefault-thirdColumn').removeClass('AknDefault-thirdColumn--resizable').resizable('destroy');
+                Resizable.destroy();
 
                 return BaseForm.prototype.shutdown.apply(this, arguments);
             },
@@ -70,14 +70,21 @@ define(
              * Toggle the thrid column
              */
             toggleThirdColumn() {
+                Resizable.set({
+                    maxWidth: 500,
+                    minWidth: 300,
+                    container: '.AknDefault-thirdColumn',
+                    storageKey: 'category-switcher'
+                });
+
                 this.getRoot().trigger('grid:third_column:toggle');
 
                 if (!this.isOpen) {
                     this.outsideEventListener = this.outsideClickListener.bind(this);
                     document.addEventListener('mousedown', this.outsideEventListener);
                 }
-                this.isOpen = !this.isOpen;
 
+                this.isOpen = !this.isOpen;
                 this.render();
             },
 
@@ -88,6 +95,7 @@ define(
              */
             outsideClickListener(event) {
                 if (this.isOpen && !$(event.target).closest('.AknDefault-thirdColumn').length) {
+                    Resizable.destroy();
                     this.toggleThirdColumn();
                     document.removeEventListener('mousedown', this.outsideEventListener);
                 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
@@ -45,6 +45,11 @@ define(
              * {@inheritdoc}
              */
             render() {
+                $('.AknDefault-thirdColumn').addClass('AknDefault-thirdColumn--resizable').resizable({
+                    maxWidth: 500,
+                    minWidth: 300
+                });
+
                 this.$el.html(this.template({
                     label: __('pim_enrich.entity.product.category'),
                     isOpen: this.isOpen,
@@ -53,6 +58,12 @@ define(
                 }));
 
                 this.renderExtensions();
+            },
+
+            shutdown() {
+                $('.AknDefault-thirdColumn').removeClass('AknDefault-thirdColumn--resizable').resizable('destroy');
+
+                return BaseForm.prototype.shutdown.apply(this, arguments);
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/CategoryTree/form.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/CategoryTree/form.html.twig
@@ -73,8 +73,9 @@
 
     {# This style is temporary and will be dropped on PEFization of this screen #}
     <div id="category-tree-container" style="display:flex; height:100%">
-        <div id="tree" {% if form.vars.value.id %} data-node-id="{{ form.vars.value.id }}"{% elseif form.vars.value.parent %} data-node-id="{{ form.vars.value.parent.id }}"{% endif %}{% if resource_granted(acl ~ '_category_edit') %} data-editable="true"{% endif %}{% if resource_granted(acl ~ '_category_create') %} data-creatable="true"{% endif %}></div>
-
+        <div class="ui-resizable-container">
+          <div id="tree" {% if form.vars.value.id %} data-node-id="{{ form.vars.value.id }}"{% elseif form.vars.value.parent %} data-node-id="{{ form.vars.value.parent.id }}"{% endif %}{% if resource_granted(acl ~ '_category_edit') %} data-editable="true"{% endif %}{% if resource_granted(acl ~ '_category_create') %} data-creatable="true"{% endif %}></div>
+        </div>
         <div class="AknTabContainer" style="flex-grow:1; padding: 0 0 0 20px;">
             {{ elements.form_navbar(view_element_aliases(form.vars.id ~ '.form_tab')) }}
             <div class="AknTabContainer-content tab-content">
@@ -88,4 +89,15 @@
 
 <script type="text/javascript">
     window.flashMessages = JSON.parse('{{ app.session.flashbag.all|json_encode()|raw }}');
+
+    require(['pim/menu/resizable'], function(Resizable) {
+        $(function() {
+            Resizable.set({
+                minWidth: 300,
+                maxWidth: 500,
+                container: '.ui-resizable-container',
+                storageKey: 'category-tree-edit'
+            })
+        });
+    });
 </script>

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/CategoryTree/index.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/CategoryTree/index.html.twig
@@ -6,7 +6,9 @@
     {{ elements.page_header({ title: title }) }}
 
     <div id="category-tree-container" style="display:flex; height:100%">
-        <div id="tree" {% if resource_granted(acl ~ '_category_edit') %} data-editable="true"{% endif %}{% if resource_granted(acl ~ '_category_create') %} data-creatable="true"{% endif %}></div>
+        <div class="ui-resizable-container">
+            <div id="tree" {% if resource_granted(acl ~ '_category_edit') %} data-editable="true"{% endif %}{% if resource_granted(acl ~ '_category_create') %} data-creatable="true"{% endif %}></div>
+        </div>
 
         <div id="category-form" style="flex-grow:1" class="AknDefault-mainContent">
             <div class="AknInfoBlock">
@@ -31,19 +33,19 @@
 
 <script>
     window.flashMessages = JSON.parse('{{ app.session.flashbag.all|json_encode()|raw }}');
-</script>
 
-<script>
     require(
         [
             'pim/common/breadcrumbs',
             'pim/fetcher-registry',
-            'pim/form-builder'
+            'pim/form-builder',
+            'pim/menu/resizable'
         ],
         function(
             Breadcrumbs,
             FetcherRegistry,
-            FormBuilder
+            FormBuilder,
+            Resizable
         ) {
             $(function() {
                 var breadcrumbs = new Breadcrumbs({
@@ -62,6 +64,13 @@
                         $('.user-menu').append(form.el);
                         form.render();
                     }.bind(this));
+                });
+
+                Resizable.set({
+                    minWidth: 300,
+                    maxWidth: 500,
+                    container: '.ui-resizable-container',
+                    storageKey: 'category-tree-edit'
                 });
             });
         }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
@@ -34,6 +34,18 @@
     &--gray {
       background: #F6F7FB; // TODO FIND COLOR
     }
+
+    &--resizable {
+      position: relative;
+
+      .ui-resizable-e {
+        height: ~"calc(100% + 2px)";
+        top: -1px;
+        right: -8px;
+        border: 1px @AknBorderColor solid;
+        border-left: 0;
+      }
+    }
   }
 
   &-columnHeader {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
@@ -32,19 +32,7 @@
     }
 
     &--gray {
-      background: #F6F7FB; // TODO FIND COLOR
-    }
-
-    &--resizable {
-      position: relative;
-
-      .ui-resizable-e {
-        height: ~"calc(100% + 2px)";
-        top: -1px;
-        right: -8px;
-        border: 1px @AknBorderColor solid;
-        border-left: 0;
-      }
+      background: @AknLightGray;
     }
   }
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery-ui.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery-ui.less
@@ -17,3 +17,32 @@
   color: @AknLightPurple;
   border-bottom: 3px solid @AknLightPurple;
 }
+
+.ui-resizable-e {
+  &:hover {
+    cursor: ew-resize;
+  }
+
+  position: absolute;
+  width: 7px;
+  border-left: 1px @AknBorderColor solid;
+  height: 100%;
+  top: 0;
+  display: block;
+  right: 0;
+
+  &:after {
+    display: block;
+    content: '...';
+    width: 100%;
+    font-size: 17px;
+    top: 50%;
+    position: absolute;
+    word-break: break-word;
+    line-height: 5px;
+    color: @AknGrey;
+    height: 24px;
+    margin-top: -24px;
+    text-align: center;
+  }
+}

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery-ui.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery-ui.less
@@ -31,6 +31,10 @@
   display: block;
   right: 0;
 
+  // Firefox
+  word-break: break-all;
+  word-break: break-word;
+
   &:after {
     display: block;
     content: '...';
@@ -38,7 +42,6 @@
     font-size: 17px;
     top: 50%;
     position: absolute;
-    word-break: break-word;
     line-height: 5px;
     color: @AknGrey;
     height: 24px;
@@ -46,3 +49,26 @@
     text-align: center;
   }
 }
+
+.ui-resizable-container {
+    position: relative;
+
+    .ui-resizable-e {
+        border-left: 0;
+        border-right: 1px @AknBorderColor solid;
+        right: -10px;
+    }
+
+    &--column {
+        position: relative;
+
+        .ui-resizable-e {
+            height: ~"calc(100% + 2px)";
+            top: -1px;
+            right: -8px;
+            border: 1px @AknBorderColor solid;
+            border-left: 0;
+        }
+    }
+}
+

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
@@ -71,9 +71,11 @@
     margin-right: @AknThirdColumnWidth;
     transition: margin 0.3s ease-in-out;
 
+    // !important is added because these values are
+    // set with jQuery (to support dynamic panel widths)
     &--open {
-      margin-left: 0;
-      margin-right: 0;
+      margin-left: 0 !important;
+      margin-right: 0 !important;
     }
   }
 
@@ -85,21 +87,6 @@
     z-index: 801;
     border-right: 1px solid @AknBorderColor;
     padding: 20px;
-
-    .ui-resizable-e{
-      &:hover {
-        cursor: e-resize;
-      }
-
-      z-index: 90;
-      position: absolute;
-      width: 14px;
-      border-left: 1px @AknBorderColor solid;
-      height: 100%;
-      top: 0;
-      display: block;
-      right: -6px;
-    }
   }
 
   &-thirdColumnButton {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
@@ -71,8 +71,8 @@
     margin-right: @AknThirdColumnWidth;
     transition: margin 0.3s ease-in-out;
 
-    // !important is added because these values are
-    // set with jQuery (to support dynamic panel widths)
+    // Added !important to fix the animation
+    // since the margin values are set with jQuery
     &--open {
       margin-left: 0 !important;
       margin-right: 0 !important;

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
@@ -85,6 +85,21 @@
     z-index: 801;
     border-right: 1px solid @AknBorderColor;
     padding: 20px;
+
+    .ui-resizable-e{
+      &:hover {
+        cursor: e-resize;
+      }
+
+      z-index: 90;
+      position: absolute;
+      width: 14px;
+      border-left: 1px @AknBorderColor solid;
+      height: 100%;
+      top: 0;
+      display: block;
+      right: -6px;
+    }
   }
 
   &-thirdColumnButton {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR updates the category panels so that they can be resized. The resized width is saved in localStorage and restored when the panel is loaded. 

The panels that were updated: 

Asset picker (in the EE PR https://github.com/akeneo/pim-enterprise-dev/pull/3276)
![asset-picker](https://user-images.githubusercontent.com/1336344/32550309-e3baca66-c48c-11e7-8b6b-d88eff94be32.png)

Product category filter
![product-categories](https://user-images.githubusercontent.com/1336344/32550317-ea339698-c48c-11e7-9391-14fc2d592dc3.png)

Categories index (and asset categories in EE)
![categories-index](https://user-images.githubusercontent.com/1336344/32550326-efebec34-c48c-11e7-8e4c-cd000a34359a.png)

Categories edit (and asset categories in EE)
![categories-edit](https://user-images.githubusercontent.com/1336344/32550335-f639c2a0-c48c-11e7-87a3-a66bece3ff11.png)



<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
