### PR TITLE
PIM-6891 Count only when object have been loaded, not before

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - IM-825: allow concurrent AJAX requests by closing the session in a listener
 - PIM-6838: Display completeness panel after Attributes in the PEF
+- PIM-6891: On the grid, execute the ES query only once, not twice
 
 # 2.0.6 (2017-11-03)
 

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ProductDatasource.php
@@ -56,12 +56,13 @@ class ProductDatasource extends Datasource
             'association_type_id' => $this->getConfiguration('association_type_id', false),
             'current_group_id'    => $this->getConfiguration('current_group_id', false),
         ];
-        $rows = ['totalRecords' => $entitiesWithValues->count(), 'data' => []];
+        $rows = ['data' => []];
 
         foreach ($entitiesWithValues as $entityWithValue) {
             $normalizedItem = $this->normalizeEntityWithValues($entityWithValue, $context);
             $rows['data'][] = new ResultRecord($normalizedItem);
         }
+        $rows['totalRecords'] = $entitiesWithValues->count();
 
         return $rows;
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When data have not yet been loaded on the cursor, a count() call executes the ES query and load the objects.

But the foreach calls rewind() on the same cursor, triggering another load of the exact same data, with the exact same query.
By putting the count() after the foreach() the data are loaded in the cursor, and the count() really counts loaded data and don't trigger any data loading.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | WIP
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -


`OK`: Done / Validated
`-`: Not needed
