### PR TITLE
Improve common fields to be able to use property paths as field names

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/property.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/property.js
@@ -14,9 +14,9 @@ define([], function () {
          *
          * @param {object} data
          * @param {string} path
-         * @param {mixed}  defaultValue
+         * @param {*}  defaultValue
          *
-         * @return {mixed}
+         * @return {*}
          */
         accessProperty: function (data, path, defaultValue) {
             defaultValue = defaultValue || null;
@@ -36,9 +36,9 @@ define([], function () {
          *
          * @param {object} data
          * @param {string} path
-         * @param {mixed}  value
+         * @param {*}  value
          *
-         * @return {mixed}
+         * @return {*}
          */
         updateProperty: function (data, path, value) {
             var pathPart = path.split('.');

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/boolean.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/boolean.js
@@ -34,7 +34,7 @@ function (
          * {@inheritdoc}
          */
         renderInput: function (templateContext) {
-            if (!_.has(this.getFormData(), this.fieldName) && _.has(this.config, 'defaultValue')) {
+            if (undefined === this.getModelValue() && _.has(this.config, 'defaultValue')) {
                 this.updateModel(this.config.defaultValue);
             }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/select.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/select.js
@@ -33,7 +33,7 @@ function (
          * {@inheritdoc}
          */
         renderInput: function (templateContext) {
-            if (!_.has(this.getFormData(), this.fieldName) && _.has(this.config, 'defaultValue')) {
+            if (undefined === this.getModelValue() && _.has(this.config, 'defaultValue')) {
                 this.updateModel(this.config.defaultValue);
             }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/values/boolean.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/values/boolean.js
@@ -15,14 +15,14 @@ define([
          * {@inheritdoc}
          */
         updateModel(value) {
-            ValuesBehavior.writeValue.call(this, value);
+            ValuesBehavior.writeValue.call(this, BaseField, value);
         },
 
         /**
          * {@inheritdoc}
          */
         getModelValue() {
-            return ValuesBehavior.readValue.call(this);
+            return ValuesBehavior.readValue.call(this, BaseField);
         }
     });
 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/values/metric.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/values/metric.js
@@ -15,14 +15,14 @@ define([
          * {@inheritdoc}
          */
         updateModel(value) {
-            ValuesBehavior.writeValue.call(this, value);
+            ValuesBehavior.writeValue.call(this, BaseField, value);
         },
 
         /**
          * {@inheritdoc}
          */
         getModelValue() {
-            return ValuesBehavior.readValue.call(this);
+            return ValuesBehavior.readValue.call(this, BaseField);
         }
     });
 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/values/simple-select-async.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/values/simple-select-async.js
@@ -15,14 +15,14 @@ define([
          * {@inheritdoc}
          */
         updateModel(value) {
-            ValuesBehavior.writeValue.call(this, value);
+            ValuesBehavior.writeValue.call(this, BaseField, value);
         },
 
         /**
          * {@inheritdoc}
          */
         getModelValue() {
-            return ValuesBehavior.readValue.call(this);
+            return ValuesBehavior.readValue.call(this, BaseField);
         }
     });
 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/values/text.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/values/text.js
@@ -15,14 +15,14 @@ define([
          * {@inheritdoc}
          */
         updateModel(value) {
-            ValuesBehavior.writeValue.call(this, value);
+            ValuesBehavior.writeValue.call(this, BaseField, value);
         },
 
         /**
          * {@inheritdoc}
          */
         getModelValue() {
-            return ValuesBehavior.readValue.call(this);
+            return ValuesBehavior.readValue.call(this, BaseField);
         }
     });
 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/values/values-behavior.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/values/values-behavior.js
@@ -13,21 +13,26 @@
 define([], () => {
     return {
         /**
-         * {@inheritdoc}
+         * Formats the value according to the standard format then store it by calling the original field's method.
+         *
+         * @param {Object} BaseField
+         * @param {*} value
          */
-        writeValue(value) {
-            const values = this.getFormData().values;
-            values[this.fieldName] = [{scope: null, locale: null, data: value}];
-            this.setData({values: values});
+        writeValue(BaseField, value) {
+            BaseField.prototype.updateModel.call(this, [{scope: null, locale: null, data: value}]);
         },
 
         /**
-         * {@inheritdoc}
+         * Read a standard formatted value and returns its data.
+         *
+         * @param {Object} BaseField
+         *
+         * @returns {*}
          */
-        readValue() {
-            const standardValues = this.getFormData().values[this.fieldName];
+        readValue(BaseField) {
+            const standardValues = BaseField.prototype.getModelValue.call(this);
 
-            return undefined === standardValues ? standardValues : standardValues[0].data;
+            return undefined === standardValues ? undefined : standardValues[0].data;
         }
     };
 });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/add-child/fields-container.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/add-child/fields-container.js
@@ -174,7 +174,7 @@ define(
                     .then((formMeta) => {
                         const newFormMeta = $.extend(true, {}, formMeta);
                         newFormMeta.code += `-${attribute.code}`;
-                        newFormMeta.config.fieldName = attribute.code;
+                        newFormMeta.config.fieldName = `values.${attribute.code}`;
                         newFormMeta.config.label = i18n.getLabel(
                             attribute.labels,
                             UserContext.get('uiLocale'),

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute/tab/properties/group.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute/tab/properties/group.html
@@ -1,5 +1,5 @@
 <select
-    id="pim_enrich_form_<%- fieldId %>_<%- fieldName %>"
+    id="pim_enrich_form_<%- fieldId %>"
     class="select2"
     name="<%- fieldName %>"
     data-placeholder="<%- labels.defaultLabel %>"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/boolean.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/boolean.html
@@ -1,6 +1,6 @@
 <div class="switch switch-small" data-on-label="<%- labels.on %>" data-off-label="<%- labels.off %>">
     <input
-        id="pim_enrich_form_<%- fieldId %>_<%- fieldName %>"
+        id="pim_enrich_form_<%- fieldId %>"
         type="checkbox"
         name="<%- fieldName %>"
         <% if (value) { %> checked<% } %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/date.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/date.html
@@ -1,6 +1,6 @@
 <span class="date-wrapper">
     <input
-        id="pim_enrich_form_<%- fieldId %>_<%- fieldName %>"
+        id="pim_enrich_form_<%- fieldId %>"
         class="AknTextField add-on value"
         type="text"
         name="<%- fieldName %>"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/field.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/field.html
@@ -1,5 +1,5 @@
 <div class="AknFieldContainer-header">
-    <label class="AknFieldContainer-label control-label" for="pim_enrich_form_<%- fieldId %>_<%- fieldName %>">
+    <label class="AknFieldContainer-label control-label" for="pim_enrich_form_<%- fieldId %>">
         <%- fieldLabel %><% if (required) { %> <em><%- requiredLabel %></em><% } %>
     </label>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/select.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/select.html
@@ -1,5 +1,5 @@
 <select
-    id="pim_enrich_form_<%- fieldId %>_<%- fieldName %>"
+    id="pim_enrich_form_<%- fieldId %>"
     class="select2"
     name="<%- fieldName %>"
     data-placeholder="<%- labels.defaultLabel %>"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/simple-select-async.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/simple-select-async.html
@@ -1,5 +1,5 @@
 <input
-    id="pim_enrich_form_<%- fieldId %>_<%- fieldName %>"
+    id="pim_enrich_form_<%- fieldId %>"
     type="hidden"
     class="select2 select-field"
     name="<%- fieldName %>"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/text.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/text.html
@@ -1,5 +1,5 @@
 <input
-    id="pim_enrich_form_<%- fieldId %>_<%- fieldName %>"
+    id="pim_enrich_form_<%- fieldId %>"
     class="AknTextField"
     type="text"
     name="<%- fieldName %>"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/textarea.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/textarea.html
@@ -1,5 +1,5 @@
 <textarea
-    id="pim_enrich_form_<%- fieldId %>_<%- fieldName %>"
+    id="pim_enrich_form_<%- fieldId %>"
     class="AknTextareaField"
     name="<%- fieldName %>"
     <% if (readOnly) { %>readonly disabled<% } %>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Until now when you used common fields it was possible to configure it like this :
```
my-code-field:
    ...
    config:
        fieldName: code
        label: pim_enrich.form.someform.label.code

my-name-field:
    ...
    config:
        fieldName: name
        label: pim_enrich.form.someform.label.name
```
The `fieldName` was used as a key to store the value in the root model.
The drawback was that all your values would be at the same level :
```
{
    code: 'michel',
    name: 'Michel',
    ...
}
```

This PR aims at adding some flexibility, for example you can now do :
```
my-code-field:
    ...
    config:
        fieldName: code
        label: pim_enrich.form.someform.label.code

my-name-field:
    ...
    config:
        fieldName: values.name
        label: pim_enrich.form.someform.label.name
```
then your root model will look like this :
```
{
    code: 'michel',
    values: [
        name: 'Michel'
    ]
    ...
}
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
