### PR TITLE
[SLA] PIM-6995: sweets in the object detacher

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.X
+
+## Bug Fixes
+
+- PIM-6995: fix memory leak in the MongoDB product association import (it bypasses a Doctrine bug about the detach method).
+
 # 1.7.13 (2017-11-09)
 
 ## Bug Fixes

--- a/src/Akeneo/Bundle/StorageUtilsBundle/spec/Doctrine/Common/Detacher/ObjectDetacherSpec.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/spec/Doctrine/Common/Detacher/ObjectDetacherSpec.php
@@ -3,7 +3,6 @@
 namespace spec\Akeneo\Bundle\StorageUtilsBundle\Doctrine\Common\Detacher;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
@@ -54,19 +53,5 @@ class ObjectDetacherSpec extends ObjectBehavior
         $manager->detach($object2)->shouldBeCalled();
 
         $this->detachAll($objects);
-    }
-
-    function it_detaches_an_object_from_document_manager(
-        $registry,
-        DocumentManager $manager,
-        ClassMetadata $classMetadata
-    ) {
-        $object = new \stdClass();
-        $registry->getManagerForClass('stdClass')->willReturn($manager);
-        $manager->getClassMetadata('stdClass')->willReturn($classMetadata);
-
-        $manager->detach($object)->shouldBeCalled();
-
-        $this->detach($object);
     }
 }


### PR DESCRIPTION
We have a customer that imports 200K products with a CSV file in MongoDB. And the step "association import" leaks badly. The import crashes telling all memory has been consumed.

Imports have not changed that much since 1.6. So how is it possible we have a memory leak on the product import? We should have seen it before.
- It happens only with MongoDB
- When there is no associations, the association step is very fast. And even if it leaks, we usually don't have time to observe it.
- The leak increases slowly, which means, unless you don't import many many products (like 50K+), you won't pay attention to it.

The fix here bypasses a Doctrine bug about the detach. It removes unnecessary objects from the private variables of the unit of work. So such kind of dirty tricks? Because in a 1.7 patch, we don't do BC breaks ;)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | arghhh, this shit is not specable...
| Added Behats                      | 
| Added integration tests           | 
| Changelog updated                 | Y
| Review and 2 GTM                  | I'll need 2 people that sell their soul to the devil
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -
