### PR TITLE
PIM-6992: Keep category panel open

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -15,6 +15,7 @@
 - PIM-6585: Add help center link in menu
 - PIM-6833: Aligns technical requirements with documentation
 - PIM-6992: Keep category panel open
+- PIM-6986: Change the image in add variant modal
 
 # 2.0.6 (2017-11-03)
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -14,6 +14,7 @@
 - PIM-6460: Preventing from deleting attributes used as axis from the family and remove the deleted attributes from the family variants.
 - PIM-6585: Add help center link in menu
 - PIM-6833: Aligns technical requirements with documentation
+- PIM-6992: Keep category panel open
 
 # 2.0.6 (2017-11-03)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-manager.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-manager.js
@@ -410,10 +410,19 @@ define(
          * like the other columns.
          */
         _updateDropdownPosition: function () {
-            const mainPanelLeft = $('.AknDefault-mainContent').position().left;
-
             this.selectWidget.getWidget().css({ left: this._getLeftStartPosition() + 'px' });
             this.selectWidget.getWidget().css({ left: this._getLeftEndPosition() + 'px' });
+        },
+
+        /**
+         * Get the width of the main column and the header
+         * @return {number}
+         */
+        _getOffsetWidth() {
+            const headerWidth = $('.AknHeader').width();
+            const mainColumnWidth = $('.AknDefault-contentWithColumn .AknColumn').width();
+
+            return headerWidth + mainColumnWidth;
         },
 
         /**
@@ -422,7 +431,7 @@ define(
          * @returns {number}
          */
         _getLeftStartPosition() {
-            return $('.AknDefault-mainContent').position().left - 300;
+            return this._getOffsetWidth() - 300;
         },
 
         /**
@@ -431,7 +440,7 @@ define(
          * @returns {number}
          */
         _getLeftEndPosition() {
-            return $('.AknDefault-mainContent').position().left;
+            return this._getOffsetWidth();
         }
 
     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/edit.yml
@@ -242,7 +242,7 @@ extensions:
         config:
             fieldName: auto_option_sorting
             label: pim_enrich.form.attribute.tab.properties.label.auto_option_sorting
-            defaultValue: false
+            defaultValue: null
 
     pim-attribute-edit-form-choices-options-grid:
         module: pim/attribute-edit-form/choices/options-grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/simple-view.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/simple-view.js
@@ -79,7 +79,7 @@ define([
             const width = thirdColumnContent.outerWidth() || 300;
 
             if (null !== thirdColumn) {
-                thirdColumn.css({marginLeft: -width, marginRight: width });
+                thirdColumn.css({marginLeft: -width});
                 thirdColumn.toggleClass('AknDefault-thirdColumnContainer--open');
             }
         }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/add-child.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/add-child.js
@@ -29,8 +29,21 @@ define(
              * {@inheritdoc}
              */
             render() {
-                this.$el.html(this.template());
+                const illustrationClass = this.getIllustrationClass();
+                this.$el.html(this.template({ illustrationClass }));
                 this.renderExtensions();
+            },
+
+            /**
+             * Get the correct illustration class for products or product models
+             *
+             * @return {String}
+             */
+            getIllustrationClass() {
+                const formData = this.getFormData();
+                const hasFamilyVariant = formData.hasOwnProperty('family_variant');
+
+                return hasFamilyVariant ? 'product-model' : 'products';
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
@@ -94,7 +94,10 @@ define(
              * @param {Event} event
              */
             outsideClickListener(event) {
-                if (this.isOpen && !$(event.target).closest('.AknDefault-thirdColumn').length) {
+                const isOpen = $('.AknDefault-thirdColumnContainer--open').length > 0;
+                const clickedFilter = $(event.target).closest('.AknFilterBox-addFilterButton').length > 0;
+
+                if (isOpen && clickedFilter) {
                     Resizable.destroy();
                     this.toggleThirdColumn();
                     document.removeEventListener('mousedown', this.outsideEventListener);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product_model/add-child-form.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product_model/add-child-form.html
@@ -1,7 +1,7 @@
 <div class="AknFullPage AknFullPage--modal">
     <div class="AknFullPage-content">
         <div class="AknFullPage-left">
-            <img src="bundles/pimui/images/illustrations/Product-model.svg" class="AknFullPage-image">
+            <div class="AknFullPage-image AknFullPage-illustration AknFullPage-illustration--<%- illustrationClass %>"></div>
         </div>
         <div class="AknFullPage-right">
             <div data-drop-zone="header"></div>

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -36,6 +36,7 @@
     padding: 10px 0 1px 0;
     margin: -10px 0 10px 0;
     top: 0px;
+    z-index: 1;
   }
 
   &--sticky:not(:empty) {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
@@ -11,6 +11,7 @@
     background: lighten(@AknGrey, 30%);
     border-bottom: 1px solid @AknBorderColor;
     padding: 10px;
+    margin: 0;
   }
 
   &-list {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
@@ -65,35 +65,32 @@
   }
 
   &-thirdColumnContainer {
-    width: 0;
     order: -5;
     margin-left: -@AknThirdColumnWidth;
-    margin-right: @AknThirdColumnWidth;
+    position: relative;
     transition: margin 0.3s ease-in-out;
 
     // Added !important to fix the animation
     // since the margin values are set with jQuery
     &--open {
       margin-left: 0 !important;
-      margin-right: 0 !important;
     }
   }
 
   &-thirdColumn {
-    width: @AknThirdColumnWidth;
-    position: fixed;
     height: 100vh;
     background: white;
     z-index: 801;
     border-right: 1px solid @AknBorderColor;
     padding: 20px;
+    margin: 0;
+    width: 300px;
   }
 
   &-thirdColumnButton {
     border-top: 1px solid @AknBorderColor;
-    position: absolute;
     bottom: 100px;
-    width: ~"calc(100% - 40px)";
+    width: 100%;
     text-align: center;
     padding: 20px 0;
   }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/pages/FullPage.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/pages/FullPage.less
@@ -122,6 +122,10 @@
         background-image: url('../../images/illustrations/Product.svg');
     }
 
+    &--product-model {
+      background-image: url('../../images/illustrations/Product-model.svg');
+    }
+
     &--delete {
         background-image: url('../../images/illustrations/Delete.svg');
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR updates the product grid to always keep the category panel open (even when the main column is collapsed). We also remove the outside click except for the filter button.

Before
![before](https://user-images.githubusercontent.com/1336344/32732911-36015bc8-c88e-11e7-8eb1-ae9e8ac2f599.png)

After
![after-2](https://user-images.githubusercontent.com/1336344/32732928-41322d10-c88e-11e7-83e0-58635472d22c.png)

![after-1](https://user-images.githubusercontent.com/1336344/32732931-4404c502-c88e-11e7-8030-9f1b52999d9a.png)

This PR also includes PIM-6986 which is for switching the modal illustration for the add variant form based on the model type. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
