### PR TITLE
PIM-6959: scopable text attributes cannot be used as Label

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -11,6 +11,7 @@
 
 - PIM-6489: fix the sort of attributes in attribute groups
 - PIM-6997: fixes product model indexing CLI command slowness
+- PIM-6959: fix getting the product label according to the scope if needed
 
 ## Improvements
 

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductModelNormalizer.php
@@ -71,7 +71,7 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
         $data['values'] = $this->normalizeValues($productModel->getValues(), $format, $context);
         $data['created'] = $this->normalizer->normalize($productModel->getCreated(), $format, $context);
         $data['updated'] = $this->normalizer->normalize($productModel->getUpdated(), $format, $context);
-        $data['label'] = $productModel->getLabel($locale);
+        $data['label'] = $productModel->getLabel($locale, $channel);
         $data['image'] = $this->normalizeImage($closestImage, $format, $context);
 
         $data['groups'] = null;

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductNormalizer.php
@@ -45,6 +45,7 @@ class ProductNormalizer implements NormalizerInterface, NormalizerAwareInterface
         $context = array_merge(['filter_types' => ['pim.transform.product_value.structured']], $context);
         $data = [];
         $locale = current($context['locales']);
+        $scope = current($context['channels']);
 
         $data['identifier'] = $product->getIdentifier();
         $data['family'] = $this->getFamilyLabel($product, $locale);
@@ -53,7 +54,7 @@ class ProductNormalizer implements NormalizerInterface, NormalizerAwareInterface
         $data['values'] = $this->normalizeValues($product->getValues(), $format, $context);
         $data['created'] = $this->normalizer->normalize($product->getCreated(), $format, $context);
         $data['updated'] = $this->normalizer->normalize($product->getUpdated(), $format, $context);
-        $data['label'] = $product->getLabel($locale);
+        $data['label'] = $product->getLabel($locale, $scope);
         $data['image'] = $this->normalizeImage($product->getImage(), $format, $context);
         $data['completeness'] = $this->getCompleteness($product, $context);
         $data['document_type'] = IdEncoder::PRODUCT_TYPE;

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -110,7 +110,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productModel->getUpdated()->willReturn($updated);
         $normalizer->normalize($updated, 'datagrid', $context)->willReturn('2017-01-01T01:04:34+01:00');
 
-        $productModel->getLabel('en_US')->willReturn('Purple tshirt');
+        $productModel->getLabel('en_US', 'ecommerce')->willReturn('Purple tshirt');
 
         $imageAsLabel->value($productModel)->willReturn($image);
         $normalizer->normalize($image, Argument::any(), Argument::any())->willReturn([
@@ -216,7 +216,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productModel->getUpdated()->willReturn($updated);
         $normalizer->normalize($updated, 'datagrid', $context)->willReturn('2017-01-01T01:04:34+01:00');
 
-        $productModel->getLabel('en_US')->willReturn('Purple tshirt');
+        $productModel->getLabel('en_US', 'ecommerce')->willReturn('Purple tshirt');
 
         $imageAsLabel->value($productModel)->willReturn($image);
         $normalizer->normalize($image, Argument::any(), Argument::any())->willReturn([

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -101,7 +101,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $updated = new \DateTime('2017-01-01T01:04:34+01:00');
         $product->getUpdated()->willReturn($updated);
         $normalizer->normalize($updated, 'datagrid', $context)->willReturn('2017-01-01T01:04:34+01:00');
-        $product->getLabel('en_US')->willReturn('Purple tshirt');
+        $product->getLabel('en_US', 'ecommerce')->willReturn('Purple tshirt');
         $product->getCompletenesses()->willReturn([$completeness]);
         $product->getImage()->willReturn($image);
         $normalizer->normalize($image, Argument::any(), Argument::any())->willReturn([
@@ -201,7 +201,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $updated = new \DateTime('2017-01-01T01:04:34+01:00');
         $product->getUpdated()->willReturn($updated);
         $normalizer->normalize($updated, 'datagrid', $context)->willReturn('2017-01-01T01:04:34+01:00');
-        $product->getLabel('en_US')->willReturn('Purple tshirt');
+        $product->getLabel('en_US', 'ecommerce')->willReturn('Purple tshirt');
         $product->getCompletenesses()->willReturn([$completeness]);
         $product->getImage()->willReturn($image);
         $normalizer->normalize($image, Argument::any(), Argument::any())->willReturn([

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -162,6 +162,8 @@ class ProductModelNormalizer implements NormalizerInterface
         $variantProductCompletenesses = $this->variantProductRatioQuery->findComplete($productModel);
         $closestImage = $this->imageAsLabel->value($productModel);
 
+        $scopeCode = $context['channel'] ?? null;
+
         $normalizedProductModel['meta'] = [
                 'variant_product_completenesses' => $variantProductCompletenesses->values(),
                 'family_variant'            => $normalizedFamilyVariant,
@@ -177,7 +179,7 @@ class ProductModelNormalizer implements NormalizerInterface
                 'ascendant_category_ids'    => $this->ascendantCategoriesQuery->getCategoryIds($productModel),
                 'completenesses'            => $this->incompleteValuesNormalizer->normalize($productModel, $format, $context),
                 'level'                     => $productModel->getVariationLevel(),
-            ] + $this->getLabels($productModel);
+            ] + $this->getLabels($productModel, $scopeCode);
 
         return $normalizedProductModel;
     }
@@ -192,15 +194,16 @@ class ProductModelNormalizer implements NormalizerInterface
 
     /**
      * @param ProductModelInterface $productModel
+     * @param string|null           $scopeCode
      *
      * @return array
      */
-    private function getLabels(ProductModelInterface $productModel): array
+    private function getLabels(ProductModelInterface $productModel, string $scopeCode = null): array
     {
         $labels = [];
 
         foreach ($this->localeRepository->getActivatedLocaleCodes() as $localeCode) {
-            $labels[$localeCode] = $productModel->getLabel($localeCode);
+            $labels[$localeCode] = $productModel->getLabel($localeCode, $scopeCode);
         }
 
         return ['label' => $labels];

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -189,6 +189,8 @@ class ProductNormalizer implements NormalizerInterface
         $created = null !== $oldestLog ? $this->versionNormalizer->normalize($oldestLog, 'internal_api') : null;
         $updated = null !== $newestLog ? $this->versionNormalizer->normalize($newestLog, 'internal_api') : null;
 
+        $scopeCode = $context['channel'] ?? null;
+
         $normalizedProduct['meta'] = [
             'form'              => $this->formProvider->getForm($product),
             'id'                => $product->getId(),
@@ -198,7 +200,7 @@ class ProductNormalizer implements NormalizerInterface
             'structure_version' => $this->structureVersionProvider->getStructureVersion(),
             'completenesses'    => $this->getNormalizedCompletenesses($product),
             'image'             => $this->normalizeImage($product->getImage(), $format, $context),
-        ] + $this->getLabels($product) + $this->getAssociationMeta($product);
+        ] + $this->getLabels($product, $scopeCode) + $this->getAssociationMeta($product);
 
         // TODO Refactor this condition in 2.1 to remove default null parameter.
         $normalizedProduct['meta']['ascendant_category_ids'] =
@@ -221,15 +223,16 @@ class ProductNormalizer implements NormalizerInterface
 
     /**
      * @param ProductInterface $product
+     * @param string|null      $scopeCode
      *
      * @return array
      */
-    protected function getLabels(ProductInterface $product)
+    protected function getLabels(ProductInterface $product, string $scopeCode = null)
     {
         $labels = [];
 
         foreach ($this->localeRepository->getActivatedLocaleCodes() as $localeCode) {
-            $labels[$localeCode] = $product->getLabel($localeCode);
+            $labels[$localeCode] = $product->getLabel($localeCode, $scopeCode);
         }
 
         return ['label' => $labels];

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -91,6 +91,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $options = [
             'decimal_separator' => ',',
             'date_format'       => 'dd/MM/yyyy',
+            'channel'           => 'mobile',
         ];
 
         $productModelNormalized = [
@@ -146,8 +147,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $pictureAttribute->getCode()->willReturn('picture');
 
         $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
-        $productModel->getLabel('en_US')->willReturn('Tshirt blue');
-        $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
+        $productModel->getLabel('en_US', 'mobile')->willReturn('Tshirt blue');
+        $productModel->getLabel('fr_FR', 'mobile')->willReturn('Tshirt bleu');
 
         $imageAsLabel->value($productModel)->willReturn($picture);
         $picture->getData()->willReturn('IMAGE_DATA');
@@ -243,6 +244,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $options = [
             'decimal_separator' => ',',
             'date_format'       => 'dd/MM/yyyy',
+            'channel'           => 'mobile',
         ];
 
         $productModelNormalized = [
@@ -286,8 +288,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $pictureAttribute->getCode()->willReturn('picture');
 
         $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
-        $productModel->getLabel('en_US')->willReturn('Tshirt blue');
-        $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
+        $productModel->getLabel('en_US', 'mobile')->willReturn('Tshirt blue');
+        $productModel->getLabel('fr_FR', 'mobile')->willReturn('Tshirt bleu');
 
         $imageAsLabel->value($productModel)->willReturn(null);
         $fileNormalizer->normalize(Argument::cetera())->shouldNotBeCalled();
@@ -383,6 +385,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $options = [
             'decimal_separator' => ',',
             'date_format'       => 'dd/MM/yyyy',
+            'channel'           => 'mobile',
         ];
 
         $productModelNormalized = [
@@ -438,8 +441,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $pictureAttribute->getCode()->willReturn('picture');
 
         $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
-        $productModel->getLabel('en_US')->willReturn('Tshirt blue');
-        $productModel->getLabel('fr_FR')->willReturn('Tshirt bleu');
+        $productModel->getLabel('en_US', 'mobile')->willReturn('Tshirt blue');
+        $productModel->getLabel('fr_FR', 'mobile')->willReturn('Tshirt bleu');
 
         $imageAsLabel->value($productModel)->willReturn($picture);
         $picture->getData()->willReturn('IMAGE_DATA');

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -117,6 +117,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $options = [
             'decimal_separator' => ',',
             'date_format'       => 'dd/MM/yyyy',
+            'channel'           => 'mobile',
         ];
 
         $productNormalized = [
@@ -169,8 +170,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         $versionNormalizer->normalize('update_version', 'internal_api')->willReturn('normalized_update_version');
 
         $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
-        $mug->getLabel('en_US')->willReturn('A nice Mug!');
-        $mug->getLabel('fr_FR')->willReturn('Un très beau Mug !');
+        $mug->getLabel('en_US', 'mobile')->willReturn('A nice Mug!');
+        $mug->getLabel('fr_FR', 'mobile')->willReturn('Un très beau Mug !');
         $mug->getImage()->willReturn($image);
         $image->getData()->willReturn($dataImage);
         $fileNormalizer->normalize($dataImage, Argument::any(), Argument::any())->willReturn([
@@ -264,6 +265,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $options = [
             'decimal_separator' => ',',
             'date_format'       => 'dd/MM/yyyy',
+            'channel'           => 'mobile',
         ];
 
         $productNormalized = [
@@ -316,8 +318,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         $versionNormalizer->normalize('update_version', 'internal_api')->willReturn('normalized_update_version');
 
         $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
-        $mug->getLabel('en_US')->willReturn('A nice Mug!');
-        $mug->getLabel('fr_FR')->willReturn('Un très beau Mug !');
+        $mug->getLabel('en_US', 'mobile')->willReturn('A nice Mug!');
+        $mug->getLabel('fr_FR', 'mobile')->willReturn('Un très beau Mug !');
         $mug->getImage()->willReturn($image);
         $image->getData()->willReturn($dataImage);
         $fileNormalizer->normalize($dataImage, Argument::any(), Argument::any())->willReturn([

--- a/src/Pim/Bundle/UserBundle/Context/UserContext.php
+++ b/src/Pim/Bundle/UserBundle/Context/UserContext.php
@@ -287,7 +287,8 @@ class UserContext
         return [
             'locales'  => $locales,
             'channels' => $channels,
-            'locale'   => $this->getUiLocale()->getCode()
+            'locale'   => $this->getUiLocale()->getCode(),
+            'channel'  => $this->getUserChannelCode()
         ];
     }
 

--- a/src/Pim/Bundle/UserBundle/spec/Context/UserContextSpec.php
+++ b/src/Pim/Bundle/UserBundle/spec/Context/UserContextSpec.php
@@ -220,7 +220,8 @@ class UserContextSpec extends ObjectBehavior
         $this->toArray()->shouldReturn([
             'locales'  => ['en_US', 'fr_FR'],
             'channels' => ['mobile', 'ecommerce'],
-            'locale'   => 'fr_FR'
+            'locale'   => 'fr_FR',
+            'channel'  => 'mobile',
         ]);
     }
 }

--- a/src/Pim/Component/Catalog/Model/AbstractProduct.php
+++ b/src/Pim/Component/Catalog/Model/AbstractProduct.php
@@ -375,7 +375,7 @@ abstract class AbstractProduct implements ProductInterface
     /**
      * {@inheritdoc}
      */
-    public function getLabel($locale = null)
+    public function getLabel($locale = null, $scope = null)
     {
         $identifier = (string) $this->getIdentifier();
 
@@ -390,7 +390,8 @@ abstract class AbstractProduct implements ProductInterface
         }
 
         $locale = $attributeAsLabel->isLocalizable() ? $locale : null;
-        $value = $this->getValue($attributeAsLabel->getCode(), $locale);
+        $scope = $attributeAsLabel->isScopable() ? $scope : null;
+        $value = $this->getValue($attributeAsLabel->getCode(), $locale, $scope);
 
         if (null === $value) {
             return $identifier;

--- a/src/Pim/Component/Catalog/Model/ProductModel.php
+++ b/src/Pim/Component/Catalog/Model/ProductModel.php
@@ -490,7 +490,7 @@ class ProductModel implements ProductModelInterface
     /**
      * {@inheritdoc}
      */
-    public function getLabel(string $localeCode = null): string
+    public function getLabel(string $localeCode = null, string $scopeCode = null): string
     {
         $code = (string) $this->getCode();
         $familyVariant = $this->familyVariant;
@@ -506,7 +506,8 @@ class ProductModel implements ProductModelInterface
         }
 
         $localeCode = $attributeAsLabel->isLocalizable() ? $localeCode : null;
-        $value = $this->getValue($attributeAsLabel->getCode(), $localeCode);
+        $scopeCode = $attributeAsLabel->isScopable() ? $scopeCode : null;
+        $value = $this->getValue($attributeAsLabel->getCode(), $localeCode, $scopeCode);
 
         if (null === $value) {
             return $code;

--- a/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
@@ -90,7 +90,7 @@ class ProductModelSpec extends ObjectBehavior
         $this->getCategoryCodes()->shouldReturn(['foobar']);
     }
 
-    function it_gets_the_label_of_the_product_model(
+    function it_gets_the_label_regardless_of_the_specified_scope_if_the_attribute_as_label_is_not_scopable(
         FamilyVariantInterface $familyVariant,
         FamilyInterface $family,
         AttributeInterface $attributeAsLabel,
@@ -102,6 +102,7 @@ class ProductModelSpec extends ObjectBehavior
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
         $attributeAsLabel->isUnique()->willReturn(false);
+        $attributeAsLabel->isScopable()->willReturn(false);
 
         $values->toArray()->willreturn(['name-<all_channels>-fr_FR' => $nameValue]);
 
@@ -114,7 +115,44 @@ class ProductModelSpec extends ObjectBehavior
         $this->setValues($values);
         $this->setCode('shovel');
 
-        $this->getLabel('fr_FR')->shouldReturn('Petit outil agricole authentique');
+        $this->getLabel('fr_FR', 'mobile')->shouldReturn('Petit outil agricole authentique');
+    }
+
+    function it_gets_the_label_if_the_scope_is_specified_and_the_attribute_as_label_is_scopable(
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $mobileNameValue,
+        ValueInterface $ecommerceNameValue
+    ) {
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(true);
+        $attributeAsLabel->isUnique()->willReturn(false);
+        $attributeAsLabel->isScopable()->willReturn(true);
+
+        $values->toArray()->willreturn([
+            'name-ecommerce-fr_FR' => $ecommerceNameValue,
+            'name-mobile-fr_FR' => $mobileNameValue,
+        ]);
+
+        $mobileNameValue->getAttribute()->willReturn($attributeAsLabel);
+        $mobileNameValue->getScope()->willReturn('mobile');
+        $mobileNameValue->getLocale()->willReturn('fr_FR');
+        $mobileNameValue->getData()->willReturn('Petite pelle');
+
+        $ecommerceNameValue->getAttribute()->willReturn($attributeAsLabel);
+        $ecommerceNameValue->getScope()->willReturn('ecommerce');
+        $ecommerceNameValue->getLocale()->willReturn('fr_FR');
+        $ecommerceNameValue->getData()->willReturn('Petit outil agricole authentique');
+
+        $this->setFamilyVariant($familyVariant);
+        $this->setValues($values);
+        $this->setCode('shovel');
+
+        $this->getLabel('fr_FR', 'mobile')->shouldReturn('Petite pelle');
     }
 
     function it_gets_the_code_as_label_if_there_is_no_attribute_as_label(
@@ -142,6 +180,7 @@ class ProductModelSpec extends ObjectBehavior
         $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
+        $attributeAsLabel->isScopable()->willReturn(false);
 
         $values->toArray()->willreturn([]);
 
@@ -164,6 +203,7 @@ class ProductModelSpec extends ObjectBehavior
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
         $attributeAsLabel->isUnique()->willReturn(false);
+        $attributeAsLabel->isScopable()->willReturn(false);
 
         $values->toArray()->willreturn(['name-<all_channels>-fr_FR' => $nameValue]);
 
@@ -171,6 +211,43 @@ class ProductModelSpec extends ObjectBehavior
         $nameValue->getScope()->willReturn(null);
         $nameValue->getLocale()->willReturn('fr_FR');
         $nameValue->getData()->willReturn(null);
+
+        $this->setFamilyVariant($familyVariant);
+        $this->setValues($values);
+        $this->setCode('shovel');
+
+        $this->getLabel('fr_FR')->shouldReturn('shovel');
+    }
+
+    function it_gets_the_code_as_label_if_no_scope_is_specified_but_the_attribute_as_label_is_scopable(
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $mobileNameValue,
+        ValueInterface $ecommerceNameValue
+    ) {
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(true);
+        $attributeAsLabel->isUnique()->willReturn(false);
+        $attributeAsLabel->isScopable()->willReturn(true);
+
+        $values->toArray()->willreturn([
+            'name-ecommerce-fr_FR' => $ecommerceNameValue,
+            'name-mobile-fr_FR' => $mobileNameValue,
+        ]);
+
+        $mobileNameValue->getAttribute()->willReturn($attributeAsLabel);
+        $mobileNameValue->getScope()->willReturn('mobile');
+        $mobileNameValue->getLocale()->willReturn('fr_FR');
+        $mobileNameValue->getData()->willReturn('Petite pelle');
+
+        $ecommerceNameValue->getAttribute()->willReturn($attributeAsLabel);
+        $ecommerceNameValue->getScope()->willReturn('ecommerce');
+        $ecommerceNameValue->getLocale()->willReturn('fr_FR');
+        $ecommerceNameValue->getData()->willReturn('Petit outil agricole authentique');
 
         $this->setFamilyVariant($familyVariant);
         $this->setValues($values);
@@ -191,6 +268,7 @@ class ProductModelSpec extends ObjectBehavior
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(false);
         $attributeAsLabel->isUnique()->willReturn(false);
+        $attributeAsLabel->isScopable()->willReturn(false);
 
         $values->toArray()->willreturn(['name-<all_channels>-fr_FR' => $nameValue]);
 

--- a/src/Pim/Component/Catalog/spec/Model/ProductSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/ProductSpec.php
@@ -126,7 +126,7 @@ class ProductSpec extends ObjectBehavior
         $this->isAttributeRemovable($attribute)->shouldReturn(true);
     }
 
-    function it_gets_the_label_of_the_product(
+    function it_gets_the_label_of_the_product_without_specified_scope(
         FamilyInterface $family,
         AttributeInterface $attributeAsLabel,
         ValueCollectionInterface $values,
@@ -140,6 +140,7 @@ class ProductSpec extends ObjectBehavior
         $family->getId()->willReturn(42);
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
+        $attributeAsLabel->isScopable()->willReturn(true);
 
         $values->getByCodes('name', null, 'fr_FR')->willReturn($nameValue);
         $values->removeByAttribute($attributeAsLabel)->shouldBeCalled();
@@ -152,6 +153,65 @@ class ProductSpec extends ObjectBehavior
         $this->setIdentifier($identifier);
 
         $this->getLabel('fr_FR')->shouldReturn('Petit outil agricole authentique');
+    }
+
+    function it_gets_the_label_regardless_of_the_specified_scope_if_the_attribute_as_label_is_not_scopable(
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $nameValue,
+        ValueInterface $identifier
+    ) {
+        $identifier->getData()->willReturn('shovel');
+        $identifier->getAttribute()->willReturn($attributeAsLabel);
+
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $family->getId()->willReturn(42);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(true);
+        $attributeAsLabel->isScopable()->willReturn(false);
+
+        $values->getByCodes('name', null, 'fr_FR')->willReturn($nameValue);
+        $values->removeByAttribute($attributeAsLabel)->shouldBeCalled();
+        $values->add($identifier)->shouldBeCalled();
+
+        $nameValue->getData()->willReturn('Petit outil agricole authentique');
+
+        $this->setFamily($family);
+        $this->setValues($values);
+        $this->setIdentifier($identifier);
+
+        $this->getLabel('fr_FR', 'mobile')->shouldReturn('Petit outil agricole authentique');
+    }
+
+    function it_gets_the_label_if_the_scope_is_specified_and_the_attribute_as_label_is_scopable(
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values,
+        ValueInterface $nameValue,
+        ValueInterface $identifier
+    ) {
+        $identifier->getData()->willReturn('shovel');
+        $identifier->getAttribute()->willReturn($attributeAsLabel);
+
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $family->getId()->willReturn(42);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(true);
+        $attributeAsLabel->isScopable()->willReturn(true);
+
+        $values->getByCodes('name', 'mobile', 'fr_FR')->willReturn($nameValue);
+        $values->removeByAttribute($attributeAsLabel)->shouldBeCalled();
+        $values->add($identifier)->shouldBeCalled();
+
+        $nameValue->getData()->willReturn('Petite pelle');
+
+        $this->setFamily($family);
+        $this->setValues($values);
+        $this->setIdentifier($identifier);
+        $this->setScope('mobile');
+
+        $this->getLabel('fr_FR', 'mobile')->shouldReturn('Petite pelle');
     }
 
     function it_gets_the_identifier_as_label_if_there_is_no_family(
@@ -208,6 +268,7 @@ class ProductSpec extends ObjectBehavior
         $family->getId()->willReturn(42);
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
+        $attributeAsLabel->isScopable()->willReturn(false);
 
         $values->removeByAttribute($attributeAsLabel)->shouldBeCalled();
         $values->add($identifier)->shouldBeCalled();
@@ -234,6 +295,7 @@ class ProductSpec extends ObjectBehavior
         $family->getId()->willReturn(42);
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
+        $attributeAsLabel->isScopable()->willReturn(false);
 
         $values->getByCodes('name', null, 'fr_FR')->willReturn($nameValue);
         $values->removeByAttribute($attributeAsLabel)->shouldBeCalled();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since 2.0 if a "scopable" attribute is setted as label in a family, the product label displayed is still the identifier.

The goal of this PR is to fix this bug to have the same behavior that in 1.7. In a future patch the behavior of a "scopable" "attribute as label" will be changed to be identical to the locales.

Technically, the product normalizer of the EnrichBundle gets the label for each locale, but the scope is not used. 

Before 2.0 the scope was used in the method `getValue` in`Pim/Component/Catalog/Model/AbstractProduct.php`, but it was rewritten and there's no longer a default value (the property `scope` of this class)

The scope must be passed to `getValue` from `getLabel`, and to it from the normalizer. We could used again the property `scope`, but it doesn't exists in ProductModel and in the absolute it should not belong to any product entity.

It's why I added a second optional parameter to the method `getLabel` to set the scope, and I added the service `UserContext` to `ProductModelNormalizer` to retrieve the user default scope. To modify the signature of the method `getLabel` in the interfaces `ProductInterface` and `ProductModelInterface` would be a bc-break more annoying so it will be done in the master.

For the datagrid, it's not the user default scope that is used, but the scope of the request context.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
