### PR TITLE
POC: transform system test into acceptance test [DO NOT MERGE]

### DIFF
--- a/features/product/validation/validate_text_attributes.feature
+++ b/features/product/validation/validate_text_attributes.feature
@@ -47,19 +47,6 @@ Feature: Validate text attributes of a product
     Then I should see validation tooltip "This value is too long. It should have 8 characters or less."
     And there should be 1 error in the "Other" tab
 
-  Scenario: Validate the email validation rule constraint of text attribute
-    Given I change the Email to "foo"
-    And I save the product
-    Then I should see validation tooltip "This value is not a valid email address."
-    And there should be 1 error in the "Other" tab
-
-  Scenario: Validate the email validation rule constraint of scopable text attribute
-    Given I switch the scope to "ecommerce"
-    And I change the Recipient to "foo"
-    And I save the product
-    Then I should see validation tooltip "This value is not a valid email address."
-    And there should be 1 error in the "Other" tab
-
   Scenario: Validate the url validation rule constraint of text attribute
     Given I change the Link to "bar"
     And I save the product

--- a/src/Pim/Component/Catalog/tests/acceptance/Value/Validation/ValidateEmailValuesIntegration.php
+++ b/src/Pim/Component/Catalog/tests/acceptance/Value/Validation/ValidateEmailValuesIntegration.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pim\Component\Catalog\tests\acceptance\Value\Validation;
+
+use Akeneo\Test\Integration\Catalog\InMemoryAttributeRepository;
+use Pim\Component\Catalog\AttributeTypes;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ValidateEmailValuesIntegration extends KernelTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        static::bootKernel(['debug' => false]);
+
+        $attributeRepository = new InMemoryAttributeRepository();
+
+        static::$kernel->getContainer()->set('pim_catalog.saver.attribute', $attributeRepository);
+        static::$kernel->getContainer()->set('pim_catalog.repository.attribute', $attributeRepository);
+
+        $attributeFactory = static::$kernel->getContainer()->get('pim_catalog.factory.attribute');
+        $identifierAttribute = $attributeFactory->createAttribute(AttributeTypes::IDENTIFIER);
+        $identifierAttribute->setCode('sku');
+        $attributeRepository->save($identifierAttribute);
+    }
+
+    public function testAcceptCorrectEmailTextValue()
+    {
+        $productBuilder = static::$kernel->getContainer()->get('pim_catalog.builder.product');
+        $attributeFactory = static::$kernel->getContainer()->get('pim_catalog.factory.attribute');
+
+        $emailAttribute = $attributeFactory->createAttribute(AttributeTypes::TEXT);
+        $emailAttribute->setCode('email');
+        $emailAttribute->setValidationRule('email');
+
+        $product = $productBuilder->createProduct('new_product');
+        $productBuilder->addOrReplaceValue($product, $emailAttribute, null, null, 'michel@akeneo.com');
+
+        $errors = static::$kernel->getContainer()->get('pim_catalog.validator.product')->validate($product);
+        $this->assertEquals(0, $errors->count());
+    }
+
+    public function testRejectIncorrectEmailTextValue()
+    {
+        $productBuilder = static::$kernel->getContainer()->get('pim_catalog.builder.product');
+        $attributeFactory = static::$kernel->getContainer()->get('pim_catalog.factory.attribute');
+
+        $emailAttribute = $attributeFactory->createAttribute(AttributeTypes::TEXT);
+        $emailAttribute->setCode('email');
+        $emailAttribute->setValidationRule('email');
+
+        $product = $productBuilder->createProduct('new_product');
+        $productBuilder->addOrReplaceValue($product, $emailAttribute, null, null, 'not an email address');
+
+        $errors = static::$kernel->getContainer()->get('pim_catalog.validator.product')->validate($product);
+        $this->assertEquals(1, $errors->count());
+        $this->assertEquals('This value is not a valid email address.', $errors[0]->getMessage());
+    }
+}

--- a/tests/Catalog/InMemoryAttributeRepository.php
+++ b/tests/Catalog/InMemoryAttributeRepository.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Akeneo\Test\Integration\Catalog;
+
+use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Doctrine\ORM\QueryBuilder;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\AttributeGroupInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
+
+/**
+ *
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class InMemoryAttributeRepository implements
+    AttributeRepositoryInterface,
+    SaverInterface
+{
+    /** @var \ArrayObject */
+    private $attributes;
+
+    public function __construct()
+    {
+        $this->attributes = new \ArrayObject();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save($attribute, array $options = [])
+    {
+        $this->attributes->append($attribute);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier()
+    {
+        foreach($this->attributes as $attribute) {
+            if (AttributeTypes::IDENTIFIER === $attribute->getType()) {
+                return $attribute;
+            }
+        }
+
+        return null;
+    }
+
+    /*********************************
+     * NOT IMPLEMENTED YET
+     ********************************/
+
+    public function findAllInDefaultGroup()
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function findUniqueAttributeCodes()
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function findMediaAttributeCodes()
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function findAllAxesQB()
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function getAttributesAsArray($withLabel = false, $locale = null, array $ids = [])
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function getAttributeIdsUseableInGrid($codes = null, $groupIds = null)
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function getIdentifierCode()
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function getAttributeTypeByCodes(array $codes)
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function getAttributeCodesByType($type)
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function getAttributeCodesByGroup(AttributeGroupInterface $group)
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function findAttributesByFamily(FamilyInterface $family)
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function countAll()
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function findAvailableAxes($locale)
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function getIdentifierProperties()
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function findOneByIdentifier($identifier)
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function find($id)
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function findAll()
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function findOneBy(array $criteria)
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+
+    public function getClassName()
+    {
+        throw new \RuntimeException(__METHOD__.' not implemented.');
+    }
+}


### PR DESCRIPTION
Here's an attempt to transform what we can call a system test (end-to-end behat scenario) into an acceptance test (not sure if it's the correct term).

**What's the advantage of doing that ?**
- It's much, much faster : on my local machine, ~17 seconds for the system test, ~300 milliseconds for the acceptance test.
- It should be more stable on the CI.
- The test is focused on the interesting part, we don't test all the stack.

**What it tests**
The test calls our validator service, so it calls Symfony's validator component, and on our side it calls the `DelegatingClassMetadataFactory`, `ProductValueMetadataFactory`, `ChainedAttributeConstraintGuesser`, the specific constraint guessers and the constraint validators.

**What it doesn't test**
The UI is not needed here. We don't care about the controller neither : it mainly normalizes the constraint violations and it can be tested elsewhere.
I also tried to avoid calling the database since it shouldn't be needed when you validate an object. In this case it's only needed here by the ProductBuilder : https://github.com/akeneo/pim-community-dev/blob/2.0/src/Pim/Component/Catalog/Builder/ProductBuilder.php#L86
So I wrote a quick & dirty implementation of an in-memory repository for the attributes. And it works \o/

The fixtures loading and the redefinition of the attribute repository service are also "à l'arrache" (it's a POC remember ?)

**Remarks**
Just writing this test shows several interesting things about the code :
- We can't create a product object without calling the database.
- We have currently no way to validate a `ValueCollection`, it has to be part of a product or a product model.
- It's possible to create an attribute without code, it shouldn't be.