### PR TITLE
[PIM-6946] "Attribute as main picture" with assets

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -192,6 +192,8 @@ services:
 
     pim_catalog.validator.constraint.family_attribute_as_image:
         class: '%pim_catalog.validator.constraint.family_attribute_as_image.class%'
+        arguments:
+            - [ 'pim_catalog_image' ]
         tags:
             - { name: validator.constraint_validator, alias: pim_family_attribute_as_image_validator }
 

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/MediaNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/MediaNormalizer.php
@@ -45,8 +45,6 @@ class MediaNormalizer implements NormalizerInterface
      */
     public function supportsNormalization($data, $format = null)
     {
-        error_log('SUPPRPRPRPRR');
-
         return $data instanceof MediaValue && in_array($format, $this->supportedFormats);
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/MediaNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/MediaNormalizer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Normalizer;
+
+use Pim\Component\Catalog\Value\MediaValue;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * MediaNormalizer.php
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MediaNormalizer implements NormalizerInterface
+{
+    /** @var FileNormalizer */
+    protected $fileNormalizer;
+
+    /** @var string[] */
+    protected $supportedFormats = ['internal_api'];
+
+    /**
+     * @param FileNormalizer $fileNormalizer
+     */
+    public function __construct(FileNormalizer $fileNormalizer)
+    {
+        $this->fileNormalizer = $fileNormalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($value, $format = null, array $context = [])
+    {
+        if (null === $value->getData()) {
+            return null;
+        }
+
+        return $this->fileNormalizer->normalize($value->getData(), $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        error_log('SUPPRPRPRPRR');
+
+        return $data instanceof MediaValue && in_array($format, $this->supportedFormats);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -81,9 +81,6 @@ class ProductNormalizer implements NormalizerInterface
     /** @var CompletenessCalculatorInterface */
     private $completenessCalculator;
 
-    /** @var FileNormalizer */
-    protected $fileNormalizer;
-
     /** @var ProductBuilderInterface */
     protected $productBuilder;
 
@@ -115,7 +112,6 @@ class ProductNormalizer implements NormalizerInterface
      * @param NormalizerInterface                       $completenessCollectionNormalizer
      * @param UserContext                               $userContext
      * @param CompletenessCalculatorInterface           $completenessCalculator
-     * @param FileNormalizer                            $fileNormalizer
      * @param ProductBuilderInterface                   $productBuilder
      * @param EntityWithFamilyValuesFillerInterface     $productValuesFiller
      * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
@@ -138,7 +134,6 @@ class ProductNormalizer implements NormalizerInterface
         NormalizerInterface $completenessCollectionNormalizer,
         UserContext $userContext,
         CompletenessCalculatorInterface $completenessCalculator,
-        FileNormalizer $fileNormalizer,
         ProductBuilderInterface $productBuilder,
         EntityWithFamilyValuesFillerInterface $productValuesFiller,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
@@ -160,7 +155,6 @@ class ProductNormalizer implements NormalizerInterface
         $this->completenessCollectionNormalizer = $completenessCollectionNormalizer;
         $this->userContext                      = $userContext;
         $this->completenessCalculator           = $completenessCalculator;
-        $this->fileNormalizer                   = $fileNormalizer;
         $this->productBuilder                   = $productBuilder;
         $this->productValuesFiller              = $productValuesFiller;
         $this->attributesProvider               = $attributesProvider;
@@ -278,19 +272,19 @@ class ProductNormalizer implements NormalizerInterface
     }
 
     /**
-     * @param ValueInterface $data
+     * @param ValueInterface $value
      * @param string         $format
      * @param array          $context
      *
      * @return array|null
      */
-    protected function normalizeImage(?ValueInterface $data, $format, $context = [])
+    protected function normalizeImage(?ValueInterface $value, $format, $context = [])
     {
-        if (null === $data || null === $data->getData()) {
+        if (null === $value || null === $value->getData()) {
             return null;
         }
 
-        return $this->fileNormalizer->normalize($data->getData(), $format, $context);
+        return $this->normalizer->normalize($value, $format, $context);
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
@@ -127,6 +127,7 @@ extensions:
             label: 'pim_enrich.form.family.tab.properties.attribute_as_image'
             emptyLabel: 'pim_enrich.form.family.tab.properties.empty_attribute_as_image'
             fieldBaseId: 'pim_enrich_family_form_label_'
+            validAttributeTypes: [ 'pim_catalog_image' ]
 
     pim-family-edit-form-properties-translation-section:
         module: pim/common/simple-view

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -19,6 +19,7 @@ parameters:
     pim_enrich.normalizer.channel.class:                           Pim\Bundle\EnrichBundle\Normalizer\ChannelNormalizer
     pim_enrich.normalizer.group.class:                             Pim\Bundle\EnrichBundle\Normalizer\GroupNormalizer
     pim_enrich.normalizer.file.class:                              Pim\Bundle\EnrichBundle\Normalizer\FileNormalizer
+    pim_enrich.normalizer.media.class:                             Pim\Bundle\EnrichBundle\Normalizer\MediaNormalizer
     pim_enrich.normalizer.product_violation.class:                 Pim\Bundle\EnrichBundle\Normalizer\ProductViolationNormalizer
     pim_enrich.normalizer.group_violation.class:                   Pim\Bundle\EnrichBundle\Normalizer\GroupViolationNormalizer
     pim_enrich.normalizer.violation.class:                         Pim\Bundle\EnrichBundle\Normalizer\ViolationNormalizer
@@ -66,7 +67,6 @@ services:
             - '@pim_enrich.normalizer.completeness_collection'
             - '@pim_user.context.user'
             - '@pim_catalog.completeness.calculator'
-            - '@pim_enrich.normalizer.file'
             - '@pim_catalog.builder.product'
             - '@pim_catalog.values_filler.product'
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
@@ -235,6 +235,13 @@ services:
         class: '%pim_enrich.normalizer.file.class%'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
+
+    pim_enrich.normalizer.media:
+        class: '%pim_enrich.normalizer.media.class%'
+        arguments:
+            - '@pim_enrich.normalizer.file'
+        tags:
+            - { name: pim_serializer.normalizer }
 
     pim_enrich.normalizer.product_violation:
         class: '%pim_enrich.normalizer.product_violation.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/properties/general/attribute-as-image.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/properties/general/attribute-as-image.js
@@ -76,8 +76,8 @@ define([
              * @param event
              */
             updateState: function (event) {
-                var data = this.getFormData();
-                var value = event.currentTarget.value;
+                let data = this.getFormData();
+                const value = event.currentTarget.value;
                 data.attribute_as_image = ('no_attribute_as_image' === value) ? null : event.currentTarget.value;
                 this.setData(data);
             },
@@ -91,12 +91,9 @@ define([
              * @returns {Promise}
              */
             getAvailableAttributes: function () {
-                const imageAttributes = _.filter(
-                    this.getFormData().attributes,
-                    (attribute) => {
-                        return _.contains(this.config.validAttributeTypes, attribute.type);
-                    }
-                );
+                const imageAttributes = this.getFormData().attributes.filter((attribute) => {
+                    return this.config.validAttributeTypes.includes(attribute.type);
+                });
 
                 const imageAttributeCodes = _.pluck(imageAttributes, 'code');
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/properties/general/attribute-as-image.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/properties/general/attribute-as-image.js
@@ -85,18 +85,20 @@ define([
             /**
              * Returns the list of available attributes for this extension:
              * - Should belong to the family
-             * - Should be pim_catalog_image
+             * - Should be a valid attribute type
              * - Should not be neither localizable nor scopable
              *
              * @returns {Promise}
              */
             getAvailableAttributes: function () {
-                var imageAttributes = _.where(
+                const imageAttributes = _.filter(
                     this.getFormData().attributes,
-                    { type: 'pim_catalog_image' }
+                    (attribute) => {
+                        return _.contains(this.config.validAttributeTypes, attribute.type);
+                    }
                 );
 
-                var imageAttributeCodes = _.pluck(imageAttributes, 'code');
+                const imageAttributeCodes = _.pluck(imageAttributes, 'code');
 
                 return FetcherRegistry.getFetcher('attribute')
                     .fetchByIdentifiers(imageAttributeCodes)

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/MediaNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/MediaNormalizerSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
+
+
+use Akeneo\Component\FileStorage\Model\FileInfoInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\Normalizer\FileNormalizer;
+use Pim\Component\Catalog\Value\MediaValue;
+
+class MediaNormalizerSpec extends ObjectBehavior
+{
+    function let(FileNormalizer $fileNormalizer)
+    {
+        $this->beConstructedWith($fileNormalizer);
+    }
+
+    function it_should_be_a_media_normalizer()
+    {
+        $this->shouldHaveType('Pim\Bundle\EnrichBundle\Normalizer\MediaNormalizer');
+    }
+
+    function it_supports_media(MediaValue $media)
+    {
+        $this->supportsNormalization($media, 'internal_api')->shouldReturn(true);
+    }
+
+    function it_does_not_support_anything_else(\stdClass $anything)
+    {
+        $this->supportsNormalization($anything, 'internal_api')->shouldReturn(false);
+    }
+
+    function it_normalizes_media($fileNormalizer, MediaValue $media, FileInfoInterface $file)
+    {
+        $media->getData()->willReturn($file);
+
+        $fileNormalizer->normalize($file, 'internal_api', [])->willReturn([
+            'filePath'         => 'fileKey',
+            'originalFilename' => 'fileOriginalFilename',
+        ]);
+
+        $this->normalize($media, 'internal_api', [])->shouldReturn([
+            'filePath'         => 'fileKey',
+            'originalFilename' => 'fileOriginalFilename',
+        ]);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -54,7 +54,6 @@ class ProductNormalizerSpec extends ObjectBehavior
         NormalizerInterface $completenessCollectionNormalizer,
         UserContext $userContext,
         CompletenessCalculatorInterface $completenessCalculator,
-        FileNormalizer $fileNormalizer,
         ProductBuilderInterface $productBuilder,
         EntityWithFamilyValuesFillerInterface $productValuesFiller,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
@@ -77,7 +76,6 @@ class ProductNormalizerSpec extends ObjectBehavior
             $completenessCollectionNormalizer,
             $userContext,
             $completenessCalculator,
-            $fileNormalizer,
             $productBuilder,
             $productValuesFiller,
             $attributesProvider,
@@ -103,7 +101,6 @@ class ProductNormalizerSpec extends ObjectBehavior
         $channelRepository,
         $userContext,
         $collectionFilter,
-        $fileNormalizer,
         $productBuilder,
         $productValuesFiller,
         ProductInterface $mug,
@@ -173,7 +170,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $mug->getLabel('fr_FR')->willReturn('Un très beau Mug !');
         $mug->getImage()->willReturn($image);
         $image->getData()->willReturn($dataImage);
-        $fileNormalizer->normalize($dataImage, Argument::any(), Argument::any())->willReturn([
+        $normalizer->normalize($image, Argument::cetera())->willReturn([
             'filePath'         => '/p/i/m/4/all.png',
             'originalFileName' => 'all.png',
         ]);
@@ -242,7 +239,6 @@ class ProductNormalizerSpec extends ObjectBehavior
         $channelRepository,
         $userContext,
         $collectionFilter,
-        $fileNormalizer,
         $productBuilder,
         $productValuesFiller,
         $navigationNormalizer,
@@ -320,7 +316,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $mug->getLabel('fr_FR')->willReturn('Un très beau Mug !');
         $mug->getImage()->willReturn($image);
         $image->getData()->willReturn($dataImage);
-        $fileNormalizer->normalize($dataImage, Argument::any(), Argument::any())->willReturn([
+        $normalizer->normalize($image, Argument::cetera())->willReturn([
             'filePath'         => '/p/i/m/4/all.png',
             'originalFileName' => 'all.png',
         ]);

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/datagrid/normalizers.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/datagrid/normalizers.yml
@@ -6,9 +6,9 @@ services:
     pim_reference_data.datagrid.normalizer.reference_data:
         class: '%pim_reference_data.datagrid.normalizer.reference_data.class%'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_serializer.normalizer, priority: 80 }
 
     pim_reference_data.datagrid.normalizer.reference_data_collection:
         class: '%pim_reference_data.datagrid.normalizer.reference_data_collection.class%'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_serializer.normalizer, priority: 80 }

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsImage.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsImage.php
@@ -17,7 +17,7 @@ class FamilyAttributeAsImage extends Constraint
     public $messageAttribute = 'Property "attribute_as_image" must belong to the family';
 
     /** @var string */
-    public $messageAttributeType = 'Property "attribute_as_image" only supports "pim_catalog_image" '.
+    public $messageAttributeType = 'Property "attribute_as_image" only supports %s '.
         'attribute type for the family';
 
     /** @var string */


### PR DESCRIPTION
This PR allows user to use "assets" (EE feature) as "main picture" of a family.

__WARNING__ This PR is done in 2.0 for now, waiting for @tamarasaurus PR to change destination to "master".

This PR
- Updates the validator to be able to change the list of attribute types managed: in CE, only images, and in EE, images and assets.
- Adds normalizers (in Enrich, for PEF, and in Datagrid, for datagrid thumbnails) to be able to serialize it, to choose between image or asset.
- Updates the JS select2 in family form to be able to change allowed attribute types directly in conf.

TODO
- [ ] Add Changelog (when changing destination)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | y
| Added Behats                      | y
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
