### PR TITLE
PIM-6985: fix right error on family variant screen

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/attribute-set.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/attribute-set.js
@@ -96,7 +96,7 @@ define([
 
                         return $.when(
                             fetcherRegistry.getFetcher('attribute-group').fetchAll(),
-                            fetcherRegistry.getFetcher('attribute').fetchByIdentifiers(attributeCodes),
+                            fetcherRegistry.getFetcher('attribute').fetchByIdentifiers(attributeCodes, {rights: 0}),
                             axesAttributeCodes,
                             family
                         );


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

If one of the attributes in one of the axes was not viewable by the user, the page was failing

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added Behats                      | NA
| Added integration tests           | NA
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
