### PR TITLE
added json error detection when creating a job

### DIFF
--- a/src/Akeneo/Bundle/BatchBundle/Command/CreateJobCommand.php
+++ b/src/Akeneo/Bundle/BatchBundle/Command/CreateJobCommand.php
@@ -56,7 +56,17 @@ class CreateJobCommand extends ContainerAwareCommand
         $label = $label ? $label : $code;
         $jsonConfig = $input->getArgument('config');
         $rawConfig = null === $jsonConfig ? [] : json_decode($jsonConfig, true);
+        $jsonError = json_last_error_msg();
+        if (null !== $jsonConfig && null !== $jsonError) {
+            $output->writeln(
+                sprintf(
+                    '<error>config JSON decoding error: "%s"</error>',
+                    $jsonError
+                )
+            );
 
+            return self::EXIT_ERROR_CODE;
+        }
         $factory = $this->getJobInstanceFactory();
         $jobInstance = $factory->createJobInstance($type);
         $jobInstance->setConnector($connector);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Simply enough, adds some json error detection instead of just converting invalid JSON to null. Will then throw an exception if invalid JSON is submitted

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
