### PR TITLE
[PIM-6990] Associations new UI

### DIFF
--- a/.ci/behat.community.yml
+++ b/.ci/behat.community.yml
@@ -86,6 +86,8 @@ default:
                     - 'Context\FeatureContext'
                 - Pim\Behat\Context\Storage\VariantProductStorage:
                     - '@pim_catalog.repository.product'
+                - Pim\Behat\Context\Domain\Enrich\ItemPickerContext:
+                    - 'Context\FeatureContext'
     extensions:
         Behat\ChainedStepsExtension: ~
         Behat\MinkExtension:

--- a/.ci/behat.enterprise.yml
+++ b/.ci/behat.enterprise.yml
@@ -31,6 +31,8 @@ default:
                     - 'Context\EnterpriseFeatureContext'
                 - Context\EnterpriseFileTransformerContext:
                     - 'Context\EnterpriseFeatureContext'
+                - Context\EnterpriseItemPickerContext:
+                    - 'Context\EnterpriseFeatureContext'
                 - Pim\Behat\Context\AttributeValidationContext:
                     - 'Context\EnterpriseFeatureContext'
                 - Pim\Behat\Context\Domain\Collect\ImportProfilesContext:

--- a/.ci/behat.enterprise.yml
+++ b/.ci/behat.enterprise.yml
@@ -96,6 +96,8 @@ default:
                     - 'Context\EnterpriseFeatureContext'
                 - Pim\Behat\Context\Storage\VariantProductStorage:
                     - '@pim_catalog.repository.product'
+                - Pim\Behat\Context\Domain\Enrich\ItemPickerContext:
+                    - 'Context\EnterpriseFeatureContext'
     extensions:
         Behat\ChainedStepsExtension: ~
         Behat\MinkExtension:

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -5,6 +5,7 @@
 - PIM-6480: Add gallery view and display selector to the product grid
 - PIM-6621: add search on label and code on products and product models
 - PIM-6966: Add tracker information for product model, product variant and family variant
+- PIM-6990: Add new screen for managing product associations
 
 ## BC breaks
 

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -16,6 +16,7 @@
 - Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductNormalizer` to replace `Symfony\Component\Serializer\Normalizer\NormalizerInterface` parameter by `Symfony\Component\Serializer\Normalizer\NormalizerInterface`
 - Change the constructor of `Pim\Component\Catalog\Validator\Constraints\FamilyAttributeAsImageValidator` to add a `string[]`
 - Change the constructor of `Pim\Bundle\AnalyticsBundle\DataCollector\DBDataCollector` to add a `Pim\Component\Catalog\Repository\ProductModelRepositoryInterface`, `Pim\Component\Catalog\Repository\VariantProductRepositoryInterface` and `Pim\Component\Catalog\Repository\FamilyVariantRepositoryInterface`
+- Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\ProductController` to add `Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface` as second parameter
 
 ### Methods
 

--- a/behat.ci.yml
+++ b/behat.ci.yml
@@ -83,6 +83,8 @@ default:
                     - 'Context\FeatureContext'
                 - Pim\Behat\Context\Storage\VariantProductStorage:
                     - '@pim_catalog.repository.product'
+                - Pim\Behat\Context\Domain\Enrich\ItemPickerContext:
+                    - 'Context\FeatureContext'
     extensions:
         Behat\ChainedStepsExtension: ~
         Behat\MinkExtension:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -83,6 +83,8 @@ default:
                     - 'Context\FeatureContext'
                 - Pim\Behat\Context\Storage\VariantProductStorage:
                     - '@pim_catalog.repository.product'
+                - Pim\Behat\Context\Domain\Enrich\ItemPickerContext:
+                    - 'Context\FeatureContext'
     extensions:
         Behat\ChainedStepsExtension: ~
         Behat\MinkExtension:

--- a/features/Context/Page/Base/Base.php
+++ b/features/Context/Page/Base/Base.php
@@ -289,6 +289,14 @@ class Base extends Page
             );
         }
         if (null === $button) {
+            $button = $this->getFirstVisible(
+                $this->findAll(
+                    'xpath',
+                    sprintf("//*[contains(@class, 'AknButton')][normalize-space(text()) = '%s']", $locator)
+                )
+            );
+        }
+        if (null === $button) {
             $button =  $this->getFirstVisible(
                 $this->findAll('css', sprintf('a[title="%s"]', $locator))
             );

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -2884,4 +2884,17 @@ class WebUser extends PimContext
 
         return (null === $badge) ? 0 : intval($badge->getText());
     }
+
+    /**
+     * @Given /^I remove "([^"]*)" from the basket$/
+     */
+    public function iRemoveFromTheBasket($entity)
+    {
+        $removeButton = $this->spin(function () use ($entity) {
+            return $this->getSession()->getPage()
+                ->find('css', sprintf('.item-picker-basket li[data-itemCode="%s"] .remove-item', $entity));
+        }, 'Cannot find button to remove from basket');
+
+        $removeButton->click();
+    }
 }

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -2897,4 +2897,29 @@ class WebUser extends PimContext
 
         $removeButton->click();
     }
+
+    /**
+     * @Then /^the item picker basket should contain (.*)$/
+     */
+    public function theItemPickerBasketShouldContain($entities)
+    {
+        foreach ($this->getMainContext()->listToArray($entities) as $entity) {
+            $this->getItemPickerBasketItems($entity);
+        }
+    }
+
+    /**
+     * @param string $code
+     *
+     * @throws \Exception
+     *
+     * @return NodeElement
+     */
+    protected function getItemPickerBasketItems($code)
+    {
+        return $this->spin(function () use ($code) {
+            return $this->getSession()->getPage()
+                ->find('css', sprintf('.item-picker-basket *[data-itemCode="%s"]', $code));
+        }, sprintf('Cannot find item "%s" in basket', $code));
+    }
 }

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -2884,42 +2884,4 @@ class WebUser extends PimContext
 
         return (null === $badge) ? 0 : intval($badge->getText());
     }
-
-    /**
-     * @Given /^I remove "([^"]*)" from the basket$/
-     */
-    public function iRemoveFromTheBasket($entity)
-    {
-        $removeButton = $this->spin(function () use ($entity) {
-            return $this->getSession()->getPage()
-                ->find('css', sprintf('.item-picker-basket li[data-itemCode="%s"] .remove-item', $entity));
-        }, 'Cannot find button to remove from basket');
-
-        $removeButton->click();
-    }
-
-    /**
-     * @Then /^the item picker basket should contain (.*)$/
-     */
-    public function theItemPickerBasketShouldContain($entities)
-    {
-        foreach ($this->getMainContext()->listToArray($entities) as $entity) {
-            $this->getItemPickerBasketItems($entity);
-        }
-    }
-
-    /**
-     * @param string $code
-     *
-     * @throws \Exception
-     *
-     * @return NodeElement
-     */
-    protected function getItemPickerBasketItems($code)
-    {
-        return $this->spin(function () use ($code) {
-            return $this->getSession()->getPage()
-                ->find('css', sprintf('.item-picker-basket *[data-itemCode="%s"]', $code));
-        }, sprintf('Cannot find item "%s" in basket', $code));
-    }
 }

--- a/features/Pim/Behat/Context/Domain/Enrich/ItemPickerContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/ItemPickerContext.php
@@ -24,14 +24,14 @@ class ItemPickerContext extends PimContext
     {
         $removeButton = $this->spin(function () use ($entity) {
             return $this->getSession()->getPage()
-                ->find('css', sprintf('.item-picker-basket li[data-itemCode="%s"] .remove-item', $entity));
+                ->find('css', sprintf('.item-picker-basket .remove-item[data-itemCode="%s"]', $entity));
         }, 'Cannot find button to remove from basket');
 
         $removeButton->click();
     }
 
     /**
-     * @Then the item picker basket should contain :entities
+     * @Then /^the item picker basket should contain (.+)$/
      */
     public function theItemPickerBasketShouldContain($entities)
     {

--- a/features/Pim/Behat/Context/Domain/Enrich/ItemPickerContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/ItemPickerContext.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Pim\Behat\Context\Domain\Enrich;
+
+use Behat\Mink\Element\NodeElement;
+use Context\Spin\SpinCapableTrait;
+use Pim\Behat\Context\PimContext;
+
+/**
+ * Context for the item picker
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ItemPickerContext extends PimContext
+{
+    use SpinCapableTrait;
+
+    /**
+     * @Given I remove :entity from the basket
+     */
+    public function iRemoveFromTheBasket($entity)
+    {
+        $removeButton = $this->spin(function () use ($entity) {
+            return $this->getSession()->getPage()
+                ->find('css', sprintf('.item-picker-basket li[data-itemCode="%s"] .remove-item', $entity));
+        }, 'Cannot find button to remove from basket');
+
+        $removeButton->click();
+    }
+
+    /**
+     * @Then the item picker basket should contain :entities
+     */
+    public function theItemPickerBasketShouldContain($entities)
+    {
+        foreach ($this->getMainContext()->listToArray($entities) as $entity) {
+            $this->getItemPickerBasketItems($entity);
+        }
+    }
+
+    /**
+     * @param string $code
+     *
+     * @throws \Exception
+     *
+     * @return NodeElement
+     */
+    protected function getItemPickerBasketItems($code)
+    {
+        return $this->spin(function () use ($code) {
+            return $this->getSession()->getPage()
+                ->find('css', sprintf('.item-picker-basket *[data-itemCode="%s"]', $code));
+        }, sprintf('Cannot find item "%s" in basket', $code));
+    }
+}

--- a/features/Pim/Behat/Context/PimContext.php
+++ b/features/Pim/Behat/Context/PimContext.php
@@ -16,7 +16,7 @@ class PimContext extends RawMinkContext implements KernelAwareContext
     /** @var KernelInterface */
     private $kernel;
 
-    /** @var  string */
+    /** @var string */
     protected $mainContextClass;
 
     /** @var FeatureContext */

--- a/features/product/update_associations.feature
+++ b/features/product/update_associations.feature
@@ -15,7 +15,7 @@ Feature: Update the product associations
     And I visit the "Associations" column tab
 
   Scenario: Successfully add an association
-    When I press the "Add associations" button and wait for modal
+    When I press the "Add associations" button
     And I check the row "patrick"
     Then the item picker basket should contain patrick
     And I press the "Confirm" button

--- a/features/product/update_associations.feature
+++ b/features/product/update_associations.feature
@@ -1,0 +1,23 @@
+@javascript
+Feature: Update the product associations
+  In order to associate products with other products
+  As a product manager
+  I need to update the product associations
+
+  Background:
+    Given the "apparel" catalog configuration
+    And I am logged in as "Julia"
+    And the following products:
+      | sku       | family  | categories |
+      | spongebob | tshirts | men_2013   |
+      | patrick   | tshirts | men_2013   |
+    And I am on the "spongebob" product page
+    And I visit the "Associations" column tab
+
+  Scenario: Successfully add an association
+    When I press the "Add products" button and wait for modal
+    And I check the row "patrick"
+    Then the item picker basket should contain patrick
+    And I press the "Confirm" button
+    And I save the product
+    Then the rows "patrick" should be checked

--- a/features/product/update_associations.feature
+++ b/features/product/update_associations.feature
@@ -15,7 +15,7 @@ Feature: Update the product associations
     And I visit the "Associations" column tab
 
   Scenario: Successfully add an association
-    When I press the "Add products" button and wait for modal
+    When I press the "Add associations" button and wait for modal
     And I check the row "patrick"
     Then the item picker basket should contain patrick
     And I press the "Confirm" button

--- a/src/Pim/Bundle/DataGridBundle/Extension/Filter/FilterExtension.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Filter/FilterExtension.php
@@ -222,6 +222,10 @@ class FilterExtension extends AbstractExtension
             'product-grid' => [
                 'type'      => 'product_category',
                 'data_name' => 'category'
+            ],
+            'association-product-picker-grid' => [
+                'type'      => 'product_category',
+                'data_name' => 'category'
             ]
         ];
 

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductAssociationNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductAssociationNormalizer.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\SerializerAwareTrait;
 class ProductAssociationNormalizer implements NormalizerInterface, SerializerAwareInterface
 {
     use SerializerAwareTrait;
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductModelNormalizer.php
@@ -80,7 +80,6 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
         $data['updated'] = $this->normalizer->normalize($productModel->getUpdated(), $format, $context);
         $data['label'] = $productModel->getLabel($locale, $channel);
         $data['image'] = $this->normalizeImage($closestImage, $context);
-
         $data['groups'] = null;
         $data['enabled'] = null;
         $data['completeness'] = null;
@@ -88,6 +87,7 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
         $data['technical_id'] = $productModel->getId();
         $data['search_id'] = IdEncoder::encode($data['document_type'], $data['technical_id']);
         $data['complete_variant_product'] = $variantProductCompleteness->value($channel, $locale);
+        $data['is_checked'] = false;
 
         return $data;
     }

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductNormalizer.php
@@ -68,6 +68,7 @@ class ProductNormalizer implements NormalizerInterface, NormalizerAwareInterface
         $data['document_type'] = IdEncoder::PRODUCT_TYPE;
         $data['technical_id'] = $product->getId();
         $data['search_id'] = IdEncoder::encode($data['document_type'], $data['technical_id']);
+        $data['is_checked'] = false;
         $data['complete_variant_product'] = null;
 
         return $data;

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/pagers.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/pagers.yml
@@ -17,3 +17,4 @@ services:
                 - 'product-variant-group-grid'
                 - 'product-group-grid'
                 - 'published-product-grid'
+                - 'association-product-picker-grid'

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/abstract-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/abstract-filter.js
@@ -17,7 +17,7 @@ function($, _, Backbone, app) {
      *     - product_completeness-filter (Displays the completeness like a select)
      *     - product_scope-filter (Displays the scope like a select)
      *     - select-row-filter (unused?)
-     *   - text-filter (Displays a choice contains/dies not contains... Only on process tracker "Type", "User")
+     *   - text-filter (Displays a choice contains/does not contains... Only on process tracker "Type", "User")
      *     - choice-filter (Displays a choice contains/does not contains/equals... and 1 text field. "SKU", all text fields)
      *       - date-filter (Displays a choice between/not between/more/less and 2 datepickers. "Created at", "Release date")
      *         - datetime-filter (unused?)

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/text-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/text-filter.js
@@ -278,8 +278,10 @@ define(
          */
         outsideClickListener(event) {
             if (!$(event.target).closest(this.criteriaSelector).length &&
-                $(event.target).closest('.app').length &&
-                this.popupCriteriaShowed) {
+                (
+                    $(event.target).closest('.app').length ||
+                    $(event.target).closest('.modal--fullPage').length
+                ) && this.popupCriteriaShowed) {
                 this._hideCriteria();
                 this.setValue(this._formatRawValue(this._readDOMValue()));
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-button.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-button.js
@@ -11,10 +11,14 @@ define(
         FiltersManager
     ) {
         return BaseForm.extend({
+            displayAsPanel: false,
+
             /**
              * @inheritdoc
              */
-            initialize() {
+            initialize(meta) {
+                this.displayAsPanel = undefined === meta.config.displayAsPanel ? false : meta.config.displayAsPanel;
+
                 mediator.once('datagrid_filters:loaded', this.showFilterManager.bind(this));
 
                 BaseForm.prototype.initialize.apply(this, arguments);
@@ -26,7 +30,10 @@ define(
              * @param {Object} options
              */
             showFilterManager(options) {
+                options.displayAsPanel = this.displayAsPanel;
+
                 const filtersList = new FiltersManager(options);
+
                 this.$el.append(filtersList.render().$el);
 
                 mediator.trigger('datagrid_filters:build.post', filtersList);

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-manager.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-manager.js
@@ -333,8 +333,8 @@ define(
                 selectedList: 0,
                 classes: 'AknFilterBox-addFilterButton AknFilterBox-addFilterButton--asPanel filter-list select-filter-widget',
                 position: {
-                    at: 'right top',
-                    my: 'right top',
+                    at: 'left top',
+                    my: 'left top',
                 }
             };
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -155,6 +155,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                 'complete' => 3,
                 'total' => 12
             ],
+            'is_checked' => false,
         ];
 
         $this->normalize($productModel, 'datagrid', $context)->shouldReturn($data);
@@ -260,6 +261,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                 'complete' => 3,
                 'total' => 12
             ],
+            'is_checked' => false,
         ];
 
         $this->normalize($productModel, 'datagrid', $context)->shouldReturn($data);

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -144,6 +144,7 @@ class ProductNormalizerSpec extends ObjectBehavior
             'document_type' => 'product',
             'technical_id' => 78,
             'search_id' => 'product_78',
+            'is_checked' => false,
             'complete_variant_product' => null,
         ];
 
@@ -245,6 +246,7 @@ class ProductNormalizerSpec extends ObjectBehavior
             'document_type' => 'product',
             'technical_id' => 78,
             'search_id' => 'product_78',
+            'is_checked' => false,
             'complete_variant_product' => null,
         ];
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -151,7 +151,7 @@ class ProductController
      *
      * @return JsonResponse
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request): JsonResponse
     {
         $productIdentifiers = explode(',', $request->get('identifiers'));
         $products = $this->cursorableRepository->getItemsFromIdentifiers($productIdentifiers);
@@ -413,7 +413,7 @@ class ProductController
      *
      * @return array
      */
-    protected function getNormalizationContext()
+    protected function getNormalizationContext(): array
     {
         return $this->userContext->toArray() + [
             'filter_types'               => ['pim.internal_api.product_value.view'],

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -153,12 +153,7 @@ class ProductController
      */
     public function indexAction(Request $request)
     {
-        $identifiers = $request->get(    'identifiers');
-        if (null === $identifiers || '' === $identifiers) {
-            return new JsonResponse([]);
-        }
-
-        $productIdentifiers = preg_split('/,/', $identifiers);
+        $productIdentifiers = explode(',', $request->get('identifiers'));
         $products = $this->cursorableRepository->getItemsFromIdentifiers($productIdentifiers);
 
         $normalizedProducts = $this->normalizer->normalize(

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\EnrichBundle\Controller\Rest;
 
 use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
+use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
@@ -37,6 +38,9 @@ class ProductController
 {
     /** @var ProductRepositoryInterface */
     protected $productRepository;
+
+    /** @var CursorableRepositoryInterface */
+    protected $cursorableRepository;
 
     /** @var AttributeRepositoryInterface */
     protected $attributeRepository;
@@ -84,25 +88,27 @@ class ProductController
     protected $variantProductBuilder;
 
     /**
-     * @param ProductRepositoryInterface   $productRepository
-     * @param AttributeRepositoryInterface $attributeRepository
-     * @param ObjectUpdaterInterface       $productUpdater
-     * @param SaverInterface               $productSaver
-     * @param NormalizerInterface          $normalizer
-     * @param ValidatorInterface           $validator
-     * @param UserContext                  $userContext
-     * @param ObjectFilterInterface        $objectFilter
-     * @param CollectionFilterInterface    $productEditDataFilter
-     * @param RemoverInterface             $productRemover
-     * @param ProductBuilderInterface      $productBuilder
-     * @param AttributeConverterInterface  $localizedConverter
-     * @param FilterInterface              $emptyValuesFilter
-     * @param ConverterInterface           $productValueConverter
-     * @param NormalizerInterface          $constraintViolationNormalizer
-     * @param ProductBuilderInterface      $variantProductBuilder
+     * @param ProductRepositoryInterface    $productRepository
+     * @param CursorableRepositoryInterface $cursorableRepository
+     * @param AttributeRepositoryInterface  $attributeRepository
+     * @param ObjectUpdaterInterface        $productUpdater
+     * @param SaverInterface                $productSaver
+     * @param NormalizerInterface           $normalizer
+     * @param ValidatorInterface            $validator
+     * @param UserContext                   $userContext
+     * @param ObjectFilterInterface         $objectFilter
+     * @param CollectionFilterInterface     $productEditDataFilter
+     * @param RemoverInterface              $productRemover
+     * @param ProductBuilderInterface       $productBuilder
+     * @param AttributeConverterInterface   $localizedConverter
+     * @param FilterInterface               $emptyValuesFilter
+     * @param ConverterInterface            $productValueConverter
+     * @param NormalizerInterface           $constraintViolationNormalizer
+     * @param ProductBuilderInterface       $variantProductBuilder
      */
     public function __construct(
         ProductRepositoryInterface $productRepository,
+        CursorableRepositoryInterface $cursorableRepository,
         AttributeRepositoryInterface $attributeRepository,
         ObjectUpdaterInterface $productUpdater,
         SaverInterface $productSaver,
@@ -120,6 +126,7 @@ class ProductController
         ProductBuilderInterface $variantProductBuilder
     ) {
         $this->productRepository = $productRepository;
+        $this->cursorableRepository = $cursorableRepository;
         $this->attributeRepository = $attributeRepository;
         $this->productUpdater = $productUpdater;
         $this->productSaver = $productSaver;
@@ -138,6 +145,32 @@ class ProductController
     }
 
     /**
+     * Returns a set of products from identifiers parameter
+     *
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function indexAction(Request $request)
+    {
+        $identifiers = $request->get(    'identifiers');
+        if (null === $identifiers || '' === $identifiers) {
+            return new JsonResponse([]);
+        }
+
+        $productIdentifiers = preg_split('/,/', $identifiers);
+        $products = $this->cursorableRepository->getItemsFromIdentifiers($productIdentifiers);
+
+        $normalizedProducts = $this->normalizer->normalize(
+            $products,
+            'internal_api',
+            $this->getNormalizationContext()
+        );
+
+        return new JsonResponse($normalizedProducts);
+    }
+
+    /**
      * @param string $id Product id
      *
      * @throws NotFoundHttpException If product is not found or the user cannot see it
@@ -148,15 +181,10 @@ class ProductController
     {
         $product = $this->findProductOr404($id);
 
-        $normalizationContext = $this->userContext->toArray() + [
-            'filter_types'               => ['pim.internal_api.product_value.view'],
-            'disable_grouping_separator' => true
-        ];
-
         $normalizedProduct = $this->normalizer->normalize(
             $product,
             'internal_api',
-            $normalizationContext
+            $this->getNormalizationContext()
         );
 
         return new JsonResponse($normalizedProduct);
@@ -192,15 +220,10 @@ class ProductController
         if (0 === $violations->count()) {
             $this->productSaver->save($product);
 
-            $normalizationContext = $this->userContext->toArray() + [
-                'filter_types'               => ['pim.internal_api.product_value.view'],
-                'disable_grouping_separator' => true
-            ];
-
             return new JsonResponse($this->normalizer->normalize(
                 $product,
                 'internal_api',
-                $normalizationContext
+                $this->getNormalizationContext()
             ));
         }
 
@@ -245,15 +268,10 @@ class ProductController
         if (0 === $violations->count()) {
             $this->productSaver->save($product);
 
-            $normalizationContext = $this->userContext->toArray() + [
-                'filter_types'               => ['pim.internal_api.product_value.view'],
-                'disable_grouping_separator' => true
-            ];
-
             $normalizedProduct = $this->normalizer->normalize(
                 $product,
                 'internal_api',
-                $normalizationContext
+                $this->getNormalizationContext()
             );
 
             return new JsonResponse($normalizedProduct);
@@ -393,5 +411,18 @@ class ProductController
         }
 
         $this->productUpdater->update($product, $data);
+    }
+
+    /**
+     * Get the context used for product normalization
+     *
+     * @return array
+     */
+    protected function getNormalizationContext()
+    {
+        return $this->userContext->toArray() + [
+            'filter_types'               => ['pim.internal_api.product_value.view'],
+            'disable_grouping_separator' => true
+        ];
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
@@ -48,6 +48,10 @@ pim_enrich_associations_view:
     type: action
     label: pim_enrich.acl.product.associations_view
     group_name: pim_enrich.acl_group.product
+pim_enrich_associations_edit:
+    type: action
+    label: pim_enrich.acl.product.associations_edit
+    group_name: pim_enrich.acl_group.product
 pim_enrich_product_change_family:
     type: action
     label: pim_enrich.acl.product.change_family

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -338,6 +338,7 @@ services:
         class: '%pim_enrich.controller.rest.product.class%'
         arguments:
             - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product'
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.updater.product'
             - '@pim_catalog.saver.product'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
@@ -5,7 +5,7 @@ datagrid:
             requireJSModules:
                 - pim/datagrid/column-form-listener
             columnListener:
-                dataField: code
+                dataField: identifier
                 columnName: is_checked
             routerEnabled: false
         source:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
@@ -50,12 +50,3 @@ datagrid:
                     sorter:    product_completeness
             default:
                 updated: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_DESC'
-        filters:
-            columns:
-                groups:
-                    type:      product_groups
-                    label:     Groups
-                    data_name: groups
-                    options:
-                        field_options:
-                            multiple: true

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
@@ -50,4 +50,32 @@ datagrid:
                     sorter:    product_completeness
             default:
                 updated: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_DESC'
-        filters: {}
+        filters:
+            columns:
+                family:
+                    type:      product_family
+                    label:     Family
+                    data_name: family
+                    options:
+                        field_options:
+                            multiple: true
+                            attr:
+                                empty_choice: true
+                enabled:
+                    type:      product_enabled
+                    ftype:     choice
+                    label:     Status
+                    data_name: enabled
+                    options:
+                        field_options:
+                            choices:
+                                Enabled: 1
+                                Disabled: 0
+                completeness:
+                    type:      product_completeness
+                    label:     Complete
+                    data_name: ratio
+                label_or_identifier:
+                    type: label_or_identifier
+                    label: Label or identifier
+                    data_name: label_or_identifier

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
@@ -40,6 +40,7 @@ datagrid:
         properties:
             id: ~
             technical_id: ~
+            document_type: ~
         sorters:
             columns:
                 identifier:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
@@ -1,0 +1,61 @@
+datagrid:
+    association-product-picker-grid:
+        options:
+            entityHint: product
+            requireJSModules:
+                - pim/datagrid/column-form-listener
+            columnListener:
+                dataField: code
+                columnName: is_checked
+            routerEnabled: false
+        source:
+            acl_resource:      pim_enrich_product_index
+            type:              pim_datasource_product
+            entity:            '%pim_catalog.entity.product.class%'
+        columns:
+            is_checked:
+                frontend_type: boolean
+                data_name:     is_checked
+                editable:      true
+            identifier:
+                label: ID
+                data_name:     identifier
+                type:          field
+            image:
+                label:         Image
+                data_name:     image
+                frontend_type: product-and-product-model-image
+            label:
+                label:         Label
+                data_name:     label
+                type:          field
+                frontend_type: product-and-product-model-label
+            completeness:
+                label:         Complete
+                frontend_type: completeness
+            complete_variant_products:
+                label:         Variant products
+                data_name:     complete_variant_product
+                frontend_type: complete-variant-product
+        properties:
+            id: ~
+            technical_id: ~
+        sorters:
+            columns:
+                identifier:
+                    data_name: identifier
+                    sorter: product_field
+                completeness:
+                    data_name: ratio
+                    sorter:    product_completeness
+            default:
+                updated: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_DESC'
+        filters:
+            columns:
+                groups:
+                    type:      product_groups
+                    label:     Groups
+                    data_name: groups
+                    options:
+                        field_options:
+                            multiple: true

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_picker.yml
@@ -50,3 +50,4 @@ datagrid:
                     sorter:    product_completeness
             default:
                 updated: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_DESC'
+        filters: {}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid_listeners.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid_listeners.yml
@@ -16,6 +16,16 @@ services:
         tags:
             - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.before.product-grid, method: buildBefore }
 
+    pim_enrich.event_listener.association_product_picker_grid_before_listener:
+        class: '%pim_datagrid.event_listener.configure_product_grid_listener.class%'
+        arguments:
+            - '@pim_datagrid.datagrid.configuration.product.context_configurator'
+            - '@pim_datagrid.datagrid.configuration.product.columns_configurator'
+            - '@pim_datagrid.datagrid.configuration.product.filters_configurator'
+            - '@pim_datagrid.datagrid.configuration.product.sorters_configurator'
+        tags:
+            - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.before.association-product-picker-grid, method: buildBefore }
+
     pim_enrich.event_listener.product_grid_after_listener:
         class: '%pim_datagrid.event_listener.add_parameters_to_product_grid.class%'
         arguments:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid_listeners.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid_listeners.yml
@@ -38,6 +38,18 @@ services:
         tags:
           - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.after.product-grid, method: onBuildAfter }
 
+    pim_enrich.event_listener.association_product_picker_grid_after_listener:
+        class: '%pim_datagrid.event_listener.add_parameters_to_product_grid.class%'
+        arguments:
+          - [dataLocale]
+          - '@oro_datagrid.datagrid.request_params'
+          - '@pim_catalog.context.catalog'
+          - '@pim_user.context.user'
+          - false
+          - '@request_stack'
+        tags:
+          - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.after.association-product-picker-grid, method: onBuildAfter }
+
     pim_enrich.event_listener.product_group_grid_before_listener:
         class: '%pim_datagrid.event_listener.configure_product_grid_listener.class%'
         arguments:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
@@ -3,7 +3,6 @@ extensions:
         module: pim/common/item-picker
         config:
             datagridName: association-product-picker-grid
-            title: pim_enrich.form.product.tab.associations.manage
             description: pim_enrich.form.product.tab.associations.manage_description
             categoryTreeRoute: pim_enrich_categorytree
             columnName: identifier

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
@@ -18,3 +18,5 @@ extensions:
         module: oro/datafilter/filters-button
         parent: pim-associations-product-picker-form
         targetZone: filters
+        config:
+            displayAsPanel: true

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
@@ -1,0 +1,18 @@
+extensions:
+    pim-associations-product-picker-form:
+        module: pim/common/item-picker
+        config:
+            datagridName: association-product-picker-grid
+            title: pimee_product_asset.form.product.asset.title
+            description: pimee_product_asset.form.product.asset.description
+            categoryTreeRoute: pimee_asset_picker_categorytree
+
+    pimee-product-asset-picker-form-filters-list:
+        module: oro/datafilter/filters-list
+        parent: pim-associations-product-picker-form
+        targetZone: filters
+
+    pimee-product-asset-picker-form-filters-manage:
+        module: oro/datafilter/filters-button
+        parent: pim-associations-product-picker-form
+        targetZone: filters

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
@@ -3,8 +3,8 @@ extensions:
         module: pim/common/item-picker
         config:
             datagridName: association-product-picker-grid
-            title: pimee_product_asset.form.product.asset.title
-            description: pimee_product_asset.form.product.asset.description
+            title: pim_enrich.form.product.tab.associations.manage
+            description: pim_enrich.form.product.tab.associations.manage_description
             categoryTreeRoute: pim_enrich_categorytree
             columnName: identifier
             fetcher: product

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
@@ -6,6 +6,8 @@ extensions:
             title: pimee_product_asset.form.product.asset.title
             description: pimee_product_asset.form.product.asset.description
             categoryTreeRoute: pim_enrich_categorytree
+            columnName: identifier
+            fetcher: product
 
     pim-association-product-picker-form-filters-list:
         module: oro/datafilter/filters-list

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
@@ -5,14 +5,14 @@ extensions:
             datagridName: association-product-picker-grid
             title: pimee_product_asset.form.product.asset.title
             description: pimee_product_asset.form.product.asset.description
-            categoryTreeRoute: pimee_asset_picker_categorytree
+            categoryTreeRoute: pim_enrich_categorytree
 
-    pimee-product-asset-picker-form-filters-list:
+    pim-association-product-picker-form-filters-list:
         module: oro/datafilter/filters-list
         parent: pim-associations-product-picker-form
         targetZone: filters
 
-    pimee-product-asset-picker-form-filters-manage:
+    pim-association-product-picker-form-filters-manage:
         module: oro/datafilter/filters-button
         parent: pim-associations-product-picker-form
         targetZone: filters

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -220,6 +220,8 @@ extensions:
         targetZone: container
         aclResourceId: pim_enrich_associations_view
         position: 130
+        config:
+            aclAddAssociations: pim_enrich_associations_edit
 
     pim-product-edit-form-attribute-group-selector:
         module: pim/form/common/attributes/attribute-group-selector

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -973,6 +973,7 @@ config:
         pim/template/common/no-data:                              pimenrich/templates/common/no-data.html
         pim/template/common/grid:                                 pimenrich/templates/common/grid.html
         pim/template/common/item-picker:                          pimenrich/templates/common/item-picker.html
+        pim/template/common/item-picker-basket:                   pimenrich/templates/common/item-picker-basket.html
 
         pim/template/form/group-selector:                         pimenrich/templates/form/group-selector.html
         pim/template/form/save:                                   pimenrich/templates/form/save.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -183,6 +183,7 @@ config:
                     options:
                         urls:
                             get: pim_enrich_product_rest_get
+                            list: pim_enrich_product_rest_index
                 product-model:
                     module: pim/product-model-fetcher
                     options:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -854,6 +854,7 @@ config:
         pim/create/properties/general:     pimenrich/js/create/form/properties/general
         pim/common/simple-view:            pimenrich/js/form/common/simple-view
         pim/common/grid-title:             pimenrich/js/form/common/grid-title
+        pim/common/item-picker:            pimenrich/js/common/item-picker
 
         # Root
         pim/form/common/edit-form: pimenrich/js/form/common/edit-form
@@ -971,6 +972,7 @@ config:
         pim/template/common/form-container:                       pimenrich/templates/common/form-container.html
         pim/template/common/no-data:                              pimenrich/templates/common/no-data.html
         pim/template/common/grid:                                 pimenrich/templates/common/grid.html
+        pim/template/common/item-picker:                          pimenrich/templates/common/item-picker.html
 
         pim/template/form/group-selector:                         pimenrich/templates/form/group-selector.html
         pim/template/form/save:                                   pimenrich/templates/form/save.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product.yml
@@ -28,6 +28,11 @@ pim_enrich_product_rest_get:
         id: '[0-9a-f]+'
     methods: [GET]
 
+pim_enrich_product_rest_index:
+    path: /rest/
+    defaults: { _controller: pim_enrich.controller.rest.product:indexAction }
+    methods: [GET]
+
 pim_enrich_product_rest_create:
     path: /rest
     defaults: { _controller: pim_enrich.controller.rest.product:createAction }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -106,7 +106,8 @@ define(
                 this.$el.html(this.template({
                     title: __(this.config.title),
                     description: __(this.config.description),
-                    locale: this.getLocale()
+                    locale: this.getLocale(),
+                    datagridIdentifier: 'grid-' + this.datagrid.name,
                 }));
 
                 this.renderGrid(this.datagrid);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -48,8 +48,11 @@ define(
             events: {
                 'click .remove-item': 'removeItemFromBasket'
             },
-            imagePath: () => {
-                throw new Error('You have to define "imagePath" method using "setImagePath" method.')
+            imagePathMethod: () => {
+                throw new Error('You have to define "imagePathMethod" method using "setImagePathMethod" method.')
+            },
+            labelMethod: () => {
+                throw new Error('You have to define "labelMethod" method using "setLabelMethod" method.')
             },
 
             /**
@@ -296,7 +299,7 @@ define(
              * @param {Event} event
              */
             removeItemFromBasket: function (event) {
-                this.removeItem(event.currentTarget.dataset.itemCode);
+                this.removeItem(event.currentTarget.dataset.itemcode);
                 if (this.datagridModel) {
                     this.updateChecked(this.datagridModel);
                 }
@@ -312,15 +315,22 @@ define(
                             items: items,
                             title: __('pim_enrich.form.basket.title'),
                             emptyLabel: __('pim_enrich.form.basket.empty_basket'),
-                            imagePath: this.imagePath.bind(this),
+                            imagePathMethod: this.imagePathMethod.bind(this),
+                            columnName: this.config.columnName,
+                            identifierName: this.config.columnName,
+                            labelMethod: this.labelMethod.bind(this),
                         }));
 
                         this.delegateEvents();
                     }.bind(this));
             },
 
-            setImagePath: function (f) {
-                this.imagePath = f;
+            setImagePathMethod: function (f) {
+                this.imagePathMethod = f;
+            },
+
+            setLabelMethod: function (f) {
+                this.labelMethod = f;
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -113,7 +113,7 @@ define(
                     title: __(this.config.title),
                     description: __(this.config.description),
                     locale: this.getLocale(),
-                    datagridIdentifier: this.datagrid.name,
+                    datagridIdentifier: this.datagrid.name
                 }));
 
                 this.renderGrid(this.datagrid);
@@ -318,7 +318,7 @@ define(
                             imagePathMethod: this.imagePathMethod.bind(this),
                             columnName: this.config.columnName,
                             identifierName: this.config.columnName,
-                            labelMethod: this.labelMethod.bind(this),
+                            labelMethod: this.labelMethod.bind(this)
                         }));
 
                         this.delegateEvents();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -48,7 +48,9 @@ define(
             events: {
                 'click .remove-item': 'removeItemFromBasket'
             },
-            imagePath: null,
+            imagePath: () => {
+                throw new Error('You have to define "imagePath" method using "setImagePath" method.')
+            },
 
             /**
              * {@inheritdoc}
@@ -56,9 +58,6 @@ define(
             initialize: function (config) {
                 this.datagridModel = null;
                 this.config = config.config;
-                this.imagePath = () => {
-                    throw new Error('You have to define "imagePath" method using "setImagePath" method.')
-                };
 
                 if (undefined === this.config.datagridName) {
                     throw new Error('You have to add parameter "datagridName" to the configuration of this module.');
@@ -280,13 +279,13 @@ define(
 
                 const items = this.getItems();
 
-                _.each(datagrid.models, function (row) {
-                    if (_.contains(items, row.get(this.config.columnName))) {
+                datagrid.models.forEach((row) => {
+                    if (items.includes(row.get(this.config.columnName))) {
                         row.set('is_checked', true);
                     } else {
                         row.set('is_checked', null);
                     }
-                }.bind(this));
+                });
 
                 this.setItems(items);
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -1,0 +1,321 @@
+'use strict';
+
+/**
+ * Extension to display full screen item picker to choose elements from a grid
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'jquery',
+        'underscore',
+        'oro/translator',
+        'backbone',
+        'routing',
+        'pim/form',
+        'pim/template/common/item-picker',
+        'pimee/template/picker/basket',
+        'oro/datagrid-builder',
+        'oro/mediator',
+        'pim/fetcher-registry',
+        'pim/user-context',
+        'oro/datafilter/product_category-filter',
+        'require-context',
+        'pim/menu/resizable'
+    ],
+    function (
+        $,
+        _,
+        __,
+        Backbone,
+        Routing,
+        BaseForm,
+        template,
+        basketTemplate,
+        datagridBuilder,
+        mediator,
+        FetcherRegistry,
+        UserContext,
+        CategoryFilter,
+        requireContext,
+        Resizable
+    ) {
+        return BaseForm.extend({
+            template: _.template(template),
+            basketTemplate: _.template(basketTemplate),
+            events: {
+                'click .remove-asset': 'removeAssetFromBasket'
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            initialize: function () {
+                this.datagridModel = null;
+
+                BaseForm.prototype.initialize.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            configure: function () {
+                this.datagrid = {
+                    name: 'asset-picker-grid',
+                    paramName: 'assetCodes'
+                };
+
+                mediator.on('datagrid:selectModel:' + this.datagrid.name, this.selectModel.bind(this));
+                mediator.on('datagrid:unselectModel:' + this.datagrid.name, this.unselectModel.bind(this));
+                mediator.on('datagrid_collection_set_after', this.updateChecked.bind(this));
+                mediator.on('datagrid_collection_set_after', this.setDatagrid.bind(this));
+                mediator.on('grid_load:complete', this.updateChecked.bind(this));
+                mediator.once('column_form_listener:initialized', function onColumnListenerReady(gridName) {
+                    if (!this.configured) {
+                        mediator.trigger(
+                            'column_form_listener:set_selectors:' + gridName,
+                            { included: '#asset-appendfield' }
+                        );
+                    }
+                }.bind(this));
+
+                return BaseForm.prototype.configure.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            render: function () {
+                if (!this.configured) {
+                    return this;
+                }
+
+                this.$el.html(this.template({
+                    title: __('pimee_product_asset.form.product.asset.title'),
+                    description: __('pimee_product_asset.form.product.asset.description'),
+                    locale: this.getLocale()
+                }));
+
+                this.renderGrid(this.datagrid);
+                this.setupResizableColumn();
+
+                return this.renderExtensions();
+            },
+
+            /**
+             * Make the categories tree resizable. Because of flexbox we get the
+             * rendered width of the column and use that as the minimum.
+             */
+            setupResizableColumn() {
+                const resizableColumn = this.$('.ui-resizable-container--column');
+                const originalColumnWidth = resizableColumn.outerWidth();
+
+                Resizable.set({
+                    minWidth: originalColumnWidth,
+                    maxWidth: 500,
+                    container: this.$('.ui-resizable-container--column-child'),
+                    storageKey: 'asset-grid'
+                });
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            shutdown() {
+                Resizable.destroy();
+
+                return BaseForm.prototype.shutdown.apply(this, arguments);
+            },
+
+            /**
+             * Render the asset grid
+             */
+            renderGrid: function () {
+                const urlParams = {
+                    alias: this.datagrid.name,
+                    params: {
+                        dataLocale: this.getLocale(),
+                        _filter: {
+                            category: { value: { categoryId: -2 }}, // -2 = all categories
+                            scope: { value: this.getScope() }
+                        }
+                    }
+                };
+
+                /* jshint nonew: false */
+                new CategoryFilter(urlParams, 'asset-grid', 'pimee_asset_picker_categorytree', '#asset-tree');
+
+                $.get(Routing.generate('pim_datagrid_load', urlParams)).done(function (response) {
+                    this.$('#grid-' + this.datagrid.name).data(
+                        { 'metadata': response.metadata, 'data': JSON.parse(response.data) }
+                    );
+
+                    let resolvedModules = [];
+                    response.metadata.requireJSModules.concat(['oro/datagrid/pagination-input'])
+                        .forEach(function(module) {
+                            resolvedModules.push(requireContext(module))
+                        });
+
+                    datagridBuilder(resolvedModules);
+                }.bind(this));
+            },
+
+            /**
+             * Triggered by the event 'datagrid_collection_set_after' to keep a locale reference to
+             * the grid model #gridCrap
+             *
+             * @param {Object} datagridModel
+             */
+            setDatagrid: function (datagridModel) {
+                this.datagridModel = datagridModel;
+            },
+
+            /**
+             * Triggered by the datagrid:selectModel:asset-picker-grid event
+             *
+             * @param {Object} model
+             */
+            selectModel: function (model) {
+                this.addAsset(model.get('code'));
+            },
+
+            /**
+             * Triggered by the datagrid:unselectModel:asset-picker-grid event
+             *
+             * @param {Object} model
+             */
+            unselectModel: function (model) {
+                this.removeAsset(model.get('code'));
+            },
+
+            /**
+             * Add an asset to the basket
+             *
+             * @param {string} code
+             *
+             * @return this
+             */
+            addAsset: function (code) {
+                let assets = this.getAssets();
+                assets.push(code);
+                assets = _.uniq(assets);
+
+                this.setAssets(assets);
+
+                return this;
+            },
+
+            /**
+             * Remove an asset from the collection
+             *
+             * @param {string} code
+             *
+             * @return this
+             */
+            removeAsset: function (code) {
+                let assets = _.without(this.getAssets(), code);
+
+                this.setAssets(assets);
+
+                return this;
+            },
+
+            /**
+             * Get all assets in the collection
+             *
+             * @return {Array}
+             */
+            getAssets: function () {
+                const assets = $('#asset-appendfield').val();
+
+                return (!_.isUndefined(assets) && '' !== assets) ? assets.split(',') : [];
+            },
+
+            /**
+             * Set assets
+             *
+             * @param {Array} assetCodes
+             *
+             * @return this
+             */
+            setAssets: function (assetCodes) {
+                $('#asset-appendfield').val(assetCodes.join(','));
+                this.updateBasket();
+
+                return this;
+            },
+
+            /**
+             * Update the checked rows in the grid according to the current model
+             *
+             * @param {Object} datagrid
+             */
+            updateChecked: function (datagrid) {
+                if (datagrid.inputName !== this.datagrid.name) {
+                    return;
+                }
+
+                const assets = this.getAssets();
+
+                _.each(datagrid.models, function (row) {
+                    if (_.contains(assets, row.get('code'))) {
+                        row.set('is_checked', true);
+                    } else {
+                        row.set('is_checked', null);
+                    }
+                }.bind(this));
+
+                this.setAssets(assets);
+            },
+
+            /**
+             * Remove an asset from the basket (triggered by 'click .remove-asset')
+             *
+             * @param {Event} event
+             */
+            removeAssetFromBasket: function (event) {
+                this.removeAsset(event.currentTarget.dataset.asset);
+                if (this.datagridModel) {
+                    this.updateChecked(this.datagridModel);
+                }
+            },
+
+            /**
+             * Render the basket to update its content
+             */
+            updateBasket: function () {
+                FetcherRegistry.getFetcher('asset').fetchByIdentifiers(this.getAssets())
+                    .then(function (assets) {
+                        this.$('.basket').html(this.basketTemplate({
+                            assets: assets,
+                            thumbnailFilter: 'thumbnail',
+                            scope: this.getScope(),
+                            locale: this.getLocale()
+                        }));
+
+                        this.delegateEvents();
+                    }.bind(this));
+            },
+
+            /**
+             * Get the current locale
+             *
+             * @return {string}
+             */
+            getLocale: function () {
+                return UserContext.get('catalogLocale');
+            },
+
+            /**
+             * Get the current scope
+             *
+             * @return {string}
+             */
+            getScope: function () {
+                return UserContext.get('catalogScope');
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -48,6 +48,7 @@ define(
             events: {
                 'click .remove-item': 'removeItemFromBasket'
             },
+            imagePath: null,
 
             /**
              * {@inheritdoc}
@@ -55,6 +56,9 @@ define(
             initialize: function (config) {
                 this.datagridModel = null;
                 this.config = config.config;
+                this.imagePath = () => {
+                    throw new Error('You have to define "imagePath" method using "setImagePath" method.')
+                };
 
                 if (undefined === this.config.datagridName) {
                     throw new Error('You have to add parameter "datagridName" to the configuration of this module.');
@@ -307,15 +311,17 @@ define(
                     .then(function (items) {
                         this.$('.basket').html(this.basketTemplate({
                             items: items,
-                            thumbnailFilter: 'thumbnail',
-                            scope: this.getScope(),
-                            locale: this.getLocale(),
                             title: __('pim_enrich.form.basket.title'),
                             emptyLabel: __('pim_enrich.form.basket.empty_basket'),
+                            imagePath: this.imagePath.bind(this),
                         }));
 
                         this.delegateEvents();
                     }.bind(this));
+            },
+
+            setImagePath: function (f) {
+                this.imagePath = f;
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -107,7 +107,7 @@ define(
                     title: __(this.config.title),
                     description: __(this.config.description),
                     locale: this.getLocale(),
-                    datagridIdentifier: 'grid-' + this.datagrid.name,
+                    datagridIdentifier: this.datagrid.name,
                 }));
 
                 this.renderGrid(this.datagrid);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -54,6 +54,7 @@ define(
             labelMethod: () => {
                 throw new Error('You have to define "labelMethod" method using "setLabelMethod" method.')
             },
+            title: '',
 
             /**
              * {@inheritdoc}
@@ -61,6 +62,7 @@ define(
             initialize: function (config) {
                 this.datagridModel = null;
                 this.config = config.config;
+                this.title = __(this.config.title);
 
                 if (undefined === this.config.datagridName) {
                     throw new Error('You have to add parameter "datagridName" to the configuration of this module.');
@@ -110,7 +112,7 @@ define(
                 }
 
                 this.$el.html(this.template({
-                    title: __(this.config.title),
+                    title: this.title,
                     description: __(this.config.description),
                     locale: this.getLocale(),
                     datagridIdentifier: this.datagrid.name
@@ -325,12 +327,31 @@ define(
                     }.bind(this));
             },
 
+            /**
+             * Updates the function generating the path of the basket images
+             *
+             * @param {Function} f
+             */
             setImagePathMethod: function (f) {
                 this.imagePathMethod = f;
             },
 
+            /**
+             * Updates the function generating the label of the basket images
+             *
+             * @param {Function} f
+             */
             setLabelMethod: function (f) {
                 this.labelMethod = f;
+            },
+
+            /**
+             * Allows overriding of the default title
+             *
+             * @param {String} title
+             */
+            setCustomTitle: function (title) {
+                this.title = title;
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -16,7 +16,7 @@ define(
         'routing',
         'pim/form',
         'pim/template/common/item-picker',
-        'pimee/template/picker/basket',
+        'pim/template/common/item-picker-basket',
         'oro/datagrid-builder',
         'oro/mediator',
         'pim/fetcher-registry',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -195,7 +195,7 @@ define(
              * @param {Object} model
              */
             selectModel: function (model) {
-                this.addItem(model.get('code'));
+                this.addItem(model.get(this.config.columnName));
             },
 
             /**
@@ -204,7 +204,7 @@ define(
              * @param {Object} model
              */
             unselectModel: function (model) {
-                this.removeItem(model.get('code'));
+                this.removeItem(model.get(this.config.columnName));
             },
 
             /**
@@ -277,7 +277,7 @@ define(
                 const items = this.getItems();
 
                 _.each(datagrid.models, function (row) {
-                    if (_.contains(items, row.get('code'))) {
+                    if (_.contains(items, row.get(this.config.columnName))) {
                         row.set('is_checked', true);
                     } else {
                         row.set('is_checked', null);
@@ -300,14 +300,13 @@ define(
             },
 
             /**
-             * TODO Render this more abstract with config
              * Render the basket to update its content
              */
             updateBasket: function () {
-                FetcherRegistry.getFetcher('asset').fetchByIdentifiers(this.getItems())
-                    .then(function (assets) {
+                FetcherRegistry.getFetcher(this.config.fetcher).fetchByIdentifiers(this.getItems())
+                    .then(function (items) {
                         this.$('.basket').html(this.basketTemplate({
-                            items: assets,
+                            items: items,
                             thumbnailFilter: 'thumbnail',
                             scope: this.getScope(),
                             locale: this.getLocale(),

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/product-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/product-fetcher.js
@@ -4,6 +4,7 @@ define(
     [
         'jquery',
         'backbone',
+        'pim/base-fetcher',
         'routing',
         'oro/mediator',
         'pim/cache-invalidator'
@@ -11,18 +12,12 @@ define(
     function (
         $,
         Backbone,
+        BaseFetcher,
         Routing,
         mediator,
         CacheInvalidator
     ) {
-        return Backbone.Model.extend({
-            /**
-             * @param {Object} options
-             */
-            initialize: function (options) {
-                this.options = options || {};
-            },
-
+        return BaseFetcher.extend({
             /**
              * Fetch an element based on its identifier
              *
@@ -33,7 +28,7 @@ define(
             fetch: function (identifier) {
                 return $.getJSON(Routing.generate(this.options.urls.get, { id: identifier }))
                     .then(function (product) {
-                        var cacheInvalidator = new CacheInvalidator();
+                        const cacheInvalidator = new CacheInvalidator();
                         cacheInvalidator.checkStructureVersion(product);
 
                         mediator.trigger('pim_enrich:form:product:post_fetch', product);
@@ -41,6 +36,13 @@ define(
                         return product;
                     })
                     .promise();
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            getIdentifierField: function () {
+                return $.Deferred().resolve('identifier');
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -631,13 +631,17 @@ define(
                     });
                     modal.open();
 
-                    form.setImagePath(function (item) {
+                    form.setImagePathMethod(function (item) {
                         let filePath = null;
                         if (item.meta.image !== null) {
                             filePath = item.meta.image.filePath;
                         }
 
                         return MediaUrlGenerator.getMediaShowUrl(filePath, 'thumbnail_small');
+                    });
+
+                    form.setLabelMethod(function (item) {
+                        return item.meta.label[this.getLocale()];
                     });
 
                     form.setElement(modal.$('.modal-body')).render();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -177,7 +177,8 @@ define(
                             currentAssociationType: _.findWhere(
                                 associationTypes,
                                 {code: this.getCurrentAssociationType()}
-                            )
+                            ),
+                            addProductsLabel: __('pim_enrich.form.product.tab.associations.add_products'),
                         })
                     );
                     this.renderPanes();
@@ -596,25 +597,25 @@ define(
              * Opens the panel to select new products
              */
             addProducts: function () {
-                this.manageAssets().then(function (productIdentifiers) {
+                this.manageProducts().then((productIdentifiers) => {
                     this.data = productIdentifiers;
 
                     this.trigger('collection:change', productIdentifiers);
                     this.render();
-                }.bind(this));
+                });
             },
 
             /**
-             * Launch the asset picker
+             * Launch the association product picker
              *
              * @return {Promise}
              */
-            manageAssets: function () {
+            manageProducts: function () {
                 let deferred = $.Deferred();
 
                 this.data = [];
 
-                FormBuilder.build('pim-associations-product-picker-form').then(function (form) {
+                FormBuilder.build('pim-associations-product-picker-form').then((form) => {
                     let modal = new Backbone.BootstrapModal({
                         className: 'modal modal--fullPage modal--topButton',
                         modalOptions: {
@@ -644,13 +645,15 @@ define(
                         .setItems(this.data);
 
                     modal.on('cancel', deferred.reject);
-                    modal.on('ok', function () {
-                        const assets = _.sortBy(form.getItems(), 'code');
+                    modal.on('ok', () => {
+                        const products = form.getItems().sort((a, b) => {
+                            return a.code < b.code;
+                        });
                         modal.close();
 
-                        deferred.resolve(assets);
-                    }.bind(this));
-                }.bind(this));
+                        deferred.resolve(products);
+                    });
+                });
 
                 return deferred.promise();
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -25,7 +25,8 @@ define(
         'oro/pageable-collection',
         'pim/datagrid/state',
         'require-context',
-        'pim/form-builder'
+        'pim/form-builder',
+        'pim/media-url-generator'
     ],
     function (
         $,
@@ -44,7 +45,8 @@ define(
         PageableCollection,
         DatagridState,
         requireContext,
-        FormBuilder
+        FormBuilder,
+        MediaUrlGenerator
     ) {
         let state = {};
 
@@ -628,6 +630,15 @@ define(
                         okText: _.__('pimee_product_asset.form.product.asset.manage_asset.confirm')
                     });
                     modal.open();
+
+                    form.setImagePath(function (item) {
+                        let filePath = null;
+                        if (item.meta.image !== null) {
+                            filePath = item.meta.image.filePath;
+                        }
+
+                        return MediaUrlGenerator.getMediaShowUrl(filePath, 'thumbnail_small');
+                    });
 
                     form.setElement(modal.$('.modal-body'))
                         .render()

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -596,11 +596,10 @@ define(
              * Opens the panel to select new products
              */
             addProducts: function () {
-                this.manageAssets().then(function (assets) {
-                    console.log(assets);
-                    this.data = assets;
+                this.manageAssets().then(function (productIdentifiers) {
+                    this.data = productIdentifiers;
 
-                    this.trigger('collection:change', assets);
+                    this.trigger('collection:change', productIdentifiers);
                     this.render();
                 }.bind(this));
             },
@@ -617,17 +616,17 @@ define(
 
                 FormBuilder.build('pim-associations-product-picker-form').then(function (form) {
                     let modal = new Backbone.BootstrapModal({
-                        className: 'modal modal-asset modal--fullPage modal--topButton',
+                        className: 'modal modal--fullPage modal--topButton',
                         modalOptions: {
                             backdrop: 'static',
                             keyboard: false
                         },
                         allowCancel: true,
                         okCloses: false,
-                        title: _.__('pimee_product_asset.form.product.asset.manage_asset.title'),
+                        title: '',
                         content: '',
-                        cancelText: _.__('pimee_product_asset.form.product.asset.manage_asset.cancel'),
-                        okText: _.__('pimee_product_asset.form.product.asset.manage_asset.confirm')
+                        cancelText: '',
+                        okText: __('confirmation.title'),
                     });
                     modal.open();
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -57,7 +57,7 @@ define(
             events: {
                 'click .associations-list li': 'changeAssociationType',
                 'click .target-button': 'changeAssociationTargets',
-                'click .add-products': 'addProducts',
+                'click .add-products': 'addProducts'
             },
             datagrids: {},
 
@@ -178,7 +178,7 @@ define(
                                 associationTypes,
                                 {code: this.getCurrentAssociationType()}
                             ),
-                            addProductsLabel: __('pim_enrich.form.product.tab.associations.add_products'),
+                            addProductsLabel: __('pim_enrich.form.product.tab.associations.add_products')
                         })
                     );
                     this.renderPanes();
@@ -627,7 +627,7 @@ define(
                         title: '',
                         content: '',
                         cancelText: ' ',
-                        okText: __('confirmation.title'),
+                        okText: __('confirmation.title')
                     });
                     modal.open();
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -625,7 +625,7 @@ define(
                         okCloses: false,
                         title: '',
                         content: '',
-                        cancelText: '',
+                        cancelText: ' ',
                         okText: __('confirmation.title'),
                     });
                     modal.open();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -26,7 +26,8 @@ define(
         'pim/datagrid/state',
         'require-context',
         'pim/form-builder',
-        'pim/media-url-generator'
+        'pim/media-url-generator',
+        'pim/security-context'
     ],
     function (
         $,
@@ -46,7 +47,8 @@ define(
         DatagridState,
         requireContext,
         FormBuilder,
-        MediaUrlGenerator
+        MediaUrlGenerator,
+        securityContext
     ) {
         let state = {};
 
@@ -60,11 +62,14 @@ define(
                 'click .add-associations': 'addAssociations'
             },
             datagrids: {},
+            config: {},
 
             /**
              * {@inheritdoc}
              */
-            initialize: function () {
+            initialize: function (meta) {
+                this.config = meta.config;
+
                 state = {
                     associationTarget: 'products'
                 };
@@ -178,7 +183,8 @@ define(
                                 associationTypes,
                                 {code: this.getCurrentAssociationType()}
                             ),
-                            addAssociationsLabel: __('pim_enrich.form.product.tab.associations.add_associations')
+                            addAssociationsLabel: __('pim_enrich.form.product.tab.associations.add_associations'),
+                            addAssociationVisible: this.isAddAssociationsVisible()
                         })
                     );
                     this.renderPanes();
@@ -591,6 +597,10 @@ define(
              */
             isVisible: function () {
                 return true;
+            },
+
+            isAddAssociationsVisible: function () {
+                return securityContext.isGranted(this.config.aclAddAssociations);
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -598,7 +598,9 @@ define(
              */
             addProducts: function () {
                 this.manageProducts().then((productIdentifiers) => {
-                    this.data = productIdentifiers;
+                    const assocType = this.getCurrentAssociationType();
+                    const assocTarget = this.getCurrentAssociationTarget();
+                    this.updateFormDataAssociations(productIdentifiers, assocType, assocTarget);
 
                     this.trigger('collection:change', productIdentifiers);
                     this.render();
@@ -612,8 +614,6 @@ define(
              */
             manageProducts: function () {
                 let deferred = $.Deferred();
-
-                this.data = [];
 
                 FormBuilder.build('pim-associations-product-picker-form').then((form) => {
                     let modal = new Backbone.BootstrapModal({
@@ -640,9 +640,7 @@ define(
                         return MediaUrlGenerator.getMediaShowUrl(filePath, 'thumbnail_small');
                     });
 
-                    form.setElement(modal.$('.modal-body'))
-                        .render()
-                        .setItems(this.data);
+                    form.setElement(modal.$('.modal-body')).render();
 
                     modal.on('cancel', deferred.reject);
                     modal.on('ok', () => {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker-basket.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker-basket.html
@@ -2,31 +2,26 @@
     <div class="AknColumnConfigurator-columnHeader">
         <%- title %>
     </div>
-    <div class="AknColumnConfigurator-listContainer basket-inner">
-        <!-- TODO Rename AssetCollectionField to ThumbnailCollection or something like this -->
-        <div class="AknAssetCollectionField AknAssetCollectionField--withoutBorder">
-            <ul class="AknAssetCollectionField-list">
-                <% if (!_.isEmpty(items)) { %>
-                <% _.each(items, function (item) { %>
-                <li class="AknAssetCollectionField-listItem" data-itemCode="<%- item.code %>">
-                    <div class="AknAssetCollectionField-assetThumbnail" style="background-image: url('<%- imagePath(item) %>')">
+    <div class="AknGrid--gallery AknColumnConfigurator-listContainer">
+        <div class="AknGridContainer AknGridContainer--withCheckbox">
+            <div class="AknGrid">
+                <div class="AknGrid-body basket-inner">
+                    <% if (!_.isEmpty(items)) { %>
+                    <% _.each(items, function (item) { %>
+                    <div data-itemCode="<%- item[columnName] %>" class="AknGrid-bodyRow AknGrid-bodyRow--thumbnail AknGrid-bodyRow--withoutTopBorder">
+                        <div class="AknGrid-fullImage" style="background-image: url('<%- imagePathMethod(item) %>')"></div>
+                        <div class="AknButton AknButton--important AknButton--micro AknButton-squareIcon AknButton-squareIcon--delete AknAssetCollectionField-icon remove-item" data-itemCode="<%- item[columnName] %>"></div>
+                        <div class="AknGrid-title"><%- labelMethod(item) %></div>
+                        <div class="AknGrid-subTitle"><%- item[identifierName] %></div>
                     </div>
-                    <div>
-                        <% if (item.description) { %>
-                        <%- item.description.substring(0, 120) %><%- item.description.length > 120 ? '...' : '' %>
-                        <% } %>
+                    <% }); %>
+                    <% } else { %>
+                    <div class="empty-basket">
+                        <%- emptyLabel %>
                     </div>
-                    <div class="AknIconButton AknIconButton--grey AknIconButton--small AknAssetCollectionField-icon">
-                        <i class="icon-trash remove-item" data-itemCode="<%- item.code %>"></i>
-                    </div>
-                </li>
-                <% }); %>
-                <% } else { %>
-                <li class="empty-basket">
-                    <%- emptyLabel %>
-                </li>
-                <% } %>
-            </ul>
+                    <% } %>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker-basket.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker-basket.html
@@ -1,33 +1,34 @@
-<div class="asset-basket panel-container">
+<div class="item-picker-basket panel-container">
     <div class="AknColumnConfigurator-columnHeader">
-        <%- _.__('pimee_product_asset.form.product.asset.panel.basket.title') %>
+        <%- title %>
     </div>
     <div class="AknColumnConfigurator-listContainer basket-inner">
+        <!-- TODO Rename AssetCollectionField to ThumbnailCollection or something like this -->
         <div class="AknAssetCollectionField AknAssetCollectionField--withoutBorder">
             <ul class="AknAssetCollectionField-list">
-                <% if (!_.isEmpty(assets)) { %>
-                <% _.each(assets, function (asset) { %>
-                <li class="AknAssetCollectionField-listItem" data-asset="<%- asset.code %>">
-                    <div class="AknAssetCollectionField-assetThumbnail asset-thumbnail" style="background-image: url('<%- Routing.generate('pimee_product_asset_thumbnail', {
-                                    code: asset.code,
+                <% if (!_.isEmpty(items)) { %>
+                <% _.each(items, function (item) { %>
+                <li class="AknAssetCollectionField-listItem" data-itemCode="<%- item.code %>">
+                    <div class="AknAssetCollectionField-assetThumbnail" style="background-image: url('<%- Routing.generate('pimee_product_asset_thumbnail', {
+                                    code: item.code,
                                     filter: thumbnailFilter,
                                     channelCode: scope,
                                     localeCode: locale
                                 }) %>')">
                     </div>
-                    <div class="asset-description">
-                        <% if (asset.description) { %>
-                        <%- asset.description.substring(0, 120) %><%- asset.description.length > 120 ? '...' : '' %>
+                    <div>
+                        <% if (item.description) { %>
+                        <%- item.description.substring(0, 120) %><%- item.description.length > 120 ? '...' : '' %>
                         <% } %>
                     </div>
-                    <div class="AknIconButton AknIconButton--grey AknIconButton--small AknAssetCollectionField-icon asset-action">
-                        <i class="icon-trash remove-asset" data-asset="<%- asset.code %>"></i>
+                    <div class="AknIconButton AknIconButton--grey AknIconButton--small AknAssetCollectionField-icon">
+                        <i class="icon-trash remove-item" data-itemCode="<%- item.code %>"></i>
                     </div>
                 </li>
                 <% }); %>
                 <% } else { %>
                 <li class="empty-basket">
-                    <%- _.__('pimee_product_asset.form.product.asset.panel.basket.empty_basket') %>
+                    <%- emptyLabel %>
                 </li>
                 <% } %>
             </ul>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker-basket.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker-basket.html
@@ -1,0 +1,36 @@
+<div class="asset-basket panel-container">
+    <div class="AknColumnConfigurator-columnHeader">
+        <%- _.__('pimee_product_asset.form.product.asset.panel.basket.title') %>
+    </div>
+    <div class="AknColumnConfigurator-listContainer basket-inner">
+        <div class="AknAssetCollectionField AknAssetCollectionField--withoutBorder">
+            <ul class="AknAssetCollectionField-list">
+                <% if (!_.isEmpty(assets)) { %>
+                <% _.each(assets, function (asset) { %>
+                <li class="AknAssetCollectionField-listItem" data-asset="<%- asset.code %>">
+                    <div class="AknAssetCollectionField-assetThumbnail asset-thumbnail" style="background-image: url('<%- Routing.generate('pimee_product_asset_thumbnail', {
+                                    code: asset.code,
+                                    filter: thumbnailFilter,
+                                    channelCode: scope,
+                                    localeCode: locale
+                                }) %>')">
+                    </div>
+                    <div class="asset-description">
+                        <% if (asset.description) { %>
+                        <%- asset.description.substring(0, 120) %><%- asset.description.length > 120 ? '...' : '' %>
+                        <% } %>
+                    </div>
+                    <div class="AknIconButton AknIconButton--grey AknIconButton--small AknAssetCollectionField-icon asset-action">
+                        <i class="icon-trash remove-asset" data-asset="<%- asset.code %>"></i>
+                    </div>
+                </li>
+                <% }); %>
+                <% } else { %>
+                <li class="empty-basket">
+                    <%- _.__('pimee_product_asset.form.product.asset.panel.basket.empty_basket') %>
+                </li>
+                <% } %>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker-basket.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker-basket.html
@@ -9,12 +9,7 @@
                 <% if (!_.isEmpty(items)) { %>
                 <% _.each(items, function (item) { %>
                 <li class="AknAssetCollectionField-listItem" data-itemCode="<%- item.code %>">
-                    <div class="AknAssetCollectionField-assetThumbnail" style="background-image: url('<%- Routing.generate('pimee_product_asset_thumbnail', {
-                                    code: item.code,
-                                    filter: thumbnailFilter,
-                                    channelCode: scope,
-                                    localeCode: locale
-                                }) %>')">
+                    <div class="AknAssetCollectionField-assetThumbnail" style="background-image: url('<%- imagePath(item) %>')">
                     </div>
                     <div>
                         <% if (item.description) { %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
@@ -8,14 +8,14 @@
     <div class="AknColumnConfigurator-column ui-resizable-container--column">
         <div class="AknColumnConfigurator-listContainer ui-resizable-container--column-child">
             <div class="AknColumnConfigurator-relativeContent categories-container">
-                <div id="item-picker-tree" data-datalocale="<%= locale %>" data-name="category" data-type="tree" class="filter-item" data-relatedentity="asset"></div>
+                <div id="item-picker-tree" data-datalocale="<%= locale %>" data-name="category" data-type="tree" class="filter-item" data-relatedentity="product"></div>
             </div>
         </div>
     </div>
     <div class="AknColumnConfigurator-column AknColumnConfigurator-column--large">
         <div class="AknColumnConfigurator-listContainer">
-            <div id="asset-picker-grid" class="asset-grid">
-                <div id="<%- datagridIdentifier %>" data-type="datagrid">
+            <div id="<%- datagridIdentifier %>" class="asset-grid">
+                <div id="grid-<%- datagridIdentifier %>" data-type="datagrid">
                     <div class="AknFilterBox AknFilterBox--search AknFilterBox--sticky filter-box" data-drop-zone="filters"></div>
                 </div>
             </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
@@ -8,7 +8,7 @@
     <div class="AknColumnConfigurator-column ui-resizable-container--column">
         <div class="AknColumnConfigurator-listContainer ui-resizable-container--column-child">
             <div class="AknColumnConfigurator-relativeContent categories-container">
-                <div id="asset-tree" data-datalocale="<%= locale %>" data-name="category" data-type="tree" class="filter-item" data-relatedentity="asset"></div>
+                <div id="item-picker-tree" data-datalocale="<%= locale %>" data-name="category" data-type="tree" class="filter-item" data-relatedentity="asset"></div>
             </div>
         </div>
     </div>
@@ -24,7 +24,7 @@
     <div class="AknColumnConfigurator-column">
         <div class="basket"></div>
         <div class="selection-inputs">
-            <input type="hidden" id="asset-appendfield"/>
+            <input type="hidden" id="item-picker-append-field"/>
         </div>
     </div>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
@@ -14,7 +14,7 @@
     </div>
     <div class="AknColumnConfigurator-column AknColumnConfigurator-column--large">
         <div class="AknColumnConfigurator-listContainer">
-            <div id="<%- datagridIdentifier %>" class="asset-grid">
+            <div id="<%- datagridIdentifier %>">
                 <div id="grid-<%- datagridIdentifier %>" data-type="datagrid">
                     <div class="AknFilterBox AknFilterBox--search AknFilterBox--sticky filter-box" data-drop-zone="filters"></div>
                 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
@@ -15,7 +15,7 @@
     <div class="AknColumnConfigurator-column AknColumnConfigurator-column--large">
         <div class="AknColumnConfigurator-listContainer">
             <div id="asset-picker-grid" class="asset-grid">
-                <div id="grid-asset-picker-grid" data-type="datagrid">
+                <div id="<%- datagridIdentifier %>" data-type="datagrid">
                     <div class="AknFilterBox AknFilterBox--search AknFilterBox--sticky filter-box" data-drop-zone="filters"></div>
                 </div>
             </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
@@ -1,0 +1,30 @@
+<div class="AknColumnConfigurator">
+    <div class="AknColumnConfigurator-title AknFullPage-title">
+        <%- title %>
+    </div>
+    <div class="AknColumnConfigurator-subTitle AknFullPage-description">
+        <%- description %>
+    </div>
+    <div class="AknColumnConfigurator-column ui-resizable-container--column">
+        <div class="AknColumnConfigurator-listContainer ui-resizable-container--column-child">
+            <div class="AknColumnConfigurator-relativeContent categories-container">
+                <div id="asset-tree" data-datalocale="<%= locale %>" data-name="category" data-type="tree" class="filter-item" data-relatedentity="asset"></div>
+            </div>
+        </div>
+    </div>
+    <div class="AknColumnConfigurator-column AknColumnConfigurator-column--large">
+        <div class="AknColumnConfigurator-listContainer">
+            <div id="asset-picker-grid" class="asset-grid">
+                <div id="grid-asset-picker-grid" data-type="datagrid">
+                    <div class="AknFilterBox AknFilterBox--search AknFilterBox--sticky filter-box" data-drop-zone="filters"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="AknColumnConfigurator-column">
+        <div class="basket"></div>
+        <div class="selection-inputs">
+            <input type="hidden" id="asset-appendfield"/>
+        </div>
+    </div>
+</div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker.html
@@ -21,7 +21,7 @@
             </div>
         </div>
     </div>
-    <div class="AknColumnConfigurator-column">
+    <div class="AknColumnConfigurator-column AknColumnConfigurator-column--fixed">
         <div class="basket"></div>
         <div class="selection-inputs">
             <input type="hidden" id="item-picker-append-field"/>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
@@ -10,8 +10,8 @@
             <div class="association-product-grid<% if ('products' !== currentAssociationTarget) { %> hide<% } %>">
                 <div id="grid-association-product-grid" data-type="datagrid">
                     <div class="AknButtonList AknButtonList--right">
-                        <div class="AknButton AknButton--action AknButtonList-item add-products">
-                            <%- addProductsLabel %>
+                        <div class="AknButton AknButton--action AknButtonList-item add-associations">
+                            <%- addAssociationsLabel %>
                         </div>
                     </div>
                 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
@@ -9,11 +9,13 @@
         <div class="tab-content">
             <div class="association-product-grid<% if ('products' !== currentAssociationTarget) { %> hide<% } %>">
                 <div id="grid-association-product-grid" data-type="datagrid">
+                    <% if (addAssociationVisible) { %>
                     <div class="AknButtonList AknButtonList--right">
                         <div class="AknButton AknButton--action AknButtonList-item add-associations">
                             <%- addAssociationsLabel %>
                         </div>
                     </div>
+                    <% } %>
                 </div>
             </div>
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
@@ -8,7 +8,13 @@
     <div class="tabbable">
         <div class="tab-content">
             <div class="association-product-grid<% if ('products' !== currentAssociationTarget) { %> hide<% } %>">
-                <div id="grid-association-product-grid" data-type="datagrid"></div>
+                <div id="grid-association-product-grid" data-type="datagrid">
+                    <div class="AknButtonList AknButtonList--right">
+                        <div class="AknButton AknButton--action AknButtonList-item add-products">
+                            Add products
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <div class="association-group-grid<% if ('groups' !== currentAssociationTarget) { %> hide<% } %>">

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associations.html
@@ -11,7 +11,7 @@
                 <div id="grid-association-product-grid" data-type="datagrid">
                     <div class="AknButtonList AknButtonList--right">
                         <div class="AknButton AknButton--action AknButtonList-item add-products">
-                            Add products
+                            <%- addProductsLabel %>
                         </div>
                     </div>
                 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -478,9 +478,9 @@ pim_enrich:
                         number_of_associations: "{{ productCount }} product(s) and {{ groupCount }} group(s)"
                     association_type_selector: Association type
                     target: Target
-                    manage: Add products to association
-                    manage_description: Select the products you want to add to the current product
-                    add_products: Add products
+                    manage: Add {{ associationType }} associations
+                    manage_description: Select the products you want to associate with the current product
+                    add_associations: Add associations
                 attributes:
                     title: Attributes
                     btn:

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -1,5 +1,6 @@
 # Grid action messages
 confirmation:
+    title: Confirm
     remove:
         item:             Are you sure you want to delete this item?
         association_type: Are you sure you want to delete this association type?
@@ -477,6 +478,8 @@ pim_enrich:
                         number_of_associations: "{{ productCount }} product(s) and {{ groupCount }} group(s)"
                     association_type_selector: Association type
                     target: Target
+                    manage: Add products to association
+                    manage_description: Select the products you want to add to the current product
                 attributes:
                     title: Attributes
                     btn:

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -480,6 +480,7 @@ pim_enrich:
                     target: Target
                     manage: Add products to association
                     manage_description: Select the products you want to add to the current product
+                    add_products: Add products
                 attributes:
                     title: Attributes
                     btn:

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -797,7 +797,9 @@ pim_enrich:
                         select_attributes: Add attributes
                         add: Add
                         attributes_groups_selected: '{{ itemsCount }} group(s) selected'
-
+        basket:
+            title: Basket
+            empty_basket: Basket is empty
     job:
         upload: Drop your {{ type }} file here, or click to browse disk
     export:

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -174,7 +174,8 @@ pim_enrich:
             add_attribute: Add an attribute to a product
             remove_attribute: Remove an attribute from a product
             categories_view: Consult the categories of a product
-            associations_view: View the association types of a product
+            associations_view: View the associations of a product
+            associations_edit: Edit the associations of a product
             change_family: Change product family
             change_state: Change state of product
             add_to_groups: Add product to groups

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
@@ -34,6 +34,10 @@
     &--gray {
       background: @AknLightGray;
     }
+
+    &--fixed {
+      flex-basis: 300px;
+    }
   }
 
   &-columnHeader {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
@@ -103,7 +103,7 @@
     padding: 10px 0;
   }
 
-  &-search {
+  &-search:not(:empty) {
     flex: 1;
     border-bottom: 1px solid @AknBorderColor;
   }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/Button.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/Button.less
@@ -260,5 +260,18 @@
     &--assetCollection {
       background-image: url("../../../images/attribute/icon-assetCollection.svg");
     }
+
+    &--delete {
+      background-image: url("../../../images/icon-delete-white.svg")
+    }
+  }
+
+  &-squareIcon&--micro {
+    background-position: center;
+    background-size: 75%;
+    width: @AknMicroButtonSize;
+    height: @AknMicroButtonSize;
+    padding: 0;
+    background-repeat: no-repeat;
   }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -24,9 +24,8 @@
     justify-content: flex-end;
     padding: 0 0 1px 0;
     background: none;
-    margin: 0 0 10px 0;
+    margin: 10px 0 10px 0;
     flex-wrap: wrap;
-    margin-top: -@AknPaddingLeftColumn;
     background: white;
   }
 
@@ -35,7 +34,7 @@
     background: white;
     padding: 10px 0 1px 0;
     margin: -10px 0 10px 0;
-    top: 0px;
+    top: 0;
     z-index: 1;
   }
 
@@ -65,13 +64,17 @@
     order: -1;
     flex-grow: 1;
     display: flex;
+    margin-top: -20px;
   }
 
   &-filterContainer {
-    margin-right: 30px;
     cursor: pointer;
     position: relative;
-    margin-top: @AknPaddingLeftColumn;
+    margin-top: 20px;
+  }
+
+  &--search &-filterContainer {
+    margin-top: 10px;
   }
 
   &-filter {
@@ -158,10 +161,12 @@
   }
 
   &--search &-list {
+    margin-right: 30px;
     display: flex;
     flex-grow: 1;
     align-items: center;
     justify-content: flex-end;
+    flex-wrap: wrap;
   }
 
   &--search &-addFilterButton {
@@ -175,7 +180,7 @@
     background: url("../../../images/icon-filters.svg") no-repeat left 50%;
     flex-grow: 1;
     padding-left: 35px !important; // The padding is updated by JS method.
-    margin-top: 30px;
     margin-left: 10px;
+    margin-top: 10px;
   }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -175,6 +175,7 @@
     background: url("../../../images/icon-filters.svg") no-repeat left 50%;
     flex-grow: 1;
     padding-left: 35px !important; // The padding is updated by JS method.
-    margin-top: 26px;
+    margin-top: 30px;
+    margin-left: 10px;
   }
 }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery.multiselect.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery.multiselect.less
@@ -221,15 +221,25 @@
   }
 
   &.ui-multiselect-menu {
-    top: 0 !important;
-    width: @AknThirdColumnWidth !important;
-    min-width: @AknThirdColumnWidth !important;
-    height: 100vh !important;
-    border-right: 1px solid @AknBorderColor;
     background: white;
     padding: 15px 20px !important;
-    z-index: 750;
-    transition: left @AknColumnTiming @AknColumnTransition;
+
+    &:not(.AknFilterBox-addFilterButton--asPanel) {
+      top: 0 !important;
+      width: @AknThirdColumnWidth !important;
+      min-width: @AknThirdColumnWidth !important;
+      height: 100vh !important;
+      border-right: 1px solid @AknBorderColor;
+      z-index: 750;
+      transition: left @AknColumnTiming @AknColumnTransition;
+    }
+
+    &.AknFilterBox-addFilterButton--asPanel {
+      height: auto;
+      border: 1px solid @AknBorderColor;
+      max-height: 300px;
+      overflow: auto;
+    }
 
     .ui-multiselect-filter {
       border-bottom: 1px solid @AknLightPurple;


### PR DESCRIPTION
# Description

This PR is a complete new screen to manage associations with the new UI. As it's more or less the same screen than the asset picker, we moved the asset picker JS module from EE to CE, and rename it `item-picker` to be more abstract and be able to use it for several entities.

## A warning

For now, this PR will only add a "Add products" button to display the new screen to be able to add products. As the existing association grid is still here and will be removed in another story, the validation of this screen DOES NOTHING (for now, put the checked products into a useless variable).
So, just before merging it, I will hide the button to keep the existing features. That's why there is no behats.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | y
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -