### PR TITLE
Query checker config fix

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Resources/config/checkers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/checkers.yml
@@ -8,4 +8,4 @@ services:
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.category'
-            - ['family', 'enabled', 'groups', 'categories', 'completeness', 'created', 'updated']
+            - ['family', 'enabled', 'groups', 'categories', 'completeness', 'identifier', 'created', 'updated']

--- a/src/Pim/Bundle/ApiBundle/Resources/config/checkers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/checkers.yml
@@ -8,4 +8,4 @@ services:
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.category'
-            - ['family', 'enabled', 'groups', 'categories', 'completeness']
+            - ['family', 'enabled', 'groups', 'categories', 'completeness', 'created', 'updated']


### PR DESCRIPTION
Currently, it is not possible to filter products by `updated` or `created` property as described in the API docs.

This PR should fix this.

