### PR TITLE
PIM-6621: add search on label and identifier

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -3,6 +3,7 @@
 ## Improvements
 
 - PIM-6480: Add gallery view and display selector to the product grid
+- PIM-6621: add search on label and code on products and product models
 
 ## BC breaks
 

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -133,6 +133,9 @@ class Grid extends Index
         'akeneo-attribute-media-filter' => [
             'Pim\Behat\Decorator\Export\Filter\BaseDecorator',
             'Pim\Behat\Decorator\Export\Filter\MediaDecorator',
+        ],
+        'label_or_identifier' => [
+            'Pim\Behat\Decorator\Grid\Filter\SearchDecorator',
         ]
     ];
 

--- a/features/Pim/Behat/Decorator/Grid/Filter/SearchDecorator.php
+++ b/features/Pim/Behat/Decorator/Grid/Filter/SearchDecorator.php
@@ -2,10 +2,65 @@
 
 namespace Pim\Behat\Decorator\Grid\Filter;
 
+use Context\Spin\SpinCapableTrait;
+use Context\Spin\TimeoutException;
 use Pim\Behat\Decorator\ElementDecorator;
 
 class SearchDecorator extends ElementDecorator
 {
+    use SpinCapableTrait;
+
+    /**
+     * Opens the filter
+     */
+    public function open()
+    {
+    }
+
+    /**
+     * Remove the filter from the grid
+     */
+    public function remove()
+    {
+    }
+
+    /**
+     * Sets value in the filter
+     *
+     * @param string $operator
+     * @param string $value
+     */
+    public function filter($operator, $value)
+    {
+        $field = $this->find('css', '[name="value"]');
+        $field->setValue($value);
+        $this->getSession()->executeScript(
+            sprintf(
+                '$(\'.filter-item[data-name="%s"][data-type="%s"] [name="value"]\').trigger(\'change\')',
+                $this->getAttribute('data-name'),
+                $this->getAttribute('data-type')
+            )
+        );
+    }
+
+    /**
+     * Return whether this filter input value is visible
+     *
+     * @return bool
+     */
+    public function isInputValueVisible()
+    {
+        try {
+            $filterInput = $this->spin(function () {
+                return $this->find('css', '[name="value"]');
+            }, 'Cannot find the value input');
+        } catch (TimeoutException $exception) {
+            return false;
+        }
+
+        return $filterInput && $filterInput->isVisible();
+    }
+
     /**
      * Search a value in the search filter
      *

--- a/features/product/filtering/filter_products_per_label_or_identifier.feature
+++ b/features/product/filtering/filter_products_per_label_or_identifier.feature
@@ -1,0 +1,42 @@
+@javascript
+Feature: Filter products by label or identifier field
+  In order to ease the search of products in the products grid
+  As a regular user
+  I need to be able to filter products in the catalog
+
+  Background:
+    Given the "default" catalog configuration
+    And I am logged in as "Julia"
+
+  Scenario: Successfully filter products on their label or identifier
+    Given I add the "english" locale to the "mobile" channel
+    And the following attributes:
+      | label-en_US | type             | localizable | scopable | useable_as_grid_filter | group | code |
+      | name        | pim_catalog_text | 1           | 1        | 1                      | other | name |
+      | ean         | pim_catalog_text | 0           | 1        | 1                      | other | ean  |
+      | isbn        | pim_catalog_text | 1           | 0        | 1                      | other | isbn |
+    And the following families:
+      | code   | attribute_as_label | attributes    |
+      | office | name               | name,ean      |
+      | home   | ean                | name,ean      |
+      | book   | isbn               | name,ean,isbn |
+    And the following products:
+      | sku               | family | name-en_US-ecommerce | ean-ecommerce | isbn-en_US |
+      | 125824            | office | Post it              | 2525          |            |
+      | 6589              | office | paper                | post          |            |
+      | mug               | home   | Mug                  | 2412          |            |
+      | 50_shades_of_grey | book   | 50 shades of grey    | 1212          | 2424       |
+    And I am on the products page
+    Then the grid should contain 4 elements
+    And I should see products 125824, 6589, mug and 50_shades_of_grey
+    And I should be able to use the following filters:
+      | filter              | operator | value   | result                         |
+      | label_or_identifier | equals   | 125824  | 125824                         |
+      | label_or_identifier | equals   | post    | 125824                         |
+      | label_or_identifier | equals   | post it | 125824                         |
+      | label_or_identifier | equals   | paper   | 6589                           |
+      | label_or_identifier | equals   | 2412    | mug                            |
+      | label_or_identifier | equals   | pape    | 6589                           |
+      | label_or_identifier | equals   | 24      | 50_shades_of_grey              |
+      | label_or_identifier | equals   | shade   | 50_shades_of_grey              |
+      | label_or_identifier | equals   | 24      | 125824, mug, 50_shades_of_grey |

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/LabelOrIdentifierFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/LabelOrIdentifierFilter.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * Label or identifier filter for an Elasticsearch query
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LabelOrIdentifierFilter extends AbstractFieldFilter
+{
+    /**
+     * @param array $supportedFields
+     * @param array $supportedOperators
+     */
+    public function __construct(
+        array $supportedFields = [],
+        array $supportedOperators = []
+    ) {
+        $this->supportedFields = $supportedFields;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldFilter(
+        $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkValue($operator, $value);
+
+        $clause[] = [
+            'wildcard' => [
+                'identifier' => sprintf('*%s*', $this->escapeValue($value)),
+            ]
+        ];
+
+        if (null !== $channel && null !== $locale) {
+            $clause[] = [
+                'wildcard' => [
+                    sprintf('label.%s.%s', $channel, $locale) => sprintf('*%s*', $this->escapeValue($value)),
+                ]
+            ];
+        }
+
+        if (null !== $channel) {
+            $clause[] = [
+                'wildcard' => [
+                    sprintf('label.%s.<all_locales>', $channel) => sprintf('*%s*', $this->escapeValue($value)),
+                ]
+            ];
+        }
+
+        if (null !== $locale) {
+            $clause[] = [
+                'wildcard' => [
+                    sprintf('label.<all_channels>.%s', $locale) => sprintf('*%s*', $this->escapeValue($value)),
+                ]
+            ];
+        }
+
+        $clause[] = [
+            'wildcard' => [
+                'label.<all_channels>.<all_locales>' => sprintf('*%s*', $this->escapeValue($value)),
+            ]
+        ];
+
+        $this->searchQueryBuilder->addShould($clause);
+
+        return $this;
+    }
+
+    /**
+     * Checks that the value is a number.
+     *
+     * @param string $operator
+     * @param mixed  $value
+     */
+    protected function checkValue($operator, $value): void
+    {
+        FieldFilterHelper::checkString('label_or_identifier', $value, static::class);
+
+        if (!in_array($operator, [Operators::CONTAINS])) {
+            throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+    }
+
+    /**
+     * Escapes particular values prior than doing a search query escaping whitespace or newlines.
+     *
+     * This is useful when using ES 'query_string' clauses in a search query.
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
+     *
+     * TODO: TIP-706 - This may move somewhere else
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    protected function escapeValue(string $value): string
+    {
+        $regex = '#[-+=|! &(){}\[\]^"~*<>?:/\\\]#';
+
+        return preg_replace($regex, '\\\$0', $value);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -14,6 +14,7 @@ parameters:
     pim_catalog.doctrine.query.filter.object_id_resolver.class:   Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectIdResolver
     pim_catalog.doctrine.query.filter.object_code_resolver.class: Pim\Bundle\CatalogBundle\Doctrine\Common\Filter\ObjectCodeResolver
 
+    pim_catalog.query.elasticsearch.filter.label_or_identifier.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\LabelOrIdentifierFilter
     pim_catalog.query.elasticsearch.filter.identifier.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\IdentifierFilter
     pim_catalog.query.elasticsearch.filter.id.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\IdFilter
     pim_catalog.query.elasticsearch.filter.family.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\FamilyFilter
@@ -44,6 +45,7 @@ parameters:
     pim_catalog.query.elasticsearch.sorter.attribute.text_area.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attribute\TextAreaSorter
 
 services:
+
     pim_catalog.query.product_query_builder_factory:
         class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
         arguments:
@@ -174,6 +176,17 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.filter.label_or_identifier:
+        class: '%pim_catalog.query.elasticsearch.filter.label_or_identifier.class%'
+        arguments:
+            - ['label_or_identifier']
+            - ['CONTAINS']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
+            - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
+
 
     pim_catalog.query.elasticsearch.filter.id:
         class: '%pim_catalog.query.elasticsearch.filter.id.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -28,6 +28,18 @@ mappings:
                 type: 'keyword'
         dynamic_templates:
             -
+                label_scopable_localizable_structure:
+                    path_match: 'label.*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
+            -
+                label:
+                    path_match: 'label.*'
+                    mapping:
+                        type: 'keyword'
+                        normalizer: 'text_normalizer'
+            -
                 family:
                     path_match: 'family.labels.*'
                     mapping:

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/LabelOrIdentifierFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/LabelOrIdentifierFilterSpec.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\AbstractFieldFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\LabelOrIdentifierFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Exception\ObjectNotFoundException;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
+
+/**
+ * Label or identifier filter spec for an Elasticsearch query
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LabelOrIdentifierFilterSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(
+            ['label_or_identifier'],
+            ['CONTAINS']
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(LabelOrIdentifierFilter::class);
+    }
+
+    function it_is_a_filter()
+    {
+        $this->shouldImplement(FieldFilterInterface::class);
+        $this->shouldBeAnInstanceOf(AbstractFieldFilter::class);
+    }
+
+    function it_supports_operators()
+    {
+        $this->getOperators()->shouldReturn([
+            'CONTAINS'
+        ]);
+        $this->supportsOperator('CONTAINS')->shouldReturn(true);
+        $this->supportsOperator('DOES NOT CONTAIN')->shouldReturn(false);
+    }
+
+    function it_supports_label_or_identifier_field()
+    {
+        $this->supportsField('label_or_identifier')->shouldReturn(true);
+        $this->supportsField('a_not_supported_field')->shouldReturn(false);
+    }
+
+    function it_adds_a_filter_with_operator_without_locale_and_scope(
+        SearchQueryBuilder $sqb
+    ) {
+        $sqb->addShould([
+            ['wildcard' => ['identifier' => '*book*']],
+            ['wildcard' => ['label.<all_channels>.<all_locales>' => '*book*']]
+        ])->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter('label_or_identifier', Operators::CONTAINS, 'book', null, null, []);
+    }
+
+    function it_adds_a_filter_with_operator_without_locale_but_with_scope(
+        SearchQueryBuilder $sqb
+    ) {
+        $sqb->addShould([
+            ['wildcard' => ['identifier' => '*book*']],
+            ['wildcard' => ['label.ecommerce.<all_locales>' => '*book*']],
+            ['wildcard' => ['label.<all_channels>.<all_locales>' => '*book*']]
+        ])->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter('label_or_identifier', Operators::CONTAINS, 'book', null, 'ecommerce', []);
+    }
+
+    function it_adds_a_filter_with_operator_without_scope_but_with_locale(
+        SearchQueryBuilder $sqb
+    ) {
+        $sqb->addShould([
+            ['wildcard' => ['identifier' => '*book*']],
+            ['wildcard' => ['label.<all_channels>.en_US' => '*book*']],
+            ['wildcard' => ['label.<all_channels>.<all_locales>' => '*book*']]
+        ])->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter('label_or_identifier', Operators::CONTAINS, 'book', 'en_US', null, []);
+    }
+
+    function it_adds_a_filter_with_operator_with_scope_and_locale(
+        SearchQueryBuilder $sqb
+    ) {
+        $sqb->addShould([
+            ['wildcard' => ['identifier' => '*book*']],
+            ['wildcard' => ['label.ecommerce.en_US' => '*book*']],
+            ['wildcard' => ['label.ecommerce.<all_locales>' => '*book*']],
+            ['wildcard' => ['label.<all_channels>.en_US' => '*book*']],
+            ['wildcard' => ['label.<all_channels>.<all_locales>' => '*book*']]
+        ])->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter('label_or_identifier', Operators::CONTAINS, 'book', 'en_US', 'ecommerce', []);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/AbstractProductQueryBuilderTestCase.php
@@ -89,6 +89,18 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
     }
 
     /**
+     * @param array $data
+     */
+    protected function createFamily(array $data)
+    {
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $this->get('pim_catalog.updater.family')->update($family, $data);
+        $constraints = $this->get('validator')->validate($family);
+        $this->assertCount(0, $constraints);
+        $this->get('pim_catalog.saver.family')->save($family);
+    }
+
+    /**
      * @param array $filters
      *
      * @return CursorInterface

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/LabelOrIdentifierFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/LabelOrIdentifierFilterIntegration.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Filter;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductAndProductModelQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * @author    Julien Sanchez <julien@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LabelOrIdentifierFilterIntegration extends AbstractProductAndProductModelQueryBuilderTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    /**
+     * We search labels and identifiers both on products and product models and
+     * check that we get both in the same result
+     */
+    public function testSearch()
+    {
+        $result = $this->executeFilter([['label_or_identifier', Operators::CONTAINS, 'hat', ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
+        $this->assert($result, ['model-braided-hat', '1111111240']);
+
+        $result = $this->executeFilter([['label_or_identifier', Operators::CONTAINS, 'ha', ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
+        $this->assert($result, ['model-braided-hat', 'hades', '1111111240']);
+    }
+}

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
@@ -103,6 +103,7 @@ config:
         oro/multiselect-decorator:                  pimdatagrid/js/multiselect-decorator
 
         oro/datafilter/search-filter:               pimdatagrid/js/datafilter/filter/search-filter
+        oro/datafilter/label_or_identifier-filter:  pimdatagrid/js/datafilter/filter/label_or_identifier-filter
         oro/datafilter/price-filter:                pimdatagrid/js/datafilter/filter/price-filter
         oro/datafilter/metric-filter:               pimdatagrid/js/datafilter/filter/metric-filter
         oro/datafilter/product_scope-filter:        pimdatagrid/js/datafilter/filter/product_scope-filter

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/label_or_identifier-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/label_or_identifier-filter.js
@@ -1,0 +1,97 @@
+'use strict';
+
+define(
+    [
+        'jquery',
+        'underscore',
+        'oro/translator',
+        'oro/datafilter/abstract-filter',
+        'pim/template/datagrid/filter/search-filter'
+    ], function (
+        $,
+        _,
+        __,
+        AbstractFilter,
+        template
+    ) {
+        return AbstractFilter.extend({
+            inputValueSelector: 'input[name="value"]',
+
+            events: {
+                'keydown input[name="value"]': 'runTimeout',
+                'keypress input[name="value"]': 'runTimeout'
+            },
+
+            emptyValue: {
+                value: ''
+            },
+
+            timer: null,
+
+            isSearch: true,
+
+            timeoutDelay: 500,
+
+            className: 'AknFilterBox-searchContainer filter-item search-filter',
+
+            template: _.template(template),
+
+            /**
+             * {@inheritDoc}
+             */
+            render: function () {
+                this.$el.html(
+                    this.template({
+                        label: __('Search', {label: this.label})
+                    })
+                );
+            },
+
+            /**
+             * @inheritDoc
+             */
+            _writeDOMValue: function (value) {
+                this._setInputValue(this.inputValueSelector, value.value);
+
+                return this;
+            },
+
+            /**
+             * @inheritDoc
+             */
+            _readDOMValue: function () {
+                return {
+                    value: this._getInputValue(this.inputValueSelector)
+                };
+            },
+
+            /**
+             * Runs a timer to wait some time. When the time is done, it execute the search.
+             * If the user types another time in the search box, it resets the timer and restart one.
+             *
+             * @param {Event} event
+             */
+            runTimeout: function (event) {
+                if (null !== this.timer) {
+                    clearTimeout(this.timer);
+                }
+
+                if (13 === event.keyCode) { // Enter key
+                    this.doSearch();
+                } else {
+                    this.timer = setTimeout(
+                        this.doSearch.bind(this),
+                        this.timeoutDelay
+                    );
+                }
+            },
+
+            /**
+             * Executes the search by setting the value.
+             */
+            doSearch: function () {
+                this.setValue(this._readDOMValue());
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-list.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-list.js
@@ -99,7 +99,11 @@ define(['underscore', 'pim/form', 'oro/mediator', 'oro/tools'],
                         filter.render();
                     }
                     if (filter.$el.length > 0) {
-                        this.$el.append(filter.$el.get(0));
+                        if (filter.isSearch) {
+                            $('.search-zone').empty().append(filter.$el.get(0));
+                        } else {
+                            this.$el.append(filter.$el.get(0));
+                        }
                     }
                 }, this);
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -275,3 +275,7 @@ datagrid:
                     ftype:     date
                     data_name: updated
                     label:     Updated At
+                label_or_identifier:
+                    type: label_or_identifier
+                    label: Label or identifier
+                    data_name: label_or_identifier

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/default-template.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/default-template.html
@@ -34,6 +34,9 @@
                 <div class="AknTitleContainer-line">
                     <div data-drop-zone="navigation" class="AknTitleContainer-navigation"></div>
                 </div>
+                <div class="AknTitleContainer-line">
+                    <div data-drop-zone="search" class="AknTitleContainer-search search-zone"></div>
+                </div>
             </header>
 
             <div data-drop-zone="content" class="content"></div>

--- a/src/Pim/Bundle/FilterBundle/Filter/Product/LabelOrIdentifierFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/Product/LabelOrIdentifierFilter.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Bundle\FilterBundle\Filter\Product;
+
+use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
+use Oro\Bundle\FilterBundle\Filter\StringFilter as OroStringFilter;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * Filter on label and identifier
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LabelOrIdentifierFilter extends OroStringFilter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(FilterDatasourceAdapterInterface $ds, $data): bool
+    {
+        $data = $this->parseData($data);
+        if (!$data) {
+            return false;
+        }
+
+        $this->util->applyFilter($ds, 'label_or_identifier', Operators::CONTAINS, $data['value']);
+
+        return true;
+    }
+}

--- a/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
+++ b/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
@@ -4,23 +4,24 @@ parameters:
 
     pim_filter.ajax_choice_filter.class:  Pim\Bundle\FilterBundle\Filter\AjaxChoiceFilter
 
-    pim_filter.product_scope_filter.class:         Pim\Bundle\FilterBundle\Filter\Product\ScopeFilter
-    pim_filter.product_groups_filter.class:        Pim\Bundle\FilterBundle\Filter\Product\GroupsFilter
-    pim_filter.product_family_filter.class:        Pim\Bundle\FilterBundle\Filter\Product\FamilyFilter
-    pim_filter.product_completeness_filter.class:  Pim\Bundle\FilterBundle\Filter\CompletenessFilter
-    pim_filter.product_date_filter.class:          Pim\Bundle\FilterBundle\Filter\ProductValue\DateTimeRangeFilter
-    pim_filter.category_filter.class:              Pim\Bundle\FilterBundle\Filter\CategoryFilter
-    pim_filter.product_enabled_filter.class:       Pim\Bundle\FilterBundle\Filter\Product\EnabledFilter
-    pim_filter.product_in_group_filter.class:      Pim\Bundle\FilterBundle\Filter\Product\InGroupFilter
-    pim_filter.product_is_associated_filter.class: Pim\Bundle\FilterBundle\Filter\Product\IsAssociatedFilter
-    pim_filter.product_value_string.class:         Pim\Bundle\FilterBundle\Filter\ProductValue\StringFilter
-    pim_filter.product_value_choice.class:         Pim\Bundle\FilterBundle\Filter\ProductValue\ChoiceFilter
-    pim_filter.product_value_number.class:         Pim\Bundle\FilterBundle\Filter\ProductValue\NumberFilter
-    pim_filter.product_value_date.class:           Pim\Bundle\FilterBundle\Filter\ProductValue\DateRangeFilter
-    pim_filter.product_value_datetime.class:       Pim\Bundle\FilterBundle\Filter\ProductValue\DateTimeRangeFilter
-    pim_filter.product_value_boolean.class:        Pim\Bundle\FilterBundle\Filter\ProductValue\BooleanFilter
-    pim_filter.product_value_metric.class:         Pim\Bundle\FilterBundle\Filter\ProductValue\MetricFilter
-    pim_filter.product_value_price.class:          Pim\Bundle\FilterBundle\Filter\ProductValue\PriceFilter
+    pim_filter.product_scope_filter.class:               Pim\Bundle\FilterBundle\Filter\Product\ScopeFilter
+    pim_filter.product_groups_filter.class:              Pim\Bundle\FilterBundle\Filter\Product\GroupsFilter
+    pim_filter.product_family_filter.class:              Pim\Bundle\FilterBundle\Filter\Product\FamilyFilter
+    pim_filter.product_completeness_filter.class:        Pim\Bundle\FilterBundle\Filter\CompletenessFilter
+    pim_filter.product_date_filter.class:                Pim\Bundle\FilterBundle\Filter\ProductValue\DateTimeRangeFilter
+    pim_filter.category_filter.class:                    Pim\Bundle\FilterBundle\Filter\CategoryFilter
+    pim_filter.product_enabled_filter.class:             Pim\Bundle\FilterBundle\Filter\Product\EnabledFilter
+    pim_filter.product_in_group_filter.class:            Pim\Bundle\FilterBundle\Filter\Product\InGroupFilter
+    pim_filter.product_is_associated_filter.class:       Pim\Bundle\FilterBundle\Filter\Product\IsAssociatedFilter
+    pim_filter.product_value_string.class:               Pim\Bundle\FilterBundle\Filter\ProductValue\StringFilter
+    pim_filter.product_value_choice.class:               Pim\Bundle\FilterBundle\Filter\ProductValue\ChoiceFilter
+    pim_filter.product_value_number.class:               Pim\Bundle\FilterBundle\Filter\ProductValue\NumberFilter
+    pim_filter.product_value_date.class:                 Pim\Bundle\FilterBundle\Filter\ProductValue\DateRangeFilter
+    pim_filter.product_value_datetime.class:             Pim\Bundle\FilterBundle\Filter\ProductValue\DateTimeRangeFilter
+    pim_filter.product_value_boolean.class:              Pim\Bundle\FilterBundle\Filter\ProductValue\BooleanFilter
+    pim_filter.product_value_metric.class:               Pim\Bundle\FilterBundle\Filter\ProductValue\MetricFilter
+    pim_filter.product_value_price.class:                Pim\Bundle\FilterBundle\Filter\ProductValue\PriceFilter
+    pim_filter.product_label_or_identifier_filter.class: Pim\Bundle\FilterBundle\Filter\Product\LabelOrIdentifierFilter
 
 services:
     pim_filter.ajax_choice_filter:
@@ -182,3 +183,11 @@ services:
             - '@pim_filter.product_utility'
         tags:
             - { name: oro_filter.extension.orm_filter.filter, type: product_value_price }
+
+    pim_filter.product_label_or_identifier_filter:
+        class: '%pim_filter.product_label_or_identifier_filter.class%'
+        arguments:
+            - '@form.factory'
+            - '@pim_filter.product_utility'
+        tags:
+            - { name: oro_filter.extension.orm_filter.filter, type: label_or_identifier }

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/Product/LabelOrIdentifierFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/Product/LabelOrIdentifierFilterSpec.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace spec\Pim\Bundle\FilterBundle\Filter\Product;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
+use Pim\Bundle\FilterBundle\Filter\ProductFilterUtility;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class LabelOrIdentifierFilterSpec extends ObjectBehavior
+{
+    function let(
+        FormFactoryInterface $factory,
+        ProductFilterUtility $utility
+    ) {
+        $this->beConstructedWith($factory, $utility);
+    }
+
+    function it_is_an_oro_choice_filter()
+    {
+        $this->shouldBeAnInstanceOf('Oro\Bundle\FilterBundle\Filter\StringFilter');
+    }
+
+    function it_applies_a_filter_on_product_when_its_in_an_expected_group(
+        $utility,
+        FilterDatasourceAdapterInterface $datasource
+    ) {
+        $utility->applyFilter($datasource, 'label_or_identifier', 'CONTAINS', 'toto')->shouldBeCalled();
+
+        $this->apply($datasource, ['type' => null, 'value' => 'toto']);
+    }
+}

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
@@ -103,6 +103,11 @@
     padding: 10px 0;
   }
 
+  &-search {
+    flex: 1;
+    border-bottom: 1px solid @AknBorderColor;
+  }
+
   &-metaItem {
     & + & {
       &:before {

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -73,7 +73,34 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
                 $context
             ) : [];
 
+        $data[StandardPropertiesNormalizer::FIELD_LABEL] = $this->getLabel(
+            $data[StandardPropertiesNormalizer::FIELD_VALUES],
+            $product
+        );
+
         return $data;
+    }
+
+    /**
+     * Get label of the given product
+     *
+     * @param array            $values
+     * @param ProductInterface $product
+     *
+     * @return array
+     */
+    private function getLabel(array $values, ProductInterface $product): array
+    {
+        if (null === $product->getFamily()) {
+            return [];
+        }
+
+        $valuePath = sprintf('%s-text', $product->getFamily()->getAttributeAsLabel()->getCode());
+        if (!isset($values[$valuePath])) {
+            return [];
+        }
+
+        return $values[$valuePath];
     }
 
     /**

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
@@ -87,7 +87,34 @@ class ProductModelPropertiesNormalizer implements NormalizerInterface, Serialize
         $data[self::FIELD_AT_LEAST_COMPLETE] = $normalizedData->atLeastComplete();
         $data[self::FIELD_AT_LEAST_INCOMPLETE] = $normalizedData->atLeastIncomplete();
 
+
+        $data[StandardPropertiesNormalizer::FIELD_LABEL] = $this->getLabel(
+            $data[StandardPropertiesNormalizer::FIELD_VALUES],
+            $productModel
+        );
+
         return $data;
+    }
+
+    /**
+     * Get label of the given product model
+     *
+     * @param array                 $values
+     * @param ProductModelInterface $productModel
+     *
+     * @return array
+     */
+    private function getLabel(array $values, ProductModelInterface $productModel): array
+    {
+        if (null === $productModel->getFamily()) {
+            return [];
+        }
+        $valuePath = sprintf('%s-text', $productModel->getFamily()->getAttributeAsLabel()->getCode());
+        if (!isset($values[$valuePath])) {
+            return [];
+        }
+
+        return $values[$valuePath];
     }
 
     /**

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
@@ -93,7 +93,34 @@ class ProductPropertiesNormalizer implements NormalizerInterface, SerializerAwar
                 $context
             ) : [];
 
+        $data[StandardPropertiesNormalizer::FIELD_LABEL] = $this->getLabel(
+            $data[StandardPropertiesNormalizer::FIELD_VALUES],
+            $product
+        );
+
         return $data;
+    }
+
+    /**
+     * Get label of the given product
+     *
+     * @param array            $values
+     * @param ProductInterface $product
+     *
+     * @return array
+     */
+    private function getLabel(array $values, ProductInterface $product): array
+    {
+        if (null === $product->getFamily()) {
+            return [];
+        }
+
+        $valuePath = sprintf('%s-text', $product->getFamily()->getAttributeAsLabel()->getCode());
+        if (!isset($values[$valuePath])) {
+            return [];
+        }
+
+        return $values[$valuePath];
     }
 
     /**

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizer.php
@@ -72,7 +72,35 @@ class ProductModelPropertiesNormalizer implements NormalizerInterface, Serialize
                 $context
             ) : [];
 
+
+        $data[StandardPropertiesNormalizer::FIELD_LABEL] = $this->getLabel(
+            $data[StandardPropertiesNormalizer::FIELD_VALUES],
+            $productModel
+        );
+
         return $data;
+    }
+
+    /**
+     * Get label of the given product model
+     *
+     * @param array                 $values
+     * @param ProductModelInterface $productModel
+     *
+     * @return array
+     */
+    private function getLabel(array $values, ProductModelInterface $productModel): array
+    {
+        if (null === $productModel->getFamily()) {
+            return [];
+        }
+
+        $valuePath = sprintf('%s-text', $productModel->getFamily()->getAttributeAsLabel()->getCode());
+        if (!isset($values[$valuePath])) {
+            return [];
+        }
+
+        return $values[$valuePath];
     }
 
     /**

--- a/src/Pim/Component/Catalog/Normalizer/Standard/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/Product/PropertiesNormalizer.php
@@ -24,6 +24,7 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
     use SerializerAwareTrait;
 
     const FIELD_IDENTIFIER = 'identifier';
+    const FIELD_LABEL = 'label';
     const FIELD_FAMILY = 'family';
     const FIELD_PARENT = 'parent';
     const FIELD_GROUPS = 'groups';

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
@@ -5,6 +5,7 @@ namespace spec\Pim\Component\Catalog\Normalizer\Indexing\Product;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\Group;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
@@ -38,7 +39,8 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $serializer,
         ProductInterface $product,
         ValueCollectionInterface $valueCollection,
-        Collection $completenesses
+        Collection $completenesses,
+        AttributeInterface $sku
     ) {
         $product->getId()->willReturn(67);
         $family = null;
@@ -46,6 +48,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
         $product->getIdentifier()->willReturn('sku-001');
+        $product->getFamily()->willReturn($family);
         $product->getCreated()->willReturn($now);
         $serializer
             ->normalize($family, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
@@ -79,6 +82,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
                 'groups'        => [],
                 'completeness'  => [],
                 'values'        => [],
+                'label'         => [],
             ]
         );
     }
@@ -87,13 +91,15 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $serializer,
         ProductInterface $product,
         ValueCollectionInterface $valueCollection,
-        Collection $completenesses
+        Collection $completenesses,
+        AttributeInterface $sku
     ) {
         $product->getId()->willReturn(67);
         $family = null;
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
         $product->getIdentifier()->willReturn('sku-001');
+        $product->getFamily()->willReturn($family);
 
         $product->getFamily()->willReturn($family);
         $serializer->normalize($family, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)->willReturn($family);
@@ -134,6 +140,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
                 'groups'        => [],
                 'completeness'  => ['the completenesses'],
                 'values'        => [],
+                'label'         => [],
             ]
         );
     }
@@ -143,12 +150,16 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         ProductInterface $product,
         ValueCollectionInterface $valueCollection,
         FamilyInterface $family,
-        Collection $completenesses
+        Collection $completenesses,
+        AttributeInterface $sku
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
         $product->getId()->willReturn(67);
         $product->getIdentifier()->willReturn('sku-001');
+        $product->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
 
         $product->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -243,6 +254,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'label'         => [],
             ]
         );
     }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizerSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
@@ -62,6 +63,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         ProductModelInterface $productModel,
         ValueCollectionInterface $productValueCollection,
         FamilyInterface $family,
+        AttributeInterface $sku,
         FamilyVariantInterface $familyVariant
     ) {
         $productModel->getId()->willReturn(67);
@@ -70,6 +72,9 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $productModel->getParent()->willReturn(null);
 
         $productModel->getCode()->willReturn('sku-001');
+        $productModel->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
         $productModel->getCreated()->willReturn($now);
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
@@ -119,6 +124,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                         'fr_FR' => 1
                     ]
                 ],
+                'label' => []
             ]
         );
     }
@@ -130,12 +136,16 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         ProductModelInterface $productModel,
         ValueCollectionInterface $productValueCollection,
         FamilyInterface $family,
+        AttributeInterface $sku,
         FamilyVariantInterface $familyVariant
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
         $productModel->getId()->willReturn(67);
         $productModel->getCode()->willReturn('sku-001');
+        $productModel->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
 
         $productModel->getParent()->willReturn(null);
 
@@ -216,6 +226,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                         'fr_FR' => 1
                     ]
                 ],
+                'label' => []
             ]
         );
     }
@@ -228,12 +239,16 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         ProductModelInterface $parent,
         ValueCollectionInterface $valueCollection,
         FamilyInterface $family,
+        AttributeInterface $sku,
         FamilyVariantInterface $familyVariant
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
         $productModel->getId()->willReturn(67);
         $productModel->getCode()->willReturn('sku-001');
+        $productModel->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
 
         $productModel->getParent()->willReturn($parent);
         $parent->getCode()->willReturn('parent_A');
@@ -334,6 +349,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                         'fr_FR' => 1
                     ]
                 ],
+                'label' => []
             ]
         );
     }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizerSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel;
 
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -98,6 +99,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
                 'family_variant' => null,
                 'parent'         => null,
                 'values'         => [],
+                'label'          => []
             ]
         );
     }
@@ -107,6 +109,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         ProductInterface $product,
         ValueCollectionInterface $valueCollection,
         FamilyInterface $family,
+        AttributeInterface $sku,
         Collection $completenesses
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
@@ -127,6 +130,8 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         )->willReturn($now->format('c'));
 
         $product->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn([
@@ -210,6 +215,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'label'          => [],
             ]
         );
     }
@@ -220,6 +226,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         ValueCollectionInterface $valueCollection,
         Collection $completenesses,
         FamilyInterface $family,
+        AttributeInterface $sku,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent
     ) {
@@ -230,6 +237,9 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $variantProduct->getId()->willReturn(67);
         $variantProduct->getIdentifier()->willReturn('sku-001');
+        $variantProduct->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
 
         $variantProduct->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -286,6 +296,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
                 'family_variant' => 'family_variant_A',
                 'parent'        => 'parent_A',
                 'values'        => [],
+                'label'         => [],
             ]
         );
     }
@@ -296,6 +307,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         ValueCollectionInterface $valueCollection,
         Collection $completenesses,
         FamilyInterface $family,
+        AttributeInterface $sku,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent
     ) {
@@ -306,6 +318,9 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $variantProduct->getId()->willReturn(67);
         $variantProduct->getIdentifier()->willReturn('sku-001');
+        $variantProduct->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
 
         $variantProduct->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -426,6 +441,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'label'          => [],
             ]
         );
     }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizerSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Component\Catalog\Normalizer\Indexing\ProductModel;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
@@ -41,6 +42,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         ProductModelInterface $productModel,
         ValueCollectionInterface $productValueCollection,
         FamilyInterface $family,
+        AttributeInterface $sku,
         FamilyVariantInterface $familyVariant
     ) {
         $productModel->getId()->willReturn(67);
@@ -49,6 +51,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $productModel->getParent()->willReturn(null);
 
         $productModel->getCode()->willReturn('sku-001');
+        $productModel->getFamily()->willReturn(null);
         $productModel->getCreated()->willReturn($now);
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
@@ -66,6 +69,8 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $familyVariant->getCode()->willReturn('family_variant_1');
         $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
         $productModel->getFamilyVariant()->willReturn($familyVariant);
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
@@ -86,6 +91,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                 'categories'     => ['category_A', 'category_B'],
                 'parent'         => null,
                 'values'         => [],
+                'label'          => [],
             ]
         );
     }
@@ -95,12 +101,14 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         ProductModelInterface $productModel,
         ValueCollectionInterface $productValueCollection,
         FamilyInterface $family,
+        AttributeInterface $sku,
         FamilyVariantInterface $familyVariant
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
         $productModel->getId()->willReturn(67);
         $productModel->getCode()->willReturn('sku-001');
+        $productModel->getFamily()->willReturn(null);
 
         $productModel->getParent()->willReturn(null);
 
@@ -118,6 +126,8 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $familyVariant->getCode()->willReturn('family_variant_B');
         $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
         $productModel->getFamilyVariant()->willReturn($familyVariant);
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
@@ -169,6 +179,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'label'          => [],
             ]
         );
     }
@@ -179,12 +190,14 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         ProductModelInterface $parent,
         ValueCollectionInterface $valueCollection,
         FamilyInterface $family,
+        AttributeInterface $sku,
         FamilyVariantInterface $familyVariant
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
         $productModel->getId()->willReturn(67);
         $productModel->getCode()->willReturn('sku-001');
+        $productModel->getFamily()->willReturn(null);
 
         $productModel->getParent()->willReturn($parent);
         $parent->getCode()->willReturn('parent_A');
@@ -203,6 +216,8 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $familyVariant->getCode()->willReturn('family_variant_B');
         $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
         $productModel->getFamilyVariant()->willReturn($familyVariant);
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
@@ -218,7 +233,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $valueCollection->isEmpty()->willReturn(false);
 
         $productModel->getCategoryCodes()->willReturn(['category_A', 'category_B']);
-        
+
         $serializer->normalize($valueCollection, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX, [])
             ->willReturn(
                 [
@@ -273,6 +288,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'label'          => [],
             ]
         );
     }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
@@ -55,6 +55,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
             ],
             'at_least_complete' => [],
             'at_least_incomplete' => [],
+            'label'         => [],
             'document_type' => ProductModelInterface::class,
             'attributes_for_this_level' => ['a_text']
         ];
@@ -100,6 +101,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
             ],
             'at_least_complete' => [],
             'at_least_incomplete' => [],
+            'label'         => [],
             'document_type' => ProductModelInterface::class,
             'attributes_for_this_level' => ['a_simple_select']
         ];
@@ -151,6 +153,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ],
                 ],
             ],
+            'label'         => [],
             'document_type' => ProductInterface::class,
             'attributes_for_this_level' => ['sku', 'a_yes_no']
         ];
@@ -179,7 +182,8 @@ class ProductAndProductModelIndexingIntegration extends TestCase
             'family_variant'            => null,
             'parent'                    => null,
             'values'                    => [],
-            'document_type'              => ProductInterface::class,
+            'label'                     => [],
+            'document_type'             => ProductInterface::class,
             'attributes_for_this_level' => ['sku'],
         ];
 
@@ -420,6 +424,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ],
                 ],
             ],
+            'label' => [],
             'document_type' => ProductInterface::class,
             'attributes_for_this_level' => [
                 123,

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -39,6 +39,7 @@ class ProductIndexingIntegration extends TestCase
             'groups'        => [],
             'completeness'  => [],
             'values'        => [],
+            'label'         => []
         ];
 
         $this->assertIndexingFormat('bar', $expected);
@@ -63,6 +64,7 @@ class ProductIndexingIntegration extends TestCase
             'groups'        => [],
             'completeness'  => [],
             'values'        => [],
+            'label'         => []
         ];
 
         $this->assertIndexingFormat('baz', $expected);
@@ -297,8 +299,9 @@ class ProductIndexingIntegration extends TestCase
 
                         ],
                     ],
-                ],
+                ]
             ],
+            'label'         => []
         ];
 
         $this->assertIndexingFormat('foo', $expected);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add search on label and identifiers. We did some benchmark on my machine to test if this will work with big catalogs

Here are the result with 4.7 million products and 1000 calls:

```
Concurrency Level: 1
Time taken for tests: 36.238 seconds
Complete requests: 1000
Failed requests: 1
(Connect: 0, Receive: 0, Length: 1, Exceptions: 0)
Total transferred: 2893001 bytes
Total body sent: 1156000
HTML transferred: 2615001 bytes
Requests per second: 27.60 /sec (mean)
Time per request: 36.238 [ms] (mean)
Time per request: 36.238 [ms] (mean, across all concurrent requests)
Transfer rate: 77.96 [Kbytes/sec] received
31.15 kb/s sent
109.11 kb/s total
Connection Times (ms)
min mean[+/-sd] median max
Connect: 0 0 0.1 0 1
Processing: 18 36 14.4 35 380
Waiting: 18 36 14.4 35 380
Total: 18 36 14.4 35 381
Percentage of the requests served within a certain time (ms)
50% 35
66% 39
75% 42
80% 43
90% 48
95% 53
98% 58
99% 65
100% 381 (longest request)
So longuest is 381ms and average is 36ms for 831 387 results. We decided that those numbers are ok and we can implement this feature
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Added integration tests           | Y
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
