### PR TITLE
[WIP] Fix `ObjectIdHydrator::hydrate` for MongoDb

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/ObjectIdHydrator.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ResultRecord/MongoDbOdm/ObjectIdHydrator.php
@@ -18,7 +18,7 @@ class ObjectIdHydrator implements HydratorInterface
      */
     public function hydrate($qb, array $options = [])
     {
-        $qb->hydrate(false)->select('_id');
+        $qb->select('_id');
 
         $results = $qb->getQuery()->execute();
 


### PR DESCRIPTION
There is not `hydrate` method in Query Builder. I don't even know why this error was not detected before.
