### PR TITLE
 PIM-6357: mass edit attributes of products and product models from the grid

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Better manage products with variants!
 
 - PIM-6349: Adds mass edit to add products to an existing product model
+- PIM-6357: Adds mass edit of attributes for product and product models
 
 ## Update jobs
 

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -1022,6 +1022,7 @@ class FixturesContext extends BaseFixturesContext
      * @param string $value
      *
      * @Given /^attribute (\w+) of "([^"]*)" should be "(.*)"$/
+     * @Given /^the product value (\w+) of "([^"]*)" should be "(.*)"$/
      */
     public function theOfShouldBe($attribute, $identifier, $value)
     {
@@ -1071,7 +1072,7 @@ class FixturesContext extends BaseFixturesContext
      * @param string $identifier
      * @param string $value
      *
-     * @Given /^the (\w+) (\w+) (\w+) of "([^"]*)" should be "(.*)"$/
+     * @Given /^the ((?!product)\w+) (\w+) (\w+) of "([^"]*)" should be "(.*)"$/
      */
     public function theScopableAndLocalizableOfShouldBe($lang, $scope, $attribute, $identifier, $value)
     {
@@ -1212,6 +1213,20 @@ class FixturesContext extends BaseFixturesContext
             $productValue = $this->getProductValue($identifier, strtolower($attribute));
             assertEquals($data, $productValue->getData()->getData());
         }
+    }
+
+    /**
+     * @param string $attribute
+     * @param string $identifier
+     * @param string $value
+     *
+     * @Given /^the product model value (\w+) of "([^"]*)" should be "(.*)"$/
+     */
+    public function theValueOfShouldBe(string $attribute, string $identifier, string $value)
+    {
+        $productValue = $this->getProductModelValue($identifier, strtolower($attribute));
+
+        $this->assertDataEquals((string) $productValue->getData(), $value);
     }
 
     /**
@@ -1907,6 +1922,36 @@ class FixturesContext extends BaseFixturesContext
             throw new \InvalidArgumentException(
                 sprintf(
                     'Could not find product value for attribute "%s" in locale "%s" for scope "%s"',
+                    $attribute,
+                    $locale,
+                    $scope
+                )
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string $identifier
+     * @param string $attribute
+     * @param string $locale
+     * @param string $scope
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return ValueInterface
+     */
+    protected function getProductModelValue($identifier, $attribute, $locale = null, $scope = null)
+    {
+        if (null === $productModel = $this->getProductModel($identifier)) {
+            throw new \InvalidArgumentException(sprintf('Could not find product model with code "%s"', $identifier));
+        }
+
+        if (null === $value = $productModel->getValue($attribute, $locale, $scope)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Could not find product model value for attribute "%s" in locale "%s" for scope "%s"',
                     $attribute,
                     $locale,
                     $scope

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -1222,7 +1222,7 @@ class FixturesContext extends BaseFixturesContext
      *
      * @Given /^the product model value (\w+) of "([^"]*)" should be "(.*)"$/
      */
-    public function theValueOfShouldBe(string $attribute, string $identifier, string $value)
+    public function theProductModelValueOfShouldBe(string $attribute, string $identifier, string $value)
     {
         $productValue = $this->getProductModelValue($identifier, strtolower($attribute));
 
@@ -1942,7 +1942,7 @@ class FixturesContext extends BaseFixturesContext
      *
      * @return ValueInterface
      */
-    protected function getProductModelValue($identifier, $attribute, $locale = null, $scope = null)
+    private function getProductModelValue(string $identifier, string $attribute, string $locale = null, string $scope = null)
     {
         if (null === $productModel = $this->getProductModel($identifier)) {
             throw new \InvalidArgumentException(sprintf('Could not find product model with code "%s"', $identifier));

--- a/features/mass-action/edit_common_attributes_product_model.feature
+++ b/features/mass-action/edit_common_attributes_product_model.feature
@@ -57,6 +57,10 @@ Feature: Edit common attributes of many products and product models at once
     And the product "col-white-m" should have the following values:
       | composition | 100% cotton   |
       | weight      | 500.0000 GRAM |
+    When I go on the last executed job resume of "edit_common_attributes"
+    Then I should see the text "COMPLETED"
+    And I should see the text "read 3"
+    And I should see the text "processed 3"
 
   Scenario: Mass edit attributes of a sub product model inside a family variant with 2 levels of hierarchy
     Given I am on the products grid
@@ -75,6 +79,10 @@ Feature: Edit common attributes of many products and product models at once
     And the product "col-white-m" should have the following values:
       | composition | 100% cotton   |
       | weight      | 500.0000 GRAM |
+    When I go on the last executed job resume of "edit_common_attributes"
+    Then I should see the text "COMPLETED"
+    And I should see the text "read 2"
+    And I should see the text "processed 2"
 
   Scenario: Mass edit attributes of a product model inside a family variant with 1 levels of hierarchy
     Given I am on the products grid
@@ -90,6 +98,10 @@ Feature: Edit common attributes of many products and product models at once
     Then the product model value brand of "model-nin" should be "[Nyke]"
     And the product value brand of "nin-s" should be "[Nyke]"
     And the product value composition of "nin-s" should be "100% cotton"
+    When I go on the last executed job resume of "edit_common_attributes"
+    Then I should see the text "COMPLETED"
+    And I should see the text "read 2"
+    And I should see the text "processed 2"
 
   Scenario: Mass edit attributes of a product model and a non variant product at the same time
     Given I am on the products grid
@@ -112,12 +124,16 @@ Feature: Edit common attributes of many products and product models at once
       | weight | 500.0000 GRAM |
     And the product "tool-tee" should have the following values:
       | weight | 500.0000 GRAM |
+    When I go on the last executed job resume of "edit_common_attributes"
+    Then I should see the text "COMPLETED"
+    And I should see the text "read 4"
+    And I should see the text "processed 4"
 
   Scenario: It does not update ancestors' attributes
     Given I am on the products grid
     And I show the filter "color"
-    And I filter by "color" with operator "IN LIST" and value "[white]"
     And I show the filter "size"
+    And I filter by "color" with operator "IN LIST" and value "[white]"
     And I filter by "size" with operator "IN LIST" and value "[m]"
     And I select rows col-white-m
     And I press the "Bulk actions" button
@@ -131,10 +147,14 @@ Feature: Edit common attributes of many products and product models at once
     When I confirm mass edit
     And I wait for the "edit_common_attributes" job to finish
     Then the product model value brand of "model-col" should be "[Abibas]"
-    Then the product model value brand of "model-col-white" should be "[Abibas]"
-    Then the product model value composition of "model-col-white" should be "cotton 90%, viscose 10%"
-    Then the product model "model-col" should not have the following values "composition, weight"
-    Then the product model "model-col-white" should not have the following values weight
+    And the product model value brand of "model-col-white" should be "[Abibas]"
+    And the product model value composition of "model-col-white" should be "cotton 90%, viscose 10%"
+    And the product model "model-col" should not have the following values "composition, weight"
+    And the product model "model-col-white" should not have the following values weight
+    When I go on the last executed job resume of "edit_common_attributes"
+    Then I should see the text "COMPLETED"
+    And I should see the text "read 1"
+    And I should see the text "processed 1"
 
   Scenario: Mass edit attributes of all selected products and product models
     Given I am on the products grid
@@ -165,8 +185,12 @@ Feature: Edit common attributes of many products and product models at once
     And the product "nin-s" should have the following values:
       | weight      | 500.0000 GRAM |
       | composition | 100% cotton   |
+    When I go on the last executed job resume of "edit_common_attributes"
+    Then I should see the text "COMPLETED"
+    And I should see the text "read 6"
+    And I should see the text "processed 6"
 
-  Scenario: Mass edit attributes of all but some one product model
+  Scenario: Mass edit attributes of all but one product model
     Given I am on the products grid
     And I select rows model-col
     And I select all entities
@@ -196,3 +220,7 @@ Feature: Edit common attributes of many products and product models at once
       | brand       |           |
       | weight      |           |
       | composition | 100% wool |
+    When I go on the last executed job resume of "edit_common_attributes"
+    Then I should see the text "COMPLETED"
+    And I should see the text "read 4"
+    And I should see the text "processed 4"

--- a/features/mass-action/edit_common_attributes_product_model.feature
+++ b/features/mass-action/edit_common_attributes_product_model.feature
@@ -131,9 +131,7 @@ Feature: Edit common attributes of many products and product models at once
 
   Scenario: It does not update ancestors' attributes
     Given I am on the products grid
-    And I show the filter "color"
     And I show the filter "size"
-    And I filter by "color" with operator "IN LIST" and value "[white]"
     And I filter by "size" with operator "IN LIST" and value "[m]"
     And I select rows col-white-m
     And I press the "Bulk actions" button

--- a/features/mass-action/edit_common_attributes_product_model.feature
+++ b/features/mass-action/edit_common_attributes_product_model.feature
@@ -1,0 +1,198 @@
+@javascript
+Feature: Edit common attributes of many products and product models at once
+  In order to update many products with the same information
+  As a product manager
+  I need to be able to edit attributes of many products and product models at once
+
+  Background:
+    Given the "default" catalog configuration
+    And the following attributes:
+      | code        | label-en_US | type                     | unique | group | decimals_allowed | negative_allowed | metric_family | default_metric_unit | useable_as_grid_filter |
+      | color       | Color       | pim_catalog_simpleselect | 0      | other |                  |                  |               |                     | 1                      |
+      | size        | Size        | pim_catalog_simpleselect | 0      | other |                  |                  |               |                     | 1                      |
+      | brand       | Brand       | pim_catalog_simpleselect | 0      | other |                  |                  |               |                     | 0                      |
+      | composition | Composition | pim_catalog_text         | 0      | other |                  |                  |               |                     | 0                      |
+      | weight      | Weight      | pim_catalog_metric       | 0      | other | 0                | 0                | Weight        | GRAM                | 0                      |
+    And the following "Brand" attribute options: Abibas, Nyke, Ribouk
+    And the following "Size" attribute options: s, m, l
+    And the following "color" attribute options: white, black
+    And the following family:
+      | code     | label-en_US | attributes                              |
+      | clothing | Clothing    | sku,color,size,brand,composition,weight |
+    And the following family variants:
+      | code                | family   | label-en_US                | variant-axes_1 | variant-axes_2 | variant-attributes_1   | variant-attributes_2 |
+      | clothing_color_size | clothing | Clothing by color and size | color          | size           | color,composition      | size,sku,weight      |
+      | clothing_size       | clothing | Clothing by color/size     | color,size     |                | color,size,composition |                      |
+    And the following root product models:
+      | code      | family_variant      | brand  |
+      | model-col | clothing_color_size | abibas |
+      | model-nin | clothing_size       |        |
+    And the following sub product models:
+      | code            | parent    | family_variant      | color | composition             |
+      | model-col-white | model-col | clothing_color_size | white | cotton 90%, viscose 10% |
+    And the following products:
+      | sku         | family   | parent          | color | size | brand  | composition | weight   |
+      | col-white-m | clothing | model-col-white |       | m    |        |             | 478 GRAM |
+      | nin-s       | clothing | model-nin       | black | s    |        | 100% wool   |          |
+      | tool-tee    | clothing |                 | black | m    | ribouk |             |          |
+    And I am logged in as "Julia"
+
+  Scenario: Mass edit attributes of a product model inside a family variant with 2 levels of hierarchy
+    Given I am on the products grid
+    And I select rows model-col
+    And I press the "Bulk actions" button
+    And I choose the "Edit common attributes" operation
+    And I display the Brand attribute
+    And I change the "Brand" to "Nyke"
+    And I display the Composition attribute
+    And I change the "Composition" to "100% cotton"
+    And I display the Weight attribute
+    And I change the "Weight" to "500 Gram"
+    When I confirm mass edit
+    And I wait for the "edit_common_attributes" job to finish
+    Then the product model value brand of "model-col" should be "[Nyke]"
+    And the product model value brand of "model-col-white" should be "[Nyke]"
+    And the product model value composition of "model-col-white" should be "100% cotton"
+    And the product value brand of "col-white-m" should be "[Nyke]"
+    And the product "col-white-m" should have the following values:
+      | composition | 100% cotton   |
+      | weight      | 500.0000 GRAM |
+
+  Scenario: Mass edit attributes of a sub product model inside a family variant with 2 levels of hierarchy
+    Given I am on the products grid
+    And I show the filter "color"
+    And I filter by "color" with operator "IN LIST" and value "[white]"
+    And I select rows model-col-white
+    And I press the "Bulk actions" button
+    And I choose the "Edit common attributes" operation
+    And I display the Composition attribute
+    And I change the "Composition" to "100% cotton"
+    And I display the Weight attribute
+    And I change the "Weight" to "500 Gram"
+    When I confirm mass edit
+    And I wait for the "edit_common_attributes" job to finish
+    Then the product model value composition of "model-col-white" should be "100% cotton"
+    And the product "col-white-m" should have the following values:
+      | composition | 100% cotton   |
+      | weight      | 500.0000 GRAM |
+
+  Scenario: Mass edit attributes of a product model inside a family variant with 1 levels of hierarchy
+    Given I am on the products grid
+    And I select rows model-nin
+    And I press the "Bulk actions" button
+    And I choose the "Edit common attributes" operation
+    And I display the Brand attribute
+    And I change the "Brand" to "Nyke"
+    And I display the Composition attribute
+    And I change the "Composition" to "100% cotton"
+    When I confirm mass edit
+    And I wait for the "edit_common_attributes" job to finish
+    Then the product model value brand of "model-nin" should be "[Nyke]"
+    And the product value brand of "nin-s" should be "[Nyke]"
+    And the product value composition of "nin-s" should be "100% cotton"
+
+  Scenario: Mass edit attributes of a product model and a non variant product at the same time
+    Given I am on the products grid
+    And I select rows model-col and tool-tee
+    And I press the "Bulk actions" button
+    And I choose the "Edit common attributes" operation
+    And I display the Brand attribute
+    And I change the "Brand" to "Nyke"
+    And I display the Composition attribute
+    And I change the "Composition" to "100% cotton"
+    And I display the Weight attribute
+    And I change the "Weight" to "500 Gram"
+    When I confirm mass edit
+    And I wait for the "edit_common_attributes" job to finish
+    Then the product model value brand of "model-col" should be "[Nyke]"
+    And the product value brand of "tool-tee" should be "[Nyke]"
+    And the product model value composition of "model-col-white" should be "100% cotton"
+    And the product value composition of "tool-tee" should be "100% cotton"
+    And the product "col-white-m" should have the following values:
+      | weight | 500.0000 GRAM |
+    And the product "tool-tee" should have the following values:
+      | weight | 500.0000 GRAM |
+
+  Scenario: It does not update ancestors' attributes
+    Given I am on the products grid
+    And I show the filter "color"
+    And I filter by "color" with operator "IN LIST" and value "[white]"
+    And I show the filter "size"
+    And I filter by "size" with operator "IN LIST" and value "[m]"
+    And I select rows col-white-m
+    And I press the "Bulk actions" button
+    And I choose the "Edit common attributes" operation
+    And I display the Brand attribute
+    And I change the "Brand" to "Nyke"
+    And I display the Composition attribute
+    And I change the "Composition" to "100% cotton"
+    And I display the Weight attribute
+    And I change the "Weight" to "500 gram"
+    When I confirm mass edit
+    And I wait for the "edit_common_attributes" job to finish
+    Then the product model value brand of "model-col" should be "[Abibas]"
+    Then the product model value brand of "model-col-white" should be "[Abibas]"
+    Then the product model value composition of "model-col-white" should be "cotton 90%, viscose 10%"
+    Then the product model "model-col" should not have the following values "composition, weight"
+    Then the product model "model-col-white" should not have the following values weight
+
+  Scenario: Mass edit attributes of all selected products and product models
+    Given I am on the products grid
+    And I select rows model-col
+    And I select all entities
+    And I press the "Bulk actions" button
+    And I choose the "Edit common attributes" operation
+    And I display the Brand attribute
+    And I change the "Brand" to "Nyke"
+    And I display the Composition attribute
+    And I change the "Composition" to "100% cotton"
+    And I display the Weight attribute
+    And I change the "Weight" to "500 Gram"
+    When I confirm mass edit
+    And I wait for the "edit_common_attributes" job to finish
+    Then the product model value brand of "model-col" should be "[Nyke]"
+    And the product model value composition of "model-col-white" should be "100% cotton"
+    And the product model value brand of "model-col-white" should be "[Nyke]"
+    And the product "col-white-m" should have the following values:
+      | brand       | [Nyke]        |
+      | composition | 100% cotton   |
+      | weight      | 500.0000 GRAM |
+    And the product "tool-tee" should have the following values:
+      | composition | 100% cotton   |
+      | weight      | 500.0000 GRAM |
+      | brand       | [Nyke]        |
+    And the product model value brand of "model-nin" should be "[Nyke]"
+    And the product "nin-s" should have the following values:
+      | weight      | 500.0000 GRAM |
+      | composition | 100% cotton   |
+
+  Scenario: Mass edit attributes of all but some one product model
+    Given I am on the products grid
+    And I select rows model-col
+    And I select all entities
+    And I unselect rows model-nin
+    And I press the "Bulk actions" button
+    And I choose the "Edit common attributes" operation
+    And I display the Brand attribute
+    And I change the "Brand" to "Nyke"
+    And I display the Composition attribute
+    And I change the "Composition" to "100% cotton"
+    And I display the Weight attribute
+    And I change the "Weight" to "500 Gram"
+    When I confirm mass edit
+    And I wait for the "edit_common_attributes" job to finish
+    Then the product model value brand of "model-col" should be "[Nyke]"
+    And the product model value composition of "model-col-white" should be "100% cotton"
+    And the product model value brand of "model-col-white" should be "[Nyke]"
+    And the product "col-white-m" should have the following values:
+      | brand       | [Nyke]        |
+      | composition | 100% cotton   |
+      | weight      | 500.0000 GRAM |
+    And the product "tool-tee" should have the following values:
+      | composition | 100% cotton   |
+      | weight      | 500.0000 GRAM |
+      | brand       | [Nyke]        |
+    And the product "nin-s" should have the following values:
+      | brand       |           |
+      | weight      |           |
+      | composition | 100% wool |

--- a/features/mass-action/mass_edit_products_and_product_models.feature
+++ b/features/mass-action/mass_edit_products_and_product_models.feature
@@ -37,24 +37,6 @@ Feature: Apply a mass action on products only (and not product models)
     When I move to the confirm page
     Then I should see the text "You are about to update 6 products with the following information, please confirm."
 
-  Scenario: Mass edits common attributes of only products within a selection of products and product models
-    Given I show the filter "color"
-    And I filter by "color" with operator "in list" and value "Crimson red"
-    And I select rows model-tshirt-divided-crimson-red, running-shoes-m-crimson-red and tshirt-unique-size-crimson-red
-    And I press the "Bulk actions" button
-    And I choose the "Edit common attributes" operation
-    And I display the Composition attribute
-    And I change the "Composition" to "My composition"
-    When I confirm mass edit
-    And I wait for the "edit_common_attributes" job to finish
-    When I go on the last executed job resume of "edit_common_attributes"
-    Then I should see the text "COMPLETED"
-    And I should see the text "processed 2"
-    And I should see the text "skipped 1"
-    And I should see the text "Bulk actions do not support Product models entities yet."
-    And attribute composition of "tshirt-unique-size-crimson-red" should be "My composition"
-    And attribute composition of "running-shoes-m-crimson-red" should be "My composition"
-
   Scenario: Mass edits family of only products within a selection of products and product models
     Given I show the filter "color"
     And I filter by "color" with operator "in list" and value "Navy blue"

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/AncestorFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/AncestorFilter.php
@@ -17,15 +17,15 @@ use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
  *
  * Imagine the following tree:
  *      RPM
- *       \___PM1
- *            \___P11
- *            \___P12
- *       \___PM2
- *            \___P21
+ *         \PM1
+ *            \P11
+ *            \P12
+ *         \PM2
+ *            \P21
  *
  * Using this filter with "IN LIST PM1" would return:
- *            \___P11
- *            \___P12
+ *            \P11
+ *            \P12
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/AncestorFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/AncestorFilter.php
@@ -15,6 +15,18 @@ use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
  * An ancestor is a product model that is either a parent or a grand parent.
  * Look for documents having the given ancestor(s).
  *
+ * Imagine the following tree:
+ *      RPM
+ *       \___PM1
+ *            \___P11
+ *            \___P12
+ *       \___PM2
+ *            \___P21
+ *
+ * Using this filter with "IN LIST PM1" would return:
+ *            \___P11
+ *            \___P12
+ *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
@@ -23,14 +23,14 @@ use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
  *            \P12
  *         \PM2
  *            \P21
- * 
+ *
  * Using this filter with "IN LIST PM1" would return:
  *         \PM1
  *            \P11
  *            \P12
- * 
+ *
  * Contrary to the ancestor filter, here PM1 itself is as well returned.
- * 
+ *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
+
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Exception\ObjectNotFoundException;
+use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
+
+/**
+ * An ancestor is a product model that is either a parent or a grand parent.
+ * Look for documents having the given ancestor(s).
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SelfAndAncestorFilter extends AbstractFieldFilter
+{
+    private const ANCESTOR_ID_ES_FIELD = 'ancestors.ids';
+
+    /** @var IdentifiableObjectRepositoryInterface */
+    private $productModelRepository;
+
+    /** @var ProductRepositoryInterface */
+    private $productRepository;
+
+    /**
+     * @param ProductModelRepositoryInterface $productModelRepository
+     * @param array                           $supportedFields
+     * @param array                           $supportedOperators
+     */
+    public function __construct(
+        ProductModelRepositoryInterface $productModelRepository,
+        ProductRepositoryInterface $productRepository,
+        array $supportedFields,
+        array $supportedOperators
+    ) {
+        $this->productModelRepository = $productModelRepository;
+        $this->productRepository = $productRepository;
+        $this->supportedFields = $supportedFields;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldFilter($field, $operator, $values, $locale = null, $channel = null, $options = []): void
+    {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        if (!$this->supportsOperator($operator)) {
+            throw InvalidOperatorException::notSupported($operator, SelfAndAncestorFilter::class);
+        }
+
+        $this->checkValues($values);
+
+        switch ($operator) {
+            case Operators::IN_LIST:
+                $ancestorClause = [
+                    'terms' => [
+                        'id' => $values,
+                    ],
+                ];
+                $ancestorsClause = [
+                    'terms' => [
+                        self::ANCESTOR_ID_ES_FIELD => $values,
+                    ],
+                ];
+                $this->searchQueryBuilder->addShould($ancestorClause);
+                $this->searchQueryBuilder->addShould($ancestorsClause);
+                break;
+            case Operators::NOT_IN_LIST:
+                $ancestorClause = [
+                    'terms' => [
+                        self::ANCESTOR_ID_ES_FIELD => $values,
+                    ],
+                ];
+                $selfClause = [
+                    'terms' => [
+                        'id' => $values,
+                    ]
+                ];
+                $this->searchQueryBuilder->addMustNot($selfClause);
+                $this->searchQueryBuilder->addMustNot($ancestorClause);
+                break;
+        }
+    }
+
+    /**
+     * Checks the value we want to filter on is valid
+     *
+     * @param $values
+     *
+     * @throws ObjectNotFoundException
+     */
+    private function checkValues($values): void
+    {
+        FieldFilterHelper::checkArray(self::ANCESTOR_ID_ES_FIELD, $values, static::class);
+        foreach ($values as $value) {
+            FieldFilterHelper::checkString(self::ANCESTOR_ID_ES_FIELD, $value, static::class);
+            if (!$this->isValidProductModelId($value) && !$this->isValidProductId($value)) {
+                throw new ObjectNotFoundException(
+                    sprintf('Object with ID "%s" does not exist as a product nor as a product model', $value)
+                );
+            }
+        }
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return bool
+     */
+    private function isValidProductModelId(string $value): bool
+    {
+        if (0 !== strpos($value, 'product_model_')) {
+            return false;
+        }
+
+        $id = str_replace('product_model_', '', $value);
+
+        return null !== $this->productModelRepository->findOneBy(['id' => $id]);
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return bool
+     */
+    private function isValidProductId(string $value): bool
+    {
+        if (0 !== strpos($value, 'product_')) {
+            return false;
+        }
+
+        $id = str_replace('product_', '', $value);
+
+        return null !== $this->productRepository->findOneBy(['id' => $id]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
@@ -32,6 +32,7 @@ class SelfAndAncestorFilter extends AbstractFieldFilter
 
     /**
      * @param ProductModelRepositoryInterface $productModelRepository
+     * @param ProductRepositoryInterface      $productRepository
      * @param array                           $supportedFields
      * @param array                           $supportedOperators
      */

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
@@ -18,19 +18,19 @@ use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
  *
  * Imagine the following tree:
  *      RPM
- *       \___PM1
- *            \___P11
- *            \___P12
- *       \___PM2
- *            \___P21
- *
+ *         \PM1
+ *            \P11
+ *            \P12
+ *         \PM2
+ *            \P21
+ * 
  * Using this filter with "IN LIST PM1" would return:
- *       \___PM1
- *            \___P11
- *            \___P12
- *
- * Contrary to the ancestor filter, here PM1 itself is returned.
- *
+ *         \PM1
+ *            \P11
+ *            \P12
+ * 
+ * Contrary to the ancestor filter, here PM1 itself is as well returned.
+ * 
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
@@ -64,7 +64,7 @@ class SelfAndAncestorFilter extends AbstractFieldFilter
 
         switch ($operator) {
             case Operators::IN_LIST:
-                $ancestorClause = [
+                $selfClause = [
                     'terms' => [
                         'id' => $values,
                     ],
@@ -74,22 +74,22 @@ class SelfAndAncestorFilter extends AbstractFieldFilter
                         self::ANCESTOR_ID_ES_FIELD => $values,
                     ],
                 ];
-                $this->searchQueryBuilder->addShould($ancestorClause);
+                $this->searchQueryBuilder->addShould($selfClause);
                 $this->searchQueryBuilder->addShould($ancestorsClause);
                 break;
             case Operators::NOT_IN_LIST:
-                $ancestorClause = [
-                    'terms' => [
-                        self::ANCESTOR_ID_ES_FIELD => $values,
-                    ],
-                ];
                 $selfClause = [
                     'terms' => [
                         'id' => $values,
                     ]
                 ];
+                $ancestorsClause = [
+                    'terms' => [
+                        self::ANCESTOR_ID_ES_FIELD => $values,
+                    ],
+                ];
                 $this->searchQueryBuilder->addMustNot($selfClause);
-                $this->searchQueryBuilder->addMustNot($ancestorClause);
+                $this->searchQueryBuilder->addMustNot($ancestorsClause);
                 break;
         }
     }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
@@ -16,6 +16,21 @@ use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
  * An ancestor is a product model that is either a parent or a grand parent.
  * Look for documents having the given ancestor(s).
  *
+ * Imagine the following tree:
+ *      RPM
+ *       \___PM1
+ *            \___P11
+ *            \___P12
+ *       \___PM2
+ *            \___P21
+ *
+ * Using this filter with "IN LIST PM1" would return:
+ *       \___PM1
+ *            \___P11
+ *            \___P12
+ *
+ * Contrary to the ancestor filter, here PM1 itself is returned.
+ *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/entity_with_family_variant.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/entity_with_family_variant.yml
@@ -1,6 +1,10 @@
 parameters:
     pim_catalog.entity_with_family_variant.keep_only_values_for_variation.class: Pim\Component\Catalog\EntityWithFamilyVariant\KeepOnlyValuesForVariation
+    pim_catalog.entity_with_family_variant.check_attribute_editable.class: Pim\Component\Catalog\EntityWithFamilyVariant\CheckAttributeEditable
 
 services:
     pim_catalog.entity_with_family_variant.keep_only_values_for_variation:
         class: '%pim_catalog.entity_with_family_variant.keep_only_values_for_variation.class%'
+
+    pim_catalog.entity_with_family_variant.check_attribute_editable:
+        class: '%pim_catalog.entity_with_family_variant.check_attribute_editable.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -36,6 +36,7 @@ parameters:
     pim_catalog.query.elasticsearch.filter.media.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\MediaFilter
     pim_catalog.query.elasticsearch.filter.boolean.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\BooleanFilter
     pim_catalog.query.elasticsearch.filter.ancestor.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\AncestorFilter
+    pim_catalog.query.elasticsearch.filter.self_and_ancestor.class: Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\SelfAndAncestorFilter
 
     pim_catalog.query.elasticsearch.sorter.base_field.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Field\BaseFieldSorter
     pim_catalog.query.elasticsearch.sorter.family.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Field\FamilySorter
@@ -331,6 +332,16 @@ services:
         arguments:
             - '@pim_catalog.repository.product_model'
             - ['ancestor.id']
+            - ['IN', 'NOT IN']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.filter.self_and_ancestor:
+        class: '%pim_catalog.query.elasticsearch.filter.self_and_ancestor.class%'
+        arguments:
+            - '@pim_catalog.repository.product_model'
+            - '@pim_catalog.repository.product'
+            - ['self_and_ancestor.id']
             - ['IN', 'NOT IN']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/SelfAndAncestorFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/SelfAndAncestorFilterSpec.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\AbstractFieldFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\SelfAndAncestorFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Exception\ObjectNotFoundException;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
+use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
+
+class SelfAndAncestorFilterSpec extends ObjectBehavior
+{
+    function let(
+        ProductModelRepositoryInterface $productModelRepository,
+        ProductRepositoryInterface $productRepository
+    ) {
+        $this->beConstructedWith(
+            $productModelRepository,
+            $productRepository,
+            ['self_and_ancestors.id'],
+            ['IN', 'NOT IN']
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(SelfAndAncestorFilter::class);
+    }
+
+    function it_is_a_field_filter()
+    {
+        $this->shouldImplement(FieldFilterInterface::class);
+        $this->shouldBeAnInstanceOf(AbstractFieldFilter::class);
+    }
+
+    function it_supports_operator()
+    {
+        $this->getOperators()->shouldReturn(['IN', 'NOT IN']);
+        $this->supportsOperator('IN')->shouldReturn(true);
+        $this->supportsOperator('NOT IN')->shouldReturn(true);
+        $this->supportsOperator('=')->shouldReturn(false);
+    }
+
+    function it_supports_field()
+    {
+        $this->supportsField('self_and_ancestors.id')->shouldReturn(true);
+        $this->supportsField('not_supported_field')->shouldReturn(false);
+    }
+
+    function it_adds_a_filter_with_operator_IN(
+        $productModelRepository,
+        $productRepository,
+        SearchQueryBuilder $sqb,
+        ProductModelInterface $productModel,
+        ProductInterface $product
+    ) {
+        $productModelRepository->findOneBy(['id' => '1'])->shouldNotBeCalled();
+        $productModelRepository->findOneBy(['id' => '2'])->willReturn($productModel);
+        $productRepository->findOneBy(['id' => '1'])->willReturn($product);
+        $productRepository->findOneBy(['id' => '2'])->shouldNotBeCalled();
+
+        $sqb->addShould(
+            [
+                'terms' => ['id' => ['product_1', 'product_model_2']],
+            ]
+        )->shouldBeCalled();
+
+        $sqb->addShould(
+            [
+                'terms' => ['ancestors.ids' => ['product_1', 'product_model_2']],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter(
+            'self_and_ancestors.id',
+            Operators::IN_LIST,
+            ['product_1', 'product_model_2'],
+            null,
+            null,
+            []
+        );
+    }
+
+    function it_adds_a_filter_with_operator_NOT_IN(
+        $productModelRepository,
+        $productRepository,
+        SearchQueryBuilder $sqb,
+        ProductModelInterface $productModel,
+        ProductInterface $product
+    ) {
+        $productModelRepository->findOneBy(['id' => '1'])->shouldNotBeCalled();
+        $productModelRepository->findOneBy(['id' => '2'])->willReturn($productModel);
+        $productRepository->findOneBy(['id' => '1'])->willReturn($product);
+        $productRepository->findOneBy(['id' => '2'])->shouldNotBeCalled();
+
+        $sqb->addMustNot(
+            [
+                'terms' => ['id' => ['product_1', 'product_model_2']],
+            ]
+        )->shouldBeCalled();
+
+        $sqb->addMustNot(
+            [
+                'terms' => ['ancestors.ids' => ['product_1', 'product_model_2']],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter(
+            'self_and_ancestors.id',
+            Operators::NOT_IN_LIST,
+            ['product_1', 'product_model_2'],
+            null,
+            null,
+            []
+        );
+    }
+
+    function it_throws_an_exception_when_the_search_query_builder_is_not_initialized()
+    {
+        $this->shouldThrow(
+            new \LogicException('The search query builder is not initialized in the filter.')
+        )->during('addFieldFilter', ['self_and_ancestors.id', Operators::IN_LIST, ['product_1'], null, null, []]);
+    }
+
+    function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
+        SearchQueryBuilder $sqb
+    ) {
+        $this->setQueryBuilder($sqb);
+        $this->shouldThrow(
+            InvalidOperatorException::notSupported(
+                'IN CHILDREN',
+                SelfAndAncestorFilter::class
+            )
+        )->during('addFieldFilter', ['self_and_ancestors.id', Operators::IN_CHILDREN_LIST, ['product_1'], null, null, []]);
+    }
+
+    function it_throws_if_the_value_is_not_a_product_id_nor_a_product_model_id(
+        SearchQueryBuilder $sqb
+    ) {
+        $this->setQueryBuilder($sqb);
+        $this->shouldThrow(
+            new ObjectNotFoundException(
+                'Object with ID "not_a_product_id_nor_a_product_model_id" does not exist as a product nor as a product model'
+            )
+        )->during(
+            'addFieldFilter',
+            ['self_and_ancestors.id', Operators::IN_LIST, ['not_a_product_id_nor_a_product_model_id'], null, null, []]
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchSelfAndAncestorsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchSelfAndAncestorsIntegration.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration;
+
+/**
+ * Search use cases of products and product models using the "ancestors" field.
+ *
+ * @author    Samir Boulil <samir.boulil@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class SearchSelfAndAncestorsIntegration extends AbstractPimCatalogProductModelIntegration
+{
+    /**
+     * Find all products and products models with Id + documents which are ancestors of this document
+     * (a root product model with two levels)
+     */
+    public function testFindAllProductsAndProductModelsWithIdAndAncestorsOf()
+    {
+        $query = [
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'should' => [
+                                [
+                                    'terms' => [
+                                        'id' => ['product_model_8'],
+                                    ],
+                                ],
+                                [
+                                    'terms' => [
+                                        'ancestors.ids' => ['product_model_8'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsAndProductModelsFound = $this->getSearchQueryResults($query);
+
+        $this->assertDocument(
+            $productsAndProductModelsFound,
+            [
+                'model-running-shoes',
+                'model-running-shoes-s',
+                'running-shoes-s-white',
+                'running-shoes-s-blue',
+                'running-shoes-s-red',
+                'model-running-shoes-m',
+                'running-shoes-m-white',
+                'running-shoes-m-blue',
+                'running-shoes-m-red',
+                'model-running-shoes-l',
+                'running-shoes-l-white',
+                'running-shoes-l-blue',
+                'running-shoes-l-red',
+            ]
+        );
+    }
+
+    /**
+     * Find all products and products models with Id + documents which are ancestors of this document
+     * (a root product model with one level)
+     */
+    public function testFindAllProductsAndProductModelsWithIdAndAncestorsOf1()
+    {
+        $query = [
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'should' => [
+                                [
+                                    'terms' => [
+                                        'id' => ['product_model_6'],
+                                    ],
+                                ],
+                                [
+                                    'terms' => [
+                                        'ancestors.ids' => ['product_model_6'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsAndProductModelsFound = $this->getSearchQueryResults($query);
+
+        $this->assertDocument(
+            $productsAndProductModelsFound,
+            [
+                'model-hat',
+                'hat-m',
+                'hat-l',
+            ]
+        );
+    }
+
+    /**
+     * Find all products and products models with Id + documents which are ancestors of this document
+     * (a sub product model)
+     */
+    public function testFindAllProductsAndProductModelsWithIdAndAncestorsOf2()
+    {
+        $query = [
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'should' => [
+                                [
+                                    'terms' => [
+                                        'id' => ['product_model_10'],
+                                    ],
+                                ],
+                                [
+                                    'terms' => [
+                                        'ancestors.ids' => ['product_model_10'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsAndProductModelsFound = $this->getSearchQueryResults($query);
+
+        $this->assertDocument(
+            $productsAndProductModelsFound,
+            [
+                'model-running-shoes-m',
+                'running-shoes-m-white',
+                'running-shoes-m-blue',
+                'running-shoes-m-red',
+            ]
+        );
+    }
+
+    /**
+     * Find all products and products models with Id + documents which have for ancestors the document with ids
+     * (multiple product models and a product) model and a product model id)
+     */
+    public function testFindAllProductsAndProductModelsWithIdAndAncestorsOf3()
+    {
+        $query = [
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'should' => [
+                                [
+                                    'terms' => [
+                                        'id' => ['product_model_10', 'product_17', 'product_model_5'],
+                                    ],
+                                ],
+                                [
+                                    'terms' => [
+                                        'ancestors.ids' => ['product_model_10', 'product_17', 'product_model_5'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsAndProductModelsFound = $this->getSearchQueryResults($query);
+
+        $this->assertDocument(
+            $productsAndProductModelsFound,
+            [
+                'model-running-shoes-m',
+                'running-shoes-m-white',
+                'running-shoes-m-blue',
+                'running-shoes-m-red',
+                'watch',
+                'model-tshirt-unique-color',
+                'tshirt-unique-color-s',
+                'tshirt-unique-color-m',
+                'tshirt-unique-color-l',
+                'tshirt-unique-color-xl',
+            ]
+        );
+    }
+
+    public function testFindAllProductsAndProductModelsWhichDoesNotHaveIdAndAreNotAncestorsOf()
+    {
+        $query = [
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'must_not' => [
+                                [
+                                    'terms' => [
+                                        'ancestors.ids' => [
+                                            'product_model_1',
+                                            'product_model_5',
+                                            'product_model_6',
+                                            'product_model_7',
+                                            'product_model_8',
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    'terms' => [
+                                        'id' => [
+                                            'product_model_1',
+                                            'product_model_5',
+                                            'product_model_6',
+                                            'product_model_7',
+                                            'product_model_8',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsAndProductModelsFound = $this->getSearchQueryResults($query);
+
+        $this->assertDocument(
+            $productsAndProductModelsFound,
+            [
+                'model-biker-jacket',
+                'biker-jacket-leather-s',
+                'biker-jacket-leather-m',
+                'biker-jacket-leather-l',
+                'biker-jacket-polyester-s',
+                'biker-jacket-polyester-m',
+                'biker-jacket-polyester-l',
+                'model-biker-jacket-leather',
+                'model-biker-jacket-polyester',
+                'watch',
+            ]
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/SelfAndAncestorFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/SelfAndAncestorFilterIntegration.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Filter;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductAndProductModelQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SelfAndAncestorFilterIntegration extends AbstractProductAndProductModelQueryBuilderTestCase
+{
+    public function testOperatorInListForRootProductModel()
+    {
+        $result = $this->executeFilter([['self_and_ancestor.id', Operators::IN_LIST, ['product_model_48']]]);
+        $this->assert(
+            $result,
+            [
+                'model-running-shoes',
+                'model-running-shoes-m',
+                'model-running-shoes-xxs',
+                'model-running-shoes-xxxl',
+                'running-shoes-m-antique-white',
+                'running-shoes-m-navy-blue',
+                'running-shoes-m-crimson-red',
+                'running-shoes-xxs-antique-white',
+                'running-shoes-xxs-navy-blue',
+                'running-shoes-xxs-crimson-red',
+                'running-shoes-xxxl-antique-white',
+                'running-shoes-xxxl-navy-blue',
+                'running-shoes-xxxl-crimson-red',
+            ]
+        );
+    }
+
+    public function testOperatorInListForSubProductModel()
+    {
+        $result = $this->executeFilter([['self_and_ancestor.id', Operators::IN_LIST, ['product_model_76']]]);
+        $this->assert(
+            $result,
+            [
+                'model-running-shoes-xxs',
+                'running-shoes-xxs-antique-white',
+                'running-shoes-xxs-navy-blue',
+                'running-shoes-xxs-crimson-red',
+            ]
+        );
+    }
+
+    public function testOperatorInListForMultipleProductModels()
+    {
+        $result = $this->executeFilter(
+            [['self_and_ancestor.id', Operators::IN_LIST, ['product_model_76', 'product_model_46']]]
+        );
+        $this->assert(
+            $result,
+            [
+                'model-running-shoes-xxs',
+                'running-shoes-xxs-antique-white',
+                'running-shoes-xxs-navy-blue',
+                'running-shoes-xxs-crimson-red',
+                'model-braided-hat',
+                'braided-hat-m',
+                'braided-hat-xxxl',
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditAttributesProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditAttributesProcessor.php
@@ -28,9 +28,6 @@ class EditAttributesProcessor extends AbstractProcessor
     /** @var ValidatorInterface */
     protected $productModelValidator;
 
-    /** @var array */
-    protected $skippedAttributes = [];
-
     /** @var ObjectUpdaterInterface */
     protected $productUpdater;
 
@@ -100,7 +97,7 @@ class EditAttributesProcessor extends AbstractProcessor
     }
 
     /**
-     * Set data from $actions to the given $product
+     * Set data from $actions to the given $entity
      *
      * @param EntityWithFamilyInterface $entity
      * @param array                     $filteredValues
@@ -134,7 +131,7 @@ class EditAttributesProcessor extends AbstractProcessor
     }
 
     /**
-     * Validate the product
+     * Validate the entity
      *
      * @param EntityWithFamilyInterface $entity
      *
@@ -153,6 +150,8 @@ class EditAttributesProcessor extends AbstractProcessor
     }
 
     /**
+     * Sadly, this is override in Enterprise Edition to check the permissions of the entity.
+     *
      * @param EntityWithFamilyInterface $entity
      *
      * @return bool
@@ -167,10 +166,6 @@ class EditAttributesProcessor extends AbstractProcessor
      */
     protected function addWarning(EntityWithFamilyInterface $entity): void
     {
-        /*
-         * We don't give the product to addWarning because we don't want that step executor
-         * calls the toString method which hydrate lot of model
-         */
         $this->stepExecution->addWarning(
             'pim_enrich.mass_edit_action.edit-common-attributes.message.no_valid_attribute',
             [],

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditAttributesProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditAttributesProcessor.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Product;
+
+use Akeneo\Component\Batch\Item\DataInvalidItem;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Doctrine\Common\Util\ClassUtils;
+use Pim\Bundle\EnrichBundle\Connector\Processor\AbstractProcessor;
+use Pim\Component\Catalog\EntityWithFamilyVariant\CheckAttributeEditable;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Processor to add product value in a mass edit
+ *
+ * @author    Julien.* <julien@akeneo.com>|<j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class EditAttributesProcessor extends AbstractProcessor
+{
+    /** @var ValidatorInterface */
+    protected $productValidator;
+
+    /** @var ValidatorInterface */
+    protected $productModelValidator;
+
+    /** @var array */
+    protected $skippedAttributes = [];
+
+    /** @var ObjectUpdaterInterface */
+    protected $productUpdater;
+
+    /** @var ObjectUpdaterInterface */
+    protected $productModelUpdater;
+
+    /** @var IdentifiableObjectRepositoryInterface */
+    protected $attributeRepository;
+
+    /** @var CheckAttributeEditable */
+    protected $checkAttributeEditable;
+
+    /**
+     * @param ValidatorInterface                    $productValidator
+     * @param ValidatorInterface                    $productModelValidator
+     * @param ObjectUpdaterInterface                $productUpdater
+     * @param ObjectUpdaterInterface                $productModelUpdater
+     * @param ObjectDetacherInterface               $detacher
+     * @param IdentifiableObjectRepositoryInterface $attributeRepository
+     * @param CheckAttributeEditable                $checkAttributeEditable
+     */
+    public function __construct(
+        ValidatorInterface $productValidator,
+        ValidatorInterface $productModelValidator,
+        ObjectUpdaterInterface $productUpdater,
+        ObjectUpdaterInterface $productModelUpdater,
+        IdentifiableObjectRepositoryInterface $attributeRepository,
+        CheckAttributeEditable $checkAttributeEditable
+    ) {
+        $this->productValidator = $productValidator;
+        $this->productModelValidator = $productModelValidator;
+        $this->productUpdater = $productUpdater;
+        $this->productModelUpdater = $productModelUpdater;
+        $this->attributeRepository = $attributeRepository;
+        $this->checkAttributeEditable = $checkAttributeEditable;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process($entity)
+    {
+        $actions = $this->getConfiguredActions();
+
+        if (!$this->isEntityEditable($entity)) {
+            $this->stepExecution->incrementSummaryInfo('skipped_products');
+
+            return null;
+        }
+
+        $filteredValues = $this->extractValuesToUpdate($entity, $actions[0]);
+
+        if (empty($filteredValues)) {
+            $this->stepExecution->incrementSummaryInfo('skipped_products');
+
+            return null;
+        }
+
+        $entity = $this->updateEntity($entity, $filteredValues);
+        if (!$this->isValid($entity)) {
+            $this->stepExecution->incrementSummaryInfo('skipped_products');
+
+            return null;
+        }
+
+        return $entity;
+    }
+
+    /**
+     * Set data from $actions to the given $product
+     *
+     * @param EntityWithFamilyInterface $entity
+     * @param array                     $filteredValues
+     *
+     * @return EntityWithFamilyInterface
+     */
+    protected function updateEntity(EntityWithFamilyInterface $entity, array $filteredValues): EntityWithFamilyInterface
+    {
+        if ($entity instanceof ProductInterface) {
+            $this->productUpdater->update($entity, ['values' => $filteredValues]);
+        } else {
+            $this->productModelUpdater->update($entity, ['values' => $filteredValues]);
+        }
+
+        return $entity;
+    }
+
+    /**
+     * @param EntityWithFamilyInterface $entity
+     * @param string                    $attributeCode
+     *
+     * @return bool
+     *
+     * @throws \Exception
+     */
+    protected function isAttributeEditable(EntityWithFamilyInterface $entity, string $attributeCode): bool
+    {
+        $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
+
+        return $this->checkAttributeEditable->isEditable($entity, $attribute);
+    }
+
+    /**
+     * Validate the product
+     *
+     * @param EntityWithFamilyInterface $entity
+     *
+     * @return bool
+     */
+    protected function isValid(EntityWithFamilyInterface $entity): bool
+    {
+        if ($entity instanceof ProductInterface) {
+            $violations = $this->productValidator->validate($entity);
+        } else {
+            $violations = $this->productModelValidator->validate($entity);
+        }
+        $this->addWarningMessage($violations, $entity);
+
+        return 0 === $violations->count();
+    }
+
+    /**
+     * @param EntityWithFamilyInterface $entity
+     *
+     * @return bool
+     */
+    protected function isEntityEditable(EntityWithFamilyInterface $entity): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param EntityWithFamilyInterface $entity
+     */
+    protected function addWarning(EntityWithFamilyInterface $entity): void
+    {
+        /*
+         * We don't give the product to addWarning because we don't want that step executor
+         * calls the toString method which hydrate lot of model
+         */
+        $this->stepExecution->addWarning(
+            'pim_enrich.mass_edit_action.edit-common-attributes.message.no_valid_attribute',
+            [],
+            new DataInvalidItem(
+                [
+                    'class'  => ClassUtils::getClass($entity),
+                    'id'     => $entity->getId(),
+                    'string' => $entity instanceof ProductInterface ? $entity->getIdentifier() : $entity->getCode(),
+                ]
+            )
+        );
+    }
+
+    /**
+     * Actions should look like that
+     *
+     * $actions =
+     * [
+     *      'normalized_values' => [
+     *          'name' => [
+     *              [
+     *                  'locale' => null,
+     *                  'scope'  => null,
+     *                  'data' => 'The name'
+     *              ]
+     *          ],
+     *          'description' => [
+     *              [
+     *                  'locale' => 'en_US',
+     *                  'scope' => 'ecommerce',
+     *                  'data' => 'The description for en_US ecommerce'
+     *              ]
+     *          ]
+     *      ]
+     * ]
+     *
+     * @param EntityWithFamilyInterface $entity
+     * @param array                     $actions
+     *
+     * @return array
+     */
+    private function extractValuesToUpdate(EntityWithFamilyInterface $entity, array $actions): array
+    {
+        $filteredValues = [];
+        $normalizedValues = $actions['normalized_values'];
+        foreach ($normalizedValues as $attributeCode => $values) {
+            if ($this->isAttributeEditable($entity, $attributeCode)) {
+                $filteredValues[$attributeCode] = $values;
+            }
+        }
+
+        return $filteredValues;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Product/EditCommonAttributesProcessor.php
@@ -17,6 +17,9 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @author    Olivier Soulet <olivier.soulet@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @deprecated will be removed in 2.1, please use instead
+ *             Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Product\EditAttributesProcessor
  */
 class EditCommonAttributesProcessor extends AbstractProcessor
 {

--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/ProductAndProductModelReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/ProductAndProductModelReader.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit;
+
+use Akeneo\Component\Batch\Item\DataInvalidItem;
+use Akeneo\Component\Batch\Item\InitializableInterface;
+use Akeneo\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Pim\Component\Catalog\Converter\MetricConverter;
+use Pim\Component\Catalog\Exception\ObjectNotFoundException;
+use Pim\Component\Catalog\Manager\CompletenessManager;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+
+/**
+ * Product reader that only returns product entities and skips product models.
+ *
+ * TODO: This class is unused for now (replaced by both FilteredProductReader and FilteredProductModelReader).
+ * This class has to be used for mass actions PIM-6357 after removing the skip part.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductAndProductModelReader implements
+    ItemReaderInterface,
+    InitializableInterface,
+    StepExecutionAwareInterface
+{
+    /** @var ProductQueryBuilderFactoryInterface */
+    private $pqbFactory;
+
+    /** @var ChannelRepositoryInterface */
+    private $channelRepository;
+
+    /** @var CompletenessManager */
+    private $completenessManager;
+
+    /** @var MetricConverter */
+    private $metricConverter;
+
+    /** @var bool */
+    private $generateCompleteness;
+
+    /** @var StepExecution */
+    private $stepExecution;
+
+    /** @var CursorInterface */
+    private $productsAndProductModels;
+
+    /**
+     * @param ProductQueryBuilderFactoryInterface $pqbFactory
+     * @param ChannelRepositoryInterface          $channelRepository
+     * @param CompletenessManager                 $completenessManager
+     * @param MetricConverter                     $metricConverter
+     * @param bool                                $generateCompleteness
+     */
+    public function __construct(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager,
+        MetricConverter $metricConverter,
+        $generateCompleteness
+    ) {
+        $this->pqbFactory = $pqbFactory;
+        $this->channelRepository = $channelRepository;
+        $this->completenessManager = $completenessManager;
+        $this->metricConverter = $metricConverter;
+        $this->generateCompleteness = (bool) $generateCompleteness;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize(): void
+    {
+        $channel = $this->getConfiguredChannel();
+        if (null !== $channel && $this->generateCompleteness) {
+            $this->completenessManager->generateMissingForChannel($channel);
+        }
+
+        $filters = $this->getConfiguredFilters();
+        $this->productsAndProductModels = $this->getProductsCursor($filters, $channel);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read(): ?EntityWithFamilyInterface
+    {
+        $entityWithFamily = $this->getNextEntityWithFamily();
+
+        if (null !== $entityWithFamily) {
+            $channel = $this->getConfiguredChannel();
+            if (null !== $channel) {
+                $this->metricConverter->convert($entityWithFamily, $channel);
+            }
+        }
+
+        return $entityWithFamily;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStepExecution(StepExecution $stepExecution): void
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    /**
+     * Returns the configured channel from the parameters.
+     * If no channel is specified, returns null.
+     *
+     * @throws ObjectNotFoundException
+     *
+     * @return ChannelInterface|null
+     */
+    private function getConfiguredChannel(): ?ChannelInterface
+    {
+        $parameters = $this->stepExecution->getJobParameters();
+        if (!isset($parameters->get('filters')['structure']['scope'])) {
+            return null;
+        }
+
+        $channelCode = $parameters->get('filters')['structure']['scope'];
+        $channel = $this->channelRepository->findOneByIdentifier($channelCode);
+        if (null === $channel) {
+            throw new ObjectNotFoundException(sprintf('Channel with "%s" code does not exist', $channelCode));
+        }
+
+        return $channel;
+    }
+
+    /**
+     * Returns the filters from the configuration.
+     * The parameters can be in the 'filters' root node, or in filters data node (e.g. for export).
+     *
+     * @return array
+     */
+    private function getConfiguredFilters(): array
+    {
+        $filters = $this->stepExecution->getJobParameters()->get('filters');
+
+        if (array_key_exists('data', $filters)) {
+            $filters = $filters['data'];
+        }
+
+        $filters = array_map(function ($filter) {
+            if ('id' === $filter['field']) {
+                $filter['field'] = 'self_and_ancestor.id';
+            }
+
+            return $filter;
+        }, $filters);
+
+        return array_filter($filters, function ($filter) {
+            return count($filter) > 0;
+        });
+    }
+
+    /**
+     * @param array            $filters
+     * @param ChannelInterface $channel
+     *
+     * @return CursorInterface
+     */
+    private function getProductsCursor(array $filters, ChannelInterface $channel = null): CursorInterface
+    {
+        $options = ['filters' => $filters];
+
+        if (null !== $channel) {
+            $options['default_scope'] = $channel->getCode();
+        }
+
+        $productQueryBuilder = $this->pqbFactory->create($options);
+
+        return $productQueryBuilder->execute();
+    }
+
+    /**
+     * This reader makes sure we return only product entities.
+     *
+     * @return null|EntityWithFamilyInterface
+     */
+    private function getNextEntityWithFamily(): ?EntityWithFamilyInterface
+    {
+        $entity = null;
+
+        if ($this->productsAndProductModels->valid()) {
+            $entity = $this->productsAndProductModels->current();
+            $this->productsAndProductModels->next();
+            $this->stepExecution->incrementSummaryInfo('read');
+        }
+
+        return $entity;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/ProductAndProductModelReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/ProductAndProductModelReader.php
@@ -21,10 +21,8 @@ use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 
 /**
- * Product reader that only returns product entities and skips product models.
- *
- * TODO: This class is unused for now (replaced by both FilteredProductReader and FilteredProductModelReader).
- * This class has to be used for mass actions PIM-6357 after removing the skip part.
+ * Special reader that will select all the ancestry of the selected items
+ * (to get all the product models and products that are possibly impacted by the mass edit).
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -88,7 +86,7 @@ class ProductAndProductModelReader implements
         }
 
         $filters = $this->getConfiguredFilters();
-        $this->productsAndProductModels = $this->getProductsCursor($filters, $channel);
+        $this->productsAndProductModels = $this->getCursor($filters, $channel);
     }
 
     /**
@@ -144,6 +142,9 @@ class ProductAndProductModelReader implements
      * Returns the filters from the configuration.
      * The parameters can be in the 'filters' root node, or in filters data node (e.g. for export).
      *
+     * Here we transform the ID filter into SELF_AND_ANCESTOR.ID in order to retrieve
+     * all the product models and products that are possibly impacted by the mass edit.
+     *
      * @return array
      */
     private function getConfiguredFilters(): array
@@ -173,7 +174,7 @@ class ProductAndProductModelReader implements
      *
      * @return CursorInterface
      */
-    private function getProductsCursor(array $filters, ChannelInterface $channel = null): CursorInterface
+    private function getCursor(array $filters, ChannelInterface $channel = null): CursorInterface
     {
         $options = ['filters' => $filters];
 
@@ -181,9 +182,9 @@ class ProductAndProductModelReader implements
             $options['default_scope'] = $channel->getCode();
         }
 
-        $productQueryBuilder = $this->pqbFactory->create($options);
+        $queryBuilder = $this->pqbFactory->create($options);
 
-        return $productQueryBuilder->execute();
+        return $queryBuilder->execute();
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/ProductAndProductModelReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/ProductAndProductModelReader.php
@@ -45,9 +45,6 @@ class ProductAndProductModelReader implements
     /** @var MetricConverter */
     private $metricConverter;
 
-    /** @var bool */
-    private $generateCompleteness;
-
     /** @var StepExecution */
     private $stepExecution;
 
@@ -59,20 +56,17 @@ class ProductAndProductModelReader implements
      * @param ChannelRepositoryInterface          $channelRepository
      * @param CompletenessManager                 $completenessManager
      * @param MetricConverter                     $metricConverter
-     * @param bool                                $generateCompleteness
      */
     public function __construct(
         ProductQueryBuilderFactoryInterface $pqbFactory,
         ChannelRepositoryInterface $channelRepository,
         CompletenessManager $completenessManager,
-        MetricConverter $metricConverter,
-        $generateCompleteness
+        MetricConverter $metricConverter
     ) {
         $this->pqbFactory = $pqbFactory;
         $this->channelRepository = $channelRepository;
         $this->completenessManager = $completenessManager;
         $this->metricConverter = $metricConverter;
-        $this->generateCompleteness = (bool) $generateCompleteness;
     }
 
     /**
@@ -81,7 +75,7 @@ class ProductAndProductModelReader implements
     public function initialize(): void
     {
         $channel = $this->getConfiguredChannel();
-        if (null !== $channel && $this->generateCompleteness) {
+        if (null !== $channel) {
             $this->completenessManager->generateMissingForChannel($channel);
         }
 

--- a/src/Pim/Bundle/EnrichBundle/Connector/Writer/MassEdit/ProductAndProductModelWriter.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Writer/MassEdit/ProductAndProductModelWriter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Component\Connector\Writer\Database;
+namespace Pim\Bundle\EnrichBundle\Connector\Writer\MassEdit;
 
 use Akeneo\Component\Batch\Item\InitializableInterface;
 use Akeneo\Component\Batch\Item\ItemWriterInterface;
@@ -9,16 +9,18 @@ use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Pim\Bundle\VersioningBundle\Manager\VersionManager;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
 
 /**
- * Product writer
+ * Product and product model writer for mass edit
  *
- * @author    Benoit Jacquemont <benoit@akeneo.com>
- * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductWriter implements ItemWriterInterface, StepExecutionAwareInterface, InitializableInterface
+class ProductAndProductModelWriter implements ItemWriterInterface, StepExecutionAwareInterface, InitializableInterface
 {
     /** @var VersionManager */
     protected $versionManager;
@@ -29,6 +31,9 @@ class ProductWriter implements ItemWriterInterface, StepExecutionAwareInterface,
     /** @var BulkSaverInterface */
     protected $productSaver;
 
+    /** @var BulkSaverInterface */
+    protected $productModelSaver;
+
     /** @var CacheClearerInterface */
     protected $cacheClearer;
 
@@ -37,15 +42,18 @@ class ProductWriter implements ItemWriterInterface, StepExecutionAwareInterface,
      *
      * @param VersionManager        $versionManager
      * @param BulkSaverInterface    $productSaver
+     * @param BulkSaverInterface    $productModelSaver
      * @param CacheClearerInterface $cacheClearer
      */
     public function __construct(
         VersionManager $versionManager,
         BulkSaverInterface $productSaver,
+        BulkSaverInterface $productModelSaver,
         CacheClearerInterface $cacheClearer
     ) {
         $this->versionManager = $versionManager;
         $this->productSaver = $productSaver;
+        $this->productModelSaver = $productModelSaver;
         $this->cacheClearer = $cacheClearer;
     }
 
@@ -54,11 +62,19 @@ class ProductWriter implements ItemWriterInterface, StepExecutionAwareInterface,
      */
     public function write(array $items)
     {
-        foreach ($items as $item) {
-            $this->incrementCount($item);
-        }
+        $products = array_filter($items, function ($item) {
+            return $item instanceof ProductInterface;
+        });
+        $productModels = array_filter($items, function ($item) {
+            return $item instanceof ProductModelInterface;
+        });
 
-        $this->productSaver->saveAll($items);
+        array_walk($items, function ($item) {
+            $this->incrementCount($item);
+        });
+
+        $this->productSaver->saveAll($products);
+        $this->productModelSaver->saveAll($productModels);
         $this->cacheClearer->clear();
     }
 
@@ -81,11 +97,11 @@ class ProductWriter implements ItemWriterInterface, StepExecutionAwareInterface,
     }
 
     /**
-     * @param ProductInterface $product
+     * @param EntityWithFamilyInterface $entity
      */
-    protected function incrementCount(ProductInterface $product)
+    protected function incrementCount(EntityWithFamilyInterface $entity)
     {
-        if ($product->getId()) {
+        if ($entity->getId()) {
             $this->stepExecution->incrementSummaryInfo('process');
         } else {
             $this->stepExecution->incrementSummaryInfo('create');

--- a/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
+++ b/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
@@ -70,6 +70,7 @@ class PimEnrichExtension extends Extension
         $loader->load('view_elements/category.yml');
         $loader->load('view_elements/group_type.yml');
         $loader->load('view_elements/mass_edit.yml');
+        $loader->load('writers.yml');
 
         if ($config['record_mails']) {
             $loader->load('mail_recorder.yml');

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/CountImpactedProducts.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/CountImpactedProducts.php
@@ -74,7 +74,6 @@ class CountImpactedProducts
         $pmqb = $this->productAndProductModelQueryBuilderFactory->create(['filters' => $filters]);
         $pmqb->addFilter('entity_type', Operators::EQUALS, ProductInterface::class);
         $pmqb->addFilter('ancestor.id', Operators::IN_LIST, $productModelIds);
-
         $count = $pmqb->execute()->count();
 
         return $count;

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/MassEditProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/MassEditProductAndProductModelQueryBuilder.php
@@ -8,7 +8,7 @@ use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
 /**
  * Provides a way to search simply and efficiently product and product models.
  *
- * @author    Julien Sanchez <j.janvier@gmail.com>
+ * @author    Julien Sanchez <julien@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/MassEditProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/MassEditProductAndProductModelQueryBuilder.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\ProductQueryBuilder;
+
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+
+/**
+ * Provides a way to search simply and efficiently product and product models.
+ *
+ * @author    Julien Sanchez <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MassEditProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
+{
+    /** @var ProductQueryBuilderInterface */
+    private $pqb;
+
+    /**
+     * @param ProductQueryBuilderInterface $pqb
+     */
+    public function __construct(ProductQueryBuilderInterface $pqb)
+    {
+        $this->pqb = $pqb;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFilter($field, $operator, $value, array $context = [])
+    {
+        return $this->pqb->addFilter($field, $operator, $value, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addSorter($field, $direction, array $context = [])
+    {
+        return $this->pqb->addSorter($field, $direction, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRawFilters()
+    {
+        return $this->pqb->getRawFilters();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getQueryBuilder()
+    {
+        return $this->pqb->getQueryBuilder();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setQueryBuilder($queryBuilder)
+    {
+        return $this->pqb->setQueryBuilder($queryBuilder);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute()
+    {
+        return $this->pqb->execute();
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -117,16 +117,26 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
         $hasIdentifierFilter = $this->hasRawFilter('field', 'identifier');
         $hasEntityTypeFilter = $this->hasRawFilter('field', 'entity_type');
         $hasAncestorsIdsFilter = $this->hasRawFilter('field', 'ancestor.id');
+        $hasSelfAndAncestorsIdsFilter = $this->hasRawFilter('field', 'self_and_ancestor.id');
 
         return !$hasAttributeFilters &&
             !$hasParentFilter &&
             !$hasIdFilter &&
             !$hasIdentifierFilter &&
             !$hasEntityTypeFilter &&
-            !$hasAncestorsIdsFilter;
+            !$hasAncestorsIdsFilter &&
+            !$hasSelfAndAncestorsIdsFilter;
     }
 
-    private function hasRawFilter(string $filterProperty, string $value)
+    /**
+     * Checks whether the raw filters contains a filter on a particular field.
+     *
+     * @param string $filterProperty
+     * @param string $value
+     *
+     * @return bool
+     */
+    private function hasRawFilter(string $filterProperty, string $value): bool
     {
         return !empty(array_filter(
             $this->getRawFilters(),

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/connector/processors.yml
@@ -4,6 +4,7 @@ parameters:
     pim_enrich.connector.processor.mass_edit.product.remove_value.class:                       Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Product\RemoveProductValueProcessor
     pim_enrich.connector.processor.mass_edit.product.edit_common_attributes.class:             Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Product\EditCommonAttributesProcessor
     pim_enrich.connector.processor.mass_edit.product.add_to_existing_product_model.class:      Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Product\AddToExistingProductModelProcessor
+    pim_enrich.connector.processor.mass_edit.product.edit_attributes.class:        Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Product\EditAttributesProcessor
     pim_enrich.connector.processor.mass_edit.family.set_requirements.class:                    Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Family\SetAttributeRequirements
     pim_enrich.connector.processor.quick_export.product_and_product_model.class:               Pim\Bundle\EnrichBundle\Connector\Processor\QuickExport\ProductAndProductModelProcessor
 
@@ -33,6 +34,16 @@ services:
             - '@pim_catalog.repository.product'
             - '@pim_catalog.updater.product'
             - '@akeneo_storage_utils.doctrine.object_detacher'
+
+    pim_enrich.connector.processor.mass_edit.product.edit_attributes:
+        class: '%pim_enrich.connector.processor.mass_edit.product.edit_attributes.class%'
+        arguments:
+            - '@pim_catalog.validator.product'
+            - '@pim_catalog.validator.product_model'
+            - '@pim_catalog.updater.product'
+            - '@pim_catalog.updater.product_model'
+            - '@pim_catalog.repository.cached_attribute'
+            - '@pim_catalog.entity_with_family_variant.check_attribute_editable'
 
     pim_enrich.connector.processor.mass_edit.product.add_to_existing_product_model:
         class: '%pim_enrich.connector.processor.mass_edit.product.add_to_existing_product_model.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
@@ -5,6 +5,7 @@ parameters:
     pim_enrich.elasticsearch.cursor_factory.class: Pim\Bundle\EnrichBundle\Elasticsearch\CursorFactory
     pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class: Pim\Bundle\EnrichBundle\Elasticsearch\ProductAndProductModelQueryBuilderFactory
     pim_enrich.query.product_and_product_model_query_builder.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelQueryBuilder
+    pim_enrich.query.mass_edit_product_and_product_model_query_builder.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\MassEditProductAndProductModelQueryBuilder
 
 services:
     # Filters
@@ -77,4 +78,10 @@ services:
         class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
         arguments:
             - '%pim_enrich.query.product_and_product_model_query_builder.class%'
+            - '@pim_enrich.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor'
+
+    pim_enrich.query.mass_edit_product_and_product_model_query_builder_factory:
+        class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
+        arguments:
+            - '%pim_enrich.query.mass_edit_product_and_product_model_query_builder.class%'
             - '@pim_enrich.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
@@ -20,7 +20,6 @@ services:
             - '@pim_enrich.query.mass_edit_product_and_product_model_query_builder_factory'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.manager.completeness'
-            - '@pim_catalog.converter.metric'
 
     pim_enrich.reader.database.product:
         class: '%pim_enrich.reader.database.filtered_product_reader.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
@@ -1,13 +1,23 @@
 parameters:
     pim_enrich.reader.database.filtered_product_and_product_model_reader.class: Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit\FilteredProductAndProductModelReader
+    pim_enrich.reader.database.product_and_product_model_reader.class: Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit\ProductAndProductModelReader
     pim_enrich.reader.database.filtered_product_reader.class: Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit\FilteredProductReader
     pim_enrich.reader.database.filtered_product_model_reader.class: Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit\FilteredProductModelReader
 
 services:
-    pim_enrich.reader.database.product_and_product_model:
+    pim_enrich.reader.database.filtered_product_and_product_model:
         class: '%pim_enrich.reader.database.filtered_product_and_product_model_reader.class%'
         arguments:
-            - '@pim_enrich.query.product_and_product_model_query_builder_factory'
+            - '@pim_enrich.query.mass_edit_product_and_product_model_query_builder_factory'
+            - '@pim_catalog.repository.channel'
+            - '@pim_catalog.manager.completeness'
+            - '@pim_catalog.converter.metric'
+            - true
+
+    pim_enrich.reader.database.product_and_product_model:
+        class: '%pim_enrich.reader.database.product_and_product_model_reader.class%'
+        arguments:
+            - '@pim_enrich.query.mass_edit_product_and_product_model_query_builder_factory'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.manager.completeness'
             - '@pim_catalog.converter.metric'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
@@ -21,7 +21,6 @@ services:
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.manager.completeness'
             - '@pim_catalog.converter.metric'
-            - true
 
     pim_enrich.reader.database.product:
         class: '%pim_enrich.reader.database.filtered_product_reader.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
@@ -8,7 +8,7 @@ services:
     pim_enrich.reader.database.filtered_product_and_product_model:
         class: '%pim_enrich.reader.database.filtered_product_and_product_model_reader.class%'
         arguments:
-            - '@pim_enrich.query.mass_edit_product_and_product_model_query_builder_factory'
+            - '@pim_enrich.query.product_and_product_model_query_builder_factory'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.manager.completeness'
             - '@pim_catalog.converter.metric'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/steps.yml
@@ -55,7 +55,7 @@ services:
             - 'perform'
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
-            - '@pim_enrich.reader.database.product_and_product_model'
+            - '@pim_enrich.reader.database.filtered_product_and_product_model'
             - '@pim_enrich.connector.processor.mass_edit.product.update_value'
             - '@pim_connector.writer.database.product'
 
@@ -65,7 +65,7 @@ services:
             - 'perform'
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
-            - '@pim_enrich.reader.database.product_and_product_model'
+            - '@pim_enrich.reader.database.filtered_product_and_product_model'
             - '@pim_enrich.connector.processor.mass_edit.product.add_value'
             - '@pim_connector.writer.database.product'
 
@@ -75,7 +75,7 @@ services:
             - 'perform'
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
-            - '@pim_enrich.reader.database.product_and_product_model'
+            - '@pim_enrich.reader.database.filtered_product_and_product_model'
             - '@pim_enrich.connector.processor.mass_edit.product.remove_value'
             - '@pim_connector.writer.database.product'
 
@@ -86,8 +86,8 @@ services:
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
             - '@pim_enrich.reader.database.product_and_product_model'
-            - '@pim_enrich.connector.processor.mass_edit.product.edit_common_attributes'
-            - '@pim_connector.writer.database.product'
+            - '@pim_enrich.connector.processor.mass_edit.product.edit_attributes'
+            - '@pim_enrich.writer.database.product_and_product_model_writer'
 
     pim_enrich.step.add_to_existing_product_model.mass_edit:
         class: '%pim_connector.step.item_step.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/writers.yml
@@ -1,0 +1,11 @@
+parameters:
+    pim_enrich.writer.database.product_and_product_model_writer.class: Pim\Bundle\EnrichBundle\Connector\Writer\MassEdit\ProductAndProductModelWriter
+
+services:
+    pim_enrich.writer.database.product_and_product_model_writer:
+        class: '%pim_enrich.writer.database.product_and_product_model_writer.class%'
+        arguments:
+            - '@pim_versioning.manager.version'
+            - '@pim_catalog.saver.product'
+            - '@pim_catalog.saver.product_model'
+            - '@pim_connector.doctrine.cache_clearer'

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Processor/MassEdit/Product/EditAttributesProcessorSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Processor/MassEdit/Product/EditAttributesProcessorSpec.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Product;
+
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\EntityWithFamilyVariant\CheckAttributeEditable;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Prophecy\Argument;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class EditAttributesProcessorSpec extends ObjectBehavior
+{
+    function let(
+        ValidatorInterface $productValidator,
+        ValidatorInterface $productModelValidator,
+        ObjectUpdaterInterface $productUpdater,
+        ObjectUpdaterInterface $productModelUpdater,
+        IdentifiableObjectRepositoryInterface $attributeRepository,
+        CheckAttributeEditable $checkAttributeEditable
+    ) {
+        $this->beConstructedWith(
+            $productValidator,
+            $productModelValidator,
+            $productUpdater,
+            $productModelUpdater,
+            $attributeRepository,
+            $checkAttributeEditable
+        );
+    }
+
+    function it_sets_the_step_execution(StepExecution $stepExecution)
+    {
+        $this->setStepExecution($stepExecution)->shouldReturn($this);
+    }
+
+    function it_sets_values_to_products_attributes(
+        $productValidator,
+        $productUpdater,
+        $attributeRepository,
+        $checkAttributeEditable,
+        ProductInterface $product,
+        StepExecution $stepExecution,
+        JobExecution $jobExecution,
+        JobParameters $jobParameters,
+        AttributeInterface $attribute
+    ) {
+        $this->setStepExecution($stepExecution);
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filters')->willReturn([]);
+        $jobParameters->get('actions')->willReturn([[
+                'normalized_values' => [
+                    'number' => [
+                        [
+                            'scope' => null,
+                            'locale' => null,
+                            'data' => '2.5'
+                        ]
+                    ]
+                ],
+                'ui_locale'         => 'fr_FR',
+                'attribute_locale'  => 'en_US',
+                'attribute_channel' => null
+            ]]);
+
+        $violations = new ConstraintViolationList([]);
+        $productValidator->validate($product)->willReturn($violations);
+        $product->getId()->willReturn(10);
+
+        $attributeRepository->findOneByIdentifier('number')->willReturn($attribute);
+        $checkAttributeEditable->isEditable($product, $attribute)->willReturn(true);
+
+        $productUpdater->update($product, [
+            'values' => [
+                'number' => [
+                    [
+                        'scope' => null,
+                        'locale' => null,
+                        'data' => '2.5'
+                    ]
+                ]
+            ]
+        ])->shouldBeCalled();
+
+        $this->process($product)->shouldReturn($product);
+    }
+
+    function it_skips_invalid_products(
+        $productValidator,
+        $productUpdater,
+        $attributeRepository,
+        $checkAttributeEditable,
+        ProductInterface $product,
+        ConstraintViolationListInterface $violations,
+        StepExecution $stepExecution,
+        JobExecution $jobExecution,
+        JobParameters $jobParameters,
+        AttributeInterface $attribute
+    ) {
+        $this->setStepExecution($stepExecution);
+
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filters')->willReturn([]);
+        $jobParameters->get('actions')->willReturn([[
+                'normalized_values' => [
+                    'categories' => [
+                        [
+                            'scope' => null,
+                            'locale' => null,
+                            'data' => ['office', 'bedroom']
+                        ]
+                    ]
+                ],
+                'ui_locale'         => 'fr_FR',
+                'attribute_locale'  => 'en_US',
+                'attribute_channel' => null
+            ]]);
+
+        $productValidator->validate($product)->willReturn($violations);
+        $violation = new ConstraintViolation('error2', 'spec', [], '', '', $product);
+        $violations = new ConstraintViolationList([$violation, $violation]);
+        $productValidator->validate($product)->willReturn($violations);
+
+        $product->getId()->willReturn(10);
+
+        $attributeRepository->findOneByIdentifier('categories')->willReturn($attribute);
+        $checkAttributeEditable->isEditable($product, $attribute)->willReturn(true);
+
+        $productUpdater->update($product, [
+            'values' => [
+                'categories' => [
+                    [
+                        'scope' => null,
+                        'locale' => null,
+                        'data' => ['office', 'bedroom']
+                    ]
+                ]
+            ]
+        ])->shouldBeCalled();
+
+        $this->setStepExecution($stepExecution);
+        $stepExecution->addWarning(Argument::cetera())->shouldBeCalled();
+        $stepExecution->incrementSummaryInfo('skipped_products')->shouldBeCalled();
+
+        $this->process($product)->shouldReturn(null);
+    }
+
+    function it_sets_values_to_product_models_attributes(
+        $productModelValidator,
+        $productModelUpdater,
+        $attributeRepository,
+        $checkAttributeEditable,
+        ProductModelInterface $productModel,
+        StepExecution $stepExecution,
+        JobExecution $jobExecution,
+        JobParameters $jobParameters,
+        AttributeInterface $attribute
+    ) {
+        $this->setStepExecution($stepExecution);
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filters')->willReturn([]);
+        $jobParameters->get('actions')->willReturn([
+            [
+                'normalized_values' => [
+                    'number' => [
+                        [
+                            'scope'  => null,
+                            'locale' => null,
+                            'data'   => '2.5',
+                        ],
+                    ],
+                ],
+                'ui_locale'         => 'fr_FR',
+                'attribute_locale'  => 'en_US',
+                'attribute_channel' => null,
+            ],
+        ]);
+
+        $violations = new ConstraintViolationList([]);
+        $productModelValidator->validate($productModel)->willReturn($violations);
+        $productModel->getId()->willReturn(10);
+
+        $attributeRepository->findOneByIdentifier('number')->willReturn($attribute);
+        $checkAttributeEditable->isEditable($productModel, $attribute)->willReturn(true);
+
+        $productModelUpdater->update($productModel, [
+            'values' => [
+                'number' => [
+                    [
+                        'scope' => null,
+                        'locale' => null,
+                        'data' => '2.5'
+                    ]
+                ]
+            ]
+        ])->shouldBeCalled();
+
+        $this->process($productModel)->shouldReturn($productModel);
+    }
+
+    function it_skips_entity_when_attribute_is_not_editable(
+        $productModelValidator,
+        $productModelUpdater,
+        $productValidator,
+        $productUpdater,
+        $attributeRepository,
+        $checkAttributeEditable,
+        EntityWithFamilyInterface $entityWithFamily,
+        ConstraintViolationListInterface $violations,
+        StepExecution $stepExecution,
+        JobExecution $jobExecution,
+        JobParameters $jobParameters,
+        AttributeInterface $attribute
+    ) {
+        $this->setStepExecution($stepExecution);
+
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filters')->willReturn([]);
+        $jobParameters->get('actions')->willReturn([
+            [
+                'normalized_values' => [
+                    'categories' => [
+                        [
+                            'scope'  => null,
+                            'locale' => null,
+                            'data'   => ['office', 'bedroom'],
+                        ],
+                    ],
+                ],
+                'ui_locale'         => 'fr_FR',
+                'attribute_locale'  => 'en_US',
+                'attribute_channel' => null,
+            ],
+        ]);
+
+        $attributeRepository->findOneByIdentifier('categories')->willReturn($attribute);
+        $checkAttributeEditable->isEditable($entityWithFamily, $attribute)->willReturn(false);
+
+        $productModelUpdater->update()->shouldNotBeCalled();
+        $productUpdater->update()->shouldNotBeCalled();
+
+        $productModelValidator->validate($entityWithFamily)->shouldNotBeCalled();
+        $productValidator->validate($entityWithFamily)->shouldNotBeCalled();
+
+        $this->setStepExecution($stepExecution);
+        $stepExecution->incrementSummaryInfo('skipped_products')->shouldBeCalled();
+
+        $this->process($entityWithFamily)->shouldReturn(null);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/ProductAndProductModelReaderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/ProductAndProductModelReaderSpec.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit;
+
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\Connector\Reader\MassEdit\ProductAndProductModelReader;
+use Pim\Component\Catalog\Manager\CompletenessManager;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\Converter\MetricConverter;
+use Prophecy\Argument;
+use Prophecy\Promise\ReturnPromise;
+
+class ProductAndProductModelReaderSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProductAndProductModelReader::class);
+    }
+
+    function let(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager,
+        MetricConverter $metricConverter,
+        ObjectDetacherInterface $objectDetacher,
+        StepExecution $stepExecution
+    ) {
+        $this->beConstructedWith(
+            $pqbFactory,
+            $channelRepository,
+            $completenessManager,
+            $metricConverter,
+            $objectDetacher,
+            true
+        );
+
+        $this->setStepExecution($stepExecution);
+    }
+
+    function it_set_step_execution(
+        $stepExecution
+    ) {
+        $this->setStepExecution($stepExecution)->shouldReturn(null);
+    }
+
+    function it_reads_products_and_product_models(
+        $pqbFactory,
+        $channelRepository,
+        $metricConverter,
+        $stepExecution,
+        $completenessManager,
+        ChannelInterface $channel,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $cursor,
+        ProductModelInterface $productModel1,
+        ProductModelInterface $productModel2,
+        ProductModelInterface $productModel3,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3,
+        JobParameters $jobParameters
+    ) {
+        $filters = [
+            'data'      => [
+                [
+                    'field'    => 'enabled',
+                    'operator' => '=',
+                    'value'    => true,
+                ],
+                [
+                    'field'    => 'family',
+                    'operator' => 'IN',
+                    'value'    => [
+                        'camcorder',
+                    ],
+                ],
+            ],
+            'structure' => [
+                'scope'   => 'mobile',
+                'locales' => ['fr_FR', 'en_US'],
+            ],
+        ];
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filters')->willReturn($filters);
+
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getCode()->willReturn('mobile');
+
+        $pqbFactory->create(['filters' => $filters['data'], 'default_scope' => 'mobile'])
+            ->shouldBeCalled()
+            ->willReturn($pqb);
+        $pqb->execute()
+            ->shouldBeCalled()
+            ->willReturn($cursor);
+
+        $completenessManager->generateMissingForChannel($channel)->shouldBeCalled();
+        $products = [$productModel1, $product1, $productModel2, $product2, $product3, $productModel3];
+        $productsCount = count($products);
+        $cursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $cursor->current()->will(new ReturnPromise($products));
+        $cursor->next()->shouldBeCalled();
+
+        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(6);
+        $metricConverter->convert(Argument::any(), $channel)->shouldBeCalledTimes(6);
+
+        $productModel1->getCode()->willReturn('product_model_1');
+        $productModel2->getCode()->willReturn('product_model_2');
+        $productModel3->getCode()->willReturn('product_model_3');
+
+        $this->initialize();
+        $this->read()->shouldReturn($productModel1);
+        $this->read()->shouldReturn($product1);
+        $this->read()->shouldReturn($productModel2);
+        $this->read()->shouldReturn($product2);
+        $this->read()->shouldReturn($product3);
+        $this->read()->shouldReturn($productModel3);
+        $this->read()->shouldReturn(null);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/ProductAndProductModelReaderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/ProductAndProductModelReaderSpec.php
@@ -30,7 +30,6 @@ class ProductAndProductModelReaderSpec extends ObjectBehavior
         ProductQueryBuilderFactoryInterface $pqbFactory,
         ChannelRepositoryInterface $channelRepository,
         CompletenessManager $completenessManager,
-        MetricConverter $metricConverter,
         ObjectDetacherInterface $objectDetacher,
         StepExecution $stepExecution
     ) {
@@ -38,9 +37,7 @@ class ProductAndProductModelReaderSpec extends ObjectBehavior
             $pqbFactory,
             $channelRepository,
             $completenessManager,
-            $metricConverter,
-            $objectDetacher,
-            true
+            $objectDetacher
         );
 
         $this->setStepExecution($stepExecution);
@@ -55,7 +52,6 @@ class ProductAndProductModelReaderSpec extends ObjectBehavior
     function it_reads_products_and_product_models(
         $pqbFactory,
         $channelRepository,
-        $metricConverter,
         $stepExecution,
         $completenessManager,
         ChannelInterface $channel,
@@ -114,7 +110,6 @@ class ProductAndProductModelReaderSpec extends ObjectBehavior
         $cursor->next()->shouldBeCalled();
 
         $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(6);
-        $metricConverter->convert(Argument::any(), $channel)->shouldBeCalledTimes(6);
 
         $productModel1->getCode()->willReturn('product_model_1');
         $productModel2->getCode()->willReturn('product_model_2');

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Writer/MassEdit/ProductAndProductModelWriterSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Writer/MassEdit/ProductAndProductModelWriterSpec.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Connector\Writer\MassEdit;
+
+use Akeneo\Component\Batch\Item\ItemWriterInterface;
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\Connector\Writer\MassEdit\ProductAndProductModelWriter;
+use Pim\Bundle\VersioningBundle\Manager\VersionManager;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModel;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Prophecy\Argument;
+
+class ProductAndProductModelWriterSpec extends ObjectBehavior
+{
+    function let(
+        VersionManager $versionManager,
+        BulkSaverInterface $productSaver,
+        BulkSaverInterface $productModelSaver,
+        CacheClearerInterface $cacheClearer,
+        StepExecution $stepExecution
+    ) {
+        $this->beConstructedWith($versionManager, $productSaver, $productModelSaver, $cacheClearer);
+        $this->setStepExecution($stepExecution);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProductAndProductModelWriter::class);
+    }
+
+    function it_is_an_item_writer()
+    {
+        $this->shouldHaveType(ItemWriterInterface::class);
+    }
+
+    function it_is_step_execution_aware()
+    {
+        $this->shouldHaveType(StepExecutionAwareInterface::class);
+    }
+
+    function it_saves_items(
+        $productSaver,
+        $productModelSaver,
+        $stepExecution,
+        ProductInterface $product1,
+        ProductModelInterface $productModel1,
+        ProductInterface $product2,
+        JobParameters $jobParameters
+    ) {
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('realTimeVersioning')->willReturn(true);
+
+        $items = [$product1, $productModel1, $product2];
+
+        $products = $items;
+        unset($products[1]);
+        $productModels = $items;
+        unset($productModels[0]);
+        unset($productModels[2]);
+
+        $productSaver->saveAll($products)->shouldBeCalled();
+        $productModelSaver->saveAll($productModels)->shouldBeCalled();
+
+        $stepExecution->incrementSummaryInfo('create')->shouldBeCalled();
+
+        $this->write($items);
+    }
+
+    function it_increments_summary_info(
+        $stepExecution,
+        $productSaver,
+        $productModelSaver,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductModelInterface $productModel1,
+        JobParameters $jobParameters
+    ) {
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('realTimeVersioning')->willReturn(true);
+
+        $items = [$product1, $productModel1, $product2];
+
+        $product1->getId()->willReturn('45');
+        $product2->getId()->willReturn(null);
+        $productModel1->getId()->willReturn('89');
+
+        $productSaver->saveAll(Argument::any())->shouldBeCalled();
+        $productModelSaver->saveAll(Argument::any())->shouldBeCalled();
+
+        $stepExecution->incrementSummaryInfo('create')->shouldBeCalled();
+        $stepExecution->incrementSummaryInfo('process')->shouldBeCalledTimes(2);
+
+        $this->write($items);
+    }
+
+    function it_clears_cache(
+        $cacheClearer,
+        $stepExecution,
+        ProductInterface $product,
+        ProductModelInterface $productModel,
+        JobParameters $jobParameters
+    ) {
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('realTimeVersioning')->willReturn(true);
+
+        $items = [$product, $productModel];
+
+        $stepExecution->incrementSummaryInfo('create')->shouldBeCalled();
+        $cacheClearer->clear()->shouldBeCalled();
+
+        $this->write($items);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/tests/Unit/Form/Subscriber/FilterLocaleValueSubscriberTest.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/Unit/Form/Subscriber/FilterLocaleValueSubscriberTest.php
@@ -3,6 +3,8 @@
 namespace Pim\Bundle\EnrichBundle\tests\Unit\Form\Subscriber;
 
 use Pim\Bundle\EnrichBundle\Form\Subscriber\FilterLocaleValueSubscriber;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
 
 /**
  * Test related class
@@ -147,11 +149,11 @@ class FilterLocaleValueSubscriberTest extends \PHPUnit_Framework_TestCase
      * @param mixed $attribute
      * @param mixed $locale
      *
-     * @return \Pim\Component\Catalog\Model\ProductValue
+     * @return \Pim\Component\Catalog\Model\ValueInterface
      */
     private function getProductValueMock($attribute, $locale)
     {
-        $value = $this->createMock('Pim\Component\Catalog\Model\ProductValue');
+        $value = $this->createMock(ValueInterface::class);
 
         $value->expects($this->any())
             ->method('getAttribute')
@@ -171,7 +173,7 @@ class FilterLocaleValueSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private function getAttributeMock($localizable = true)
     {
-        $attribute = $this->createMock('Pim\Bundle\CatalogBundle\Entity\Attribute');
+        $attribute = $this->createMock(AttributeInterface::class);
 
         $attribute->expects($this->any())
             ->method('isLocalizable')

--- a/src/Pim/Component/Catalog/EntityWithFamilyVariant/CheckAttributeEditable.php
+++ b/src/Pim/Component/Catalog/EntityWithFamilyVariant/CheckAttributeEditable.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\EntityWithFamilyVariant;
+
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+
+/**
+ * This service checks if an attribute of an entity with family is editable.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class CheckAttributeEditable
+{
+    /**
+     * @param EntityWithFamilyInterface $entity
+     * @param AttributeInterface        $attribute
+     *
+     * @return bool
+     * @throws \Exception
+     */
+    public function isEditable(EntityWithFamilyInterface $entity, AttributeInterface $attribute): bool
+    {
+        $family = $entity->getFamily();
+
+        if (null === $family) {
+            return true;
+        }
+
+        if (!$family->hasAttribute($attribute)) {
+            return false;
+        }
+
+        if ($this->isNonVariantProduct($entity)) {
+            return true;
+        }
+
+        $familyVariant = $entity->getFamilyVariant();
+        if (null === $familyVariant) {
+            throw new \Exception('A family variant was expected for the entity.');
+        }
+
+        $level = $entity->getVariationLevel();
+        if (0 === $level) {
+            return $familyVariant->getCommonAttributes()->contains($attribute);
+        }
+
+        $attributeSet = $familyVariant->getVariantAttributeSet($level);
+        if (null === $attributeSet) {
+            throw new \Exception(
+                sprintf(
+                    'The variant attribute set of level "%d" was expected for the family variant "%s".',
+                    $level,
+                    $familyVariant->getCode()
+                )
+            );
+        }
+
+        return $attributeSet->hasAttribute($attribute);
+    }
+
+    /**
+     * @param EntityWithFamilyInterface $entity
+     *
+     * @return bool
+     */
+    private function isNonVariantProduct(EntityWithFamilyInterface $entity): bool
+    {
+        return !$entity instanceof VariantProductInterface && !$entity instanceof ProductModelInterface;
+    }
+}

--- a/src/Pim/Component/Catalog/Model/EntityWithFamilyVariantInterface.php
+++ b/src/Pim/Component/Catalog/Model/EntityWithFamilyVariantInterface.php
@@ -29,6 +29,8 @@ interface EntityWithFamilyVariantInterface extends EntityWithFamilyInterface
      * For example, if this entity has 2 parents, it's on level 2.
      * If it has 0 parent, it's on level 0.
      *
+     * Which means the oldest is at level 0.
+     *
      * @return int
      */
     public function getVariationLevel(): int;

--- a/src/Pim/Component/Catalog/spec/EntityWithFamilyVariant/CheckAttributeEditableSpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamilyVariant/CheckAttributeEditableSpec.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\EntityWithFamilyVariant;
+
+use Pim\Component\Catalog\EntityWithFamilyVariant\CheckAttributeEditable;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\CommonAttributeCollection;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Prophecy\Argument;
+
+class CheckAttributeEditableSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CheckAttributeEditable::class);
+    }
+
+    function it_is_editable_if_the_entity_has_no_family(
+        EntityWithFamilyInterface $entity,
+        AttributeInterface $attribute
+    ) {
+        $entity->getFamily()->willReturn(null);
+        $this->isEditable($entity, $attribute)->shouldReturn(true);
+    }
+
+    function it_is_not_editable_if_the_attribute_is_not_part_of_the_family(
+        EntityWithFamilyInterface $entity,
+        FamilyInterface $family,
+        AttributeInterface $attribute
+    ) {
+        $entity->getFamily()->willReturn($family);
+        $family->hasAttribute($attribute)->willReturn(false);
+        $this->isEditable($entity, $attribute)->shouldReturn(false);
+    }
+
+    function it_is_editable_if_the_attribute_is_part_of_the_family_and_the_product_is_not_variant(
+        ProductInterface $product,
+        FamilyInterface $family,
+        AttributeInterface $attribute
+    ) {
+        $product->getFamily()->willReturn($family);
+        $family->hasAttribute($attribute)->willReturn(true);
+        $this->isEditable($product, $attribute)->shouldReturn(true);
+    }
+
+    function it_throws_an_exception_if_the_variant_product_has_no_family_variant(
+        VariantProductInterface $product,
+        FamilyInterface $family,
+        AttributeInterface $attribute
+    ) {
+        $family->hasAttribute($attribute)->willReturn(true);
+        $product->getFamily()->willReturn($family);
+        $product->getFamilyVariant()->willReturn(null);
+
+        $this->shouldThrow(\Exception::class)->during('isEditable', [$product, $attribute]);
+    }
+
+    function it_throws_an_exception_if_the_product_model_has_no_family_variant(
+        ProductModelInterface $productModel,
+        FamilyInterface $family,
+        AttributeInterface $attribute
+    ) {
+        $family->hasAttribute($attribute)->willReturn(true);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn(null);
+
+        $this->shouldThrow(\Exception::class)->during('isEditable', [$productModel, $attribute]);
+    }
+
+    function it_throws_an_exception_if_the_family_variant_of_the_product_has_not_the_expected_variant_set(
+        VariantProductInterface $product,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attribute
+    ) {
+        $family->hasAttribute($attribute)->willReturn(true);
+        $product->getFamily()->willReturn($family);
+        $product->getFamilyVariant()->willReturn($familyVariant);
+        $product->getVariationLevel()->willReturn(1);
+        $familyVariant->getVariantAttributeSet(1)->willReturn(null);
+
+        $this->shouldThrow(\Exception::class)->during('isEditable', [$product, $attribute]);
+    }
+
+    function it_throws_an_exception_if_the_family_variant_of_the_product_model_has_not_the_expected_variant_set(
+        ProductModelInterface $productModel,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attribute
+    ) {
+        $family->hasAttribute($attribute)->willReturn(true);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $productModel->getVariationLevel()->willReturn(1);
+        $familyVariant->getVariantAttributeSet(1)->willReturn(null);
+
+        $this->shouldThrow(\Exception::class)->during('isEditable', [$productModel, $attribute]);
+    }
+
+    function it_is_editable_if_it_is_a_variant_product_and_the_attribute_is_part_of_the_variant_set(
+        VariantProductInterface $product,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attribute,
+        VariantAttributeSetInterface $attributeSet
+    ) {
+        $family->hasAttribute($attribute)->willReturn(true);
+        $product->getFamily()->willReturn($family);
+        $product->getVariationLevel()->willReturn(1);
+        $product->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getVariantAttributeSet(1)->willReturn($attributeSet);
+
+        $attributeSet->hasAttribute($attribute)->willReturn(true);
+
+        $this->isEditable($product, $attribute)->shouldReturn(true);
+    }
+
+    function it_is_not_editable_if_it_is_a_variant_product_and_the_attribute_is_not_part_of_the_variant_set(
+        VariantProductInterface $product,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attribute,
+        VariantAttributeSetInterface $attributeSet
+    ) {
+        $family->hasAttribute($attribute)->willReturn(true);
+        $product->getFamily()->willReturn($family);
+        $product->getVariationLevel()->willReturn(1);
+        $product->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getVariantAttributeSet(1)->willReturn($attributeSet);
+
+        $attributeSet->hasAttribute($attribute)->willReturn(false);
+
+        $this->isEditable($product, $attribute)->shouldReturn(false);
+    }
+
+    function it_is_editable_if_it_is_a_product_model_and_the_attribute_is_part_of_the_variant_set(
+        ProductModelInterface $productModel,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attribute,
+        VariantAttributeSetInterface $attributeSet
+    ) {
+        $family->hasAttribute($attribute)->willReturn(true);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getVariationLevel()->willReturn(1);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getVariantAttributeSet(1)->willReturn($attributeSet);
+
+        $attributeSet->hasAttribute($attribute)->willReturn(true);
+
+        $this->isEditable($productModel, $attribute)->shouldReturn(true);
+    }
+
+    function it_is_not_editable_if_it_is_a_product_model_and_the_attribute_is_not_part_of_the_variant_set(
+        ProductModelInterface $productModel,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attribute,
+        VariantAttributeSetInterface $attributeSet
+    ) {
+        $family->hasAttribute($attribute)->willReturn(true);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getVariationLevel()->willReturn(1);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getVariantAttributeSet(1)->willReturn($attributeSet);
+
+        $attributeSet->hasAttribute($attribute)->willReturn(false);
+
+        $this->isEditable($productModel, $attribute)->shouldReturn(false);
+    }
+
+    function it_is_editable_if_it_is_a_root_product_model_and_the_attribute_is_part_of_the_common_attributes(
+        ProductModelInterface $productModel,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attribute,
+        CommonAttributeCollection $commonAttributes
+    ) {
+        $family->hasAttribute($attribute)->willReturn(true);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getVariationLevel()->willReturn(0);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getCommonAttributes()->willReturn($commonAttributes);
+
+        $commonAttributes->contains($attribute)->willReturn(true);
+
+        $this->isEditable($productModel, $attribute)->shouldReturn(true);
+    }
+
+    function it_is_not_editable_if_it_is_a_root_product_model_and_the_attribute_is_not_part_of_the_common_attributes(
+        ProductModelInterface $productModel,
+        FamilyInterface $family,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $attribute,
+        CommonAttributeCollection $commonAttributes
+    ) {
+        $family->hasAttribute($attribute)->willReturn(true);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getVariationLevel()->willReturn(0);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getCommonAttributes()->willReturn($commonAttributes);
+
+        $commonAttributes->contains($attribute)->willReturn(false);
+
+        $this->isEditable($productModel, $attribute)->shouldReturn(false);
+    }
+}


### PR DESCRIPTION
Done by 3 three different teammates: @SamirBoulil @juliensnz @jjanvier

In the grid, you can select root product models, sub product models and products depending on your search criterias and your catalog structure. Today, product models are skipped during the _mass edit common attributes_ operation.

This PR aims to mass edit both products and product models in a smart way. Let say you mass edit the description to put `foobar` and you selected the root product model `RPM`.
- if the description is put at the root product model level, you want to edit `RPM`
- if the description is put at the sub product model level, you want to edit its sons `SPM1` and `SPM2`
- if the description is put at the product level, you want to edit its grandsons `P1`, `P2`, `P3`, `P4`...

To achieve that we:
- introduced a special reader that will select all the ancestry of the items you have selected (to get all the product models and products that are possibly impacted)
- introduced a special processor that is able to smartly update (or not) the items given by the reader
- introduced a special writer that is able to save both products and product models in database

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | Ok
| Added integration tests           | Ok
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

