### PR TITLE
PIM-7017: Permission on "Add attribute to a product" is not properly applied

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,6 +1,7 @@
 # 1.7.X 
 
 - GITHUB-7202: Ensure commit batch size value is always an int, cheers @bghitulescu!
+- PIM-7017: Permission on "Add attribute to a product" is not properly applied
 
 # 1.7.14 (2017-11-21)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_edit.yml
@@ -168,6 +168,7 @@ extensions:
         module: pim/product/add-select/attribute
         parent: pim-product-edit-form-attributes
         targetZone: other-actions
+        aclResourceId: pim_enrich_product_add_attribute
         position: 90
         config:
             searchParameters:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When the ACL "Add attribute to a product" is unchecked you must not see the SELECT "Add an attribute" on the PEF

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
