### PR TITLE
PIM-7037: Product Model Import - Error the field "code" should contain a string

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,10 @@
 # 2.0.x
 
+## Bug fixes
+
+- PIM-7037: Allows code to be an integer on product model import
+- PIM-7011: XLS Options Import - Simple select attribute option cannot be updated for options with numeric codes
+
 ## Better manage products with variants!
 
 - PIM-6341: Allow cascade deletion of product models via the grid and PEF
@@ -17,7 +22,6 @@
 - PIM-7035: fix reset login page style and error 500 thrown after submitting form
 - PIM-7045: fix memory leak in step `Compute product model descendants` for product model import
 - PIM-6958: fix loading a product with a reference data that is not available (simpleselect or multiselect)
-- PIM-7011: XLS Options Import - Simple select attribute option cannot be updated for options with numeric codes
 
 ## Better manage products with variants!
 

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/FieldConverterInterface.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/FieldConverterInterface.php
@@ -12,16 +12,15 @@ namespace Pim\Component\Connector\ArrayConverter\FlatToStandard;
 interface FieldConverterInterface
 {
     /**
-     *
      * Convert a field from a flat file data (CSV or XLSX file for instance).
      * It guesses its names and its values depending on the data read from the data source.
      *
      * For instance, the category value "cat1,cat2" should be transformed in an array ['cat1', 'cat2']
      *
      * @param string $fieldName
-     * @param string $value
+     * @param mixed  $value
      *
      * @return ConvertedField
      */
-    public function convert(string $fieldName, string $value): ConvertedField;
+    public function convert(string $fieldName, $value): ConvertedField;
 }

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldConverter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldConverter.php
@@ -42,7 +42,7 @@ class FieldConverter implements FieldConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function convert(string $fieldName, string $value): ConvertedField
+    public function convert(string $fieldName, $value): ConvertedField
     {
         $associationFields = $this->assocFieldResolver->resolveAssociationColumns();
 

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ProductModel.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ProductModel.php
@@ -14,7 +14,6 @@ use Pim\Component\Connector\Exception\DataArrayConversionException;
 use Pim\Component\Connector\Exception\StructureArrayConversionException;
 
 /**
- *
  * @author    Arnaud Langlade <arnaud.langlade@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
@@ -140,9 +139,9 @@ class ProductModel implements ArrayConverterInterface
         $stringFields = ['code', 'categories', 'family_variant', 'parent'];
 
         foreach ($mappedFlatProductModel as $field => $value) {
-            if (in_array($field, $stringFields) && !is_string($value)) {
+            if (in_array($field, $stringFields) && !is_scalar($value)) {
                 throw new DataArrayConversionException(
-                    sprintf('The field "%s" should contain a string, "%s" provided', $field, $value)
+                    sprintf('The field "%s" should contain a scalar, "%s" provided', $field, gettype($value))
                 );
             }
         }

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ProductModel/FieldConverter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ProductModel/FieldConverter.php
@@ -35,7 +35,7 @@ class FieldConverter implements FieldConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function convert(string $fieldName, string $value): ConvertedField
+    public function convert(string $fieldName, $value): ConvertedField
     {
         $associationFields = $this->assocFieldResolver->resolveAssociationColumns();
 
@@ -50,6 +50,11 @@ class FieldConverter implements FieldConverterInterface
             $categories = $this->fieldSplitter->splitCollection($value);
 
             return new ConvertedField($fieldName, $categories);
+        }
+
+        // Code must be alpha-numeric
+        if (in_array($fieldName, ['parent', 'code', 'family_variant'])) {
+            return new ConvertedField($fieldName, (string) $value);
         }
 
         return new ConvertedField($fieldName, $value);

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductModel/FieldConverterSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductModel/FieldConverterSpec.php
@@ -53,6 +53,19 @@ class FieldConverterSpec extends ObjectBehavior
             ->shouldBeLike(new ConvertedField('family_variant', 'family_variant'));
     }
 
+    function it_converts_the_value_of_the_other_fields_to_a_string($assocFieldResolver, $fieldSplitter)
+    {
+        $assocFieldResolver->resolveAssociationColumns()->willReturn([]);
+        $this->convert('family_variant', 123456)
+            ->shouldBeLike(new ConvertedField('family_variant', '123456'));
+
+        $this->convert('code', 123456)
+            ->shouldBeLike(new ConvertedField('code', '123456'));
+
+        $this->convert('parent', 123456)
+            ->shouldBeLike(new ConvertedField('parent', '123456'));
+    }
+
     function it_only_converts_a_specific_column($assocFieldResolver)
     {
         $assocFieldResolver->resolveAssociationColumns()->willReturn(['upsell']);

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductModelSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductModelSpec.php
@@ -11,6 +11,7 @@ use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\ColumnsMapper;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\Product\ColumnsMerger;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\ProductModel\FieldConverter;
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\ProductModel;
+use Pim\Component\Connector\Exception\DataArrayConversionException;
 use Pim\Component\Connector\Exception\StructureArrayConversionException;
 
 class ProductModelSpec extends ObjectBehavior
@@ -162,6 +163,18 @@ class ProductModelSpec extends ObjectBehavior
                 ]
             ]
         ]);
+    }
+
+    function it_throws_an_exception_if_the_fields_are_not_scalar($attributeColumnsResolver)
+    {
+        $attributeColumnsResolver->resolveAttributeColumns()->willReturn([]);
+
+        $this->shouldThrow(DataArrayConversionException::class)->during('convert', [[
+            'code' => ['code'],
+            'parent' => '1234',
+            'family_variant' => 'family_variant',
+            'categories' => 'tshirt,pull',
+        ]]);
     }
 
     function it_throws_an_exception_if_family_variant_is_different_from_the_parent(

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ProductSpec.php
@@ -323,7 +323,7 @@ class ProductSpec extends ObjectBehavior
         $fieldConverter->supportsColumn('sku')->willReturn(false);
         $fieldConverter->supportsColumn('enabled')->willReturn(true);
 
-        $fieldConverter->convert('enabled', '1')->willReturn($enable);
+        $fieldConverter->convert('enabled', true)->willReturn($enable);
         $enable->appendTo([])
             ->willReturn([
                 'enabled' => true


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The product model array convert only accept string for the following field `code`, `categories`, `parent` and `family_variant` but these fields should be scalars. For instance, if I want to create a product model with a integer as a code, it should be possible because the code validation rules is `\/^[^,;]+$/`. The regex used to validate the code of other entities is `/^[a-zA-Z0-9_]+$/` for you information. That means that you can create a family with a code 1234 for instance.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | yes
| Migration script                  | -
| Tech Doc                          | -
