### PR TITLE
PIM-7045: Inject doctrine clearer in ProductModelDescendantsWriter to avoid memory leak

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -14,6 +14,7 @@ Changes the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\ProductModel
 
 ## Bug fixes
 
+- PIM-7045: fix memory leak in step `Compute product model descendants` for product model import
 - PIM-6958: fix loading a product with a reference data that is not available (simpleselect or multiselect)
 
 # 2.0.7 (2017-11-23)

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -14,7 +14,6 @@ parameters:
     pim_catalog.event_subscriber.add_unique_attributes_to_variant_product_attribute_set.class: Pim\Bundle\CatalogBundle\EventSubscriber\AddUniqueAttributesToVariantProductAttributeSetSubscriber
     pim_catalog.event_subscriber.index_product_model_complete.class: Pim\Bundle\CatalogBundle\EventSubscriber\IndexProductModelCompleteDataSubscriber
     pim_catalog.event_subscriber.compute_completeness_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeCompletenessOnFamilyUpdateSubscriber
-    pim_catalog.event_subscriber.compute_product_models_descendants.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeProductModelDescendantsSubscriber
     pim_catalog.event_subscriber.compute_family_variant_structure_changes.class: Pim\Bundle\CatalogBundle\EventSubscriber\ComputeFamilyVariantStructureChangesSubscriber
     pim_catalog.event_subscriber.remove_attributes_from_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriber
     pim_catalog.event_subscriber.save_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber
@@ -108,16 +107,6 @@ services:
         arguments:
             - '@security.token_storage'
             - '@akeneo_batch_queue.launcher.queue_job_launcher'
-            - '@akeneo_batch.job.job_instance_repository'
-            - '%pim_catalog.compute_product_models_descendants.job_name%'
-        tags:
-            - { name: kernel.event_subscriber }
-
-    pim_catalog.event_subscriber.compute_product_models_descendants:
-        class: '%pim_catalog.event_subscriber.compute_product_models_descendants.class%'
-        arguments:
-            - '@security.token_storage'
-            - '@akeneo_batch.launcher.simple_job_launcher'
             - '@akeneo_batch.job.job_instance_repository'
             - '%pim_catalog.compute_product_models_descendants.job_name%'
         tags:

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -67,6 +67,7 @@ services:
         class: '%pim_connector.writer.database.product_model_descendants.class%'
         arguments:
             - '@pim_catalog.saver.product_model_descendants'
+            - '@pim_connector.doctrine.cache_clearer'
 
     pim_connector.writer.database.product_association:
         class: '%pim_connector.writer.database.product_association.class%'

--- a/src/Pim/Component/Connector/Writer/Database/ProductModelDescendantsWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/ProductModelDescendantsWriter.php
@@ -7,9 +7,7 @@ use Akeneo\Component\Batch\Item\ItemWriterInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
-use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
-use Pim\Bundle\VersioningBundle\Manager\VersionManager;
 
 /**
  * Save all descendance of a product model.
@@ -24,14 +22,21 @@ class ProductModelDescendantsWriter implements ItemWriterInterface, StepExecutio
     protected $stepExecution;
 
     /** @var SaverInterface */
-    private $descendantsSaver;
+    protected $descendantsSaver;
+
+    /** @var CacheClearerInterface */
+    protected $cacheClearer;
 
     /**
-     * @param SaverInterface $descendantsSaver
+     * @param SaverInterface        $descendantsSaver
+     * @param CacheClearerInterface $cacheClearer
      */
-    public function __construct(SaverInterface $descendantsSaver)
-    {
+    public function __construct(
+        SaverInterface $descendantsSaver,
+        CacheClearerInterface $cacheClearer = null
+    ) {
         $this->descendantsSaver = $descendantsSaver;
+        $this->cacheClearer = $cacheClearer;
     }
 
     /**
@@ -45,6 +50,8 @@ class ProductModelDescendantsWriter implements ItemWriterInterface, StepExecutio
                 $this->stepExecution->incrementSummaryInfo('process');
             }
         }
+
+        $this->cacheClearer->clear();
     }
 
     /**

--- a/src/Pim/Component/Connector/Writer/Database/ProductModelDescendantsWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/ProductModelDescendantsWriter.php
@@ -51,7 +51,9 @@ class ProductModelDescendantsWriter implements ItemWriterInterface, StepExecutio
             }
         }
 
-        $this->cacheClearer->clear();
+        if (null !== $this->cacheClearer) {
+            $this->cacheClearer->clear();
+        }
     }
 
     /**

--- a/src/Pim/Component/Connector/spec/Writer/Database/ProductModelDescendantsWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/Database/ProductModelDescendantsWriterSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Component\Connector\Writer\Database;
 
 use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Connector\Writer\Database\ProductModelDescendantsWriter;
@@ -10,9 +11,9 @@ use PhpSpec\ObjectBehavior;
 
 class ProductModelDescendantsWriterSpec extends ObjectBehavior
 {
-    function let(StepExecution $stepExecution, SaverInterface $descendantsSaver)
+    function let(StepExecution $stepExecution, SaverInterface $descendantsSaver, CacheClearerInterface $cacheClearer)
     {
-        $this->beConstructedWith($descendantsSaver);
+        $this->beConstructedWith($descendantsSaver, $cacheClearer);
         $this->setStepExecution($stepExecution);
     }
 
@@ -23,6 +24,7 @@ class ProductModelDescendantsWriterSpec extends ObjectBehavior
 
     function it_handles_product_model_descendants(
         $descendantsSaver,
+        $cacheClearer,
         $stepExecution,
         ProductModelInterface $productModel1,
         ProductModelInterface $productModel2
@@ -31,6 +33,8 @@ class ProductModelDescendantsWriterSpec extends ObjectBehavior
         $descendantsSaver->save($productModel2)->shouldBeCalled();
 
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalledTimes(2);
+
+        $cacheClearer->clear()->shouldBeCalled();
 
         $this->write([$productModel1, $productModel2]);
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix a memory leak in product model import
Remove duplicated event subscriber

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
