### PR TITLE
PIM-7035: Fix User Reset action

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -14,6 +14,7 @@ Changes the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\ProductModel
 
 ## Bug fixes
 
+- PIM-7035: fix reset login page style and error 500 thrown after submitting form
 - PIM-7045: fix memory leak in step `Compute product model descendants` for product model import
 - PIM-6958: fix loading a product with a reference data that is not available (simpleselect or multiselect)
 

--- a/src/Oro/Bundle/UserBundle/Form/Handler/AbstractUserHandler.php
+++ b/src/Oro/Bundle/UserBundle/Form/Handler/AbstractUserHandler.php
@@ -49,7 +49,7 @@ abstract class AbstractUserHandler
         $this->form->setData($user);
 
         if (in_array($this->getRequest()->getMethod(), ['POST', 'PUT'])) {
-            $this->form->submit($this->getRequest());
+            $this->form->handleRequest($this->getRequest());
 
             if ($this->form->isValid()) {
                 $this->onSuccess($user);

--- a/src/Pim/Bundle/UserBundle/Resources/views/Reset/reset.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/Reset/reset.html.twig
@@ -3,8 +3,8 @@
 {% block bodyClass %}AknLogin{% endblock %}
 
 {% block content %}
-<div class="container">
-    <div class="title-box">
+<div class="AknLogin-mainContainer container">
+    <div class="AknLogin-title">
         {% embed 'PimUIBundle::logo.html.twig' %}{% endembed %}
     </div>
 
@@ -18,9 +18,12 @@
         {{ form_errors(form) }}
         {{ form_widget(form.plainPassword) }}
         {{ form_widget(form._token) }}
-        <div class="form-row">
-            <a href="{{ path('oro_user_security_login') }}" class="btn btn-large extra-btn-large">{{ 'Cancel'|trans }}</a>
-            <button type="submit" class="btn btn-large pull-right btn-primary">{{ 'Reset'|trans }}</button>
+        <div class="AknLogin-form">
+            <div class="AknLogin-formCell"></div>
+            <div class="AknLogin-formCell AknLogin-formCell--small">
+                <a href="{{ path('oro_user_security_login') }}" class="AknLogin-link">{{ 'Cancel'|trans }}</a>
+                <button type="submit" class="AknButton AknButton--apply AknButton--big AknButton--uppercase">{{ 'Reset'|trans }}</button>
+            </div>
         </div>
     </fieldset>
     {{ form_end(form) }}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Fix reset, it was throwing an error 500 after validating form
Fix reset password style

Now looks like that
![screen shot 2017-12-06 at 16 20 15](https://user-images.githubusercontent.com/17565301/33669049-adb5e57e-daa1-11e7-97a0-797d801e534f.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
