### PR TITLE
API-443: Prevent getting asset via media file url

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,3 +1,12 @@
+# 2.1.x
+
+## Improvements
+
+- PIM-6996: Associate products to product models during import using the `<assocType>-product_models` pattern in an new column
+- API-443: Prevent getting asset via media file url of the API
+- PIM-6996: Associate products to product models during import using the `<assocType>-product_models` pattern in an new column
+- PIM-6342: Display and remove associations gallery view
+
 # 2.1.0-ALPHA1
 
 ## Improvements
@@ -6,9 +15,6 @@
 - PIM-6621: add search on label and code on products and product models
 - PIM-6966: Add tracker information for product model, product variant and family variant
 - PIM-6990: Add new screen for managing product associations
-- PIM-6996: Associate products to product models during import using the `<assocType>-product_models` pattern in an new column
-- PIM-6342: Display and remove associations gallery view
-
 
 ## BC breaks
 

--- a/src/Pim/Bundle/ApiBundle/Controller/MediaFileController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/MediaFileController.php
@@ -149,7 +149,7 @@ class MediaFileController
     public function getAction(Request $request, $code)
     {
         $media = $this->mediaRepository->findOneByIdentifier(urldecode($code));
-        if (null === $media) {
+        if (null === $media || FileStorage::CATALOG_STORAGE_ALIAS !== $media->getStorage()) {
             throw new NotFoundHttpException(sprintf('Media file "%s" does not exist.', $code));
         }
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Attribute/ListAttributeIntegration.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Attribute;
 
-use Akeneo\Test\Integration\Configuration;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -25,11 +24,11 @@ class ListAttributeIntegration extends ApiTestCase
 		"self": {
 			"href": "http://localhost/api/rest/v1/attributes?page=1&limit=10&with_count=false"
 		},
-		"next": {
-			"href": "http://localhost/api/rest/v1/attributes?page=2&limit=10&with_count=false"
-		},
 		"first": {
 			"href": "http://localhost/api/rest/v1/attributes?page=1&limit=10&with_count=false"
+		},
+		"next": {
+			"href": "http://localhost/api/rest/v1/attributes?page=2&limit=10&with_count=false"
 		}
 	},
 	"current_page": 1,
@@ -309,15 +308,15 @@ JSON;
     "max_characters"         : null,
     "validation_rule"        : null,
     "validation_regexp"      : null,
-    "wysiwyg_enabled"        : false,
+    "wysiwyg_enabled"        : null,
     "number_min"             : null,
     "number_max"             : null,
-    "decimals_allowed"       : false,
-    "negative_allowed"       : false,
+    "decimals_allowed"       : null,
+    "negative_allowed"       : null,
     "date_min"               : null,
     "date_max"               : null,
     "max_file_size"          : null,
-    "minimum_input_length"   : 0,
+    "minimum_input_length"   : null,
     "sort_order"             : 0,
     "localizable"            : true,
     "scopable"               : false,
@@ -346,15 +345,15 @@ JSON;
     "max_characters"         : null,
     "validation_rule"        : null,
     "validation_regexp"      : null,
-    "wysiwyg_enabled"        : false,
+    "wysiwyg_enabled"        : null,
     "number_min"             : null,
     "number_max"             : null,
-    "decimals_allowed"       : false,
-    "negative_allowed"       : false,
+    "decimals_allowed"       : null,
+    "negative_allowed"       : null,
     "date_min"               : null,
     "date_max"               : null,
     "max_file_size"          : null,
-    "minimum_input_length"   : 0,
+    "minimum_input_length"   : null,
     "sort_order"             : 0,
     "localizable"            : true,
     "scopable"               : true,
@@ -386,12 +385,12 @@ JSON;
     "wysiwyg_enabled"        : false,
     "number_min"             : null,
     "number_max"             : null,
-    "decimals_allowed"       : false,
-    "negative_allowed"       : false,
+    "decimals_allowed"       : null,
+    "negative_allowed"       : null,
     "date_min"               : null,
     "date_max"               : null,
     "max_file_size"          : null,
-    "minimum_input_length"   : 0,
+    "minimum_input_length"   : null,
     "sort_order"             : 10,
     "localizable"            : true,
     "scopable"               : true,
@@ -428,8 +427,8 @@ JSON;
     "date_min"               : null,
     "date_max"               : null,
     "max_file_size"          : null,
-    "minimum_input_length"   : 0,
-    "sort_order"             : null,
+    "minimum_input_length"   : null,
+    "sort_order"             : 0,
     "localizable"            : false,
     "scopable"               : false,
     "labels"                 : {},


### PR DESCRIPTION
## Description

When getting a media file with the API, the storage is not checked. As a result, in EE, it is possible to get an asset reference or variation file. This should not happen.

This PR adds the verification of the storage used when retrieving the media, accepting only media coming from the catalog storage.

Test is added in EE.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
