### PR TITLE
PIM-6980: Missing labels for attribute prevent you from creating a variant family

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,7 @@
 - PIM-7037: Allows code to be an integer on product model import
 - PIM-7011: XLS Options Import - Simple select attribute option cannot be updated for options with numeric codes
 - PIM-7039: Association grid, scopable attributes used as labels do not appear
+- PIM-6980: Missing labels for attribute prevent you from creating a variant family
 
 ## Better manage products with variants!
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant-fields-container.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant-fields-container.js
@@ -73,7 +73,7 @@ define(
             render() {
                 const catalogLocale = UserContext.get('catalogLocale');
                 const familyVariant = _.defaults(this.getFormData(), this.getNewFamilyVariant());
-                const label = familyVariant.labels[catalogLocale];
+                const label = this.getEntityLabel(familyVariant, catalogLocale);
                 const axes1 = familyVariant.variant_attribute_sets[0].axes.join(',');
                 const axes2 = familyVariant.variant_attribute_sets[1]
                     ? familyVariant.variant_attribute_sets[1].axes.join(',')
@@ -146,9 +146,11 @@ define(
                             const catalogLocale = UserContext.get('catalogLocale');
                             const attributeResults = this.searchOnResults(options.term, attributes);
                             const entities = _.map(attributeResults, (attribute) => {
-                                return {
+                                const label = this.getEntityLabel(attribute, catalogLocale);
+
+                            return {
                                     id: attribute.code,
-                                    text: attribute.labels[catalogLocale]
+                                    text: label
                                 }
                             });
 
@@ -174,7 +176,7 @@ define(
                 term = term.toLowerCase();
 
                 return attributes.filter((entity) => {
-                    const label = entity.labels[catalogLocale].toLowerCase();
+                    const label = this.getEntityLabel(entity, catalogLocale).toLowerCase();
 
                     return -1 !== label.search(term);
                 });
@@ -198,14 +200,16 @@ define(
                 $.when.apply($, fetchAttributesPromises)
                     .then(function () {
                         const data = _.map(arguments, (attribute) => {
-                            return {
+                            const label = this.getEntityLabel(attribute, catalogLocale);
+
+return {
                                 id: attribute.code,
-                                text: attribute.labels[catalogLocale]
+                                text: label
                             }
                         });
 
                         callback(data);
-                    });
+                    }.bind(this));
             },
 
             /**
@@ -264,6 +268,21 @@ define(
              */
             setValidationErrors(errors) {
                 this.validationErrors = errors;
+            },
+
+            /**
+             * Return the label/code of a serialized entity.
+             *
+             * @param {string} entity
+             * @param {string} locale
+             * @returns {string}
+             */
+            getEntityLabel(entity, locale) {
+                if (0 === entity.labels.length) {
+                    return '[' + entity.code + ']';
+                }
+
+                return entity.labels[locale]
             }
         });
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The serialized attribute labels look like 
```
[
    'en_US': 'label',
    'fr_FR': 'label'
]
```
but when there is no translation configured for an attribute, the normalizer return an empty array. So trying to get something that does not exist raise an error and break the select render.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Javascript test                      | I did not find them, weird :trollface: 
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

