### PR TITLE
PIM-7011: XLS Options Import - Simple select attribute option cannot be updated for options with numeric codes

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -17,6 +17,7 @@
 - PIM-7035: fix reset login page style and error 500 thrown after submitting form
 - PIM-7045: fix memory leak in step `Compute product model descendants` for product model import
 - PIM-6958: fix loading a product with a reference data that is not available (simpleselect or multiselect)
+- PIM-7011: XLS Options Import - Simple select attribute option cannot be updated for options with numeric codes
 
 ## Better manage products with variants!
 

--- a/src/Pim/Bundle/CatalogBundle/Entity/AttributeOptionValue.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/AttributeOptionValue.php
@@ -121,7 +121,7 @@ class AttributeOptionValue implements AttributeOptionValueInterface
      */
     public function setLabel($label)
     {
-        $this->value = $label;
+        $this->value = (string) $label;
 
         return $this;
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Entity/AttributeOptionSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Entity/AttributeOptionSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Bundle\CatalogBundle\Entity;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\AttributeOption;
+use Pim\Bundle\CatalogBundle\Entity\AttributeOptionValue;
 use Pim\Component\Catalog\Model\AttributeOptionValueInterface;
 use Prophecy\Argument;
 
@@ -32,5 +33,17 @@ class AttributeOptionSpec extends ObjectBehavior
         $this->setLocale('fr');
 
         $this->getOptionValue()->shouldReturn($fr);
+    }
+
+    function it_display_an_attribute_option()
+    {
+        $value = new AttributeOptionValue();
+        $value->setLabel(100);
+        $value->setLocale('en_US');
+
+        $this->setLocale('en_US');
+        $this->addOptionValue($value);
+
+        $this->__toString()->shouldReturn('100');
     }
 }


### PR DESCRIPTION

**Description (for Contributor and Core Developer)**

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

