### PR TITLE
[PIM-7033] Association with product models UI

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -4,6 +4,7 @@
 
 - API-415: Update a list of options of a simple or multi select attribute
 - PIM-6652: Add a parent filter into the product and product model grid
+- PIM-7033: Allow user to select product models as associations in UI
 
 ## BC breaks
 
@@ -19,7 +20,6 @@
 - API-443: Prevent getting asset via media file url of the API
 - PIM-6996: Associate products to product models during import using the `<assocType>-product_models` pattern in an new column
 - PIM-6342: Display and remove associations gallery view
-- PIM-7033: Allow user to select product models as associations in UI
 - PIM-7051: Add images to associated products that have asset collection as main image
 - PIM-7046: Add ability to customise empty grid message and illustration
 - PIM-6917: Fix CSS glitches

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -19,6 +19,7 @@
 - API-443: Prevent getting asset via media file url of the API
 - PIM-6996: Associate products to product models during import using the `<assocType>-product_models` pattern in an new column
 - PIM-6342: Display and remove associations gallery view
+- PIM-7033: Allow user to select product models as associations in UI
 - PIM-7051: Add images to associated products that have asset collection as main image
 - PIM-7046: Add ability to customise empty grid message and illustration
 - PIM-6917: Fix CSS glitches
@@ -47,7 +48,7 @@ Removed typehint of ProductInterface in the Pim\Component\Catalog\Updater\Setter
 ## Improvements
 
 - PIM-6480: Add gallery view and display selector to the product grid
-- PIM-6621: add search on label and code on products and product models
+- PIM-6621: Add search on label and code on products and product models
 - PIM-6966: Add tracker information for product model, product variant and family variant
 - PIM-6990: Add new screen for managing product associations
 

--- a/features/Context/DataGridContext.php
+++ b/features/Context/DataGridContext.php
@@ -860,7 +860,7 @@ class DataGridContext extends PimContext implements PageObjectAware
                 $gridRow  = $this->getDatagrid()->getRow($row);
                 $checkbox = $gridRow->find('css', 'td.boolean-cell input[type="checkbox"]:not(:disabled)');
 
-                if (null !== $checkbox) {
+                if (null !== $checkbox && $checkbox->isVisible()) {
                     $checkbox->check();
 
                     if ($checkbox->isChecked()) {
@@ -917,7 +917,7 @@ class DataGridContext extends PimContext implements PageObjectAware
             $this->spin(function () use ($row) {
                 $gridRow  = $this->getDatagrid()->getRow($row);
                 $gridRow->mouseOver();
-                $removeButton = $gridRow->find('css', '.AknGrid-bodyRow-remove');
+                $removeButton = $gridRow->find('css', '.AknGrid-bodyRowRemove');
                 $removeButton->click();
                 return true;
             }, sprintf('Unable to remove the row "%s"', $row));

--- a/features/Context/Page/Base/Grid.php
+++ b/features/Context/Page/Base/Grid.php
@@ -186,26 +186,31 @@ class Grid extends Index
      */
     public function getGrid()
     {
+        return $this->spin(function () {
+            $container = $this->getContainer();
+            $grids = $container->findAll('css', $this->elements['Grid']['css']);
+
+            foreach ($grids as $grid) {
+                if ($grid->isVisible()) {
+                    return $grid;
+                }
+            }
+        }, 'No visible grid found');
+    }
+
+    /**
+     * @return NodeElement
+     */
+    protected function getContainer()
+    {
         $body = $this->getElement('Body');
-        $container = $this->getElement('Container');
+        $modal = $body->find('css', $this->elements['Dialog']['css']);
 
-        return $this->spin(
-            function () use ($body, $container) {
-                $modal = $body->find('css', $this->elements['Dialog']['css']);
-                if (null !== $modal && $modal->isVisible()) {
-                    return $modal->find('css', $this->elements['Grid']['css']);
-                }
+        if (null === $modal || !$modal->isVisible()) {
+            return $this->getElement('Container');
+        }
 
-                $grids = $container->findAll('css', $this->elements['Grid']['css']);
-
-                foreach ($grids as $grid) {
-                    if ($grid->isVisible()) {
-                        return $grid;
-                    }
-                }
-            },
-            'No visible grid found'
-        );
+        return $modal;
     }
 
     /**
@@ -337,13 +342,14 @@ class Grid extends Index
     public function search($value)
     {
         $this->spin(function () use ($value) {
-            $input = $this->getElement('Search filter');
+            $input = $this ->getContainer()->find('css', $this->elements['Search filter']['css']);
             if (null !== $input) {
+                $input = $this->decorate($input, $this->elements['Search filter']['decorators']);
                 $input->search($value);
 
                 return true;
             }
-        }, 'Unable to find the search filter');
+        }, sprintf('Unable to search "%s"', $value));
     }
 
     /**

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -667,4 +667,28 @@ class Edit extends ProductEditForm
             return $dropdownMenu->find('css', '.save-product-and-back');
         }, '"Save and back" button not found');
     }
+
+    /**
+     * Select a row in the association datagrid
+     *
+     * @param string $value
+     * @param bool   $check
+     */
+    public function selectRow($value, $check = true)
+    {
+        $this->spin(function () use ($value) {
+            $title = $this->find('css', sprintf('.AknGrid .AknGrid-title:contains("%s")', $value));
+            if (null === $title) {
+                return null;
+            }
+
+            $row = $this->getClosest($title, 'AknGrid-bodyRow');
+            $row->mouseOver();
+
+            $removeButton = $row->find('css', '.AknGrid-bodyRow-remove');
+            $removeButton->click();
+
+            return true;
+        }, sprintf('Impossible to find a row with "%s"', $value));
+    }
 }

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -667,28 +667,4 @@ class Edit extends ProductEditForm
             return $dropdownMenu->find('css', '.save-product-and-back');
         }, '"Save and back" button not found');
     }
-
-    /**
-     * Select a row in the association datagrid
-     *
-     * @param string $value
-     * @param bool   $check
-     */
-    public function selectRow($value, $check = true)
-    {
-        $this->spin(function () use ($value) {
-            $title = $this->find('css', sprintf('.AknGrid .AknGrid-title:contains("%s")', $value));
-            if (null === $title) {
-                return null;
-            }
-
-            $row = $this->getClosest($title, 'AknGrid-bodyRow');
-            $row->mouseOver();
-
-            $removeButton = $row->find('css', '.AknGrid-bodyRow-remove');
-            $removeButton->click();
-
-            return true;
-        }, sprintf('Impossible to find a row with "%s"', $value));
-    }
 }

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1664,14 +1664,14 @@ class WebUser extends PimContext
     public function iPressTheButton($button, $modalWait = null)
     {
         $this->spin(function () use ($button, $modalWait) {
-            $this->getCurrentPage()->pressButton($button, true);
-
-            if (null !== $modalWait) {
-                return null !== $this->getCurrentPage()->find('css', '.modal');
+            if (null !== $modalWait && null !== $this->getCurrentPage()->find('css', '.modal')) {
+                return true;
             }
 
-            return true;
-        }, sprintf("Can not find any '%s' button", $button));
+            $this->getCurrentPage()->pressButton($button, true);
+
+            return null === $modalWait;
+        }, sprintf("Can not find any '%s' button%s", $button, null !== $modalWait ? ' or no modal found' : ''));
     }
 
     /**

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1664,8 +1664,12 @@ class WebUser extends PimContext
     public function iPressTheButton($button, $modalWait = null)
     {
         $this->spin(function () use ($button, $modalWait) {
-            if (null !== $modalWait && null !== $this->getCurrentPage()->find('css', '.modal')) {
-                return true;
+            if (null !== $modalWait) {
+                foreach ($this->getCurrentPage()->findAll('css', '.modal') as $modal) {
+                    if ($modal->isVisible()) {
+                        return true;
+                    }
+                }
             }
 
             $this->getCurrentPage()->pressButton($button, true);

--- a/features/Pim/Behat/Context/Domain/Enrich/ItemPickerContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/ItemPickerContext.php
@@ -51,7 +51,12 @@ class ItemPickerContext extends PimContext
     {
         return $this->spin(function () use ($code) {
             return $this->getSession()->getPage()
-                ->find('css', sprintf('.item-picker-basket .AknGrid-subTitle:contains("%s")', $code));
+                ->find('css', sprintf(
+                    '.item-picker-basket .AknGrid-subTitle:contains("%s"),
+                    .item-picker-basket .AknGrid-title:contains("%s")',
+                    $code,
+                    $code
+                ));
         }, sprintf('Cannot find item "%s" in basket', $code));
     }
 }

--- a/features/Pim/Behat/Context/Domain/Enrich/ItemPickerContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/ItemPickerContext.php
@@ -51,7 +51,7 @@ class ItemPickerContext extends PimContext
     {
         return $this->spin(function () use ($code) {
             return $this->getSession()->getPage()
-                ->find('css', sprintf('.item-picker-basket .AknGrid-title:contains("%s")', $code));
+                ->find('css', sprintf('.item-picker-basket .AknGrid-subTitle:contains("%s")', $code));
         }, sprintf('Cannot find item "%s" in basket', $code));
     }
 }

--- a/features/Pim/Behat/Context/Domain/Enrich/ItemPickerContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/ItemPickerContext.php
@@ -51,7 +51,7 @@ class ItemPickerContext extends PimContext
     {
         return $this->spin(function () use ($code) {
             return $this->getSession()->getPage()
-                ->find('css', sprintf('.item-picker-basket *[data-itemCode="%s"]', $code));
+                ->find('css', sprintf('.item-picker-basket .AknGrid-title:contains("%s")', $code));
         }, sprintf('Cannot find item "%s" in basket', $code));
     }
 }

--- a/features/Pim/Behat/Decorator/Grid/Filter/SearchDecorator.php
+++ b/features/Pim/Behat/Decorator/Grid/Filter/SearchDecorator.php
@@ -70,8 +70,5 @@ class SearchDecorator extends ElementDecorator
     public function search($value)
     {
         $this->setValue($value);
-        $this->getSession()->executeScript(
-            '$(\'.search-filter [name="value"]\')[0].dispatchEvent(new KeyboardEvent(\'keydown\', {\'key\':\'Shift\'}))'
-        );
     }
 }

--- a/features/Pim/Behat/Decorator/Grid/Filter/SearchDecorator.php
+++ b/features/Pim/Behat/Decorator/Grid/Filter/SearchDecorator.php
@@ -63,11 +63,15 @@ class SearchDecorator extends ElementDecorator
 
     /**
      * Search a value in the search filter
+     * It dispatch a fake keydown event to run the search.
      *
      * @param string $value
      */
     public function search($value)
     {
         $this->setValue($value);
+        $this->getSession()->executeScript(
+            '$(\'.search-filter [name="value"]\')[0].dispatchEvent(new KeyboardEvent(\'keydown\', {\'key\':\'Shift\'}))'
+        );
     }
 }

--- a/features/import/product/import_products_with_associations.feature
+++ b/features/import/product/import_products_with_associations.feature
@@ -81,7 +81,7 @@ Feature: Execute a job
     Given I edit the "SKU-001" product
     When I visit the "Associations" column tab
     And I visit the "Cross sell" association type
-    Then I should see the text "2 product(s) and 1 group(s)"
+    Then I should see the text "2 product(s), 0 product model(s) and 1 group(s)"
     And the english localizable value name of "SKU-001" should be "Before"
 
   Scenario: Successfully skip associations without modification
@@ -132,7 +132,7 @@ Feature: Execute a job
     When I edit the "SKU-001" product
     And I visit the "Associations" column tab
     And I visit the "Cross sell" association type
-    Then I should see the text "0 product(s) and 0 group(s)"
+    Then I should see the text "0 product(s), 0 product model(s) and 0 group(s)"
 
   @jira https://akeneo.atlassian.net/browse/PIM-6019
   Scenario: Successfully import product without remove already existing associations when option "compare values" is set to false

--- a/features/import/product/import_products_with_associations.feature
+++ b/features/import/product/import_products_with_associations.feature
@@ -28,7 +28,7 @@ Feature: Execute a job
     Given I edit the "SKU-001" product
     When I visit the "Associations" column tab
     And I visit the "Cross sell" association type
-    Then I should see the text "2 product(s) and 1 group(s)"
+    Then I should see the text "2 product(s), 0 product model(s) and 1 group(s)"
 
   @pim-2445
   Scenario: Successfully skip associations with not existing product (owner side)

--- a/features/import/product/xlsx/import_products_with_associations.feature
+++ b/features/import/product/xlsx/import_products_with_associations.feature
@@ -28,7 +28,7 @@ Feature: Execute a job
     Given I edit the "SKU-001" product
     When I visit the "Associations" column tab
     And I visit the "Cross sell" association type
-    Then I should see the text "2 product(s) and 1 group(s)"
+    Then I should see the text "2 product(s), 0 product model(s) and 1 group(s)"
 
   Scenario: Successfully skip associations with not existing product (owner side)
     Given the following XLSX file to import:
@@ -80,7 +80,7 @@ Feature: Execute a job
     Given I edit the "SKU-001" product
     When I visit the "Associations" column tab
     And I visit the "Cross sell" association type
-    Then I should see the text "2 product(s) and 1 group(s)"
+    Then I should see the text "2 product(s), 0 product model(s) and 1 group(s)"
     And the english localizable value name of "SKU-001" should be "Before"
 
   Scenario: Successfully skip associations without modification
@@ -131,7 +131,7 @@ Feature: Execute a job
     When I edit the "SKU-001" product
     And I visit the "Associations" column tab
     And I visit the "Cross sell" association type
-    Then I should see the text "0 product(s) and 0 group(s)"
+    Then I should see the text "0 product(s), 0 product model(s) and 0 group(s)"
 
   @jira https://akeneo.atlassian.net/browse/PIM-5696
   Scenario: Successfully import products with associations and numeric value as SKU
@@ -148,4 +148,4 @@ Feature: Execute a job
     And I edit the "123" product
     And I visit the "Associations" column tab
     And I visit the "Cross sell" association type
-    Then I should see the text "0 product(s) and 1 group(s)"
+    Then I should see the text "0 product(s), 0 product model(s) and 1 group(s)"

--- a/features/product/associate_product.feature
+++ b/features/product/associate_product.feature
@@ -26,7 +26,7 @@ Feature: Associate a product
     And I press the "Add associations" button
     And I check the row "shoelaces"
     And I press the "Confirm" button in the popin
-    Then I should see the text "1 product(s) and 0 group(s)"
+    Then I should see the text "1 product(s), 0 product model(s) and 0 group(s)"
     Then I should see product "shoelaces"
 
   @jira https://akeneo.atlassian.net/browse/PIM-4788
@@ -40,7 +40,7 @@ Feature: Associate a product
     And I edit the "charcoal-boots" product
     And I visit the "Associations" column tab
     And I visit the "Upsell" association type
-    Then I should see the text "0 product(s) and 1 group(s)"
+    Then I should see the text "0 product(s), 0 product model(s) and 1 group(s)"
     And the row "caterpillar_boots" should be checked
 
   @jira https://akeneo.atlassian.net/browse/PIM-4788

--- a/features/product/associate_product.feature
+++ b/features/product/associate_product.feature
@@ -66,13 +66,13 @@ Feature: Associate a product
     And I check the rows "shoelaces, gray-boots, brown-boots and green-boots"
     When I press the "Confirm" button in the popin
     Then I should not see the text "There are unsaved changes."
-    And I should see the text "4 product(s) and 1 group(s)"
+    And I should see the text "4 product(s), 0 product model(s) and 1 group(s)"
     And I visit the "Upsell" association type
-    Then I should see the text "1 product(s) and 1 group(s)"
+    Then I should see the text "1 product(s), 0 product model(s) and 1 group(s)"
     And I visit the "Substitution" association type
-    Then I should see the text "1 product(s) and 0 group(s)"
+    Then I should see the text "1 product(s), 0 product model(s) and 0 group(s)"
     And I visit the "Pack" association type
-    Then I should see the text "0 product(s) and 0 group(s)"
+    Then I should see the text "0 product(s), 0 product model(s) and 0 group(s)"
 
   @jira https://akeneo.atlassian.net/browse/PIM-4668
   Scenario: Detect unsaved changes when modifying associations
@@ -128,7 +128,7 @@ Feature: Associate a product
     And I save the product
     And I should not see the text "There are unsaved changes."
     When I visit the "Substitution" association type
-    Then I should see the text "0 product(s) and 0 group(s)"
+    Then I should see the text "0 product(s), 0 product model(s) and 0 group(s)"
     And the row "caterpillar_boots" should not be checked
 
   @jira https://akeneo.atlassian.net/browse/PIM-6960
@@ -145,7 +145,7 @@ Feature: Associate a product
     And I press the "Add associations" button
     And I check the row "shoelaces"
     And I press the "Confirm" button in the popin
-    Then I should see the text "1 product(s) and 0 group(s)"
+    Then I should see the text "1 product(s), 0 product model(s) and 0 group(s)"
     When I am on the association types page
     Then I should see association type social_sell
     When I click on the "Delete" action of the row which contains "social_sell"

--- a/features/product/update_associations.feature
+++ b/features/product/update_associations.feature
@@ -15,39 +15,43 @@ Feature: Update the product associations
     And I visit the "Associations" column tab
 
   Scenario: Successfully add an association
-    When I press the "Add associations" button
+    Given I press the "Add associations" button
     And I check the row "patrick"
-    Then the item picker basket should contain patrick
-    And I press the "Confirm" button in the popin
+    And the item picker basket should contain patrick
+    When I press the "Confirm" button in the popin
     Then I should see product "patrick"
+    And I should see the text "1 product(s), 0 product model(s) and 0 group(s)"
 
   Scenario: Successfully delete an association
-    When I press the "Add associations" button
+    Given I press the "Add associations" button
     And I check the row "patrick"
-    Then the item picker basket should contain patrick
+    And the item picker basket should contain patrick
     And I press the "Confirm" button in the popin
-    Then I should see product "patrick"
-    When I select rows patrick
-    Then I should see the text "There are unsaved changes"
+    And I should see product "patrick"
+    And I remove the row "patrick"
+    And I should see the text "There are unsaved changes"
     And I should not see product "patrick"
     When I save the product
     Then I should not see product "patrick"
+    And I should see the text "0 product(s), 0 product model(s) and 0 group(s)"
 
   Scenario: Successfully add a product model as association
-    When I press the "Add associations" button
+    Given I press the "Add associations" button
     And I check the row "Elegance"
-    Then the item picker basket should contain Elegance
-    And I press the "Confirm" button in the popin
+    And the item picker basket should contain Elegance
+    When I press the "Confirm" button in the popin
     Then I should see product "Elegance"
+    And I should see the text "0 product(s), 1 product model(s) and 0 group(s)"
 
   Scenario: Successfully delete a product model as association
-    When I press the "Add associations" button
+    Given I press the "Add associations" button
     And I check the row "Elegance"
-    Then the item picker basket should contain Elegance
+    And the item picker basket should contain Elegance
     And I press the "Confirm" button in the popin
-    Then I should see product "Elegance"
-    When I select rows Elegance
-    Then I should see the text "There are unsaved changes"
+    And I should see product "Elegance"
+    And I remove the row "Elegance"
+    And I should see the text "There are unsaved changes"
     And I should not see product "Elegance"
     When I save the product
     Then I should not see product "Elegance"
+    And I should see the text "0 product(s), 0 product model(s) and 0 group(s)"

--- a/features/product/update_associations.feature
+++ b/features/product/update_associations.feature
@@ -5,18 +5,35 @@ Feature: Update the product associations
   I need to update the product associations
 
   Background:
-    Given the "apparel" catalog configuration
+    Given the "catalog_modeling" catalog configuration
     And I am logged in as "Julia"
     And the following products:
-      | sku       | family  | categories |
-      | spongebob | tshirts | men_2013   |
-      | patrick   | tshirts | men_2013   |
+      | sku       | family   | categories |
+      | spongebob | clothing | tshirts    |
+      | patrick   | clothing | tshirts    |
     And I am on the "spongebob" product page
     And I visit the "Associations" column tab
 
-  Scenario: Successfully add an association
+  Scenario: Successfully add and delete an association
     When I press the "Add associations" button
     And I check the row "patrick"
     Then the item picker basket should contain patrick
     And I press the "Confirm" button in the popin
     Then I should see product "patrick"
+    When I select rows patrick
+    Then I should see the text "There are unsaved changes"
+    And I should not see product "patrick"
+    When I save the product
+    Then I should not see product "patrick"
+
+  Scenario: Successfully add and delete a product model as association
+    When I press the "Add associations" button
+    And I check the row "Elegance"
+    Then the item picker basket should contain Elegance
+    And I press the "Confirm" button in the popin
+    Then I should see product "Elegance"
+    When I select rows Elegance
+    Then I should see the text "There are unsaved changes"
+    And I should not see product "Elegance"
+    When I save the product
+    Then I should not see product "Elegance"

--- a/features/product/update_associations.feature
+++ b/features/product/update_associations.feature
@@ -37,21 +37,23 @@ Feature: Update the product associations
 
   Scenario: Successfully add a product model as association
     Given I press the "Add associations" button
-    And I check the row "Elegance"
-    And the item picker basket should contain Elegance
+    And I search "juno"
+    And I check the row "juno"
+    And the item picker basket should contain juno
     When I press the "Confirm" button in the popin
-    Then I should see product "Elegance"
+    Then I should see product "juno"
     And I should see the text "0 product(s), 1 product model(s) and 0 group(s)"
 
   Scenario: Successfully delete a product model as association
     Given I press the "Add associations" button
-    And I check the row "Elegance"
-    And the item picker basket should contain Elegance
+    And I search "juno"
+    And I check the row "juno"
+    And the item picker basket should contain juno
     And I press the "Confirm" button in the popin
-    And I should see product "Elegance"
-    And I remove the row "Elegance"
+    And I should see product "juno"
+    And I remove the row "juno"
     And I should see the text "There are unsaved changes"
-    And I should not see product "Elegance"
+    And I should not see product "juno"
     When I save the product
-    Then I should not see product "Elegance"
+    Then I should not see product "juno"
     And I should see the text "0 product(s), 0 product model(s) and 0 group(s)"

--- a/features/product/update_associations.feature
+++ b/features/product/update_associations.feature
@@ -36,7 +36,8 @@ Feature: Update the product associations
     And I should see the text "0 product(s), 0 product model(s) and 0 group(s)"
 
   Scenario: Successfully add a product model as association
-    Given I press the "Add associations" button and wait for modal
+    Given I should see the text "There are no associated products"
+    And I press the "Add associations" button and wait for modal
     And I should see the text "Add Cross sell associations"
     And I should see the text "Belt"
     And I search "juno"
@@ -47,7 +48,8 @@ Feature: Update the product associations
     And I should see the text "0 product(s), 1 product model(s) and 0 group(s)"
 
   Scenario: Successfully delete a product model as association
-    Given I press the "Add associations" button and wait for modal
+    Given I should see the text "There are no associated products"
+    And I press the "Add associations" button and wait for modal
     And I should see the text "Add Cross sell associations"
     And I should see the text "Belt"
     And I search "juno"

--- a/features/product/update_associations.feature
+++ b/features/product/update_associations.feature
@@ -14,7 +14,14 @@ Feature: Update the product associations
     And I am on the "spongebob" product page
     And I visit the "Associations" column tab
 
-  Scenario: Successfully add and delete an association
+  Scenario: Successfully add an association
+    When I press the "Add associations" button
+    And I check the row "patrick"
+    Then the item picker basket should contain patrick
+    And I press the "Confirm" button in the popin
+    Then I should see product "patrick"
+
+  Scenario: Successfully delete an association
     When I press the "Add associations" button
     And I check the row "patrick"
     Then the item picker basket should contain patrick
@@ -26,7 +33,14 @@ Feature: Update the product associations
     When I save the product
     Then I should not see product "patrick"
 
-  Scenario: Successfully add and delete a product model as association
+  Scenario: Successfully add a product model as association
+    When I press the "Add associations" button
+    And I check the row "Elegance"
+    Then the item picker basket should contain Elegance
+    And I press the "Confirm" button in the popin
+    Then I should see product "Elegance"
+
+  Scenario: Successfully delete a product model as association
     When I press the "Add associations" button
     And I check the row "Elegance"
     Then the item picker basket should contain Elegance

--- a/features/product/update_associations.feature
+++ b/features/product/update_associations.feature
@@ -15,7 +15,7 @@ Feature: Update the product associations
     And I visit the "Associations" column tab
 
   Scenario: Successfully add an association
-    Given I press the "Add associations" button
+    Given I press the "Add associations" button and wait for modal
     And I check the row "patrick"
     And the item picker basket should contain patrick
     When I press the "Confirm" button in the popin
@@ -23,7 +23,7 @@ Feature: Update the product associations
     And I should see the text "1 product(s), 0 product model(s) and 0 group(s)"
 
   Scenario: Successfully delete an association
-    Given I press the "Add associations" button
+    Given I press the "Add associations" button and wait for modal
     And I check the row "patrick"
     And the item picker basket should contain patrick
     And I press the "Confirm" button in the popin
@@ -36,7 +36,9 @@ Feature: Update the product associations
     And I should see the text "0 product(s), 0 product model(s) and 0 group(s)"
 
   Scenario: Successfully add a product model as association
-    Given I press the "Add associations" button
+    Given I press the "Add associations" button and wait for modal
+    And I should see the text "Add Cross sell associations"
+    And I should see the text "Belt"
     And I search "juno"
     And I check the row "juno"
     And the item picker basket should contain juno
@@ -45,7 +47,9 @@ Feature: Update the product associations
     And I should see the text "0 product(s), 1 product model(s) and 0 group(s)"
 
   Scenario: Successfully delete a product model as association
-    Given I press the "Add associations" button
+    Given I press the "Add associations" button and wait for modal
+    And I should see the text "Add Cross sell associations"
+    And I should see the text "Belt"
     And I search "juno"
     And I check the row "juno"
     And the item picker basket should contain juno

--- a/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
@@ -57,6 +57,9 @@ class AssociatedProductDatasource extends ProductDatasource
         }
 
         $association = $this->getAssociation($sourceProduct, $this->getConfiguration('association_type_id'));
+        if (null === $association) {
+            return ['totalRecords' => 0, 'data' => []];
+        }
 
         $associatedProductsIdentifiers = $this->getAssociatedProductIdentifiers($association);
         $associatedProductModelsIdentifiers = $this->getAssociatedProductModelIdentifiers($association);
@@ -248,7 +251,7 @@ class AssociatedProductDatasource extends ProductDatasource
     }
 
     /**
-     * @param ProductInterface           $product
+     * @param ProductInterface           $sourceProduct
      * @param mixed                      $associationTypeId
      * @return null|AssociationInterface
      */

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
@@ -137,8 +137,8 @@ services:
         class: '%pim_datagrid.datasource.associated_product.class%'
         arguments:
             - '@pim_catalog.object_manager.product'
-            - '@pim_catalog.query.product_query_builder_from_size_factory'
-            - '@pim_datagrid.normalizer.product_association'
+            - '@pim_enrich.query.product_and_product_model_query_builder_from_size_factory'
+            - '@pim_serializer'
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_associated_product }
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-button.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-button.js
@@ -12,6 +12,7 @@ define(
     ) {
         return BaseForm.extend({
             displayAsPanel: false,
+            className: 'Toto',
 
             /**
              * @inheritdoc

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-list.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-list.js
@@ -23,6 +23,7 @@ define(['underscore', 'pim/form', 'oro/mediator', 'oro/tools'],
             initialize(options) {
                 this.options = options.config;
                 mediator.once('datagrid_collection_set_after', this.loadFilterModules.bind(this));
+
                 BaseForm.prototype.initialize.apply(this, arguments);
             },
 
@@ -106,6 +107,8 @@ define(['underscore', 'pim/form', 'oro/mediator', 'oro/tools'],
                         }
                     }
                 }, this);
+
+                BaseForm.prototype.render.apply(this, arguments);
             }
         });
     }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-manager.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-manager.js
@@ -333,8 +333,8 @@ define(
                 selectedList: 0,
                 classes: 'AknFilterBox-addFilterButton AknFilterBox-addFilterButton--asPanel filter-list select-filter-widget',
                 position: {
-                    at: 'left top',
-                    my: 'left top',
+                    at: 'right top',
+                    my: 'right top',
                 }
             };
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Bundle\DataGridBundle\Datasource;
 
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\ObjectManager;
 use Oro\Bundle\DataGridBundle\Datagrid\Datagrid;
@@ -119,6 +120,7 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
         $associationIterator->next()->shouldBeCalled();
 
         $association->getProducts()->willReturn([$associatedProduct1, $associatedProduct2]);
+        $association->getProductModels()->willReturn(new ArrayCollection());
         $association->getAssociationType()->willReturn($associationType);
         $associationType->getId()->willReturn(1);
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
@@ -171,7 +171,6 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
         $associatedProductCursor->current()->willReturn($associatedProduct1, $associatedProduct2);
         $associatedProductCursor->next()->shouldBeCalled();
 
-        // Prout prout
         $pqbFactory->create([
             'repository_parameters' => [],
             'repository_method'     => 'createQueryBuilder',

--- a/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
@@ -111,13 +111,10 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
 
         $associatedProduct1->getIdentifier()->willReturn('associated_product_1');
         $associatedProduct1->getId()->willReturn('2');
-        $associatedProduct1->getImage()->willReturn('imagePath.png');
         $associatedProduct2->getIdentifier()->willReturn('associated_product_2');
         $associatedProduct2->getId()->willReturn('3');
-        $associatedProduct2->getImage()->willReturn('imagePath.png');
         $associatedProductModel->getCode()->willReturn('associated_product_model_1');
         $associatedProductModel->getId()->willReturn('2');
-        $associatedProductModel->getImage()->shouldBeCalled();
         $currentProduct->getAssociations()->willReturn($associationCollection);
         $currentProduct->getIdentifier()->willReturn('current_product');
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
@@ -181,6 +181,25 @@ class ProductModelController
     }
 
     /**
+     * Returns a set of product models from identifiers parameter
+     *
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function indexAction(Request $request): JsonResponse
+    {
+        $productModelIdentifiers = explode(',', $request->get('identifiers'));
+        $productModels = $this->productModelRepository->findByIdentifiers($productModelIdentifiers);
+
+        $normalizedProductModels = array_map(function ($productModel) {
+            return $this->normalizeProductModel($productModel);
+        }, $productModels);
+
+        return new JsonResponse($normalizedProductModels);
+    }
+
+    /**
      * @param Request $request
      *
      * @AclAncestor("pim_enrich_product_model_create")

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
@@ -44,6 +44,10 @@ datagrid:
             completeness:
                 label:         Complete
                 frontend_type: completeness
+            complete_variant_products:
+                label:         Variant products
+                data_name:     complete_variant_product
+                frontend_type: complete-variant-product
             created:
                 label:         Created At
                 type:          field
@@ -52,6 +56,7 @@ datagrid:
                 type:          field
         properties:
             id: ~
+            document_type: ~
         filters:
             columns:
                 label_or_identifier:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
@@ -1,6 +1,6 @@
 extensions:
     pim-associations-product-picker-form:
-        module: pim/common/item-picker
+        module: pim/product-edit-form/product-and-product-model-picker
         config:
             datagridName: association-product-picker-grid
             description: pim_enrich.form.product.tab.associations.manage_description

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/associations/product.yml
@@ -15,7 +15,6 @@ extensions:
 
     pim-association-product-picker-form-filters-manage:
         module: oro/datafilter/filters-button
-        parent: pim-associations-product-picker-form
-        targetZone: filters
+        parent: pim-association-product-picker-form-filters-list
         config:
             displayAsPanel: true

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -192,6 +192,7 @@ config:
                         urls:
                             get: pim_enrich_product_model_rest_get
                             children: pim_enrich_product_model_rest_children_list
+                            list: pim_enrich_product_model_rest_index
                 product-model-by-code:
                     module: pim/base-fetcher
                     options:
@@ -715,6 +716,7 @@ config:
         pim/product-edit-form/start-copy:                        pimenrich/js/product/form/start-copy
         pim/product-edit-form/variant-navigation:                pimenrich/js/product/form/variant-navigation
         pim/product-edit-form/attributes/variant-axes:           pimenrich/js/product/form/attributes/variant-axes
+        pim/product-edit-form/product-and-product-model-picker:  pimenrich/js/product/form/product-and-product-model-picker
         pim/product-edit-form/attributes/read-only-parent-attributes: pimenrich/js/product/form/attributes/read-only-parent-attributes
 
         # Product model

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product_model.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product_model.yml
@@ -31,6 +31,11 @@ pim_enrich_product_model_rest_children_list:
     defaults: { _controller: pim_enrich.controller.rest.product_model:childrenAction }
     methods: [GET]
 
+pim_enrich_product_model_rest_index:
+    path: /rest/
+    defaults: { _controller: pim_enrich.controller.rest.product_model:indexAction }
+    methods: [GET]
+
 pim_enrich_product_model_family_variant_leaf:
     path: /rest/family-variant-leaf
     defaults: { _controller: pim_enrich.controller.rest.product_model:searchLastLevelProductModelByCode }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -320,7 +320,8 @@ define(
                             imagePathMethod: this.imagePathMethod.bind(this),
                             columnName: this.config.columnName,
                             identifierName: this.config.columnName,
-                            labelMethod: this.labelMethod.bind(this)
+                            labelMethod: this.labelMethod.bind(this),
+                            itemCodeMethod: this.itemCodeMethod.bind(this)
                         }));
 
                         this.delegateEvents();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -308,24 +308,31 @@ define(
             },
 
             /**
-             * Render the basket to update its content
+             * Fetches the new items and render the basket
              */
             updateBasket: function () {
                 FetcherRegistry.getFetcher(this.config.fetcher).fetchByIdentifiers(this.getItems())
                     .then(function (items) {
-                        this.$('.basket').html(this.basketTemplate({
-                            items: items,
-                            title: __('pim_enrich.form.basket.title'),
-                            emptyLabel: __('pim_enrich.form.basket.empty_basket'),
-                            imagePathMethod: this.imagePathMethod.bind(this),
-                            columnName: this.config.columnName,
-                            identifierName: this.config.columnName,
-                            labelMethod: this.labelMethod.bind(this),
-                            itemCodeMethod: this.itemCodeMethod.bind(this)
-                        }));
-
+                        this.renderBasket(items);
                         this.delegateEvents();
                     }.bind(this));
+            },
+
+            /**
+             * Renders the basket to update its content
+             * @param items
+             */
+            renderBasket: function (items) {
+                this.$('.basket').html(this.basketTemplate({
+                    items: items,
+                    title: __('pim_enrich.form.basket.title'),
+                    emptyLabel: __('pim_enrich.form.basket.empty_basket'),
+                    imagePathMethod: this.imagePathMethod.bind(this),
+                    columnName: this.config.columnName,
+                    identifierName: this.config.columnName,
+                    labelMethod: this.labelMethod.bind(this),
+                    itemCodeMethod: this.itemCodeMethod.bind(this)
+                }));
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/item-picker.js
@@ -355,6 +355,16 @@ define(
             },
 
             /**
+             * Returns the method to display unique codes for basket deletion
+             *
+             * @param {Object} item
+             * @returns {string}
+             */
+            itemCodeMethod: function (item) {
+                return item[this.config.columnName];
+            },
+
+            /**
              * Get the current locale
              *
              * @return {string}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/product-model-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/product-model-fetcher.js
@@ -33,6 +33,13 @@ define(
             },
 
             /**
+             * {@inheritdoc}
+             */
+            getIdentifierField: function () {
+                return $.Deferred().resolve('code');
+            },
+
+            /**
              * Fetch all children of the given parent.
              *
              * @return {Promise}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -626,8 +626,8 @@ define(
                     });
 
                     const assocType = this.getCurrentAssociationType();
-                    const previousProductIds = this.getFormData().associations[assocType]['products'];
-                    const previousProductModelIds = this.getFormData().associations[assocType]['product_models'];
+                    const previousProductIds = this.getFormData().associations[assocType].products;
+                    const previousProductModelIds = this.getFormData().associations[assocType].product_models;
 
                     this.updateFormDataAssociations(
                         previousProductIds.concat(productIds),

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -482,16 +482,23 @@ define(
              * @param {Object} datagrid
              */
             unselectModel: function (model, datagrid) {
-                const assocType           = this.getCurrentAssociationType();
-                const assocTarget         = this.getDatagridTarget(datagrid);
-                let currentAssociations = _.uniq(this.getCurrentAssociations(datagrid));
+                const assocType = this.getCurrentAssociationType();
+                const assocTarget = this.getDatagridTarget(datagrid);
 
-                const index = currentAssociations.indexOf(datagrid.getModelIdentifier(model));
-                if (-1 !== index) {
-                    currentAssociations.splice(index, 1);
+                let assocSubTarget = assocTarget;
+                if (assocTarget === 'products') {
+                    // We check from what association target we have to remove model (products or product_models)
+                    assocSubTarget = (model.attributes.document_type === 'product') ? 'products' : 'product_models';
                 }
 
-                this.updateFormDataAssociations(currentAssociations, assocType, assocTarget);
+                const associationsField = this.getFormData().associations;
+                let associations = associationsField[assocType][assocSubTarget];
+                const index = associations.indexOf(datagrid.getModelIdentifier(model));
+                if (-1 !== index) {
+                    associations.splice(index, 1);
+                }
+
+                this.updateFormDataAssociations(associations, assocType, assocSubTarget);
                 this.updateSelectedAssociations('unselect', datagrid, model.id);
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associations.js
@@ -287,6 +287,8 @@ define(
                     const association = associations[assocType.code];
 
                     assocType.productCount = association && association.products ? association.products.length : 0;
+                    assocType.productModelCount = association && association.product_models ?
+                        association.product_models.length : 0;
                     assocType.groupCount = association && association.groups ? association.groups.length : 0;
                 });
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-and-product-model-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-and-product-model-picker.js
@@ -12,11 +12,13 @@
  */
 define(
     [
+        'jquery',
         'oro/translator',
         'pim/common/item-picker',
         'pim/fetcher-registry',
         'pim/media-url-generator'
     ], function (
+        $,
         __,
         ItemPicker,
         FetcherRegistry,
@@ -57,19 +59,19 @@ define(
                     FetcherRegistry.getFetcher('product-model').fetchByIdentifiers(productModelIds),
                     FetcherRegistry.getFetcher('product').fetchByIdentifiers(productIds)
                 ).then(function (productModels, products) {
-                        this.$('.basket').html(this.basketTemplate({
-                            items: products.concat(productModels),
-                            title: __('pim_enrich.form.basket.title'),
-                            emptyLabel: __('pim_enrich.form.basket.empty_basket'),
-                            imagePathMethod: this.imagePathMethod.bind(this),
-                            columnName: this.config.columnName,
-                            identifierName: this.config.columnName,
-                            labelMethod: this.labelMethod.bind(this),
-                            itemCodeMethod: this.itemCodeMethod.bind(this),
-                        }));
+                    this.$('.basket').html(this.basketTemplate({
+                        items: products.concat(productModels),
+                        title: __('pim_enrich.form.basket.title'),
+                        emptyLabel: __('pim_enrich.form.basket.empty_basket'),
+                        imagePathMethod: this.imagePathMethod.bind(this),
+                        columnName: this.config.columnName,
+                        identifierName: this.config.columnName,
+                        labelMethod: this.labelMethod.bind(this),
+                        itemCodeMethod: this.itemCodeMethod.bind(this)
+                    }));
 
-                        this.delegateEvents();
-                    }.bind(this));
+                    this.delegateEvents();
+                }.bind(this));
             },
 
             /**
@@ -92,10 +94,7 @@ define(
             },
 
             /**
-             * Returns the method to display unique codes for basket deletion
-             *
-             * @param {Object} item
-             * @returns {string}
+             * {@inheritdoc}
              */
             itemCodeMethod: function (item) {
                 if (item.code) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-and-product-model-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-and-product-model-picker.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/**
+ * Extension to display full screen item picker to choose elements from a grid
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'oro/translator',
+        'pim/common/item-picker',
+        'pim/fetcher-registry'
+    ], function (
+        __,
+        ItemPicker,
+        FetcherRegistry
+    ) {
+        return ItemPicker.extend({
+            // Remove this.config.fetcher
+
+            /**
+             * {@inheritdoc}
+             */
+            selectModel: function (model) {
+                this.addItem(model.attributes.document_type + '_' + model.get(this.config.columnName));
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            unselectModel: function (model) {
+                this.removeItem(model.attributes.document_type + '_' + model.get(this.config.columnName));
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            updateBasket: function () {
+                let productIds = [];
+                let productModelIds = [];
+                this.getItems().forEach((item) => {
+                    const matchProductModel = item.match(/^product_model_(.*)$/);
+                    if (matchProductModel) {
+                        productModelIds.push(matchProductModel[1]);
+                    } else {
+                        const matchProduct = item.match(/^product_(.*)$/);
+                        productIds.push(matchProduct[1]);
+                    }
+                });
+
+                $.when(
+                    FetcherRegistry.getFetcher('product-model').fetchByIdentifiers(productModelIds),
+                    FetcherRegistry.getFetcher('product').fetchByIdentifiers(productIds)
+                ).then(function (productModels, products) {
+                        this.$('.basket').html(this.basketTemplate({
+                            items: products.concat(productModels),
+                            title: __('pim_enrich.form.basket.title'),
+                            emptyLabel: __('pim_enrich.form.basket.empty_basket'),
+                            imagePathMethod: this.imagePathMethod.bind(this),
+                            columnName: this.config.columnName,
+                            identifierName: this.config.columnName,
+                            labelMethod: this.labelMethod.bind(this),
+                            itemCodeMethod: this.itemCodeMethod.bind(this),
+                        }));
+
+                        this.delegateEvents();
+                    }.bind(this));
+            },
+
+            itemCodeMethod: function (item) {
+                if (item.code) {
+                    return 'product_model_' + item.code;
+                } else {
+                    return 'product_' + item[this.config.columnName];
+                }
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-and-product-model-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-and-product-model-picker.js
@@ -29,14 +29,14 @@ define(
              * {@inheritdoc}
              */
             selectModel: function (model) {
-                this.addItem(model.attributes.document_type + '_' + model.get(this.config.columnName));
+                this.addItem(`${model.attributes.document_type}_${model.get(this.config.columnName)}`);
             },
 
             /**
              * {@inheritdoc}
              */
             unselectModel: function (model) {
-                this.removeItem(model.attributes.document_type + '_' + model.get(this.config.columnName));
+                this.removeItem(`${model.attributes.document_type}_${model.get(this.config.columnName)}`);
             },
 
             /**
@@ -59,17 +59,7 @@ define(
                     FetcherRegistry.getFetcher('product-model').fetchByIdentifiers(productModelIds),
                     FetcherRegistry.getFetcher('product').fetchByIdentifiers(productIds)
                 ).then(function (productModels, products) {
-                    this.$('.basket').html(this.basketTemplate({
-                        items: products.concat(productModels),
-                        title: __('pim_enrich.form.basket.title'),
-                        emptyLabel: __('pim_enrich.form.basket.empty_basket'),
-                        imagePathMethod: this.imagePathMethod.bind(this),
-                        columnName: this.config.columnName,
-                        identifierName: this.config.columnName,
-                        labelMethod: this.labelMethod.bind(this),
-                        itemCodeMethod: this.itemCodeMethod.bind(this)
-                    }));
-
+                    this.renderBasket(products.concat(productModels));
                     this.delegateEvents();
                 }.bind(this));
             },
@@ -98,9 +88,9 @@ define(
              */
             itemCodeMethod: function (item) {
                 if (item.code) {
-                    return 'product_model_' + item.code;
+                    return `product_model_${item.code}`;
                 } else {
-                    return 'product_' + item[this.config.columnName];
+                    return `product_${item[this.config.columnName]}`;
                 }
             }
         });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-and-product-model-picker.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-and-product-model-picker.js
@@ -1,7 +1,10 @@
 'use strict';
 
 /**
- * Extension to display full screen item picker to choose elements from a grid
+ * This extension allows user to display a fullscreen item picker.
+ * It overrides the default item picker because we have to manage 2 types of entities:
+ * - products (identified by their identifier)
+ * - product models (identifier by their code)
  *
  * @author    Pierre Allard <pierre.allard@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -11,15 +14,15 @@ define(
     [
         'oro/translator',
         'pim/common/item-picker',
-        'pim/fetcher-registry'
+        'pim/fetcher-registry',
+        'pim/media-url-generator'
     ], function (
         __,
         ItemPicker,
-        FetcherRegistry
+        FetcherRegistry,
+        MediaUrlGenerator
     ) {
         return ItemPicker.extend({
-            // Remove this.config.fetcher
-
             /**
              * {@inheritdoc}
              */
@@ -69,6 +72,31 @@ define(
                     }.bind(this));
             },
 
+            /**
+             * {@inheritdoc}
+             */
+            imagePathMethod: function (item) {
+                let filePath = null;
+                if (item.meta.image !== null) {
+                    filePath = item.meta.image.filePath;
+                }
+
+                return MediaUrlGenerator.getMediaShowUrl(filePath, 'thumbnail_small');
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            labelMethod: function (item) {
+                return item.meta.label[this.getLocale()];
+            },
+
+            /**
+             * Returns the method to display unique codes for basket deletion
+             *
+             * @param {Object} item
+             * @returns {string}
+             */
             itemCodeMethod: function (item) {
                 if (item.code) {
                     return 'product_model_' + item.code;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker-basket.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/item-picker-basket.html
@@ -8,9 +8,9 @@
                 <div class="AknGrid-body basket-inner">
                     <% if (!_.isEmpty(items)) { %>
                     <% _.each(items, function (item) { %>
-                    <div data-itemCode="<%- item[columnName] %>" class="AknGrid-bodyRow AknGrid-bodyRow--thumbnail AknGrid-bodyRow--withoutTopBorder">
+                    <div data-itemCode="<%- itemCodeMethod(item) %>" class="AknGrid-bodyRow AknGrid-bodyRow--thumbnail AknGrid-bodyRow--withoutTopBorder">
                         <div class="AknGrid-fullImage" style="background-image: url('<%- imagePathMethod(item) %>')"></div>
-                        <div class="AknButton AknButton--important AknButton--micro AknButton-squareIcon AknButton-squareIcon--delete AknAssetCollectionField-icon remove-item" data-itemCode="<%- item[columnName] %>"></div>
+                        <div class="AknButton AknButton--important AknButton--micro AknButton-squareIcon AknButton-squareIcon--delete AknAssetCollectionField-icon remove-item" data-itemCode="<%- itemCodeMethod(item) %>"></div>
                         <div class="AknGrid-title"><%- labelMethod(item) %></div>
                         <div class="AknGrid-subTitle"><%- item[identifierName] %></div>
                     </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associated-product-row.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/associated-product-row.html
@@ -1,5 +1,5 @@
 <% if (canRemoveAssociation) { %>
-    <div class="AknGrid-bodyRow-remove AknIconButton AknIconButton--remove AknIconButton--topLeft"></div>
+    <div class="AknGrid-bodyRowRemove AknIconButton AknIconButton--remove AknIconButton--topLeft"></div>
 <% } %>
 <div class="AknGrid-fullImage" style="background-image: url('<%- imagePath %>')"></div>
 <td class="AknGrid-title"><%- label %></td>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/association-panes.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/association-panes.html
@@ -20,7 +20,7 @@
             <div class="AknButtonList-item">
                 <%- __(
                     numberAssociationLabelKey,
-                    { productCount: associationType.productCount, groupCount: associationType.groupCount }
+                    { productCount: associationType.productCount, productModelCount: associationType.productModelCount, groupCount: associationType.groupCount }
                 ) %>
             </div>
         </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -483,7 +483,7 @@ pim_enrich:
                         none_exist: No association types exist.
                         show_products: Display products
                         show_groups: Display groups
-                        number_of_associations: "{{ productCount }} product(s) and {{ groupCount }} group(s)"
+                        number_of_associations: "{{ productCount }} product(s), {{ productModelCount }} product model(s) and {{ groupCount }} group(s)"
                     association_type_selector: Association type
                     target: Target
                     manage: Add {{ associationType }} associations

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -24,7 +24,7 @@
     justify-content: flex-end;
     padding: 0 0 1px 0;
     background: none;
-    margin: 10px 0 10px 0;
+    margin: 0 0 10px 0;
     flex-wrap: wrap;
     background: white;
   }
@@ -39,9 +39,11 @@
   }
 
   &--sticky:not(:empty) {
-    top: -28px;
     padding: 0;
     margin-bottom: 0;
+    margin-top: -10px;
+    padding-top: 10px;
+    top: -10px;
   }
 
   &-search {
@@ -65,6 +67,7 @@
     flex-grow: 1;
     display: flex;
     margin-top: -20px;
+    min-width: 300px;
   }
 
   &-filterContainer {
@@ -161,7 +164,7 @@
   }
 
   &--search &-list {
-    margin-right: 30px;
+    margin-right: 10px;
     display: flex;
     flex-grow: 1;
     align-items: center;

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -376,8 +376,9 @@
     }
   }
 
-  &-bodyRow-remove {
+  &-bodyRowRemove {
     display: none;
+    z-index: 3;
   }
 
   &-bodyRow--thumbnail:hover {
@@ -403,7 +404,7 @@
     opacity: 0.7;
   }
 
-  &-bodyRow--thumbnail:hover &-bodyRow-remove {
+  &-bodyRow--thumbnail:hover &-bodyRowRemove {
     display: block;
   }
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/GridToolbar.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/GridToolbar.less
@@ -12,6 +12,7 @@
     justify-content: center;
     display: flex;
     align-items: center;
+    margin-bottom: 10px;
   }
 
   &-right {


### PR DESCRIPTION
This PR allow use to select product models in associations panel.
A little bit tricky to avoid refactor all this part, so what I've done is, instead of returning a list of product ids (e.g. 123,456), it returns a list of mix of product and product_models (e.g. product_123, product_model_apollon).

In the association page, we always have to check if the identifier is a product_ or a product_model. Not the best solution, but I'm open to any other one.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | y
| Added Behats                      | y
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -