### PR TITLE
PIM-7039: Association grid, scopable attributes used as labels do not appear

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - PIM-7037: Allows code to be an integer on product model import
 - PIM-7011: XLS Options Import - Simple select attribute option cannot be updated for options with numeric codes
+- PIM-7039: Association grid, scopable attributes used as labels do not appear
 
 ## Better manage products with variants!
 

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductAssociationNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductAssociationNormalizer.php
@@ -28,6 +28,7 @@ class ProductAssociationNormalizer implements NormalizerInterface, SerializerAwa
 
         $data = [];
         $locale = current($context['locales']);
+        $channel = current($context['channels']);
 
         $data['identifier'] = $product->getIdentifier();
         $data['family'] = $this->getFamilyLabel($product, $locale);
@@ -37,7 +38,7 @@ class ProductAssociationNormalizer implements NormalizerInterface, SerializerAwa
 
         $data['is_checked'] = $context['is_associated'];
         $data['is_associated'] = $context['is_associated'];
-        $data['label'] = $product->getLabel($locale);
+        $data['label'] = $product->getLabel($locale, $channel);
         $data['completeness'] = $this->getCompleteness($product, $context);
 
         return $data;

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductAssociationNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductAssociationNormalizerSpec.php
@@ -3,31 +3,34 @@
 namespace spec\Pim\Bundle\DataGridBundle\Normalizer;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\DataGridBundle\Normalizer\ProductAssociationNormalizer;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\Completeness;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyTranslationInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class ProductAssociationNormalizerSpec extends ObjectBehavior
 {
     function let(SerializerInterface $serializer)
     {
-        $serializer->implement('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
+        $serializer->implement(NormalizerInterface::class);
         $this->setSerializer($serializer);
     }
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Pim\Bundle\DataGridBundle\Normalizer\ProductAssociationNormalizer');
-        $this->shouldBeAnInstanceOf('Symfony\Component\Serializer\SerializerAwareInterface');
+        $this->shouldHaveType(ProductAssociationNormalizer::class);
+        $this->shouldBeAnInstanceOf(SerializerAwareInterface::class);
     }
 
     function it_is_a_normalizer()
     {
-        $this->shouldImplement('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
+        $this->shouldImplement(NormalizerInterface::class);
     }
 
     function it_supports_datagrid_format_and_product_value(ProductInterface $product)
@@ -72,7 +75,7 @@ class ProductAssociationNormalizerSpec extends ObjectBehavior
         $updated = new \DateTime('2017-01-01T01:04:34+01:00');
         $product->getUpdated()->willReturn($updated);
         $serializer->normalize($updated, 'datagrid', $context)->willReturn('2017-01-01T01:04:34+01:00');
-        $product->getLabel('en_US')->willReturn('Purple tshirt');
+        $product->getLabel('en_US', 'ecommerce')->willReturn('Purple tshirt');
         $product->getCompletenesses()->willReturn([$completeness]);
         $completeness->getLocale()->willReturn($localeEN);
         $completeness->getChannel()->willReturn($channelEcommerce);
@@ -129,7 +132,7 @@ class ProductAssociationNormalizerSpec extends ObjectBehavior
         $updated = new \DateTime('2017-01-01T01:04:34+01:00');
         $product->getUpdated()->willReturn($updated);
         $serializer->normalize($updated, 'datagrid', $context)->willReturn('2017-01-01T01:04:34+01:00');
-        $product->getLabel('en_US')->willReturn('Purple tshirt');
+        $product->getLabel('en_US', 'ecommerce')->willReturn('Purple tshirt');
         $product->getCompletenesses()->willReturn([$completeness]);
         $completeness->getLocale()->willReturn($localeEN);
         $completeness->getChannel()->willReturn($channelEcommerce);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The normalizer called the method `Product::getLabel()` with a locale but without the channel. The identifier was returned all the time because we could not find the value without the channel.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | yes
| Migration script                  | -
| Tech Doc                          | -

