### PR TITLE
PIM-7051: Fix image normalization for associated products

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -6,6 +6,10 @@
 - API-443: Prevent getting asset via media file url of the API
 - PIM-6996: Associate products to product models during import using the `<assocType>-product_models` pattern in an new column
 - PIM-6342: Display and remove associations gallery view
+- PIM-7051: Add images to associated products that have asset collection as main image
+
+## BC breaks
+- Change the constructor of `Pim\Bundle\DataGridBundle\Normalizer\ProductAssociationNormalizer` to add `Pim\Bundle\EnrichBundle\Normalizer\ImageNormalizer` parameter
 
 ## Update jobs
 

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -9,6 +9,7 @@
 - PIM-7051: Add images to associated products that have asset collection as main image
 
 ## BC breaks
+
 - Change the constructor of `Pim\Bundle\DataGridBundle\Normalizer\ProductAssociationNormalizer` to add `Pim\Bundle\EnrichBundle\Normalizer\ImageNormalizer` parameter
 
 ## Update jobs

--- a/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
@@ -157,7 +157,6 @@ class AssociatedProductDatasource extends ProductDatasource
                 $this->normalizer->normalize($product, 'datagrid', $context),
                 [
                     'id'         => $product->getId(),
-                    'image'      => $product->getImage(),
                     'dataLocale' => $dataLocale,
                 ]
             );

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/ProductAssociationNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/ProductAssociationNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\DataGridBundle\Normalizer;
 
+use Pim\Bundle\EnrichBundle\Normalizer\ImageNormalizer;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
@@ -17,6 +18,17 @@ use Symfony\Component\Serializer\SerializerAwareTrait;
 class ProductAssociationNormalizer implements NormalizerInterface, SerializerAwareInterface
 {
     use SerializerAwareTrait;
+
+    /** @var ImageNormalizer */
+    protected $imageNormalizer;
+
+    /**
+     * @param ImageNormalizer           $imageNormalizer
+     */
+    public function __construct(ImageNormalizer $imageNormalizer)
+    {
+        $this->imageNormalizer = $imageNormalizer;
+    }
 
     /**
      * {@inheritdoc}
@@ -40,6 +52,7 @@ class ProductAssociationNormalizer implements NormalizerInterface, SerializerAwa
         $data['is_associated'] = $context['is_associated'];
         $data['label'] = $product->getLabel($locale);
         $data['completeness'] = $this->getCompleteness($product, $context);
+        $data['image'] = $this->imageNormalizer->normalize($product->getImage(), $context['data_locale']);
 
         return $data;
     }

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/normalizers.yml
@@ -32,6 +32,8 @@ services:
 
     pim_datagrid.normalizer.product_association:
         class: '%pim_datagrid.normalizer.product_association.class%'
+        arguments:
+            - '@pim_enrich.normalizer.image'
         tags:
             - { name: pim_serializer.normalizer }
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductAssociationNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/ProductAssociationNormalizerSpec.php
@@ -3,18 +3,23 @@
 namespace spec\Pim\Bundle\DataGridBundle\Normalizer;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\Normalizer\ImageNormalizer;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\Completeness;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyTranslationInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Prophecy\Argument;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class ProductAssociationNormalizerSpec extends ObjectBehavior
 {
-    function let(SerializerInterface $serializer)
+    function let(SerializerInterface $serializer, ImageNormalizer $imageNormalizer)
     {
+        $this->beConstructedWith($imageNormalizer);
+
         $serializer->implement('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
         $this->setSerializer($serializer);
     }
@@ -40,16 +45,20 @@ class ProductAssociationNormalizerSpec extends ObjectBehavior
 
     function it_normalizes_a_product_with_label(
         $serializer,
+        $imageNormalizer,
         ProductInterface $product,
         FamilyInterface $family,
         FamilyTranslationInterface $familyEN,
         Completeness $completeness,
         LocaleInterface $localeEN,
         ChannelInterface $channelEcommerce,
-        ProductInterface $currentProduct
-    ) {
+        ProductInterface $currentProduct,
+        ValueInterface $image
+    )
+    {
         $context = [
             'locales'             => ['en_US'],
+            'data_locale'         => 'en_US',
             'channels'            => ['ecommerce'],
             'current_product'     => $currentProduct,
             'association_type_id' => 1,
@@ -81,6 +90,12 @@ class ProductAssociationNormalizerSpec extends ObjectBehavior
         $localeEN->getCode()->willReturn('en_US');
         $channelEcommerce->getCode()->willReturn('ecommerce');
 
+        $product->getImage()->willReturn($image);
+        $imageNormalizer->normalize($image, Argument::any())->willReturn([
+            'filePath' => '/p/i/m/4/all.png',
+            'originalFileName' => 'all.png',
+        ]);
+
         $data = [
             'identifier'    => 'purple_tshirt',
             'family'        => 'Tshirt',
@@ -90,23 +105,32 @@ class ProductAssociationNormalizerSpec extends ObjectBehavior
             'is_checked'    => false,
             'is_associated' => false,
             'label'         => 'Purple tshirt',
-            'completeness'  => 76
+            'completeness'  => 76,
+            'image'         => [
+                'filePath' => '/p/i/m/4/all.png',
+                'originalFileName' => 'all.png',
+            ]
         ];
 
         $this->normalize($product, 'datagrid', $context)->shouldReturn($data);
     }
+
     function it_normalizes_a_product_without_label(
         $serializer,
+        $imageNormalizer,
         ProductInterface $product,
         FamilyInterface $family,
         FamilyTranslationInterface $familyEN,
         Completeness $completeness,
         LocaleInterface $localeEN,
         ChannelInterface $channelEcommerce,
-        ProductInterface $currentProduct
-    ) {
+        ProductInterface $currentProduct,
+        ValueInterface $image
+    )
+    {
         $context = [
             'locales'             => ['en_US'],
+            'data_locale'         => 'en_US',
             'channels'            => ['ecommerce'],
             'current_product'     => $currentProduct,
             'association_type_id' => 1,
@@ -138,6 +162,12 @@ class ProductAssociationNormalizerSpec extends ObjectBehavior
         $localeEN->getCode()->willReturn('en_US');
         $channelEcommerce->getCode()->willReturn('ecommerce');
 
+        $product->getImage()->willReturn($image);
+        $imageNormalizer->normalize($image, Argument::any())->willReturn([
+            'filePath' => '/p/i/m/4/all.png',
+            'originalFileName' => 'all.png',
+        ]);
+
         $data = [
             'identifier'    => 'purple_tshirt',
             'family'        => '[tshirt]',
@@ -147,7 +177,11 @@ class ProductAssociationNormalizerSpec extends ObjectBehavior
             'is_checked'    => false,
             'is_associated' => false,
             'label'         => 'Purple tshirt',
-            'completeness'  => 76
+            'completeness'  => 76,
+            'image'         => [
+                'filePath' => '/p/i/m/4/all.png',
+                'originalFileName' => 'all.png',
+            ]
         ];
 
         $this->normalize($product, 'datagrid', $context)->shouldReturn($data);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associated-product-row.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associated-product-row.js
@@ -28,19 +28,6 @@ define(
             thumbnailTemplate: _.template(thumbnailTemplate),
 
             /**
-             * {@inheritdoc}
-             */
-            getThumbnailImagePath() {
-                const image = this.model.get('image');
-
-                if (undefined === image || null === image) {
-                    return '/media/show/undefined/preview';
-                }
-
-                return mediaUrlGenerator.getMediaShowUrl(image, 'thumbnail');
-            },
-
-            /**
              * Returns true if the user has the right to remove an association,
              * hide the remove button in this case.
              *


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a bug where setting asset collection for "attribute used as image" on a family caused the wrong image data to be returned for a product in the association grid. Now the image normalizer is used to return the correct image filePath (before it was returning the original filename). 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
