### PR TITLE
PIM-7011: XLS Options Import - Simple select attribute option cannot be updated for options with numeric codes

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Entity/AttributeOption.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/AttributeOption.php
@@ -137,7 +137,7 @@ class AttributeOption implements AttributeOptionInterface
      */
     public function setCode($code)
     {
-        $this->code = $code;
+        $this->code = (string) $code;
 
         return $this;
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Entity/AttributeOptionSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Entity/AttributeOptionSpec.php
@@ -20,6 +20,12 @@ class AttributeOptionSpec extends ObjectBehavior
         $this->getOptionValue()->shouldReturn(null);
     }
 
+    function its_code_is_a_string()
+    {
+        $this->setCode(1234);
+        $this->getCode()->shouldReturn('1234');
+    }
+
     function it_returns_the_expected_translation(AttributeOptionValueInterface $en, AttributeOptionValueInterface $fr)
     {
         $en->getLocale()->willReturn('en');


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When you try to import an attribute option with an integer as code during a XSLX import we got that error: `Warning code: This property cannot be changed.: 10000`. 

Spout does not convert all field into string like CSV, for instance if I want to import option with a code like `1234` , Spout will give us a integer instead of a string. We storage this code as a string in the database.

We apply Immutable constraint on that code, the validation do a strict comparison. That means that `"1234" !== 1234`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | yes
| Micro Demo to the PO (Story only) | yes
| Migration script                  | -
| Tech Doc                          | -