### PR TITLE
PIM-7046: Add ability to customise empty grid message and pic

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -7,6 +7,7 @@
 - PIM-6996: Associate products to product models during import using the `<assocType>-product_models` pattern in an new column
 - PIM-6342: Display and remove associations gallery view
 - PIM-7051: Add images to associated products that have asset collection as main image
+- PIM-7046: Add ability to customise empty grid message and illustration
 
 ## BC breaks
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid-builder.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid-builder.js
@@ -189,7 +189,8 @@ define([
                     entityHint: metadata.options.entityHint,
                     row: metadata.options.rowView ? requireContext(metadata.options.rowView) : null,
                     displayTypes: metadata.options.displayTypes,
-                    manageColumns: metadata.options.manageColumns
+                    manageColumns: metadata.options.manageColumns,
+                    emptyGridOptions: metadata.options.emptyGridOptions
                 };
             },
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/grid.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/grid.js
@@ -94,7 +94,8 @@ define(
                 multipleSorting:     true,
                 rowActions:          [],
                 massActionsGroups:   [],
-                massActions:         []
+                massActions:         [],
+                emptyGridOptions: null
             },
 
             /**
@@ -354,22 +355,34 @@ define(
                 this.loadingMask.hide();
             },
 
-            /**
-             * Render no data block.
-             */
-            renderNoDataBlock: function () {
-                var entityHint = (this.entityHint || __('oro.datagrid.entityHint')).toLowerCase();
-                var key = 'oro.datagrid.' + (_.isEmpty(this.collection.state.filters) ? 'noentities' : 'noresults');
+            getDefaultNoDataOptions() {
+                const entityHint = (this.entityHint || __('oro.datagrid.entityHint')).toLowerCase();
+                let key = 'oro.datagrid.' + (_.isEmpty(this.collection.state.filters) ? 'noentities' : 'noresults');
 
                 if (Translator.has('jsmessages:' + key + '.' + entityHint)) {
                     key += '.' + entityHint;
                 }
 
-                this.$(this.selectors.noDataBlock).html($(this.noDataTemplate({
-                    hint: __(key, {entityHint: entityHint}).replace('\n', '<br />'),
-                    subHint: __('oro.datagrid.noresults_subTitle')
-                }))).hide();
+                const hint = __(key, {entityHint: entityHint}).replace('\n', '<br />');
+                const subHint = __('oro.datagrid.noresults_subTitle');
 
+                return { hint, subHint, imageClass: '' };
+            },
+
+            /**
+             * Render no data block.
+             */
+            renderNoDataBlock: function () {
+                const customOptions = this.emptyGridOptions;
+                let options = this.getDefaultNoDataOptions();
+
+                if (null !== customOptions && undefined !== customOptions) {
+                    options = customOptions;
+                    options.hint = __(options.hint);
+                    options.subHint = __(options.subHint);
+                }
+
+                this.$(this.selectors.noDataBlock).html($(this.noDataTemplate(options))).hide();
                 this._updateNoDataBlock();
             },
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
@@ -127,3 +127,8 @@ grid.display_selector:
 # Credentials cell
 Client ID: Client ID
 Secret: Secret
+
+grid.empty_results:
+    associated_product:
+        hint: There are no associated products
+        subHint: 'Click on the button "Add associations" to associate this product'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
@@ -9,6 +9,10 @@ datagrid:
                 columnName: is_checked
             rowView: pim/product-edit-form/associated-product-row
             manageFilters: false
+            emptyGridOptions:
+                hint: grid.empty_results.associated_product.hint
+                subHint: grid.empty_results.associated_product.subHint
+                imageClass: AknGridContainer-noDataImage--associations
         source:
             type:              pim_datasource_associated_product
             entity:            '%pim_catalog.entity.product.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -225,7 +225,8 @@ define(
                             if (_.isEmpty(fields)) {
                                 objectValuesDom.append(this.noDataTemplate({
                                     hint: __('oro.datagrid.noresults'),
-                                    subHint: __('oro.datagrid.noresults_subTitle')
+                                    subHint: __('oro.datagrid.noresults_subTitle'),
+                                    imageClass: ''
                                 }));
                             } else {
                                 objectValuesDom.append(fieldsView);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/no-data.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/common/no-data.html
@@ -1,5 +1,5 @@
 <div class="AknGridContainer-noData">
-    <div class="AknGridContainer-noDataImage"></div>
+    <div class="AknGridContainer-noDataImage <%- imageClass %>"></div>
     <div class="AknGridContainer-noDataTitle"><%- hint %></div>
     <div class="AknGridContainer-noDataSubtitle"><%- subHint %></div>
 </div>

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/GridContainer.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/GridContainer.less
@@ -23,6 +23,10 @@
     height: 200px;
     width: 200px;
     margin-bottom: 30px;
+
+    &--associations {
+       background: url("../../../images/illustrations/Association-types.svg") no-repeat center center;
+    }
   }
 
   &-noDataTitle {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR updates the product associations grid to replace the empty message and illustrations with custom ones. Any other grid can be customised the same way by specifying the options in the datagrid yml: 

```diff
 datagrid:
     association-product-grid:
         options:
+            emptyGridOptions:
+                hint: grid.empty_results.associated_product.hint
+                subHint: grid.empty_results.associated_product.subHint
+                imageClass: AknGridContainer-noDataImage--associations
```

![associations_empty](https://user-images.githubusercontent.com/1336344/33898541-0f4909a8-df69-11e7-8ab8-16d4cd86805b.png)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
