### PR TITLE
PIM-6357: clean P&PM query builder for mass edit

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/GridCompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/GridCompletenessFilterIntegration.php
@@ -115,7 +115,9 @@ class GridCompletenessFilterIntegration extends AbstractProductQueryBuilderTestC
      */
     protected function executeFilter(array $filters)
     {
-        $pqb = $this->get('pim_enrich.query.product_and_product_model_query_builder_factory')->create();
+        $pqb = $this->get('pim_enrich.query.product_and_product_model_query_builder_from_size_factory')->create(
+            ['limit' => 100]
+        );
 
         foreach ($filters as $filter) {
             $context = isset($filter[3]) ? $filter[3] : [];

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -6,7 +6,14 @@ use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
 
 /**
- * Provides a way to search simply and efficiently product and product models.
+ * Provides a way to search product and product models.
+ * The results are gathered by the most top level product model matching the search criteria.
+ *
+ * The most simple use case is that we look for documents without any parent
+ * (cf method shouldSearchDocumentsWithoutParent).
+ *
+ * Otherwise, we have to smartly look for products and product models depending on the values
+ * they contain (we add the filter "attributes_for_this_level" in this case).
  *
  * @author    Julien Janvier <j.janvier@gmail.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -70,7 +77,7 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
      */
     public function execute()
     {
-        if ($this->isSearchGroupedByProductModels()) {
+        if ($this->shouldSearchDocumentsWithoutParent()) {
             $this->addFilter('parent', Operators::IS_EMPTY, null);
         }
 
@@ -101,15 +108,12 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
     }
 
     /**
-     * If there are no filter on the following fields, the request should not try to group the result by product models.
-     * - field Id or identifier
-     * - on any attributes
-     * - on the parent field
-     * - on the ancestor field
+     * If there no "particular" filter, that means we want to look for documents that do not have any parent.
+     * This happens for instance with the default grid view.
      *
      * @return bool
      */
-    private function isSearchGroupedByProductModels(): bool
+    private function shouldSearchDocumentsWithoutParent(): bool
     {
         $hasAttributeFilters = $this->hasRawFilter('type', 'attribute');
         $hasParentFilter = $this->hasRawFilter('field', 'parent');

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
@@ -62,7 +62,7 @@ services:
     pim_enrich.query.product_and_product_model_query_builder_factory:
         class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
         arguments:
-            - '%pim_enrich.query.product_and_product_model_query_builder.class%'
+            - '%pim_enrich.query.mass_edit_product_and_product_model_query_builder.class%'
             - '@pim_enrich.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor'
 
     pim_enrich.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor:
@@ -85,10 +85,3 @@ services:
             - '@pim_catalog.repository.product_model'
             - '%pim_catalog.factory.product_cursor.page_size%'
             - 'pim_catalog_product'
-
-    # Misc
-    pim_enrich.query.mass_edit_product_and_product_model_query_builder_factory:
-        class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
-        arguments:
-            - '%pim_enrich.query.mass_edit_product_and_product_model_query_builder.class%'
-            - '@pim_enrich.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
@@ -29,6 +29,7 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
     # Services used by the products and product models' grid
+    # here, products and product models should be gathered by the most top level product model
     pim_enrich.query.product_and_product_model_query_builder_from_size_factory:
         class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
         arguments:
@@ -57,6 +58,7 @@ services:
             - 'pim_catalog_product'
 
     # Services used by the mass edit
+    # here, products and product models should not be gathered
     pim_enrich.query.product_and_product_model_query_builder_factory:
         class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
         arguments:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
@@ -28,23 +28,12 @@ services:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
-    pim_enrich.factory.product_and_product_model_from_size_cursor:
-        class: '%pim_enrich.elasticsearch.from_size_cursor_factory.class%'
+    # Services used by the products and product models' grid
+    pim_enrich.query.product_and_product_model_query_builder_from_size_factory:
+        class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
         arguments:
-            - '@akeneo_elasticsearch.client.product_and_product_model'
-            - '@pim_catalog.repository.product'
-            - '@pim_catalog.repository.product_model'
-            - '%pim_catalog.factory.product_cursor.page_size%'
-            - 'pim_catalog_product'
-
-    pim_enrich.factory.product_and_product_model_cursor:
-        class: '%pim_enrich.elasticsearch.cursor_factory.class%'
-        arguments:
-            - '@akeneo_elasticsearch.client.product_and_product_model'
-            - '@pim_catalog.repository.product'
-            - '@pim_catalog.repository.product_model'
-            - '%pim_catalog.factory.product_cursor.page_size%'
-            - 'pim_catalog_product'
+            - '%pim_enrich.query.product_and_product_model_query_builder.class%'
+            - '@pim_enrich.query.product_query_builder_from_size_factory.with_product_and_product_model_from_size_cursor'
 
     pim_enrich.query.product_query_builder_from_size_factory.with_product_and_product_model_from_size_cursor:
         public: false
@@ -57,11 +46,22 @@ services:
             - '@pim_enrich.factory.product_and_product_model_from_size_cursor'
             - '@pim_catalog.elasticsearch.product_query_builder_from_size_resolver'
 
-    pim_enrich.query.product_and_product_model_query_builder_from_size_factory:
+    pim_enrich.factory.product_and_product_model_from_size_cursor:
+        public: false
+        class: '%pim_enrich.elasticsearch.from_size_cursor_factory.class%'
+        arguments:
+            - '@akeneo_elasticsearch.client.product_and_product_model'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_model'
+            - '%pim_catalog.factory.product_cursor.page_size%'
+            - 'pim_catalog_product'
+
+    # Services used by the mass edit
+    pim_enrich.query.product_and_product_model_query_builder_factory:
         class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
         arguments:
             - '%pim_enrich.query.product_and_product_model_query_builder.class%'
-            - '@pim_enrich.query.product_query_builder_from_size_factory.with_product_and_product_model_from_size_cursor'
+            - '@pim_enrich.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor'
 
     pim_enrich.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor:
         public: false
@@ -74,12 +74,17 @@ services:
             - '@pim_enrich.factory.product_and_product_model_cursor'
             - '@pim_catalog.query.product_query_builder_resolver'
 
-    pim_enrich.query.product_and_product_model_query_builder_factory:
-        class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
+    pim_enrich.factory.product_and_product_model_cursor:
+        public: false
+        class: '%pim_enrich.elasticsearch.cursor_factory.class%'
         arguments:
-            - '%pim_enrich.query.product_and_product_model_query_builder.class%'
-            - '@pim_enrich.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor'
+            - '@akeneo_elasticsearch.client.product_and_product_model'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_model'
+            - '%pim_catalog.factory.product_cursor.page_size%'
+            - 'pim_catalog_product'
 
+    # Misc
     pim_enrich.query.mass_edit_product_and_product_model_query_builder_factory:
         class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
         arguments:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
@@ -17,7 +17,7 @@ services:
     pim_enrich.reader.database.product_and_product_model:
         class: '%pim_enrich.reader.database.product_and_product_model.class%'
         arguments:
-            - '@pim_enrich.query.mass_edit_product_and_product_model_query_builder_factory'
+            - '@pim_enrich.query.product_and_product_model_query_builder_factory'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.manager.completeness'
 

--- a/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
@@ -79,13 +79,14 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
             ]
         );
 
+        $pqb->addFilter('parent', Operators::IS_EMPTY, null, [])->shouldNotBeCalled();
         $pqb->addFilter('attributes_for_this_level', Operators::IN_LIST, ['foo', 'baz'], [])->shouldBeCalled();
         $pqb->execute()->willReturn($cursor);
 
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_executes_the_query_by_adding_a_default_filter_on_parents_when_there_is_no_attribute_filter_nor_parent_filter($pqb, CursorInterface $cursor)
+    function it_executes_the_query_by_adding_a_default_filter_on_parents($pqb, CursorInterface $cursor)
     {
         $pqb->getRawFilters()->willReturn(
             [
@@ -106,31 +107,31 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_executes_the_query_by_adding_a_filter_on_attributes_and_filter_on_parent($pqb, CursorInterface $cursor)
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_attribute_filter($pqb, CursorInterface $cursor)
     {
         $pqb->getRawFilters()->willReturn(
             [
-                [
-                    'field'    => 'foo',
-                    'operator' => 'CONTAINS',
-                    'value'    => '42',
-                    'context'  => [],
-                    'type'     => 'attribute'
-                ],
                 [
                     'field'    => 'bar',
                     'operator' => 'IN LIST',
                     'value'    => ['toto'],
                     'context'  => [],
-                    'type'     => 'field'
-                ],
-                [
-                    'field'    => 'baz',
-                    'operator' => 'EQUALS',
-                    'value'    => 'sku_893042',
-                    'context'  => [],
                     'type'     => 'attribute'
                 ],
+            ]
+        );
+
+        $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
+        $pqb->addFilter('attributes_for_this_level', Argument::cetera())->shouldBeCalled();
+        $pqb->execute()->willReturn($cursor);
+
+        $this->execute()->shouldReturn($cursor);
+    }
+
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_parent_filter($pqb, CursorInterface $cursor)
+    {
+        $pqb->getRawFilters()->willReturn(
+            [
                 [
                     'field'    => 'parent',
                     'operator' => 'IN LIST',
@@ -141,8 +142,107 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
             ]
         );
 
-        $pqb->addFilter('parent', Operators::IS_EMPTY, null, [])->shouldNotBeCalled();
-        $pqb->addFilter('attributes_for_this_level', Operators::IN_LIST, ['foo', 'baz'], [])->shouldBeCalled();
+        $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
+        $pqb->execute()->willReturn($cursor);
+
+        $this->execute()->shouldReturn($cursor);
+    }
+
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_id_filter($pqb, CursorInterface $cursor)
+    {
+        $pqb->getRawFilters()->willReturn(
+            [
+                [
+                    'field'    => 'id',
+                    'operator' => 'IN LIST',
+                    'value'    => ['toto'],
+                    'context'  => [],
+                    'type'     => 'field'
+                ],
+            ]
+        );
+
+        $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
+        $pqb->execute()->willReturn($cursor);
+
+        $this->execute()->shouldReturn($cursor);
+    }
+
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_identifier_filter($pqb, CursorInterface $cursor)
+    {
+        $pqb->getRawFilters()->willReturn(
+            [
+                [
+                    'field'    => 'identifier',
+                    'operator' => 'IN LIST',
+                    'value'    => ['toto'],
+                    'context'  => [],
+                    'type'     => 'field'
+                ],
+            ]
+        );
+
+        $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
+        $pqb->execute()->willReturn($cursor);
+
+        $this->execute()->shouldReturn($cursor);
+    }
+
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_entity_type_filter($pqb, CursorInterface $cursor)
+    {
+        $pqb->getRawFilters()->willReturn(
+            [
+                [
+                    'field'    => 'entity_type',
+                    'operator' => 'EQUALS',
+                    'value'    => 'toto',
+                    'context'  => [],
+                    'type'     => 'field'
+                ],
+            ]
+        );
+
+        $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
+        $pqb->execute()->willReturn($cursor);
+
+        $this->execute()->shouldReturn($cursor);
+    }
+
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_ancestor_filter($pqb, CursorInterface $cursor)
+    {
+        $pqb->getRawFilters()->willReturn(
+            [
+                [
+                    'field'    => 'ancestor.id',
+                    'operator' => 'IN LIST',
+                    'value'    => ['toto'],
+                    'context'  => [],
+                    'type'     => 'field'
+                ],
+            ]
+        );
+
+        $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
+        $pqb->execute()->willReturn($cursor);
+
+        $this->execute()->shouldReturn($cursor);
+    }
+
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_ancestor_or_self_filter($pqb, CursorInterface $cursor)
+    {
+        $pqb->getRawFilters()->willReturn(
+            [
+                [
+                    'field'    => 'self_and_ancestor.id',
+                    'operator' => 'IN LIST',
+                    'value'    => ['toto'],
+                    'context'  => [],
+                    'type'     => 'field'
+                ],
+            ]
+        );
+
+        $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
 
         $this->execute()->shouldReturn($cursor);


### PR DESCRIPTION
What's done here:

- re organize the `query_builders.yml` file to understand what's used by the grid, what's used by the mass edit
- add specs and docs for the P&PMQB class
- remove a useless service

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

