### PR TITLE
PIM-7030: not allow null Metric data Attribute for NotEmptyVariantAxesValidator // BIS

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -6,6 +6,7 @@
 - PIM-7011: XLS Options Import - Simple select attribute option cannot be updated for options with numeric codes
 - PIM-7039: Association grid, scopable attributes used as labels do not appear
 - PIM-6980: Missing labels for attribute prevent you from creating a variant family
+- PIM-7030: Not allow empty Metric value as axis for variant products
 
 ## Better manage products with variants!
 

--- a/features/mass-action/mass_add_to_existing_product_model.feature
+++ b/features/mass-action/mass_add_to_existing_product_model.feature
@@ -62,3 +62,32 @@ Feature: Apply a add to products to existing product model
     Then I should see the text "COMPLETED"
     And I should see the text "Processed 1"
     And the parent of the product "1111111171" should be "model-braided-hat"
+    
+  Scenario: Fail to adds products to product model with null metric axis
+    Given I am on the products page
+    And the following attributes:
+      | code                  | label-en_US           | type                     | unique | group     | decimals_allowed | negative_allowed | metric_family | default_metric_unit | useable_as_grid_filter |
+      | display_diagonal      | Display diagonal      | pim_catalog_metric       | 0      | other     | 0                | 0                | Length        | INCH                | 1                      |
+    And the following family:
+      | code     | label-en_US | attributes                              |
+      | led_tvs  | LED TVs     | display_diagonal,sku,color,weight |
+    And the following family variants:
+      | code                | family   | label-en_US                | variant-axes_1      | variant-attributes_1   |
+      | tv_diagonal         | led_tvs  | Tv by display diagonal     | display_diagonal    | display_diagonal,sku   |
+    And the following root product models:
+      | code      | family_variant |
+      | model-tv  | tv_diagonal    |
+    And the following products:
+      | sku         | family   | parent          | color | weight   |
+      | 68591524    | led_tvs  |                 | black | 478 GRAM |
+    And I filter by "family" with operator "in list" and value "LED TVs"
+    And I select rows 68591524
+    And I press the "Bulk actions" button
+    And I choose the "Add to an existing product model" operation
+    And I fill in the following information:
+      | Family (required)        | LED TVs |
+      | Product model (required) | model-tv |
+    When I confirm mass edit
+    And I wait for the "add_to_existing_product_model" job to finish
+    Then I should see the text "COMPLETED"
+    And I should see the text "attribute: Attribute \"display_diagonal\" cannot be empty"

--- a/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
@@ -60,9 +60,10 @@ class NotEmptyVariantAxesValidator extends ConstraintValidator
 
         foreach ($axes as $axis) {
             $value = $entity->getValue($axis->getCode());
+            $isEmptyMetricValue = (null !== $value && $value->getData() instanceof MetricInterface &&
+                null === $value->getData()->getData());
 
-            if ((null === $value || (empty($value->getData()) && !is_bool($value->getData()))) ||
-                (null !== $value && $value->getData() instanceof MetricInterface && null === $value->getData()->getData())) {
+            if ((null === $value || (empty($value->getData()) && !is_bool($value->getData()))) || $isEmptyMetricValue) {
                 $this->context->buildViolation(NotEmptyVariantAxes::EMPTY_AXIS_VALUE, [
                     '%attribute%' => $axis->getCode()
                 ])->atPath($constraint->propertyPath)->addViolation();

--- a/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
@@ -4,7 +4,7 @@ namespace Pim\Component\Catalog\Validator\Constraints;
 
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
-use Pim\Component\Catalog\Model\Metric;
+use Pim\Component\Catalog\Model\MetricInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -62,7 +62,7 @@ class NotEmptyVariantAxesValidator extends ConstraintValidator
             $value = $entity->getValue($axis->getCode());
 
             if ((null === $value || (empty($value->getData()) && !is_bool($value->getData()))) ||
-                (null !== $value && $value->getData() instanceof Metric && null === $value->getData()->getData())) {
+                (null !== $value && $value->getData() instanceof MetricInterface && null === $value->getData()->getData())) {
                 $this->context->buildViolation(NotEmptyVariantAxes::EMPTY_AXIS_VALUE, [
                     '%attribute%' => $axis->getCode()
                 ])->atPath($constraint->propertyPath)->addViolation();

--- a/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/NotEmptyVariantAxesValidator.php
@@ -4,6 +4,7 @@ namespace Pim\Component\Catalog\Validator\Constraints;
 
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\Metric;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -49,7 +50,8 @@ class NotEmptyVariantAxesValidator extends ConstraintValidator
         // be on the 3 level sub_product_model_2 -> sub_product_model_1 -> root_product_model) and will return the axes
         // on the 3 level.
         if ($entity instanceof ProductModelInterface && null !== $entity->getParent()) {
-            if (null !== $entity->getParent()->getParent() || 1 === (int) $entity->getParent()->getFamilyVariant()->getNumberOfLevel()) {
+            if (null !== $entity->getParent()->getParent() ||
+                1 === (int) $entity->getParent()->getFamilyVariant()->getNumberOfLevel()) {
                 return;
             }
         }
@@ -59,7 +61,8 @@ class NotEmptyVariantAxesValidator extends ConstraintValidator
         foreach ($axes as $axis) {
             $value = $entity->getValue($axis->getCode());
 
-            if (null === $value || (empty($value->getData()) && !is_bool($value->getData()))) {
+            if ((null === $value || (empty($value->getData()) && !is_bool($value->getData()))) ||
+                (null !== $value && $value->getData() instanceof Metric && null === $value->getData()->getData())) {
                 $this->context->buildViolation(NotEmptyVariantAxes::EMPTY_AXIS_VALUE, [
                     '%attribute%' => $axis->getCode()
                 ])->atPath($constraint->propertyPath)->addViolation();

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/NotEmptyVariantAxesValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/NotEmptyVariantAxesValidatorSpec.php
@@ -7,6 +7,7 @@ use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvide
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\MetricInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Validator\Constraints\NotEmptyVariantAxes;
 use Prophecy\Argument;
@@ -109,6 +110,38 @@ class NotEmptyVariantAxesValidatorSpec extends ObjectBehavior
             ->buildViolation(
                 NotEmptyVariantAxes::EMPTY_AXIS_VALUE, [
                     '%attribute%' => 'color'
+                ]
+            )
+            ->willReturn($violation);
+        $violation->atPath('attribute')->willReturn($violation);
+        $violation->addViolation()->shouldBeCalled();
+
+        $this->validate($entity, $constraint);
+    }
+
+    function it_raises_a_violation_if_the_entity_has_no_value_for_an_metric_axis(
+        $axesProvider,
+        $context,
+        EntityWithFamilyVariantInterface $entity,
+        FamilyVariantInterface $familyVariant,
+        NotEmptyVariantAxes $constraint,
+        AttributeInterface $attribute,
+        MetricInterface $metric,
+        ValueInterface $value,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $entity->getFamilyVariant()->willReturn($familyVariant);
+        $axesProvider->getAxes($entity)->willReturn([$attribute]);
+        
+        $value->getData()->willReturn($metric);
+        $metric->getData()->willReturn(null);
+        $attribute->getCode()->willReturn('display_diagonal');
+        $entity->getValue('display_diagonal')->willReturn(null);
+
+        $context
+            ->buildViolation(
+                NotEmptyVariantAxes::EMPTY_AXIS_VALUE, [
+                    '%attribute%' => 'display_diagonal'
                 ]
             )
             ->willReturn($violation);


### PR DESCRIPTION
I make a mistake on rebase - already 2 GTM on it : 
https://github.com/akeneo/pim-community-dev/pull/7307