### PR TITLE
PIM-7059: Test product and variant product mass deletion

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/ORM/Repository/ProductMassActionRepositoryIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/ORM/Repository/ProductMassActionRepositoryIntegration.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Doctrine\ORM\Repository;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+
+/**
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductMassActionRepositoryIntegration extends TestCase
+{
+    public function testCanMassDeleteNonVariantProduct()
+    {
+        $product = $this->createNonVariantProduct();
+        $productId = $product->getId();
+
+        $deletedProductsCount = $this->get('pim_catalog.repository.product_mass_action')->deleteFromIds([$productId]);
+        $this->assertSame(1, $deletedProductsCount);
+        $this->assertNull($this->get('pim_catalog.repository.product')->findOneById($productId));
+    }
+
+    public function testCanMassDeleteVariantProduct()
+    {
+        $variantProduct = $this->createVariantProduct();
+        $variantProductId = $variantProduct->getId();
+
+        $deletedVariantProductsCount = $this->get('pim_catalog.repository.product_mass_action')->deleteFromIds(
+            [$variantProductId]
+        );
+        $this->assertSame(1, $deletedVariantProductsCount);
+        $this->assertNull($this->get('pim_catalog.repository.variant_product')->findOneById($variantProductId));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @return ProductInterface
+     */
+    private function createNonVariantProduct(): ProductInterface
+    {
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
+
+        return $entityBuilder->createProduct('a_product', 'familyA', []);
+    }
+
+    /**
+     * @return VariantProductInterface
+     */
+    private function createVariantProduct(): VariantProductInterface
+    {
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
+
+        $productModel = $entityBuilder->createProductModel('a_product_model', 'familyVariantA2', null, []);
+
+        return $entityBuilder->createVariantProduct(
+            'a_variant_product',
+            'familyA',
+            'familyVariantA2',
+            $productModel,
+            [
+                'values' => [
+                    'a_simple_select' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => 'optionA',
+                        ],
+                    ],
+                    'a_yes_no' =>  [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => true,
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+}

--- a/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Handler/DeleteProductsMassActionHandler.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Handler/DeleteProductsMassActionHandler.php
@@ -6,7 +6,6 @@ use Akeneo\Component\StorageUtils\Indexer\IndexerInterface;
 use Akeneo\Component\StorageUtils\Remover\BulkRemoverInterface;
 use Oro\Bundle\DataGridBundle\Datagrid\DatagridInterface;
 use Oro\Bundle\DataGridBundle\Datasource\ResultRecord;
-use Oro\Bundle\DataGridBundle\Datasource\ResultRecordInterface;
 use Oro\Bundle\DataGridBundle\Extension\MassAction\Actions\MassActionInterface;
 use Oro\Bundle\DataGridBundle\Extension\MassAction\MassActionResponse;
 use Pim\Bundle\DataGridBundle\Datasource\ResultRecord\HydratorInterface;


### PR DESCRIPTION
## Description

When removing a variant product (belonging to a product model) via a mass delete on Enterprise Edition, the product is removed from Elasticsearch, but not from MySQL.

This is caused by a wrong service declaration, only in EE, and only for variant products. This PR adds the same integration tests on the `ProductMassActionRepository` than the EE pull request to prevent any future regression.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
