### PR TITLE
PIM-7087: Fix completeness normalizer on numeric channel code

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -11,6 +11,8 @@
 - PIM-7049: Fix random order of attribute options 
 - PIM-7080: Fix memory leak on product export
 - PIM-6955: Fix delete user
+- PIM-7065: Fix versioning when attribute codes are numerics.
+- PIM-7087: Fix completeness normalization when channel code is numeric.
 
 ## Improvements
 
@@ -28,7 +30,6 @@
 
 - PIM-7032: Fix close button when clicking on "Compare/Translate" option on the product edit form
 - PIM-7063: Add validation for AttributeGroup - cannot remove AttributeGroup containing attributes and cannot remove AttributGroup "other"
-- PIM-7065: Fix versioning when attribute codes are numerics.
 
 # 2.0.9 (2017-12-15)
 

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/CompletenessCollectionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/CompletenessCollectionNormalizer.php
@@ -96,6 +96,7 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
         }
 
         foreach ($sortedCompletenesses as $channelCode => $channelCompletenesses) {
+            $channelCode = (string) $channelCode;
             $normalizedCompletenesses[] = [
                 'channel'   => $channelCode,
                 'labels'    => $this->getChannelLabels($channels, $locales, $channelCode),
@@ -223,7 +224,7 @@ class CompletenessCollectionNormalizer implements NormalizerInterface
      *
      * @return string[]
      */
-    protected function getChannelLabels(array $channels, array $locales, $channelCode)
+    protected function getChannelLabels(array $channels, array $locales, string $channelCode)
     {
         $matchingChannels = array_filter($channels, function (ChannelInterface $channel) use ($channelCode) {
             return $channel->getCode() === $channelCode;

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/CompletenessCollectionNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/CompletenessCollectionNormalizerSpec.php
@@ -6,7 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\AttributeTranslation;
 use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Model\AttributeTranslationInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\ChannelTranslationInterface;
 use Pim\Component\Catalog\Model\CompletenessInterface;
@@ -37,31 +36,42 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
         ArrayCollection $attributeCollectionMobileFrFR,
         ArrayCollection $attributeCollectionPrintEnUS,
         ArrayCollection $attributeCollectionPrintFrFR,
+        ArrayCollection $attributeCollectionNumericEnUS,
+        ArrayCollection $attributeCollectionNumericFrFR,
         \ArrayIterator $attributeIteratorMobileEnUS,
         \ArrayIterator $attributeIteratorMobileFrFR,
         \ArrayIterator $attributeIteratorPrintEnUS,
         \ArrayIterator $attributeIteratorPrintFrFR,
+        \ArrayIterator $attributeIteratorNumericEnUS,
+        \ArrayIterator $attributeIteratorNumericFrFR,
         CompletenessInterface $completenessMobileEnUS,
         CompletenessInterface $completenessMobileFrFR,
         CompletenessInterface $completenessPrintEnUS,
         CompletenessInterface $completenessPrintFrFR,
+        CompletenessInterface $completenessNumericEnUS,
+        CompletenessInterface $completenessNumericFrFR,
         ChannelInterface $mobile,
         ChannelInterface $print,
+        ChannelInterface $numeric,
         LocaleInterface $enUS,
         LocaleInterface $frFR,
         ChannelTranslationInterface $translationMobileEn,
         ChannelTranslationInterface $translationMobileFr,
         ChannelTranslationInterface $translationPrintEn,
-        ChannelTranslationInterface $translationPrintFr
+        ChannelTranslationInterface $translationPrintFr,
+        ChannelTranslationInterface $translationNumericEn,
+        ChannelTranslationInterface $translationNumericFr
     ) {
         $completenessCollection->getIterator()->willReturn($completenessIterator);
         $completenessIterator->rewind()->shouldBeCalled();
-        $completenessIterator->valid()->willReturn(true, true, true, true, false);
+        $completenessIterator->valid()->willReturn(true, true, true, true, true, true, false);
         $completenessIterator->current()->willReturn(
             $completenessMobileEnUS,
             $completenessMobileFrFR,
             $completenessPrintEnUS,
-            $completenessPrintFrFR
+            $completenessPrintFrFR,
+            $completenessNumericEnUS,
+            $completenessNumericFrFR
         );
         $completenessIterator->next()->shouldBeCalled();
 
@@ -88,6 +98,18 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
         $attributeIteratorPrintFrFR->valid()->willReturn(true, false);
         $attributeIteratorPrintFrFR->current()->willReturn($attribute);
         $attributeIteratorPrintFrFR->next()->shouldBeCalled();
+
+        $attributeCollectionNumericEnUS->getIterator()->willReturn($attributeIteratorNumericEnUS);
+        $attributeIteratorNumericEnUS->rewind()->shouldBeCalled();
+        $attributeIteratorNumericEnUS->valid()->willReturn(true, false);
+        $attributeIteratorNumericEnUS->current()->willReturn($attribute);
+        $attributeIteratorNumericEnUS->next()->shouldBeCalled();
+
+        $attributeCollectionNumericFrFR->getIterator()->willReturn($attributeIteratorNumericFrFR);
+        $attributeIteratorNumericFrFR->rewind()->shouldBeCalled();
+        $attributeIteratorNumericFrFR->valid()->willReturn(true, false);
+        $attributeIteratorNumericFrFR->current()->willReturn($attribute);
+        $attributeIteratorNumericFrFR->next()->shouldBeCalled();
 
         $completenessMobileEnUS->getChannel()->willReturn($mobile);
         $completenessMobileEnUS->getLocale()->willReturn($enUS);
@@ -117,8 +139,23 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
         $completenessPrintFrFR->getMissingCount()->willReturn(1);
         $completenessPrintFrFR->getMissingAttributes()->willReturn($attributeCollectionPrintFrFR);
 
+        $completenessNumericEnUS->getChannel()->willReturn($numeric);
+        $completenessNumericEnUS->getLocale()->willReturn($enUS);
+        $completenessNumericEnUS->getRatio()->willReturn(50);
+        $completenessNumericEnUS->getRequiredCount()->willReturn(2);
+        $completenessNumericEnUS->getMissingCount()->willReturn(1);
+        $completenessNumericEnUS->getMissingAttributes()->willReturn($attributeCollectionNumericEnUS);
+
+        $completenessNumericFrFR->getChannel()->willReturn($numeric);
+        $completenessNumericFrFR->getLocale()->willReturn($frFR);
+        $completenessNumericFrFR->getRatio()->willReturn(50);
+        $completenessNumericFrFR->getRequiredCount()->willReturn(2);
+        $completenessNumericFrFR->getMissingCount()->willReturn(1);
+        $completenessNumericFrFR->getMissingAttributes()->willReturn($attributeCollectionNumericFrFR);
+
         $mobile->getCode()->willReturn('mobile');
         $print->getCode()->willReturn('print');
+        $numeric->getCode()->willReturn("1234567890");
         $enUS->getCode()->willReturn('en_US');
         $frFR->getCode()->willReturn('fr_FR');
         $enUS->getName()->willReturn('English');
@@ -127,10 +164,14 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
         $mobile->getTranslation('fr_FR')->willReturn($translationMobileFr);
         $print->getTranslation('en_US')->willReturn($translationPrintEn);
         $print->getTranslation('fr_FR')->willReturn($translationPrintFr);
+        $numeric->getTranslation('en_US')->willReturn($translationNumericEn);
+        $numeric->getTranslation('fr_FR')->willReturn($translationNumericFr);
         $translationMobileEn->getLabel()->willReturn('mobile');
         $translationMobileFr->getLabel()->willReturn('mobile');
         $translationPrintEn->getLabel()->willReturn('print');
         $translationPrintFr->getLabel()->willReturn('impression');
+        $translationNumericEn->getLabel()->willReturn("1234567890");
+        $translationNumericFr->getLabel()->willReturn("1234567890");
 
         $attribute->getCode()->willReturn('name');
         $attribute->getTranslation('en_US')->willReturn($attributeTranslationEn);
@@ -138,7 +179,7 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
         $attributeTranslationEn->getLabel()->willReturn('Name');
         $attributeTranslationFr->getLabel()->willReturn('Nom');
 
-        $normalizer->normalize(Argument::cetera())->shouldBeCalledTimes(4);
+        $normalizer->normalize(Argument::cetera())->shouldBeCalledTimes(6);
         $normalizer
             ->normalize($completenessMobileEnUS, 'internal_api', ['a_context_key' => 'context_value'])
             ->willReturn([]);
@@ -151,7 +192,13 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
         $normalizer
             ->normalize($completenessPrintFrFR, 'internal_api', ['a_context_key' => 'context_value'])
             ->willReturn([]);
-        
+        $normalizer
+            ->normalize($completenessNumericEnUS, 'internal_api', ['a_context_key' => 'context_value'])
+            ->willReturn([]);
+        $normalizer
+            ->normalize($completenessNumericFrFR, 'internal_api', ['a_context_key' => 'context_value'])
+            ->willReturn([]);
+
         $this
             ->normalize($completenessCollection, 'internal_api', ['a_context_key' => 'context_value'])
             ->shouldReturn([
@@ -233,7 +280,46 @@ class CompletenessCollectionNormalizerSpec extends ObjectBehavior
                         'label'        => "French",
                     ]
                 ]
-            ]
+            ], [
+                    'channel' => "1234567890",
+                    'labels'  => [
+                        'en_US' => "1234567890",
+                        'fr_FR' => "1234567890",
+                    ],
+                    'stats'   => [
+                        'total'    => 2,
+                        'complete' => 0,
+                        'average'  => 50,
+                    ],
+                    'locales' => [
+                        'en_US' => [
+                            'completeness' => [],
+                            'missing'      => [
+                                [
+                                    'code'   => "name",
+                                    'labels' => [
+                                        'en_US' => 'Name',
+                                        'fr_FR' => 'Nom'
+                                    ]
+                                ],
+                            ],
+                            'label'        => "English",
+                        ],
+                        'fr_FR' => [
+                            'completeness' => [],
+                            'missing'      => [
+                                [
+                                    'code'  => "name",
+                                    'labels' => [
+                                        'en_US' => 'Name',
+                                        'fr_FR' => 'Nom'
+                                    ]
+                                ],
+                            ],
+                            'label'        => "French",
+                        ],
+                    ],
+                ]
         ]);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

During generation of data using data generator, we encountered a problem because it generates numeric channel code on the completeness normalizer. This PR aims to allow it.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
