### PR TITLE
PIM-7032: change css from AttributeActions to ActionButton

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # 2.0.x
 
+## Bug fixes
+
+- PIM-7032: Fix close button when clicking on "Compare/Translate" option on the product edit form
+
 # 2.0.9 (2017-12-15)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/copy.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/tab/attributes/copy.html
@@ -15,7 +15,7 @@
                 </ul>
             </div>
             <div class="AknButtonList-item AknButton AknButton--small AknButton--apply copy"><%- _.__('pim_enrich.entity.product.copy.copy') %></div>
-            <div class="AknButtonList-item AknAttributeActions-close stop-copying"></div>
+            <div class="AknButtonList-item AknAttributeActions-close AknIconButton--delete stop-copying"></div>
         </div>
     </div>
 <% } %>

--- a/src/Pim/Bundle/UIBundle/Resources/config/assets.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/config/assets.yml
@@ -48,6 +48,7 @@ css:
         - bundles/pimui/less/components/grid/MassActions.less
 
         - bundles/pimui/less/components/product-edit-form/AssetCollectionField.less
+        - bundles/pimui/less/components/product-edit-form/AttributeActions.less
         - bundles/pimui/less/components/product-edit-form/ChoicesField.less
         - bundles/pimui/less/components/product-edit-form/CommentPanel.less
         - bundles/pimui/less/components/product-edit-form/CompletenessPanel.less

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AttributeActions.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AttributeActions.less
@@ -1,0 +1,28 @@
+@import '../../base/variables';
+
+.AknAttributeActions {
+  display: flex;
+  flex-wrap: wrap;
+
+  &-close {
+    width: 20px;
+    height: 20px;
+  }
+
+  &-copyActions {
+    flex-basis: 100%;
+    display: flex;
+    justify-content: space-between;
+    margin-top: 16px;
+    padding-left: @AknMaxFormWidth;
+  }
+
+  &-editActions {
+    flex-basis: 100%;
+  }
+
+  &-contextSelectors {
+    border-left: 1px solid @AknBorderColor;
+    padding-left: 10px;
+  }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
In Version 2.0.7 the PEF, when clicking on the "Compare/Translate" option, the close button is missing and "locale" and "Channel" are misaligned.
This is a regression, it was fine in V2.0.6

![capture du 2017-12-18 14-52-54](https://user-images.githubusercontent.com/34027529/34109219-2f6cd8c4-e403-11e7-8c79-a37683c7f11f.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
