### PR TITLE
Fix some JS code style on family variant forms

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes.js
@@ -7,7 +7,8 @@
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-define([
+define(
+    [
         'underscore',
         'oro/translator',
         'pim/form',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/family-variant.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/family-variant.js
@@ -1,6 +1,7 @@
 'use strict';
 
-define([
+define(
+    [
         'underscore',
         'pim/form',
         'oro/mediator',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant-fields-container.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant-fields-container.js
@@ -148,10 +148,10 @@ define(
                             const entities = _.map(attributeResults, (attribute) => {
                                 const label = this.getEntityLabel(attribute, catalogLocale);
 
-                            return {
+                                return {
                                     id: attribute.code,
                                     text: label
-                                }
+                                };
                             });
 
                             const sortedEntities = _.sortBy(entities, 'text');
@@ -202,10 +202,10 @@ define(
                         const data = _.map(arguments, (attribute) => {
                             const label = this.getEntityLabel(attribute, catalogLocale);
 
-return {
+                            return {
                                 id: attribute.code,
                                 text: label
-                            }
+                            };
                         });
 
                         callback(data);
@@ -282,7 +282,7 @@ return {
                     return '[' + entity.code + ']';
                 }
 
-                return entity.labels[locale]
+                return entity.labels[locale];
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant-form.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant-form.js
@@ -38,8 +38,7 @@ define(
                 return $.post(
                     Routing.generate('pim_enrich_family_variant_rest_create'),
                     JSON.stringify(this.getFormData())
-                )
-                .fail((xhr) => {
+                ).fail((xhr) => {
                     this.trigger('pim_enrich:form:entity:validation_error', xhr.responseJSON);
                 });
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant-header.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant-header.js
@@ -43,7 +43,7 @@ define(
                                 familyName: i18n.getLabel(family.labels, catalogLocal, family.code)
                             })
                         );
-                    })
+                    });
             }
         });
     }


### PR DESCRIPTION
## Description

Some weird JavaScript code style was spotted in the last merge of 2.0 into 2.1. The problems came from 2.0, not from the merge itself. This PR fixes it.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
