### PR TITLE
PIM-7065 Fix versioning when attribute code is numeric

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -27,6 +27,7 @@
 
 - PIM-7032: Fix close button when clicking on "Compare/Translate" option on the product edit form
 - PIM-7063: Add validation for AttributeGroup - cannot remove AttributeGroup containing attributes and cannot remove AttributGroup "other"
+- PIM-7065: Fix versioning when attribute codes are numerics.
 
 # 2.0.9 (2017-12-15)
 

--- a/src/Pim/Bundle/VersioningBundle/Builder/VersionBuilder.php
+++ b/src/Pim/Bundle/VersioningBundle/Builder/VersionBuilder.php
@@ -147,7 +147,7 @@ class VersionBuilder
             $oldSnapshot
         );
 
-        $mergedSnapshot = array_merge_recursive($localNewSnapshot, $localOldSnapshot);
+        $mergedSnapshot = array_replace_recursive($localNewSnapshot, $localOldSnapshot);
 
         return array_map(
             function ($mergedItem) {

--- a/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/CollectionNormalizer.php
+++ b/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/CollectionNormalizer.php
@@ -47,7 +47,7 @@ class CollectionNormalizer implements NormalizerInterface, SerializerAwareInterf
                         // for prices and metric
                         $result[$key] = $result[$key] . ',' . $value;
                     } else {
-                        $result = array_merge($result, $normalizedItem);
+                        $result = array_replace($result, $normalizedItem);
                     }
                 }
             } else {

--- a/src/Pim/Bundle/VersioningBundle/spec/Builder/VersionBuilderSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Builder/VersionBuilderSpec.php
@@ -48,7 +48,7 @@ class VersionBuilderSpec extends ObjectBehavior
         $pending->setSnapshot(['foo' => 'bar'])->willReturn($pending);
         $pending->getChangeset()->willReturn(['foo' => 'bar']);
 
-        $pending->setChangeset(['foo' => ['old' => '', 'new' => 'bar']])->willReturn($pending);
+        $pending->setChangeset(['foo' => ['old' => '', 'new' => 'bar']])->shouldBeCalled()->willReturn($pending);
 
         $this->buildPendingVersion($pending);
     }

--- a/src/Pim/Bundle/VersioningBundle/spec/Builder/VersionBuilderSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Builder/VersionBuilderSpec.php
@@ -52,4 +52,15 @@ class VersionBuilderSpec extends ObjectBehavior
 
         $this->buildPendingVersion($pending);
     }
+
+    function it_builds_pending_versions_with_attribute_with_numeric_code(Version $pending)
+    {
+        $pending->setVersion(1)->willReturn($pending);
+        $pending->setSnapshot([12345678 => 'bar'])->willReturn($pending);
+        $pending->getChangeset()->willReturn([12345678 => 'bar']);
+
+        $pending->setChangeset([12345678 => ['old' => '', 'new' => 'bar']])->shouldBeCalled()->willReturn($pending);
+
+        $this->buildPendingVersion($pending);
+    }
 }

--- a/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/CollectionNormalizerSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/CollectionNormalizerSpec.php
@@ -59,7 +59,7 @@ class CollectionNormalizerSpec extends ObjectBehavior
         $this->normalize($collection, null, ['field_name' => 'even'])->shouldReturn(['even' => 'Four,Eight,Fifteen']);
     }
 
-    function it_concatenate_normalized_elements_using_the_same_key(
+    function it_concatenates_normalized_elements_using_the_same_key(
         $serializer,
         Collection $collection
     ) {
@@ -71,7 +71,7 @@ class CollectionNormalizerSpec extends ObjectBehavior
         $this->normalize($collection, null, ['field_name' => 'even'])->shouldReturn(['even' => 'Four,Eight,Fifteen']);
     }
 
-    function its_normalize_method_throw_exception_when_required_field_name_key_is_not_passed(
+    function it_normalizes_method_throw_exception_when_required_field_name_key_is_not_passed(
         $serializer,
         Collection $collection
     ) {
@@ -83,5 +83,21 @@ class CollectionNormalizerSpec extends ObjectBehavior
         $this
             ->shouldThrow(new InvalidArgumentException('Missing required "field_name" context value, got "foo"'))
             ->duringNormalize($collection, null, ['foo' => 'bar']);
+    }
+
+    function it_normalizes_attribute_with_numeric_code(
+        $serializer,
+        Collection $collection
+    ) {
+        $collection->getIterator()->willReturn(new \ArrayIterator([4, 8, 15]));
+        $serializer->normalize(4, null, ['field_name' => 98796])->willReturn([98796 => 'Four']);
+        $serializer->normalize(8, null, ['field_name' => 98796])->willReturn([12345 => 'Eight']);
+        $serializer->normalize(15, null, ['field_name' => 98796])->willReturn([78901 => 'Fifteen']);
+
+        $this->normalize($collection, null, ['field_name' => 98796])->shouldReturn([
+            98796 => 'Four',
+            12345 => 'Eight',
+            78901 => 'Fifteen',
+        ]);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This aims to make the history useable when some attributes have a numeric code. Before, using array_merge, the code was normalized from '12345678' to '1' because array_merge reindexes the array.
Use array_replace instead fix this bug by reusing the key. Furthermore, array_replace conserve the ensemblist union from the right to the left.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
