### PR TITLE
Pim 7063: Add validation for AttributeGroup - cannot remove AttributeGroup containing attributes and cannot remove AttributGroup "other"

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7032: Fix close button when clicking on "Compare/Translate" option on the product edit form
+- PIM-7063: Add validation for AttributeGroup - cannot remove AttributeGroup containing attributes and cannot remove AttributGroup "other"
 
 # 2.0.9 (2017-12-15)
 

--- a/features/attribute-group/delete_attribute_group.feature
+++ b/features/attribute-group/delete_attribute_group.feature
@@ -21,9 +21,14 @@ Feature: Attribute group creation
     And I confirm the deletion
     Then I should see the flash message "Attribute group successfully removed"
 
-  @javascript @skip
   Scenario: Fail to delete an attribute group that contains attributes
     Given I am on the "colors" attribute group page
-    When I press the "Delete" button and wait for modal
+    When I press the secondary action "Delete"
     And I confirm the deletion
-    Then I should see the flash message "Attribute group can't be removed as it contains attributes"
+    Then I should see the flash message "Attribute group containing attributes cannot be removed. Please remove its attributes prior to delete it."
+
+  Scenario: Fail to delete the attribute "other"
+    Given I am on the "other" attribute group page
+    When I press the secondary action "Delete"
+    And I confirm the deletion
+    Then I should see the flash message "Attribute group \"other\" cannot be removed."

--- a/features/user/edit_user_group_and_role_assignations.feature
+++ b/features/user/edit_user_group_and_role_assignations.feature
@@ -52,7 +52,7 @@ Feature: Edit a user groups and roles
   Scenario: Assign a group to a user from the group page
     Given I edit the "Redactor" user group
     And I visit the "Users" tab
-    When I click on the "Peter" row
+    When I check the rows "Peter"
     And I save the group
     And I visit the "Users" tab
     Then the row "Peter" should be checked
@@ -60,7 +60,7 @@ Feature: Edit a user groups and roles
   Scenario: Assign a role to a user from the role page
     Given I edit the "Catalog manager" role
     And I visit the "Users" tab
-    When I click on the "Peter" row
+    When I check the rows "Peter"
     And I save the role
     Then the row "Peter" should be checked
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
@@ -338,19 +338,18 @@ class AttributeGroupController
 
         if ('other' === $attributeGroup->getCode()) {
             return new JsonResponse(
-                array(
+                [
                     'message' => 'Attribute group "other" cannot be removed.'
-                ),
+                ],
                 Response::HTTP_UNPROCESSABLE_ENTITY
             );
         }
 
         if (0 < $attributeGroup->getAttributes()->count()) {
             return new JsonResponse(
-                array(
-                    'message' => 'Attribute group containing attributes cannot be removed. 
-                    Please remove its attributes prior to delete it.'
-                ),
+                [
+                    'message' => 'Attribute group containing attributes cannot be removed. Please remove its attributes prior to delete it.'
+                ],
                 Response::HTTP_UNPROCESSABLE_ENTITY
             );
         }

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
@@ -336,6 +336,25 @@ class AttributeGroupController
     {
         $attributeGroup = $this->getAttributeGroupOr404($identifier);
 
+        if ('other' === $attributeGroup->getCode()) {
+            return new JsonResponse(
+                array(
+                    'message' => 'Attribute group "other" cannot be removed.'
+                ),
+                Response::HTTP_UNPROCESSABLE_ENTITY
+            );
+        }
+
+        if (0 < $attributeGroup->getAttributes()->count()) {
+            return new JsonResponse(
+                array(
+                    'message' => 'Attribute group containing attributes cannot be removed. 
+                    Please remove its attributes prior to delete it.'
+                ),
+                Response::HTTP_UNPROCESSABLE_ENTITY
+            );
+        }
+
         $this->remover->remove($attributeGroup);
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
@@ -347,9 +347,7 @@ class AttributeGroupController
 
         if (0 < $attributeGroup->getAttributes()->count()) {
             return new JsonResponse(
-                [
-                    'message' => 'Attribute group containing attributes cannot be removed. Please remove its attributes prior to delete it.'
-                ],
+                ['message' => 'Attribute group containing attributes cannot be removed. Please remove its attributes prior to delete it.'],
                 Response::HTTP_UNPROCESSABLE_ENTITY
             );
         }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
If you remove an attribute group, you cannot access the attributes belonging to this group anymore. 
They cannot be moved to another group.

Expected behaviour: 
- you cannot remove an attribute group if you have attributes in it
![capture du 2017-12-20 17-05-51](https://user-images.githubusercontent.com/34027529/34216294-1acd173e-e5a8-11e7-9e15-06ba9db68f3a.png)
- you can never remove the OTHER attribute group
![capture du 2017-12-20 17-05-35](https://user-images.githubusercontent.com/34027529/34216308-26274dc0-e5a8-11e7-8863-662c8dfc1960.png)

If you have attributes in your attribute group, the pim should display a message. 
In 1.6 we displayed: “Attribute group can’t be removed as it contains attributes” I suggest (a bit long): “Attribute group containing attributes cannot be removed. Please remove its attributes prior to delete it.” 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
