### PR TITLE
PIM-7048: Family imports return a cascade persist issue when families have variant family

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -6,10 +6,12 @@
 - PIM-6944: Fix delta export for variant products
 - PIM-7070: Fix sequential edit when selecting multiple product models
 - PIM-6812: Change the message when delete an attribute as variant axis
+- PIM-7048: Fix cascade persist issue during import of families with variant
 
 ## BC breaks
 
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\AttributeController` add `Doctrine\ORM\EntityManagerInterface` and `Symfony\Component\Translation\TranslatorInterface`
+- Changes the constructor of `Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber` add `Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface`
 
 # 2.0.10 (2017-12-22)
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pim\Bundle\CatalogBundle\EventSubscriber;
 
+use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Component\StorageUtils\StorageEvents;
 use Pim\Component\Catalog\Model\FamilyInterface;
@@ -26,14 +27,22 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
     /** @var BulkSaverInterface */
     private $familyVariantSaver;
 
+    /** @var BulkObjectDetacherInterface */
+    private $objectDetacher;
+
     /**
-     * @param ValidatorInterface $validator
-     * @param BulkSaverInterface $familyVariantSaver
+     * @param ValidatorInterface          $validator
+     * @param BulkSaverInterface          $familyVariantSaver
+     * @param BulkObjectDetacherInterface $objectDetacher
      */
-    public function __construct(ValidatorInterface $validator, BulkSaverInterface $familyVariantSaver)
-    {
+    public function __construct(
+        ValidatorInterface $validator,
+        BulkSaverInterface $familyVariantSaver,
+        BulkObjectDetacherInterface $objectDetacher = null
+    ) {
         $this->validator = $validator;
         $this->familyVariantSaver = $familyVariantSaver;
+        $this->objectDetacher = $objectDetacher;
     }
 
     /**
@@ -74,6 +83,10 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         }
 
         $this->familyVariantSaver->saveAll($validFamilyVariants);
+
+        if (null !== $this->objectDetacher) {
+            $this->objectDetacher->detachAll($validFamilyVariants);
+        }
 
         if (!empty($allViolations)) {
             $errorMessage = $this->getErrorMessage($allViolations);

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -166,5 +166,6 @@ services:
         arguments:
             - '@validator'
             - '@pim_catalog.saver.family_variant'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
 
+use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Component\StorageUtils\StorageEvents;
 use Doctrine\Common\Collections\Collection;
@@ -16,9 +17,13 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 {
-    function let(ValidatorInterface $validator, BulkSaverInterface $familyVariantSaver)
+    function let(
+        ValidatorInterface $validator,
+        BulkSaverInterface $familyVariantSaver,
+        BulkObjectDetacherInterface $objectDetacher
+    )
     {
-        $this->beConstructedWith($validator, $familyVariantSaver);
+        $this->beConstructedWith($validator, $familyVariantSaver, $objectDetacher);
     }
 
     function it_is_initializable()
@@ -49,6 +54,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
     function it_validates_and_saves_family_variants_on_family_update(
         $validator,
         $familyVariantSaver,
+        $objectDetacher,
         GenericEvent $event,
         FamilyInterface $family,
         Collection $familyVariants,
@@ -71,6 +77,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $constraintViolationList->count()->willReturn(0);
 
         $familyVariantSaver->saveAll([$familyVariants1, $familyVariants2])->shouldBeCalled();
+        $objectDetacher->detachAll([$familyVariants1, $familyVariants2])->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
         $this->validateAndSaveFamilyVariants($event);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

During a family import, family variants are loaded in the unit of work but they are not detached after the family saving. At the end of the job we send notification to user, notification are saved in database. So the `flush` method is called here that means that the previous loaded family variant are synchronize with the DB but cascade persist is not configured between Family and Family Variant.

We got this error:
```
A new entity was found through the relationship 'Pim\Component\Catalog\Model\FamilyVariant#family' that was not configured to cascade persist operations for entity: Accessories. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example @ManyToOne(..,cascade={"persist"}). 
```

If we detach family cariant we avoid that error.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
