### PR TITLE
[PIM-7049] Fix random sort of attribute options

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -7,6 +7,7 @@
 - PIM-7070: Fix sequential edit when selecting multiple product models
 - PIM-6812: Change the message when delete an attribute as variant axis
 - PIM-7048: Fix cascade persist issue during import of families with variant
+- PIM-7049: Fix random order of attribute options 
 
 ## BC breaks
 

--- a/features/Context/Page/Attribute/Creation.php
+++ b/features/Context/Page/Attribute/Creation.php
@@ -65,6 +65,12 @@ class Creation extends Form
 
     public function createOption()
     {
+        $this->spin(function () {
+            $loadingWrapper = $this->find('css', '.loading-mask');
+
+            return (null === $loadingWrapper || !$loadingWrapper->isVisible());
+        }, 'Loading mask is still visible');
+
         $table = $this->getElement('attribute_option_table');
 
         $this->spin(function () use ($table) {

--- a/features/attribute/option/sort_attribute_options.feature
+++ b/features/attribute/option/sort_attribute_options.feature
@@ -68,7 +68,7 @@ Feature: Sort attribute options
       | Code    | shoes_variant     |
       | Family  | Clothing          |
       | Variant | Clothing by color |
-    And I press the "Save" button
+    And I press the "Save" button in the popin
     And I am on the "amor" product model page
     When I open the variant navigation children selector for level 1
     And I press the "Add new" button and wait for modal

--- a/features/attribute/option/sort_attribute_options.feature
+++ b/features/attribute/option/sort_attribute_options.feature
@@ -4,15 +4,13 @@ Feature: Sort attribute options
   As a product manager
   I need to sort options for attributes of type "Multi select" and "Simple select"
 
-  Background:
+  Scenario: Auto sorting disable reorder
     Given the "footwear" catalog configuration
     And I am logged in as "Julia"
     And I am on the attributes page
     And I am on the "color" attribute page
     And I visit the "Options" tab
-
-  Scenario: Auto sorting disable reorder
-    Given I check the "Sort automatically options by alphabetical order" switch
+    And I check the "Sort automatically options by alphabetical order" switch
     Then I should not see reorder handles
     And the attribute options order should be black, blue, charcoal, greem, maroon, red, saddle, white
     When I uncheck the "Sort automatically options by alphabetical order" switch
@@ -20,7 +18,12 @@ Feature: Sort attribute options
     And the attribute options order should be white, black, blue, maroon, saddle, greem, red, charcoal
 
   Scenario: Display attribute options ordered in PEF
-    Given I check the "Sort automatically options by alphabetical order" switch
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the attributes page
+    And I am on the "color" attribute page
+    And I visit the "Options" tab
+    And I check the "Sort automatically options by alphabetical order" switch
     And I save the attribute
     And I should not see the text "There are unsaved changes"
     And I am on the products grid
@@ -34,7 +37,12 @@ Feature: Sort attribute options
     Then I should see the ordered choices Black, Blue, Charcoal, Greem, Maroon, Red, Saddle, White in Color
 
   Scenario: Display attribute options ordered in PEF when there are options without label
-    Given I check the "Sort automatically options by alphabetical order" switch
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the attributes page
+    And I am on the "color" attribute page
+    And I visit the "Options" tab
+    And I check the "Sort automatically options by alphabetical order" switch
     And I create the following attribute options:
       | Code   |
       | yellow |
@@ -50,3 +58,19 @@ Feature: Sort attribute options
     And I wait to be on the "boots" product page
     When I visit the "Colors" group
     Then I should see the ordered choices [pink], [yellow], Black, Blue, Charcoal, Greem, Maroon, Red, Saddle, White in Color
+
+  Scenario: Display attribute options ordered in a product variant creation (even twice)
+    Given the "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the products grid
+    And I create a product model
+    When I fill in the following information in the popin:
+      | Code    | shoes_variant     |
+      | Family  | Clothing          |
+      | Variant | Clothing by color |
+    And I press the "Save" button
+    And I am on the "amor" product model page
+    When I open the variant navigation children selector for level 1
+    And I press the "Add new" button and wait for modal
+    Then I should see the ordered choices Black, Blue, Brown, Green, Grey, Navy blue, Orange, Pink, Red, White, Yellow, Battleship grey, Crimson red, Electric yellow, Antique white in Color
+    And I should see the ordered choices Black, Blue, Brown, Green, Grey, Navy blue, Orange, Pink, Red, White, Yellow, Battleship grey, Crimson red, Electric yellow, Antique white in Color

--- a/features/product/history/display_removed_value_history.feature
+++ b/features/product/history/display_removed_value_history.feature
@@ -22,7 +22,7 @@ Feature: Display the product history
     Then there should be 2 update
     And I should see history:
       | version | property           | value      |
-      | 2       | Weather conditions | cold,snowy |
+      | 2       | Weather conditions | snowy,cold |
     When I am on the "weather_conditions" attribute page
     And I visit the "Options" tab
     And I remove the "snowy" option
@@ -34,7 +34,7 @@ Feature: Display the product history
     Then there should be 2 updates
     And I should see history:
       | version | property           | value      |
-      | 2       | Weather conditions | cold,snowy |
+      | 2       | Weather conditions | snowy,cold |
 
   @skip @info https://akeneo.atlassian.net/browse/TIP-233
   Scenario: Update product history when a linked category is removed
@@ -155,7 +155,7 @@ Feature: Display the product history
     Then there should be 2 update
     And I should see history:
       | version | property           | value      |
-      | 2       | Weather conditions | cold,snowy |
+      | 2       | Weather conditions | snowy,cold |
       | 2       | Name en            | Nice boots |
     When I am on the "weather_conditions" attribute page
     And I press the secondary action "Delete"
@@ -169,5 +169,5 @@ Feature: Display the product history
     Then there should be 2 update
     And I should see history:
       | version | property           | value      |
-      | 2       | weather_conditions | cold,snowy |
+      | 2       | weather_conditions | snowy,cold |
       | 2       | name-en_US         | Nice boots |

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeOptionRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AttributeOptionRepository.php
@@ -46,7 +46,7 @@ class AttributeOptionRepository extends EntityRepository implements
             ->leftJoin('o.optionValues', 'v', 'WITH', 'v.locale=:locale')
             ->leftJoin('o.attribute', 'a')
             ->where('o.attribute=:attribute')
-            ->orderBy('o.sortOrder')
+            ->orderBy('o.sortOrder, o.code')
             ->setParameter('locale', $dataLocale)
             ->setParameter('attribute', $collectionId);
         if ($search) {

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Attribute.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/doctrine/Attribute.orm.yml
@@ -140,6 +140,7 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
                 - detach
             orderBy:
                 sortOrder: ASC
+                code: ASC
         translations:
             targetEntity: Pim\Component\Catalog\Model\AttributeTranslationInterface
             mappedBy: foreignKey

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeOptionSearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeOptionSearchableRepository.php
@@ -69,7 +69,7 @@ class AttributeOptionSearchableRepository implements SearchableRepositoryInterfa
         } else {
             $qb
                 ->leftJoin('o.optionValues', 'v')
-                ->orderBy('o.sortOrder');
+                ->orderBy('o.sortOrder, o.code');
         }
 
         if ($search) {

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
@@ -115,7 +115,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
             'identifier'         => $identifier,
             'axes_values_labels' => $this->getAxesValuesLabelsForLocales($entity, $localeCodes),
             'labels'             => $labels,
-            'order_string'       => $this->getOrderString($entity),
+            'order'              => $this->getOrder($entity),
             'image'              => $this->normalizeImage($image, $format, $context),
             'model_type'         => $entity instanceof ProductModelInterface ? 'product_model' : 'product',
             'completeness'       => $this->getCompletenessDependingOnEntity($entity)
@@ -229,32 +229,33 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
     }
 
     /**
-     * Generate a string for the given $entity to represent its order among all its axes values.
+     * Generate an array for the given $entity to represent its order among all its axes values.
      *
      * For example, if its axes values are "Blue, 10 CENTIMETER" and Blue is an option with a sort order equals to 4,
-     * it will return "4, 10 CENTIMETER".
+     * it will return [4, blue, 10 CENTIMETER].
      *
-     * It allows to sort on this string to respect sort orders of attribute options.
+     * It allows to sort on front-end to respect sort orders of attribute options.
      *
      * @param EntityWithFamilyVariantInterface $entity
      *
-     * @return string
+     * @return array
      */
-    private function getOrderString(EntityWithFamilyVariantInterface $entity): string
+    private function getOrder(EntityWithFamilyVariantInterface $entity): array
     {
-        $orderStringArray = [];
+        $orderArray = [];
 
         foreach ($this->attributesProvider->getAxes($entity) as $axisAttribute) {
             $value = $entity->getValue($axisAttribute->getCode());
 
             if (AttributeTypes::OPTION_SIMPLE_SELECT === $axisAttribute->getType()) {
                 $option = $value->getData();
-                $orderStringArray[] = $option->getSortOrder();
+                $orderArray[] = $option->getSortOrder();
+                $orderArray[] = $option->getCode();
             } else {
-                $orderStringArray[] = (string) $value;
+                $orderArray[] = (string) $value;
             }
         }
 
-        return implode(', ', $orderStringArray);
+        return $orderArray;
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -156,6 +156,8 @@ define(
                             this.stopEditItem();
                             if (!this.parent.sortable) {
                                 this.parent.render();
+                            } else {
+                                this.parent.updateSorting();
                             }
                         }.bind(this),
                         error: this.showValidationErrors.bind(this)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -462,7 +462,6 @@ define(
                 }
             },
             updateSorting: function () {
-                this.inLoading(true);
                 var sorting = [];
 
                 var rows = this.$el.find('tbody tr');
@@ -474,9 +473,7 @@ define(
                     url: this.sortingUrl,
                     type: 'PUT',
                     data: JSON.stringify(sorting)
-                }).done(function () {
-                    this.inLoading(false);
-                }.bind(this));
+                });
             },
             inLoading: function (loading) {
                 if (loading) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -392,7 +392,17 @@ define(
                         .fetchChildren(parentId)
                         .then((children) => {
                             const childrenResults = this.searchOnResults(options.term, children);
-                            const sortedChildrenResults = _.sortBy(childrenResults, 'order_string');
+                            const sortedChildrenResults = childrenResults.sort((item1, item2) => {
+                                for (let i = 0; i < item1.order.length; i++) {
+                                    if (item1.order[i] > item2.order[i]) {
+                                        return 1;
+                                    } else if (item1.order[i] < item2.order[i]) {
+                                        return -1;
+                                    }
+                                }
+
+                                return 0;
+                            });
 
                             options.callback({
                                 results: sortedChildrenResults

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
@@ -90,6 +90,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         $colorAttributeOption->setLocale('fr_FR')->shouldBeCalled();
         $colorAttributeOption->setLocale('en_US')->shouldBeCalled();
         $colorAttributeOption->getSortOrder()->willReturn(2);
+        $colorAttributeOption->getCode()->willReturn('white');
         $colorAttributeOption->getTranslation()->willReturn($colorAttributeOptionValue);
         $colorAttributeOptionValue->getLabel()->willReturn('Blanc', 'White');
         $sizeValue->__toString()->willReturn('S');
@@ -115,7 +116,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
                 'fr_FR' => 'Tshirt Blanc S',
                 'en_US' => 'Tshirt White S',
             ],
-            'order_string'       => '2, S',
+            'order'              => [2, 'white', 'S'],
             'image'              => null,
             'model_type'         => 'product',
             'completeness'       => ['NORMALIZED_COMPLETENESS']
@@ -151,6 +152,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         $colorAttributeOption->setLocale('fr_FR')->shouldBeCalled();
         $colorAttributeOption->setLocale('en_US')->shouldBeCalled();
         $colorAttributeOption->getSortOrder()->willReturn(2);
+        $colorAttributeOption->getCode()->willReturn('white');
         $colorAttributeOption->getTranslation()->willReturn($colorAttributeOptionValue);
         $colorAttributeOptionValue->getLabel()->willReturn('Blanc', 'White');
 
@@ -168,7 +170,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
                 'fr_FR' => 'Tshirt Blanc',
                 'en_US' => 'Tshirt White',
             ],
-            'order_string'       => '2',
+            'order'              => [2, 'white'],
             'image'              => null,
             'model_type'         => 'product_model',
             'completeness'       => ['NORMALIZED COMPLETENESS']

--- a/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/ValueNormalizer.php
+++ b/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/ValueNormalizer.php
@@ -176,7 +176,9 @@ class ValueNormalizer implements NormalizerInterface, SerializerAwareInterface
         usort(
             $options,
             function ($first, $second) {
-                return $first->getSortOrder() - $second->getSortOrder();
+                $sort = $first->getSortOrder() - $second->getSortOrder();
+
+                return $sort !== 0 ?? $first->getCode() - $second->getCode();
             }
         );
         $sortedCollection = new ArrayCollection($options);


### PR DESCRIPTION
Sometimes where sort_order are the same (ex all with 1 at the initialization of the PIM), they are not displalyed on the same order in the different places of the PIM.

I added a new sort with code to ensure at each place of the PIM they are sorted by code if they have the same sort_order.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | y
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | y
| Micro Demo to the PO (Story only) | y
| Migration script                  | -
| Tech Doc                          | -

