### PR TITLE
PIM-6812: Change the message when delete an attribute as variant axis

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,13 +5,18 @@
 - PIM-7062: Allow to delete attributes contained in a family variant
 - PIM-6944: Fix delta export for variant products
 - PIM-7070: Fix sequential edit when selecting multiple product models
+- PIM-6812: Change the message when delete an attribute as variant axis
+
+## BC breaks
+
+- Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\AttributeController` add `Doctrine\ORM\EntityManagerInterface` and `Symfony\Component\Translation\TranslatorInterface`
 
 # 2.0.10 (2017-12-22)
 
 ## Bug fixes
 
 - PIM-7032: Fix close button when clicking on "Compare/Translate" option on the product edit form
-- PIM-7063: Add validation for AttributeGroup
+- PIM-7063: Add validation for AttributeGroup - cannot remove AttributeGroup containing attributes and cannot remove AttributGroup "other"
 
 # 2.0.9 (2017-12-15)
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/AttributeIsAFamilyVariantAxis.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/AttributeIsAFamilyVariantAxis.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Query;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
+
+/**
+ * Checks if an attribute is used as family variant axis
+ *
+ * @author    Arnaud Langlade <arnaud.langlade@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AttributeIsAFamilyVariantAxis
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /**
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * @param string $attributeCode
+     *
+     * @return bool
+     */
+    public function execute(string $attributeCode): bool
+    {
+        $query = $this->entityManager->createQueryBuilder()
+            ->select('COUNT(attribute_set.id)')
+            ->from(VariantAttributeSetInterface::class, 'attribute_set')
+            ->innerJoin('attribute_set.axes', 'attribute')
+            ->where('attribute.code = :attribute_code')
+            ->setParameter('attribute_code', $attributeCode)
+            ->getQuery();
+
+        return 0 < $query->getSingleScalarResult();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
@@ -2,6 +2,7 @@ parameters:
     pim_catalog.doctrine.query.find_variant_product_completeness.class: 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\VariantProductRatio'
     pim_catalog.doctrine.query.complete_filter.class: 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\CompleteFilter'
     pim_catalog.doctrine.query.convert_product_to_variant_product.class: 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\ConvertProductToVariantProduct'
+    pim_catalog.doctrine.query.attribute_is_an_family_variant_axis.class: 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\AttributeIsAFamilyVariantAxis'
 
 services:
     pim_catalog.doctrine.query.find_variant_product_completeness:
@@ -16,5 +17,10 @@ services:
 
     pim_catalog.doctrine.query.convert_product_to_variant_product:
         class: '%pim_catalog.doctrine.query.convert_product_to_variant_product.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'
+
+    pim_catalog.doctrine.query.attribute_is_an_family_variant_axis:
+        class: '%pim_catalog.doctrine.query.attribute_is_an_family_variant_axis.class%'
         arguments:
             - '@doctrine.orm.entity_manager'

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Query/AttributeIsAFamilyVariantAxisSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Query/AttributeIsAFamilyVariantAxisSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Doctrine\ORM\Query;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\AttributeIsAFamilyVariantAxis;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
+use Prophecy\Argument;
+
+class AttributeIsAFamilyVariantAxisSpec extends ObjectBehavior
+{
+    function let(EntityManagerInterface $entityManager)
+    {
+        $this->beConstructedWith($entityManager);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AttributeIsAFamilyVariantAxis::class);
+    }
+
+    function it_checks_if_an_attribute_is_used_as_variant_axis(
+        $entityManager,
+        QueryBuilder $queryBuilder,
+        AbstractQuery $query
+    ) {
+        $entityManager->createQueryBuilder()->willReturn($queryBuilder);
+        $queryBuilder->from(VariantAttributeSetInterface::class, 'attribute_set')->willReturn($queryBuilder);
+        $queryBuilder->select('COUNT(attribute_set.id)')->willReturn($queryBuilder);
+        $queryBuilder->innerJoin('attribute_set.axes', 'attribute')->willReturn($queryBuilder);
+        $queryBuilder->where('attribute.code = :attribute_code')->willReturn($queryBuilder);
+        $queryBuilder->setParameter('attribute_code', 'size')->willReturn($queryBuilder);
+        $queryBuilder->getQuery()->willReturn($query);
+
+        $query->getSingleScalarResult()->willReturn(1);
+
+        $this->execute('size')->shouldReturn(true);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Attribute/Query/AttributeIsAFamilyVariantAxisIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Attribute/Query/AttributeIsAFamilyVariantAxisIntegration.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Attribute\Query;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+class AttributeIsAFamilyVariantAxisIntegration extends TestCase
+{
+    /**
+     * @test
+     */
+    function it_returns_true_if_an_attribute_is_used_as_variant_axis()
+    {
+        $result = $this->getFromTestContainer('pim_catalog.doctrine.query.attribute_is_an_family_variant_axis')
+            ->execute('color');
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    function it_returns_false_if_an_attribute_is_not_used_as_variant_axis()
+    {
+        $result = $this->getFromTestContainer('pim_catalog.doctrine.query.attribute_is_an_family_variant_axis')
+            ->execute('sku');
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+}

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
@@ -57,8 +57,13 @@ define([
                 this.model.destroy({
                     url: this.getLink(),
                     wait: true,
-                    error: function() {
-                        this.getErrorDialog().open();
+                    error: function(element, response) {
+                        let message = '';
+                        const decodedResponse = JSON.parse(response.responseText);
+                        if (undefined !== decodedResponse.message) {
+                            message = decodedResponse.message
+                        }
+                        this.getErrorDialog(message).open();
                     }.bind(this),
                     success: function() {
                         var messageText = __('flash.' + this.getEntityCode() + '.removed');
@@ -93,11 +98,11 @@ define([
              *
              * @return {oro.Modal}
              */
-            getErrorDialog: function() {
+            getErrorDialog: function(message) {
                 if (!this.errorModal) {
                     this.errorModal = new Modal({
                         title: __('Delete Error'),
-                        content: __('error.removing.' + this.getEntityHint()),
+                        content: '' === message ? __('error.removing.' + this.getEntityHint()) : message,
                         cancelText: false
                     });
                 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -194,6 +194,8 @@ services:
             - '@pim_user.context.user'
             - '@pim_catalog.localization.localizer.number'
             - '@pim_enrich.normalizer.attribute'
+            - '@translator'
+            - '@pim_catalog.doctrine.query.attribute_is_an_family_variant_axis'
 
     pim_enrich.controller.rest.attribute_type:
         class: '%pim_enrich.controller.rest.attribute_type.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -24,6 +24,8 @@ pim_enrich:
             history.title:   History
     # Family
     family:
+        info:
+            cant_remove_attribute_used_as_axis: Cannot remove this attribute used as a variant axis in a family variant
         tab:
             property.title:  Properties
             attribute.title: Attributes


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We cannot delete an attribute use as family variant axis (business rule). When the front send a request to remove an attribute, we check if the attribute belongs to a family variant before. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added Behats                      | -
| Added integration tests           | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
