### PR TITLE
PIM-7041: Fix reference data sorter

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,6 +1,13 @@
+# 1.6.x
+
+## Bug fixes
+
+- PIM-7041: Fix a bug that prevents to sort on a reference data attribute on product grid
+
 # 1.6.20 (2017-10-25) 
 
 ## Bug fixes
+
 - GITHUB-6984: Fix wrong path when generating js routes, cheers @amansilla!
 
 # 1.6.19 (2017-09-05)

--- a/features/reference-data/product/sorting/sort_products_per_reference_data.feature
+++ b/features/reference-data/product/sorting/sort_products_per_reference_data.feature
@@ -2,9 +2,9 @@
 Feature: Sort products
   In order to enrich my catalog
   As a regular user
-  I need to be able to manually sort products per attributes
+  I need to be able to manually sort products per reference data attributes
 
-  Background:
+  Scenario: Successfully sort products by simple reference data
     Given the "footwear" catalog configuration
     And the following "sole_color" attribute reference data: Red, Blue and Green
     And the following "sole_fabric" attribute reference data: Cashmerewool, Neoprene and Silk
@@ -19,9 +19,31 @@ Feature: Sort products
       | postit  | heel_color  | Pink              |
       | postit  | sole_fabric | Cashmerewool,Silk |
     And I am logged in as "Mary"
+    When I am on the products page
+    Then the grid should contain 2 elements
+    When I display the columns SKU, Sole color, Heel color and Sole fabric
+    Then I sort by "Sole color" value ascending
 
-  Scenario: Successfully sort products by simple reference data
-    Given I am on the products page
-    And the grid should contain 2 elements
-    And I display the columns SKU, Sole color, Heel color and Sole fabric
-    And I sort by "Sole color" value ascending
+  @jira https://akeneo.atlassian.net/browse/PIM-7041
+  Scenario: Sort a simple-select reference data attribute with the same name than its reference data
+    Given the "default" catalog configuration
+    And the following attribute:
+      | code  | label | type                        | reference_data_name | useable_as_grid_filter |
+      | color | Color | reference_data_simpleselect | color               | yes                    |
+    And the following "color" attribute reference data: Red, Blue and Green
+    And the following family:
+      | code     | requirements-mobile | requirements-ecommerce |
+      | whatever | sku, color          | sku, color             |
+    And the following products:
+      | sku      | family   |
+      | productA | whatever |
+      | productB | whatever |
+    And the following product values:
+      | product  | attribute | value |
+      | productA | color     | Red   |
+    And I am logged in as "Mary"
+    When I am on the products page
+    And I display the columns SKU and color
+    Then I should see the text "Red"
+    When I sort by "Color" value ascending
+    Then I should see the text "Red"

--- a/src/Pim/Bundle/ReferenceDataBundle/Doctrine/ORM/Sorter/ReferenceDataSorter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/Doctrine/ORM/Sorter/ReferenceDataSorter.php
@@ -63,8 +63,9 @@ class ReferenceDataSorter implements AttributeSorterInterface
         );
 
         // join to reference data
-        $joinAliasOpt = $attribute->getCode();
-        $this->qb->leftJoin($joinAlias . '.' . $attribute->getReferenceDataName(), $joinAliasOpt);
+        $referenceDataName = $attribute->getReferenceDataName();
+        $joinAliasOpt = $this->getUniqueAlias('reference_data' . $referenceDataName);
+        $this->qb->leftJoin($joinAlias . '.' . $referenceDataName, $joinAliasOpt);
 
         $this->qb->addOrderBy($joinAliasOpt . '.code', $direction);
         $idField = current($this->qb->getRootAliases()) . '.id';
@@ -93,8 +94,6 @@ class ReferenceDataSorter implements AttributeSorterInterface
      * @param string             $locale    the locale
      * @param string             $scope     the scope
      *
-     * @throws \Pim\Component\Catalog\Exception\ProductQueryException
-     *
      * @return string
      */
     protected function prepareAttributeJoinCondition(
@@ -106,5 +105,17 @@ class ReferenceDataSorter implements AttributeSorterInterface
         $joinHelper = new ValueJoin($this->qb);
 
         return $joinHelper->prepareCondition($attribute, $joinAlias, $locale, $scope);
+    }
+
+    /**
+     * Get a unique alias
+     *
+     * @param string $alias
+     *
+     * @return string
+     */
+    protected function getUniqueAlias($alias)
+    {
+        return uniqid($alias);
     }
 }


### PR DESCRIPTION
## Description

Let's say you have a simple-select reference data named `color`, and you create an attribute to use it, its code being `color` too, and make this attribute usable in grid filter.
You'll then be able to add a column for this attribute in the product grid and you'll see the values in the column.

But the moment you sort on this attribute, the values will disappear (and be back if you sort on an other attribute or reinitialize the grid). This bug is caused by a wrong datagrid query in the simple-select reference data sorter, fixed by this PR. The problem is present only in ORM.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
