### PR TITLE
PIM-6968 - fix mass delete product

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - PIM-7032: Fix close button when clicking on "Compare/Translate" option on the product edit form
 - PIM-7063: Add validation for AttributeGroup - cannot remove AttributeGroup containing attributes and cannot remove AttributGroup "other"
+- PIM-6968: Fix mass delete product
 
 # 2.0.9 (2017-12-15)
 

--- a/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Handler/DeleteProductsMassActionHandler.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Handler/DeleteProductsMassActionHandler.php
@@ -72,12 +72,9 @@ class DeleteProductsMassActionHandler extends DeleteMassActionHandler
             ));
         }
 
-        while ($cursor->valid()) {
-            $objectIds = [];
-            foreach ($cursor as $productObject) {
-                $objectIds[] = $productObject->getId();
-            }
-            $cursor->next();
+        $objectIds = [];
+        foreach ($cursor as $productObject) {
+            $objectIds[] = $productObject->getId();
         }
 
         try {

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/mass_actions.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/mass_actions.yml
@@ -79,6 +79,7 @@ services:
         class: '%pim_datagrid.extension.mass_action.handler.product_delete.class%'
         arguments:
             - '@pim_catalog.elasticsearch.indexer.product'
+            - '@pim_enrich.factory.product_and_product_model_cursor'
         parent: pim_datagrid.extension.mass_action.handler.delete
         tags:
             - { name: pim_datagrid.extension.mass_action.handler, alias: product_mass_delete }

--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/messages.en.yml
@@ -11,6 +11,7 @@ oro.grid.mass_action.error_content: Cannot perform mass action
 oro.grid.mass_action.delete.label: Delete
 oro.grid.mass_action.delete.confirm_title: Mass Delete Confirmation
 oro.grid.mass_action.delete.confirm_content: Are you sure you want to do delete selected items?
+oro.grid.mass_action.delete.item_limit: You cannot mass delete more than %limit% products (%count% selected)
 oro.grid.datagrid.page_size.all: All
 oro.grid.mass_action.delete.success_message: "{0} No entities were removed|{1} One entity was removed|]1,Inf[ %count% entities were removed"
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/Handler/DeleteProductsMassActionHandlerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/Handler/DeleteProductsMassActionHandlerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\DataGridBundle\Extension\MassAction\Handler;
 
+use Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface;
 use Akeneo\Component\StorageUtils\Remover\BulkRemoverInterface;
 use Oro\Bundle\DataGridBundle\Datagrid\DatagridInterface;
 use Oro\Bundle\DataGridBundle\Datasource\ResultRecord;
@@ -31,13 +32,16 @@ class DeleteProductsMassActionHandlerSpec extends ObjectBehavior
         DeleteMassAction $massAction,
         ActionConfiguration $options,
         ProductMassActionRepositoryInterface $massActionRepo,
-        BulkRemoverInterface $indexRemover
+        BulkRemoverInterface $indexRemover,
+        CursorFactoryInterface $cursorFactory
+
     ) {
         $this->beConstructedWith(
             $hydrator,
             $translator,
             $eventDispatcher,
-            $indexRemover
+            $indexRemover,
+            $cursorFactory
         );
 
         $translator->trans('qux')->willReturn('qux');


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In the product grid, delete action is not working as expected, when all product are selected : only the 25 products on the first page are deleted. 
Don't allow to delete more than 1000 products.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | Todo
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
