### PR TITLE
PIM-6968 - fix mass delete product

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -11,6 +11,7 @@
 - PIM-7049: Fix random order of attribute options 
 - PIM-7080: Fix memory leak on product export
 - PIM-6955: Fix delete user
+- PIM-6968: Fix mass delete product
 
 ## Improvements
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -19,9 +19,10 @@
 
 ## BC breaks
 
-- Change the constructor of  `Pim\Component\Catalog\ProductModel\Filter\ProductModelAttributeFilter` add `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface` 
-- Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\AttributeController` add `Doctrine\ORM\EntityManagerInterface` and `Symfony\Component\Translation\TranslatorInterface`
+- Changes the constructor of  `Pim\Component\Catalog\ProductModel\Filter\ProductModelAttributeFilter` add `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface` 
+- Changes the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\AttributeController` add `Doctrine\ORM\EntityManagerInterface` and `Symfony\Component\Translation\TranslatorInterface`
 - Changes the constructor of `Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber` add `Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface`
+- Changes the constructor of `Pim/Bundle/DataGridBundle/Extension/MassAction/Handler/DeleteProductsMassActionHandler` to add `Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface`
 
 # 2.0.10 (2017-12-22)
 

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -489,6 +489,8 @@ class WebUser extends PimContext
     public function iConfirmThe()
     {
         $this->getCurrentPage()->confirmDialog();
+        
+        $this->wait();
     }
 
     /**

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -489,8 +489,6 @@ class WebUser extends PimContext
     public function iConfirmThe()
     {
         $this->getCurrentPage()->confirmDialog();
-
-        $this->wait();
     }
 
     /**

--- a/features/mass-action/mass_delete_products_and_product_models.feature
+++ b/features/mass-action/mass_delete_products_and_product_models.feature
@@ -14,7 +14,7 @@ Feature: Delete many products but not the product models
     And I filter by "color" with operator "in list" and value "Crimson red"
     And I select rows model-tshirt-divided-crimson-red, tshirt-unique-size-crimson-red and running-shoes-m-crimson-red
     And I press the "Delete" button
-    Then I should see the text "Are you sure you want to delete the selected products?"
+    And I should see the text "Are you sure you want to delete the selected products?"
     When I confirm the removal
     And I refresh current page
     Then I should not see products tshirt-unique-size-crimson-red and running-shoes-m-crimson-red
@@ -27,4 +27,5 @@ Feature: Delete many products but not the product models
     And I press the "Delete" button and wait for modal
     When I confirm the removal
     Then I should not see products 1111111171 and 1111111172
-    Then I should see the product models athena and aurora
+    And I filter by "family" with operator "in list" and value "Clothing"
+    And I should see the product models amor

--- a/features/mass-action/mass_delete_products_and_product_models.feature
+++ b/features/mass-action/mass_delete_products_and_product_models.feature
@@ -19,3 +19,12 @@ Feature: Delete many products but not the product models
     And I refresh current page
     Then I should not see products tshirt-unique-size-crimson-red and running-shoes-m-crimson-red
     And I should see the product models model-tshirt-divided-crimson-red
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6968
+  Scenario: Successfully mass delete products when selected all
+    Given I select rows 1111111171
+    And I select all entities
+    And I press the "Delete" button and wait for modal
+    When I confirm the removal
+    Then I should not see products 1111111171 and 1111111172
+    Then I should see the product models athena and aurora

--- a/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Handler/DeleteProductsMassActionHandler.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Handler/DeleteProductsMassActionHandler.php
@@ -72,12 +72,9 @@ class DeleteProductsMassActionHandler extends DeleteMassActionHandler
             ));
         }
 
-        while ($cursor->valid()) {
-            $objectIds = [];
-            foreach ($cursor as $productObject) {
-                $objectIds[] = $productObject->getId();
-            }
-            $cursor->next();
+        $objectIds = [];
+        foreach ($cursor as $productObject) {
+            $objectIds[] = $productObject->getId();
         }
 
         try {
@@ -99,28 +96,5 @@ class DeleteProductsMassActionHandler extends DeleteMassActionHandler
         $this->eventDispatcher->dispatch(MassActionEvents::MASS_DELETE_POST_HANDLER, $massActionEvent);
 
         return $this->getResponse($massAction, $countRemoved);
-    }
-
-    /**
-     * Only returns the product records within a list of product and product models records.
-     *
-     * TODO: PIM-6357 - Scenario should be removed once mass edits work for product models
-     *
-     * @param array $resultRecords
-     *
-     * @return array
-     */
-    private function filterProductRecords(array $resultRecords): array
-    {
-        $productRecords = [];
-        foreach ($resultRecords['data'] as $resultRecord) {
-            /** @var ResultRecord $resultRecord */
-            if ($resultRecord->getValue('document_type') === IdEncoder::PRODUCT_TYPE) {
-                $productRecords[] = $resultRecord;
-            }
-        }
-        $resultRecords['data'] = $productRecords;
-
-        return $resultRecords;
     }
 }

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/mass_actions.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/mass_actions.yml
@@ -79,6 +79,7 @@ services:
         class: '%pim_datagrid.extension.mass_action.handler.product_delete.class%'
         arguments:
             - '@pim_catalog.elasticsearch.indexer.product'
+            - '@pim_enrich.factory.product_and_product_model_cursor'
         parent: pim_datagrid.extension.mass_action.handler.delete
         tags:
             - { name: pim_datagrid.extension.mass_action.handler, alias: product_mass_delete }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/pageable-collection.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/pageable-collection.js
@@ -283,7 +283,7 @@ function(_, Backbone, BackbonePageableCollection, app) {
             var links = this.links;
             var totalRecords = state.totalRecords;
             var pageSize = state.pageSize;
-            var currentPage = state.currentPage;
+            var currentPage = (state.currentPage < 0) ? 1 : state.currentPage;
             var firstPage = state.firstPage;
             var totalPages = state.totalPages;
 
@@ -306,6 +306,7 @@ function(_, Backbone, BackbonePageableCollection, app) {
                 }
 
                 state.lastPage = firstPage === 0 ? totalPages - 1 : totalPages;
+                state.lastPage = state.lastPage < 0 ? 1 : state.lastPage;
 
                 // page out of range
                 if (currentPage > state.lastPage && state.pageSize > 0) {

--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/messages.en.yml
@@ -11,6 +11,7 @@ oro.grid.mass_action.error_content: Cannot perform mass action
 oro.grid.mass_action.delete.label: Delete
 oro.grid.mass_action.delete.confirm_title: Mass Delete Confirmation
 oro.grid.mass_action.delete.confirm_content: Are you sure you want to do delete selected items?
+oro.grid.mass_action.delete.item_limit: You cannot mass delete more than %limit% products (%count% selected)
 oro.grid.datagrid.page_size.all: All
 oro.grid.mass_action.delete.success_message: "{0} No entities were removed|{1} One entity was removed|]1,Inf[ %count% entities were removed"
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/Handler/DeleteProductsMassActionHandlerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/Handler/DeleteProductsMassActionHandlerSpec.php
@@ -14,6 +14,7 @@ use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
 use Pim\Bundle\DataGridBundle\Datasource\ProductDatasource;
 use Pim\Bundle\DataGridBundle\Datasource\ResultRecord\HydratorInterface;
 use Pim\Bundle\DataGridBundle\Extension\MassAction\Actions\Ajax\DeleteMassAction;
+use Pim\Bundle\DataGridBundle\Extension\MassAction\Event\MassActionEvent;
 use Pim\Bundle\DataGridBundle\Extension\MassAction\Event\MassActionEvents;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\ProductEvents;
@@ -57,7 +58,7 @@ class DeleteProductsMassActionHandlerSpec extends ObjectBehavior
 
         $eventDispatcher->dispatch(
             MassActionEvents::MASS_DELETE_PRE_HANDLER,
-            Argument::type('Pim\Bundle\DataGridBundle\Extension\MassAction\Event\MassActionEvent')
+            Argument::type(MassActionEvent::class)
         )->shouldBeCalled();
     }
 
@@ -96,7 +97,7 @@ class DeleteProductsMassActionHandlerSpec extends ObjectBehavior
 
         $eventDispatcher->dispatch(
             MassActionEvents::MASS_DELETE_POST_HANDLER,
-            Argument::type('Pim\Bundle\DataGridBundle\Extension\MassAction\Event\MassActionEvent')
+            Argument::type(MassActionEvent::class)
         )->shouldBeCalled();
         $eventDispatcher->dispatch(
             ProductEvents::PRE_MASS_REMOVE,

--- a/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/Handler/DeleteProductsMassActionHandlerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/Handler/DeleteProductsMassActionHandlerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\DataGridBundle\Extension\MassAction\Handler;
 
+use Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface;
 use Akeneo\Component\StorageUtils\Remover\BulkRemoverInterface;
 use Oro\Bundle\DataGridBundle\Datagrid\DatagridInterface;
 use Oro\Bundle\DataGridBundle\Datasource\ResultRecord;
@@ -31,13 +32,16 @@ class DeleteProductsMassActionHandlerSpec extends ObjectBehavior
         DeleteMassAction $massAction,
         ActionConfiguration $options,
         ProductMassActionRepositoryInterface $massActionRepo,
-        BulkRemoverInterface $indexRemover
+        BulkRemoverInterface $indexRemover,
+        CursorFactoryInterface $cursorFactory
+
     ) {
         $this->beConstructedWith(
             $hydrator,
             $translator,
             $eventDispatcher,
-            $indexRemover
+            $indexRemover,
+            $cursorFactory
         );
 
         $translator->trans('qux')->willReturn('qux');

--- a/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/Handler/DeleteProductsMassActionHandlerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/Handler/DeleteProductsMassActionHandlerSpec.php
@@ -15,8 +15,6 @@ use Pim\Bundle\DataGridBundle\Datasource\ProductDatasource;
 use Pim\Bundle\DataGridBundle\Datasource\ResultRecord\HydratorInterface;
 use Pim\Bundle\DataGridBundle\Extension\MassAction\Actions\Ajax\DeleteMassAction;
 use Pim\Bundle\DataGridBundle\Extension\MassAction\Event\MassActionEvents;
-use Pim\Bundle\DataGridBundle\Normalizer\IdEncoder;
-use Pim\Component\Catalog\Model\Product;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\ProductEvents;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
@@ -51,12 +49,11 @@ class DeleteProductsMassActionHandlerSpec extends ObjectBehavior
         $datasource->getProductQueryBuilder()->willReturn($pqb);
         $pqb->getQueryBuilder()->willReturn($qb);
         $qb->getQuery()->willReturn([]);
-        //$translator->trans('qux')->willReturn('qux');
 
         $datagrid->getDatasource()->willReturn($datasource);
         $datasource->setHydrator($hydrator)->shouldBeCalled();
 
-        $cursorFactory->createCursor([], ['from' => 0])->willReturn($productCursor);
+        $cursorFactory->createCursor([])->willReturn($productCursor);
 
         $eventDispatcher->dispatch(
             MassActionEvents::MASS_DELETE_PRE_HANDLER,
@@ -114,7 +111,7 @@ class DeleteProductsMassActionHandlerSpec extends ObjectBehavior
         $this->handle($datagrid, $massAction);
     }
 
-    function it_dont_run_if_max_limit_selected(
+    function it_does_not_run_if_max_limit_is_exceeded(
         $datagrid,
         $translator,
         $productCursor,


### PR DESCRIPTION
**Description**

In the product grid, delete action is not working as expected, when all product are selected : only the 25 products on the first page are deleted.
Don't allow to delete more than 1000 products.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
