### PR TITLE
PIM-7070: fix sequential edit for product models

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - PIM-7062: Allow to delete attributes contained in a family variant
 - PIM-6944: Fix delta export for variant products
+- PIM-7070: Fix sequential edit when selecting multiple product models
 
 # 2.0.10 (2017-12-22)
 

--- a/features/product/sequential_edit/sequential_edit_product_and_product_model.feature
+++ b/features/product/sequential_edit/sequential_edit_product_and_product_model.feature
@@ -18,3 +18,15 @@ Feature: Edit sequentially some products
     When I press the "Sequential edit" button
     Then I should see the text "Divided crimson red"
     And I should see the text "Save and next"
+
+  Scenario: Successfully sequentially edit some product models
+    Given I show the filter "color"
+    And I filter by "color" with operator "in list" and value "Crimson red"
+    And I sort by "ID" value ascending
+    And I select rows model-tshirt-divided-crimson-red, model-tshirt-unique-color-kurt
+    When I press the "Sequential edit" button
+    Then I should see the text "Divided crimson red"
+    And I should see the text "Save and next"
+    And I press the "Save and next" button
+    And I should see the text "Model-tshirt-unique-color-kurt"
+    And I should see the text "Save and finish"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/sequential-edit.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/sequential-edit.js
@@ -120,14 +120,16 @@ define(
 
                 var promises = [];
                 if (previous) {
-                    promises.push(FetcherRegistry.getFetcher(previous.type).fetch(previous.id).then(function (product) {
-                        previousObject = getObjectViewParams(product);
-                    }));
+                    promises.push(FetcherRegistry.getFetcher(previous.type.replace('_', '-'))
+                        .fetch(previous.id).then(function (product) {
+                            previousObject = getObjectViewParams(product);
+                        }));
                 }
                 if (next) {
-                    promises.push(FetcherRegistry.getFetcher(next.type).fetch(next.id).then(function (product) {
-                        nextObject = getObjectViewParams(product);
-                    }));
+                    promises.push(FetcherRegistry.getFetcher(next.type.replace('_', '-'))
+                        .fetch(next.id).then(function (product) {
+                            nextObject = getObjectViewParams(product);
+                        }));
                 }
 
                 return $.when.apply($, promises).then(function () {


### PR DESCRIPTION
**Description**

Sequential edit doesn't work when selecting more than two product models.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
