### PR TITLE
PIM-7079: improve datagrid loading by 30% with big products

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,9 +1,13 @@
-# 2.0.X
+# 2.0.x
 
 ## Bug fixes
 
 - PIM-7062: Allow to delete attributes contained in a family variant
 - PIM-6944: Fix delta export for variant products
+
+## Improvements
+
+- PIM-7079: Improve indexation performance of ValueCollection when deleting values
 
 # 2.0.10 (2017-12-22)
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
It could be called "Improve indexation performance of ValueCollection when deleting values" but I prefer baiting title :trollface: 

Each time we delete a product value in the value collection, we iterate over all the values, just to refresh the attribute index.

So, the more we have values, slower it is to re-index the attributes.

In CE and EE, when loading the datagrid, 30% of the time is taken by the re-indexation of the values with product with more than 500 product values.

The fix is an easy workaround, that will work for a lot of things as it improves directly the model.
The datagrid is still too slow, but a little bit less.

![before](https://user-images.githubusercontent.com/1942439/34386165-9f82696e-eb27-11e7-94c4-c2ec5e0332cd.png)

![after](https://user-images.githubusercontent.com/1942439/34386167-a43abcae-eb27-11e7-9bb9-4be6cde94ca1.png)



<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
