### PR TITLE
PIM-7066: fix permissions problems on required missing attributes

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,8 +1,18 @@
 # 2.1.X
 
-# Bug fixes
+## Bug fixes
 
 - PIM-7074: Fix label and completeness filters for search
+
+## BC breaks
+
+### Services
+
+- Rename the service `pim_enrich.normalizer.product_model_incomplete_values` to `pim_enrich.normalizer.incomplete_values` because it works not only for product models
+
+### Constructors
+
+- Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductNormalizer` to add a `Pim\Bundle\EnrichBundle\Normalizer\IncompleteValuesNormalizer` as last argument
 
 # 2.1.0 (2017-12-21)
 

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -9,6 +9,7 @@ use Behat\Mink\Exception\ExpectationException;
 use Behat\Symfony2Extension\Context\KernelAwareContext;
 use Behat\Testwork\Counter\Exception\TimerException;
 use Context\Spin\SpinCapableTrait;
+use Context\Spin\TimeoutException;
 use Pim\Behat\Context\AttributeValidationContext;
 use Pim\Behat\Context\Domain\Collect\ImportProfilesContext;
 use Pim\Behat\Context\Domain\Enrich\AttributeTabContext;
@@ -347,6 +348,8 @@ class FeatureContext extends PimContext implements KernelAwareContext
 
     /**
      * @When /^I open the completeness dropdown$/
+     *
+     * @throws TimeoutException
      */
     public function iOpenTheCompletenessDropdown()
     {
@@ -359,6 +362,8 @@ class FeatureContext extends PimContext implements KernelAwareContext
 
     /**
      * @When /^I click on the missing required attributes overview link$/
+     *
+     * @throws TimeoutException
      */
     public function iClickOnTheMissingRequiredAttributesOverviewLink()
     {
@@ -367,6 +372,49 @@ class FeatureContext extends PimContext implements KernelAwareContext
         }, 'Cannot find the missing required attributes link');
 
         $link->click();
+    }
+
+    /**
+     * @When /^I should not see any missing required attribute$/
+     *
+     * @throws ExpectationException
+     */
+    public function iShouldNotSeeAnyMissingRequiredAttribute()
+    {
+        $link = $this->getCurrentPage()->getMissingRequiredAttributesOverviewLink();
+
+        if ($link->isValid()) {
+            throw new ExpectationException(
+                'No missing required attribute should be seen, but some found',
+                $this->getSession()
+            );
+        }
+    }
+
+    /**
+     * @When /^I should see the text "(?P<text>(?:[^"]|\\")*)" in the total missing required attributes$/
+     *
+     * @throws TimeoutException
+     * @throws ExpectationException
+     */
+    public function iShouldSeeTheTextInTotalMissingRequiredAttributes($text)
+    {
+        $link = $this->spin(function () {
+            $link = $this->getCurrentPage()->getMissingRequiredAttributesOverviewLink();
+
+            return $link->isValid() ? $link : false;
+        }, 'Cannot find the missing required attributes link');
+
+        if ($link->getText() !== $text) {
+            throw new ExpectationException(
+                sprintf(
+                    'Cannot find text "%s" in the total missing required attributes, text "%s" found instead',
+                    $text,
+                    $link->getText()
+                ),
+                $this->getSession()
+            );
+        }
     }
 
     /**

--- a/features/Context/Page/Batch/Operation.php
+++ b/features/Context/Page/Batch/Operation.php
@@ -17,7 +17,7 @@ class Operation extends Wizard
     protected $steps = [
         'Change status'                    => 'Batch ChangeStatus',
         'Edit attributes'                  => 'Batch EditCommonAttributes',
-        'Modifier les attributs communs'   => 'Batch EditCommonAttributes',
+        'Modifier des attributs'           => 'Batch EditCommonAttributes',
         'Change family'                    => 'Batch ChangeFamily',
         'Add to groups'                    => 'Batch AddToGroups',
         'Set attributes requirements'      => 'Batch SetAttributeRequirements',

--- a/features/localization/mass-action/edit_common_attributes.feature
+++ b/features/localization/mass-action/edit_common_attributes.feature
@@ -27,7 +27,7 @@ Feature: Edit common localized attributes of many products at once
   Scenario: Successfully update many price values at once
     Given I select rows boots and sandals
     And I press the "Actions de masse" button
-    When I choose the "Modifier les attributs communs" operation
+    When I choose the "Modifier des attributs" operation
     And I display the Price attribute
     And I change the "Price" to "100,50 USD"
     And I change the "Price" to "150,75 EUR"
@@ -41,7 +41,7 @@ Feature: Edit common localized attributes of many products at once
   Scenario: Successfully update many metric values at once
     Given I select rows boots and sandals
     And I press the "Actions de masse" button
-    When I choose the "Modifier les attributs communs" operation
+    When I choose the "Modifier des attributs" operation
     And I display the Weight attribute
     And I change the "Weight" to "600,55"
     And I confirm mass edit
@@ -51,7 +51,7 @@ Feature: Edit common localized attributes of many products at once
   Scenario: Successfully update many number values at once
     Given I select rows boots and sandals
     And I press the "Actions de masse" button
-    When I choose the "Modifier les attributs communs" operation
+    When I choose the "Modifier des attributs" operation
     And I display the Time attribute
     And I change the "Time" to "25,75"
     And I confirm mass edit
@@ -64,7 +64,7 @@ Feature: Edit common localized attributes of many products at once
   Scenario: Successfully update many date values at once
     Given I select rows boots and sandals
     And I press the "Actions de masse" button
-    When I choose the "Modifier les attributs communs" operation
+    When I choose the "Modifier des attributs" operation
     And I display the Date attribute
     And I change the "Date" to "28/05/2015"
     And I confirm mass edit
@@ -77,7 +77,7 @@ Feature: Edit common localized attributes of many products at once
   Scenario: Fail to update many price values at once
     Given I select rows boots and sandals
     And I press the "Actions de masse" button
-    When I choose the "Modifier les attributs communs" operation
+    When I choose the "Modifier des attributs" operation
     And I display the Price attribute
     And I change the "Price" to "100.50 USD"
     And I change the "Price" to "150.75 EUR"
@@ -87,7 +87,7 @@ Feature: Edit common localized attributes of many products at once
   Scenario: Fail to update many metric values at once
     Given I select rows boots and sandals
     And I press the "Actions de masse" button
-    When I choose the "Modifier les attributs communs" operation
+    When I choose the "Modifier des attributs" operation
     And I display the Weight attribute
     And I change the "Weight" to "600.55"
     And I move on to the next step
@@ -96,7 +96,7 @@ Feature: Edit common localized attributes of many products at once
   Scenario: Fail to update many number values at once
     Given I select rows boots and sandals
     And I press the "Actions de masse" button
-    When I choose the "Modifier les attributs communs" operation
+    When I choose the "Modifier des attributs" operation
     And I display the Time attribute
     And I change the "Time" to "25.75"
     And I move on to the next step

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/IncompleteValuesNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/IncompleteValuesNormalizer.php
@@ -8,9 +8,9 @@ use Pim\Component\Catalog\EntityWithFamily\IncompleteValueCollectionFactory;
 use Pim\Component\Catalog\EntityWithFamily\RequiredValueCollectionFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
-use Pim\Component\Catalog\Model\ProductModelInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -20,7 +20,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class ProductModelIncompleteValuesNormalizer implements NormalizerInterface
+class IncompleteValuesNormalizer implements NormalizerInterface
 {
     /** @var NormalizerInterface */
     private $normalizer;
@@ -49,9 +49,9 @@ class ProductModelIncompleteValuesNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($productModel, $format = null, array $context = []): array
+    public function normalize($entityWithFamily, $format = null, array $context = []): array
     {
-        $family = $productModel->getFamily();
+        $family = $entityWithFamily->getFamily();
         if (null === $family) {
             return [];
         }
@@ -73,7 +73,7 @@ class ProductModelIncompleteValuesNormalizer implements NormalizerInterface
                     $requiredValues,
                     $channel,
                     $locale,
-                    $productModel
+                    $entityWithFamily
                 );
 
                 $missingAttributes = [];
@@ -108,7 +108,7 @@ class ProductModelIncompleteValuesNormalizer implements NormalizerInterface
      */
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof ProductModelInterface && 'internal_api' === $format;
+        return $data instanceof EntityWithFamilyInterface && 'internal_api' === $format;
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/IncompleteValuesNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/IncompleteValuesNormalizer.php
@@ -56,6 +56,10 @@ class IncompleteValuesNormalizer implements NormalizerInterface
             return [];
         }
 
+        if (!$this->isEntityGranted($entityWithFamily)) {
+            return [];
+        }
+
         $kindOfCompletenesses = [];
 
         foreach ($this->getChannelsFromRequirements($family) as $channel) {
@@ -78,6 +82,14 @@ class IncompleteValuesNormalizer implements NormalizerInterface
 
                 $missingAttributes = [];
                 foreach ($incompleteValues->attributes() as $attribute) {
+                    if (!$this->isAttributeGranted($attribute)) {
+                        continue;
+                    }
+
+                    if ($attribute->isLocalizable() && !$this->isLocaleGranted($locale)) {
+                        continue;
+                    }
+
                     $missingAttributes[] = [
                         'code' => $attribute->getCode(),
                         'labels' => $this->normalizeAttributeLabels($attribute, $channel->getLocales()->toArray())
@@ -102,6 +114,36 @@ class IncompleteValuesNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return $data instanceof EntityWithFamilyInterface && 'internal_api' === $format;
+    }
+
+    /**
+     * @param EntityWithFamilyInterface $entityWithFamily
+     *
+     * @return bool
+     */
+    protected function isEntityGranted(EntityWithFamilyInterface $entityWithFamily)
+    {
+        return true;
+    }
+
+    /**
+     * @param AttributeInterface $attribute
+     *
+     * @return bool
+     */
+    protected function isAttributeGranted(AttributeInterface $attribute)
+    {
+        return true;
+    }
+
+    /**
+     * @param LocaleInterface $locale
+     *
+     * @return bool
+     */
+    protected function isLocaleGranted(LocaleInterface $locale)
+    {
+        return true;
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/IncompleteValuesNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/IncompleteValuesNormalizer.php
@@ -85,13 +85,6 @@ class IncompleteValuesNormalizer implements NormalizerInterface
                 }
 
                 $kindOfCompleteness['locales'][$locale->getCode()] = [
-                    'completeness' => [
-                        'required' => $requiredValues->count(),
-                        'missing' => $incompleteValues->count(),
-                        'ratio' => null,
-                        'locale' => $locale->getCode(),
-                        'channel' => $channel->getCode(),
-                    ],
                     'missing' => $missingAttributes,
                     'label' => $locale->getName(),
                 ];

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -178,7 +178,6 @@ class ProductModelNormalizer implements NormalizerInterface
                 'image'                     => $this->normalizeImage($closestImage, $context),
                 'variant_navigation'        => $this->navigationNormalizer->normalize($productModel, $format, $context),
                 'ascendant_category_ids'    => $this->ascendantCategoriesQuery->getCategoryIds($productModel),
-                'completenesses'            => $this->incompleteValuesNormalizer->normalize($productModel, $format, $context),
                 'required_missing_attributes' => $this->incompleteValuesNormalizer->normalize($productModel, $format, $context),
                 'level'                     => $productModel->getVariationLevel(),
             ] + $this->getLabels($productModel, $scopeCode);

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -179,6 +179,7 @@ class ProductModelNormalizer implements NormalizerInterface
                 'variant_navigation'        => $this->navigationNormalizer->normalize($productModel, $format, $context),
                 'ascendant_category_ids'    => $this->ascendantCategoriesQuery->getCategoryIds($productModel),
                 'completenesses'            => $this->incompleteValuesNormalizer->normalize($productModel, $format, $context),
+                'required_missing_attributes' => $this->incompleteValuesNormalizer->normalize($productModel, $format, $context),
                 'level'                     => $productModel->getVariationLevel(),
             ] + $this->getLabels($productModel, $scopeCode);
 

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -99,6 +99,9 @@ class ProductNormalizer implements NormalizerInterface
     /** @var AscendantCategoriesInterface */
     protected $ascendantCategoriesQuery;
 
+    /** @var NormalizerInterface */
+    protected $incompleteValuesNormalizer;
+
     /**
      * @param NormalizerInterface                       $normalizer
      * @param NormalizerInterface                       $versionNormalizer
@@ -121,6 +124,7 @@ class ProductNormalizer implements NormalizerInterface
      * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
      * @param VariantNavigationNormalizer               $navigationNormalizer
      * @param AscendantCategoriesInterface|null         $ascendantCategoriesQuery
+     * @param NormalizerInterface                       $incompleteValuesNormalizer
      */
     public function __construct(
         NormalizerInterface $normalizer,
@@ -143,7 +147,8 @@ class ProductNormalizer implements NormalizerInterface
         EntityWithFamilyValuesFillerInterface $productValuesFiller,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
         VariantNavigationNormalizer $navigationNormalizer,
-        AscendantCategoriesInterface $ascendantCategoriesQuery
+        AscendantCategoriesInterface $ascendantCategoriesQuery,
+        NormalizerInterface $incompleteValuesNormalizer = null
     ) {
         $this->normalizer                       = $normalizer;
         $this->versionNormalizer                = $versionNormalizer;
@@ -166,6 +171,7 @@ class ProductNormalizer implements NormalizerInterface
         $this->attributesProvider               = $attributesProvider;
         $this->navigationNormalizer             = $navigationNormalizer;
         $this->ascendantCategoriesQuery         = $ascendantCategoriesQuery;
+        $this->incompleteValuesNormalizer       = $incompleteValuesNormalizer;
     }
 
     /**
@@ -191,6 +197,12 @@ class ProductNormalizer implements NormalizerInterface
 
         $scopeCode = $context['channel'] ?? null;
 
+        $incompleteValues = [];
+        // TODO: remove this check on master
+        if (null !== $this->incompleteValuesNormalizer) {
+            $incompleteValues = $this->incompleteValuesNormalizer->normalize($product);
+        }
+
         $normalizedProduct['meta'] = [
             'form'              => $this->formProvider->getForm($product),
             'id'                => $product->getId(),
@@ -199,6 +211,7 @@ class ProductNormalizer implements NormalizerInterface
             'model_type'        => 'product',
             'structure_version' => $this->structureVersionProvider->getStructureVersion(),
             'completenesses'    => $this->getNormalizedCompletenesses($product),
+            'required_missing_attributes' => $incompleteValues,
             'image'             => $this->normalizeImage($product->getImage(), $context),
         ] + $this->getLabels($product, $scopeCode) + $this->getAssociationMeta($product);
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -4,7 +4,7 @@ parameters:
     pim_enrich.normalizer.attribute_option_value.class:            Pim\Bundle\EnrichBundle\Normalizer\AttributeOptionValueNormalizer
     pim_enrich.normalizer.product.class:                           Pim\Bundle\EnrichBundle\Normalizer\ProductNormalizer
     pim_enrich.normalizer.product_model.class:                     Pim\Bundle\EnrichBundle\Normalizer\ProductModelNormalizer
-    pim_enrich.normalizer.product_model_incomplete_values.class:   Pim\Bundle\EnrichBundle\Normalizer\ProductModelIncompleteValuesNormalizer
+    pim_enrich.normalizer.incomplete_values.class:                 Pim\Bundle\EnrichBundle\Normalizer\IncompleteValuesNormalizer
     pim_enrich.normalizer.completeness.class:                      Pim\Bundle\EnrichBundle\Normalizer\CompletenessNormalizer
     pim_enrich.normalizer.completeness_collection.class:           Pim\Bundle\EnrichBundle\Normalizer\CompletenessCollectionNormalizer
     pim_enrich.normalizer.version.class:                           Pim\Bundle\EnrichBundle\Normalizer\VersionNormalizer
@@ -73,6 +73,7 @@ services:
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
             - '@pim_enrich.normalizer.variant_navigation'
             - '@pim_enrich.doctrine.query.ascendant_categories'
+            - '@pim_enrich.normalizer.incomplete_values'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 
@@ -93,12 +94,12 @@ services:
             - '@pim_catalog.doctrine.query.find_variant_product_completeness'
             - '@pim_catalog.product_models.image_as_label'
             - '@pim_enrich.doctrine.query.ascendant_categories'
-            - '@pim_enrich.normalizer.product_model_incomplete_values'
+            - '@pim_enrich.normalizer.incomplete_values'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 
-    pim_enrich.normalizer.product_model_incomplete_values:
-        class: '%pim_enrich.normalizer.product_model_incomplete_values.class%'
+    pim_enrich.normalizer.incomplete_values:
+        class: '%pim_enrich.normalizer.incomplete_values.class%'
         arguments:
             - '@pim_serializer'
             - '@pim_catalog.entity_with_family.required_value_collection_factory'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -203,7 +203,6 @@ define(
                         ).then((attributeGroups) => {
                             const scope = UserContext.get('catalogScope');
                             const locale = UserContext.get('catalogLocale');
-
                             const fieldsToFill = toFillFieldProvider.getMissingRequiredFields(data, scope, locale);
 
                             const sections = _.values(

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -199,9 +199,13 @@ define(
                     .then((fields) => {
                         this.rendering = false;
                         $.when(
-                            AttributeGroupManager.getAttributeGroupsForObject(data),
-                            toFillFieldProvider.getFields(this.getRoot(), data.values)
-                        ).then((attributeGroups, fieldsToFill) => {
+                            AttributeGroupManager.getAttributeGroupsForObject(data)
+                        ).then((attributeGroups) => {
+                            const scope = UserContext.get('catalogScope');
+                            const locale = UserContext.get('catalogLocale');
+
+                            const fieldsToFill = toFillFieldProvider.getMissingRequiredFields(data, scope, locale);
+
                             const sections = _.values(
                                 fields.reduce(groupFieldsBySection(attributeGroups, fieldsToFill), {})
                             ).sort((firstSection, secondSection) =>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/attribute-group-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/attribute-group-selector.js
@@ -102,10 +102,13 @@ define(
              */
             render: function () {
                 $.when(
-                    toFillFieldProvider.getFields(this.getRoot(), this.getFormData().values),
                     AttributeGroupManager.getAttributeGroupsForObject(this.getFormData())
-                ).then(function (attributes, attributeGroups) {
-                    var toFillAttributeGroups = _.uniq(_.map(attributes, function (attribute) {
+                ).then(function (attributeGroups) {
+                    const scope = UserContext.get('catalogScope');
+                    const locale = UserContext.get('catalogLocale');
+                    const attributes = toFillFieldProvider.getMissingRequiredFields(this.getFormData(), scope, locale);
+
+                    const toFillAttributeGroups = _.uniq(_.map(attributes, function (attribute) {
                         return AttributeGroupManager.getAttributeGroupForAttribute(
                             attributeGroups,
                             attribute

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-missing-required.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-missing-required.js
@@ -8,8 +8,22 @@
  */
 
 define(
-    ['underscore', 'oro/translator', 'pim/form', 'pim/provider/to-fill-field-provider'],
-    function (_, __, BaseForm, toFillFieldProvider) {
+    [
+        'jquery',
+        'underscore',
+        'oro/translator',
+        'pim/form',
+        'pim/provider/to-fill-field-provider',
+        'pim/user-context'
+    ],
+    function (
+        $,
+        _,
+        __,
+        BaseForm,
+        toFillFieldProvider,
+        UserContext
+    ) {
         return BaseForm.extend({
             /**
              * @returns {String}
@@ -31,8 +45,13 @@ define(
              * @returns {Promise}
              */
             filterValues(values) {
-                return toFillFieldProvider.getFields(this.getRoot(), values)
-                    .then(fieldCodes => _.pick(values, fieldCodes));
+                const scope = UserContext.get('catalogScope');
+                const locale = UserContext.get('catalogLocale');
+
+                const fieldsToFill = toFillFieldProvider.getMissingRequiredFields(this.getFormData(), scope, locale);
+                const valuesToFill = _.pick(values, fieldsToFill);
+
+                return $.Deferred().resolve(valuesToFill).promise();
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
@@ -1,4 +1,4 @@
- 'use strict';
+'use strict';
 /**
  * @author    Yohan Blain <yohan.blain@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -44,7 +44,7 @@ define(
 
                 this.$el.html(this.template({
                     filters: this.getFilters().map((filter) => {
-                        return { code: filter.getCode(), label: filter.getLabel() }
+                        return { code: filter.getCode(), label: filter.getLabel() };
                     }),
                     currentFilter: { code: currentFilter.getCode(), label: currentFilter.getLabel() },
                     __: __

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attributes/completeness.js
@@ -19,73 +19,26 @@ define(
         return BaseForm.extend({
             configure: function () {
                 this.listenTo(this.getRoot(), 'pim_enrich:form:field:extension:add', this.addFieldExtension);
-                this.listenTo(this.getRoot(), 'pim_enrich:form:field:to-fill-filter', this.addFieldFilter);
 
                 return BaseForm.prototype.configure.apply(this, arguments);
-            },
-
-            /**
-             * Add filter on field if the user doesn't have the right to edit it.
-             *
-             * @param {object} event
-             */
-            addFieldFilter: function (event) {
-                event.filters.push($.Deferred().resolve({
-                    completenesses: this.getFormData().meta.completenesses,
-                    family: this.getFormData().family
-                }).then(function (completenesses) {
-                    if (null === completenesses.family) {
-                        return $.Deferred().resolve([]);
-                    }
-
-                    var channelCompletenesses = _.findWhere(
-                        completenesses.completenesses,
-                        {channel: UserContext.get('catalogScope')}
-                    );
-
-                    if (undefined === channelCompletenesses ||
-                        undefined === channelCompletenesses.locales[UserContext.get('catalogLocale')]
-                    ) {
-                        return $.Deferred().resolve([]);
-                    }
-
-                    var missingAttributeCodes = _.pluck(
-                        channelCompletenesses.locales[UserContext.get('catalogLocale')].missing,
-                        'code'
-                    );
-
-                    return fetcherRegistry.getFetcher('attribute').fetchByIdentifiers(missingAttributeCodes);
-                })
-                .then(function (missingAttributes) {
-                    return function (attributes) {
-                        return _.filter(missingAttributes, function (missingAttribute) {
-                            return _.contains(_.pluck(attributes, 'code'), missingAttribute.code);
-                        });
-                    };
-                }));
             },
 
             /**
              * {@inheritDoc}
              */
             addFieldExtension: function (event) {
-                event.promises.push(
-                    toFillFieldProvider.getFields(this.getRoot(), this.getFormData()).then(function (fields) {
-                        var field = event.field;
+                const scope = UserContext.get('catalogScope');
+                const locale = UserContext.get('catalogLocale');
+                const fieldsToFill = toFillFieldProvider.getMissingRequiredFields(this.getFormData(), scope, locale);
+                const field = event.field;
 
-                        if (_.contains(fields, field.attribute.code)) {
-                            field.addElement(
-                                'badge',
-                                'completeness',
-                                '<span class="AknBadge AknBadge--small AknBadge--highlight"></span>'
-                            );
-                        }
-
-                        return event;
-                    }.bind(this))
-                );
-
-                return this;
+                if (_.contains(fieldsToFill, field.attribute.code)) {
+                    field.addElement(
+                        'badge',
+                        'completeness',
+                        '<span class="AknBadge AknBadge--small AknBadge--highlight"></span>'
+                    );
+                }
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/provider/to-fill-field-provider.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/provider/to-fill-field-provider.js
@@ -9,17 +9,11 @@
 define(
     [
         'jquery',
-        'underscore',
-        'oro/mediator',
-        'pim/attribute-manager',
-        'pim/fetcher-registry'
+        'underscore'
     ],
     function (
         $,
-        _,
-        mediator,
-        attributeManager,
-        fetcherRegistry
+        _
     ) {
         return {
             fieldsPromise: null,
@@ -48,42 +42,6 @@ define(
                 const levelAttributeCodes = Object.keys(product.values);
 
                 return missingAttributeCodes.filter(missingAttribute => levelAttributeCodes.includes(missingAttribute));
-            },
-
-            /**
-             * Get list of fields that need to be filled to complete the product
-             *
-             * @param {Object} root
-             * @param {Object} values
-             *
-             * @return {Promise}
-             */
-            getFields: function (root, values) {
-
-                if (null === this.fieldsPromise) {
-                    let filterPromises = [];
-                    root.trigger(
-                        'pim_enrich:form:field:to-fill-filter',
-                        {'filters': filterPromises}
-                    );
-
-                    this.fieldsPromise = $.when.apply($, filterPromises).then(function () {
-                        return arguments;
-                    }).then(function (filters) {
-                        return fetcherRegistry.getFetcher('attribute').fetchByIdentifiers(Object.keys(values))
-                            .then(function (attributesToFilter) {
-                                const filteredAttributes = _.reduce(filters, function (attributes, filter) {
-                                    return filter(attributes);
-                                }, attributesToFilter);
-
-                                return _.map(filteredAttributes, function (attribute) {
-                                    return attribute.code;
-                                });
-                            });
-                    });
-                }
-
-                return this.fieldsPromise;
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/provider/to-fill-field-provider.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/provider/to-fill-field-provider.js
@@ -14,9 +14,41 @@ define(
         'pim/attribute-manager',
         'pim/fetcher-registry'
     ],
-    function ($, _, mediator, attributeManager, fetcherRegistry) {
+    function (
+        $,
+        _,
+        mediator,
+        attributeManager,
+        fetcherRegistry
+    ) {
         return {
             fieldsPromise: null,
+
+            /**
+             * Returns the missing required attributes of the current scope and locale for the given product
+             *
+             * @param product Object
+             * @param scope String
+             * @param locale String
+             *
+             * @return Array
+             */
+            getMissingRequiredFields: function (product, scope, locale) {
+                const scopeMissingAttributes =  _.findWhere(product.meta.required_missing_attributes, {channel: scope});
+                if (undefined === scopeMissingAttributes) {
+                    return [];
+                }
+
+                const localeMissingAttributes = scopeMissingAttributes.locales[locale];
+                if (undefined === localeMissingAttributes) {
+                    return [];
+                }
+
+                const missingAttributeCodes = localeMissingAttributes.missing.map(missing => missing.code);
+                const levelAttributeCodes = Object.keys(product.values);
+
+                return missingAttributeCodes.filter(missingAttribute => levelAttributeCodes.includes(missingAttribute));
+            },
 
             /**
              * Get list of fields that need to be filled to complete the product
@@ -28,8 +60,8 @@ define(
              */
             getFields: function (root, values) {
 
-                if (null == this.fieldsPromise) {
-                    var filterPromises = [];
+                if (null === this.fieldsPromise) {
+                    let filterPromises = [];
                     root.trigger(
                         'pim_enrich:form:field:to-fill-filter',
                         {'filters': filterPromises}
@@ -40,7 +72,7 @@ define(
                     }).then(function (filters) {
                         return fetcherRegistry.getFetcher('attribute').fetchByIdentifiers(Object.keys(values))
                             .then(function (attributesToFilter) {
-                                var filteredAttributes = _.reduce(filters, function (attributes, filter) {
+                                const filteredAttributes = _.reduce(filters, function (attributes, filter) {
                                     return filter(attributes);
                                 }, attributesToFilter);
 
@@ -51,7 +83,7 @@ define(
                     });
                 }
 
-                return this.fieldsPromise
+                return this.fieldsPromise;
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/IncompleteValuesNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/IncompleteValuesNormalizerSpec.php
@@ -112,20 +112,13 @@ class IncompleteValuesNormalizerSpec extends ObjectBehavior
                     ],
                     'locales' => [
                         'en_US' => [
-                            'completeness' => [
-                                'required' => 1,
-                                'missing'  => 1,
-                                'ratio'    => null,
-                                'locale'   => 'en_US',
-                                'channel'  => 'ecommerce',
-                            ],
-                            'missing'      => [
+                            'missing' => [
                                 [
-                                    'code'   => 'description',
+                                    'code' => 'description',
                                     'labels' => ['en_US' => 'Description'],
                                 ],
                             ],
-                            'label'        => 'English (United States)',
+                            'label' => 'English (United States)',
                         ],
                     ],
                 ]

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/IncompleteValuesNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/IncompleteValuesNormalizerSpec.php
@@ -88,6 +88,7 @@ class IncompleteValuesNormalizerSpec extends ObjectBehavior
         $attributes->getIterator()->willReturn($attributesIterator);
         $attribute->getCode()->willReturn('description');
         $attribute->getTranslation('en_US')->willReturn($attributeTranslation);
+        $attribute->isLocalizable()->willReturn(false);
 
         $requiredValueCollectionFactory->forChannel($family, $channel)->willReturn($requiredValues);
         $requiredValues->filterByChannelAndLocale($channel, $locale)->willReturn($requiredValues);

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/IncompleteValuesNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/IncompleteValuesNormalizerSpec.php
@@ -3,8 +3,8 @@
 namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
 
 use Doctrine\Common\Collections\Collection;
-use Pim\Bundle\EnrichBundle\Normalizer\ProductModelIncompleteValuesNormalizer;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\Normalizer\IncompleteValuesNormalizer;
 use Pim\Component\Catalog\EntityWithFamily\IncompleteValueCollection;
 use Pim\Component\Catalog\EntityWithFamily\IncompleteValueCollectionFactory;
 use Pim\Component\Catalog\EntityWithFamily\RequiredValueCollection;
@@ -12,15 +12,15 @@ use Pim\Component\Catalog\EntityWithFamily\RequiredValueCollectionFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeRequirementInterface;
 use Pim\Component\Catalog\Model\AttributeTranslationInterface;
+use Pim\Component\Catalog\Model\CategoryInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\ChannelTranslationInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
-use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Catalog\Model\ProductModelInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-class ProductModelIncompleteValuesNormalizerSpec extends ObjectBehavior
+class IncompleteValuesNormalizerSpec extends ObjectBehavior
 {
     function let(
         NormalizerInterface $normalizer,
@@ -32,20 +32,20 @@ class ProductModelIncompleteValuesNormalizerSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType(ProductModelIncompleteValuesNormalizer::class);
+        $this->shouldHaveType(IncompleteValuesNormalizer::class);
     }
 
-    function it_supports_product_model(ProductModelInterface $productModel, ProductInterface $product)
+    function it_supports_entity_with_family(EntityWithFamilyInterface $entityWithFamily, CategoryInterface $category)
     {
-        $this->supportsNormalization($productModel, 'internal_api')->shouldReturn(true);
-        $this->supportsNormalization($productModel, 'unsupported')->shouldReturn(false);
-        $this->supportsNormalization($product, 'internal_api')->shouldReturn(false);
+        $this->supportsNormalization($entityWithFamily, 'internal_api')->shouldReturn(true);
+        $this->supportsNormalization($entityWithFamily, 'unsupported')->shouldReturn(false);
+        $this->supportsNormalization($category, 'internal_api')->shouldReturn(false);
     }
 
-    function it_normalizes_the_incomplete_values_of_a_product_model(
+    function it_normalizes_the_incomplete_values_of_an_entity_with_family(
         $requiredValueCollectionFactory,
         $incompleteValueCollectionFactory,
-        ProductModelInterface $productModel,
+        EntityWithFamilyInterface $entityWithFamily,
         AttributeRequirementInterface $attributeRequirement,
         FamilyInterface $family,
         ChannelInterface $channel,
@@ -61,7 +61,7 @@ class ProductModelIncompleteValuesNormalizerSpec extends ObjectBehavior
         AttributeTranslationInterface $attributeTranslation
     ) {
 
-        $productModel->getFamily()->willReturn($family);
+        $entityWithFamily->getFamily()->willReturn($family);
         $family->getAttributeRequirements()->willReturn([$attributeRequirement]);
         $attributeRequirement->getChannel()->willReturn($channel);
         $attributeRequirement->isRequired()->willReturn(true);
@@ -97,13 +97,13 @@ class ProductModelIncompleteValuesNormalizerSpec extends ObjectBehavior
             $requiredValues,
             $channel,
             $locale,
-            $productModel
+            $entityWithFamily
         )->willReturn($incompleteValues);
 
         $incompleteValues->attributes()->willReturn($attributes);
         $incompleteValues->count()->willReturn(1);
 
-        $this->normalize($productModel, 'internal_api')->shouldReturn(
+        $this->normalize($entityWithFamily, 'internal_api')->shouldReturn(
             [
                 [
                     'channel' => 'ecommerce',
@@ -133,10 +133,10 @@ class ProductModelIncompleteValuesNormalizerSpec extends ObjectBehavior
         );
     }
 
-    function it_returns_an_empty_array_when_the_product_model_has_no_family(ProductModelInterface $productModel)
+    function it_returns_an_empty_array_when_the_entity_with_family_has_no_family(EntityWithFamilyInterface $entityWithFamily)
     {
-        $productModel->getFamily()->willReturn(null);
+        $entityWithFamily->getFamily()->willReturn(null);
 
-        $this->normalize($productModel, 'internal_api')->shouldReturn([]);
+        $this->normalize($entityWithFamily, 'internal_api')->shouldReturn([]);
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -210,7 +210,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                     'image'          => $fileNormalized,
                     'variant_navigation' => ['NAVIGATION NORMALIZED'],
                     'ascendant_category_ids' => [42],
-                    'completenesses' => ['kind of completenesses data normalized here'],
+                    'required_missing_attributes' => ['kind of completenesses data normalized here'],
                     'level'          => 0,
                     'label'          => [
                         'en_US' => 'Tshirt blue',
@@ -351,7 +351,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                     'image'          => null,
                     'variant_navigation' => ['NAVIGATION NORMALIZED'],
                     'ascendant_category_ids' => [42],
-                    'completenesses' => ['kind of completenesses data normalized here'],
+                    'required_missing_attributes' => ['kind of completenesses data normalized here'],
                     'level'          => 0,
                     'label'          => [
                         'en_US' => 'Tshirt blue',
@@ -505,7 +505,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
                     'image'          => $fileNormalized,
                     'variant_navigation' => ['NAVIGATION NORMALIZED'],
                     'ascendant_category_ids' => [42],
-                    'completenesses' => ['kind of completenesses data normalized here'],
+                    'required_missing_attributes' => ['kind of completenesses data normalized here'],
                     'level'          => 0,
                     'label'          => [
                         'en_US' => 'Tshirt blue',

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -60,7 +60,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         EntityWithFamilyValuesFillerInterface $productValuesFiller,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
         VariantNavigationNormalizer $navigationNormalizer,
-        AscendantCategoriesInterface $ascendantCategories
+        AscendantCategoriesInterface $ascendantCategories,
+        NormalizerInterface $incompleteValuesNormalizer
     ) {
         $this->beConstructedWith(
             $normalizer,
@@ -83,7 +84,8 @@ class ProductNormalizerSpec extends ObjectBehavior
             $productValuesFiller,
             $attributesProvider,
             $navigationNormalizer,
-            $ascendantCategories
+            $ascendantCategories,
+            $incompleteValuesNormalizer
         );
     }
 
@@ -107,6 +109,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $collectionFilter,
         $productBuilder,
         $productValuesFiller,
+        $incompleteValuesNormalizer,
         ProductInterface $mug,
         AssociationInterface $upsell,
         AssociationTypeInterface $groupType,
@@ -194,6 +197,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         $productBuilder->addMissingAssociations($mug)->shouldBeCalled();
         $productValuesFiller->fillMissingValues($mug)->shouldBeCalled();
 
+        $incompleteValuesNormalizer->normalize($mug)->willReturn('INCOMPLETE VALUES');
+
         $this->normalize($mug, 'internal_api', $options)->shouldReturn(
             [
                 'enabled'    => true,
@@ -208,6 +213,7 @@ class ProductNormalizerSpec extends ObjectBehavior
                     'model_type'        => 'product',
                     'structure_version' => 12,
                     'completenesses'    => null,
+                    'required_missing_attributes' => 'INCOMPLETE VALUES',
                     'image'             => [
                         'filePath'         => '/p/i/m/4/all.png',
                         'originalFileName' => 'all.png',
@@ -249,6 +255,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $navigationNormalizer,
         $attributesProvider,
         $ascendantCategories,
+        $incompleteValuesNormalizer,
         VariantProductInterface $mug,
         AssociationInterface $upsell,
         AssociationTypeInterface $groupType,
@@ -363,6 +370,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $description->getCode()->willReturn('description');
 
         $ascendantCategories->getCategoryIds($mug)->willReturn([42]);
+        $incompleteValuesNormalizer->normalize($mug)->willReturn('INCOMPLETE VALUES');
 
         $this->normalize($mug, 'internal_api', $options)->shouldReturn(
             [
@@ -378,6 +386,7 @@ class ProductNormalizerSpec extends ObjectBehavior
                     'model_type'        => 'product',
                     'structure_version' => 12,
                     'completenesses'    => null,
+                    'required_missing_attributes' => 'INCOMPLETE VALUES',
                     'image'             => [
                         'filePath'         => '/p/i/m/4/all.png',
                         'originalFileName' => 'all.png',

--- a/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollection.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollection.php
@@ -104,7 +104,7 @@ class IncompleteValueCollection implements \Countable, \IteratorAggregate
         $attribute = $value->getAttribute();
         $channelCode = null !== $value->getScope() ? $value->getScope() : ' < all_channels>';
         $localeCode = null !== $value->getLocale() ? $value->getLocale() : '<all_locales > ';
-        $key = sprintf(' % s -%s -%s', $attribute->getCode(), $channelCode, $localeCode);
+        $key = sprintf('%s-%s-%s', $attribute->getCode(), $channelCode, $localeCode);
 
         return $key;
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We used to get missing required attributes with the completeness, then apply some permissions on frontend side, but now the backend sends only missing required attributes for the current user, taking in account its permissions.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | Y
| Added integration tests           | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Y
