### PR TITLE
[PIM-7080] Fix memory leak on product export

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -8,15 +8,17 @@
 - PIM-6812: Change the message when delete an attribute as variant axis
 - PIM-7048: Fix cascade persist issue during import of families with variant
 - PIM-7049: Fix random order of attribute options 
+- PIM-7080: Fix memory leak on product export
+
+## Improvements
+
+- PIM-7079: Improve indexation performance of ValueCollection when deleting values
 
 ## BC breaks
 
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\AttributeController` add `Doctrine\ORM\EntityManagerInterface` and `Symfony\Component\Translation\TranslatorInterface`
 - Changes the constructor of `Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber` add `Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface`
-
-## Improvements
-
-- PIM-7079: Improve indexation performance of ValueCollection when deleting values
+- Adds a method `cleanEntityManager($object)` to the interface `Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface`
 
 # 2.0.10 (2017-12-22)
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -18,7 +18,6 @@
 
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\AttributeController` add `Doctrine\ORM\EntityManagerInterface` and `Symfony\Component\Translation\TranslatorInterface`
 - Changes the constructor of `Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber` add `Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface`
-- Adds a method `cleanEntityManager($object)` to the interface `Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface`
 
 # 2.0.10 (2017-12-22)
 

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
@@ -40,19 +40,9 @@ class ObjectDetacher implements ObjectDetacherInterface, BulkObjectDetacherInter
      */
     public function detach($object)
     {
-        $objectManager = $this->getObjectManager($object);
         $visited = [];
-        $objectManager->detach($object);
+        $this->objectManager->detach($object);
         $this->doDetachScheduled($object, $visited);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function cleanEntityManager($object): void
-    {
-        $objectManager = $this->getObjectManager($object);
-        $objectManager->clear();
     }
 
     /**
@@ -78,7 +68,7 @@ class ObjectDetacher implements ObjectDetacherInterface, BulkObjectDetacherInter
             return;
         }
 
-        $objectManager = $this->getObjectManager($entity);
+        $objectManager = $this->objectManager;
         $uow = $objectManager->getUnitOfWork();
         $class = $objectManager->getClassMetadata(ClassUtils::getClass($entity));
         $rootClassName = $class->rootEntityName;
@@ -104,9 +94,7 @@ class ObjectDetacher implements ObjectDetacherInterface, BulkObjectDetacherInter
      */
     protected function cascadeDetachScheduled($entity, array &$visited)
     {
-        $objectManager = $this->getObjectManager($entity);
-
-        $class = $objectManager->getClassMetadata(ClassUtils::getClass($entity));
+        $class = $this->objectManager->getClassMetadata(ClassUtils::getClass($entity));
 
         $associationMappings = array_filter(
             $class->associationMappings,
@@ -152,15 +140,5 @@ class ObjectDetacher implements ObjectDetacherInterface, BulkObjectDetacherInter
         }, null, $uow);
 
         return $closure($uow);
-    }
-
-    /**
-     * @param object $object
-     *
-     * @return ObjectManager
-     */
-    protected function getObjectManager($object)
-    {
-        return $this->objectManager;
     }
 }

--- a/src/Akeneo/Component/StorageUtils/Cache/CacheClearerInterface.php
+++ b/src/Akeneo/Component/StorageUtils/Cache/CacheClearerInterface.php
@@ -5,6 +5,9 @@ namespace Akeneo\Component\StorageUtils\Cache;
 /**
  * Clears the cache
  *
+ * TODO This interface is not a "cache clearer", it's an entity manager clearer, was not renamed to avoid BC.
+ * This has to be renamed on merge to master.
+ *
  * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/src/Akeneo/Component/StorageUtils/Detacher/ObjectDetacherInterface.php
+++ b/src/Akeneo/Component/StorageUtils/Detacher/ObjectDetacherInterface.php
@@ -15,11 +15,4 @@ interface ObjectDetacherInterface
      * @param object $object
      */
     public function detach($object);
-
-    /**
-     * Clean the object using the entity manager.
-     *
-     * @param $object
-     */
-    public function cleanEntityManager($object): void;
 }

--- a/src/Akeneo/Component/StorageUtils/Detacher/ObjectDetacherInterface.php
+++ b/src/Akeneo/Component/StorageUtils/Detacher/ObjectDetacherInterface.php
@@ -15,4 +15,11 @@ interface ObjectDetacherInterface
      * @param object $object
      */
     public function detach($object);
+
+    /**
+     * Clean the object using the entity manager.
+     *
+     * @param $object
+     */
+    public function cleanEntityManager($object): void;
 }

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
@@ -241,6 +241,7 @@ services:
             - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_connector.processor.bulk_media_fetcher'
             - '@pim_catalog.values_filler.product'
+            - '@pim_connector.doctrine.cache_clearer'
 
     pim_connector.processor.normalization.product_model:
         class: '%pim_connector.processor.normalization.product_model.class%'

--- a/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
@@ -8,8 +8,8 @@ use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
-use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
@@ -47,6 +47,9 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
     /** @var EntityWithFamilyValuesFillerInterface */
     protected $productValuesFiller;
 
+    /** @var CacheClearerInterface */
+    protected $cacheClearer;
+
     /**
      * @param NormalizerInterface                   $normalizer
      * @param ChannelRepositoryInterface            $channelRepository
@@ -54,6 +57,7 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
      * @param ObjectDetacherInterface               $detacher
      * @param BulkMediaFetcher                      $mediaFetcher
      * @param EntityWithFamilyValuesFillerInterface $productValuesFiller
+     * @param CacheClearerInterface                 $cacheClearer
      */
     public function __construct(
         NormalizerInterface $normalizer,
@@ -61,7 +65,8 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
         AttributeRepositoryInterface $attributeRepository,
         ObjectDetacherInterface $detacher,
         BulkMediaFetcher $mediaFetcher,
-        EntityWithFamilyValuesFillerInterface $productValuesFiller
+        EntityWithFamilyValuesFillerInterface $productValuesFiller,
+        CacheClearerInterface $cacheClearer = null
     ) {
         $this->normalizer = $normalizer;
         $this->detacher = $detacher;
@@ -69,6 +74,7 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
         $this->attributeRepository = $attributeRepository;
         $this->mediaFetcher = $mediaFetcher;
         $this->productValuesFiller = $productValuesFiller;
+        $this->cacheClearer = $cacheClearer;
     }
 
     /**
@@ -110,7 +116,12 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
             );
         }
 
-        $this->detacher->cleanEntityManager($product);
+        if (null !== $this->cacheClearer) {
+            $this->cacheClearer->clear();
+        } else {
+            // TODO Remove $this->detacher, the upper condition and update the constructor on merge to 2.1
+            $this->detacher->detach($product);
+        }
 
         return $productStandard;
     }

--- a/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
@@ -119,7 +119,7 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
         if (null !== $this->cacheClearer) {
             $this->cacheClearer->clear();
         } else {
-            // TODO Remove $this->detacher, the upper condition and update the constructor on merge to 2.1
+            // TODO Remove $this->detacher, the upper condition and update the constructor on merge to master
             $this->detacher->detach($product);
         }
 

--- a/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
@@ -110,7 +110,7 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
             );
         }
 
-        $this->detacher->detach($product);
+        $this->detacher->cleanEntityManager($product);
 
         return $productStandard;
     }


### PR DESCRIPTION
# What was wrong ?

Doing a product export on our test environments raised a `Can not allocate memory` after 20-30 minutes of computing.
After running a PHP MemInfo, we saw that some `VariantProduct` entities were still loaded in memory, though Doctrine services.

# What does the fix ?

The fix simply changes the `detach` method to a direct call to `clear()` of UnitOfWork.

# And the impacts on perfs ?

The performances are better with the UoW clear:
- Before the fix: 1227 products / minute
- After the fix: 1842 products / minutes


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
