### PR TITLE
API-544: Forbid the use of an non existing attribute in product models creation and update

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- API-544: Forbid the use of an non existing attribute in product models creation and update
 - PIM-7062: Allow to delete attributes contained in a family variant
 - PIM-6944: Fix delta export for variant products
 - PIM-7070: Fix sequential edit when selecting multiple product models
@@ -16,6 +17,7 @@
 
 ## BC breaks
 
+- Change the constructor of  `Pim\Component\Catalog\ProductModel\Filter\ProductModelAttributeFilter` add `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface` 
 - Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\AttributeController` add `Doctrine\ORM\EntityManagerInterface` and `Symfony\Component\Translation\TranslatorInterface`
 - Changes the constructor of `Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber` add `Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface`
 

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
@@ -399,7 +399,10 @@ class ProductModelController
     protected function updateProductModel(ProductModelInterface $productModel, array $data, string $anchor): void
     {
         try {
-            $data = $this->productModelAttributeFilter->filter($data);
+            if (array_key_exists('values', $data)) {
+                $data = $this->productModelAttributeFilter->filter($data);
+            }
+
             $this->updater->update($productModel, $data);
         } catch (PropertyException $exception) {
             throw new DocumentedHttpException(

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
@@ -184,12 +184,7 @@ class ProductModelController
     public function createAction(Request $request): Response
     {
         $data = $this->getDecodedContent($request->getContent());
-        $data = $this->productModelAttributeFilter->filter($data);
         $productModel = $this->factory->create();
-
-        if (!isset($data['code'])) {
-            $data['code'] = '';
-        }
 
         $this->updateProductModel($productModel, $data, 'post_product_model');
         $this->validateProductModel($productModel);
@@ -212,7 +207,6 @@ class ProductModelController
     {
         $data = $this->getDecodedContent($request->getContent());
         $data['code'] = array_key_exists('code', $data) ? $data['code'] : $code;
-        $data = $this->productModelAttributeFilter->filter($data);
 
         $productModel = $this->productModelRepository->findOneByIdentifier($code);
         $isCreation = null === $productModel;
@@ -236,6 +230,7 @@ class ProductModelController
      * @param Request $request
      *
      * @throws UnprocessableEntityHttpException
+     * @throws ServerErrorResponseException
      *
      * @return JsonResponse
      */
@@ -404,6 +399,7 @@ class ProductModelController
     protected function updateProductModel(ProductModelInterface $productModel, array $data, string $anchor): void
     {
         try {
+            $data = $this->productModelAttributeFilter->filter($data);
             $this->updater->update($productModel, $data);
         } catch (PropertyException $exception) {
             throw new DocumentedHttpException(

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\ProductModel;
 
-use Akeneo\Test\Integration\Configuration;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -52,21 +51,21 @@ class PartialUpdateProductModelIntegration extends AbstractProductModelTestCase
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sub_sweat",
-        "family_variant": "familyVariantA1",
-        "parent": "sweat",
-        "values": {
-          "a_text": [
+            <<<JSON
+{
+    "code": "sub_sweat",
+    "family_variant": "familyVariantA1",
+    "parent": "sweat",
+    "values": {
+        "a_text": [
             {
-              "locale": null,
-              "scope": null,
-              "data": "My awesome text"
+                "locale": null,
+                "scope": null,
+                "data": "My awesome text"
             }
-          ]
-        }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
@@ -86,25 +85,59 @@ JSON;
         $this->assertSame($standardizedProduct['values']['a_text'][0]['data'], 'My awesome text');
     }
 
+    public function testUpdateSubProductModelWithNonExistingProperty()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+            <<<JSON
+{
+    "code": "sub_sweat",
+    "michel": "field"
+}
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
+
+        $expectedContent =
+            <<<JSON
+{
+    "code": 422,
+    "message": "Property \"michel\" does not exist. Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+          "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+        }
+    }
+}
+JSON;
+
+        $response = $client->getResponse();
+
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+
+    }
+
     public function testUpdateSubProductModelWithNoCode()
     {
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "family_variant": "familyVariantA1",
-        "parent": "sweat",
-        "values": {
-          "a_text": [
+            <<<JSON
+{
+    "family_variant": "familyVariantA1",
+    "parent": "sweat",
+    "values": {
+        "a_text": [
             {
-              "locale": null,
-              "scope": null,
-              "data": "My awesome text"
+                "locale": null,
+                "scope": null,
+                "data": "My awesome text"
             }
-          ]
-        }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
@@ -129,20 +162,20 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "family_variant": "familyVariantA1",
-        "parent": "sub_sweat",
-        "values": {
-          "a_text": [
+            <<<JSON
+{
+    "family_variant": "familyVariantA1",
+    "parent": "sub_sweat",
+    "values": {
+        "a_text": [
             {
-              "locale": null,
-              "scope": null,
-              "data": "My awesome text"
+                "locale": null,
+                "scope": null,
+                "data": "My awesome text"
             }
-          ]
-        }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/new_sub_sweat', [], [], [], $data);
@@ -150,14 +183,14 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Validation failed.",
-  "errors": [
-    {
-      "property": "parent",
-      "message": "The product model \"new_sub_sweat\" cannot have the product model \"sub_sweat\" as parent"
-    }
-  ]
+    "code": 422,
+    "message": "Validation failed.",
+    "errors": [
+        {
+          "property": "parent",
+          "message": "The product model \"new_sub_sweat\" cannot have the product model \"sub_sweat\" as parent"
+        }
+    ]
 }
 JSON;
 
@@ -172,21 +205,21 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sub_sweat",
-        "family_variant": "familyVariantA1",
-        "parent": "sweat",
-        "values": {
-          "a_simple_select": [
+            <<<JSON
+{
+    "code": "sub_sweat",
+    "family_variant": "familyVariantA1",
+    "parent": "sweat",
+    "values": {
+        "a_simple_select": [
             {
-              "locale": null,
-              "scope": null,
-              "data": "optionA"
+            "locale": null,
+            "scope": null,
+            "data": "optionA"
             }
-          ]
-        }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
@@ -194,14 +227,14 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Validation failed.",
-  "errors": [
-    {
-      "property": "attribute",
-      "message": "Variant axis \"a_simple_select\" cannot be modified, \"Option A\" given"
-    }
-  ]
+    "code": 422,
+    "message": "Validation failed.",
+    "errors": [
+        {
+          "property": "attribute",
+          "message": "Variant axis \"a_simple_select\" cannot be modified, \"Option A\" given"
+        }
+    ]
 }
 JSON;
 
@@ -216,20 +249,20 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sub_sweat",
-        "family_variant": "familyVariantA1",
-        "values": {
-          "a_text": [
+            <<<JSON
+{
+    "code": "sub_sweat",
+    "family_variant": "familyVariantA1",
+    "values": {
+        "a_text": [
             {
               "locale": null,
               "scope": null,
               "data": "My awesome text"
             }
-          ]
-        }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
@@ -250,19 +283,19 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sub_sweat",
-        "values": {
-          "a_text": [
+            <<<JSON
+{
+    "code": "sub_sweat",
+    "values": {
+        "a_text": [
             {
-              "locale": null,
-              "scope": null,
-              "data": "My awesome text"
+            "locale": null,
+            "scope": null,
+            "data": "My awesome text"
             }
-          ]
-        }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
@@ -283,21 +316,21 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sub_sweat",
-        "family_variant": "familyVariantA2",
-        "parent": "sweat",
-        "values": {
-          "a_text": [
+            <<<JSON
+{
+    "code": "sub_sweat",
+    "family_variant": "familyVariantA2",
+    "parent": "sweat",
+    "values": {
+        "a_text": [
             {
-              "locale": null,
-              "scope": null,
-              "data": "My awesome text"
+            "locale": null,
+            "scope": null,
+            "data": "My awesome text"
             }
-          ]
-        }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
@@ -305,13 +338,13 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Property \"family_variant\" cannot be modified, \"familyVariantA2\" given. Check the expected format on the API documentation.",
-  "_links": {
-    "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    "code": 422,
+    "message": "Property \"family_variant\" cannot be modified, \"familyVariantA2\" given. Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+          "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+        }
     }
-  }
 }
 JSON;
 
@@ -326,20 +359,20 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sub_sweat",
-        "parent": "shoes",
-        "values": {
-          "a_text": [
+            <<<JSON
+{
+    "code": "sub_sweat",
+    "parent": "shoes",
+    "values": {
+        "a_text": [
             {
-              "locale": null,
-              "scope": null,
-              "data": "My awesome text"
+                "locale": null,
+                "scope": null,
+                "data": "My awesome text"
             }
-          ]
-        }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
@@ -347,13 +380,13 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Property \"parent\" cannot be modified, \"shoes\" given. Check the expected format on the API documentation.",
-  "_links": {
-    "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    "code": 422,
+    "message": "Property \"parent\" cannot be modified, \"shoes\" given. Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+          "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+        }
     }
-  }
 }
 JSON;
 
@@ -368,20 +401,20 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sweat",
-        "family_variant": "familyVariantA1",
-        "values": {
-            "a_number_float":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"15.3"
-                }
-            ]
-        }
+            <<<JSON
+{
+    "code": "sweat",
+    "family_variant": "familyVariantA1",
+    "values": {
+        "a_number_float":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"15.3"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sweat', [], [], [], $data);
@@ -408,20 +441,20 @@ JSON;
 
         $data =
             <<<JSON
-    {
-        "code": "sub_product_model",
-        "family_variant": "familyVariantA1",
-        "parent": "sweat",
-        "values": {
-          "a_simple_select": [
+{
+    "code": "sub_product_model",
+    "family_variant": "familyVariantA1",
+    "parent": "sweat",
+    "values": {
+        "a_simple_select": [
             {
-              "locale": null,
-              "scope": null,
-              "data": "optionA"
+                "locale": null,
+                "scope": null,
+                "data": "optionA"
             }
-          ]
-        }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_product_model', [], [], [], $data);
@@ -480,19 +513,19 @@ JSON;
 
         $data =
             <<<JSON
-    {
-        "code": "root_product_model",
-        "family_variant": "familyVariantA1",
-        "values": {
-            "a_number_float":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"12.5000"
-                }
-            ]
-        }
+{
+    "code": "root_product_model",
+    "family_variant": "familyVariantA1",
+    "values": {
+        "a_number_float":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"12.5000"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/root_product_model', [], [], [], $data);
@@ -528,20 +561,20 @@ JSON;
 
         $data =
             <<<JSON
-    {
-        "code": "root_product_model",
-        "family_variant": "familyVariantA1",
-        "parent": null,
-        "values": {
-            "a_number_float":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"12.5000"
-                }
-            ]
-        }
+{
+    "code": "root_product_model",
+    "family_variant": "familyVariantA1",
+    "parent": null,
+    "values": {
+        "a_number_float":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"12.5000"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/root_product_model', [], [], [], $data);
@@ -577,20 +610,20 @@ JSON;
 
         $data =
             <<<JSON
-    {
-        "code": "sweat",
-        "family_variant": "familyVariantA1",
-        "parent": null,
-        "values": {
-            "a_number_float":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"12.5000"
-                }
-            ]
-        }
+{
+    "code": "sweat",
+    "family_variant": "familyVariantA1",
+    "parent": null,
+    "values": {
+        "a_number_float":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"12.5000"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sweat', [], [], [], $data);
@@ -607,21 +640,21 @@ JSON;
 
         $data =
             <<<JSON
-    {
-        "code": "sub_sweat",
-        "parent": null,
-        "family_variant": "familyVariantA1",
-        "parent": null,
-        "values": {
-            "a_simple_select":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"optionB"
-                }
-            ]
-        }
+{
+    "code": "sub_sweat",
+    "parent": null,
+    "family_variant": "familyVariantA1",
+    "parent": null,
+    "values": {
+        "a_simple_select":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"optionB"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
@@ -629,13 +662,13 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Property \"parent\" cannot be modified, \"NULL\" given. Check the expected format on the API documentation.",
-  "_links": {
-    "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    "code": 422,
+    "message": "Property \"parent\" cannot be modified, \"NULL\" given. Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+          "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+        }
     }
-  }
 }
 JSON;
 
@@ -651,19 +684,19 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sweat",
-        "values": {
-            "a_number_float":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"15.3"
-                }
-            ]
-        }
+            <<<JSON
+{
+    "code": "sweat",
+    "values": {
+        "a_number_float":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"15.3"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sweat', [], [], [], $data);
@@ -684,18 +717,18 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "values": {
-            "a_description":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"trololo le texte"
-                }
-            ]
-        }
+            <<<JSON
+{
+    "values": {
+        "non_existing_attribute":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"trololo le texte"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
@@ -703,15 +736,15 @@ JSON;
         $response = $client->getResponse();
 
         $expectedContent =
-<<<JSON
+            <<<JSON
 {
-  "code": 422,
-  "message": "Property \"a_description\" does not exist. Check the expected format on the API documentation.",
-  "_links": {
-    "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    "code": 422,
+    "message": "Property \"non_existing_attribute\" does not exist. Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+          "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+        }
     }
-  }
 }
 JSON;
 
@@ -726,34 +759,32 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "values": {
-            "a_description":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"trololo le texte"
-                }
-            ]
-        }
+            <<<JSON
+{
+    "values": {
+        "a_description":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"trololo le texte"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sweat', [], [], [], $data);
 
-        $response = $client->getResponse();
-
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Property \"a_description\" does not exist. Check the expected format on the API documentation.",
-  "_links": {
-    "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    "code": 422,
+    "message": "Property \"a_description\" does not exist. Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+            "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+        }
     }
-  }
 }
 JSON;
 
@@ -769,18 +800,18 @@ JSON;
 
         $data =
             <<<JSON
-    {
-        "family_variant": "familyVariantA1",
-        "values": {
-            "a_number_float":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"12.5000"
-                }
-            ]
-        }
+{
+    "family_variant": "familyVariantA1",
+    "values": {
+        "a_number_float":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"12.5000"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sweat', [], [], [], $data);
@@ -796,20 +827,20 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "new_sub_sweat",
-        "parent": "sweat",
-        "values": {
-            "a_simple_select":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"optionA"
-                }
-            ]
-        }
+            <<<JSON
+{
+    "code": "new_sub_sweat",
+    "parent": "sweat",
+    "values": {
+        "a_simple_select":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"optionA"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/wrong_code', [], [], [], $data);
@@ -817,8 +848,8 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "The code \"new_sub_sweat\" provided in the request body must match the code \"wrong_code\" provided in the url."
+    "code": 422,
+    "message": "The code \"new_sub_sweat\" provided in the request body must match the code \"wrong_code\" provided in the url."
 }
 JSON;
 
@@ -833,19 +864,19 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "new_root_sweat",
-        "values": {
-            "a_number_float":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"15.3"
-                }
-            ]
-        }
+            <<<JSON
+{
+    "code": "new_root_sweat",
+    "values": {
+        "a_number_float":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"15.3"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/wrong_code', [], [], [], $data);
@@ -853,8 +884,8 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "The code \"new_root_sweat\" provided in the request body must match the code \"wrong_code\" provided in the url."
+    "code": 422,
+    "message": "The code \"new_root_sweat\" provided in the request body must match the code \"wrong_code\" provided in the url."
 }
 JSON;
 
@@ -869,20 +900,20 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sub_sweat_bis",
-        "parent": "sweat",
-        "values": {
-            "a_simple_select":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"optionB"
-                }
-            ]
-        }
+            <<<JSON
+{
+    "code": "sub_sweat_bis",
+    "parent": "sweat",
+    "values": {
+        "a_simple_select":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"optionB"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat_bis', [], [], [], $data);
@@ -890,14 +921,14 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Validation failed.",
-  "errors": [
-    {
-      "property": "attribute",
-      "message": "Cannot set value \"Option B\" for the attribute axis \"a_simple_select\", as another sibling entity already has this value"
-    }
-  ]
+    "code": 422,
+    "message": "Validation failed.",
+    "errors": [
+        {
+            "property": "attribute",
+            "message": "Cannot set value \"Option B\" for the attribute axis \"a_simple_select\", as another sibling entity already has this value"
+        }
+    ]
 }
 JSON;
 
@@ -912,20 +943,20 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sweat",
-        "parent": "hat",
-        "values": {
-            "a_number_float":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"15.3"
-                }
-            ]
-        }
+            <<<JSON
+{
+    "code": "sweat",
+    "parent": "hat",
+    "values": {
+        "a_number_float":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"15.3"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sweat', [], [], [], $data);
@@ -933,13 +964,13 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Property \"parent\" cannot be modified, \"hat\" given. Check the expected format on the API documentation.",
-  "_links": {
-    "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    "code": 422,
+    "message": "Property \"parent\" cannot be modified, \"hat\" given. Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+            "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+        }
     }
-  }
 }
 JSON;
 
@@ -954,20 +985,20 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sub_sweat",
-        "parent": "hat",
-        "values": {
-            "a_simple_select":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"optionB"
-                }
-            ]
-        }
+            <<<JSON
+{
+    "code": "sub_sweat",
+    "parent": "hat",
+    "values": {
+        "a_simple_select":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"optionB"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
@@ -975,13 +1006,13 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Property \"parent\" cannot be modified, \"hat\" given. Check the expected format on the API documentation.",
-  "_links": {
-    "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    "code": 422,
+    "message": "Property \"parent\" cannot be modified, \"hat\" given. Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+            "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+        }
     }
-  }
 }
 JSON;
 
@@ -1006,20 +1037,20 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sub_product",
-        "parent": "root_product_model",
-        "values": {
-            "a_simple_select":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"optionB"
-                }
-            ]
-        }
+            <<<JSON
+{
+    "code": "sub_product",
+    "parent": "root_product_model",
+    "values": {
+        "a_simple_select":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"optionB"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_product', [], [], [], $data);
@@ -1027,14 +1058,14 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Validation failed.",
-  "errors": [
-    {
-      "property": "parent",
-      "message": "The product model \"sub_product\" cannot have a parent"
-    }
-  ]
+    "code": 422,
+    "message": "Validation failed.",
+    "errors": [
+        {
+            "property": "parent",
+            "message": "The product model \"sub_product\" cannot have a parent"
+        }
+    ]
 }
 JSON;
 
@@ -1049,20 +1080,20 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $data =
-<<<JSON
-    {
-        "code": "sweat",
-        "family_variant": "familyVariantA2",
-        "values": {
-            "a_number_float":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"15.3"
-                }
-            ]
-        }
+            <<<JSON
+{
+    "code": "sweat",
+    "family_variant": "familyVariantA2",
+    "values": {
+        "a_number_float":[
+            {
+                "locale":null,
+                "scope":null,
+                "data":"15.3"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sweat', [], [], [], $data);
@@ -1070,13 +1101,13 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Property \"family_variant\" cannot be modified, \"familyVariantA2\" given. Check the expected format on the API documentation.",
-  "_links": {
-    "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    "code": 422,
+    "message": "Property \"family_variant\" cannot be modified, \"familyVariantA2\" given. Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+            "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+        }
     }
-  }
 }
 JSON;
 
@@ -1092,19 +1123,19 @@ JSON;
 
         $data =
             <<<JSON
-    {
-        "code": "sub_sweat",
-        "parent": "sweat",
-        "family_variant": "familyVariantA1",
-        "values": {
-          "a_simple_select": [
-            {
-              "locale": null,
-              "data": "optionB"
-            }
-          ]
+{
+    "code": "sub_sweat",
+    "parent": "sweat",
+    "family_variant": "familyVariantA1",
+    "values": {
+      "a_simple_select": [
+        {
+          "locale": null,
+          "data": "optionB"
         }
+      ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
@@ -1112,13 +1143,13 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Property \"a_simple_select\" expects an array with the key \"scope\". Check the expected format on the API documentation.",
-  "_links": {
-    "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    "code": 422,
+    "message": "Property \"a_simple_select\" expects an array with the key \"scope\". Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+            "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+        }
     }
-  }
 }
 JSON;
 
@@ -1134,18 +1165,18 @@ JSON;
 
         $data =
             <<<JSON
-    {
-        "code": "sweat",
-        "family_variant": "familyVariantA1",
-        "values": {
-            "a_number_float":[
-                {
-                    "locale":null,
-                    "data":"15.3"
-                }
-            ]
-        }
+{
+    "code": "sweat",
+    "family_variant": "familyVariantA1",
+    "values": {
+        "a_number_float":[
+            {
+                "locale":null,
+                "data":"15.3"
+            }
+        ]
     }
+}
 JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sweat', [], [], [], $data);
@@ -1153,13 +1184,13 @@ JSON;
         $expectedContent =
             <<<JSON
 {
-  "code": 422,
-  "message": "Property \"a_number_float\" expects an array with the key \"scope\". Check the expected format on the API documentation.",
-  "_links": {
-    "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    "code": 422,
+    "message": "Property \"a_number_float\" expects an array with the key \"scope\". Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+            "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+        }
     }
-  }
 }
 JSON;
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
@@ -679,7 +679,7 @@ JSON;
         $this->assertSame('', $response->getContent());
     }
 
-    public function testUpdateSubProductModelWithNoParentAndIgnoreAttribute()
+    public function testUpdateSubProductModelWithNonExistingAttribute()
     {
         $client = $this->createAuthenticatedClient();
 
@@ -702,16 +702,26 @@ JSON;
 
         $response = $client->getResponse();
 
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertArrayHasKey('location', $response->headers->all());
-        $this->assertSame(
-            'http://localhost/api/rest/v1/product-models/sub_sweat',
-            $response->headers->get('location')
-        );
-        $this->assertSame('', $response->getContent());
+        $expectedContent =
+<<<JSON
+{
+  "code": 422,
+  "message": "Property \"a_description\" does not exist. Check the expected format on the API documentation.",
+  "_links": {
+    "documentation": {
+      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    }
+  }
+}
+JSON;
+
+        $response = $client->getResponse();
+
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
-    public function testUpdateRootProductModelWithNoParentAndIgnoreAttribute()
+    public function testUpdateRootProductModelWithNonExistingAttribute()
     {
         $client = $this->createAuthenticatedClient();
 
@@ -734,13 +744,23 @@ JSON;
 
         $response = $client->getResponse();
 
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertArrayHasKey('location', $response->headers->all());
-        $this->assertSame(
-            'http://localhost/api/rest/v1/product-models/sweat',
-            $response->headers->get('location')
-        );
-        $this->assertSame('', $response->getContent());
+        $expectedContent =
+            <<<JSON
+{
+  "code": 422,
+  "message": "Property \"a_description\" does not exist. Check the expected format on the API documentation.",
+  "_links": {
+    "documentation": {
+      "href": "http://api.akeneo.com/api-reference.html#patch_product_models__code_"
+    }
+  }
+}
+JSON;
+
+        $response = $client->getResponse();
+
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
     public function testUpdateRootProductModelWithNoCode()
@@ -769,39 +789,6 @@ JSON;
 
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-    }
-
-    public function testUpdateRootProductModelWithInvalidValue()
-    {
-        $client = $this->createAuthenticatedClient();
-
-        $data =
-<<<JSON
-    {
-        "code": "sweat",
-        "values": {
-            "invalid":[
-                {
-                    "locale":null,
-                    "scope":null,
-                    "data":"15.3"
-                }
-            ]
-        }
-    }
-JSON;
-
-        $client->request('PATCH', 'api/rest/v1/product-models/sweat', [], [], [], $data);
-
-        $response = $client->getResponse();
-
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertArrayHasKey('location', $response->headers->all());
-        $this->assertSame(
-            'http://localhost/api/rest/v1/product-models/sweat',
-            $response->headers->get('location')
-        );
-        $this->assertSame('', $response->getContent());
     }
 
     public function testUpdateSubProductModelWithDifferentCodeInUrlThanInData()

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
@@ -331,6 +331,7 @@ services:
         arguments:
             - '@pim_catalog.repository.family_variant'
             - '@pim_catalog.repository.product_model'
+            - '@pim_catalog.repository.attribute'
 
     pim_connector.processor.attribute_filter.product:
         class: '%pim_connector.processor.attribute_filter.product.class%'

--- a/src/Pim/Component/Catalog/spec/ProductModel/Filter/ProductModelAttributeFilterSpec.php
+++ b/src/Pim/Component/Catalog/spec/ProductModel/Filter/ProductModelAttributeFilterSpec.php
@@ -2,9 +2,11 @@
 
 namespace spec\Pim\Component\Catalog\ProductModel\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\CommonAttributeCollection;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
@@ -17,9 +19,10 @@ class ProductModelAttributeFilterSpec extends ObjectBehavior
 {
     function let(
         IdentifiableObjectRepositoryInterface $familyVariantRepository,
-        IdentifiableObjectRepositoryInterface $productModelRepository
+        IdentifiableObjectRepositoryInterface $productModelRepository,
+        IdentifiableObjectRepositoryInterface $attributeRepository
     ) {
-        $this->beConstructedWith($familyVariantRepository, $productModelRepository, ['code', 'parent', 'family_variant']);
+        $this->beConstructedWith($familyVariantRepository, $productModelRepository, $attributeRepository, ['code', 'parent', 'family_variant']);
     }
 
     function it_is_initializable()
@@ -34,9 +37,14 @@ class ProductModelAttributeFilterSpec extends ObjectBehavior
 
     function it_filters_the_attributes_for_a_root_product_model(
         $familyVariantRepository,
+        $attributeRepository,
         FamilyVariantInterface $familyVariant,
-        CommonAttributeCollection $commonAttributeCollection
+        CommonAttributeCollection $commonAttributeCollection,
+        AttributeInterface $attribute
     ) {
+        $attributeRepository->findOneByIdentifier('name')->willReturn($attribute);
+        $attributeRepository->findOneByIdentifier('description')->willReturn($attribute);
+
         $familyVariantRepository->findOneByIdentifier('family_variant')->willreturn($familyVariant);
         $familyVariant->getCommonAttributes()->willReturn($commonAttributeCollection);
         $commonAttributeCollection->exists(Argument::any())->willReturn(true, false);
@@ -46,15 +54,27 @@ class ProductModelAttributeFilterSpec extends ObjectBehavior
             'parent' => '',
             'family_variant' => 'family_variant',
             'values' => [
-                'name-en_US' => 'name',
-                'description-en_US-ecommerce' => 'description',
+                'name' => [
+                    'locale' => 'en_US',
+                    'scope' => null,
+                    'data' => 'name'
+                ],
+                'description' => [
+                    'locale' => 'en_US',
+                    'scope' => 'ecommerce',
+                    'data' => 'description'
+                ],
             ]
         ])->shouldReturn([
             'code' => 'code',
             'parent' => '',
             'family_variant' => 'family_variant',
             'values' => [
-                'name-en_US' => 'name',
+                'name' => [
+                    'locale' => 'en_US',
+                    'scope' => null,
+                    'data' => 'name'
+                ],
             ]
         ]);
     }
@@ -62,11 +82,16 @@ class ProductModelAttributeFilterSpec extends ObjectBehavior
     function it_filters_the_attributes_for_a_sub_product_model(
         $familyVariantRepository,
         $productModelRepository,
+        $attributeRepository,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $productModel,
         VariantAttributeSetInterface $variantAttributeSet,
-        Collection $familyVariantAttribute
+        Collection $familyVariantAttribute,
+        AttributeInterface $attribute
     ) {
+        $attributeRepository->findOneByIdentifier('name')->willReturn($attribute);
+        $attributeRepository->findOneByIdentifier('description')->willReturn($attribute);
+
         $familyVariantRepository->findOneByIdentifier('family_variant')->willreturn($familyVariant);
         $productModelRepository->findOneByIdentifier('code')->willreturn($productModel);
         $productModel->getParent()->willReturn(null);
@@ -81,15 +106,27 @@ class ProductModelAttributeFilterSpec extends ObjectBehavior
             'parent' => 'parent',
             'family_variant' => 'family_variant',
             'values' => [
-                'name-en_US' => 'name',
-                'description-en_US-ecommerce' => 'description',
+                'name' => [
+                    'locale' => 'en_US',
+                    'scope' => null,
+                    'data' => 'name'
+                ],
+                'description' => [
+                    'locale' => 'en_US',
+                    'scope' => 'ecommerce',
+                    'data' => 'description'
+                ],
             ]
         ])->shouldReturn([
             'code' => 'code',
             'parent' => 'parent',
             'family_variant' => 'family_variant',
             'values' => [
-                'description-en_US-ecommerce' => 'description',
+                'description' => [
+                    'locale' => 'en_US',
+                    'scope' => 'ecommerce',
+                    'data' => 'description'
+                ],
             ]
         ]);
     }
@@ -123,5 +160,25 @@ class ProductModelAttributeFilterSpec extends ObjectBehavior
             'family_variant' => 'family_variant',
             'values' => [],
         ]);
+    }
+
+    function it_throws_an_exception_when_attribute_does_not_exists()
+    {
+        $data = [
+            'code' => 'code',
+            'parent' => 'parent',
+            'family_variant' => 'family_variant',
+            'values' => [
+                'description' => [
+                    'locale' => 'en_US',
+                    'scope' => 'ecommerce',
+                    'data' => 'description'
+                ],
+            ],
+        ];
+
+        $this->shouldThrow(
+            UnknownPropertyException::unknownProperty('description')
+        )->during('filter', [$data]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/ProductModel/Filter/ProductModelAttributeFilterSpec.php
+++ b/src/Pim/Component/Catalog/spec/ProductModel/Filter/ProductModelAttributeFilterSpec.php
@@ -162,7 +162,7 @@ class ProductModelAttributeFilterSpec extends ObjectBehavior
         ]);
     }
 
-    function it_throws_an_exception_when_attribute_does_not_exists()
+    function it_throws_an_exception_when_attribute_does_not_exist()
     {
         $data = [
             'code' => 'code',

--- a/src/Pim/Component/Catalog/spec/Updater/ProductModelUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ProductModelUpdaterSpec.php
@@ -5,6 +5,8 @@ namespace spec\Pim\Component\Catalog\Updater;
 use Akeneo\Component\StorageUtils\Exception\ImmutablePropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\Component\StorageUtils\Updater\PropertySetterInterface;
@@ -177,5 +179,45 @@ class ProductModelUpdaterSpec extends ObjectBehavior
     function it_only_works_with_product_model(ProductInterface $product)
     {
         $this->shouldThrow(InvalidObjectException::class)->during('update', [$product, [], []]);
+    }
+
+    function it_throws_an_exception_when_giving_a_non_scalar_code(
+        ProductModelInterface $productModel
+    ) {
+        $this->shouldThrow(
+            InvalidPropertyTypeException::class
+        )->during('update', [$productModel, ['code' => []]]);
+    }
+
+    function it_throws_an_exception_when_giving_a_non_scalar_family_variant(
+        ProductModelInterface $productModel
+    ) {
+        $this->shouldThrow(
+            InvalidPropertyTypeException::class
+        )->during('update', [$productModel, ['family_variant' => []]]);
+    }
+
+    function it_throws_an_exception_when_giving_non_scalar_categories(
+        ProductModelInterface $productModel
+    ) {
+        $this->shouldThrow(
+            InvalidPropertyTypeException::class
+        )->during('update', [$productModel, ['categories' => '']]);
+    }
+
+    function it_throws_an_exception_when_giving_an_array_of_categories_with_non_scalar_values(
+        ProductModelInterface $productModel
+    ) {
+        $this->shouldThrow(
+            InvalidPropertyTypeException::class
+        )->during('update', [$productModel, ['categories' => [[]]]]);
+    }
+
+    function it_throws_an_exception_when_giving_an_unknown_property(
+        ProductModelInterface $productModel
+    ) {
+        $this->shouldThrow(
+            UnknownPropertyException::class
+        )->during('update', [$productModel, ['michel' => [[]]]]);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Forbid the use of a non-existing attribute in product models creation and update,
Throw exception when trying to create or update a product model with a non-existing attribute,
it will throw an exception like that:
Property \"a_description\" does not exist. Check the expected format on the API documentation.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | Ok
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
