### PR TITLE
PIM-7082: remove double user menu on product import edit form

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -7,6 +7,9 @@
 - API-567: Fix validation of product-models on API
 - PIM-7085: Fix translation missing
 - PIM-6965: Show short view|project name in the grid
+- PIM-7083: fix access to product edit form if no right to view default locale
+- PIM-7082: remove double user menu on product import edit form
+- PIM-7084: fix attribute suppression
 
 ## Improvements
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
@@ -11,7 +11,7 @@ extensions:
 
     pim-job-instance-xlsx-product-model-import-edit-user-navigation:
         module: pim/menu/user-navigation
-        parent: pim-job-instance-xlsx-product-import-edit
+        parent: pim-job-instance-xlsx-product-model-import-edit
         targetZone: user-menu
         config:
             userAccount: pim_menu.user.user_account

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -70,7 +70,7 @@ define(
 
 
 
-                        let currentLocale = _.findWhere(locales, {code: params.localeCode});
+                        let currentLocale = locales.find(locale => locale.code === params.localeCode);
                         if (undefined === currentLocale) {
                             currentLocale = _.first(locales);
                         }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -68,10 +68,17 @@ define(
                         };
                         this.getRoot().trigger('pim_enrich:form:locale_switcher:pre_render', params);
 
+
+
+                        let currentLocale = _.findWhere(locales, {code: params.localeCode});
+                        if (undefined === currentLocale) {
+                            currentLocale = _.first(locales);
+                        }
+
                         this.$el.html(
                             this.template({
                                 locales: locales,
-                                currentLocale: _.findWhere(locales, {code: params.localeCode}),
+                                currentLocale,
                                 i18n: i18n,
                                 displayInline: this.displayInline,
                                 displayLabel: this.displayLabel,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -68,8 +68,6 @@ define(
                         };
                         this.getRoot().trigger('pim_enrich:form:locale_switcher:pre_render', params);
 
-
-
                         let currentLocale = locales.find(locale => locale.code === params.localeCode);
                         if (undefined === currentLocale) {
                             currentLocale = _.first(locales);

--- a/src/Pim/Component/Catalog/Factory/ValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ValueCollectionFactory.php
@@ -3,6 +3,7 @@
 namespace Pim\Component\Catalog\Factory;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface;
 use Pim\Component\Catalog\Exception\InvalidAttributeException;
 use Pim\Component\Catalog\Exception\InvalidOptionException;
@@ -97,6 +98,15 @@ class ValueCollectionFactory implements ValueCollectionFactoryInterface
                                     $e->getPropertyValue()
                                 )
                             );
+                        } catch (InvalidPropertyTypeException $e) {
+                            $this->logger->warning(
+                                sprintf(
+                                    'Tried to load a product value for attribute "%s" that does not have the ' .
+                                    'good type in database.',
+                                    $attribute->getCode()
+                                )
+                            );
+                            $values[] = $this->valueFactory->create($attribute, $channelCode, $localeCode, null);
                         }
                     }
                 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix double user menu on product import
Fix access to product edit form when default locale is not viewable
Fix on attribute removal and re-creation with another type

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
