### PR TITLE
Pim 7079: fix behats about the refactoring of value collection

### DIFF
--- a/features/export/product-export-builder/export_variant_products_by_specific_date.feature
+++ b/features/export/product-export-builder/export_variant_products_by_specific_date.feature
@@ -22,8 +22,8 @@ Feature: Export updated variant products according to a date
     And I wait for the "csv_catalog_modeling_product_export" job to finish
     Then exported file of "csv_catalog_modeling_product_export" should contain:
       """
-      sku;categories;enabled;family;parent;groups;brand;collection;color;composition;description-en_US-mobile;ean;erp_name-en_US;image;keywords-en_US;material;meta_description-en_US;meta_title-en_US;name-en_US;notice;price-EUR;size;supplier;variation_image;variation_name-en_US;weight;weight-unit
-      braided-hat-m;master_accessories_hats;1;accessories;model-braided-hat;;;summer_2017;battleship_grey;;;1234567890348;;files/braided-hat-m/image/braided-hat.jpg;;wool;;;"Braided hat ";;;m;;;"Braided hat medium";700.0000;GRAM
-      braided-hat-xxxl;master_accessories_hats;1;accessories;model-braided-hat;;;summer_2017;battleship_grey;;;1234567890349;;files/braided-hat-xxxl/image/braided-hat.jpg;;wool;;;"Braided hat ";;;xxxl;;;"Braided hat large";700.0000;GRAM
+      sku;categories;enabled;family;parent;groups;brand;collection;color;composition;description-en_US-mobile;ean;erp_name-en_US;image;keywords-en_US;material;meta_description-en_US;meta_title-en_US;name-en_US;notice;price-EUR;price-USD;size;supplier;variation_image;variation_name-en_US;weight;weight-unit
+      braided-hat-m;master_accessories_hats;1;accessories;model-braided-hat;;;summer_2017;battleship_grey;;;1234567890348;;files/braided-hat-m/image/braided-hat.jpg;;wool;;;"Braided hat ";;;;m;;;"Braided hat medium";700.0000;GRAM
+      braided-hat-xxxl;master_accessories_hats;1;accessories;model-braided-hat;;;summer_2017;battleship_grey;;;1234567890349;;files/braided-hat-xxxl/image/braided-hat.jpg;;wool;;;"Braided hat ";;;;xxxl;;;"Braided hat large";700.0000;GRAM
       """
 

--- a/features/export/variant_product/csv/export_variant_products.feature
+++ b/features/export/variant_product/csv/export_variant_products.feature
@@ -14,20 +14,20 @@ Feature: Export variant products through CSV export
     And I wait for the "csv_summer_2016_shoes_products_export" job to finish
     Then exported file of "csv_summer_2016_shoes_products_export" should contain:
     """
-    sku;categories;enabled;family;parent;groups;brand;collection;color;composition;description-en_US-ecommerce;ean;erp_name-en_US;eu_shoes_size;image;keywords-en_US;material;meta_description-en_US;meta_title-en_US;name-en_US;notice;price-EUR;size;sole_composition;supplier;top_composition;variation_image;variation_name-en_US;weight;weight-unit
-    1111111173;master_men_shoes,supplier_abibas;1;shoes;brogueshoe;;;summer_2016;;;;;"Brogue shoe";410;;;;;;brogueshoe;;267.00;;;abibas;;;;900.0000;GRAM
-    1111111174;master_men_shoes,supplier_abibas;1;shoes;brogueshoe;;;summer_2016;;;;;"Brogue shoe";400;;;;;;brogueshoe;;267.00;;;abibas;;;;900.0000;GRAM
-    1111111175;master_men_shoes,supplier_abibas;1;shoes;brogueshoe;;;summer_2016;;;;;"Brogue shoe";390;;;;;;brogueshoe;;267.00;;;abibas;;;;800.0000;GRAM
-    1111111176;master_men_shoes,supplier_abibas;1;shoes;brogueshoe;;;summer_2016;;;;;"Brogue shoe";380;;;;;;brogueshoe;;267.00;;;abibas;;;;800.0000;GRAM
-    1111111199;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";410;;;;;;derby;;123.00;;;abibas;;;;900.0000;GRAM
-    1111111200;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";400;;;;;;derby;;123.00;;;abibas;;;;900.0000;GRAM
-    1111111201;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";390;;;;;;derby;;123.00;;;abibas;;;;800.0000;GRAM
-    1111111202;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";380;;;;;;derby;;123.00;;;abibas;;;;800.0000;GRAM
-    1111111203;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";370;;;;;;derby;;123.00;;;abibas;;;;800.0000;GRAM
-    1111111204;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";360;;;;;;derby;;123.00;;;abibas;;;;800.0000;GRAM
-    1111111229;master_men_shoes,print_shoes,supplier_abibas;1;shoes;galesh;;;summer_2016;;;;;"Galesh shoe";410;;;;;;galesh;;144.00;;;abibas;;;;900.0000;GRAM
-    1111111230;master_men_shoes,print_shoes,supplier_abibas;1;shoes;galesh;;;summer_2016;;;;;"Galesh shoe";400;;;;;;galesh;;144.00;;;abibas;;;;900.0000;GRAM
-    1111111231;master_men_shoes,print_shoes,supplier_abibas;1;shoes;galesh;;;summer_2016;;;;;"Galesh shoe";390;;;;;;galesh;;144.00;;;abibas;;;;800.0000;GRAM
-    1111111232;master_men_shoes,print_shoes,supplier_abibas;1;shoes;galesh;;;summer_2016;;;;;"Galesh shoe";380;;;;;;galesh;;144.00;;;abibas;;;;800.0000;GRAM
-    1111111233;master_men_shoes,print_shoes,supplier_abibas;1;shoes;galesh;;;summer_2016;;;;;"Galesh shoe";360;;;;;;galesh;;144.00;;;abibas;;;;800.0000;GRAM
+    sku;categories;enabled;family;parent;groups;brand;collection;color;composition;description-en_US-ecommerce;ean;erp_name-en_US;eu_shoes_size;image;keywords-en_US;material;meta_description-en_US;meta_title-en_US;name-en_US;notice;price-EUR;price-USD;size;sole_composition;supplier;top_composition;variation_image;variation_name-en_US;weight;weight-unit
+    1111111173;master_men_shoes,supplier_abibas;1;shoes;brogueshoe;;;summer_2016;;;;;"Brogue shoe";410;;;;;;brogueshoe;;267.00;;;;abibas;;;;900.0000;GRAM
+    1111111174;master_men_shoes,supplier_abibas;1;shoes;brogueshoe;;;summer_2016;;;;;"Brogue shoe";400;;;;;;brogueshoe;;267.00;;;;abibas;;;;900.0000;GRAM
+    1111111175;master_men_shoes,supplier_abibas;1;shoes;brogueshoe;;;summer_2016;;;;;"Brogue shoe";390;;;;;;brogueshoe;;267.00;;;;abibas;;;;800.0000;GRAM
+    1111111176;master_men_shoes,supplier_abibas;1;shoes;brogueshoe;;;summer_2016;;;;;"Brogue shoe";380;;;;;;brogueshoe;;267.00;;;;abibas;;;;800.0000;GRAM
+    1111111199;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";410;;;;;;derby;;123.00;;;;abibas;;;;900.0000;GRAM
+    1111111200;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";400;;;;;;derby;;123.00;;;;abibas;;;;900.0000;GRAM
+    1111111201;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";390;;;;;;derby;;123.00;;;;abibas;;;;800.0000;GRAM
+    1111111202;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";380;;;;;;derby;;123.00;;;;abibas;;;;800.0000;GRAM
+    1111111203;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";370;;;;;;derby;;123.00;;;;abibas;;;;800.0000;GRAM
+    1111111204;master_men_shoes,print_shoes,supplier_abibas;1;shoes;derby;;;summer_2016;;;;;"Derby shoe";360;;;;;;derby;;123.00;;;;abibas;;;;800.0000;GRAM
+    1111111229;master_men_shoes,print_shoes,supplier_abibas;1;shoes;galesh;;;summer_2016;;;;;"Galesh shoe";410;;;;;;galesh;;144.00;;;;abibas;;;;900.0000;GRAM
+    1111111230;master_men_shoes,print_shoes,supplier_abibas;1;shoes;galesh;;;summer_2016;;;;;"Galesh shoe";400;;;;;;galesh;;144.00;;;;abibas;;;;900.0000;GRAM
+    1111111231;master_men_shoes,print_shoes,supplier_abibas;1;shoes;galesh;;;summer_2016;;;;;"Galesh shoe";390;;;;;;galesh;;144.00;;;;abibas;;;;800.0000;GRAM
+    1111111232;master_men_shoes,print_shoes,supplier_abibas;1;shoes;galesh;;;summer_2016;;;;;"Galesh shoe";380;;;;;;galesh;;144.00;;;;abibas;;;;800.0000;GRAM
+    1111111233;master_men_shoes,print_shoes,supplier_abibas;1;shoes;galesh;;;summer_2016;;;;;"Galesh shoe";360;;;;;;galesh;;144.00;;;;abibas;;;;800.0000;GRAM
     """

--- a/features/export/variant_product/xlsx/export_variant_products.feature
+++ b/features/export/variant_product/xlsx/export_variant_products.feature
@@ -13,19 +13,19 @@ Feature: Export variant products through XLSX export
     And I launch the export job
     And I wait for the "xlsx_summer_2016_shoes_products_export" job to finish
     Then exported xlsx file of "xlsx_summer_2016_shoes_products_export" should contain:
-      |sku       |categories                                  |enabled|family|parent    |groups|brand|collection|color|composition|description-en_US-ecommerce|ean|erp_name-en_US|eu_shoes_size|image|keywords-en_US|material|meta_description-en_US|meta_title-en_US|name-en_US|notice|price-EUR|size|sole_composition|supplier|top_composition|variation_image|variation_name-en_US|weight|weight-unit|
-      |1111111173|master_men_shoes,supplier_abibas            |1      |shoes |brogueshoe|      ||summer_2016|||||Brogue shoe|410||||||brogueshoe||267.00|||abibas||||900.0000|GRAM|
-      |1111111174|master_men_shoes,supplier_abibas            |1      |shoes |brogueshoe|      ||summer_2016|||||Brogue shoe|400||||||brogueshoe||267.00|||abibas||||900.0000|GRAM|
-      |1111111175|master_men_shoes,supplier_abibas            |1      |shoes |brogueshoe|      ||summer_2016|||||Brogue shoe|390||||||brogueshoe||267.00|||abibas||||800.0000|GRAM|
-      |1111111176|master_men_shoes,supplier_abibas            |1      |shoes |brogueshoe|      ||summer_2016|||||Brogue shoe|380||||||brogueshoe||267.00|||abibas||||800.0000|GRAM|
-      |1111111199|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|410||||||derby||123.00|||abibas||||900.0000|GRAM|
-      |1111111200|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|400||||||derby||123.00|||abibas||||900.0000|GRAM|
-      |1111111201|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|390||||||derby||123.00|||abibas||||800.0000|GRAM|
-      |1111111202|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|380||||||derby||123.00|||abibas||||800.0000|GRAM|
-      |1111111203|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|370||||||derby||123.00|||abibas||||800.0000|GRAM|
-      |1111111204|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|360||||||derby||123.00|||abibas||||800.0000|GRAM|
-      |1111111229|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |galesh    |      ||summer_2016|||||Galesh shoe|410||||||galesh||144.00|||abibas||||900.0000|GRAM|
-      |1111111230|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |galesh    |      ||summer_2016|||||Galesh shoe|400||||||galesh||144.00|||abibas||||900.0000|GRAM|
-      |1111111231|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |galesh    |      ||summer_2016|||||Galesh shoe|390||||||galesh||144.00|||abibas||||800.0000|GRAM|
-      |1111111232|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |galesh    |      ||summer_2016|||||Galesh shoe|380||||||galesh||144.00|||abibas||||800.0000|GRAM|
-      |1111111233|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |galesh    |      ||summer_2016|||||Galesh shoe|360||||||galesh||144.00|||abibas||||800.0000|GRAM|
+      |sku       |categories                                  |enabled|family|parent    |groups|brand|collection|color|composition|description-en_US-ecommerce|ean|erp_name-en_US|eu_shoes_size|image|keywords-en_US|material|meta_description-en_US|meta_title-en_US|name-en_US|notice|price-EUR|price-USD|size|sole_composition|supplier|top_composition|variation_image|variation_name-en_US|weight|weight-unit|
+      |1111111173|master_men_shoes,supplier_abibas            |1      |shoes |brogueshoe|      ||summer_2016|||||Brogue shoe|410||||||brogueshoe||267.00||||abibas||||900.0000|GRAM|
+      |1111111174|master_men_shoes,supplier_abibas            |1      |shoes |brogueshoe|      ||summer_2016|||||Brogue shoe|400||||||brogueshoe||267.00||||abibas||||900.0000|GRAM|
+      |1111111175|master_men_shoes,supplier_abibas            |1      |shoes |brogueshoe|      ||summer_2016|||||Brogue shoe|390||||||brogueshoe||267.00||||abibas||||800.0000|GRAM|
+      |1111111176|master_men_shoes,supplier_abibas            |1      |shoes |brogueshoe|      ||summer_2016|||||Brogue shoe|380||||||brogueshoe||267.00||||abibas||||800.0000|GRAM|
+      |1111111199|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|410||||||derby||123.00||||abibas||||900.0000|GRAM|
+      |1111111200|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|400||||||derby||123.00||||abibas||||900.0000|GRAM|
+      |1111111201|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|390||||||derby||123.00||||abibas||||800.0000|GRAM|
+      |1111111202|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|380||||||derby||123.00||||abibas||||800.0000|GRAM|
+      |1111111203|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|370||||||derby||123.00||||abibas||||800.0000|GRAM|
+      |1111111204|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |derby     |      ||summer_2016|||||Derby shoe|360||||||derby||123.00||||abibas||||800.0000|GRAM|
+      |1111111229|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |galesh    |      ||summer_2016|||||Galesh shoe|410||||||galesh||144.00||||abibas||||900.0000|GRAM|
+      |1111111230|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |galesh    |      ||summer_2016|||||Galesh shoe|400||||||galesh||144.00||||abibas||||900.0000|GRAM|
+      |1111111231|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |galesh    |      ||summer_2016|||||Galesh shoe|390||||||galesh||144.00||||abibas||||800.0000|GRAM|
+      |1111111232|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |galesh    |      ||summer_2016|||||Galesh shoe|380||||||galesh||144.00||||abibas||||800.0000|GRAM|
+      |1111111233|master_men_shoes,print_shoes,supplier_abibas|1      |shoes |galesh    |      ||summer_2016|||||Galesh shoe|360||||||galesh||144.00||||abibas||||800.0000|GRAM|


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
I broke the (green :trollface: ) CI when I merged this PR: https://github.com/akeneo/pim-community-dev/pull/7411

When exporting variant products, missing values about the price were not exported.
Headers of the export were `code;price-EUR` instead of `code;price-EUR;price-USD`.

With PO, we decided to fix the scenarios, because displaying `price-USD`was the expected behavior.

So, why the refactoring we did with Anaël broke the scenarios?

## Explanation of the bug

### State of our products before processing:

- ProductModel PM1 : price[EUR, 10]
- VariantProduct VP1 : parent[PM1]

### Add missing price product values

1. we add missing prices to the variant product VP1 https://github.com/akeneo/pim-community-dev/blob/2.0/src/Pim/Component/Catalog/ValuesFiller/AbstractEntityWithFamilyValuesFiller.php#L131 

2. to do that, it deletes the price product value and then insert the new one: https://github.com/akeneo/pim-community-dev/blob/2.0/src/Pim/Component/Catalog/Builder/EntityWithValuesBuilder.php#L59

But the price product value is at the product model level. 
The `getValue` of VP1 returns product values of the variant product+ product values of the parent product model.
Then, the remove does not work as it does not remove the price product value in the product model.

Therefore, after execution of the function `addOrReplaceValue`, the state is:

ProductModel PM1 : price[EUR, 10]
VariantProduct VP1 : parent[PM1], price[EUR, 10 - USD, null]

We are in a pretty weird state, as the price is normally defined at the product model level.

3. When normalizing the product, we call `getValue` on the variant product. This function returns product values of the variant product + the product model.

```
    private function getAllValues(
        EntityWithFamilyVariantInterface $entity,
        ValueCollectionInterface $valueCollection
    ) {
        $parent = $entity->getParent();

        if (null === $parent) {
            return $valueCollection;
        }

        foreach ($parent->getValuesForVariation() as $value) {
            $valueCollection->add($value);
        }

        return $this->getAllValues($parent, $valueCollection);
    }
```
Do note that we use the function `add` on the collection of values.

And here is the problem:
**Before refactoring**, `add ` were doing an array search, adding the value if it does exist:

```
        if (false !== array_search($value, $this->values, true)) {
            return false;
        }
```
As the research was by reference, the price of the product model was added in the list, overriding the price product value of the variant product. The returned  price product value was `price[EUR, 10]`.

**After refactoring**, we are adding the value if the key  does not exist:
```
        $attribute = $value->getAttribute();
        $channelCode = null !== $value->getScope() ? $value->getScope() : '<all_channels>';
        $localeCode = null !== $value->getLocale() ? $value->getLocale() : '<all_locales>';
        $key = sprintf('%s-%s-%s', $attribute->getCode(), $channelCode, $localeCode);

        if (isset($this->values[$key])) {
            return false;
        }
```

As the research is on the key this time, the price product value of the product model is not added, because the value is already in the product variant. So, The returned  price product value is `price[EUR, 10 - USD, null]`.

For now, I only fix behats. But there is clearly a problem somewhere about variant products modelisation. @jjanvier is refactoring this part.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
