### PR TITLE
API-567: validation on product models

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - PIM-6874: Fix select attribute groups from PEF when there are more than 25
 - PIM-7086: Fix enable loading message in system configuration
+- API-567: Fix validation of product-models on API
 
 # 2.0.11 (2018-01-05)
 

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -139,6 +139,7 @@ class ProductController
      * @param PrimaryKeyEncrypter                   $primaryKeyEncrypter
      * @param ProductQueryBuilderFactoryInterface   $fromSizePqbFactory
      * @param ProductBuilderInterface               $variantProductBuilder
+     * @param AttributeFilterInterface              $productAttributeFilter
      * @param array                                 $apiConfiguration
      */
     public function __construct(

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -180,7 +180,7 @@ services:
             - '@pim_catalog.factory.product_model'
             - '@pim_catalog.saver.product_model'
             - '@router'
-            - '@validator'
+            - '@pim_catalog.validator.product_model'
             - '@pim_connector.processor.attribute_filter.product_model'
             - '@pim_catalog.repository.product_model'
             - '@pim_api.stream.product_model_partial_update_stream'

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
@@ -759,6 +759,55 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
+    public function testCreateRootProductModelWithErrorOnFileExtension()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $pdfPath = $this->getFixturePath('akeneo.jpg');
+
+        $data =
+<<<JSON
+    {
+        "code": "root_product_model",
+        "family_variant": "familyVariantA1",
+        "values": {
+            "a_file":[
+                {
+                    "locale":null,
+                    "scope":null,
+                    "data": "$pdfPath"
+                }
+            ]
+        }
+    }
+JSON;
+
+        $expectedContent =
+<<<JSON
+    {
+        "code": 422,
+        "message": "Validation failed.",
+        "errors": [
+            {
+                "property": "values",
+                "message": "The file extension is not allowed (allowed extensions: pdf, doc, docx, txt).",
+                "attribute": "a_file",
+                "locale": null,
+                "scope": null
+            }
+        ]
+    }
+JSON;
+
+
+        $client->request('POST', 'api/rest/v1/product-models', [], [], [], $data);
+
+        $response = $client->getResponse();
+
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
     /**
      * @param array  $expectedProductModel normalized data of the product model that should be created
      * @param string $identifier           identifier of the product that should be created

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
@@ -733,8 +733,6 @@ JSON;
 
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
 
-        $response = $client->getResponse();
-
         $expectedContent =
             <<<JSON
 {
@@ -973,6 +971,55 @@ JSON;
     }
 }
 JSON;
+
+        $response = $client->getResponse();
+
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testUpdateRootProductModelWithErrorOnFileExtension()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $pdfPath = $this->getFixturePath('akeneo.jpg');
+
+        $data =
+            <<<JSON
+    {
+        "code": "new_root_sweat",
+        "family_variant": "familyVariantA1",
+        "values": {
+            "a_file":[
+                {
+                    "locale":null,
+                    "scope":null,
+                    "data": "$pdfPath"
+                }
+            ]
+        }
+    }
+JSON;
+
+        $expectedContent =
+            <<<JSON
+    {
+        "code": 422,
+        "message": "Validation failed.",
+        "errors": [
+            {
+                "property": "values",
+                "message": "The file extension is not allowed (allowed extensions: pdf, doc, docx, txt).",
+                "attribute": "a_file",
+                "locale": null,
+                "scope": null
+            }
+        ]
+    }
+JSON;
+
+
+        $client->request('PATCH', 'api/rest/v1/product-models/new_root_sweat', [], [], [], $data);
 
         $response = $client->getResponse();
 

--- a/src/Pim/Component/Api/Normalizer/Exception/ViolationNormalizer.php
+++ b/src/Pim/Component/Api/Normalizer/Exception/ViolationNormalizer.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Inflector\Inflector;
 use Pim\Component\Api\Exception\ViolationHttpException;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\ChannelInterface;
-use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\EntityWithValuesInterface;
 use Pim\Component\Catalog\Validator\Constraints\UniqueValue;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\ConstraintViolationInterface;
@@ -78,7 +78,7 @@ class ViolationNormalizer implements NormalizerInterface
             $propertyPath = $violation->getPropertyPath();
             $violationMessage = $violation->getMessageTemplate();
 
-            if ($violation->getRoot() instanceof ProductInterface &&
+            if ($violation->getRoot() instanceof EntityWithValuesInterface &&
                 1 === preg_match(
                     '|^values\[(?P<attribute>[a-z0-9-_\<\>]+)|i',
                     $violation->getPropertyPath(),

--- a/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
+++ b/src/Pim/Component/Api/spec/Normalizer/Exception/ViolationNormalizerSpec.php
@@ -5,6 +5,7 @@ namespace spec\Pim\Component\Api\Normalizer\Exception;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Api\Exception\ViolationHttpException;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\EntityWithValuesInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
@@ -37,7 +38,7 @@ class ViolationNormalizerSpec extends ObjectBehavior
         ViolationHttpException $exception,
         ConstraintViolationList $constraintViolations,
         ConstraintViolation $violation,
-        ProductInterface $product,
+        EntityWithValuesInterface $product,
         \ArrayIterator $iterator,
         ValueCollectionInterface $values,
         ValueInterface $identifier,
@@ -84,7 +85,7 @@ class ViolationNormalizerSpec extends ObjectBehavior
         ViolationHttpException $exception,
         ConstraintViolationList $constraintViolations,
         ConstraintViolation $violationProductValue,
-        ProductInterface $product,
+        EntityWithValuesInterface $product,
         \ArrayIterator $iterator,
         ValueCollectionInterface $productValues,
         ValueInterface $sku,
@@ -140,7 +141,7 @@ class ViolationNormalizerSpec extends ObjectBehavior
         ConstraintViolationList $constraintViolations,
         ConstraintViolation $violationIdentifier,
         ConstraintViolation $violationProductValue,
-        ProductInterface $product,
+        EntityWithValuesInterface $product,
         \ArrayIterator $iterator,
         ValueCollectionInterface $productValues,
         ValueInterface $sku,
@@ -201,7 +202,7 @@ class ViolationNormalizerSpec extends ObjectBehavior
         ViolationHttpException $exception,
         ConstraintViolationList $constraintViolations,
         ConstraintViolation $violation,
-        ProductInterface $product,
+        EntityWithValuesInterface $product,
         \ArrayIterator $iterator,
         ValueCollectionInterface $productValues,
         ValueInterface $description,


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The ProductModelController for the API didn't use the right validator, indeed it used the `@validator` service instead of the `@pim_catalog.validator.product_model'`.

Moreover the normalizer of this type of Exception (`ViolationNormalizer::class`) worked only for `ProductInterface::class`, I have switched it to `EntityWithValuesInterface::class`

Green CI, rebased it for the CHANGELOG afterward: https://ci.akeneo.com/blue/organizations/jenkins/akeneo%2Fpim-community-dev/detail/PR-7431/8/pipeline

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

  
  