### PR TITLE
PIM-6355: Fix count by categories in the grid to count products

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -40,6 +40,7 @@
 - PIM-7065: Fix versioning when attribute codes are numerics.
 - PIM-7087: Fix completeness normalization when channel code is numeric.
 - PIM-6968: Fix mass delete product
+- PIM-6355: Fix the count by categories on the product grid
 
 ## Improvements
 
@@ -55,6 +56,7 @@
 - Changes the constructor of `Pim\Bundle\ApiBundle\Controller\MediaFileController` to add `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface`
 - Changes the constructor of `Pim\Bundle\ApiBundle\Controller\MediaFileController` to add `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface`
 - Changes the constructor of `Pim\Bundle\ApiBundle\Controller\MediaFileController` to add `Akeneo\Component\StorageUtils\Saver\SaverInterface`
+- Changes the service `pim_enrich.doctrine.counter.category_product` class to `pim_enrich.doctrine.counter.category_product.class` and change first argument to `@pim_catalog.query.product_query_builder_factory`
 
 ## Better manage products with variants!
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -10,6 +10,7 @@
 - PIM-7083: fix access to product edit form if no right to view default locale
 - PIM-7082: remove double user menu on product import edit form
 - PIM-7084: fix attribute suppression
+- PIM-6355: Fix the count by categories on the product grid
 
 ## Improvements
 
@@ -22,6 +23,7 @@
 ## BC Breaks
 
 - Changes the constructor of `Pim\Bundle\ApiBundle\Controller\ProductController` to add `Pim\Component\Catalog\EntityWithFamilyVariant\AddParent`
+- Changes the service `pim_enrich.doctrine.counter.category_product` first argument to a `@pim_catalog.query.product_query_builder_factory`
 
 # 2.0.11 (2018-01-05)
 
@@ -40,7 +42,6 @@
 - PIM-7065: Fix versioning when attribute codes are numerics.
 - PIM-7087: Fix completeness normalization when channel code is numeric.
 - PIM-6968: Fix mass delete product
-- PIM-6355: Fix the count by categories on the product grid
 
 ## Improvements
 
@@ -56,7 +57,6 @@
 - Changes the constructor of `Pim\Bundle\ApiBundle\Controller\MediaFileController` to add `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface`
 - Changes the constructor of `Pim\Bundle\ApiBundle\Controller\MediaFileController` to add `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface`
 - Changes the constructor of `Pim\Bundle\ApiBundle\Controller\MediaFileController` to add `Akeneo\Component\StorageUtils\Saver\SaverInterface`
-- Changes the service `pim_enrich.doctrine.counter.category_product` first argument to a `@pim_catalog.query.product_query_builder_factory`
 
 ## Better manage products with variants!
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -56,7 +56,7 @@
 - Changes the constructor of `Pim\Bundle\ApiBundle\Controller\MediaFileController` to add `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface`
 - Changes the constructor of `Pim\Bundle\ApiBundle\Controller\MediaFileController` to add `Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface`
 - Changes the constructor of `Pim\Bundle\ApiBundle\Controller\MediaFileController` to add `Akeneo\Component\StorageUtils\Saver\SaverInterface`
-- Changes the service `pim_enrich.doctrine.counter.category_product` class to `pim_enrich.doctrine.counter.category_product.class` and change first argument to `@pim_catalog.query.product_query_builder_factory`
+- Changes the service `pim_enrich.doctrine.counter.category_product` first argument to a `@pim_catalog.query.product_query_builder_factory`
 
 ## Better manage products with variants!
 

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/Cursor.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Cursor/Cursor.php
@@ -66,6 +66,18 @@ class Cursor extends AbstractCursor implements CursorInterface
 
     /**
      * {@inheritdoc}
+     */
+    public function count()
+    {
+        if (null === $this->items) {
+            $this->getNextIdentifiers($this->esQuery);
+        }
+
+        return $this->count;
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-search-after.html
      */

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/Counter/CategoryProductsCounter.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/Counter/CategoryProductsCounter.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Doctrine\Counter;
+
+use Akeneo\Component\Classification\Model\CategoryInterface;
+use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+
+/**
+ * Category product counter, using a PQB.
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CategoryProductsCounter implements CategoryItemsCounterInterface
+{
+    /** @var ProductQueryBuilderFactoryInterface */
+    protected $pqbFactory;
+
+    /** @var CategoryRepositoryInterface */
+    protected $categoryRepository;
+
+    /**
+     * @param ProductQueryBuilderFactoryInterface $pqbFactory
+     * @param CategoryRepositoryInterface         $categoryRepository
+     */
+    public function __construct(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        CategoryRepositoryInterface $categoryRepository
+    ) {
+        $this->pqbFactory = $pqbFactory;
+        $this->categoryRepository = $categoryRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItemsCountInCategory(CategoryInterface $category, $inChildren = false, $inProvided = true)
+    {
+        $categoryCodes = $inChildren
+            ? $this->categoryRepository->getAllChildrenCodes($category, $inProvided)
+            : [$category->getCode()];
+
+        $options = [
+            'filters' => [
+                [
+                    'field' => 'categories',
+                    'operator' => Operators::IN_LIST,
+                    'value' => $categoryCodes
+                ]
+            ]
+        ];
+
+        $pqb = $this->pqbFactory->create($options);
+        $items = $pqb->execute();
+
+        return $items->count();
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/Counter/CategoryProductsCounter.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/Counter/CategoryProductsCounter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Pim\Bundle\EnrichBundle\Doctrine\Counter;
 
 use Akeneo\Component\Classification\Model\CategoryInterface;

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/category_counters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/category_counters.yml
@@ -1,12 +1,13 @@
 parameters:
     pim_enrich.doctrine.counter.category_items.class:    Pim\Bundle\EnrichBundle\Doctrine\Counter\CategoryItemsCounter
     pim_enrich.doctrine.counter.category_registry.class: Pim\Bundle\EnrichBundle\Doctrine\Counter\CategoryItemsCounterRegistry
+    pim_enrich.doctrine.counter.category_product.class: Pim\Bundle\EnrichBundle\Doctrine\Counter\CategoryProductsCounter
 
 services:
     pim_enrich.doctrine.counter.category_product:
-        class: '%pim_enrich.doctrine.counter.category_items.class%'
+        class: '%pim_enrich.doctrine.counter.category_product.class%'
         arguments:
-            - '@pim_catalog.repository.product_category'
+            - '@pim_catalog.query.product_query_builder_factory'
             - '@pim_catalog.repository.category'
         tags:
             - { name: pim_enrich.doctrine.counter.category_item, type: product }

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/Counter/CategoryProductsCounterSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/Counter/CategoryProductsCounterSpec.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\Doctrine\Counter;
+
+use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\CategoryInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+
+class CategoryProductsCounterSpec extends ObjectBehavior
+{
+    function let(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        CategoryRepositoryInterface $categoryRepository
+    ) {
+        $this->beConstructedWith($pqbFactory, $categoryRepository);
+    }
+
+    function it_gets_items_count_in_category_without_children(
+        $pqbFactory,
+        $categoryRepository,
+        CategoryInterface $category,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $cursor
+    ) {
+        $category->getCode()->willReturn('short');
+        $categoryRepository->getAllChildrenCodes($category, true)->shouldNotBeCalled();
+
+        $pqbFactory->create([
+            'filters' => [
+                [
+                    'field' => 'categories',
+                    'operator' => Operators::IN_LIST,
+                    'value' => ['short']
+                ]
+            ]
+        ])->willReturn($pqb);
+        $pqb->execute()->willReturn($cursor);
+        $cursor->count()->willReturn(114);
+
+        $this->getItemsCountInCategory($category, false, true)->shouldReturn(114);
+    }
+
+    function it_gets_items_count_in_category_with_children(
+        $pqbFactory,
+        $categoryRepository,
+        CategoryInterface $category,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $cursor
+    ) {
+        $category->getCode()->willReturn('short');
+        $categoryRepository->getAllChildrenCodes($category, true)->willReturn([
+            'short', 'short_children', 'short_adults'
+        ]);
+
+        $pqbFactory->create([
+            'filters' => [
+                [
+                    'field' => 'categories',
+                    'operator' => Operators::IN_LIST,
+                    'value' => ['short', 'short_children', 'short_adults']
+                ]
+            ]
+        ])->willReturn($pqb);
+        $pqb->execute()->willReturn($cursor);
+        $cursor->count()->willReturn(1220);
+
+        $this->getItemsCountInCategory($category, true, true)->shouldReturn(1220);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/Counter/CategoryProductsCounterSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/Counter/CategoryProductsCounterSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Pim\Bundle\EnrichBundle\Doctrine\Counter;
 
 use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/Doctrine/Counter/CountProductsPerCategoriesIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/Doctrine/Counter/CountProductsPerCategoriesIntegration.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\tests\integration\Doctrine\Counter;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+class CountProductsPerCategoriesIntegration extends TestCase
+{
+    public function testProductsAreCountedInCategories(): void
+    {
+        $category = $this->getFromTestContainer('pim_catalog.repository.category')
+            ->findOneByCode('master_accessories');
+
+        $productsCount = $this->getFromTestContainer('pim_enrich.doctrine.counter.category_product')
+            ->getItemsCountInCategory($category, false);
+
+        $this->assertEquals(0, $productsCount);
+    }
+
+    public function testProductsAreCountedInSubcategories(): void
+    {
+        $category = $this->getFromTestContainer('pim_catalog.repository.category')
+            ->findOneByCode('master_accessories_hats');
+        $this->getFromTestContainer('pim_catalog.remover.category')
+            ->remove($category);
+
+        $category = $this->getFromTestContainer('pim_catalog.repository.category')
+            ->findOneByCode('master_accessories');
+
+        $productsCount = $this->getFromTestContainer('pim_enrich.doctrine.counter.category_product')
+            ->getItemsCountInCategory($category, true);
+
+        $this->assertEquals(4, $productsCount);
+    }
+
+    public function testVariantProductsAreCountedInCategories(): void
+    {
+        $category = $this->getFromTestContainer('pim_catalog.repository.category')
+            ->findOneByCode('master_men_pants_jeans');
+        $productsCount = $this->getFromTestContainer('pim_enrich.doctrine.counter.category_product')
+            ->getItemsCountInCategory($category, false);
+
+        $this->assertEquals(12, $productsCount);
+
+        $category = $this->getFromTestContainer('pim_catalog.repository.category')
+            ->findOneByCode('master_women_dresses');
+        $productsCount = $this->getFromTestContainer('pim_enrich.doctrine.counter.category_product')
+            ->getItemsCountInCategory($category, false);
+
+        $this->assertEquals(21, $productsCount);
+    }
+
+    public function testVariantProductsAreCountedInSubcategories(): void
+    {
+        $category = $this->getFromTestContainer('pim_catalog.repository.category')
+            ->findOneByCode('master_men_pants');
+        $productsCount = $this->getFromTestContainer('pim_enrich.doctrine.counter.category_product')
+            ->getItemsCountInCategory($category, true);
+
+        $this->assertEquals(48, $productsCount);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PRs changes the way we count the number of products in category tree.
Now we use ES index to retrieve the number of product per category.

**This results in a small performance improvement**.
For **103k products**:

- Before (MySQL COUNT): `200~300ms`
- After (ES): `50~150ms`

_Tested on my machine (Intel Core i7, 8Gb RAM, SSD)_

![screenshot at 2018-01-09 16-29-21](https://user-images.githubusercontent.com/301169/34730298-470f1c5e-f55f-11e7-8e4d-4ba238199cc7.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added Behats                      | N
| Added integration tests           | Y
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
  
  