### PR TITLE
PIM-7086: fix save configuration in OroBundle

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Bug fixes
+
+- PIM-7086: Fix enable loading message in system configuration
+
 # 2.0.11 (2018-01-05)
 
 ## Bug fixes
@@ -15,7 +21,6 @@
 - PIM-7065: Fix versioning when attribute codes are numerics.
 - PIM-7087: Fix completeness normalization when channel code is numeric.
 - PIM-6968: Fix mass delete product
-- PIM-7086: Fix enable loading message in system configuration
 
 ## Improvements
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -15,6 +15,7 @@
 - PIM-7065: Fix versioning when attribute codes are numerics.
 - PIM-7087: Fix completeness normalization when channel code is numeric.
 - PIM-6968: Fix mass delete product
+- PIM-7086: Fix enable loading message in system configuration
 
 ## Improvements
 

--- a/src/Oro/Bundle/ConfigBundle/Config/ConfigManager.php
+++ b/src/Oro/Bundle/ConfigBundle/Config/ConfigManager.php
@@ -77,16 +77,17 @@ class ConfigManager
 
     /**
      * Save settings with fallback to global scope (default)
+     * and change storedSettings with the new settings
      */
     public function save($newSettings)
     {
-        $entity = $this->getScopedEntityName();
-        $entityId = $this->getScopeId();
+        $entityName = $this->getScopedEntityName();
+        $entityId   = $this->getScopeId();
 
         /** @var Config $config */
         $config = $this->om
             ->getRepository('OroConfigBundle:Config')
-            ->getByEntity($entity, $entityId);
+            ->getByEntity($entityName, $entityId);
 
         list($updated, $removed) = $this->getChanged($newSettings);
 
@@ -99,9 +100,8 @@ class ConfigManager
             $value->setValue($newItemValue);
 
             $config->getValues()->add($value);
-            if (isset($this->storedSettings[$entity][$entityId][$newItemKey[0]][$newItemKey[1]])) {
-                $this->storedSettings[$entity][$entityId][$newItemKey[0]][$newItemKey[1]] = $newItemValue;
-            }
+            
+            $this->storedSettings[$entityName][$entityId][$newItemKey[0]][$newItemKey[1]] = $newItemValue;
         }
 
         $this->om->persist($config);

--- a/src/Oro/Bundle/ConfigBundle/Config/ConfigManager.php
+++ b/src/Oro/Bundle/ConfigBundle/Config/ConfigManager.php
@@ -80,11 +80,13 @@ class ConfigManager
      */
     public function save($newSettings)
     {
-        $repository = $this->om->getRepository('OroConfigBundle:ConfigValue');
+        $entity = $this->getScopedEntityName();
+        $entityId = $this->getScopeId();
+
         /** @var Config $config */
         $config = $this->om
             ->getRepository('OroConfigBundle:Config')
-            ->getByEntity($this->getScopedEntityName(), $this->getScopeId());
+            ->getByEntity($entity, $entityId);
 
         list($updated, $removed) = $this->getChanged($newSettings);
 
@@ -97,6 +99,9 @@ class ConfigManager
             $value->setValue($newItemValue);
 
             $config->getValues()->add($value);
+            if (isset($this->storedSettings[$entity][$entityId][$newItemKey[0]][$newItemKey[1]])) {
+                $this->storedSettings[$entity][$entityId][$newItemKey[0]][$newItemKey[1]] = $newItemValue;
+            }
         }
 
         $this->om->persist($config);


### PR DESCRIPTION
**Description**

In System --> Configuration, when changing the "Enable loading messages" and saving and modifying the message and saving again, if we reload the page the enable loading message backs to "no"

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
