### PR TITLE
PIM-6965: show short view names in the grid

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -14,6 +14,7 @@
 - PIM-7065: Fix versioning when attribute codes are numerics.
 - PIM-7087: Fix completeness normalization when channel code is numeric.
 - PIM-6968: Fix mass delete product
+- PIM-6965: Show short view|project name in the grid
 
 ## Improvements
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -279,7 +279,6 @@
           overflow: hidden;
           line-height: 33px;
           height: 30px;
-          margin-right: -30px;
         }
       }
 


### PR DESCRIPTION
**Description**

When your view/project's name is too short (like 'tot'), you can select it but it doesn't appear.
It's like nothing is selected.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
