### PR TITLE
AOB-17: add configuration for routes

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Resources/views/macros.html.twig
+++ b/src/Pim/Bundle/DataGridBundle/Resources/views/macros.html.twig
@@ -28,7 +28,7 @@
             [
                 'underscore',
                 'jquery',
-                'pim-router',
+                'pim/router',
                 'oro/datagrid-builder',
                 'oro/pageable-collection',
                 'pim/datagrid/state',

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -13,6 +13,8 @@ config:
             exports: Translator
 
     config:
+        pim/router:
+            indexRoute: pim_dashboard_index
         # Forwarded events from mediator
         pim/form/common/edit-form:
             forwarded-events:
@@ -513,7 +515,6 @@ config:
         translator: pimenrich/js/translator
         routing: pimenrich/js/fos-routing-wrapper
         pim/datagrid-view-fetcher: pimdatagrid/js/fetcher/datagrid-view-fetcher
-        pim-router: pimenrich/js/router
         jquery-setup: pimui/js/jquery-setup.js
 
         # Controllers

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/builder.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/builder.js
@@ -39,7 +39,11 @@ https://docs.akeneo.com/latest/design_pim/overview.html#register-it`
                 const form = new FormClass(formMeta);
                 form.code = formMeta.code;
 
-                const extensionPromises = extensionsMeta.map((extension) => {
+                const filteredExtensionsMeta = extensionsMeta.filter(
+                    (extensionsMeta) => null !== extensionsMeta.module
+                );
+
+                const extensionPromises = filteredExtensionsMeta.map((extension) => {
                     return getFormMeta(extension.code)
                         .then(buildForm)
                         .then(function (loadedModule) {
@@ -50,7 +54,7 @@ https://docs.akeneo.com/latest/design_pim/overview.html#register-it`
                 });
 
                 return $.when.apply($, extensionPromises).then(function () {
-                    extensionsMeta.forEach((extension) => {
+                    filteredExtensionsMeta.forEach((extension) => {
                         form.addExtension(
                             extension.code,
                             extension.loadedModule,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/logo.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/logo.js
@@ -40,7 +40,11 @@ define(
              * Redirect the user to app's home
              */
             backHome: function () {
-                router.redirectToRoute('oro_default');
+                if (_.isUndefined(this.options.config.to)) {
+                    router.redirectToRoute('oro_default');
+                } else {
+                    router.redirectToRoute(this.options.config.to);
+                }
             }
         });
     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/page-title.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/page-title.js
@@ -1,6 +1,6 @@
 'use strict';
 
-define(['pim-router', 'oro/translator'], function (router, __) {
+define(['pim/router', 'oro/translator'], function (router, __) {
     let routeParams = {};
     let render = (name, params) => {
         document.title = __('page_title.' + name, params);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/table.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/table.js
@@ -2,7 +2,7 @@ define(
     [
         'underscore',
         'jquery',
-        'pim-router',
+        'pim/router',
         'oro/datagrid-builder',
         'oro/pageable-collection',
         'pim/datagrid/state',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/router.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/router.js
@@ -31,9 +31,10 @@ define(
         var Router = Backbone.Router.extend({
             DEFAULT_ROUTE: 'oro_default',
             routes: {
-                '': 'dashboard',
+                '': 'index',
                 '*path': 'defaultRoute'
             },
+            indexRoute: null,
             loadingMask: null,
             currentController: null,
 
@@ -45,16 +46,18 @@ define(
                 this.loadingMask.render().$el.appendTo($('.hash-loading-mask'));
                 _.bindAll(this, 'showLoadingMask', 'hideLoadingMask');
 
+                this.indexRoute = __moduleConfig.indexRoute;
+
                 this.listenTo(mediator, 'route_complete', this._processLinks);
             },
 
             /**
-             * Go to the homepage of the app
+             * Go to the index of the app
              *
              * @return {String}
              */
-            dashboard: function () {
-                return this.defaultRoute(this.generate('pim_dashboard_index'));
+            index: function () {
+                return this.defaultRoute(this.generate(this.indexRoute));
             },
 
             /**
@@ -76,7 +79,7 @@ define(
                     return this.notFound();
                 }
                 if (this.DEFAULT_ROUTE === route.name) {
-                    return this.dashboard();
+                    return this.index();
                 }
 
                 this.showLoadingMask();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

For the onboarder, we need to configure the dashboard and the logo routes.

Currently, the dashboard route is hardcoded in router.js. To fix that, we added the configuation `indexRoute` in the requirejs.yml. But it did not work, why ? Because the path `pimenrich/js/router` is duplicated in the config file with two different key (`pim/router` & `pim-router`), that's why we removed the key `pim-router` and replace it by `pim/router` in js files.
Thanks @phaseinducer for his help :)

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

  