### PR TITLE
PIM-7085: mass delete translation missing

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,7 @@
 - PIM-6874: Fix select attribute groups from PEF when there are more than 25
 - PIM-7086: Fix enable loading message in system configuration
 - API-567: Fix validation of product-models on API
+- PIM-7085: Fix translation missing
 
 # 2.0.11 (2018-01-05)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -129,7 +129,7 @@ datagrid:
                 messages:
                     confirm_title: pim_datagrid.mass_action.delete.confirm_title
                     confirm_content: pim_datagrid.mass_action.delete.confirm_content
-                    confirm_ok: pim_datagrid.mass_action.delete.label
+                    confirm_ok: pim_datagrid.mass_action.delete.confirm_ok
                     success: pim_datagrid.mass_action.delete.success
                     error: pim_datagrid.mass_action.delete.error
                     empty_selection: pim_datagrid.mass_action.delete.empty_selection

--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-dialog.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-dialog.js
@@ -107,7 +107,7 @@ define(
                     type: __(subTitle || ''),
                     title: __(title),
                     content: __(content),
-                    okText: buttonText || __('OK'),
+                    okText: __(buttonText) || __('OK'),
                     cancelText: __('Cancel'),
                     buttonClass: buttonClass || 'AknButton--action',
                     template: this.template,


### PR DESCRIPTION
**Description**

In the product grid, when selecting products for mass delete, "DELETE" translation is missing.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -


  