### PR TITLE
PIM-6874: Fix select attribute groups from PEF when there are more than 25

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -9,12 +9,13 @@
 - PIM-7070: Fix sequential edit when selecting multiple product models
 - PIM-6812: Change the message when delete an attribute as variant axis
 - PIM-7048: Fix cascade persist issue during import of families with variant
-- PIM-7049: Fix random order of attribute options 
+- PIM-7049: Fix random order of attribute options
 - PIM-7080: Fix memory leak on product export
 - PIM-6955: Fix delete user
 - PIM-7065: Fix versioning when attribute codes are numerics.
 - PIM-7087: Fix completeness normalization when channel code is numeric.
 - PIM-6968: Fix mass delete product
+- PIM-6874: Fix select attribute groups from PEF when there are more than 25
 
 ## Improvements
 
@@ -23,7 +24,7 @@
 ## BC breaks
 
 - Changes the constructor of  `Pim\Component\Catalog\ProductModel\Filter\ProductAttributeFilter` add `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface`
-- Changes the constructor of  `Pim\Component\Catalog\ProductModel\Filter\ProductModelAttributeFilter` add `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface` 
+- Changes the constructor of  `Pim\Component\Catalog\ProductModel\Filter\ProductModelAttributeFilter` add `Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface`
 - Changes the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\AttributeController` add `Doctrine\ORM\EntityManagerInterface` and `Symfony\Component\Translation\TranslatorInterface`
 - Changes the constructor of `Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber` add `Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface`
 - Changes the constructor of `Pim/Bundle/DataGridBundle/Extension/MassAction/Handler/DeleteProductsMassActionHandler` to add `Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface`
@@ -80,10 +81,10 @@ IMPORTANT: In order to use the new mass edit, please execute `bin/console akeneo
 
 ## BC breaks
 
-- Changes the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\ProductModelController` to add `Pim\Component\Catalog\Repository\FamilyVariantRepositoryInterface` 
-- Changes the constructor of `Akeneo\Bundle\ElasticsearchBundle\Cursor\CursorFactory` to add `Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface` and remove `Doctrine\Common\Persistence\ObjectManager` and string `$entityClassName` 
-- Changes the constructor of `Akeneo\Bundle\ElasticsearchBundle\Cursor\FromSizeCursorFactory` to add `Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface` and remove `Doctrine\Common\Persistence\ObjectManager` and string `$entityClassName` 
-- Changes the constructor of `Akeneo\Bundle\ElasticsearchBundle\Cursor\SearchAfterSizeCursorFactory` to add `Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface` and remove `Doctrine\Common\Persistence\ObjectManager` and string `$entityClassName` 
+- Changes the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\ProductModelController` to add `Pim\Component\Catalog\Repository\FamilyVariantRepositoryInterface`
+- Changes the constructor of `Akeneo\Bundle\ElasticsearchBundle\Cursor\CursorFactory` to add `Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface` and remove `Doctrine\Common\Persistence\ObjectManager` and string `$entityClassName`
+- Changes the constructor of `Akeneo\Bundle\ElasticsearchBundle\Cursor\FromSizeCursorFactory` to add `Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface` and remove `Doctrine\Common\Persistence\ObjectManager` and string `$entityClassName`
+- Changes the constructor of `Akeneo\Bundle\ElasticsearchBundle\Cursor\SearchAfterSizeCursorFactory` to add `Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface` and remove `Doctrine\Common\Persistence\ObjectManager` and string `$entityClassName`
 - Deletes `Pim\Component\Catalog\Repository\ProductRepositoryInterface::getAssociatedProductIds()`
 - Changes the constructor of `Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxesValuesValidator` to remove `Doctrine\ORM\EntityManagerInterface`
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/lib/bootstrap/js/bootstrap.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/lib/bootstrap/js/bootstrap.js
@@ -694,11 +694,15 @@
         const gap = 30;
         const outerWidth = $parent.find('.AknDropdown-menu').outerWidth();
         const outerHeight = $parent.find('.AknDropdown-menuLink').length * 26 + 44;
-        if (outerHeight + $parent.offset().top + gap > $('body').height()) {
-            $parent.addClass('top');
-        } else {
-            $parent.removeClass('top');
-        }
+        const bodyHeight = $('body').height();
+
+        // Lists have a max height of 70vh
+        const maxHeight = bodyHeight * 0.7;
+        const parentOffset = $parent.offset().top;
+        const boundedHeight = Math.min(outerHeight, maxHeight);
+        const listIsLongerThanPage = (boundedHeight + parentOffset + gap) > bodyHeight;
+        $parent.toggleClass('top', listIsLongerThanPage);
+
         if (outerWidth + $parent.offset().left + gap > $('body').width()) {
             $parent.addClass('left');
         } else {

--- a/src/Pim/Bundle/UIBundle/Resources/public/lib/bootstrap/js/bootstrap.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/lib/bootstrap/js/bootstrap.js
@@ -700,8 +700,12 @@
         const maxHeight = bodyHeight * 0.7;
         const parentOffset = $parent.offset().top;
         const boundedHeight = Math.min(outerHeight, maxHeight);
+        const isScrollable = outerHeight > maxHeight;
         const listIsLongerThanPage = (boundedHeight + parentOffset + gap) > bodyHeight;
-        $parent.toggleClass('top', listIsLongerThanPage);
+
+        if (false === isScrollable && listIsLongerThanPage) {
+          $parent.toggleClass('top', listIsLongerThanPage);
+        }
 
         if (outerWidth + $parent.offset().left + gap > $('body').width()) {
             $parent.addClass('left');


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a bug in the display of dropdown lists. The logic to calculate whether to render a dropdown above/below was not right - it wasn't taking into account the max possible height of the list (with scrollbars).

Before
![25groupattributs](https://user-images.githubusercontent.com/1336344/34568689-e8ffe180-f166-11e7-81f2-96eeedd87c19.png)

After
![screen shot 2018-01-04 at 15 49 29](https://user-images.githubusercontent.com/1336344/34568674-de372dc6-f166-11e7-971f-549ade97bba4.png)



<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

  
  
  