### PR TITLE
PIM-6965: Show short view|project name in the grid

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -6,6 +6,7 @@
 - PIM-7086: Fix enable loading message in system configuration
 - API-567: Fix validation of product-models on API
 - PIM-7085: Fix translation missing
+- PIM-6965: Show short view|project name in the grid
 
 # 2.0.11 (2018-01-05)
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -273,13 +273,12 @@
         margin-right: 30px;
 
         .current {
-          max-width: 110px;
+          max-width: 80px;
           text-overflow: ellipsis;
           display: inline-block;
           overflow: hidden;
           line-height: 33px;
           height: 30px;
-          margin-right: -30px;
         }
       }
 


### PR DESCRIPTION
**Description**

When your view/project's name is too short (like 'tot'), you can select it but it doesn't appear.
It's like nothing is selected.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -
  