### PR TITLE
PIM-7064: [SLA] Keep family attribute panel state on edit

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -4,12 +4,13 @@
 
 - PIM-7347: Fix the edit form of multi-select attributes with a lot of options
 - PIM-7031: Removes 'required' label for product grid filters on user creation
+- PIM-7064: Keep family attribute panel state on edit
 
 ## BC-break:
 
 - Remove class `Pim\Bundle\EnrichBundle\Form\Type\AttributeProperty\OptionsType` and service `pim_enrich.form.type.options`
 
-# 1.7.15 (2017-12-18) 
+# 1.7.15 (2017-12-18)
 
 - GITHUB-7202: Ensure commit batch size value is always an int, cheers @bghitulescu!
 - PIM-7017: Permission on "Add attribute to a product" is not properly applied

--- a/features/family/remove_attribute_from_a_family.feature
+++ b/features/family/remove_attribute_from_a_family.feature
@@ -22,6 +22,7 @@ Feature: Remove attribute from a family
   Scenario: Successfully remove an attribute from a family and display it as removable from product
     Given I am on the "Bags" family page
     And I visit the "Attributes" tab
+    Then I should see attributes "Long Description, Manufacturer" in group "Other"
     When I remove the "manufacturer" attribute
     And I save the family
     And I should not see the text "There are unsaved changes."

--- a/features/family/set_the_attribute_used_as_label.feature
+++ b/features/family/set_the_attribute_used_as_label.feature
@@ -49,6 +49,7 @@ Feature: Set the attribute used as label
     Given the attribute "Brand" has been chosen as the family "Bags" label
     When I am on the "Bags" family page
     And I visit the "Attributes" tab
+    Then I should see attributes "Brand, Model, Size, Description" in group "Other"
     And I remove the "brand" attribute
     Then I should see the flash message "This attribute can not be removed because it is used as the label of the family"
     And I should see attributes "Brand" in group "Other"

--- a/features/reference-data/product/sorting/sort_products_per_reference_data.feature
+++ b/features/reference-data/product/sorting/sort_products_per_reference_data.feature
@@ -27,13 +27,13 @@ Feature: Sort products
   @jira https://akeneo.atlassian.net/browse/PIM-7041
   Scenario: Sort a simple-select reference data attribute with the same name than its reference data
     Given the "default" catalog configuration
-    And the following attribute:
-      | code  | label | type                        | reference_data_name | useable_as_grid_filter |
-      | color | Color | reference_data_simpleselect | color               | yes                    |
+    And the following attributes:
+      | code  |  label-en_US  | type                            | reference_data_name | useable_as_grid_filter | group |
+      | color |  Color        | pim_reference_data_simpleselect | color               | yes                    | other |
     And the following "color" attribute reference data: Red, Blue and Green
     And the following family:
       | code     | requirements-mobile | requirements-ecommerce |
-      | whatever | sku, color          | sku, color             |
+      | whatever | sku                 | sku                    |
     And the following products:
       | sku      | family   |
       | productA | whatever |

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -128,9 +128,9 @@ define([
                         groupedAttributes: groupedAttributes,
                         attributeRequirements: data.attribute_requirements,
                         channels: this.channels,
-                        attributeGroups: _.map(attributeGroups, function(group) {
+                        attributeGroups: _.map(attributeGroups, function (group) {
                             var panel = $('tbody[data-group="' + group.code + '"]');
-                            group.collapsed = $(panel).hasClass(this.collapsedClass)
+                            group.collapsed = $(panel).hasClass(this.collapsedClass);
 
                             return group;
                         }.bind(this)),

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -39,6 +39,7 @@ define([
             className: 'tabsection-content tab-content',
             attributeRequiredIconClass: 'AknAcl-icon AknAcl-icon--granted icon-ok required',
             attributeNotRequiredIconClass: 'AknAcl-icon icon-circle non-required',
+            collapsedClass: 'AknGrid-bodyContainer--collapsed',
             requiredLabel: __('pim_enrich.form.family.tab.attributes.required_label'),
             notRequiredLabel: __('pim_enrich.form.family.tab.attributes.not_required_label'),
             identifierAttribute: 'pim_catalog_identifier',
@@ -127,7 +128,12 @@ define([
                         groupedAttributes: groupedAttributes,
                         attributeRequirements: data.attribute_requirements,
                         channels: this.channels,
-                        attributeGroups: attributeGroups,
+                        attributeGroups: _.map(attributeGroups, function(group) {
+                            var panel = $('tbody[data-group="' + group.code + '"]');
+                            group.collapsed = $(panel).hasClass(this.collapsedClass)
+
+                            return group;
+                        }.bind(this)),
                         colspan: (this.channels.length + 2),
                         i18n: i18n,
                         identifierAttribute: this.identifierAttribute,
@@ -149,9 +155,8 @@ define([
             toggleGroup: function (event) {
                 event.preventDefault();
                 var target = event.currentTarget;
-
-                $(target).parent().find('tr:not(.group)').toggle();
                 $(target).find('i').toggleClass('icon-expand-alt icon-collapse-alt');
+                $(target).parent().toggleClass(this.collapsedClass);
 
                 return this;
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family/tab/attributes/attributes.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family/tab/attributes/attributes.html
@@ -14,7 +14,7 @@
         <% var collapsed = (true === attributeGroup.collapsed) %>
 
         <tbody class="AknGrid-bodyContainer <%- collapsed ? 'AknGrid-bodyContainer--collapsed': '' %>"  data-group="<%- group %>">
-            <tr class="AknGrid-bodyRow AknGrid-bodyRow--highlight group">
+            <tr class="AknGrid-bodyRow AknGrid-bodyRow--highlight AknGrid-headerToggle group">
                 <td class="AknGrid-bodyCell" colspan="<%- colspan %>">
                     <i class="<%- collapsed ? 'icon-expand-alt' : 'icon-collapse-alt' %>"></i>
                     <%-

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family/tab/attributes/attributes.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family/tab/attributes/attributes.html
@@ -10,11 +10,13 @@
             <th class="AknGrid-headerCell">&nbsp;</th>
         </thead>
         <% _.each(_.keys(groupedAttributes), function (group) { %>
-        <tbody>
+        <% var attributeGroup = _.findWhere(attributeGroups, {code: group}) %>
+        <% var collapsed = (true === attributeGroup.collapsed) %>
+
+        <tbody class="AknGrid-bodyContainer <%- collapsed ? 'AknGrid-bodyContainer--collapsed': '' %>"  data-group="<%- group %>">
             <tr class="AknGrid-bodyRow AknGrid-bodyRow--highlight group">
                 <td class="AknGrid-bodyCell" colspan="<%- colspan %>">
-                    <i class="icon-collapse-alt"></i>
-                    <% var attributeGroup = _.findWhere(attributeGroups, {code: group}) %>
+                    <i class="<%- collapsed ? 'icon-expand-alt' : 'icon-collapse-alt' %>"></i>
                     <%-
                         i18n.getLabel(
                             attributeGroup.labels,

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -27,6 +27,10 @@
     background: @AknDefaultHoverBackground;
   }
 
+  &-bodyContainer--collapsed &-bodyRow:not(.group) {
+    display: none;
+  }
+
   &-bodyCell {
     cursor: pointer;
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -27,7 +27,7 @@
     background: @AknDefaultHoverBackground;
   }
 
-  &-bodyContainer--collapsed &-bodyRow:not(.group) {
+  &-bodyContainer--collapsed &-bodyRow:not(&-headerToggle) {
     display: none;
   }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes an issue in the family edit attributes screen where all panels were being reopened after any change was made (e.g add/remove attribute or group). Now the panel state is restored on re-render 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

  