### PR TITLE
PIM-7057: Compute product models in dedicated step for family import

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,11 @@
 - PIM-7111: Fix display bug on variant axis completeness
 - PIM-6908: Fix cancel button on unsaved changes dialog
 - PIM-6913: Fix incorrect product completeness percentage
+- PIM-7057: Fix import families by adding a dedicated step regarding the computing of product models data
+
+## BC Breaks
+
+- Changes the constructor of `\Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber` to add `Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface`
 
 # 2.0.12 (2018-01-12)
 

--- a/features/Context/catalog/catalog_modeling/jobs.yml
+++ b/features/Context/catalog/catalog_modeling/jobs.yml
@@ -109,7 +109,15 @@ jobs:
             groupsColumn:       groups
             realTimeVersioning: true
             decimalSeparator:   .
-
+    csv_catalog_modeling_family_import:
+        connector: Akeneo CSV Connector
+        alias:     csv_family_import
+        label:     CSV catalog modeling family import
+        type:      import
+        configuration:
+            uploadAllowed: true
+            delimiter:     ;
+            enclosure:     '"'
     csv_catalog_modeling_family_variant_import:
         connector: Akeneo CSV Connector
         alias:     csv_family_variant_import
@@ -126,7 +134,13 @@ jobs:
         type:      import
         configuration:
             uploadAllowed: true
-
+    xlsx_catalog_modeling_family_import:
+        connector: Akeneo XLSX Connector
+        alias:     xlsx_family_import
+        label:     XLSX catalog modeling family import
+        type:      import
+        configuration:
+            uploadAllowed: true
     csv_catalog_modeling_family_variant_export:
         connector: Akeneo CSV Connector
         alias:     csv_family_variant_export

--- a/features/Pim/Behat/Context/JobContext.php
+++ b/features/Pim/Behat/Context/JobContext.php
@@ -165,6 +165,31 @@ class JobContext extends PimContext
     }
 
     /**
+     * @Given /^there should only be the following job instance executed:$/
+     *
+     * @throws \LogicException
+     */
+    public function thereShouldBeTheFollowingJobInstanceExecuted(TableNode $jobExecutionsTable)
+    {
+        $jobInstances = $this->getService('pim_enrich.repository.job_instance')->findAll();
+        foreach ($jobInstances as $jobInstance) {
+            $this->getFixturesContext()->refresh($jobInstance);
+            $jobExecutionCount = $jobInstance->getJobExecutions()->count();
+            $expectedJobExecutionCount = $this->getExpectedJobExecutionCount($jobInstance, $jobExecutionsTable);
+            if ($jobExecutionCount !== $expectedJobExecutionCount) {
+                throw new \LogicException(
+                    sprintf(
+                        'Expected job "%s" to run %d times, %d given',
+                        $jobInstance->getCode(),
+                        $jobExecutionCount,
+                        $expectedJobExecutionCount
+                    )
+                );
+            }
+        }
+    }
+
+    /**
      * @param string   $code
      * @param int|null $number
      *
@@ -281,5 +306,22 @@ class JobContext extends PimContext
         }
 
         return $currentFilters;
+    }
+
+    /**
+     * @param JobInstance $jobInstance
+     * @param TableNode   $jobExecutionTable
+     *
+     * @return int
+     */
+    private function getExpectedJobExecutionCount(JobInstance $jobInstance, TableNode $jobExecutionTable): int
+    {
+        foreach ($jobExecutionTable->getHash() as $jobExecutionRow) {
+            if ($jobExecutionRow['job_instance'] === $jobInstance->getCode()) {
+                return (int) $jobExecutionRow['times'];
+            }
+        }
+
+        return 0;
     }
 }

--- a/features/import/import_families.feature
+++ b/features/import/import_families.feature
@@ -17,9 +17,33 @@ Feature: Import families
     When I am on the "csv_footwear_family_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_family_import" job to finish
+    And I should see the text "Family import"
+    And I should see the text "Compute product models data"
     Then there should be the following family:
       | code     | attributes            | attribute_as_label | requirements-mobile | requirements-tablet | label-en_US |
       | tractors | sku,name,manufacturer | name               | sku,manufacturer    | sku,manufacturer    | Tractors    |
+
+  Scenario: Successfully update an existing family computes all product models data in a dedicated step for csv
+    Given the "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+    And the product model value material of "model-braided-hat" should be "[wool]"
+    # Removed the 'material' attributes from the 'accessories' + remove 'collection' attribute requirement for ecommerce
+    And the following CSV file to import:
+      """
+      code;label-de_DE;label-en_US;label-fr_FR;attributes;attribute_as_image;attribute_as_label;requirements-ecommerce;requirements-mobile;requirements-print
+      accessories;Accessories;Accessories;Accessories;brand,collection,color,composition,ean,erp_name,image,keywords,meta_description,meta_title,name,notice,price,size,sku,supplier,variation_image,variation_name,weight;image;name;name,sku,variation_name,weight;collection,name,sku,variation_name,weight;collection,name,sku,variation_name,weight
+      """
+    And the following job "csv_catalog_modeling_family_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_catalog_modeling_family_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_family_import" job to finish
+    And I should see the text "Family import"
+    And I should see the text "Compute product models data"
+    And the product model "model-braided-hat" should not have the following values "material"
+    And there should only be the following job instance executed:
+      | job_instance                       | times |
+      | csv_catalog_modeling_family_import | 1     |
 
   Scenario: Successfully update existing family and add a new one
     Given the "footwear" catalog configuration
@@ -56,6 +80,28 @@ Feature: Import families
     Then there should be the following family:
       | code     | attributes            | attribute_as_label | requirements-mobile | requirements-tablet | label-en_US |
       | tractors | sku,name,manufacturer | name               | sku,manufacturer    | sku,manufacturer    | Tractors    |
+
+  Scenario: Successfully update an existing family computes of product models in a dedicated step for xlsx
+    Given the "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+    And the product model value material of "model-braided-hat" should be "[wool]"
+    # Removed the 'material' attributes from the 'accessories' + remove 'collection' attribute requirement for ecommerce
+    And the following XLSX file to import:
+      """
+      code;label-de_DE;label-en_US;label-fr_FR;attributes;attribute_as_image;attribute_as_label;requirements-ecommerce;requirements-mobile;requirements-print
+      accessories;Accessories;Accessories;Accessories;brand,collection,color,composition,ean,erp_name,image,keywords,meta_description,meta_title,name,notice,price,size,sku,supplier,variation_image,variation_name,weight;image;name;name,sku,variation_name,weight;collection,name,sku,variation_name,weight;collection,name,sku,variation_name,weight
+      """
+    And the following job "xlsx_catalog_modeling_family_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "xlsx_catalog_modeling_family_import" import job page
+    And I launch the import job
+    And I wait for the "xlsx_catalog_modeling_family_import" job to finish
+    And I should see the text "Family import"
+    And I should see the text "Compute product models data"
+    And the product model "model-braided-hat" should not have the following values "material"
+    And there should only be the following job instance executed:
+      | job_instance                        | times |
+      | xlsx_catalog_modeling_family_import | 1     |
 
   @jira https://akeneo.atlassian.net/browse/PIM-6107
   Scenario: Import an empty label should display the family code on the product datagrid

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriber.php
@@ -91,6 +91,10 @@ class ComputeCompletenessOnFamilyUpdateSubscriber implements EventSubscriberInte
             return;
         }
 
+        if (!$event->hasArgument('unitary') || false === $event->getArgument('unitary')) {
+            return;
+        }
+
         if (null === $subject->getId()) {
             $this->areAttributeRequirementsUpdatedForFamilies = false;
 
@@ -114,6 +118,10 @@ class ComputeCompletenessOnFamilyUpdateSubscriber implements EventSubscriberInte
         $subject = $event->getSubject();
 
         if (!$subject instanceof FamilyInterface) {
+            return;
+        }
+
+        if (!$event->hasArgument('unitary') || false === $event->getArgument('unitary')) {
             return;
         }
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
@@ -101,6 +101,10 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
             return;
         }
 
+        if (!$event->hasArgument('unitary') || false === $event->getArgument('unitary')) {
+            return;
+        }
+
         $user = $this->tokenStorage->getToken()->getUser();
         $jobInstance = $this->jobInstanceRepository->findOneByIdentifier($this->jobName);
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -36,6 +36,8 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
     private $bulkfamilyVariantSaver;
 
     /**
+     * TODO: @migration 2.2 : remove $bulkFamilyVariantSaver and $objectDetacher
+     *
      * @param ValidatorInterface          $validator
      * @param SaverInterface              $familyVariantSaver
      * @param BulkSaverInterface          $bulkFamilyVariantSaver

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -167,6 +167,7 @@ services:
         arguments:
             - '@validator'
             - '@pim_catalog.saver.family_variant'
+            - '@pim_catalog.saver.family_variant'
             - '@akeneo_storage_utils.doctrine.object_detacher'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -196,6 +196,7 @@ services:
             - ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
+            - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
 
     pim_catalog.query.elasticsearch.filter.group:

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeCompletenessOnFamilyUpdateSubscriberSpec.php
@@ -54,6 +54,8 @@ class ComputeCompletenessOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         UserInterface $user
     ) {
         $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
 
         $family->getId()->willReturn(152);
 
@@ -95,6 +97,8 @@ class ComputeCompletenessOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         AttributeRequirementInterface $attributeRequirement2
     ) {
         $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
 
         $family->getId()->willReturn(152);
 
@@ -129,6 +133,9 @@ class ComputeCompletenessOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         GenericEvent $event,
         FamilyInterface $family
     ) {
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
+
         $family->getId()->willReturn(null);
         $event->getSubject()->willReturn($family);
         $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
@@ -142,6 +149,21 @@ class ComputeCompletenessOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         GenericEvent $event
     ) {
         $event->getSubject()->willReturn(new \StdClass());
+
+        $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
+
+        $this->areAttributeRequirementsUpdated($event);
+        $this->computeCompletenessOfProductsFamily($event);
+    }
+
+    function it_only_handles_unitary_events(
+        $jobLauncher,
+        GenericEvent $event,
+        FamilyInterface $family
+    ) {
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(false);
 
         $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
 

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriberSpec.php
@@ -48,6 +48,8 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
         UserInterface $user,
         JobInstance $jobInstance
     ) {
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
         $event->getSubject()->willReturn($familyVariant);
         $familyVariant->getId()->willReturn(12);
 
@@ -61,6 +63,33 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
         $jobLauncher->launch($jobInstance, $user, [
             'family_variant_codes' => ['family_variant_one']
         ])->shouldBeCalled();
+
+        $this->checkIsFamilyVariantNew($event);
+        $this->computeVariantStructureChanges($event);
+    }
+
+    function it_does_not_comute_variant_structure_for_non_unitary_save(
+        $tokenStorage,
+        $jobLauncher,
+        $jobInstanceRepository,
+        GenericEvent $event,
+        FamilyVariantInterface $familyVariant,
+        TokenInterface $token,
+        UserInterface $user,
+        JobInstance $jobInstance
+    ) {
+        $familyVariant->getId()->willReturn(150);
+        $familyVariant->getCode()->willReturn('my_family_variant');
+        $event->getSubject()->willReturn($familyVariant);
+
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(false);
+
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
+        $jobInstanceRepository->findOneByIdentifier('compute_family_variant_structure_changes')
+            ->willReturn($jobInstance);
+        $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
 
         $this->checkIsFamilyVariantNew($event);
         $this->computeVariantStructureChanges($event);

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
 
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\StorageEvents;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
@@ -19,11 +20,11 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 {
     function let(
         ValidatorInterface $validator,
-        BulkSaverInterface $familyVariantSaver,
+        SaverInterface $familyVariantSaver,
+        BulkSaverInterface $bulkFamilyVariantSaver,
         BulkObjectDetacherInterface $objectDetacher
-    )
-    {
-        $this->beConstructedWith($validator, $familyVariantSaver, $objectDetacher);
+    ) {
+        $this->beConstructedWith($validator, $familyVariantSaver, $bulkFamilyVariantSaver, $objectDetacher);
     }
 
     function it_is_initializable()
@@ -34,7 +35,8 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
     function it_subscribes_to_events()
     {
         $this->getSubscribedEvents()->shouldReturn([
-            StorageEvents::POST_SAVE => 'validateAndSaveFamilyVariants',
+            StorageEvents::POST_SAVE => 'onUnitarySave',
+            StorageEvents::POST_SAVE_ALL => 'onBulkSave',
         ]);
     }
 
@@ -45,13 +47,13 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         \stdClass $object
     ) {
         $validator->validate()->shouldNotBeCalled();
-        $familyVariantSaver->saveAll()->shouldNotBeCalled();
+        $familyVariantSaver->save()->shouldNotBeCalled();
 
         $event->getSubject()->willReturn($object);
-        $this->validateAndSaveFamilyVariants($event);
+        $this->onUnitarySave($event);
     }
 
-    function it_validates_and_saves_family_variants_on_family_update(
+    function it_validates_and_saves_family_variants_on_family_update_on_unitary_save(
         $validator,
         $familyVariantSaver,
         $objectDetacher,
@@ -76,14 +78,17 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $validator->validate($familyVariants2)->willReturn($constraintViolationList);
         $constraintViolationList->count()->willReturn(0);
 
-        $familyVariantSaver->saveAll([$familyVariants1, $familyVariants2])->shouldBeCalled();
+        $familyVariantSaver->save($familyVariants1)->shouldBeCalled();
+        $familyVariantSaver->save($familyVariants2)->shouldBeCalled();
         $objectDetacher->detachAll([$familyVariants1, $familyVariants2])->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
-        $this->validateAndSaveFamilyVariants($event);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
+        $this->onUnitarySave($event);
     }
 
-    function it_throws_an_exception_when_family_variants_are_invalid_and_saves_the_valid_ones(
+    function it_throws_an_exception_when_family_variants_are_invalid_and_saves_the_valid_ones_on_unitary_save(
         $validator,
         $familyVariantSaver,
         GenericEvent $event,
@@ -116,12 +121,120 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $validator->validate($familyVariants2)->willReturn($constraintViolationList2);
         $validator->validate($familyVariants3)->willReturn($constraintViolationList3);
 
-        $familyVariantSaver->saveAll([$familyVariants3])->shouldBeCalled();
+        $familyVariantSaver->save($familyVariants3)->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
         $errorMessage = 'One or more errors occured while updating the following family variants:\n' .
             'family_variant_1:\n- Error 1 with family variant\n- Error 2 with family variant\n' .
             'family_variant_2:\n- Error 1 with family variant\n';
-        $this->shouldThrow(new \LogicException($errorMessage))->during('validateAndSaveFamilyVariants', [$event]);
+        $this->shouldThrow(new \LogicException($errorMessage))->during('onUnitarySave', [$event]);
+    }
+
+    function it_does_not_save_if_on_non_unitary_save_and_POST_SAVE(
+        $familyVariantSaver,
+        GenericEvent $event,
+        FamilyInterface $family
+    ) {
+        $familyVariantSaver->save()->shouldNotBeCalled();
+
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(false);
+
+        $this->onUnitarySave($event);
+    }
+
+    function it_validates_and_saves_family_variants_on_family_update_on_bulk_save(
+        $validator,
+        $bulkFamilyVariantSaver,
+        $objectDetacher,
+        GenericEvent $event,
+        FamilyInterface $family,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantsIterator,
+        FamilyVariantInterface $familyVariants1,
+        FamilyVariantInterface $familyVariants2,
+        ConstraintViolationList $constraintViolationList
+    ) {
+        $family->getFamilyVariants()->willReturn($familyVariants);
+
+        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
+        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2);
+        $familyVariantsIterator->valid()->willReturn(true, true, false);
+        $familyVariantsIterator->rewind()->shouldBeCalled();
+        $familyVariantsIterator->next()->shouldBeCalled();
+
+        $validator->validate($familyVariants1)->willReturn($constraintViolationList);
+        $constraintViolationList->count()->willReturn(0);
+        $validator->validate($familyVariants2)->willReturn($constraintViolationList);
+        $constraintViolationList->count()->willReturn(0);
+
+        $bulkFamilyVariantSaver->saveAll([$familyVariants1, $familyVariants2])->shouldBeCalled();
+        $objectDetacher->detachAll([$familyVariants1, $familyVariants2])->shouldBeCalled();
+
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(false);
+        $this->onBulkSave($event);
+    }
+
+    function it_throws_an_exception_when_family_variants_are_invalid_and_saves_the_valid_ones_on_bulk_save(
+        $validator,
+        $bulkFamilyVariantSaver,
+        GenericEvent $event,
+        FamilyInterface $family,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantsIterator,
+        FamilyVariantInterface $familyVariants1,
+        FamilyVariantInterface $familyVariants2,
+        FamilyVariantInterface $familyVariants3
+    ) {
+        $family->getFamilyVariants()->willReturn($familyVariants);
+
+        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
+        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2, $familyVariants3);
+        $familyVariantsIterator->valid()->willReturn(true, true, true, false);
+        $familyVariantsIterator->rewind()->shouldBeCalled();
+        $familyVariantsIterator->next()->shouldBeCalled();
+
+        $familyVariants1->getCode()->willReturn('family_variant_1');
+        $familyVariants2->getCode()->willReturn('family_variant_2');
+
+        $constraintViolation1 = new ConstraintViolation('Error 1 with family variant', '', [], '', '', '10,45');
+        $constraintViolation2 = new ConstraintViolation('Error 2 with family variant', '', [], '', '', '10,45');
+
+        $constraintViolationList1 = new ConstraintViolationList([$constraintViolation1, $constraintViolation2]);
+        $constraintViolationList2 = new ConstraintViolationList([$constraintViolation1]);
+        $constraintViolationList3 = new ConstraintViolationList();
+
+        $validator->validate($familyVariants1)->willReturn($constraintViolationList1);
+        $validator->validate($familyVariants2)->willReturn($constraintViolationList2);
+        $validator->validate($familyVariants3)->willReturn($constraintViolationList3);
+
+        $bulkFamilyVariantSaver->saveAll([$familyVariants3])->shouldBeCalled();
+
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(false);
+        $errorMessage = 'One or more errors occured while updating the following family variants:\n' .
+            'family_variant_1:\n- Error 1 with family variant\n- Error 2 with family variant\n' .
+            'family_variant_2:\n- Error 1 with family variant\n';
+        $this->shouldThrow(new \LogicException($errorMessage))->during('onBulkSave', [$event]);
+    }
+
+    function it_does_not_bulk_save_if_on_non_unitary_save_and_POST_SAVE_ALL_event(
+        $bulkFamilyVariantSaver,
+        GenericEvent $event,
+        FamilyInterface $family
+    ) {
+        $bulkFamilyVariantSaver->saveAll()->shouldNotBeCalled();
+
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
+
+        $this->onBulkSave($event);
     }
 }

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/jobs.yml
@@ -109,6 +109,7 @@ services:
             -
                 - '@pim_connector.step.charset_validator'
                 - '@pim_connector.step.csv_family.import'
+                - '@pim_connector.step.csv_family.compute_data_related_to_family_variants'
         tags:
             - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.csv%', type: '%pim_connector.job.import_type%' }
 
@@ -436,6 +437,7 @@ services:
             -
                 - '@pim_connector.step.charset_validator'
                 - '@pim_connector.step.xlsx_family.import'
+                - '@pim_connector.step.xlsx_family.compute_data_related_to_family_variants'
         tags:
             - { name: akeneo_batch.job, connector: '%pim_connector.connector_name.xlsx%', type: '%pim_connector.job.import_type%' }
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -72,10 +72,10 @@ services:
             - '@pim_connector.reader.file.csv_family'
             - '@pim_catalog.entity_with_family_variant.keep_only_values_for_variation'
             - '@validator'
-            - '@pim_catalog.saver.family_variant'
             - '@pim_catalog.saver.product_model'
             - '@pim_catalog.saver.product'
             - '@pim_connector.doctrine.cache_clearer'
+            - '@akeneo_batch.job_repository'
 
     pim_connector.step.csv_family_variant.import:
         class: '%pim_connector.step.item_step.class%'
@@ -413,10 +413,10 @@ services:
             - '@pim_connector.reader.file.xlsx_family'
             - '@pim_catalog.entity_with_family_variant.keep_only_values_for_variation'
             - '@validator'
-            - '@pim_catalog.saver.family_variant'
             - '@pim_catalog.saver.product_model'
             - '@pim_catalog.saver.product'
             - '@pim_connector.doctrine.cache_clearer'
+            - '@akeneo_batch.job_repository'
 
     pim_connector.step.xlsx_family_variant.import:
         class: '%pim_connector.step.item_step.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -3,6 +3,7 @@ parameters:
     pim_connector.step.tasklet.class:   Pim\Component\Connector\Step\TaskletStep
     pim_connector.step.product.import.bulk_size: 1000
     pim_connector.step.product_model.import.bulk_size: 100
+    pim_connector.tasklet.family.compute_data_related_to_family_variants.class: Pim\Component\Connector\Job\ComputeDataRelatedToFamilyVariantsTasklet
 
 services:
     # Validator steps -------------------------------------------------------------------------------------------------
@@ -54,6 +55,27 @@ services:
             - '@pim_connector.reader.file.csv_family'
             - '@pim_connector.processor.denormalization.family'
             - '@pim_connector.writer.database.family'
+
+    pim_connector.step.csv_family.compute_data_related_to_family_variants:
+        class: '%pim_connector.step.tasklet.class%'
+        arguments:
+            - 'compute_data_related_to_family_variants'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_connector.tasklet.csv_family.compute_data_related_to_family_variants'
+
+    pim_connector.tasklet.csv_family.compute_data_related_to_family_variants:
+        class: '%pim_connector.tasklet.family.compute_data_related_to_family_variants.class%'
+        arguments:
+            - '@pim_catalog.repository.family'
+            - '@pim_catalog.query.product_model_query_builder_factory'
+            - '@pim_connector.reader.file.csv_family'
+            - '@pim_catalog.entity_with_family_variant.keep_only_values_for_variation'
+            - '@validator'
+            - '@pim_catalog.saver.family_variant'
+            - '@pim_catalog.saver.product_model'
+            - '@pim_catalog.saver.product'
+            - '@pim_connector.doctrine.cache_clearer'
 
     pim_connector.step.csv_family_variant.import:
         class: '%pim_connector.step.item_step.class%'
@@ -374,6 +396,27 @@ services:
             - '@pim_connector.reader.file.xlsx_family'
             - '@pim_connector.processor.denormalization.family'
             - '@pim_connector.writer.database.family'
+
+    pim_connector.step.xlsx_family.compute_data_related_to_family_variants:
+        class: '%pim_connector.step.tasklet.class%'
+        arguments:
+            - 'compute_data_related_to_family_variants'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_connector.tasklet.xlsx_family.compute_data_related_to_family_variants'
+
+    pim_connector.tasklet.xlsx_family.compute_data_related_to_family_variants:
+        class: '%pim_connector.tasklet.family.compute_data_related_to_family_variants.class%'
+        arguments:
+            - '@pim_catalog.repository.family'
+            - '@pim_catalog.query.product_model_query_builder_factory'
+            - '@pim_connector.reader.file.xlsx_family'
+            - '@pim_catalog.entity_with_family_variant.keep_only_values_for_variation'
+            - '@validator'
+            - '@pim_catalog.saver.family_variant'
+            - '@pim_catalog.saver.product_model'
+            - '@pim_catalog.saver.product'
+            - '@pim_connector.doctrine.cache_clearer'
 
     pim_connector.step.xlsx_family_variant.import:
         class: '%pim_connector.step.item_step.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -74,6 +74,7 @@ services:
             - '@validator'
             - '@pim_catalog.saver.product_model'
             - '@pim_catalog.saver.product'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_connector.doctrine.cache_clearer'
             - '@akeneo_batch.job_repository'
 
@@ -415,6 +416,7 @@ services:
             - '@validator'
             - '@pim_catalog.saver.product_model'
             - '@pim_catalog.saver.product'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_connector.doctrine.cache_clearer'
             - '@akeneo_batch.job_repository'
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -1232,6 +1232,7 @@ batch_jobs:
         label: Family import in CSV
         validation.label: File validation
         import.label: Family import
+        compute_data_related_to_family_variants.label: Compute product models data
     csv_family_variant_import:
         label: Family variant import in CSV
         validation.label: File validation
@@ -1295,6 +1296,7 @@ batch_jobs:
         label: Family import in XLSX
         validation.label: File validation
         import.label: Family import
+        compute_data_related_to_family_variants.label: Compute product models data
     xlsx_family_variant_import:
         label: Family variant import in XLSX
         validation.label: File validation

--- a/src/Pim/Component/Catalog/Job/ComputeFamilyVariantStructureChangesTasklet.php
+++ b/src/Pim/Component/Catalog/Job/ComputeFamilyVariantStructureChangesTasklet.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Pim\Component\Catalog\Job;
 
 use Akeneo\Component\Batch\Model\StepExecution;
-use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityRepository;

--- a/src/Pim/Component/Catalog/spec/Job/ComputeFamilyVariantStructureChangesTaskletSpec.php
+++ b/src/Pim/Component/Catalog/spec/Job/ComputeFamilyVariantStructureChangesTaskletSpec.php
@@ -4,7 +4,6 @@ namespace spec\Pim\Component\Catalog\Job;
 
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
-use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityRepository;

--- a/src/Pim/Component/Connector/Job/ComputeDataRelatedToFamilyVariantsTasklet.php
+++ b/src/Pim/Component/Connector/Job/ComputeDataRelatedToFamilyVariantsTasklet.php
@@ -167,7 +167,7 @@ class ComputeDataRelatedToFamilyVariantsTasklet implements TaskletInterface, Ini
      *
      * @param array $entitiesWithFamilyVariant
      */
-    private function updateProductModelAndDescendants(array $entitiesWithFamilyVariant)
+    private function updateProductModelAndDescendants(array $entitiesWithFamilyVariant): void
     {
         foreach ($entitiesWithFamilyVariant as $entityWithFamilyVariant) {
             if ($entityWithFamilyVariant instanceof ProductModelInterface) {
@@ -222,10 +222,8 @@ class ComputeDataRelatedToFamilyVariantsTasklet implements TaskletInterface, Ini
 
     /**
      * Update the step execution to make sure the progress is shown in the UI.
-     *
-     * @return StepExecution
      */
-    private function updateStepExecution()
+    private function updateStepExecution(): void
     {
         $this->jobRepository->updateStepExecution($this->stepExecution);
     }

--- a/src/Pim/Component/Connector/Job/ComputeDataRelatedToFamilyVariantsTasklet.php
+++ b/src/Pim/Component/Connector/Job/ComputeDataRelatedToFamilyVariantsTasklet.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Connector\Job;
+
+use Akeneo\Component\Batch\Item\InitializableInterface;
+use Akeneo\Component\Batch\Item\InvalidItemException;
+use Akeneo\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use Pim\Component\Catalog\EntityWithFamilyVariant\KeepOnlyValuesForProductModelsTrees;
+use Pim\Component\Catalog\EntityWithFamilyVariant\KeepOnlyValuesForVariation;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
+use Pim\Component\Connector\Step\TaskletInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Foreach line of the file to import we will:
+ * - fetch the corresponding family object
+ * - fetch all the root product models of this family
+ * - save this root product model and all its descendants (in order to such things as recompute completeness for instance)
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ComputeDataRelatedToFamilyVariantsTasklet implements TaskletInterface, InitializableInterface
+{
+    /** @var StepExecution */
+    private $stepExecution;
+
+    /** @var ItemReaderInterface */
+    private $familyReader;
+
+    /** @var FamilyRepositoryInterface */
+    private $familyRepository;
+
+    /** @var BulkSaverInterface */
+    private $productModelSaver;
+
+    /** @var BulkSaverInterface */
+    private $productSaver;
+
+    /** @var CacheClearerInterface */
+    private $cacheClearer;
+
+    /** @var BulkSaverInterface */
+    private $familyVariantSaver;
+
+    /** @var ProductQueryBuilderFactoryInterface */
+    private $productQueryBuilderFactory;
+
+    /** @var KeepOnlyValuesForVariation */
+    private $keepOnlyValuesForVariation;
+
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /**
+     * @param FamilyRepositoryInterface           $familyRepository
+     * @param ProductQueryBuilderFactoryInterface $productQueryBuilderFactory
+     * @param ItemReaderInterface                 $familyReader
+     * @param KeepOnlyValuesForProductModelsTrees $keepOnlyValuesForVariation
+     * @param ValidatorInterface                  $validator
+     * @param BulkSaverInterface                  $productModelSaver
+     * @param BulkSaverInterface                  $productSaver
+     * @param CacheClearerInterface               $cacheClearer
+     */
+    public function __construct(
+        FamilyRepositoryInterface $familyRepository,
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        ItemReaderInterface $familyReader,
+        KeepOnlyValuesForVariation $keepOnlyValuesForVariation,
+        ValidatorInterface $validator,
+        BulkSaverInterface $familyVariantSaver,
+        BulkSaverInterface $productModelSaver,
+        BulkSaverInterface $productSaver,
+        CacheClearerInterface $cacheClearer
+    ) {
+        $this->familyReader = $familyReader;
+        $this->familyRepository = $familyRepository;
+        $this->productQueryBuilderFactory = $productQueryBuilderFactory;
+        $this->productModelSaver = $productModelSaver;
+        $this->productSaver = $productSaver;
+        $this->cacheClearer = $cacheClearer;
+        $this->keepOnlyValuesForVariation = $keepOnlyValuesForVariation;
+        $this->familyVariantSaver = $familyVariantSaver;
+        $this->validator = $validator;
+    }
+
+    /**
+     * @param StepExecution $stepExecution
+     */
+    public function setStepExecution(StepExecution $stepExecution)
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    /**
+     * Execute the tasklet
+     */
+    public function execute()
+    {
+        $this->initialize();
+
+        while (true) {
+            try {
+                $familyItem = $this->familyReader->read();
+                if (null === $familyItem) {
+                    break;
+                }
+            } catch (InvalidItemException $e) {
+                continue;
+            }
+
+            $family = $this->familyRepository->findOneByIdentifier($familyItem['code']);
+            if (null === $family) {
+                $this->stepExecution->incrementSummaryInfo('skip');
+                continue;
+            }
+
+            foreach ($this->getRootProductModelsForFamily($family) as $rootProductModel) {
+                $this->updateProductModelAndDescendants([$rootProductModel]);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize()
+    {
+        $this->cacheClearer->clear();
+    }
+
+    /**
+     * @param FamilyInterface $family
+     *
+     * @return CursorInterface
+     */
+    private function getRootProductModelsForFamily(FamilyInterface $family): CursorInterface
+    {
+        $pqb = $this->productQueryBuilderFactory->create();
+        $pqb->addFilter('family', Operators::IN_LIST, [$family->getCode()]);
+        $pqb->addFilter('parent', Operators::IS_EMPTY, null);
+
+        return $pqb->execute();
+    }
+
+    /**
+     * Recursively (upwards) updates, validates each elements of the tree and save them if they are valid.
+     *
+     * It is important to validate and save the product model tree upward. Starting from the products up to the root
+     * product model otherwise we may loose information when moving attribute from the attribute sets in the
+     * family variant.
+     *
+     * @param array $entitiesWithFamilyVariant
+     */
+    private function updateProductModelAndDescendants(array $entitiesWithFamilyVariant)
+    {
+        foreach ($entitiesWithFamilyVariant as $entityWithFamilyVariant) {
+            if ($entityWithFamilyVariant instanceof ProductModelInterface) {
+                if ($entityWithFamilyVariant->hasProductModels()) {
+                    $this->updateProductModelAndDescendants(
+                        $entityWithFamilyVariant->getProductModels()->toArray()
+                    );
+                } elseif (!$entityWithFamilyVariant->getProducts()->isEmpty()) {
+                    $this->updateProductModelAndDescendants(
+                        $entityWithFamilyVariant->getProducts()->toArray()
+                    );
+                }
+            }
+
+            $this->keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant($entitiesWithFamilyVariant);
+
+            if (!$this->isValid($entityWithFamilyVariant)) {
+                $this->stepExecution->incrementSummaryInfo('skip');
+                continue;
+            }
+
+            $this->saveEntity($entityWithFamilyVariant);
+            $this->stepExecution->incrementSummaryInfo('process');
+        }
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $entityWithFamilyVariant
+     *
+     * @return bool
+     */
+    private function isValid(EntityWithFamilyVariantInterface $entityWithFamilyVariant): bool
+    {
+        $violations = $this->validator->validate($entityWithFamilyVariant);
+
+        return $violations->count() === 0;
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $entityWithFamilyVariant
+     */
+    private function saveEntity(EntityWithFamilyVariantInterface $entityWithFamilyVariant): void
+    {
+        if ($entityWithFamilyVariant instanceof ProductModelInterface) {
+            $this->productModelSaver->saveAll([$entityWithFamilyVariant]);
+        } else {
+            $this->productSaver->saveAll([$entityWithFamilyVariant]);
+        }
+    }
+}

--- a/src/Pim/Component/Connector/Job/ComputeDataRelatedToFamilyVariantsTasklet.php
+++ b/src/Pim/Component/Connector/Job/ComputeDataRelatedToFamilyVariantsTasklet.php
@@ -7,15 +7,14 @@ namespace Pim\Component\Connector\Job;
 use Akeneo\Component\Batch\Item\InitializableInterface;
 use Akeneo\Component\Batch\Item\InvalidItemException;
 use Akeneo\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
-use Pim\Component\Catalog\EntityWithFamilyVariant\KeepOnlyValuesForProductModelsTrees;
 use Pim\Component\Catalog\EntityWithFamilyVariant\KeepOnlyValuesForVariation;
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
-use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
@@ -27,7 +26,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * Foreach line of the file to import we will:
  * - fetch the corresponding family object
  * - fetch all the root product models of this family
- * - save this root product model and all its descendants (in order to such things as recompute completeness for instance)
+ * - save this root product model and all its descendants (in order to do such things as recompute completeness for
+ * instance)
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
@@ -53,9 +53,6 @@ class ComputeDataRelatedToFamilyVariantsTasklet implements TaskletInterface, Ini
     /** @var CacheClearerInterface */
     private $cacheClearer;
 
-    /** @var BulkSaverInterface */
-    private $familyVariantSaver;
-
     /** @var ProductQueryBuilderFactoryInterface */
     private $productQueryBuilderFactory;
 
@@ -65,15 +62,20 @@ class ComputeDataRelatedToFamilyVariantsTasklet implements TaskletInterface, Ini
     /** @var ValidatorInterface */
     private $validator;
 
+    /** @var JobRepositoryInterface */
+    private $jobRepository;
+
     /**
      * @param FamilyRepositoryInterface           $familyRepository
      * @param ProductQueryBuilderFactoryInterface $productQueryBuilderFactory
      * @param ItemReaderInterface                 $familyReader
-     * @param KeepOnlyValuesForProductModelsTrees $keepOnlyValuesForVariation
+     * @param KeepOnlyValuesForVariation          $keepOnlyValuesForVariation
      * @param ValidatorInterface                  $validator
+     * @param BulkSaverInterface                  $familyVariantSaver
      * @param BulkSaverInterface                  $productModelSaver
      * @param BulkSaverInterface                  $productSaver
      * @param CacheClearerInterface               $cacheClearer
+     * @param JobRepositoryInterface              $jobRepository
      */
     public function __construct(
         FamilyRepositoryInterface $familyRepository,
@@ -81,10 +83,10 @@ class ComputeDataRelatedToFamilyVariantsTasklet implements TaskletInterface, Ini
         ItemReaderInterface $familyReader,
         KeepOnlyValuesForVariation $keepOnlyValuesForVariation,
         ValidatorInterface $validator,
-        BulkSaverInterface $familyVariantSaver,
         BulkSaverInterface $productModelSaver,
         BulkSaverInterface $productSaver,
-        CacheClearerInterface $cacheClearer
+        CacheClearerInterface $cacheClearer,
+        JobRepositoryInterface $jobRepository
     ) {
         $this->familyReader = $familyReader;
         $this->familyRepository = $familyRepository;
@@ -93,8 +95,8 @@ class ComputeDataRelatedToFamilyVariantsTasklet implements TaskletInterface, Ini
         $this->productSaver = $productSaver;
         $this->cacheClearer = $cacheClearer;
         $this->keepOnlyValuesForVariation = $keepOnlyValuesForVariation;
-        $this->familyVariantSaver = $familyVariantSaver;
         $this->validator = $validator;
+        $this->jobRepository = $jobRepository;
     }
 
     /**
@@ -190,6 +192,8 @@ class ComputeDataRelatedToFamilyVariantsTasklet implements TaskletInterface, Ini
             $this->saveEntity($entityWithFamilyVariant);
             $this->stepExecution->incrementSummaryInfo('process');
         }
+
+        $this->updateStepExecution();
     }
 
     /**
@@ -214,5 +218,15 @@ class ComputeDataRelatedToFamilyVariantsTasklet implements TaskletInterface, Ini
         } else {
             $this->productSaver->saveAll([$entityWithFamilyVariant]);
         }
+    }
+
+    /**
+     * Update the step execution to make sure the progress is shown in the UI.
+     *
+     * @return StepExecution
+     */
+    private function updateStepExecution()
+    {
+        $this->jobRepository->updateStepExecution($this->stepExecution);
     }
 }

--- a/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilyVariantsTaskletSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilyVariantsTaskletSpec.php
@@ -6,6 +6,7 @@ namespace spec\Pim\Component\Connector\Job;
 
 use Akeneo\Component\Batch\Item\InvalidItemException;
 use Akeneo\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
@@ -35,10 +36,10 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         ItemReaderInterface $familyReader,
         KeepOnlyValuesForVariation $keepOnlyValuesForVariation,
         ValidatorInterface $validator,
-        BulkSaverInterface $familyVariantSaver,
         BulkSaverInterface $productModelSaver,
         BulkSaverInterface $productSaver,
-        CacheClearerInterface $cacheClearer
+        CacheClearerInterface $cacheClearer,
+        JobRepositoryInterface $jobRepository
     ) {
         $this->beConstructedWith(
             $familyRepository,
@@ -46,10 +47,10 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
             $familyReader,
             $keepOnlyValuesForVariation,
             $validator,
-            $familyVariantSaver,
             $productModelSaver,
             $productSaver,
-            $cacheClearer
+            $cacheClearer,
+            $jobRepository
         );
     }
 

--- a/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilyVariantsTaskletSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilyVariantsTaskletSpec.php
@@ -67,6 +67,7 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $productModelSaver,
         $productSaver,
         $productModelQueryBuilderFactory,
+        $jobRepository,
         FamilyInterface $family,
         ProductModelInterface $rootProductModel,
         ProductModelInterface $subProductModel,
@@ -124,6 +125,8 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalledTimes(3);
         $stepExecution->incrementSummaryInfo('skip')->shouldNotBeCalled();
 
+        $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
+
         $this->setStepExecution($stepExecution);
         $this->execute();
     }
@@ -136,6 +139,7 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $productModelSaver,
         $productSaver,
         $productModelQueryBuilderFactory,
+        $jobRepository,
         FamilyInterface $family1,
         FamilyInterface $family2,
         ProductModelInterface $rootProductModel1,
@@ -228,6 +232,9 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $productSaver->saveAll([$product2])->shouldBeCalled();
 
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalledTimes(5);
+
+        $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
+
         $this->setStepExecution($stepExecution);
         $this->execute();
     }
@@ -237,6 +244,7 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $familyRepository,
         $productModelQueryBuilderFactory,
         $productModelSaver,
+        $jobRepository,
         StepExecution $stepExecution
     ) {
         $familyReader->read()->willReturn(['code' => 'unkown_family'], null);
@@ -247,6 +255,8 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $productModelQueryBuilderFactory->create()->shouldNotBeCalled();
         $productModelSaver->saveAll(Argument::any())->shouldNotBeCalled();
 
+        $jobRepository->updateStepExecution($stepExecution)->shouldNotBeCalled();
+
         $this->setStepExecution($stepExecution);
         $this->execute();
     }
@@ -256,6 +266,7 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $familyRepository,
         $productModelQueryBuilderFactory,
         $productModelSaver,
+        $jobRepository,
         StepExecution $stepExecution
     ) {
         $familyReader->read()->willThrow(InvalidItemException::class);
@@ -264,6 +275,8 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $familyRepository->findOneByIdentifier(Argument::any())->shouldNotBeCalled();
         $productModelQueryBuilderFactory->create()->shouldNotBeCalled();
         $productModelSaver->saveAll(Argument::any())->shouldNotBeCalled();
+
+        $jobRepository->updateStepExecution($stepExecution)->shouldNotBeCalled();
 
         $this->setStepExecution($stepExecution);
         $this->execute();

--- a/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilyVariantsTaskletSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilyVariantsTaskletSpec.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Component\Connector\Job;
+
+use Akeneo\Component\Batch\Item\InvalidItemException;
+use Akeneo\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use Box\Spout\Reader\IteratorInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelQueryBuilder;
+use Pim\Component\Catalog\EntityWithFamilyVariant\KeepOnlyValuesForVariation;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
+use Pim\Component\Connector\Job\ComputeDataRelatedToFamilyVariantsTasklet;
+use Prophecy\Argument;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
+{
+    function let(
+        FamilyRepositoryInterface $familyRepository,
+        ProductQueryBuilderFactoryInterface $productModelQueryBuilderFactory,
+        ItemReaderInterface $familyReader,
+        KeepOnlyValuesForVariation $keepOnlyValuesForVariation,
+        ValidatorInterface $validator,
+        BulkSaverInterface $familyVariantSaver,
+        BulkSaverInterface $productModelSaver,
+        BulkSaverInterface $productSaver,
+        CacheClearerInterface $cacheClearer
+    ) {
+        $this->beConstructedWith(
+            $familyRepository,
+            $productModelQueryBuilderFactory,
+            $familyReader,
+            $keepOnlyValuesForVariation,
+            $validator,
+            $familyVariantSaver,
+            $productModelSaver,
+            $productSaver,
+            $cacheClearer
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->beAnInstanceOf(ComputeDataRelatedToFamilyVariantsTasklet::class);
+    }
+
+    function it_saves_the_product_model_and_its_descendants_belonging_to_the_family(
+        $familyReader,
+        $familyRepository,
+        $keepOnlyValuesForVariation,
+        $validator,
+        $productModelSaver,
+        $productSaver,
+        $productModelQueryBuilderFactory,
+        FamilyInterface $family,
+        ProductModelInterface $rootProductModel,
+        ProductModelInterface $subProductModel,
+        VariantProductInterface $product,
+        StepExecution $stepExecution,
+        ProductAndProductModelQueryBuilder $pqb,
+        CursorInterface $cursor,
+        ArrayCollection $subProductModels,
+        ArrayCollection $products,
+        ConstraintViolationListInterface $rootProductModelViolationLists,
+        ConstraintViolationListInterface $subProductModelViolationLists,
+        ConstraintViolationListInterface $productViolationLists
+    ) {
+        $familyReader->read()->willReturn(['code' => 'my_family'], null);
+        $familyRepository->findOneByIdentifier('my_family')->willReturn($family);
+
+        $family->getCode()->willReturn('family_code');
+
+        $productModelQueryBuilderFactory->create()->willReturn($pqb);
+        $pqb->addFilter('family', Operators::IN_LIST, ['family_code'])->shouldBeCalled();
+        $pqb->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
+        $pqb->execute()->willReturn($cursor);
+
+        $cursor->rewind()->shouldBeCalled();
+        $cursor->valid()->willReturn(true, false);
+        $cursor->next()->willReturn($rootProductModel);
+        $cursor->current()->willReturn($rootProductModel);
+
+        $rootProductModel->hasProductModels()->willReturn(true);
+        $rootProductModel->getProductModels()->willReturn($subProductModels);
+
+        $subProductModels->toArray()->willReturn([$subProductModel]);
+        $subProductModel->hasProductModels()->willReturn(false);
+        $subProductModel->getProducts()->willReturn($products);
+
+        $products->isEmpty()->willReturn(false);
+        $products->toArray()->willReturn([$product]);
+
+        $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$product])->shouldBeCalled();
+        $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$subProductModel])->shouldBeCalled();
+        $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$rootProductModel])->shouldBeCalled();
+
+        $rootProductModelViolationLists->count()->willReturn(0);
+        $subProductModelViolationLists->count()->willReturn(0);
+        $productViolationLists->count()->willReturn(0);
+
+        $validator->validate($rootProductModel)->willReturn($rootProductModelViolationLists);
+        $validator->validate($subProductModel)->willReturn($subProductModelViolationLists);
+        $validator->validate($product)->willReturn($productViolationLists);
+
+        $productModelSaver->saveAll([$rootProductModel])->shouldBeCalled();
+        $productModelSaver->saveAll([$subProductModel])->shouldBeCalled();
+        $productSaver->saveAll([$product])->shouldBeCalled();
+
+        $stepExecution->incrementSummaryInfo('process')->shouldBeCalledTimes(3);
+        $stepExecution->incrementSummaryInfo('skip')->shouldNotBeCalled();
+
+        $this->setStepExecution($stepExecution);
+        $this->execute();
+    }
+
+    function it_saves_the_product_models_and_its_descendants_belonging_to_the_families(
+        $familyReader,
+        $familyRepository,
+        $keepOnlyValuesForVariation,
+        $validator,
+        $productModelSaver,
+        $productSaver,
+        $productModelQueryBuilderFactory,
+        FamilyInterface $family1,
+        FamilyInterface $family2,
+        ProductModelInterface $rootProductModel1,
+        ArrayCollection $subProductModelCollection1,
+        ArrayCollection $productCollection1,
+        ArrayCollection $productCollection2,
+        ProductModelInterface $subProductModel1,
+        ProductModelInterface $rootProductModel2,
+        VariantProductInterface $product1,
+        VariantProductInterface $product2,
+        StepExecution $stepExecution,
+        ProductAndProductModelQueryBuilder $pqb1,
+        ProductAndProductModelQueryBuilder $pqb2,
+        CursorInterface $cursor1,
+        CursorInterface $cursor2,
+        ConstraintViolationListInterface $rootProductModelViolationLists1,
+        ConstraintViolationListInterface $rootProductModelViolationLists2,
+        ConstraintViolationListInterface $subProductModelViolationLists1,
+        ConstraintViolationListInterface $productViolationLists1,
+        ConstraintViolationListInterface $productViolationLists2
+    ) {
+        $familyReader->read()->willReturn(['code' => 'first_family'], ['code' => 'second_family'], null);
+        $familyRepository->findOneByIdentifier('first_family')->willReturn($family1);
+
+        $family1->getCode()->willReturn('first_family');
+        $family2->getCode()->willReturn('second_family');
+
+        $productModelQueryBuilderFactory->create()->willReturn($pqb1, $pqb2);
+
+        $pqb1->addFilter('family', Operators::IN_LIST, ['first_family'])->shouldBeCalled();
+        $pqb1->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
+        $pqb1->execute()->willReturn($cursor1);
+
+        $cursor1->rewind()->shouldBeCalled();
+        $cursor1->valid()->willReturn(true, false);
+        $cursor1->next()->willReturn($rootProductModel1);
+        $cursor1->current()->willReturn($rootProductModel1);
+
+        $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$product1])->shouldBeCalled();
+        $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$subProductModel1])->shouldBeCalled();
+        $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$rootProductModel1])->shouldBeCalled();
+
+        $rootProductModel1->hasProductModels()->willReturn(true);
+        $rootProductModel1->getProductModels()->willReturn($subProductModelCollection1);
+        $subProductModelCollection1->toArray()->willReturn([$subProductModel1]);
+
+        $subProductModel1->hasProductModels()->willReturn(false);
+        $subProductModel1->getProducts()->willReturn($productCollection1);
+        $productCollection1->isEmpty()->willReturn(false);
+        $productCollection1->toArray()->willReturn([$product1]);
+
+        $validator->validate($rootProductModel1)->willReturn($rootProductModelViolationLists1);
+        $validator->validate($subProductModel1)->willReturn($subProductModelViolationLists1);
+        $validator->validate($product1)->willReturn($productViolationLists1);
+
+        $rootProductModelViolationLists1->count()->willReturn(0);
+        $subProductModelViolationLists1->count()->willReturn(0);
+        $productViolationLists1->count()->willReturn(0);
+
+        $productModelSaver->saveAll([$rootProductModel1])->shouldBeCalled();
+        $productModelSaver->saveAll([$subProductModel1])->shouldBeCalled();
+        $productSaver->saveAll([$product1])->shouldBeCalled();
+
+        $familyRepository->findOneByIdentifier('second_family')->willReturn($family2);
+
+        $pqb2->addFilter('family', Operators::IN_LIST, ['second_family'])->shouldBeCalled();
+        $pqb2->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
+        $pqb2->execute()->willReturn($cursor2);
+
+        $cursor2->rewind()->shouldBeCalled();
+        $cursor2->valid()->willReturn(true, false);
+        $cursor2->next()->willReturn($rootProductModel2);
+        $cursor2->current()->willReturn($rootProductModel2);
+
+        $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$product2])->shouldBeCalled();
+        $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$rootProductModel2])->shouldBeCalled();
+
+        $rootProductModel2->hasProductModels()->willReturn(false);
+        $rootProductModel2->getProducts()->willReturn($productCollection2);
+        $productCollection2->isEmpty()->willReturn(false);
+        $productCollection2->toArray()->willReturn([$product2]);
+
+        $validator->validate($rootProductModel2)->willReturn($rootProductModelViolationLists2);
+        $validator->validate($product2)->willReturn($productViolationLists2);
+
+        $rootProductModelViolationLists2->count()->willReturn(0);
+        $productViolationLists2->count()->willReturn(0);
+
+        $productModelSaver->saveAll([$rootProductModel2])->shouldBeCalled();
+        $productSaver->saveAll([$product2])->shouldBeCalled();
+
+        $stepExecution->incrementSummaryInfo('process')->shouldBeCalledTimes(5);
+        $this->setStepExecution($stepExecution);
+        $this->execute();
+    }
+
+    function it_skips_if_the_family_is_unknown(
+        $familyReader,
+        $familyRepository,
+        $productModelQueryBuilderFactory,
+        $productModelSaver,
+        StepExecution $stepExecution
+    ) {
+        $familyReader->read()->willReturn(['code' => 'unkown_family'], null);
+        $familyRepository->findOneByIdentifier('unkown_family')->willReturn(null);
+
+        $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
+
+        $productModelQueryBuilderFactory->create()->shouldNotBeCalled();
+        $productModelSaver->saveAll(Argument::any())->shouldNotBeCalled();
+
+        $this->setStepExecution($stepExecution);
+        $this->execute();
+    }
+
+    function it_handles_invalid_lines(
+        $familyReader,
+        $familyRepository,
+        $productModelQueryBuilderFactory,
+        $productModelSaver,
+        StepExecution $stepExecution
+    ) {
+        $familyReader->read()->willThrow(InvalidItemException::class);
+        $familyReader->read()->willReturn(null);
+
+        $familyRepository->findOneByIdentifier(Argument::any())->shouldNotBeCalled();
+        $productModelQueryBuilderFactory->create()->shouldNotBeCalled();
+        $productModelSaver->saveAll(Argument::any())->shouldNotBeCalled();
+
+        $this->setStepExecution($stepExecution);
+        $this->execute();
+    }
+}

--- a/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilyVariantsTaskletSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilyVariantsTaskletSpec.php
@@ -10,14 +10,13 @@ use Akeneo\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
-use Box\Spout\Reader\IteratorInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelQueryBuilder;
 use Pim\Component\Catalog\EntityWithFamilyVariant\KeepOnlyValuesForVariation;
 use Pim\Component\Catalog\Model\FamilyInterface;
-use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\VariantProductInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -38,6 +37,7 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         ValidatorInterface $validator,
         BulkSaverInterface $productModelSaver,
         BulkSaverInterface $productSaver,
+        ObjectDetacherInterface $objectDetacher,
         CacheClearerInterface $cacheClearer,
         JobRepositoryInterface $jobRepository
     ) {
@@ -49,6 +49,7 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
             $validator,
             $productModelSaver,
             $productSaver,
+            $objectDetacher,
             $cacheClearer,
             $jobRepository
         );
@@ -68,6 +69,7 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $productSaver,
         $productModelQueryBuilderFactory,
         $jobRepository,
+        $objectDetacher,
         FamilyInterface $family,
         ProductModelInterface $rootProductModel,
         ProductModelInterface $subProductModel,
@@ -122,6 +124,10 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $productModelSaver->saveAll([$subProductModel])->shouldBeCalled();
         $productSaver->saveAll([$product])->shouldBeCalled();
 
+        $objectDetacher->detach($rootProductModel)->shouldBeCalled();
+        $objectDetacher->detach($subProductModel)->shouldBeCalled();
+        $objectDetacher->detach($product)->shouldBeCalled();
+
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalledTimes(3);
         $stepExecution->incrementSummaryInfo('skip')->shouldNotBeCalled();
 
@@ -140,6 +146,7 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $productSaver,
         $productModelQueryBuilderFactory,
         $jobRepository,
+        $objectDetacher,
         FamilyInterface $family1,
         FamilyInterface $family2,
         ProductModelInterface $rootProductModel1,
@@ -234,6 +241,12 @@ class ComputeDataRelatedToFamilyVariantsTaskletSpec extends ObjectBehavior
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalledTimes(5);
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
+
+        $objectDetacher->detach($rootProductModel1)->shouldBeCalled();
+        $objectDetacher->detach($subProductModel1)->shouldBeCalled();
+        $objectDetacher->detach($product1)->shouldBeCalled();
+        $objectDetacher->detach($rootProductModel2)->shouldBeCalled();
+        $objectDetacher->detach($product2)->shouldBeCalled();
 
         $this->setStepExecution($stepExecution);
         $this->execute();

--- a/tests/IntegrationTestsBundle/Jobs/JobExecutionObserver.php
+++ b/tests/IntegrationTestsBundle/Jobs/JobExecutionObserver.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Akeneo\Test\IntegrationTestsBundle\Jobs;
 
-use Akeneo\Bundle\BatchBundle\Job\JobInstanceRepository;
-use Symfony\Component\HttpKernel\KernelInterface;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
 
 /**
  * Utility class used to get observe the job executions.
@@ -16,25 +19,34 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class JobExecutionObserver
 {
+    /** @var SaverInterface */
     private $jobSaver;
 
+    /** @var EntityManager */
     private $entityManager;
 
-    /** @var JobInstanceRepository */
+    /** @var EntityRepository */
     private $jobInstanceRepository;
 
-    /** EntityRepository */
+    /** @var EntityRepository */
     private $jobExecutionsRepository;
 
     /**
-     * @param KernelInterface $kernel
+     * @param IdentifiableObjectRepositoryInterface $jobInstanceRepository
+     * @param IdentifiableObjectRepositoryInterface $jobExecutionRepository
+     * @param SaverInterface                        $jobSaver
+     * @param EntityManagerInterface                $entityManager
      */
-    public function __construct(KernelInterface $kernel)
-    {
-        $this->jobInstanceRepository = $kernel->getContainer()->get('pim_enrich.repository.job_instance');
-        $this->jobExecutionsRepository = $kernel->getContainer()->get('pim_enrich.repository.job_execution');
-        $this->jobSaver = $kernel->getContainer()->get('akeneo_batch.saver.job_instance');
-        $this->entityManager = $kernel->getContainer()->get('doctrine.orm.default_entity_manager');
+    public function __construct(
+        EntityRepository $jobInstanceRepository,
+        EntityRepository $jobExecutionRepository,
+        SaverInterface $jobSaver,
+        EntityManagerInterface $entityManager
+    ) {
+        $this->jobInstanceRepository = $jobInstanceRepository;
+        $this->jobExecutionsRepository = $jobExecutionRepository;
+        $this->jobSaver = $jobSaver;
+        $this->entityManager = $entityManager;
     }
 
     public function jobExecutions(): array

--- a/tests/IntegrationTestsBundle/Jobs/JobExecutionObserver.php
+++ b/tests/IntegrationTestsBundle/Jobs/JobExecutionObserver.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\IntegrationTestsBundle\Jobs;
+
+use Akeneo\Bundle\BatchBundle\Job\JobInstanceRepository;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Utility class used to get observe the job executions.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class JobExecutionObserver
+{
+    private $jobSaver;
+
+    private $entityManager;
+
+    /** @var JobInstanceRepository */
+    private $jobInstanceRepository;
+
+    /** EntityRepository */
+    private $jobExecutionsRepository;
+
+    /**
+     * @param KernelInterface $kernel
+     */
+    public function __construct(KernelInterface $kernel)
+    {
+        $this->jobInstanceRepository = $kernel->getContainer()->get('pim_enrich.repository.job_instance');
+        $this->jobExecutionsRepository = $kernel->getContainer()->get('pim_enrich.repository.job_execution');
+        $this->jobSaver = $kernel->getContainer()->get('akeneo_batch.saver.job_instance');
+        $this->entityManager = $kernel->getContainer()->get('doctrine.orm.default_entity_manager');
+    }
+
+    public function jobExecutions(): array
+    {
+        return $this->jobExecutionsRepository->findAll();
+    }
+
+    public function jobExecutionsWithJobName(string $jobName): array
+    {
+        $jobInstance = $this->jobInstanceRepository->findOneBy(['code' => $jobName]);
+        if (null === $jobInstance) {
+            throw new \InvalidArgumentException(sprintf('No job instance found for job name "%s"', $jobName));
+        }
+
+        $jobExecutions = $jobInstance->getJobExecutions()->toArray();
+
+        return $jobExecutions;
+    }
+
+    public function purge(string $jobName): void
+    {
+        $jobInstance = $this->jobInstanceRepository->findOneBy(['code' => $jobName]);
+        if (null === $jobInstance) {
+            throw new \InvalidArgumentException(sprintf('No job instance found for job name "%s"', $jobName));
+        }
+
+        $jobExecutions = $jobInstance->getJobExecutions();
+        foreach ($jobExecutions as $jobExecution) {
+            $jobInstance->removeJobExecution($jobExecution);
+        }
+
+        $this->jobSaver->save($jobInstance);
+        $this->entityManager->clear();
+    }
+}

--- a/tests/IntegrationTestsBundle/Resources/config/services.yml
+++ b/tests/IntegrationTestsBundle/Resources/config/services.yml
@@ -6,6 +6,7 @@ parameters:
     akeneo_integration_tests.security.system_user_authenticator.class: Akeneo\Test\IntegrationTestsBundle\Security\SystemUserAuthenticator
     akeneo_integration_tests.configuration.catalog.class: Akeneo\Test\IntegrationTestsBundle\Configuration\Catalog
     akeneo_integration_tests.launcher.job_launcher.class: Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher
+    akeneo_integration_tests.launcher.job_execution_observer.class: Akeneo\Test\IntegrationTestsBundle\Jobs\JobExecutionObserver
 
 services:
     akeneo_integration_tests.loader.reference_data_loader:
@@ -55,16 +56,16 @@ services:
         arguments:
             - '@kernel'
 
+    akeneo_integration_tests.launcher.job_execution_observer:
+        class: '%akeneo_integration_tests.launcher.job_execution_observer.class%'
+        arguments:
+            - '@kernel'
+
     akeneo_integration_tests.configuration.catalog:
         class: '%akeneo_integration_tests.configuration.catalog.class%'
 
     akeneo_integration_tests.catalog.configuration:
         synthetic: true
-
-    akeneo_integration_tests.launcher.job_launcher:
-        class: '%akeneo_integration_tests.launcher.job_launcher.class%'
-        arguments:
-            - '@kernel'
 
     akeneo_integration_tests.catalog.factory.product:
         class: 'Akeneo\Test\IntegrationTestsBundle\Fixture\Factory\Product'

--- a/tests/IntegrationTestsBundle/Resources/config/services.yml
+++ b/tests/IntegrationTestsBundle/Resources/config/services.yml
@@ -59,7 +59,10 @@ services:
     akeneo_integration_tests.launcher.job_execution_observer:
         class: '%akeneo_integration_tests.launcher.job_execution_observer.class%'
         arguments:
-            - '@kernel'
+            - '@pim_enrich.repository.job_instance'
+            - '@pim_enrich.repository.job_execution'
+            - '@akeneo_batch.saver.job_instance'
+            - '@doctrine.orm.default_entity_manager'
 
     akeneo_integration_tests.configuration.catalog:
         class: '%akeneo_integration_tests.configuration.catalog.class%'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR is one of more to come regarding the improvements of the user experience/performance on the import jobs that triggers a "compute_product_models_descendants" job.

**What is 'compute_product_models_descendant' is supposed to do ?**
Well it's kind of greedy approach but, we mainly used this job when an information has changed in the "structure" domain. Like, let's say "an attribute as been removed from a family", or "an attribute has been moved up a level in the family variant". 

We use this job to iterate over all the descendants of a root product model, to reindex the right information in ES or to recompute the completeness of the products.

**Get it, what's the issue?**
The issue is that it's not clear when this job is run from a technical point of view and even less clear from the point of view of the user.

When one of the event above happened in the PIM, we made sure some subscriber would catch it, and execute this `compute_product_model_descendants` by taking advantage of the job queue we now have in 2.0.

Here is an example of a family update made via import and the queue state:

| Queue state | job_param |
| -------------------------------- |------------- |
|  csv_family_import  (in progress) | "my_family" |


| Queue state | job_param |
| ------------- |------------- |
|  csv_family_import  (DONE) | "my_family" |
| compute_family_variant_structure (in progress) | "my_family_variante_1" |
| compute_family_variant_structure (in progress) | "my_family_variante_2" |
| compute_family_variant_structure (in progress) | "my_family_variante_3" |

*(at this point, from a user point of view the import job is completed, and he can move onto other tasks or imports)*

| Queue state | job_param |
| ------------- |------------- |
|  csv_family_import  (DONE) | "my_family" |
| compute_family_variant_structure (DONE) | "my_family_variante_1" |
| compute_family_variant_structure (DONE) | "my_family_variante_2" |
| compute_family_variant_structure (DONE) | "my_family_variante_3" |
| compute_product_model_descendants (in_progress) | "root_pm_1_of_fv_1" |
| compute_product_model_descendants (in_progress) | "root_pm_2_of_fv_1" |
| compute_product_model_descendants (in_progress) | "root_pm_1_of_fv_2" |
| compute_product_model_descendants (in_progress) | "root_pm_2_of_fv_2" |
| compute_product_model_descendants (in_progress) | "root_pm_1_of_fv_3" |
| compute_product_model_descendants (in_progress) | "root_pm_2_of_fv_3" |

(but sadly, he won't be able to have anything executed soon because the queue has plenty of jobs  to execute and the consumers should execute those jobs first).

Here is a global overview of who triggers what:
![image uploaded from ios](https://user-images.githubusercontent.com/1826473/34776304-ad767ab6-f616-11e7-8f54-aa257a00c477.jpg)

**I see the issue, what's the solution implemented ?**

In this PR we didn't improve the performance of the `compute_product_model_descendants` job per say, but we tried to rationalize its execution and give more visibility to what's going  on to the user under the hood by:
- Making sure the `compute_product_model_descendants` is only executed on unitary save (just on save in the UI for instance).
- Adding a new step for the family imports dedicated to do what the "compute_product_model_descendants" job is doing but synchronously with the job.


_**Edit 17/01**: Prevent the PIM from recalculating the completeness on non-unitary family save._

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | Ok
| Added integration tests           | Ok
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -