### PR TITLE
PIM-7103: improve performance of the datagrid

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -8,13 +8,17 @@
 - PIM-7085: Fix translation missing
 - PIM-6965: Show short view|project name in the grid
 
-## BC Breaks
+## Improvements
 
-- Changes the constructor of `Pim\Bundle\ApiBundle\Controller\ProductController` to add `Pim\Component\Catalog\EntityWithFamilyVariant\AddParent`
+- PIM-7103: Improve product datagrid performance
 
 ## Better manage products with variants!
 
 - API-516: be able to add a parent to a product via API
+
+## BC Breaks
+
+- Changes the constructor of `Pim\Bundle\ApiBundle\Controller\ProductController` to add `Pim\Component\Catalog\EntityWithFamilyVariant\AddParent`
 
 # 2.0.11 (2018-01-05)
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/LoadEntityWithValuesSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/LoadEntityWithValuesSubscriber.php
@@ -10,8 +10,8 @@ use Pim\Component\Catalog\Model\EntityWithValuesInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Load real product values object from the $rawValues field (ie: values in JSON)
- * when a product is loaded by Doctrine.
+ * Load real entity values object from the $rawValues field (ie: values in JSON)
+ * when an entity with values is loaded by Doctrine.
  *
  * @author    Julien Janvier <j.janvier@gmail.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -56,8 +56,9 @@ class LoadEntityWithValuesSubscriber implements EventSubscriber
 
     /**
      * Here we load the real object values from the raw values field.
-     * We also add the identifier as a regular value so that it can be used in the product
-     * edit form transparently.
+     *
+     * For products, we also add the identifier as a regular value
+     * so that it can be used in the product edit form transparently.
      *
      * @param LifecycleEventArgs $event
      */

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -82,7 +82,7 @@ services:
         arguments:
             - '@service_container'
         tags:
-            - { name: doctrine.event_subscriber }
+            - { name: doctrine.event_subscriber, priority: 50 }
 
     pim_catalog.event_subscriber.index_products:
         class: '%pim_catalog.event_subscriber.index_products.class%'

--- a/src/Pim/Bundle/DataGridBundle/Datasource/ProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/ProductDatasource.php
@@ -4,6 +4,8 @@ namespace Pim\Bundle\DataGridBundle\Datasource;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Oro\Bundle\DataGridBundle\Datasource\ResultRecord;
+use Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriber;
+use Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriberConfiguration;
 use Pim\Bundle\DataGridBundle\Extension\Pager\PagerExtension;
 use Pim\Component\Catalog\Model\EntityWithValuesInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
@@ -28,19 +30,25 @@ class ProductDatasource extends Datasource
     /** @var NormalizerInterface */
     protected $normalizer;
 
+    /** @var FilterEntityWithValuesSubscriber */
+    protected $filterEntityWithValuesSubscriber;
+
     /**
      * @param ObjectManager                       $om
      * @param ProductQueryBuilderFactoryInterface $factory
      * @param NormalizerInterface                 $serializer
+     * @param FilterEntityWithValuesSubscriber    $filterEntityWithValuesSubscriber
      */
     public function __construct(
         ObjectManager $om,
         ProductQueryBuilderFactoryInterface $factory,
-        NormalizerInterface $serializer
+        NormalizerInterface $serializer,
+        FilterEntityWithValuesSubscriber $filterEntityWithValuesSubscriber = null
     ) {
         $this->om = $om;
         $this->factory = $factory;
         $this->normalizer = $serializer;
+        $this->filterEntityWithValuesSubscriber = $filterEntityWithValuesSubscriber;
     }
 
     /**
@@ -48,6 +56,16 @@ class ProductDatasource extends Datasource
      */
     public function getResults()
     {
+        // TODO: remove null condition on master
+        if (null !== $this->filterEntityWithValuesSubscriber) {
+            $attributeIdsToDisplay = $this->getConfiguration('displayed_attribute_ids');
+            $attributes = $this->getConfiguration('attributes_configuration');
+            $attributeCodesToFilter = $this->getAttributeCodesToFilter($attributeIdsToDisplay, $attributes);
+            $this->filterEntityWithValuesSubscriber->configure(
+                FilterEntityWithValuesSubscriberConfiguration::filterEntityValues($attributeCodesToFilter)
+            );
+        }
+
         $entitiesWithValues = $this->pqb->execute();
         $context = [
             'locales'             => [$this->getConfiguration('locale_code')],
@@ -129,5 +147,23 @@ class ProductDatasource extends Datasource
         );
 
         return $normalizedItem;
+    }
+
+    /**
+     * @param array $attributeIdsToDisplay
+     * @param array $attributes
+     *
+     * @return array array of attribute codes
+     */
+    private function getAttributeCodesToFilter(array $attributeIdsToDisplay, array $attributes): array
+    {
+        $attributeCodes = [];
+        foreach ($attributes as $attribute) {
+            if (in_array($attribute['id'], $attributeIdsToDisplay)) {
+                $attributeCodes[] = $attribute['code'];
+            }
+        }
+
+        return $attributeCodes;
     }
 }

--- a/src/Pim/Bundle/DataGridBundle/EventSubscriber/FilterEntityWithValuesSubscriber.php
+++ b/src/Pim/Bundle/DataGridBundle/EventSubscriber/FilterEntityWithValuesSubscriber.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\DataGridBundle\EventSubscriber;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\Events;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
+use Pim\Component\Catalog\Model\EntityWithValuesInterface;
+
+/**
+ * Aims to filter raw values field (JSON array) when an entity with values is loaded by Doctrine.
+ *
+ * This subscriber have to be executed before Pim\Bundle\CatalogBundle\EventSubscriber\LoadEntityWithValuesSubscriber.
+ * It allows to increase drastically performance of the datagrid loading,
+ * because it avoids to hydrate all the values of an entity.
+ * Hydration is very costly when the number of values is important.
+ *
+ * WARNING: With this fix, we are partially loading products: it has to be done only for read purpose.
+ * Saving an entity partially loaded could result in a loss of data.
+ * This subscriber should be activated only for the datagrid.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * TODO: use an Entity Listener instead, as for Pim\Bundle\CatalogBundle\EventSubscriber\LoadEntityWithValuesSubscriber
+ * TODO: refactor the loading of the datagrid to not use ProductInterface entity
+ */
+class FilterEntityWithValuesSubscriber implements EventSubscriber
+{
+    /** @var FilterEntityWithValuesSubscriberConfiguration */
+    protected $configuration;
+
+    public function __construct()
+    {
+        $this->configuration = FilterEntityWithValuesSubscriberConfiguration::doNotFilterEntityValues();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubscribedEvents(): array
+    {
+        return [
+            Events::postLoad
+        ];
+    }
+
+    /**
+     * Filter directly the real object values from the raw values field.
+     * Should only be used in the datagrid context.
+     *
+     * @param LifecycleEventArgs $event
+     */
+    public function postLoad(LifecycleEventArgs $event): void
+    {
+        $entity = $event->getObject();
+        if (!$entity instanceof EntityWithValuesInterface || !$this->configuration->shouldFilterEntityValues()
+        ) {
+            return;
+        }
+
+        $attributeCodes = $this->configuration->attributeCodesToFilterEntityValues();
+        if ($entity instanceof EntityWithFamilyInterface && null !== $entity->getFamily()) {
+            $family = $entity->getFamily();
+            if (null !== $family->getAttributeAsLabel()) {
+                $attributeCodes[] = $family->getAttributeAsLabel()->getCode();
+            }
+            if (null !== $family->getAttributeAsImage()) {
+                $attributeCodes[] = $family->getAttributeAsImage()->getCode();
+            }
+        }
+
+        $rawValues = $entity->getRawValues();
+
+        $filteredRawValues = [];
+        foreach ($attributeCodes as $attributeCode) {
+            if (isset($rawValues[$attributeCode])) {
+                $filteredRawValues[$attributeCode] = $rawValues[$attributeCode];
+            }
+        }
+        $entity->setRawValues($filteredRawValues);
+    }
+
+    /**
+     * Configure attributes to keep in the raw values.
+     * As it is a doctrine event, there is no way to pass a context (containing the attributes to filter).
+     *
+     * Therefore, this subscriber is stateful.
+     *
+     * @param FilterEntityWithValuesSubscriberConfiguration $configuration
+     */
+    public function configure(FilterEntityWithValuesSubscriberConfiguration $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
+}

--- a/src/Pim/Bundle/DataGridBundle/EventSubscriber/FilterEntityWithValuesSubscriberConfiguration.php
+++ b/src/Pim/Bundle/DataGridBundle/EventSubscriber/FilterEntityWithValuesSubscriberConfiguration.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\DataGridBundle\EventSubscriber;
+
+use Pim\Component\Catalog\Model\AttributeInterface;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FilterEntityWithValuesSubscriberConfiguration
+{
+    /** @var AttributeInterface[] */
+    protected $attributeCodes = [];
+
+    /** @var boolean */
+    protected $filterEntityWithValues;
+
+    /**
+     * @param AttributeInterface[] $attributeCodes
+     * @param bool                 $filterEntityWithValues
+     */
+    private function __construct(array $attributeCodes, bool $filterEntityWithValues)
+    {
+        $this->attributeCodes = $attributeCodes;
+        $this->filterEntityWithValues = $filterEntityWithValues;
+    }
+
+    /**
+     * Hydrate entity with only the values belonging to a list of attribute codes.
+     * WARNING: Should only be used when loading entities for the datagrid.
+     *
+     * @param array $attributeCodes
+     *
+     * @return FilterEntityWithValuesSubscriberConfiguration
+     */
+    public static function filterEntityValues(array $attributeCodes): FilterEntityWithValuesSubscriberConfiguration
+    {
+        return new self($attributeCodes, true);
+    }
+
+    /**
+     * Hydrates entity with values with all the values.
+     *
+     * @return FilterEntityWithValuesSubscriberConfiguration
+     */
+    public static function doNotFilterEntityValues(): FilterEntityWithValuesSubscriberConfiguration
+    {
+        return new self([], false);
+    }
+
+    /**
+     * @return array
+     */
+    public function attributeCodesToFilterEntityValues(): array
+    {
+        return $this->attributeCodes;
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldFilterEntityValues(): bool
+    {
+        return $this->filterEntityWithValues;
+    }
+}

--- a/src/Pim/Bundle/DataGridBundle/PimDataGridBundle.php
+++ b/src/Pim/Bundle/DataGridBundle/PimDataGridBundle.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\DataGridBundle;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Pim\Bundle\DataGridBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
@@ -128,6 +128,7 @@ services:
             - '@pim_catalog.object_manager.product'
             - '@pim_enrich.query.product_and_product_model_query_builder_from_size_factory'
             - '@pim_serializer'
+            - '@pim_datagrid.event_subscriber.filter_entity_with_values_subscriber'
         calls:
             - [ setMassActionRepository, ['@pim_catalog.repository.product_mass_action'] ]
         tags:
@@ -139,6 +140,7 @@ services:
             - '@pim_catalog.object_manager.product'
             - '@pim_catalog.query.product_query_builder_from_size_factory'
             - '@pim_datagrid.normalizer.product_association'
+            - '@pim_datagrid.event_subscriber.filter_entity_with_values_subscriber'
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_associated_product }
 
@@ -148,6 +150,7 @@ services:
             - '@pim_catalog.object_manager.product'
             - '@pim_catalog.query.product_query_builder_from_size_factory'
             - '@pim_datagrid.normalizer.group_product'
+            - '@pim_datagrid.event_subscriber.filter_entity_with_values_subscriber'
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_group_product }
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/subscribers.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/subscribers.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_datagrid.event_subscriber.default_view.class: Pim\Bundle\DataGridBundle\EventSubscriber\DefaultViewSubscriber
+    pim_datagrid.event_subscriber.filter_entity_with_values_subscriber.class: Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriber
 
 services:
     pim_datagrid.event_subscriber.default_view:
@@ -8,3 +9,8 @@ services:
             - '@pim_datagrid.repository.datagrid_view'
         tags:
             - { name: kernel.event_subscriber }
+
+    pim_datagrid.event_subscriber.filter_entity_with_values_subscriber:
+        class: '%pim_datagrid.event_subscriber.filter_entity_with_values_subscriber.class%'
+        tags:
+            - { name: doctrine.event_subscriber, priority: 100 }

--- a/src/Pim/Bundle/DataGridBundle/spec/Datasource/ProductDatasourceSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Datasource/ProductDatasourceSpec.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace spec\Pim\Bundle\DataGridBundle\Datasource;
+
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Persistence\ObjectManager;
+use Oro\Bundle\DataGridBundle\Datagrid\Datagrid;
+use Oro\Bundle\DataGridBundle\Datasource\ResultRecord;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\DataGridBundle\Datasource\AssociatedProductDatasource;
+use Pim\Bundle\DataGridBundle\Datasource\DatasourceInterface;
+use Pim\Bundle\DataGridBundle\Datasource\ParameterizableInterface;
+use Pim\Bundle\DataGridBundle\Datasource\ProductDatasource;
+use Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriber;
+use Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriberConfiguration;
+use Pim\Bundle\DataGridBundle\Extension\Pager\PagerExtension;
+use Pim\Component\Catalog\Model\AssociationInterface;
+use Pim\Component\Catalog\Model\AssociationTypeInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+use Pim\Component\Catalog\Query\Sorter\Directions;
+use Prophecy\Argument;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ProductDatasourceSpec extends ObjectBehavior
+{
+    public function let(
+        ObjectManager $objectManager,
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        NormalizerInterface $productNormalizer,
+        FilterEntityWithValuesSubscriber $subscriber
+    ) {
+        $this->beConstructedWith($objectManager, $pqbFactory, $productNormalizer, $subscriber);
+
+        $this->setParameters(['dataLocale' => 'fr_FR']);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProductDatasource::class);
+    }
+
+    function it_is_a_datasource()
+    {
+        $this->shouldImplement(DatasourceInterface::class);
+        $this->shouldImplement(ParameterizableInterface::class);
+    }
+
+    function it_gets_products(
+        $pqbFactory,
+        $productNormalizer,
+        $subscriber,
+        Datagrid $datagrid,
+        ProductQueryBuilderInterface $pqb,
+        ProductInterface $product1,
+        CursorInterface $productCursor
+    ) {
+        $config = [
+            'displayed_attribute_ids' => [1, 2],
+            'attributes_configuration' => [
+                'attribute_1' => [
+                    'id' => 1,
+                    'code' => 'attribute_1'
+                ],
+                'attribute_2' => [
+                    'id' => 2,
+                    'code' => 'attribute_2'
+                ],
+                'attribute_3' => [
+                    'id' => 3,
+                    'code' => 'attribute_3'
+                ],
+            ],
+            'locale_code' => 'fr_FR',
+            'scope_code' => 'ecommerce',
+
+            'association_type_id' => 2,
+            'current_group_id' => 3,
+            PagerExtension::PER_PAGE_PARAM => 15
+        ];
+
+        $pqbFactory->create([
+            'repository_parameters' => [],
+            'repository_method'     => 'createQueryBuilder',
+            'limit'                 => 15,
+            'from'                  => 0,
+            'default_locale'        => 'fr_FR',
+            'default_scope'         => 'ecommerce',
+        ])->willReturn($pqb);
+
+        $pqb->getQueryBuilder()->shouldBeCalledTimes(1);
+        $pqb->execute()->willReturn($productCursor);
+        $productCursor->count()->willReturn(1);
+
+        $productCursor->rewind()->shouldBeCalled();
+        $productCursor->valid()->willReturn(true, false);
+        $productCursor->current()->willReturn($product1);
+        $productCursor->next()->shouldBeCalled();
+
+        $this->process($datagrid, $config);
+
+        $productNormalizer->normalize($product1, 'datagrid', [
+            'locales'       => ['fr_FR'],
+            'channels'      => ['ecommerce'],
+            'data_locale'   => 'fr_FR',
+            'association_type_id' => 2,
+            'current_group_id' => 3
+        ])->willReturn([
+            'identifier'       => 'product_1',
+            'family'           => null,
+            'enabled'          => true,
+            'label'            => 'foo',
+            'values'           => [],
+            'created'          => '2000-01-01',
+            'updated'          => '2000-01-01',
+            'compleneteness'   => null,
+            'variant_products' => null,
+            'document_type'    => null,
+        ]);
+
+        $subscriber
+            ->configure(FilterEntityWithValuesSubscriberConfiguration::filterEntityValues(['attribute_1', 'attribute_2']))
+            ->shouldBeCalled();
+
+        $results = $this->getResults();
+        $results->shouldBeArray();
+        $results->shouldHaveCount(2);
+        $results->shouldHaveKey('data');
+        $results->shouldHaveKeyWithValue('totalRecords', 1);
+        $results['data']->shouldBeArray();
+        $results['data']->shouldHaveCount(1);
+        $results['data']->shouldBeAnArrayOfInstanceOf(ResultRecord::class);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'beAnArrayOfInstanceOf' => function (array $subjects, $class) {
+                foreach ($subjects as $subject) {
+                    if (!$subject instanceof $class) {
+                        return false;
+                    }
+                }
+
+                return true;
+            },
+        ];
+    }
+}

--- a/src/Pim/Bundle/DataGridBundle/spec/EventSubscriber/FilterEntityWithValuesSubscriberSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/EventSubscriber/FilterEntityWithValuesSubscriberSpec.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace spec\Pim\Bundle\DataGridBundle\EventSubscriber;
+
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\Events;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriber;
+use Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriberConfiguration;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
+use Pim\Component\Catalog\Model\EntityWithValuesInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Prophecy\Argument;
+
+class FilterEntityWithValuesSubscriberSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(FilterEntityWithValuesSubscriber::class);
+    }
+
+    function it_subscribes_to_post_load_event()
+    {
+        $this->getSubscribedEvents()->shouldReturn([Events::postLoad]);
+    }
+
+    function it_does_not_filter_non_entity_with_values_object(\StdClass $entity, LifecycleEventArgs $event)
+    {
+        $event->getObject()->willReturn($entity);
+        $this->postLoad($event);
+    }
+
+    function it_does_not_filter_entity_with_values_by_default(
+        EntityWithValuesInterface $entity,
+        LifecycleEventArgs $event
+    ) {
+        $entity->setRawValues(Argument::cetera())->shouldNotBeCalled();
+        $event->getObject()->willReturn($entity);
+        $this->postLoad($event);
+    }
+
+    function it_does_not_filter_entity_with_values_when_filtering_not_activated(
+        EntityWithValuesInterface $entity,
+        LifecycleEventArgs $event
+    ) {
+        $this->configure(FilterEntityWithValuesSubscriberConfiguration::doNotFilterEntityValues());
+        $entity->setRawValues(Argument::cetera())->shouldNotBeCalled();
+        $event->getObject()->willReturn($entity);
+        $this->postLoad($event);
+    }
+
+    function it_filters_raw_values_when_filtering_activated(
+        EntityWithValuesInterface $entity,
+        LifecycleEventArgs $event
+    ) {
+        $this->configure(FilterEntityWithValuesSubscriberConfiguration::filterEntityValues(['attribute_1', 'attribute_3']));
+        $entity->getRawValues()->willReturn([
+            'attribute_1' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+            'attribute_2' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+            'attribute_3' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+        ]);
+
+        $entity->setRawValues([
+            'attribute_1' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+            'attribute_3' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+        ])->shouldBeCalled();
+        $event->getObject()->willReturn($entity);
+        $this->postLoad($event);
+    }
+
+    function it_filters_by_keeping_keeps_attribute_as_label_and_image_for_family_entity(
+        EntityWithFamilyInterface $entity,
+        LifecycleEventArgs $event,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsImage,
+        AttributeInterface $attributeAsLabel
+    ) {
+        $this->configure(FilterEntityWithValuesSubscriberConfiguration::filterEntityValues(['attribute_1', 'attribute_3']));
+        $entity->getRawValues()->willReturn([
+            'attribute_1' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+            'attribute_2' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+            'attribute_3' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+            'attribute_as_label' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+            'attribute_as_image' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+        ]);
+
+        $entity->setRawValues([
+            'attribute_1' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+            'attribute_3' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+            'attribute_as_label' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+            'attribute_as_image' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'foo'
+                ]
+            ],
+        ])->shouldBeCalled();
+
+        $entity->getFamily()->willReturn($family);
+        $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $attributeAsImage->getCode()->willReturn('attribute_as_image');
+        $attributeAsLabel->getCode()->willReturn('attribute_as_label');
+
+        $event->getObject()->willReturn($entity);
+        $this->postLoad($event);
+
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

POC is validated.
For more information, see description here: https://github.com/akeneo/pim-community-dev/pull/7430

I did some benchmarks with products containing 3000 product values on EE, and it is ok (900 ms on my computer, on an not optimised config).

Note: it solves the problem to load the product data of the datagrid. 
Datagrid metadata are still pretty slow to load: the more you have "attribute useable as grid filter", the slower it is.

Green CI: https://ci.akeneo.com/blue/organizations/jenkins/akeneo%2Fpim-community-dev/detail/PR-7461/6/pipeline/

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

  
  