### PR TITLE
PIM-7102: do not hydrate product variant with m2m associations to avoid unit of work messing up

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7088: Fix product categories and groups being lost when attaching a product to a product model
 - PIM-6874: Fix select attribute groups from PEF when there are more than 25
 - PIM-7086: Fix enable loading message in system configuration
 - API-567: Fix validation of product-models on API

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-7088: Fix product categories and groups being lost when attaching a product to a product model
+- PIM-7102: Fix product categories and groups being lost when attaching a product to a product model
 - PIM-6874: Fix select attribute groups from PEF when there are more than 25
 - PIM-7086: Fix enable loading message in system configuration
 - API-567: Fix validation of product-models on API

--- a/src/Pim/Component/Catalog/EntityWithFamily/CreateVariantProduct.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/CreateVariantProduct.php
@@ -85,16 +85,16 @@ class CreateVariantProduct
 
         $variantProduct->setId($product->getId());
         $variantProduct->setIdentifier($identifierValue);
-        $variantProduct->setGroups($product->getGroups());
         $variantProduct->setAssociations($product->getAssociations());
         $variantProduct->setEnabled($product->isEnabled());
         $variantProduct->setCompletenesses($product->getCompletenesses());
         $variantProduct->setFamily($product->getFamily());
-        $variantProduct->setCategories($product->getCategories());
         $variantProduct->setCreated($product->getCreated());
         $variantProduct->setUpdated($product->getUpdated());
         $variantProduct->setUniqueData($product->getUniqueData());
         $variantProduct->setRawValues($product->getRawValues());
+        // IMPORTANT: we're not assigning categories and groups, because doing so would delete the association!
+        // @see AddParentAProductSubscriber and PIM-7088
 
         return $variantProduct;
     }

--- a/src/Pim/Component/Catalog/tests/integration/EntityWithFamily/CreateVariantProductFromProductIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/EntityWithFamily/CreateVariantProductFromProductIntegration.php
@@ -7,6 +7,7 @@ use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\VariantProductInterface;
 use Akeneo\Test\IntegrationTestsBundle\Assertion;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Test the variant product creation Pim\Component\Catalog\EntityWithFamily\CreateVariantProduct
@@ -89,7 +90,6 @@ final class CreateVariantProductFromProductIntegration extends TestCase
 
         $this->assertSame($this->productModel, $variantProduct->getParent());
         $this->assertSame('clothing_color_size', $variantProduct->getFamilyVariant()->getCode());
-        $this->assertSame($this->product->getGroups(), $variantProduct->getGroups());
         $this->assertSame($this->product->getCompletenesses(), $variantProduct->getCompletenesses());
         $this->assertSame($this->product->getAssociations(), $variantProduct->getAssociations());
         $this->assertSame($this->product->getCreated(), $variantProduct->getCreated());
@@ -98,8 +98,10 @@ final class CreateVariantProductFromProductIntegration extends TestCase
         $this->assertSame($this->product->getIdentifier(), $variantProduct->getIdentifier());
         $this->assertSame($this->productModel->getFamilyVariant(), $variantProduct->getFamilyVariant());
 
-        $assertCollection = new Assertion\Collection($this->product->getCategories(), $variantProduct->getCategories());
-        $assertCollection->containsEntities();
+        // IMPORTANT: we're not assigning categories and groups, because doing so would delete the association!
+        // @see AddParentAProductSubscriber and PIM-7088
+        $this->assertEquals($variantProduct->getGroups(), new ArrayCollection());
+        $this->assertEquals($variantProduct->getCategoriesForVariation(), new ArrayCollection());
     }
 
     public function test_that_the_variant_product_have_product_values_without_product_model_values()


### PR DESCRIPTION
UoW::registerManaged seems to not like the fact the m2m associations are already hydrated.
This fix resolves the problem by not generating an extra set of `DELETE` queries on the related `groups` and `categories` m2m associations.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -


  