### PR TITLE
PIM-7058: Restore select2 filter label on render

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -3,8 +3,9 @@
 ## Bug fixes
 
 - PIM-7041: Fix a bug that prevents to sort on a reference data attribute on product grid
+- PIM-7058: Restore correct simple select filter label when loading views
 
-# 1.6.20 (2017-10-25) 
+# 1.6.20 (2017-10-25)
 
 ## Bug fixes
 

--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -170,3 +170,14 @@ Feature: Datagrid views
       | column | value       |
       | Name   | Black boots |
       | Family | Boots       |
+
+  Scenario: Successfully display filter values when refreshing a saved view
+    Given I am on the products page
+    And I filter by "family" with operator "is empty" and value ""
+    And I create the view:
+      | label | Empty family |
+    Then I should be on the products page
+    And I should see the flash message "Datagrid view successfully created"
+    And I refresh current page
+    Then I should see the text "Family: is empty"
+    And I should see the text "Views Empty family"

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -160,7 +160,6 @@ define(
             _onClickCriteriaSelector: function(e) {
                 e.stopPropagation();
                 $('body').trigger('click');
-
                 if (!this.popupCriteriaShowed) {
                     this._showCriteria();
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -57,11 +57,8 @@ define(
                 $(e.currentTarget).parent().addClass('active');
                 var parentDiv = $(e.currentTarget).parent().parent().parent();
 
-                if ($(e.currentTarget).attr('data-value') === 'empty') {
-                    this._disableInput();
-                } else {
-                    this._enableInput();
-                }
+                this._setInputVisibility($(e.currentTarget).attr('data-value') === 'empty');
+
                 parentDiv.find('button').html($(e.currentTarget).html() + '<span class="caret"></span>');
                 e.preventDefault();
             },
@@ -116,9 +113,18 @@ define(
                 return config;
             },
 
+            _setInputVisibility(hideInput) {
+                if (hideInput) {
+                    this._disableInput();
+                } else {
+                    this._enableInput();
+                }
+            },
+
             _writeDOMValue: function(value) {
                 this.$('li .operator_choice[data-value="' + value.type + '"]').trigger('click');
                 var operator = this.$('li.active .operator_choice').data('value');
+
                 if ('empty' === operator) {
                     this._setInputValue(this.criteriaValueSelectors.value, []);
                 } else {
@@ -153,17 +159,26 @@ define(
                 );
 
                 initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config());
+
+                this._updateDOMValue();
+                this._updateCriteriaHint();
             },
 
             _onClickCriteriaSelector: function(e) {
                 e.stopPropagation();
                 $('body').trigger('click');
+
+                var isEmpty =  'empty' === this.getValue().type;
+
                 if (!this.popupCriteriaShowed) {
                     this._showCriteria();
+                    this._setInputVisibility(isEmpty);
 
-                    initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config())
-                        .select2('data', this._getCachedResults(this.getValue().value))
-                        .select2('open');
+                    if (false === isEmpty) {
+                        initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config())
+                            .select2('data', this._getCachedResults(this.getValue().value))
+                            .select2('open');
+                    }
                 } else {
                     this._hideCriteria();
                 }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -57,7 +57,11 @@ define(
                 $(e.currentTarget).parent().addClass('active');
                 var parentDiv = $(e.currentTarget).parent().parent().parent();
 
-                this._setInputVisibility($(e.currentTarget).attr('data-value') === 'empty');
+                if ($(e.currentTarget).attr('data-value') === 'empty') {
+                    this._disableInput();
+                } else {
+                    this._enableInput();
+                }
 
                 parentDiv.find('button').html($(e.currentTarget).html() + '<span class="caret"></span>');
                 e.preventDefault();
@@ -113,14 +117,6 @@ define(
                 return config;
             },
 
-            _setInputVisibility(hideInput) {
-                if (hideInput) {
-                    this._disableInput();
-                } else {
-                    this._enableInput();
-                }
-            },
-
             _writeDOMValue: function(value) {
                 this.$('li .operator_choice[data-value="' + value.type + '"]').trigger('click');
                 var operator = this.$('li.active .operator_choice').data('value');
@@ -160,7 +156,6 @@ define(
 
                 initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config());
 
-                this._updateDOMValue();
                 this._updateCriteriaHint();
             },
 
@@ -172,13 +167,10 @@ define(
 
                 if (!this.popupCriteriaShowed) {
                     this._showCriteria();
-                    this._setInputVisibility(isEmpty);
 
-                    if (false === isEmpty) {
-                        initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config())
-                            .select2('data', this._getCachedResults(this.getValue().value))
-                            .select2('open');
-                    }
+                    initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config())
+                        .select2('data', this._getCachedResults(this.getValue().value))
+                        .select2('open');
                 } else {
                     this._hideCriteria();
                 }
@@ -277,8 +269,10 @@ define(
 
             _getCriteriaHint: function() {
                 var operator = this.$('li.active .operator_choice').data('value');
-                if ('empty' === operator) {
-                    return this.operatorChoices[operator];
+                var type = this.getValue().type;
+
+                if ('empty' === operator || 'empty' === type) {
+                    return this.operatorChoices['empty'];
                 }
 
                 var value = (arguments.length > 0) ? this._getDisplayValue(arguments[0]) : this._getDisplayValue();

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -62,7 +62,6 @@ define(
                 } else {
                     this._enableInput();
                 }
-
                 parentDiv.find('button').html($(e.currentTarget).html() + '<span class="caret"></span>');
                 e.preventDefault();
             },
@@ -120,7 +119,6 @@ define(
             _writeDOMValue: function(value) {
                 this.$('li .operator_choice[data-value="' + value.type + '"]').trigger('click');
                 var operator = this.$('li.active .operator_choice').data('value');
-
                 if ('empty' === operator) {
                     this._setInputValue(this.criteriaValueSelectors.value, []);
                 } else {
@@ -162,8 +160,6 @@ define(
             _onClickCriteriaSelector: function(e) {
                 e.stopPropagation();
                 $('body').trigger('click');
-
-                var isEmpty =  'empty' === this.getValue().type;
 
                 if (!this.popupCriteriaShowed) {
                     this._showCriteria();

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
@@ -136,6 +136,8 @@ define(
                 );
 
                 initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config());
+
+                this._updateCriteriaHint();
             },
 
             _onClickCriteriaSelector: function(e) {
@@ -223,8 +225,10 @@ define(
 
             _getCriteriaHint: function() {
                 var operator = this.$('li.active .operator_choice').data('value');
-                if ('empty' === operator) {
-                    return this.operatorChoices[operator];
+                var type = this.getValue().type;
+
+                if ('empty' === operator || 'empty' === type) {
+                    return this.operatorChoices['empty'];
                 }
 
                 var value = (arguments.length > 0) ? this._getDisplayValue(arguments[0]) : this._getDisplayValue();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR updates the simple select filters to restore the correct filter label on render when loading a saved view. Previously, the filter was still applied but was displaying the wrong value. 



<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

  
  
  