### PR TITLE
API-392: Deprecated CategoryEvents, should be remove in 2.2

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Event/CategoryEvents.php
+++ b/src/Pim/Bundle/EnrichBundle/Event/CategoryEvents.php
@@ -8,6 +8,8 @@ namespace Pim\Bundle\EnrichBundle\Event;
  * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ *
+ * @deprecated Will be removed in 2.2
  */
 final class CategoryEvents
 {
@@ -17,7 +19,7 @@ final class CategoryEvents
      * The event listener receives an
      * Symfony\Component\EventDispatcher\GenericEvent instance.
      *
-     * @deprecated Will be removed in 2.1
+     * @deprecated Will be removed in 2.2
      */
     const PRE_EDIT = 'pim_enrich.category.pre_edit';
 
@@ -27,7 +29,7 @@ final class CategoryEvents
      * The event listener receives an
      * Symfony\Component\EventDispatcher\GenericEvent instance.
      *
-     * @deprecated Will be removed in 2.1
+     * @deprecated Will be removed in 2.2
      */
     const POST_EDIT = 'pim_enrich.category.post_edit';
 
@@ -37,7 +39,7 @@ final class CategoryEvents
      * The event listener receives an
      * Symfony\Component\EventDispatcher\GenericEvent instance.
      *
-     * @deprecated Will be removed in 2.1
+     * @deprecated Will be removed in 2.2
      */
     const PRE_CREATE = 'pim_enrich.category.pre_create';
 
@@ -47,7 +49,7 @@ final class CategoryEvents
      * The event listener receives an
      * Symfony\Component\EventDispatcher\GenericEvent instance.
      *
-     * @deprecated Will be removed in 2.1
+     * @deprecated Will be removed in 2.2
      */
     const POST_CREATE = 'pim_enrich.category.post_create';
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Deprecated CategoryEvents, used to set default permissions on category creation by the UI

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
