### PR TITLE
API-565 & API-445: Associated product and variant product to product model

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,3 +1,9 @@
+# 2.1.x
+
+## Web API
+
+- API-565: Create a product and associate it to product model
+
 # 2.1.1 (2018-01-10)
 
 ## Bug fixes

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -2,6 +2,7 @@
 
 ## Web API
 
+- API-445: Update product association to product model
 - API-565: Create a product and associate it to product model
 
 # 2.1.1 (2018-01-10)

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
@@ -581,27 +581,29 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $data =
-<<<JSON
-    {
-        "identifier": "product_variant_creation_associations",
-        "parent": "amor",
-        "values": {
-          "a_yes_no": [
+        $data = <<<JSON
+{
+    "identifier": "product_variant_creation_associations",
+    "parent": "amor",
+    "values": {
+        "a_yes_no": [
             {
-              "locale": null,
-              "scope": null,
-              "data": true
+                "locale": null,
+                "scope": null,
+                "data": true
             }
-          ]
+        ]
+    },
+    "associations": {
+        "UPSELL": {
+            "product_models": ["amor"]
         },
-        "associations": {
-            "X_SELL": {
-                "groups": ["groupA"],
-                "products": ["simple"]
-            }
+        "X_SELL": {
+            "groups": ["groupA"],
+            "products": ["simple"]
         }
     }
+}
 JSON;
 
         $client->request('POST', 'api/rest/v1/products', [], [], [], $data);
@@ -670,7 +672,7 @@ JSON;
                 "UPSELL"       => [
                     "groups"   => [],
                     "products" => [],
-                    "product_models" => [],
+                    "product_models" => ["amor"],
                 ],
                 "X_SELL"       => [
                     "groups"   => ["groupA"],

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -559,6 +559,12 @@ JSON;
      */
     public function testProductPartialUpdateWithTheAssociationsUpdated()
     {
+        $this->createProductModel([
+            'code' => 'a_product_model',
+            'family_variant' => 'familyVariantA1',
+            'values'  => [],
+        ]);
+
         $client = $this->createAuthenticatedClient();
 
         $data =
@@ -569,6 +575,9 @@ JSON;
             "PACK": {
                 "groups": ["groupA"],
                 "products": ["product_categories", "product_family"]
+            },
+            "SUBSTITUTION": {
+                "product_models": ["a_product_model"]
             }
         }
     }
@@ -591,11 +600,27 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [
-                'PACK'         => ['groups'   => ['groupA'], 'products' => ['product_categories', 'product_family'], 'product_models' => []],
-                'SUBSTITUTION' => ['groups'   => [], 'products' => [], 'product_models' => []],
-                'UPSELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
-                'X_SELL'       => ['groups'   => ['groupA'], 'products' => ['product_categories'], 'product_models' => []],
+            'associations' => [
+                'PACK' => [
+                    'groups' => ['groupA'],
+                    'products' => ['product_categories', 'product_family'],
+                    'product_models' => [],
+                ],
+                'SUBSTITUTION' => [
+                    'groups' => [],
+                    'products' => [],
+                    'product_models' => ['a_product_model']
+                ],
+                'UPSELL' => [
+                    'groups' => [],
+                    'products' => [],
+                    'product_models' => [],
+                ],
+                'X_SELL' => [
+                    'groups' => ['groupA'],
+                    'products' => ['product_categories'],
+                    'product_models' => [],
+                ],
             ],
         ];
 
@@ -1407,6 +1432,41 @@ JSON;
 
         $response = $client->getResponse();
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testResponseWhenAssociatingToNonExistingProductModel()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data = <<<JSON
+{
+    "identifier": "big_boot",
+    "associations": {
+        "X_SELL": {
+            "product_models": ["a_non_exiting_product_model"]
+        }
+    }
+}
+JSON;
+
+        $expected = <<<JSON
+{
+    "code": 422,
+    "message": "Property \"associations\" expects a valid Product model identifier. The product model does not exist, \"a_non_exiting_product_model\" given. Check the expected format on the API documentation.",
+    "_links": {
+        "documentation": {
+            "href": "http:\/\/api.akeneo.com\/api-reference.html#post_products"
+        }
+    }
+}
+JSON;
+
+        $client->request('POST', 'api/rest/v1/products', [], [], [], $data);
+
+        $response = $client->getResponse();
+
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateVariantProductIntegration.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\Collection;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
-class PartialUpdateProductVariantIntegration extends AbstractProductTestCase
+class PartialUpdateVariantProductIntegration extends AbstractProductTestCase
 {
     /** @var Collection */
     private $products;
@@ -739,6 +739,9 @@ JSON;
             "PACK": {
                 "groups": ["groupA"],
                 "products": ["apollon_optionb_false"]
+            },
+            "SUBSTITUTION": {
+                "product_models": ["amor"]
             }
         }
     }
@@ -796,11 +799,27 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [
-                'PACK'         => ['groups'   => ['groupA'], 'products' => ['apollon_optionb_false'], 'product_models' => []],
-                'SUBSTITUTION' => ['groups'   => [], 'products' => [], 'product_models' => []],
-                'UPSELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
-                'X_SELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
+            'associations' => [
+                'PACK' => [
+                    'groups' => ['groupA'],
+                    'products' => ['apollon_optionb_false'],
+                    'product_models' => [],
+                ],
+                'SUBSTITUTION' => [
+                    'groups' => [],
+                    'products' => [],
+                    'product_models' => ['amor'],
+                ],
+                'UPSELL' => [
+                    'groups' => [],
+                    'products' => [],
+                    'product_models' => [],
+                ],
+                'X_SELL' => [
+                    'groups' => [],
+                    'products' => [],
+                    'product_models' => [],
+                ],
             ],
         ];
 


### PR DESCRIPTION
## Description

This PR updates and adds some tests about product association throught the API, for both creation and partial updates:
- associate  a non variant product  to a product model
- associate a variant product to a product model (this model being the variant product ancestor)
- test the response when associating to a product model that does not exists

Bad formating of the `associations.*.product_models` field is already unit tested.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
