### PR TITLE
PIM-7105: Fix un-index variant product on deletion

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -12,6 +12,7 @@
 - PIM-7082: remove double user menu on product import edit form
 - PIM-7084: fix attribute suppression
 - PIM-6355: Fix the count by categories on the product grid
+- PIM-7105: Fix un-index variant product on deletion
 
 ## Improvements
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -121,7 +121,7 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
     {
         $ancestorsIds = [];
         $ancestorsCodes = [];
-        if ($product instanceof VariantProductInterface) {
+        if ($product instanceof EntityWithFamilyVariantInterface) {
             $ancestorsIds = $this->getAncestorsIds($product);
             $ancestorsCodes = $this->getAncestorsCodes($product);
         }
@@ -155,7 +155,7 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
      *
      * @return array
      */
-    private function getAncestorsCodes(EntityWithFamilyVariantInterface $entityWithFamilyVariant)
+    private function getAncestorsCodes(EntityWithFamilyVariantInterface $entityWithFamilyVariant): array
     {
         $ancestorsCodes = [];
         while (null !== $parent = $entityWithFamilyVariant->getParent()) {

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Normalizer\Indexing\Product;
 
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\VariantProductInterface;
 use Pim\Component\Catalog\Normalizer\Standard\Product\PropertiesNormalizer as StandardPropertiesNormalizer;
@@ -24,6 +25,7 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
     const FIELD_COMPLETENESS = 'completeness';
     const FIELD_IN_GROUP = 'in_group';
     const FIELD_ID = 'id';
+    private const FIELD_ANCESTORS = 'ancestors';
 
     /**
      * {@inheritdoc}
@@ -74,6 +76,8 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
                 $context
             ) : [];
 
+        $data[self::FIELD_ANCESTORS] = $this->getAncestors($product);
+
         return $data;
     }
 
@@ -105,5 +109,60 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
         }
 
         return $date;
+    }
+
+
+    /**
+     * @param $product
+     *
+     * @return array
+     */
+    private function getAncestors($product): array
+    {
+        $ancestorsIds = [];
+        $ancestorsCodes = [];
+        if ($product instanceof VariantProductInterface) {
+            $ancestorsIds = $this->getAncestorsIds($product);
+            $ancestorsCodes = $this->getAncestorsCodes($product);
+        }
+
+        $ancestors = [
+            'ids'   => $ancestorsIds,
+            'codes' => $ancestorsCodes,
+        ];
+
+        return $ancestors;
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $entityWithFamilyVariant
+     *
+     * @return array
+     */
+    private function getAncestorsIds(EntityWithFamilyVariantInterface $entityWithFamilyVariant): array
+    {
+        $ancestorsIds = [];
+        while (null !== $parent = $entityWithFamilyVariant->getParent()) {
+            $ancestorsIds[] = 'product_model_' . $parent->getId();
+            $entityWithFamilyVariant = $parent;
+        }
+
+        return $ancestorsIds;
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $entityWithFamilyVariant
+     *
+     * @return array
+     */
+    private function getAncestorsCodes(EntityWithFamilyVariantInterface $entityWithFamilyVariant)
+    {
+        $ancestorsCodes = [];
+        while (null !== $parent = $entityWithFamilyVariant->getParent()) {
+            $ancestorsCodes[] = $parent->getCode();
+            $entityWithFamilyVariant = $parent;
+        }
+
+        return $ancestorsCodes;
     }
 }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
@@ -144,7 +144,7 @@ class ProductPropertiesNormalizer implements NormalizerInterface, SerializerAwar
     {
         $ancestorsIds = [];
         $ancestorsCodes = [];
-        if ($product instanceof VariantProductInterface) {
+        if ($product instanceof EntityWithFamilyVariantInterface) {
             $ancestorsIds = $this->getAncestorsIds($product);
             $ancestorsCodes = $this->getAncestorsCodes($product);
         }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizer.php
@@ -25,6 +25,7 @@ class ProductModelPropertiesNormalizer implements NormalizerInterface, Serialize
     private const FIELD_FAMILY_VARIANT = 'family_variant';
     private const FIELD_ID = 'id';
     private const FIELD_PARENT = 'parent';
+    private const FIELD_ANCESTORS = 'ancestors';
 
     /**
      * {@inheritdoc}
@@ -72,6 +73,8 @@ class ProductModelPropertiesNormalizer implements NormalizerInterface, Serialize
                 $context
             ) : [];
 
+        $data[self::FIELD_ANCESTORS] = $this->getAncestors($productModel);
+
         return $data;
     }
 
@@ -82,5 +85,55 @@ class ProductModelPropertiesNormalizer implements NormalizerInterface, Serialize
     {
         return $data instanceof ProductModelInterface
             && ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX === $format;
+    }
+
+    /**
+     * @param ProductModelInterface $productModel
+     *
+     * @return array
+     */
+    private function getAncestors(ProductModelInterface $productModel): array
+    {
+        $ancestorsIds = $this->getAncestorsIds($productModel);
+        $ancestorsCodes = $this->getAncestorsCodes($productModel);
+
+        $ancestors = [
+            'ids'   => $ancestorsIds,
+            'codes' => $ancestorsCodes,
+        ];
+
+        return $ancestors;
+    }
+
+    /**
+     * @param ProductModelInterface $productModel
+     *
+     * @return array
+     */
+    private function getAncestorsIds(ProductModelInterface $productModel): array
+    {
+        $ancestorsIds = [];
+        while (null !== $parent = $productModel->getParent()) {
+            $ancestorsIds[] = 'product_model_' . $parent->getId();
+            $productModel = $parent;
+        }
+
+        return $ancestorsIds;
+    }
+
+    /**
+     * @param ProductModelInterface $productModel
+     *
+     * @return array
+     */
+    private function getAncestorsCodes(ProductModelInterface $productModel): array
+    {
+        $ancestorsCodes = [];
+        while (null !== $parent = $productModel->getParent()) {
+            $ancestorsCodes[] = $parent->getCode();
+            $productModel = $parent;
+        }
+
+        return $ancestorsCodes;
     }
 }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
@@ -80,6 +80,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
                 'groups'        => [],
                 'completeness'  => [],
                 'values'        => [],
+                'ancestors'     => ['ids' => [], 'codes' => []],
             ]
         );
     }
@@ -135,6 +136,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
                 'groups'        => [],
                 'completeness'  => ['the completenesses'],
                 'values'        => [],
+                'ancestors'     => ['ids' => [], 'codes' => []],
             ]
         );
     }
@@ -244,6 +246,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'ancestors'     => ['ids' => [], 'codes' => []],
             ]
         );
     }
@@ -272,6 +275,10 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $product->getParent()->willReturn($subProductModel);
         $subProductModel->getParent()->willReturn($rootProductModel);
         $rootProductModel->getParent()->willReturn(null);
+        $subProductModel->getId()->willReturn(2);
+        $rootProductModel->getId()->willReturn(1);
+        $subProductModel->getCode()->willReturn('sub_pm_2');
+        $rootProductModel->getCode()->willReturn('root_pm_1');
 
         $serializer->normalize(
             $now,
@@ -325,6 +332,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
                 'groups'        => [],
                 'completeness'  => [],
                 'values'        => [],
+                'ancestors'     => ['ids' => ['product_model_2', 'product_model_1'], 'codes' => ['sub_pm_2', 'root_pm_1']],
             ]
         );
     }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizerSpec.php
@@ -48,6 +48,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $productModel->getParent()->willReturn(null);
 
+        $productModel->getId()->willReturn('67');
         $productModel->getCode()->willReturn('sku-001');
         $productModel->getCreated()->willReturn($now);
         $serializer
@@ -86,6 +87,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                 'categories'     => ['category_A', 'category_B'],
                 'parent'         => null,
                 'values'         => [],
+                'ancestors'     => ['ids' => [], 'codes' => []],
             ]
         );
     }
@@ -169,6 +171,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'ancestors'     => ['ids' => [], 'codes' => []],
             ]
         );
     }
@@ -187,7 +190,9 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $productModel->getCode()->willReturn('sku-001');
 
         $productModel->getParent()->willReturn($parent);
+        $parent->getId()->willReturn(1);
         $parent->getCode()->willReturn('parent_A');
+        $parent->getParent()->willReturn(null);
 
         $productModel->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -273,6 +278,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'ancestors'     => ['ids' => ['product_model_1'], 'codes' => ['parent_A']],
             ]
         );
     }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -39,6 +39,7 @@ class ProductIndexingIntegration extends TestCase
             'groups'        => [],
             'completeness'  => [],
             'values'        => [],
+            'ancestors'     => ['ids' => [], 'codes' => []],
         ];
 
         $this->assertIndexingFormat('bar', $expected);
@@ -63,6 +64,7 @@ class ProductIndexingIntegration extends TestCase
             'groups'        => [],
             'completeness'  => [],
             'values'        => [],
+            'ancestors'     => ['ids' => [], 'codes' => []],
         ];
 
         $this->assertIndexingFormat('baz', $expected);
@@ -299,6 +301,7 @@ class ProductIndexingIntegration extends TestCase
                     ],
                 ],
             ],
+            'ancestors'     => ['ids' => [], 'codes' => []],
         ];
 
         $this->assertIndexingFormat('foo', $expected);


### PR DESCRIPTION
**Description**

When we delete a product model, its product variants are not un-indexed from the "product" index.
It's simply because the deletion query is based on "ancestors.ids" but we don't put the "ancestors.ids" in this index.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
