### PR TITLE
Fix a bug in Doctrine mapping

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductModel.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductModel.orm.yml
@@ -68,7 +68,7 @@ Pim\Component\Catalog\Model\ProductModel:
     manyToOne:
         parent:
             targetEntity: Pim\Component\Catalog\Model\ProductModelInterface
-            inversedBy: children
+            inversedBy: productModels
             joinColumns:
                 parent_id:
                     referencedColumnName: id

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/VariantProduct.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/VariantProduct.orm.yml
@@ -3,6 +3,7 @@ Pim\Component\Catalog\Model\VariantProduct:
     manyToOne:
         parent:
             targetEntity: Pim\Component\Catalog\Model\ProductModelInterface
+            inversedBy: products
             joinColumns:
                 product_model_id:
                     referencedColumnName: id


### PR DESCRIPTION
## Description

The Doctrine mapping of the `VariantProduct` and `ProductModel` entities is currently invalid.

This PR fixes the wrong `inversedBy` configuration. There is no need to run `doctrine:schema:update` for this, so no migration script needed.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
