### PR TITLE
PIM-7111: Fix display bug on variant axis completeness

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Bug fixes
+
+- PIM-7111: Fix display bug on variant axis completeness
+
 # 2.0.12 (2018-01-12)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-item.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-item.html
@@ -1,6 +1,6 @@
 <div class="AknVariantNavigation-listItem">
     <img class="AknVariantNavigation-listProductImage" src="<%- entity.image %>" alt="">
-    <span class="AknVariantNavigation-listProductLabel">
+    <span title="<%- entity.label %>" class="AknVariantNavigation-listProductLabel">
         <%- entity.label %>
     </span>
     <span class="AknVariantNavigation-listProductCompleteness AknVariantNavigation-listProductCompleteness--<%- getClass(entity.completeness.ratio) %>">

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-model-item.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/product-model-item.html
@@ -1,6 +1,6 @@
 <div class="AknVariantNavigation-listItem">
     <img class="AknVariantNavigation-listProductModelImage" src="<%- entity.image %>" alt="">
-    <span class="AknVariantNavigation-listProductModelLabel">
+    <span title="<%- entity.label %>" class="AknVariantNavigation-listProductModelLabel">
         <%- entity.label %>
     </span>
     <% if (entity.completeness) { %>

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
@@ -65,17 +65,29 @@
     }
   }
 
+  &-listItem {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
   &-listProductModelImage,
   &-listProductImage {
     border-radius: 4px;
     max-width: 25px;
     max-height: 25px;
-    margin-bottom: -8px;
   }
 
   &-listProductModelLabel,
   &-listProductLabel {
     margin-left: 5px;
+    margin-right: 5px;
+    flex: 1;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    display: inline-block;
   }
 
   &-listProductModelCompleteness,
@@ -83,7 +95,6 @@
     border-radius: 50px;
     float: right;
     padding: 0 10px;
-    margin-top: 10px;
     height: 22px;
     font-size: @AknFontSizeSmall;
     line-height: 22px;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a small display issue with variant axes completeness by adding text-overflow:ellipsis and the full title on hover. 

**Before**
![image](https://user-images.githubusercontent.com/1336344/34946116-e6afe96e-fa05-11e7-9f10-5b9ec3cd1599.png)

**After**
![screen shot 2018-01-15 at 15 12 59](https://user-images.githubusercontent.com/1336344/34946297-a2fb48e8-fa06-11e7-91d7-f365d7c65711.png)



<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
