### PR TITLE
CLOUD-393 Add slack notification on CI

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -446,7 +446,7 @@ def clearTemplateNames() {
     currentBuild.rawBuild.getAction( PodTemplateAction.class )?.stack?.clear()
 }
 
-def notifySlack(String buildStatus) {
+def notifySlack(String buildStatus="") {
     // Build status of null means success.
     buildStatus = buildStatus ?: currentBuild.result
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,6 +2,9 @@
 
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateAction
 
+slackChannelNotif ="#product-dev"
+
+
 String[] editions = ["ce"]
 String[] features = ["features"]
 String launchUnitTests = "yes"
@@ -22,6 +25,7 @@ stage("Build") {
                 string(defaultValue: '50', description: 'Number of dots per line', name: 'dotsperline'),
                 string(defaultValue: 'ee,ce', description: 'PIM edition the behat tests should run on (comma separated values)', name: 'editions'),
                 string(defaultValue: 'features,vendor/akeneo/pim-community-dev/features', description: 'Behat scenarios to build', name: 'features'),
+                string(defaultValue: "", description: 'Slack channel (#channel) or User to notify (@user.id)', name: 'slackChannelNotif'),
             ])
 
             editions = userInput['editions'].tokenize(',')
@@ -31,10 +35,11 @@ stage("Build") {
             launchBehatTests = userInput['launchBehatTests']
             verboseOutputs = userInput['verboseOutputs']
             dotsPerLine = userInput['dotsperline']
+            slackChannelNotif= userInput['slackChannelNotif']
         }
     }
     milestone 2
-
+    notifySlack("STARTED")
     parallel(
         "pim-ce": {withBuildNode({
             checkout scm
@@ -321,6 +326,7 @@ stage("Test") {
                 }
             }
         }
+        notifySlack()
     }
 }
 
@@ -438,4 +444,28 @@ def queue(body, scale, edition, verboseOutputs, dotsPerLine) {
 def clearTemplateNames() {
     // see https://issues.jenkins-ci.org/browse/JENKINS-42184
     currentBuild.rawBuild.getAction( PodTemplateAction.class )?.stack?.clear()
+}
+
+def notifySlack(String buildStatus) {
+    // Build status of null means success.
+    buildStatus = buildStatus ?: currentBuild.result
+
+    def color
+
+    if (buildStatus == 'STARTED') {
+        color = '#D4DADF'
+    } else if (buildStatus == 'SUCCESS') {
+        color = '#BDFFC3'
+    } else if (buildStatus == 'UNSTABLE') {
+        color = '#FFFE89'
+    } else {
+        color = '#FF9FA1'
+    }
+
+    def msg = "${buildStatus}: `${env.JOB_NAME}` #${env.BUILD_NUMBER}: (<${env.BUILD_URL}|Open>)"
+    if(this.respondsTo('slackSend')) {
+        slackSend(color: color, message: msg, channel:"${slackChannelNotif}")
+    } else {
+        echo "slack plugin is not installed"
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Add slack notification on start and end build.
For PR only user/channel specified on input param receive message.
For all branch it send message to default channel specified on Jenkinsfile

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
