### PR TITLE
PIM-6908: Fix cancel action on leaving page confirmation

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7111: Fix display bug on variant axis completeness
+- PIM-6908: Fix cancel button on unsaved changes dialog
 
 # 2.0.12 (2018-01-12)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/item.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/item.js
@@ -84,6 +84,7 @@ define(
             redirect: function (event) {
                 if (!_.has(event, 'extension')) {
                     event.stopPropagation();
+                    event.preventDefault();
                 }
 
                 if (!(event.metaKey || event.ctrlKey) &&

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/tab.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/tab.js
@@ -87,6 +87,7 @@ define(
             redirect: function (event) {
                 if (!_.has(event, 'extension')) {
                     event.stopPropagation();
+                    event.preventDefault();
                 }
 
                 if (!(event.metaKey || event.ctrlKey) &&


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a bug where clicking cancel on an 'unsaved changes' dialog when editing a form was useless and didn't stop the page from navigating away. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
