### PR TITLE
PIM-6913: Fix completeness wrong locale/scope

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - PIM-7111: Fix display bug on variant axis completeness
 - PIM-6908: Fix cancel button on unsaved changes dialog
+- PIM-6913: Fix incorrect product completeness percentage
 
 # 2.0.12 (2018-01-12)
 

--- a/features/Pim/Behat/Context/Domain/Enrich/CompletenessContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/CompletenessContext.php
@@ -189,4 +189,19 @@ class CompletenessContext extends PimContext
 
         return $flatCompleteness;
     }
+
+    /**
+     * @param string $completenessAmount
+     *
+     * @Then /^the completeness badge label should show "([^"]*)"$/
+     */
+    public function theCompletenessBadgeLabelShouldShow($completenessAmount)
+    {
+        $this->spin(function () use ($completenessAmount) {
+            $badge = $this->getCurrentPage()->find('css', '.AknCompletenessBadge');
+            $badgeAmount = $badge->getText();
+
+            return strtolower($badgeAmount) === strtolower($completenessAmount);
+        }, sprintf('The completeness badge does not show the amount "%s".', $completenessAmount));
+    }
 }

--- a/features/Pim/Behat/Context/Domain/Enrich/CompletenessContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/CompletenessContext.php
@@ -198,7 +198,7 @@ class CompletenessContext extends PimContext
     public function theCompletenessBadgeLabelShouldShow($completenessAmount)
     {
         $this->spin(function () use ($completenessAmount) {
-            $badge = $this->getCurrentPage()->find('css', '.AknCompletenessBadge');
+            $badge = $this->getCurrentPage()->find('css', '.completeness-badge');
             $badgeAmount = $badge->getText();
 
             return strtolower($badgeAmount) === strtolower($completenessAmount);

--- a/features/product/completeness/display_completeness.feature
+++ b/features/product/completeness/display_completeness.feature
@@ -118,7 +118,7 @@ Feature: Display the completeness of a product
     When I change the family of the product to "Sneakers"
     Then I should not see the text "No family defined. Please define a family to calculate the completeness of this product."
     When I change the family of the product to "Boots"
-    Then the completeness badge label should show "You just changed the family of the product. Please save it first to calculate the completeness for the new family."
+    Then I should see the text "You just changed the family of the product. Please save it first to calculate the completeness for the new family."
 
   @jira https://akeneo.atlassian.net/browse/PIM-4489
   Scenario: Don't display the completeness if the family is not defined on product creation

--- a/features/product/completeness/display_completeness.feature
+++ b/features/product/completeness/display_completeness.feature
@@ -118,7 +118,7 @@ Feature: Display the completeness of a product
     When I change the family of the product to "Sneakers"
     Then I should not see the text "No family defined. Please define a family to calculate the completeness of this product."
     When I change the family of the product to "Boots"
-    Then I should see the text "You just changed the family of the product. Please save it first to calculate the completeness for the new family."
+    Then the completeness badge label should show "You just changed the family of the product. Please save it first to calculate the completeness for the new family."
 
   @jira https://akeneo.atlassian.net/browse/PIM-4489
   Scenario: Don't display the completeness if the family is not defined on product creation
@@ -147,3 +147,15 @@ Feature: Display the completeness of a product
     And I switch the locale to "fr_FR"
     And I visit the "Completeness" column tab
     Then The label for the "tablet" channel should be "[tablet]"
+
+  Scenario: Display the completeness badge for the scope and locale
+    Given I am on the "sneakers" product page
+    When I visit the "Completeness" column tab
+    And I switch the scope to "Tablet"
+    Then the completeness badge label should show "Complete: 88%"
+    When I switch the locale to "fr_FR"
+    Then the completeness badge label should show "Complete: 77%"
+    When I switch the scope to "Mobile"
+    Then the completeness badge label should show "Complete: 100%"
+    When I switch the locale to "en_US"
+    Then the completeness badge label should show "Complete: 100%"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-completeness.js
@@ -35,18 +35,27 @@ define(
             configure: function () {
                 this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:change', function (scopeEvent) {
                     if ('base_product' === scopeEvent.context) {
-                        this.render({ scope: scopeEvent.scopeCode });
+                        this.renderCompleteness({ scope: scopeEvent.scopeCode });
                     }
                 }.bind(this));
                 this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', function (localeEvent) {
                     if ('base_product' === localeEvent.context) {
-                        this.render({ locale: localeEvent.localeCode});
+                        this.renderCompleteness({ locale: localeEvent.localeCode});
                     }
                 }.bind(this));
 
-                this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_fetch', this.render.bind(this));
+                this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_fetch', this.renderCompleteness.bind(this));
 
                 return BaseForm.prototype.configure.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritDoc}
+             */
+            render: function() {
+                this.renderCompleteness();
+
+                return BaseForm.prototype.render.apply(this, arguments);
             },
 
             /**
@@ -56,11 +65,12 @@ define(
              * @param options.locale String
              * @param options.scope  String
              */
-            render: function () {
-                const options = {
+            renderCompleteness: function (event) {
+                const options = Object.assign({}, {
                     locale: UserContext.get('catalogLocale'),
                     scope: UserContext.get('catalogScope')
-                };
+                }, event);
+
                 this.$el.empty();
 
                 const ratio = this.getCurrentRatio(options);
@@ -159,7 +169,7 @@ define(
                         scope: UserContext.get('catalogScope')
                     }
                 );
-                this.render();
+                this.renderCompleteness();
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/product-completeness.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/product-completeness.html
@@ -1,4 +1,4 @@
-<div class="AknBadge AknBadge--big <%- badgeClass %>" data-toggle="dropdown">
+<div class="AknBadge AknBadge--big <%- badgeClass %> AknCompletenessBadge" data-toggle="dropdown">
     <%- label %>: <%- ratio %>% <img src="bundles/pimui/images/icon-down-white.svg" class="AknBadge-icon">
 </div>
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/product-completeness.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/product-completeness.html
@@ -1,4 +1,4 @@
-<div class="AknBadge AknBadge--big <%- badgeClass %> AknCompletenessBadge" data-toggle="dropdown">
+<div class="AknBadge AknBadge--big <%- badgeClass %> completeness-badge" data-toggle="dropdown">
     <%- label %>: <%- ratio %>% <img src="bundles/pimui/images/icon-down-white.svg" class="AknBadge-icon">
 </div>
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix an issue with the completeness tab in the product edit form where the locale/scope information was outdated and not matching the completeness percentage badge. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
