### PR TITLE
API-574: fix validation of axes that are not viewable with EE permissions

### DIFF
--- a/src/Pim/Component/Catalog/Validator/Constraints/ImmutableVariantAxesValuesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/ImmutableVariantAxesValuesValidator.php
@@ -68,7 +68,7 @@ class ImmutableVariantAxesValuesValidator extends ConstraintValidator
         foreach ($axisCodes as $code) {
             $originalValue = $originalValues->getByCodes($code);
             $newValue = $entity->getValue($code);
-            if (null !== $originalValue && !$originalValue->isEqual($newValue)) {
+            if (null !== $newValue && null !== $originalValue && !$originalValue->isEqual($newValue)) {
                 if (is_bool($newValue->getData())) {
                     $newValue = $newValue ? 'true' : 'false';
                 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When permissions are applied, if attributes in axes are not viewable in EE, `$newValue = $entity->getValue($code);` returns `null`. 

What's annoying me is that it's modification for the EE applied in CE. But I don't have any idea to do that in another way.

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
