### PR TITLE
Update to Elasticsearch 5.6.6

### DIFF
--- a/.ci/k8s/pubsub_consumer_job.yaml
+++ b/.ci/k8s/pubsub_consumer_job.yaml
@@ -33,7 +33,7 @@ spec:
             exec:
               command: ["mysql", "-proot", "-h", "127.0.0.1", "-e", "SELECT 1"]
         - name: elasticsearch
-          image: docker.elastic.co/elasticsearch/elasticsearch:5.5.2
+          image: docker.elastic.co/elasticsearch/elasticsearch:5.6.6
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,7 +265,7 @@ void runIntegrationTest(String phpVersion, String edition, def testFiles) {
         sh "docker rm -f \$(docker ps -a -q) || true"
 
         try {
-            docker.image("elasticsearch:5.5").withRun("--name elasticsearch -e ES_JAVA_OPTS=\"-Xms512m -Xmx512m\"") {
+            docker.image("elasticsearch:5.6").withRun("--name elasticsearch -e ES_JAVA_OPTS=\"-Xms512m -Xmx512m\"") {
                 docker.image("mysql:5.7").withRun("--name mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_USER=akeneo_pim -e MYSQL_PASSWORD=akeneo_pim -e MYSQL_DATABASE=akeneo_pim --tmpfs=/var/lib/mysql/:rw,noexec,nosuid,size=1000m --tmpfs=/tmp/:rw,noexec,nosuid,size=300m") {
                     docker.image("akeneo/php:${phpVersion}").inside("--link mysql:mysql --link elasticsearch:elasticsearch") {
                         if ('ce' == edition) {
@@ -394,7 +394,7 @@ def runBehatTest(edition, features, phpVersion) {
             sh "cp behat.ci.yml behat.yml"
 
             try {
-                sh "php /var/lib/distributed-ci/dci-master/bin/build ${env.WORKSPACE}/behat-${edition} ${env.BUILD_NUMBER} orm ${features} ${env.JOB_NAME} 5 ${phpVersion} 5.7 \"${tags}\" \"behat-${edition}\" -e 5.5 --exit_on_failure"
+                sh "php /var/lib/distributed-ci/dci-master/bin/build ${env.WORKSPACE}/behat-${edition} ${env.BUILD_NUMBER} orm ${features} ${env.JOB_NAME} 5 ${phpVersion} 5.7 \"${tags}\" \"behat-${edition}\" -e 5.6 --exit_on_failure"
             } finally {
                 sh "find app/build/logs/behat/ -name \"*.xml\" | xargs sed -i \"s/ name=\\\"/ name=\\\"[${edition}] /\""
                 junit 'app/build/logs/behat/*.xml'

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -98,7 +98,7 @@ services:
       - behat
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.6
     environment:
       ES_JAVA_OPTS: '-Xms512m -Xmx512m'
       discovery.type: 'single-node'


### PR DESCRIPTION
## Description

This PR updates the version of Elasticsearch used in both the CI (v1 and v2) and the Docker Compose file to the latest 5.6.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
