### PR TITLE
Fix ajax parameter name.

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/simple-select-async.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/simple-select-async.js
@@ -110,7 +110,7 @@ define(
                     options: {
                         limit: this.resultsPerPage,
                         page: page,
-                        catalogLocale: UserContext.get('catalogLocale')
+                        locale: UserContext.get('catalogLocale')
                     }
                 };
             },


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When autocompleting families in the product creation dialog, the incorrect 'catalogLocale' parameter is passed to the controller, instead of 'locale'. Thus in FamilySearchableRepository#findBySearch() only the family codes are searched for matches, not the label translations.
Fixes SDS-2420.