### PR TITLE
PIM-6784: Improve the search of product models with categories in the datagrid

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogProductModelIntegration.php
@@ -17,76 +17,76 @@ use Pim\Component\Catalog\Model\ProductModelInterface;
  * |-------------|---------------------------------------------|------------------------|---------------------------------------|---------------------------------|--------------------------------|
  * | clothing    | description, color, image_1, material, size | clothing_color_size    | description                           | color (axis), image_1, material | size (axis), weight            |
  * | clothing    | description, color, image_1, material, size | clothing_size          | description, image_1, color, material | size (axis)                     | -                              |
- * | clothing    | description, color, image_1, material, size | clothing_color         | description, size                     | color (axis), image_1,material  | -                              |
+ * | clothing    | description, color, image_1, material, size | clothing_color         | description, size, material           | color (axis), image_1           | -                              |
  * | accessories | description, color, material, size          | accessories_size       | description, color, material          | size (axis)                     | -                              |
  * | accessories | -                                           | -                      | -                                     | -                               | -                              |
  * | shoes       | description, size, color, image_1, material | shoes_size_color       | description                           | size (axis)                     | color (axis), image_1, material|
- * | clothing    | description, color, image_1, material, size | clothing_material_size | description                           | material (axis), image_1, color | size (axis), weight            |
+ * | clothing    | description, color, image_1, material, size | clothing_material_size | description, color                    | material (axis), image_1,       | size (axis), weight            |
  * -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  *
  * And here are the products and product models linked to those family variants:
  *
- * |--------------------------|------------------------------------------------------------------------------------------------------------------------------------|
- * | Id                       | Label                        | Color  | Size | Material  | Completeness | Complete products | Family      | Family variant         |
- * |--------------------------|------------------------------|--------|------|-----------|--------------|-------------------|-------------|------------------------|
- * | product_model_1          | model-tshirt                 |        |      |           |              | 7/12              | clothing    | clothing_color_size    |
- * | product_model_2          | model-tshirt-grey            | grey   |      | Cotton    |              | 4/4               | clothing    | clothing_color_size    |
- * | product_1                | tshirt-grey-s                | grey   | S    | Cotton    | 100%         |                   | clothing    | clothing_color_size    |
- * | product_2                | tshirt-grey-m                | grey   | M    | Cotton    | 100%         |                   | clothing    | clothing_color_size    |
- * | product_3                | tshirt-grey-l                | grey   | L    | Cotton    | 100%         |                   | clothing    | clothing_color_size    |
- * | product_4                | tshirt-grey-xl               | grey   | XL   | Cotton    | 100%         |                   | clothing    | clothing_color_size    |
- * | product_model_3          | model-tshirt-blue            | blue   |      | Polyester |              | 3/4               | clothing    | clothing_color_size    |
- * | product_5                | tshirt-blue-s                | blue   | S    | Polyester | 80%          |                   | clothing    | clothing_color_size    |
- * | product_6                | tshirt-blue-m                | blue   | M    | Polyester | 100%         |                   | clothing    | clothing_color_size    |
- * | product_7                | tshirt-blue-l                | blue   | L    | Polyester | 100%         |                   | clothing    | clothing_color_size    |
- * | product_8                | tshirt-blue-xl               | blue   | XL   | Polyester | 100%         |                   | clothing    | clothing_color_size    |
- * | product_model_4          | model-tshirt-red             | red    |      | Cotton    |              | 0/4               | clothing    | clothing_color_size    |
- * | product_9                | tshirt-red-s                 | red    | S    | Cotton    | 70%          |                   | clothing    | clothing_color_size    |
- * | product_10               | tshirt-red-m                 | red    | M    | Cotton    | 70%          |                   | clothing    | clothing_color_size    |
- * | product_11               | tshirt-red-l                 | red    | L    | Cotton    | 60%          |                   | clothing    | clothing_color_size    |
- * | product_12               | tshirt-red-xl                | red    | XL   | Cotton    | 80%          |                   | clothing    | clothing_color_size    |
- * |--------------------------|------------------------------------------------------------------------------------------------------------------------------------|
- * | product_model_5          | model-tshirt-unique-color    | red    |      | Cotton    |              | 2/4               | clothing    | clothing_size          |
- * | product_13               | tshirt-unique-color-s        | red    | S    | Cotton    | 100%         |                   | clothing    | clothing_size          |
- * | product_14               | tshirt-unique-color-m        | red    | M    | Cotton    | 100%         |                   | clothing    | clothing_size          |
- * | product_15               | tshirt-unique-color-l        | red    | L    | Cotton    | 50%          |                   | clothing    | clothing_size          |
- * | product_16               | tshirt-unique-color-xl       | red    | XL   | Cotton    | 60%          |                   | clothing    | clothing_size          |
- * |--------------------------|------------------------------------------------------------------------------------------------------------------------------------|
- * | product_17               | watch                        | blue   |      | Metal     | 0%           |                   | clothing    | clothing_size          |
- * |--------------------------|------------------------------------------------------------------------------------------------------------------------------------|
- * | product_model_6          | model-hat                    | grey   |      | Wool      |              | 2/2               | accessories | accessories_size       |
- * | product_18               | hat-m                        | grey   | M    | Wool      | 100%         |                   | accessories | accessories_size       |
- * | product_19               | hat-l                        | grey   | L    | Wool      | 100%         |                   | accessories | accessories_size       |
- * |--------------------------|------------------------------------------------------------------------------------------------------------------------------------|
- * | product_model_7          | model-tshirt-unique-size     |        | U    | Cotton    |              | 1/3               | clothing    | clothing_color         |
- * | product_20               | tshirt-unique-size-blue      | blue   | U    | Cotton    | 100%         |                   | clothing    | clothing_color         |
- * | product_21               | tshirt-unique-size-red       | red    | U    | Cotton    | 70%          |                   | clothing    | clothing_color         |
- * | product_22               | tshirt-unique-size-yellow    | yellow | U    | Cotton    | 50%          |                   | clothing    | clothing_color         |
- * |--------------------------|------------------------------------------------------------------------------------------------------------------------------------|
- * | product_model_8          | model-running-shoes          |        |      | Leather   |              | 4/9               | shoes       | shoes_size_color       |
- * | product_model_9          | model-running-shoes-s        |        | S    | Leather   |              | 3/3               | shoes       | shoes_size_color       |
- * | product_23               | running-shoes-s-white        | white  | S    | Leather   | 100%         |                   | shoes       | shoes_size_color       |
- * | product_24               | running-shoes-s-blue         | blue   | S    | Leather   | 100%         |                   | shoes       | shoes_size_color       |
- * | product_25               | running-shoes-s-red          | red    | S    | Leather   | 100%         |                   | shoes       | shoes_size_color       |
- * | product_model_10         | model-running-shoes-m        |        | M    | Leather   |              | 0/3               | shoes       | shoes_size_color       |
- * | product_26               | running-shoes-m-white        | white  | M    | Leather   | 0%           |                   | shoes       | shoes_size_color       |
- * | product_27               | running-shoes-m-blue         | blue   | M    | Leather   | 0%           |                   | shoes       | shoes_size_color       |
- * | product_28               | running-shoes-m-red          | red    | M    | Leather   | 0%           |                   | shoes       | shoes_size_color       |
- * | product_model_11         | model-running-shoes-l        |        | L    | Leather   |              | 1/3               | shoes       | shoes_size_color       |
- * | product_29               | running-shoes-l-white        | white  | L    | Leather   | 60%          |                   | shoes       | shoes_size_color       |
- * | product_30               | running-shoes-l-blue         | blue   | L    | Leather   | 70%          |                   | shoes       | shoes_size_color       |
- * | product_31               | running-shoes-l-red          | red    | L    | Leather   | 100%         |                   | shoes       | shoes_size_color       |
- * |--------------------------|------------------------------------------------------------------------------------------------------------------------------------|
- * | product_model_12         | model-biker-jacket           | white  |      |           |              | 0/6               | clothing    | clothing_material_size |
- * | product_model_13         | model-biker-jacket-leather   | white  |      | Leather   |              | 0/3               | clothing    | clothing_material_size |
- * | product_32               | biker-jacket-leather-s       | white  | S    | Leather   | 0%           |                   | clothing    | clothing_material_size |
- * | product_33               | biker-jacket-leather-m       | white  | M    | Leather   | 0%           |                   | clothing    | clothing_material_size |
- * | product_34               | biker-jacket-leather-l       | white  | L    | Leather   | 0%           |                   | clothing    | clothing_material_size |
- * | product_model_14         | model-biker-jacket-polyester | white  |      | Polyester |              | 0/3               | clothing    | clothing_material_size |
- * | product_35               | biker-jacket-polyester-s     | white  | S    | Polyester | 19%          |                   | clothing    | clothing_material_size |
- * | product_36               | biker-jacket-polyester-m     | white  | M    | Polyester | 30%          |                   | clothing    | clothing_material_size |
- * | product_37               | biker-jacket-polyester-l     | white  | L    | Polyester | 20%          |                   | clothing    | clothing_material_size |
- * -----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ * |--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+ * | Id                       | Label                        | categories       | Color  | Size | Material  | Completeness | Complete products | Family      | Family variant         |
+ * |--------------------------|------------------------------|------------------|--------|------|-----------|--------------|-------------------|-------------|------------------------|
+ * | product_model_1          | model-tshirt                 |                  |        |      |           |              | 7/12              | clothing    | clothing_color_size    |
+ * | product_model_2          | model-tshirt-grey            |                  | grey   |      | Cotton    |              | 4/4               | clothing    | clothing_color_size    |
+ * | product_1                | tshirt-grey-s                |                  | grey   | S    | Cotton    | 100%         |                   | clothing    | clothing_color_size    |
+ * | product_2                | tshirt-grey-m                |                  | grey   | M    | Cotton    | 100%         |                   | clothing    | clothing_color_size    |
+ * | product_3                | tshirt-grey-l                |                  | grey   | L    | Cotton    | 100%         |                   | clothing    | clothing_color_size    |
+ * | product_4                | tshirt-grey-xl               |                  | grey   | XL   | Cotton    | 100%         |                   | clothing    | clothing_color_size    |
+ * | product_model_3          | model-tshirt-blue            |                  | blue   |      | Polyester |              | 3/4               | clothing    | clothing_color_size    |
+ * | product_5                | tshirt-blue-s                |                  | blue   | S    | Polyester | 80%          |                   | clothing    | clothing_color_size    |
+ * | product_6                | tshirt-blue-m                |                  | blue   | M    | Polyester | 100%         |                   | clothing    | clothing_color_size    |
+ * | product_7                | tshirt-blue-l                |                  | blue   | L    | Polyester | 100%         |                   | clothing    | clothing_color_size    |
+ * | product_8                | tshirt-blue-xl               |                  | blue   | XL   | Polyester | 100%         |                   | clothing    | clothing_color_size    |
+ * | product_model_4          | model-tshirt-red             |                  | red    |      | Cotton    |              | 0/4               | clothing    | clothing_color_size    |
+ * | product_9                | tshirt-red-s                 |                  | red    | S    | Cotton    | 70%          |                   | clothing    | clothing_color_size    |
+ * | product_10               | tshirt-red-m                 |                  | red    | M    | Cotton    | 70%          |                   | clothing    | clothing_color_size    |
+ * | product_11               | tshirt-red-l                 |                  | red    | L    | Cotton    | 60%          |                   | clothing    | clothing_color_size    |
+ * | product_12               | tshirt-red-xl                |                  | red    | XL   | Cotton    | 80%          |                   | clothing    | clothing_color_size    |
+ * |--------------------------|------------------------------|------------------|-----------------------------------------------------------------------------------------------------|
+ * | product_model_5          | model-tshirt-unique-color    |                  | red    |      | Cotton    |              | 2/4               | clothing    | clothing_size          |
+ * | product_13               | tshirt-unique-color-s        |                  | red    | S    | Cotton    | 100%         |                   | clothing    | clothing_size          |
+ * | product_14               | tshirt-unique-color-m        |                  | red    | M    | Cotton    | 100%         |                   | clothing    | clothing_size          |
+ * | product_15               | tshirt-unique-color-l        |                  | red    | L    | Cotton    | 50%          |                   | clothing    | clothing_size          |
+ * | product_16               | tshirt-unique-color-xl       |                  | red    | XL   | Cotton    | 60%          |                   | clothing    | clothing_size          |
+ * |--------------------------|------------------------------|------------------|-----------------------------------------------------------------------------------------------------|
+ * | product_17               | watch                        |                  | blue   |      | Metal     | 0%           |                   | clothing    | clothing_size          |
+ * |--------------------------|------------------------------|------------------|-----------------------------------------------------------------------------------------------------|
+ * | product_model_6          | model-hat                    |                  | grey   |      | Wool      |              | 2/2               | accessories | accessories_size       |
+ * | product_18               | hat-m                        |                  | grey   | M    | Wool      | 100%         |                   | accessories | accessories_size       |
+ * | product_19               | hat-l                        |                  | grey   | L    | Wool      | 100%         |                   | accessories | accessories_size       |
+ * |--------------------------|------------------------------|------------------|-----------------------------------------------------------------------------------------------------|
+ * | product_model_7          | model-tshirt-unique-size     |                  |        | U    | Cotton    |              | 1/3               | clothing    | clothing_color         |
+ * | product_20               | tshirt-unique-size-blue      |                  | blue   | U    | Cotton    | 100%         |                   | clothing    | clothing_color         |
+ * | product_21               | tshirt-unique-size-red       |                  | red    | U    | Cotton    | 70%          |                   | clothing    | clothing_color         |
+ * | product_22               | tshirt-unique-size-yellow    |                  | yellow | U    | Cotton    | 50%          |                   | clothing    | clothing_color         |
+ * |--------------------------|------------------------------|------------------|-----------------------------------------------------------------------------------------------------|
+ * | product_model_8          | model-running-shoes          | shoes            |        |      | Leather   |              | 4/9               | shoes       | shoes_size_color       |
+ * | product_model_9          | model-running-shoes-s        | shoes            |        | S    | Leather   |              | 3/3               | shoes       | shoes_size_color       |
+ * | product_23               | running-shoes-s-white        | shoes,men,women  | white  | S    | Leather   | 100%         |                   | shoes       | shoes_size_color       |
+ * | product_24               | running-shoes-s-blue         | shoes,men        | blue   | S    | Leather   | 100%         |                   | shoes       | shoes_size_color       |
+ * | product_25               | running-shoes-s-red          | shoes,women      | red    | S    | Leather   | 100%         |                   | shoes       | shoes_size_color       |
+ * | product_model_10         | model-running-shoes-m        | shoes            |        | M    | Leather   |              | 0/3               | shoes       | shoes_size_color       |
+ * | product_26               | running-shoes-m-white        | shoes,men,women  | white  | M    | Leather   | 0%           |                   | shoes       | shoes_size_color       |
+ * | product_27               | running-shoes-m-blue         | shoes,men        | blue   | M    | Leather   | 0%           |                   | shoes       | shoes_size_color       |
+ * | product_28               | running-shoes-m-red          | shoes,women      | red    | M    | Leather   | 0%           |                   | shoes       | shoes_size_color       |
+ * | product_model_11         | model-running-shoes-l        | shoes            |        | L    | Leather   |              | 1/3               | shoes       | shoes_size_color       |
+ * | product_29               | running-shoes-l-white        | shoes,men,women  | white  | L    | Leather   | 60%          |                   | shoes       | shoes_size_color       |
+ * | product_30               | running-shoes-l-blue         | shoes,men        | blue   | L    | Leather   | 70%          |                   | shoes       | shoes_size_color       |
+ * | product_31               | running-shoes-l-red          | shoes,women      | red    | L    | Leather   | 100%         |                   | shoes       | shoes_size_color       |
+ * |--------------------------|------------------------------|------------------|-----------------------------------------------------------------------------------------------------|
+ * | product_model_12         | model-biker-jacket           |                  | white  |      |           |              | 0/6               | clothing    | clothing_material_size |
+ * | product_model_13         | model-biker-jacket-leather   |                  | white  |      | Leather   |              | 0/3               | clothing    | clothing_material_size |
+ * | product_32               | biker-jacket-leather-s       |                  | white  | S    | Leather   | 0%           |                   | clothing    | clothing_material_size |
+ * | product_33               | biker-jacket-leather-m       |                  | white  | M    | Leather   | 0%           |                   | clothing    | clothing_material_size |
+ * | product_34               | biker-jacket-leather-l       |                  | white  | L    | Leather   | 0%           |                   | clothing    | clothing_material_size |
+ * | product_model_14         | model-biker-jacket-polyester |                  | white  |      | Polyester |              | 0/3               | clothing    | clothing_material_size |
+ * | product_35               | biker-jacket-polyester-s     |                  | white  | S    | Polyester | 19%          |                   | clothing    | clothing_material_size |
+ * | product_36               | biker-jacket-polyester-m     |                  | white  | M    | Polyester | 30%          |                   | clothing    | clothing_material_size |
+ * | product_37               | biker-jacket-polyester-l     |                  | white  | L    | Polyester | 20%          |                   | clothing    | clothing_material_size |
+ * -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
  *
  * @author    Julien Janvier <j.janvier@gmail.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -113,7 +113,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['description'],
+                'attribute_of_ancestors' => [],
+                'categories_of_ancestors' => [],
                 'parent'                    => null,
                 'ancestors'                 => [
                     'codes' => null,
@@ -141,7 +142,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['description', 'color', 'material'],
+                'attribute_of_ancestors' => [],
+                'categories_of_ancestors' => [],
                 'parent'                    => null,
                 'ancestors'                 => [
                     'codes' => null,
@@ -184,7 +186,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'Famille des chapeaux',
                     ],
                 ],
-                'attributes_for_this_level' => ['description', 'color', 'material'],
+                'attribute_of_ancestors' => [],
+                'categories_of_ancestors' => [],
                 'parent'                    => null,
                 'ancestors'                 => [
                     'codes' => null,
@@ -222,7 +225,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['description', 'size', 'material'],
+                'attribute_of_ancestors' => [],
+                'categories_of_ancestors' => [],
                 'parent'                    => null,
                 'ancestors'                 => [
                     'codes' => null,
@@ -254,6 +258,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'document_type'             => ProductModelInterface::class,
                 'level'                     => 2,
                 'family_variant'            => 'shoes_size_color',
+                'categories'                => ['shoes'],
+                'categories_of_ancestors'      => [],
+                'attribute_of_ancestors'      => [],
                 'family'                    => [
                     'code'   => 'shoes',
                     'labels' => [
@@ -293,7 +300,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des chaussures de courses',
                     ],
                 ],
-                'attributes_for_this_level' => ['description', 'color'],
+                'categories_of_ancestors'      => [],
+                'attribute_of_ancestors' => [],
                 'parent'                    => null,
                 'ancestors'                 => [
                     'codes' => null,
@@ -328,7 +336,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['color', 'material'],
+                'categories_of_ancestors'      => [],
+                'attribute_of_ancestors' => ['description'],
                 'parent'                    => 'model-tshirt',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt'],
@@ -369,7 +378,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['color', 'material'],
+                'categories_of_ancestors'      => [],
+                'attribute_of_ancestors' => ['description'],
                 'parent'                    => 'model-tshirt',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt'],
@@ -410,7 +420,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['color', 'material'],
+                'categories_of_ancestors'      => [],
+                'attribute_of_ancestors' => ['description'],
                 'parent'                    => 'model-tshirt',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt'],
@@ -444,6 +455,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'identifier'                => 'model-running-shoes-s',
                 'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
+                'categories'                => ['shoes'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -461,6 +475,11 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     'description-text' => [
                         '<all_channels>' => [
                             '<all_locales>' => 'such beautiful shoes',
+                        ],
+                    ],
+                    'material-option'  => [
+                        '<all_channels>' => [
+                            '<all_locales>' => 'leather',
                         ],
                     ],
                     'size-option'      => [
@@ -476,6 +495,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'identifier'                => 'model-running-shoes-m',
                 'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
+                'categories'                => ['shoes'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -493,6 +515,11 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     'description-text' => [
                         '<all_channels>' => [
                             '<all_locales>' => 'such beautiful shoes',
+                        ],
+                    ],
+                    'material-option'  => [
+                        '<all_channels>' => [
+                            '<all_locales>' => 'leather',
                         ],
                     ],
                     'size-option'      => [
@@ -508,6 +535,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'identifier'                => 'model-running-shoes-l',
                 'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
+                'categories'                => ['shoes'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -527,6 +557,11 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                             '<all_locales>' => 'such beautiful shoes',
                         ],
                     ],
+                    'material-option'  => [
+                        '<all_channels>' => [
+                            '<all_locales>' => 'leather',
+                        ],
+                    ],
                     'size-option'      => [
                         '<all_channels>' => [
                             '<all_locales>' => 'l',
@@ -540,6 +575,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'identifier'                => 'model-biker-jacket-leather',
                 'document_type'             => ProductModelInterface::class,
                 'level'                     => 1,
+                'categories'                => [],
                 'family_variant'            => 'clothing_material_size',
                 'family'                    => [
                     'code'   => 'clothing',
@@ -547,7 +583,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des chaussures de courses',
                     ],
                 ],
-                'attributes_for_this_level' => ['material'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'color'],
                 'parent'                    => 'model-biker-jacket',
                 'ancestors'                 => [
                     'codes' => ['model-biker-jacket'],
@@ -583,7 +620,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des chaussures de courses',
                     ],
                 ],
-                'attributes_for_this_level' => ['material'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'color'],
                 'parent'                    => 'model-biker-jacket',
                 'ancestors'                 => [
                     'codes' => ['model-biker-jacket'],
@@ -622,7 +660,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-grey',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-grey'],
@@ -677,7 +716,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-grey',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-grey'],
@@ -732,7 +772,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-grey',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-grey'],
@@ -787,7 +828,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-grey',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-grey'],
@@ -843,7 +885,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-blue',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-blue'],
@@ -898,7 +941,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-blue',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-blue'],
@@ -953,7 +997,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-blue',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-blue'],
@@ -1008,7 +1053,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-blue',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-blue'],
@@ -1064,7 +1110,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-red',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-red'],
@@ -1119,7 +1166,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-red',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-red'],
@@ -1174,7 +1222,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-red',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-red'],
@@ -1229,7 +1278,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['color', 'image', 'material', 'description'],
                 'parent'                    => 'model-tshirt-red',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt', 'model-tshirt-red'],
@@ -1286,7 +1336,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'color', 'material'],
                 'parent'                    => 'model-tshirt-unique-color',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt-unique-color'],
@@ -1331,7 +1382,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'color', 'material'],
                 'parent'                    => 'model-tshirt-unique-color',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt-unique-color'],
@@ -1376,7 +1428,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'color', 'material'],
                 'parent'                    => 'model-tshirt-unique-color',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt-unique-color'],
@@ -1421,7 +1474,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['size'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'color', 'material'],
                 'parent'                    => 'model-tshirt-unique-color',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt-unique-color'],
@@ -1468,7 +1522,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La montre unique',
                     ],
                 ],
-                'attributes_for_this_level' => ['description', 'color'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => [],
                 'parent'                    => null,
                 'ancestors'                 => [
                     'codes' => null,
@@ -1500,7 +1555,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'Famille des chapeaux',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'color', 'material'],
                 'parent'                    => 'model-hat',
                 'ancestors'                 => [
                     'codes' => ['model-hat'],
@@ -1550,7 +1606,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'Famille des chapeaux',
                     ],
                 ],
-                'attributes_for_this_level' => ['size', 'weight'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'color', 'material'],
                 'parent'                    => 'model-hat',
                 'ancestors'                 => [
                     'codes' => ['model-hat'],
@@ -1603,7 +1660,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['color'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'size', 'material'],
                 'parent'                    => 'model-tshirt-unique-size',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt-unique-size'],
@@ -1650,7 +1708,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['color'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'size', 'material'],
                 'parent'                    => 'model-tshirt-unique-size',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt-unique-size'],
@@ -1697,7 +1756,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des tshirts',
                     ],
                 ],
-                'attributes_for_this_level' => ['color'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'size', 'material'],
                 'parent'                    => 'model-tshirt-unique-size',
                 'ancestors'                 => [
                     'codes' => ['model-tshirt-unique-size'],
@@ -1737,6 +1797,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'id'                        => 'product_23',
                 'identifier'                => 'running-shoes-s-white',
                 'document_type'             => ProductInterface::class,
+                'categories'                => ['shoes', 'men', 'women'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material', 'size'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1745,7 +1808,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
-                'parent'                    => 'model-tshirt-running-shoes-s',
+                'parent'                    => 'model-running-shoes-s',
                 'ancestors'                 => [
                     'codes' => ['model-running-shoes', 'model-running-shoes-s'],
                     'ids'   => ['product_model_8', 'product_model_9'],
@@ -1778,6 +1841,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'id'                        => 'product_24',
                 'identifier'                => 'running-shoes-s-blue',
                 'document_type'             => ProductInterface::class,
+                'categories'                => ['shoes', 'men'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material', 'size'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1786,7 +1852,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
-                'parent'                    => 'model-tshirt-running-shoes-s',
+                'parent'                    => 'model-running-shoes-s',
                 'ancestors'                 => [
                     'codes' => ['model-running-shoes', 'model-running-shoes-s'],
                     'ids'   => ['product_model_8', 'product_model_9'],
@@ -1819,6 +1885,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'id'                        => 'product_25',
                 'identifier'                => 'running-shoes-s-red',
                 'document_type'             => ProductInterface::class,
+                'categories'                => ['shoes', 'women'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material', 'size'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1827,9 +1896,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
-                'parent'                    => 'model-tshirt-running-shoes-s',
+                'parent'                    => 'model-running-shoes-s',
                 'ancestors'                 => [
-                    'codes' => ['model-tshirt-running-shoes', 'model-tshirt-running-shoes-s'],
+                    'codes' => ['model-running-shoes', 'model-running-shoes-s'],
                     'ids'   => ['product_model_8', 'product_model_9'],
                 ],
                 'values'                    => [
@@ -1860,6 +1929,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'id'                        => 'product_26',
                 'identifier'                => 'running-shoes-m-white',
                 'document_type'             => ProductInterface::class,
+                'categories'                => ['shoes', 'men', 'women'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material', 'size'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1868,7 +1940,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
-                'parent'                    => 'model-tshirt-running-shoes-m',
+                'parent'                    => 'model-running-shoes-m',
                 'ancestors'                 => [
                     'codes' => ['model-running-shoes', 'model-running-shoes-m'],
                     'ids'   => ['product_model_8', 'product_model_10'],
@@ -1901,6 +1973,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'id'                        => 'product_27',
                 'identifier'                => 'running-shoes-m-blue',
                 'document_type'             => ProductInterface::class,
+                'categories'                => ['shoes', 'men'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material', 'size'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1909,7 +1984,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
-                'parent'                    => 'model-tshirt-running-shoes-m',
+                'parent'                    => 'model-running-shoes-m',
                 'ancestors'                 => [
                     'codes' => ['model-running-shoes', 'model-running-shoes-m'],
                     'ids'   => ['product_model_8', 'product_model_10'],
@@ -1942,6 +2017,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'id'                        => 'product_28',
                 'identifier'                => 'running-shoes-m-red',
                 'document_type'             => ProductInterface::class,
+                'categories'                => ['shoes', 'women'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material', 'size'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1950,7 +2028,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
-                'parent'                    => 'model-tshirt-running-shoes-m',
+                'parent'                    => 'model-running-shoes-m',
                 'ancestors'                 => [
                     'codes' => ['model-running-shoes', 'model-running-shoes-m'],
                     'ids'   => ['product_model_8', 'product_model_10'],
@@ -1983,6 +2061,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'id'                        => 'product_29',
                 'identifier'                => 'running-shoes-l-white',
                 'document_type'             => ProductInterface::class,
+                'categories'                => ['shoes', 'men', 'women'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material', 'size'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -1991,7 +2072,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
-                'parent'                    => 'model-tshirt-running-shoes-l',
+                'parent'                    => 'model-running-shoes-l',
                 'ancestors'                 => [
                     'codes' => ['model-running-shoes', 'model-running-shoes-l'],
                     'ids'   => ['product_model_8', 'product_model_11'],
@@ -2024,6 +2105,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'id'                        => 'product_30',
                 'identifier'                => 'running-shoes-l-blue',
                 'document_type'             => ProductInterface::class,
+                'categories'                => ['shoes', 'men'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material', 'size'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -2032,7 +2116,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
-                'parent'                    => 'model-tshirt-running-shoes-l',
+                'parent'                    => 'model-running-shoes-l',
                 'ancestors'                 => [
                     'codes' => ['model-running-shoes', 'model-running-shoes-l'],
                     'ids'   => ['product_model_8', 'product_model_11'],
@@ -2065,6 +2149,9 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                 'id'                        => 'product_31',
                 'identifier'                => 'running-shoes-l-red',
                 'document_type'             => ProductInterface::class,
+                'categories'                => ['shoes', 'women'],
+                'categories_of_ancestors' => ['shoes'],
+                'attribute_of_ancestors' => ['description', 'material', 'size'],
                 'family_variant'            => 'shoes_size_color',
                 'family'                    => [
                     'code'   => 'shoes',
@@ -2073,7 +2160,7 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                     ],
                 ],
                 'attributes_for_this_level' => ['color'],
-                'parent'                    => 'model-tshirt-running-shoes-l',
+                'parent'                    => 'model-running-shoes-l',
                 'ancestors'                 => [
                     'codes' => ['model-running-shoes', 'model-running-shoes-l'],
                     'ids'   => ['product_model_8', 'product_model_11'],
@@ -2114,7 +2201,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des chaussures de courses',
                     ],
                 ],
-                'attributes_for_this_level' => ['size'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'material', 'color'],
                 'parent'                    => 'model-biker-jacket-leather',
                 'ancestors'                 => [
                     'codes' => ['model-biker-jacket', 'model-biker-jacket-leather'],
@@ -2154,7 +2242,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des chaussures de courses',
                     ],
                 ],
-                'attributes_for_this_level' => ['size'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'material', 'color'],
                 'parent'                    => 'model-biker-jacket-leather',
                 'ancestors'                 => [
                     'codes' => ['model-biker-jacket', 'model-biker-jacket-leather'],
@@ -2194,7 +2283,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des chaussures de courses',
                     ],
                 ],
-                'attributes_for_this_level' => ['size'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'material', 'color'],
                 'parent'                    => 'model-biker-jacket-leather',
                 'ancestors'                 => [
                     'codes' => ['model-biker-jacket', 'model-biker-jacket-leather'],
@@ -2235,7 +2325,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des chaussures de courses',
                     ],
                 ],
-                'attributes_for_this_level' => ['size'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'material', 'color'],
                 'parent'                    => 'model-biker-jacket-polyester',
                 'ancestors'                 => [
                     'codes' => ['model-biker-jacket', 'model-biker-jacket-polyester'],
@@ -2275,7 +2366,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des chaussures de courses',
                     ],
                 ],
-                'attributes_for_this_level' => ['size'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'material', 'color'],
                 'parent'                    => 'model-biker-jacket-polyester',
                 'ancestors'                 => [
                     'codes' => ['model-biker-jacket', 'model-biker-jacket-polyester'],
@@ -2315,7 +2407,8 @@ abstract class AbstractPimCatalogProductModelIntegration extends AbstractPimCata
                         'fr_FR' => 'La famille des chaussures de courses',
                     ],
                 ],
-                'attributes_for_this_level' => ['size'],
+                'categories_of_ancestors' => [],
+                'attribute_of_ancestors' => ['description', 'material', 'color'],
                 'parent'                    => 'model-biker-jacket-polyester',
                 'ancestors'                 => [
                     'codes' => ['model-biker-jacket', 'model-biker-jacket-polyester'],

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsAndModelsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsAndModelsIntegration.php
@@ -2,9 +2,6 @@
 
 namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration;
 
-use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Catalog\Model\ProductModelInterface;
-
 /**
  * Search use cases of products and models in a "smart datagrid way".
  * It returns either products or models depending on where the information is stored.
@@ -36,20 +33,17 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
         $query = [
             'query' => [
                 'bool' => [
-                   'must_not' => [
-                       'exists' => [
-                           'field' => 'parent',
-                       ],
-                   ],
+                    'must_not' => [
+                        'exists' => [
+                            'field' => 'parent',
+                        ],
+                    ],
                 ],
             ],
         ];
 
         $productsFound = $this->getSearchQueryResults(
-            $query,
-            [
-                AbstractPimCatalogProductModelIntegration::DOCUMENT_TYPE,
-            ]
+            $query
         );
 
         $this->assertDocument(
@@ -70,20 +64,34 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'query_string' => [
-                                'default_field' => 'values.description-text.<all_channels>.<all_locales>',
-                                'query'         => '*T-shirt*',
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'query_string' => [
+                                        'default_field' => 'values.description-text.<all_channels>.<all_locales>',
+                                        'query'         => '*T-shirt*',
+                                    ],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['description']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['description']],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -111,17 +119,31 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['red']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['color']],
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['red']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -143,17 +165,31 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['color']],
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -165,17 +201,31 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['blue']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['color']],
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['blue']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -197,17 +247,31 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['size']],
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['size']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -230,17 +294,31 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['m']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['size']],
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['m']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['size']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -279,20 +357,37 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
-                        ],
-                        [
-                            'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['color', 'size']],
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
+                                ],
+                                [
+                                    'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['size']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -304,21 +399,39 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
-                        ],
-                        [
-                            'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['m']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['color', 'size']],
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
+                                ],
+                                [
+                                    'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['m']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['size']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
+
 
         $productsFound = $this->getSearchQueryResults($query);
 
@@ -329,23 +442,40 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'query_string' => [
-                                'default_field' => 'values.description-text.<all_channels>.<all_locales>',
-                                'query'         => '*T-shirt*',
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'query_string' => [
+                                        'default_field' => 'values.description-text.<all_channels>.<all_locales>',
+                                        'query'         => '*T-shirt*',
+                                    ],
+                                ],
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['description']],
+                                                    ],
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
-                        ],
-                        [
-                            'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['color', 'description']],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -357,17 +487,31 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'terms' => ['values.material-option.<all_channels>.<all_locales>' => ['cotton']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['material']],
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'terms' => ['values.material-option.<all_channels>.<all_locales>' => ['cotton']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['material']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -387,17 +531,31 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'terms' => ['values.material-option.<all_channels>.<all_locales>' => ['leather']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['material']],
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'terms' => ['values.material-option.<all_channels>.<all_locales>' => ['leather']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['material']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -415,20 +573,37 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['m']],
-                        ],
-                        [
-                            'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['white']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['size', 'color']],
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['m']],
+                                ],
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['white']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['size']],
+                                                    ],
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -441,23 +616,38 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
-                    'must_not' => [
-                        [
-                            'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
-                        ],
-                    ],
-                    'filter'   => [
-                        [
-                            'terms' => ['attributes_for_this_level' => ['color']],
-                        ],
-                        [
-                            'exists' => ['field' => 'values.color-option.<all_channels>.<all_locales>'],
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'must_not' => [
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
+                                ],
+                            ],
+                            'filter' => [
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    'exists' => ['field' => 'values.color-option.<all_channels>.<all_locales>'],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
+
 
         $productsFound = $this->getSearchQueryResults($query);
 
@@ -489,20 +679,37 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
+                'constant_score' => [
                     'filter' => [
-                        [
-                            'terms' => ['values.material-option.<all_channels>.<all_locales>' => ['cotton']],
-                        ],
-                        [
-                            'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['red']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['color', 'material']],
+                        'bool' => [
+                            'filter' => [
+                                [
+                                    'terms' => ['values.material-option.<all_channels>.<all_locales>' => ['cotton']],
+                                ],
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['red']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['material']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -521,25 +728,42 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
-                    'must_not' => [
-                        [
-                            'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
-                        ],
-                    ],
-                    'filter'   => [
-                        [
-                            'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
-                        ],
-                        [
-                            'terms' => ['attributes_for_this_level' => ['color', 'size']],
-                        ],
-                        [
-                            'exists' => ['field' => 'values.color-option.<all_channels>.<all_locales>'],
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'must_not' => [
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
+                                ],
+                            ],
+                            'filter' => [
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['size']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    'exists' => ['field' => 'values.color-option.<all_channels>.<all_locales>'],
+                                ],
+                                [
+                                    'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -563,28 +787,45 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
     {
         $query = [
             'query' => [
-                'bool' => [
-                    'must_not' => [
-                        [
-                            'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
-                        ],
-                        [
-                            'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
-                        ],
-                    ],
-                    'filter'   => [
-                        [
-                            'terms' => ['attributes_for_this_level' => ['color', 'size']],
-                        ],
-                        [
-                            'exists' => ['field' => 'values.color-option.<all_channels>.<all_locales>'],
-                        ],
-                        [
-                            'exists' => ['field' => 'values.size-option.<all_channels>.<all_locales>'],
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'must_not' => [
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['grey']],
+                                ],
+                                [
+                                    'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
+                                ],
+                            ],
+                            'filter' => [
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['size']],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    'exists' => ['field' => 'values.color-option.<all_channels>.<all_locales>'],
+                                ],
+                                [
+                                    'exists' => ['field' => 'values.size-option.<all_channels>.<all_locales>'],
+                                ],
+                            ],
                         ],
                     ],
                 ],
-            ],
+            ]
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
@@ -614,6 +855,290 @@ class SearchProductsAndModelsIntegration extends AbstractPimCatalogProductModelI
                 'biker-jacket-leather-l',
                 'biker-jacket-polyester-m',
                 'biker-jacket-polyester-l',
+            ]
+        );
+    }
+
+    public function testCategoryShoes()
+    {
+        $query = [
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'filter'   => [
+                                [
+                                    'terms' => [
+                                        'categories' => ['shoes']
+                                    ]
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['categories_of_ancestors' => ['shoes']]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertDocument(
+            $productsFound,
+            [
+                'model-running-shoes',
+            ]
+        );
+    }
+
+    public function testCategoryShoesAndSizeS()
+    {
+        $query = [
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'filter'   => [
+                                [
+                                    'terms' => ['categories' => ['shoes']],
+                                ],
+                                [
+                                    'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['size']],
+                                                    ],
+                                                    [
+                                                        'terms' => ['categories_of_ancestors' => ['shoes']]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertDocument(
+            $productsFound,
+            [
+                'model-running-shoes-s',
+            ]
+        );
+    }
+
+    public function testCategoryShoesAndColorWhite()
+    {
+        $query = [
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'filter'   => [
+                                [
+                                    'terms' => ['categories' => ['shoes']],
+                                ],
+                                [
+                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['white']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['color']],
+                                                    ],
+                                                    [
+                                                        'terms' => ['categories_of_ancestors' => ['shoes']]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertDocument(
+            $productsFound,
+            [
+                'running-shoes-l-white',
+                'running-shoes-m-white',
+                'running-shoes-s-white'
+            ]
+        );
+    }
+
+    public function testCategoryMen()
+    {
+        $query = [
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'filter'   => [
+                                [
+                                    'terms' => ['categories' => ['men']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['categories_of_ancestors' => ['men']]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertDocument(
+            $productsFound,
+            [
+                'running-shoes-l-blue',
+                'running-shoes-l-white',
+                'running-shoes-m-blue',
+                'running-shoes-m-white',
+                'running-shoes-s-blue',
+                'running-shoes-s-white',
+            ]
+        );
+    }
+
+    public function testCategoryMenAndMaterialLeather()
+    {
+        $query = [
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'filter'   => [
+                                [
+                                    'terms' => ['categories' => ['men']],
+                                ],
+                                [
+                                    'terms' => ['values.material-option.<all_channels>.<all_locales>' => ['leather']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['categories_of_ancestors' => ['men']]
+                                                    ],
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['material']]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertDocument(
+            $productsFound,
+            [
+                'running-shoes-l-blue',
+                'running-shoes-l-white',
+                'running-shoes-m-blue',
+                'running-shoes-m-white',
+                'running-shoes-s-blue',
+                'running-shoes-s-white',
+            ]
+        );
+    }
+
+    public function testCategoryFootwearAndSizeS()
+    {
+        $query = [
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'filter'   => [
+                                [
+                                    'terms' => ['values.size-option.<all_channels>.<all_locales>' => ['s']],
+                                ],
+                                [
+                                    'terms' => ['categories' => ['shoes']],
+                                ],
+                                [
+                                    'bool' => [
+                                        'must_not' => [
+                                            'bool' => [
+                                                'filter' => [
+                                                    [
+                                                        'terms' => ['attribute_of_ancestors' => ['size']]
+                                                    ],
+                                                    [
+                                                        'terms' => ['categories_of_ancestors' => ['shoes']]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $productsFound = $this->getSearchQueryResults($query);
+
+        $this->assertDocument(
+            $productsFound,
+            [
+                'model-running-shoes-s'
             ]
         );
     }


### PR DESCRIPTION
# tldr;
- Search on categories does not work properly today
- I propose a solution to make it work by indexing additional information and changing the way we search products and product models in the datagrid
- ES integration tests have been updated:
  - Updated dataset https://github.com/akeneo/pim-community-dev/blob/0bc9783562812cd62caed2f34b6dd23da1c25aed/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogProductModelIntegration.php
  - Working ES request samples are in this file https://github.com/akeneo/pim-community-dev/blob/0bc9783562812cd62caed2f34b6dd23da1c25aed/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsAndModelsIntegration.php

# Context

Prior to this PR, the search of product models in the datagrid was not fully functional with categories. To be more precise, the search was not properly working when a user would only filter on categories.

Before explaining how I propose to solve this issue, we need to understand how the actual datagrid search works and its pitfalls.

## Today's datagrid search (Also known as 'Smart search')

### Data set: Shoes

Let's say we have a product model 'shoe' and it's variance by size and color (2 levels):

![screen shot 2018-04-20 at 10 10 36](https://user-images.githubusercontent.com/1826473/39038197-2bdd0a9a-4483-11e8-92aa-ce0288e47ac4.png)

### Naïve filtering by attribute

![image](https://user-images.githubusercontent.com/1826473/39038216-3a6ea1f4-4483-11e8-8ce2-32cef3240392.png)

_(The node in blue correspond to lines shown in the datagrid)_

In this search, you can see that the search is quite naïve in the sense that it returns all the entities having a size 's'. 

This search does not correspond to our business need because it is very noisy and it does not aggregate the result towards higher product model in the hierarchy, well it is not "Smart".

### Smart filtering by attribute

The Smart Search feature could also be translated as **"Show me the most relevant nodes corresponding to my search criterias"**

![image](https://user-images.githubusercontent.com/1826473/39038238-4a628364-4483-11e8-8f0d-64e99a055637.png)

To achieve it, you can see that we use additional information (indexed in ES) like 'attribute_for_this_level'. This property is the cornerstone of the working of the actual search because it gives us the opportunity to **differienciate** nodes from one level from other levels, hence showing to the user the right node (in the right level) corresponding to the search criterias.

## Pitfalls 

### Search on Categories does not work

![image](https://user-images.githubusercontent.com/1826473/39038513-00a410de-4484-11e8-8451-879deade060d.png)

But if you look for the 'footwear' category, all the node of the tree are returned where in fact in this case, we only want the node **'model-shoe'** to be shown to the user (because it's the most relevant). 

## Expected results examples

![image](https://user-images.githubusercontent.com/1826473/39038536-11749618-4484-11e8-96ad-663f0068e0a1.png)

![image](https://user-images.githubusercontent.com/1826473/39038554-1da44e88-4484-11e8-9634-447c7e6c970e.png)

![image](https://user-images.githubusercontent.com/1826473/39038580-2a306df8-4484-11e8-9998-78bb108001ad.png)

![image](https://user-images.githubusercontent.com/1826473/39038606-39b62ccc-4484-11e8-97e0-443521090279.png)

## Brainstorming

### Idea # 1: could we use a 'categories\_for\_this\_level' ?

Could we use the same mecanism to select the node to show when selecting categories with something similar we use with the attributes ?

Yes, in this case we can index the "categories\_for\_this\_level" of each node in our tree.

**A search in the form of:**
```
'footwear' IN categories AND 'footwear' in categories_for_this_level
  ↓
'model-shoe'
```
returns the 'model-shoe' node and that's what we want !

**BUT**: Let's see how this request performs when we also filter on some attributes

![image](https://user-images.githubusercontent.com/1826473/39040206-2a2c32d0-4487-11e8-9a73-63782f3e6eff.png)

The predicate #1 here will return 'model-shoe' just like before
The predicate #2 will return 'model-shoe-s'
The intersection of those set is unfortunately **empty**.

The difficulty here is we have to deal with one data structure (Product model hierarchy) which depends on one meta structure (the family variant attribute sets) and is linked to another datastructure (the category tree).

![image](https://user-images.githubusercontent.com/1826473/39040292-49c2bb8c-4487-11e8-9042-15f954a9865b.png)

**Is it possible conciliate both meta structure in the search to always show the topmost / most relevant node in the hierarchy depending on the search criterias ?**

# Proposed solution

The proposed solution has been discussed with @pierallard and @willy-ahva. (_Thanks to them for the help!)_

Just like before, it relies on the ability to differentiate nodes of one levels from another by indexing additional information.

## Filtering on attribute and categories

We generalised the 'attribute_for_this_level' notion to create 'attributes_of_ancestors' which has the cummulative list of attributes of the parents.

The question we want to ask now changed from :
"Which level owns the property X that we try to filter on" **to** "Which node has a property that its ancestors don't have".

In fact those statements looks quite the same, but the later enable us to also ask the question:
"Which node has a category that its ancestors don't have" by indexing a new property called "categories_of_ancestors".

The good news is that combining "attributes_of_ancestors" and "categories_of_ancestors" help us achieve a "Smart search" supporting the search on attributes as well as on categories.

**The general search condition looks like this:**
```
Attribute_1 = 'value' AND 'attribute_X' = 'another_value' AND
Category = 'category_1' AND
NOT( attributes_of_ancestors HAS 'attribute_1' AND attributes_of_ancestors HAS 'attribute_X' AND categories_of_ancestors HAS 'category_1')
```

### Testing our solution

Let's take our failing search example back from above: "'footwear' IN category"

![image](https://user-images.githubusercontent.com/1826473/39040574-c29445da-4487-11e8-888b-054bf8999e56.png)

The only one node, not having a parent holding the 'footwear' category is the 'model-shoe' node. So that makes sense.

Let's try to mix it up with a filter on attributes: Let's say a user wants to filter "footwear' IN category AND size = 's'" in the datagrid.

![image](https://user-images.githubusercontent.com/1826473/39041970-12a3d1ce-448a-11e8-9f3b-76f84d63d7df.png)

This first part of the request is inclusive, it returns all the nodes matching at least the criterias of the user (category is 'footwear' and the size is 's'). 
**For sure, the right answer lies within this selection**, and it is the second part of the request that will help us to find it.

![image](https://user-images.githubusercontent.com/1826473/39042246-a0efaf3e-448a-11e8-9405-65ca6070a207.png)

The second part of the request, excludes the nodes that are children: by saying "within the large selection" excludes all the nodes which have a parent already holding the property (therefore they are children). In the end, the only nodes not removed are the topmost nodes matching the criterias.

## Updated ES document

In the example above the "s-red" node would be indexed as followed in ES:
```
{
  "_id": "s-red",
  "parent": "model-shoe-s",
  "categories": ["footwear", "women"],
  "categories_of_ancestors": ["footwear"],
  "attributes_of_ancestors": ["description", "size"],
  "values": [
  ...
  ]
}
```

## Example ES query

**Search on category: category = "men"**
```
        $query = [
            'query' => [
                'constant_score' => [
                    'filter' => [
                     // Above is some ES boilerplate to deactivate scoring
                        'bool' => [
                            'filter'   => [
                                [
                                    'terms' => ['categories' => ['men']],
                                ],
                                [
                                    'bool' => [
                                        'must_not' => [
                                            'bool' => [
                                                'filter' => [
                                                    [
                                                        'terms' => ['categories_of_ancestors' => ['men']]
                                                    ]
                                                ]
                                            ]
                                        ]
                                    ]
                                ]
                            ],
                        ],
                    ],
                ],
            ],
        ];
```
https://github.com/akeneo/pim-community-dev/blob/0bc9783562812cd62caed2f34b6dd23da1c25aed/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsAndModelsIntegration.php#L1004

**Search on attribute: color = 'red'**
```
        $query = [
            'query' => [
                'constant_score' => [
                    'filter' => [
                        'bool' => [
                            'filter' => [
                                [
                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['red']],
                                ],
                                [
                                    'bool' => [
                                        'must_not' => [
                                            'bool' => [
                                                'filter' => [
                                                    [
                                                        'terms' => ['attributes_of_ancestors' => ['color']],
                                                    ],
                                                ],
                                            ],
                                        ],
                                    ],
                                ],
                            ],
                        ],
                    ],
                ],
            ]
        ];
```
https://github.com/akeneo/pim-community-dev/blob/0bc9783562812cd62caed2f34b6dd23da1c25aed/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsAndModelsIntegration.php#L121

**Search on both Category and attributes: category = 'shoes' and color = 'white'**
```
        $query = [
            'query' => [
                'constant_score' => [
                    'filter' => [
                        'bool' => [
                            'filter'   => [
                                [
                                    'terms' => ['categories' => ['shoes']],
                                ],
                                [
                                    'terms' => ['values.color-option.<all_channels>.<all_locales>' => ['white']],
                                ],
                                [
                                    'bool' => [
                                        'must_not' => [
                                            'bool' => [
                                                'filter' => [
                                                    [
                                                        'terms' => ['attributes_of_ancestors' => ['color']],
                                                    ],
                                                    [
                                                        'terms' => ['categories_of_ancestors' => ['shoes']]
                                                    ]
                                                ]
                                            ]
                                        ]
                                    ]
                                ]
                            ],
                        ],
                    ],
                ],
            ],
        ];
```
https://github.com/akeneo/pim-community-dev/blob/0bc9783562812cd62caed2f34b6dd23da1c25aed/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/SearchProductsAndModelsIntegration.php#L955
**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
