### PR TITLE
AOB-10: Aggregate interfaces to allow dependencies to file readers

### DIFF
--- a/src/Pim/Component/Connector/Reader/File/ArrayReader.php
+++ b/src/Pim/Component/Connector/Reader/File/ArrayReader.php
@@ -2,10 +2,7 @@
 
 namespace Pim\Component\Connector\Reader\File;
 
-use Akeneo\Component\Batch\Item\FlushableInterface;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 
 /**
@@ -26,9 +23,9 @@ use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ArrayReader implements ItemReaderInterface, StepExecutionAwareInterface, FlushableInterface
+class ArrayReader implements FileReaderInterface
 {
-    /** @var ItemReaderInterface */
+    /** @var FileReaderInterface */
     protected $reader;
 
     /** @var ArrayConverterInterface */
@@ -38,11 +35,11 @@ class ArrayReader implements ItemReaderInterface, StepExecutionAwareInterface, F
     protected $remainingItems;
 
     /**
-     * @param ItemReaderInterface     $reader
+     * @param FileReaderInterface     $reader
      * @param ArrayConverterInterface $converter
      */
     public function __construct(
-        ItemReaderInterface $reader,
+        FileReaderInterface $reader,
         ArrayConverterInterface $converter
     ) {
         $this->reader = $reader;
@@ -77,9 +74,7 @@ class ArrayReader implements ItemReaderInterface, StepExecutionAwareInterface, F
      */
     public function setStepExecution(StepExecution $stepExecution)
     {
-        if ($this->reader instanceof StepExecutionAwareInterface) {
-            $this->reader->setStepExecution($stepExecution);
-        }
+        $this->reader->setStepExecution($stepExecution);
     }
 
     /**
@@ -87,8 +82,6 @@ class ArrayReader implements ItemReaderInterface, StepExecutionAwareInterface, F
      */
     public function flush()
     {
-        if ($this->reader instanceof FlushableInterface) {
-            $this->reader->flush();
-        }
+        $this->reader->flush();
     }
 }

--- a/src/Pim/Component/Connector/Reader/File/Csv/ProductAssociationReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/ProductAssociationReader.php
@@ -2,9 +2,7 @@
 
 namespace Pim\Component\Connector\Reader\File\Csv;
 
-use Akeneo\Component\Batch\Item\FlushableInterface;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 
 /**
  * Product Association CSV reader
@@ -13,10 +11,7 @@ use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductAssociationReader extends Reader implements
-    ItemReaderInterface,
-    StepExecutionAwareInterface,
-    FlushableInterface
+class ProductAssociationReader extends Reader implements FileReaderInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Pim/Component/Connector/Reader/File/Csv/ProductModelReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/ProductModelReader.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Pim\Component\Connector\Reader\File\Csv;
 
-use Akeneo\Component\Batch\Item\FlushableInterface;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 use Pim\Component\Connector\Reader\File\MediaPathTransformer;
 
 /**
@@ -18,10 +16,7 @@ use Pim\Component\Connector\Reader\File\MediaPathTransformer;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductModelReader extends Reader implements
-    ItemReaderInterface,
-    StepExecutionAwareInterface,
-    FlushableInterface
+class ProductModelReader extends Reader implements FileReaderInterface
 {
     /** @var MediaPathTransformer */
     private $mediaPathTransformer;

--- a/src/Pim/Component/Connector/Reader/File/Csv/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/ProductReader.php
@@ -2,11 +2,9 @@
 
 namespace Pim\Component\Connector\Reader\File\Csv;
 
-use Akeneo\Component\Batch\Item\FlushableInterface;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 use Pim\Component\Connector\Reader\File\MediaPathTransformer;
 
 /**
@@ -19,10 +17,7 @@ use Pim\Component\Connector\Reader\File\MediaPathTransformer;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductReader extends Reader implements
-    ItemReaderInterface,
-    StepExecutionAwareInterface,
-    FlushableInterface
+class ProductReader extends Reader implements FileReaderInterface
 {
     /** @var MediaPathTransformer */
     protected $mediaPathTransformer;

--- a/src/Pim/Component/Connector/Reader/File/Csv/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Csv/Reader.php
@@ -3,16 +3,14 @@
 namespace Pim\Component\Connector\Reader\File\Csv;
 
 use Akeneo\Component\Batch\Item\FileInvalidItem;
-use Akeneo\Component\Batch\Item\FlushableInterface;
 use Akeneo\Component\Batch\Item\InvalidItemException;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Exception\DataArrayConversionException;
 use Pim\Component\Connector\Exception\InvalidItemFromViolationsException;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
 use Pim\Component\Connector\Reader\File\FileIteratorInterface;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 
 /**
  * Csv reader
@@ -21,7 +19,7 @@ use Pim\Component\Connector\Reader\File\FileIteratorInterface;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Reader implements ItemReaderInterface, StepExecutionAwareInterface, FlushableInterface
+class Reader implements FileReaderInterface
 {
     /** @var FileIteratorFactory */
     protected $fileIteratorFactory;

--- a/src/Pim/Component/Connector/Reader/File/FileReaderInterface.php
+++ b/src/Pim/Component/Connector/Reader/File/FileReaderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Connector\Reader\File;
+
+use Akeneo\Component\Batch\Item\FlushableInterface;
+use Akeneo\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+
+/**
+ * Contract for a file reader used in a Batch item step. It must be flushable and must accept a step execution object.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+interface FileReaderInterface extends ItemReaderInterface, FlushableInterface, StepExecutionAwareInterface
+{
+}

--- a/src/Pim/Component/Connector/Reader/File/FlatFileIterator.php
+++ b/src/Pim/Component/Connector/Reader/File/FlatFileIterator.php
@@ -29,7 +29,7 @@ class FlatFileIterator implements FileIteratorInterface
     /** @var string */
     protected $filePath;
 
-    /** @var ReaderInterface */
+    /** @var FileReaderInterface */
     protected $reader;
 
     /** @var \SplFileInfo */

--- a/src/Pim/Component/Connector/Reader/File/Xlsx/ProductAssociationReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Xlsx/ProductAssociationReader.php
@@ -2,9 +2,7 @@
 
 namespace Pim\Component\Connector\Reader\File\Xlsx;
 
-use Akeneo\Component\Batch\Item\FlushableInterface;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 
 /**
  * Product Association XLSX reader
@@ -13,10 +11,7 @@ use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductAssociationReader extends Reader implements
-    ItemReaderInterface,
-    StepExecutionAwareInterface,
-    FlushableInterface
+class ProductAssociationReader extends Reader implements FileReaderInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Pim/Component/Connector/Reader/File/Xlsx/ProductModelReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Xlsx/ProductModelReader.php
@@ -2,11 +2,9 @@
 
 namespace Pim\Component\Connector\Reader\File\Xlsx;
 
-use Akeneo\Component\Batch\Item\FlushableInterface;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 use Pim\Component\Connector\Reader\File\MediaPathTransformer;
 
 /**
@@ -16,10 +14,7 @@ use Pim\Component\Connector\Reader\File\MediaPathTransformer;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductModelReader extends Reader implements
-    ItemReaderInterface,
-    StepExecutionAwareInterface,
-    FlushableInterface
+class ProductModelReader extends Reader implements FileReaderInterface
 {
     /** @var MediaPathTransformer */
     private $mediaPathTransformer;

--- a/src/Pim/Component/Connector/Reader/File/Xlsx/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/File/Xlsx/ProductReader.php
@@ -2,11 +2,9 @@
 
 namespace Pim\Component\Connector\Reader\File\Xlsx;
 
-use Akeneo\Component\Batch\Item\FlushableInterface;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 use Pim\Component\Connector\Reader\File\MediaPathTransformer;
 
 /**
@@ -19,10 +17,7 @@ use Pim\Component\Connector\Reader\File\MediaPathTransformer;
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductReader extends Reader implements
-    ItemReaderInterface,
-    StepExecutionAwareInterface,
-    FlushableInterface
+class ProductReader extends Reader implements FileReaderInterface
 {
     /** @var MediaPathTransformer */
     protected $mediaPathTransformer;

--- a/src/Pim/Component/Connector/Reader/File/Xlsx/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Xlsx/Reader.php
@@ -3,16 +3,14 @@
 namespace Pim\Component\Connector\Reader\File\Xlsx;
 
 use Akeneo\Component\Batch\Item\FileInvalidItem;
-use Akeneo\Component\Batch\Item\FlushableInterface;
 use Akeneo\Component\Batch\Item\InvalidItemException;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Exception\DataArrayConversionException;
 use Pim\Component\Connector\Exception\InvalidItemFromViolationsException;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
 use Pim\Component\Connector\Reader\File\FileIteratorInterface;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 
 /**
  * Xlsx Reader
@@ -21,7 +19,7 @@ use Pim\Component\Connector\Reader\File\FileIteratorInterface;
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Reader implements ItemReaderInterface, StepExecutionAwareInterface, FlushableInterface
+class Reader implements FileReaderInterface
 {
     /** @var FileIteratorFactory */
     protected $fileIteratorFactory;

--- a/src/Pim/Component/Connector/Reader/File/Yaml/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Yaml/Reader.php
@@ -3,14 +3,12 @@
 namespace Pim\Component\Connector\Reader\File\Yaml;
 
 use Akeneo\Component\Batch\Item\FileInvalidItem;
-use Akeneo\Component\Batch\Item\FlushableInterface;
 use Akeneo\Component\Batch\Item\InvalidItemException;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Exception\DataArrayConversionException;
 use Pim\Component\Connector\Exception\InvalidItemFromViolationsException;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -20,7 +18,7 @@ use Symfony\Component\Yaml\Yaml;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Reader implements ItemReaderInterface, StepExecutionAwareInterface, FlushableInterface
+class Reader implements FileReaderInterface
 {
     /** @var ArrayConverterInterface */
     protected $converter;

--- a/src/Pim/Component/Connector/spec/Reader/File/ArrayReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/ArrayReaderSpec.php
@@ -2,14 +2,15 @@
 
 namespace spec\Pim\Component\Connector\Reader\File;
 
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Pim\Component\Connector\Reader\File\ArrayReader;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 
 class ArrayReaderSpec extends ObjectBehavior
 {
     function let(
-        ItemReaderInterface $reader,
+        FileReaderInterface $reader,
         ArrayConverterInterface $converter
     ) {
         $this->beConstructedWith($reader, $converter);
@@ -17,22 +18,12 @@ class ArrayReaderSpec extends ObjectBehavior
     
     function it_is_initializable()
     {
-        $this->shouldHaveType('Pim\Component\Connector\Reader\File\ArrayReader');
+        $this->shouldHaveType(ArrayReader::class);
     }
 
-    function it_is_an_item_reader()
+    function it_is_a_file_reader()
     {
-        $this->shouldHaveType('Akeneo\Component\Batch\Item\ItemReaderInterface');
-    }
-
-    function it_is_step_execution_aware()
-    {
-        $this->shouldHaveType('Akeneo\Component\Batch\Step\StepExecutionAwareInterface');
-    }
-
-    function it_is_flushable()
-    {
-        $this->shouldHaveType('Akeneo\Component\Batch\Item\FlushableInterface');
+        $this->shouldHaveType(FileReaderInterface::class);
     }
 
     function it_returns_null_with_no_elements(

--- a/src/Pim/Component/Connector/spec/Reader/File/Csv/ProductAssociationReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Csv/ProductAssociationReaderSpec.php
@@ -2,14 +2,12 @@
 
 namespace spec\Pim\Component\Connector\Reader\File\Csv;
 
-use Akeneo\Component\Batch\Item\FlushableInterface;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Reader\File\Csv\ProductAssociationReader;
 use Pim\Component\Connector\Reader\File\Csv\Reader;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 
 class ProductAssociationReaderSpec extends ObjectBehavior
 {
@@ -30,10 +28,8 @@ class ProductAssociationReaderSpec extends ObjectBehavior
         $this->shouldHaveType(Reader::class);
     }
 
-    function it_should_implement()
+    function it_is_a_file_reader()
     {
-        $this->shouldImplement(ItemReaderInterface::class);
-        $this->shouldImplement(StepExecutionAwareInterface::class);
-        $this->shouldImplement(FlushableInterface::class);
+        $this->shouldImplement(FileReaderInterface::class);
     }
 }

--- a/src/Pim/Component/Connector/spec/Reader/File/Csv/ProductModelReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Csv/ProductModelReaderSpec.php
@@ -2,18 +2,15 @@
 
 namespace spec\Pim\Component\Connector\Reader\File\Csv;
 
-use Akeneo\Component\Batch\Item\FlushableInterface;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Reader\File\Csv\ProductModelReader;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
 use Pim\Component\Connector\Reader\File\FileIteratorInterface;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 use Pim\Component\Connector\Reader\File\MediaPathTransformer;
-use Prophecy\Argument;
 
 class ProductModelReaderSpec extends ObjectBehavior
 {
@@ -32,19 +29,9 @@ class ProductModelReaderSpec extends ObjectBehavior
         $this->shouldHaveType(ProductModelReader::class);
     }
 
-    function it_is_a_reader()
+    function it_is_a_file_reader()
     {
-        $this->shouldImplement(ItemReaderInterface::class);
-    }
-
-    function it_is_a_step_aware_execution()
-    {
-        $this->shouldImplement(StepExecutionAwareInterface::class);
-    }
-
-    function it_is_a_flushable()
-    {
-        $this->shouldImplement(FlushableInterface::class);
+        $this->shouldImplement(FileReaderInterface::class);
     }
 
     function it_transforms_media_paths_to_absolute_paths(

--- a/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ProductAssociationReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ProductAssociationReaderSpec.php
@@ -2,12 +2,10 @@
 
 namespace spec\Pim\Component\Connector\Reader\File\Xlsx;
 
-use Akeneo\Component\Batch\Item\FlushableInterface;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 use Pim\Component\Connector\Reader\File\Xlsx\ProductAssociationReader;
 use Pim\Component\Connector\Reader\File\Xlsx\Reader;
 
@@ -30,10 +28,8 @@ class ProductAssociationReaderSpec extends ObjectBehavior
         $this->shouldHaveType(Reader::class);
     }
 
-    function it_should_implement()
+    function it_is_a_file_reader()
     {
-        $this->shouldImplement(ItemReaderInterface::class);
-        $this->shouldImplement(StepExecutionAwareInterface::class);
-        $this->shouldImplement(FlushableInterface::class);
+        $this->shouldImplement(FileReaderInterface::class);
     }
 }

--- a/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ProductModelReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/File/Xlsx/ProductModelReaderSpec.php
@@ -2,18 +2,15 @@
 
 namespace spec\Pim\Component\Connector\Reader\File\Xlsx;
 
-use Akeneo\Component\Batch\Item\FlushableInterface;
-use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
-use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Reader\File\FileIteratorFactory;
 use Pim\Component\Connector\Reader\File\FileIteratorInterface;
+use Pim\Component\Connector\Reader\File\FileReaderInterface;
 use Pim\Component\Connector\Reader\File\MediaPathTransformer;
 use Pim\Component\Connector\Reader\File\Xlsx\ProductModelReader;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class ProductModelReaderSpec extends ObjectBehavior
 {
@@ -32,19 +29,9 @@ class ProductModelReaderSpec extends ObjectBehavior
         $this->shouldHaveType(ProductModelReader::class);
     }
 
-    function it_is_a_reader()
+    function it_is_a_file_reader()
     {
-        $this->shouldImplement(ItemReaderInterface::class);
-    }
-
-    function it_is_a_step_aware_execution()
-    {
-        $this->shouldImplement(StepExecutionAwareInterface::class);
-    }
-
-    function it_is_a_flushable()
-    {
-        $this->shouldImplement(FlushableInterface::class);
+        $this->shouldImplement(FileReaderInterface::class);
     }
 
     function it_transforms_media_paths_to_absolute_paths(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

All our file readers share the same characteristics : they are item step elements, they receive a StepExecution, and they must be flushable.
We applied the [interface segregation principle](https://en.wikipedia.org/wiki/Interface_segregation_principle) here. I don't know if it's justified or not, but it's worth noting that all file readers always implement these 3 interfaces and never other ones than these 3. It probably means that the combination of the 3 behaviors should be explicit.

The problem is very visible when you try to add a dependency to a file reader or to decorate one : you never need something that can only flush or just be "step execution aware" (whatever that means). You mainly need to read something and it feels like the fact that a reader can be flushed is secondary, or at least it makes no sense if it wasn't a reader in the first place.

A solution can be to introduce a new interface that aggregate the other 3, make the file readers implement this new interface, and use this as contract when needed. This way if we decide to get rid of the original interfaces it will be transparent for the client classes.

For the moment the new interface is called `FileReaderInterface` ¯\\_(ツ)_/¯
Don't hesitate to suggest better naming.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
