### PR TITLE
PIM-6367: Move into the Catalog component the "product and product model query builder"

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -10,7 +10,28 @@
 
 ## BC breaks
 
+### Classes
+
+- PIM-6367: Rename `Pim\Bundle\EnrichBundle\ProductQueryBuilder\MassEditProductAndProductModelQueryBuilder` into `Pim\Component\Catalog\Query\ProductAndProductModelQueryBuilder`
+- PIM-6367: Move `Pim\Bundle\EnrichBundle\Elasticsearch\ProductAndProductModelQueryBuilderFactory` to `Pim\Bundle\CatalogBundle\Elasticsearch\ProductAndProductModelQueryBuilderFactory`
+- PIM-6367: Move `Pim\Bundle\EnrichBundle\Elasticsearch\CursorFactory` to `Pim\Bundle\CatalogBundle\Elasticsearch\CursorFactory`
+- PIM-6367: Move `Pim\Bundle\EnrichBundle\Elasticsearch\Cursor` to `Pim\Bundle\CatalogBundle\Elasticsearch\Cursor`
+- PIM-6367: Move `Pim\Bundle\EnrichBundle\Elasticsearch\AbstractCursor` to `Pim\Bundle\CatalogBundle\Elasticsearch\AbstractCursor`
+- PIM-6367: Move `Pim\Bundle\EnrichBundle\Elasticsearch\IdentifierResults` to `Pim\Bundle\CatalogBundle\Elasticsearch\IdentifierResults`
+- PIM-6367: Move `Pim\Bundle\EnrichBundle\Elasticsearch\IdentifierResult` to `Pim\Bundle\CatalogBundle\Elasticsearch\IdentifierResult`
+
+### Constructors
+
 - Change the constructor of `Pim\Component\Connector\Processor\Normalization\ProductProcessor` to add `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
 - Change the constructor of `Pim\Component\Connector\Writer\Database\ProductModelDescendantsWriter` to remove `Pim\Component\Catalog\Builder\ProductBuilderInterface`
     and to add `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
 - Change the constructor of `Pim\Bundle\DataGridBundle\Datasource\ProductDatasource` to add `Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriber`
+
+### Services and parameters
+
+- PIM-6367: Rename service `pim_enrich.query.product_and_product_model_query_builder_factory` into `pim_catalog.query.product_and_product_model_query_builder_factory`
+- PIM-6367: Rename service `pim_enrich.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor` into `pim_catalog.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor`
+- PIM-6367: Rename service `pim_enrich.factory.product_and_product_model_cursor` into `pim_catalog.factory.product_and_product_model_cursor`
+- PIM-6367: Rename class parameter `pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class` into `pim_catalog.query.elasticsearch.product_and_model_query_builder_factory.class`
+- PIM-6367: Rename class parameter `pim_enrich.query.mass_edit_product_and_product_model_query_builder.class` into `pim_catalog.query.product_and_product_model_query_builder.class`
+- PIM-6367: Rename class parameter `pim_enrich.elasticsearch.cursor_factory.class` into `pim_catalog.elasticsearch.cursor_factory.class`

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/AbstractCursor.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/AbstractCursor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Pim\Bundle\EnrichBundle\Elasticsearch;
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use Akeneo\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Cursor.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Cursor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Pim\Bundle\EnrichBundle\Elasticsearch;
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use Akeneo\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
@@ -13,8 +13,7 @@ use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
  * Internally, this is implemented with the search after pagination.
  * {@see https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-search-after.html}
  *
- * This cursor is dedicated to the search in the datagrid where we need to have 2 types of objects:
- * products and product models.
+ * This cursor is dedicated to the search of both products and product models.
  *
  * @author    Julien Janvier <jjanvier@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/CursorFactory.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/CursorFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Bundle\EnrichBundle\Elasticsearch;
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use Akeneo\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface;

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/IdentifierResult.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/IdentifierResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Pim\Bundle\EnrichBundle\Elasticsearch;
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/IdentifierResults.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/IdentifierResults.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Pim\Bundle\EnrichBundle\Elasticsearch;
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndProductModelQueryBuilderFactory.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndProductModelQueryBuilderFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pim\Bundle\EnrichBundle\Elasticsearch;
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -1,6 +1,9 @@
 parameters:
     pim_catalog.query.elasticsearch.product_query_builder_factory.class: Pim\Bundle\CatalogBundle\Elasticsearch\ProductQueryBuilderFactory
+    pim_catalog.query.elasticsearch.product_and_model_query_builder_factory.class: Pim\Bundle\CatalogBundle\Elasticsearch\ProductAndProductModelQueryBuilderFactory
     pim_catalog.query.product_query_builder.class: Pim\Component\Catalog\Query\ProductQueryBuilder
+    pim_catalog.query.product_and_product_model_query_builder.class: Pim\Component\Catalog\Query\ProductAndProductModelQueryBuilder
+    pim_catalog.elasticsearch.cursor_factory.class: Pim\Bundle\CatalogBundle\Elasticsearch\CursorFactory
 
     # resolvers
     pim_catalog.elasticsearch.product_query_builder_search_after_resolver.class: Pim\Bundle\CatalogBundle\Elasticsearch\ProductQueryBuilderSearchAfterOptionsResolver
@@ -48,7 +51,6 @@ parameters:
     pim_catalog.query.elasticsearch.sorter.attribute.text_area.class: Pim\Bundle\CatalogBundle\Elasticsearch\Sorter\Attribute\TextAreaSorter
 
 services:
-
     pim_catalog.query.product_query_builder_factory:
         class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
         arguments:
@@ -108,6 +110,33 @@ services:
             - '@pim_catalog.query.sorter.registry'
             - '@pim_catalog.factory.product_model_search_after_size_cursor'
             - '@pim_catalog.elasticsearch.product_query_builder_search_after_resolver'
+
+    pim_catalog.query.product_and_product_model_query_builder_factory:
+        class: '%pim_catalog.query.elasticsearch.product_and_model_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_and_product_model_query_builder.class%'
+            - '@pim_catalog.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor'
+
+    pim_catalog.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor:
+        public: false
+        class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_query_builder.class%'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.query.filter.product_and_product_model_registry'
+            - '@pim_catalog.query.sorter.registry'
+            - '@pim_catalog.factory.product_and_product_model_cursor'
+            - '@pim_catalog.query.product_query_builder_resolver'
+
+    pim_catalog.factory.product_and_product_model_cursor:
+        public: false
+        class: '%pim_catalog.elasticsearch.cursor_factory.class%'
+        arguments:
+            - '@akeneo_elasticsearch.client.product_and_product_model'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_model'
+            - '%pim_catalog.factory.product_cursor.page_size%'
+            - 'pim_catalog_product'
 
     pim_catalog.query.product_query_builder_resolver:
         class: '%pim_catalog.query.product_query_builder_resolver.class%'

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/CursorFactorySpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/CursorFactorySpec.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace spec\Pim\Bundle\EnrichBundle\Elasticsearch;
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use Akeneo\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\EnrichBundle\Elasticsearch\CursorFactory;
+use Pim\Bundle\CatalogBundle\Elasticsearch\CursorFactory;
 
 class CursorFactorySpec extends ObjectBehavior
 {

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/CursorSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/CursorSpec.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace spec\Pim\Bundle\EnrichBundle\Elasticsearch;
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use Akeneo\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\EnrichBundle\Elasticsearch\Cursor;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Cursor;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/IdentifierResultSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/IdentifierResultSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Pim\Bundle\EnrichBundle\Elasticsearch;
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ProductInterface;

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/IdentifierResultsSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/IdentifierResultsSpec.php
@@ -1,15 +1,14 @@
 <?php
 
-namespace spec\Pim\Bundle\EnrichBundle\Elasticsearch;
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\EnrichBundle\Elasticsearch\IdentifierResult;
+use Pim\Bundle\CatalogBundle\Elasticsearch\IdentifierResult;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 
 class IdentifierResultsSpec extends ObjectBehavior
 {
-
     function it_adds_a_result_identifier()
     {
         $this->add('foo', ProductInterface::class);

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/ProductAndProductModelQueryBuilderFactorySpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/ProductAndProductModelQueryBuilderFactorySpec.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace spec\Pim\Bundle\EnrichBundle\Elasticsearch;
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Elasticsearch\ProductQueryBuilderFactory;
-use Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelQueryBuilder;
+use Pim\Component\Catalog\Query\ProductAndProductModelQueryBuilder;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/mass_actions.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/mass_actions.yml
@@ -79,7 +79,7 @@ services:
         class: '%pim_datagrid.extension.mass_action.handler.product_delete.class%'
         arguments:
             - '@pim_catalog.elasticsearch.indexer.product'
-            - '@pim_enrich.factory.product_and_product_model_cursor'
+            - '@pim_catalog.factory.product_and_product_model_cursor'
         parent: pim_datagrid.extension.mass_action.handler.delete
         tags:
             - { name: pim_datagrid.extension.mass_action.handler, alias: product_mass_delete }

--- a/src/Pim/Bundle/EnrichBundle/Elasticsearch/FromSizeCursor.php
+++ b/src/Pim/Bundle/EnrichBundle/Elasticsearch/FromSizeCursor.php
@@ -5,6 +5,8 @@ namespace Pim\Bundle\EnrichBundle\Elasticsearch;
 use Akeneo\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Elasticsearch\AbstractCursor;
+use Pim\Bundle\CatalogBundle\Elasticsearch\IdentifierResults;
 
 /**
  * Bounded cursor to iterate over items where a start and a limit are defined.

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/queries.yml
@@ -11,5 +11,5 @@ services:
     pim_enrich.doctrine.query.count_impacted_products:
         class: '%pim_enrich.doctrine.query.count_impacted_products.class%'
         arguments:
-            - '@pim_enrich.query.product_and_product_model_query_builder_factory'
+            - '@pim_catalog.query.product_and_product_model_query_builder_factory'
             - '@pim_catalog.query.product_query_builder_factory'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
@@ -2,10 +2,7 @@ parameters:
     pim_enrich.product_query_builder.filter.dummy.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\Filter\DummyFilter
     pim_enrich.query.elasticsearch.sorter.in_group.class: Pim\Bundle\EnrichBundle\Elasticsearch\Sorter\InGroupSorter
     pim_enrich.elasticsearch.from_size_cursor_factory.class: Pim\Bundle\EnrichBundle\Elasticsearch\FromSizeCursorFactory
-    pim_enrich.elasticsearch.cursor_factory.class: Pim\Bundle\EnrichBundle\Elasticsearch\CursorFactory
-    pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class: Pim\Bundle\EnrichBundle\Elasticsearch\ProductAndProductModelQueryBuilderFactory
     pim_enrich.query.product_and_product_model_query_builder.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelQueryBuilder
-    pim_enrich.query.mass_edit_product_and_product_model_query_builder.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\MassEditProductAndProductModelQueryBuilder
 
 services:
     # Filters
@@ -31,7 +28,7 @@ services:
     # Services used by the products and product models' grid
     # here, products and product models should be gathered by the most top level product model
     pim_enrich.query.product_and_product_model_query_builder_from_size_factory:
-        class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
+        class: '%pim_catalog.query.elasticsearch.product_and_model_query_builder_factory.class%'
         arguments:
             - '%pim_enrich.query.product_and_product_model_query_builder.class%'
             - '@pim_enrich.query.product_query_builder_from_size_factory.with_product_and_product_model_from_size_cursor'
@@ -50,35 +47,6 @@ services:
     pim_enrich.factory.product_and_product_model_from_size_cursor:
         public: false
         class: '%pim_enrich.elasticsearch.from_size_cursor_factory.class%'
-        arguments:
-            - '@akeneo_elasticsearch.client.product_and_product_model'
-            - '@pim_catalog.repository.product'
-            - '@pim_catalog.repository.product_model'
-            - '%pim_catalog.factory.product_cursor.page_size%'
-            - 'pim_catalog_product'
-
-    # Services used by the mass edit
-    # here, products and product models should not be gathered
-    pim_enrich.query.product_and_product_model_query_builder_factory:
-        class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
-        arguments:
-            - '%pim_enrich.query.mass_edit_product_and_product_model_query_builder.class%'
-            - '@pim_enrich.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor'
-
-    pim_enrich.query.product_and_product_model_query_builder_factory.with_product_and_product_model_cursor:
-        public: false
-        class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
-        arguments:
-            - '%pim_catalog.query.product_query_builder.class%'
-            - '@pim_catalog.repository.attribute'
-            - '@pim_catalog.query.filter.product_and_product_model_registry'
-            - '@pim_catalog.query.sorter.registry'
-            - '@pim_enrich.factory.product_and_product_model_cursor'
-            - '@pim_catalog.query.product_query_builder_resolver'
-
-    pim_enrich.factory.product_and_product_model_cursor:
-        public: false
-        class: '%pim_enrich.elasticsearch.cursor_factory.class%'
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@pim_catalog.repository.product'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
@@ -8,7 +8,7 @@ services:
     pim_enrich.reader.database.filtered_product_and_product_model:
         class: '%pim_enrich.reader.database.filtered_product_and_product_model.class%'
         arguments:
-            - '@pim_enrich.query.product_and_product_model_query_builder_factory'
+            - '@pim_catalog.query.product_and_product_model_query_builder_factory'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.manager.completeness'
             - '@pim_catalog.converter.metric'
@@ -18,7 +18,7 @@ services:
     pim_enrich.reader.database.product_and_product_model:
         class: '%pim_enrich.reader.database.product_and_product_model.class%'
         arguments:
-            - '@pim_enrich.query.product_and_product_model_query_builder_factory'
+            - '@pim_catalog.query.product_and_product_model_query_builder_factory'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.manager.completeness'
             - true
@@ -26,7 +26,7 @@ services:
     pim_enrich.reader.database.grouped_product_and_product_model:
         class: '%pim_enrich.reader.database.product_and_product_model.class%'
         arguments:
-            - '@pim_enrich.query.product_and_product_model_query_builder_factory'
+            - '@pim_catalog.query.product_and_product_model_query_builder_factory'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.manager.completeness'
             - false
@@ -34,7 +34,7 @@ services:
     pim_enrich.reader.database.add_association:
         class: '%pim_enrich.reader.database.filtered_product_and_product_model.class%'
         arguments:
-            - '@pim_enrich.query.product_and_product_model_query_builder_factory'
+            - '@pim_catalog.query.product_and_product_model_query_builder_factory'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.manager.completeness'
             - '@pim_catalog.converter.metric'
@@ -44,7 +44,7 @@ services:
     pim_enrich.reader.database.product:
         class: '%pim_enrich.reader.database.filtered_product_reader.class%'
         arguments:
-            - '@pim_enrich.query.product_and_product_model_query_builder_factory'
+            - '@pim_catalog.query.product_and_product_model_query_builder_factory'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.manager.completeness'
             - '@pim_catalog.converter.metric'
@@ -53,6 +53,6 @@ services:
     pim_enrich.reader.database.product_model:
         class: '%pim_enrich.reader.database.filtered_product_model_reader.class%'
         arguments:
-            - '@pim_enrich.query.product_and_product_model_query_builder_factory'
+            - '@pim_catalog.query.product_and_product_model_query_builder_factory'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.converter.metric'

--- a/src/Pim/Component/Catalog/Query/ProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Component/Catalog/Query/ProductAndProductModelQueryBuilder.php
@@ -1,9 +1,6 @@
 <?php
 
-namespace Pim\Bundle\EnrichBundle\ProductQueryBuilder;
-
-use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+namespace Pim\Component\Catalog\Query;
 
 /**
  * Provides a way to search simply and efficiently product and product models.
@@ -12,7 +9,7 @@ use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class MassEditProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
+class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
 {
     /** @var ProductQueryBuilderInterface */
     private $pqb;


### PR DESCRIPTION
## Description

This PR is the first step to allow the EE catalog rules to work with the product models.

For that, we need to use the "product and product model query builder", which was only used for the mass edit. So this query builder was placed in the PimEnrichBundle.

However, as we now need it for the rules, it is time to move it into the Catalog component.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
