### PR TITLE
PIM-7116: allow only xhr calls for some actions

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,3 +1,9 @@
+# 1.6.x
+
+## Security fixes
+
+- PIM-7116: Fix multiple CRSF vulnerabilities on several endpoints by allowing only XHR calls (see https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Protecting_REST_Services:_Use_of_Custom_Request_Headers)
+
 # 1.6.21 (2018-01-11)
 
 ## Bug fixes

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -62,6 +62,7 @@ class FeatureContext extends MinkContext implements KernelAwareInterface
         $this->useContext('datagrid', new DataGridContext());
         $this->useContext('command', new CommandContext());
         $this->useContext('navigation', new NavigationContext($parameters['base_url']));
+        $this->useContext('security', new SecurityContext($parameters['base_url']));
         $this->useContext('transformations', new TransformationContext());
         $this->useContext('assertions', new AssertionContext());
         $this->useContext('technical', new TechnicalContext());

--- a/features/Context/SecurityContext.php
+++ b/features/Context/SecurityContext.php
@@ -521,6 +521,27 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
         $this->doCall('DELETE', $url);
     }
 
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" group type$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheGroupType($groupTypeCode)
+    {
+        $routeName = 'pim_enrich_grouptype_remove';
+
+        $groupType = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.group_type')
+            ->findOneByIdentifier($groupTypeCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'id' => $groupType->getId(),
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
 
 //    /**
 //     * @When /^I make a direct authenticated POST call on the "([^"]*)" user group with following data:$/
@@ -573,6 +594,19 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
             ->findOneByIdentifier(sprintf('%s.%s', $attributeCode, $attributeOptionCode));
 
         assertEquals($order, $attributeOption->getSortOrder());
+    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" group type$/
+     */
+    public function thereShouldBeAGroupType($groupTypeCode)
+    {
+        $groupType = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.group_type')
+            ->findOneByIdentifier($groupTypeCode);
+
+        assertNotNull($groupType);
     }
 
     /**

--- a/features/Context/SecurityContext.php
+++ b/features/Context/SecurityContext.php
@@ -427,6 +427,28 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
         $this->doCall('DELETE', $url);
     }
 
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" channel$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheChannel($channelCode)
+    {
+        $routeName = 'pim_enrich_channel_remove';
+
+        $channel = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.channel')
+            ->findOneByIdentifier($channelCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'id' => $channel->getId(),
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
+
 //    /**
 //     * @When /^I make a direct authenticated POST call on the "([^"]*)" user group with following data:$/
 //     */
@@ -478,6 +500,19 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
             ->findOneByIdentifier(sprintf('%s.%s', $attributeCode, $attributeOptionCode));
 
         assertEquals($order, $attributeOption->getSortOrder());
+    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" channel$/
+     */
+    public function thereShouldBeAChannel($channelCode)
+    {
+        $channel = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.channel')
+            ->findOneByIdentifier($channelCode);
+
+        assertNotNull($channel);
     }
 
     /**

--- a/features/Context/SecurityContext.php
+++ b/features/Context/SecurityContext.php
@@ -543,6 +543,99 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
         $this->doCall('DELETE', $url);
     }
 
+    /**
+     * @When /^I make a direct authenticated POST call to create a "([^"]*)" product in the family "([^"]*)"$/
+     */
+    public function iMakeADirectAuthenticatedPostCallToCreateAProduct($productIdentifier, $familyCode)
+    {
+        $routeName = 'pim_enrich_product_rest_create';
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName);
+
+        $this->doCall('POST', $url, [
+            'identifier' => $productIdentifier,
+            'family' => $familyCode
+        ]);
+    }
+
+    /**
+     * @When /^I make a direct authenticated POST call to disable the "([^"]*)" product$/
+     */
+    public function iMakeADirectAuthenticatedPostCallToDisableTheProduct($productIdentifier)
+    {
+        $routeName = 'pim_enrich_product_rest_post';
+
+        $product = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.product')
+            ->findOneByIdentifier($productIdentifier);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'id' => $product->getId(),
+            ]);
+
+        $this->doCall('POST', $url, [], [
+            'enabled' => false,
+            'values' => [],
+        ]);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" product$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheProduct($productIdentifier)
+    {
+        $routeName = 'pim_enrich_product_rest_remove';
+
+        $product = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.product')
+            ->findOneByIdentifier($productIdentifier);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'id' => $product->getId(),
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" product to remove the "([^"]*)" attribute$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheProductToRemoveTheAttribute($productIdentifier, $attributeCode)
+    {
+        $routeName = 'pim_enrich_product_remove_attribute_rest';
+
+        $product = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.product')
+            ->findOneByIdentifier($productIdentifier);
+
+        $attribute = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute')
+            ->findOneByIdentifier($attributeCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'id' => $product->getId(),
+                'attributeId' => $attribute->getId(),
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
+
 //    /**
 //     * @When /^I make a direct authenticated POST call on the "([^"]*)" user group with following data:$/
 //     */
@@ -732,16 +825,20 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
     }
 
     /**
-     * @Then /^there should be a "([^"]*)" product$/
+     * @Then /^there should( not)? be a "([^"]*)" product$/
      */
-    public function thereShouldBeAProduct($productIdentifier)
+    public function thereShouldBeAProduct($not, $productIdentifier)
     {
         $product = $this->kernel
             ->getContainer()
             ->get('pim_catalog.repository.product')
             ->findOneByIdentifier($productIdentifier);
 
-        assertNotNull($product);
+        if ($not) {
+            assertNull($product);
+        } else {
+            assertNotNull($product);
+        }
     }
 
     /**

--- a/features/Context/SecurityContext.php
+++ b/features/Context/SecurityContext.php
@@ -1,0 +1,571 @@
+<?php
+
+namespace Context;
+
+
+use Behat\Behat\Exception\PendingException;
+use Behat\Gherkin\Node\TableNode;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Behat\Symfony2Extension\Context\KernelAwareInterface;
+use Doctrine\Common\Util\ClassUtils;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+class SecurityContext extends RawMinkContext implements KernelAwareInterface
+{
+    /** @var KernelInterface */
+    protected $kernel;
+
+    /** @var Client */
+    protected $client;
+
+    /**
+     * @param string $baseUrl
+     */
+    public function __construct($baseUrl)
+    {
+        $this->baseUrl = $baseUrl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setKernel(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" user group$/
+     */
+    public function iMakeADirectCallToDeleteTheUserGroup($userGroupLabel)
+    {
+        $routeName = 'oro_user_group_delete';
+
+        $userGroup = $this->kernel
+            ->getContainer()
+            ->get('pim_user.repository.group')
+            ->findOneByIdentifier($userGroupLabel);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, ['id' => $userGroup->getId()]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" user role$/
+     */
+    public function iMakeADirectCallToDeleteTheUserRole($role)
+    {
+        $routeName = 'oro_user_role_delete';
+
+        $userRole = $this->kernel
+            ->getContainer()
+            ->get('pim_user.repository.role')
+            ->findOneByIdentifier($role);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, ['id' => $userRole->getId()]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" user$/
+     */
+    public function iMakeADirectCallToDeleteTheUser($username)
+    {
+        $routeName = 'oro_user_user_delete';
+
+        $user = $this->kernel
+            ->getContainer()
+            ->get('pim_user.repository.user')
+            ->findOneByIdentifier($username);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, ['id' => $user->getId()]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the last comment of "([^"]*)" product$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheLastCommentOfProduct($productIdentifier)
+    {
+        $routeName = 'pim_comment_comment_delete';
+
+        $product = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.product')
+            ->findOneByIdentifier($productIdentifier);
+
+        $comments = $this->kernel
+            ->getContainer()
+            ->get('pim_comment.repository.comment')
+            ->getComments(
+                ClassUtils::getClass($product),
+                $product->getId()
+            );
+
+        $lastComment = end($comments);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, ['id' => $lastComment->getId()]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" datagrid view as "([^"]*)"$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheDatagridView($datagridViewLabel, $username)
+    {
+        $routeName = 'pim_datagrid_view_remove';
+
+        $view = $this->kernel
+            ->getContainer()
+            ->get('pim_datagrid.repository.datagrid_view')
+            ->findOneBy(['label' => $datagridViewLabel]);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, ['id' => $view->getId()]);
+
+        $this->doCall('DELETE', $url, [], [], $username);
+    }
+
+    /**
+     * @When /^I make a direct authenticated GET call to mass delete "([^"]*)" product$/
+     */
+    public function iMakeADirectAuthenticatedGetCallToMassDeleteProduct($productIndentifier)
+    {
+        $routeName = 'pim_datagrid_mass_action';
+
+        $product = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.product')
+            ->findOneByIdentifier($productIndentifier);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, ['gridName' => 'product-grid', 'actionName' => 'delete']);
+
+        $this->doCall('GET', $url, [
+            'inset' => 1,
+            'values' => $product->getId()
+        ]);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" association type$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheAssociationType($associationTypeCode)
+    {
+        $routeName = 'pim_enrich_associationtype_remove';
+
+        $associationType = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.association_type')
+            ->findOneByIdentifier($associationTypeCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, ['id' => $associationType->getId()]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" attribute$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheAttribute($attributeCode)
+    {
+        $routeName = 'pim_enrich_attribute_remove';
+
+        $attribute = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute')
+            ->findOneByIdentifier($attributeCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, ['id' => $attribute->getId()]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" attribute group$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheAttributeGroup($attributeGroupCode)
+    {
+        $routeName = 'pim_enrich_attributegroup_remove';
+
+        $attributeGroup = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute_group')
+            ->findOneByIdentifier($attributeGroupCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, ['id' => $attributeGroup->getId()]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" attribute in the "([^"]*)" attribute group$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheAttributeInTheAttributeGroup($attributeCode, $attributeGroupCode)
+    {
+        $routeName = 'pim_enrich_attributegroup_removeattribute';
+
+        $attribute = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute')
+            ->findOneByIdentifier($attributeCode);
+
+        $attributeGroup = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute_group')
+            ->findOneByIdentifier($attributeGroupCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'groupId' => $attributeGroup->getId(),
+                'attributeId' => $attribute->getId(),
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated POST call to create a "([^"]*)" attribute option for attribute "([^"]*)"$/
+     */
+    public function iMakeADirectAuthenticatedPostCallToCreateAAttributeOptionForAttribute($attributeOptionCode, $attributeCode)
+    {
+        $routeName = 'pim_enrich_attributeoption_create';
+
+        $attribute = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute')
+            ->findOneByIdentifier($attributeCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'attributeId' => $attribute->getId(),
+            ]);
+
+        $this->doCall('POST', $url, [], [
+            'code' => $attributeOptionCode
+        ]);
+    }
+
+    /**
+     * @When /^I make a direct authenticated PUT call to update the "([^"]*)" attribute option for attribute "([^"]*)"$/
+     */
+    public function iMakeADirectAuthenticatedPutCallToUpdateTheAttributeOptionForAttribute($attributeOptionCode, $attributeCode)
+    {
+        $routeName = 'pim_enrich_attributeoption_update';
+
+        $attribute = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute')
+            ->findOneByIdentifier($attributeCode);
+
+        $attributeOption = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier(sprintf('%s.%s', $attributeCode, $attributeOptionCode));
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'attributeId' => $attribute->getId(),
+                'attributeOptionId' => $attributeOption->getId(),
+            ]);
+
+        $this->doCall('PUT', $url, [], [
+            'code' => 'csrf_test',
+            'id' => $attributeOption->getId()
+        ]);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" attribute option for attribute "([^"]*)"$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheAttributeOptionForAttribute($attributeOptionCode, $attributeCode)
+    {
+        $routeName = 'pim_enrich_attributeoption_delete';
+
+        $attribute = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute')
+            ->findOneByIdentifier($attributeCode);
+
+        $attributeOption = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier(sprintf('%s.%s', $attributeCode, $attributeOptionCode));
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'attributeId' => $attribute->getId(),
+                'attributeOptionId' => $attributeOption->getId(),
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated PUT call to sort attribute options of attribute "([^"]*)"$/
+     */
+    public function iMakeADirectAuthenticatedPutCallToSortAttributeOptionsOfAttribute($attributeCode)
+    {
+        $routeName = 'pim_enrich_attributeoption_update_sorting';
+
+        $attribute = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute')
+            ->findOneByIdentifier($attributeCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'attributeId' => $attribute->getId(),
+            ]);
+
+        $attributeOptions = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute_option')
+            ->getOptions('en_US', $attribute->getId())['results'];
+
+        $attributeOptionIds = array_map(function ($attributeOption) {
+            return $attributeOption['id'];
+        }, $attributeOptions);
+
+        $attributeOptionIds = array_reverse($attributeOptionIds);
+
+        $this->doCall('PUT', $url, [], $attributeOptionIds);
+    }
+
+
+//    /**
+//     * @When /^I make a direct authenticated POST call on the "([^"]*)" user group with following data:$/
+//     */
+//    public function iMakeADirectAuthenticatedPostCallOnTheUserGroupWithFollowingData($userGroupCode, TableNode $table)
+//    {
+//        $routeName = 'oro_user_group_update';
+//        $params = [];
+//
+//        foreach ($table->getRows() as $data) {
+//            $params[$data[0]] = $data[1];
+//        }
+//
+//        $userGroup = $this->kernel
+//            ->getContainer()
+//            ->get('pim_user.repository.group')
+//            ->findOneByIdentifier($userGroupCode);
+//
+//        $url = $this->kernel
+//            ->getContainer()
+//            ->get('router')
+//            ->generate($routeName, ['id' => $userGroup->getId()]);
+//
+//
+//        $this->doCall('POST', $url, $params);
+//        var_dump($params);
+//    }
+
+    /**
+     * @Then /^the order for attribute options "([^"]*)" of attribute "([^"]*)" should be (\d+)$/
+     */
+    public function theOrderForAttributeOptionsOfAttributeShouldBe($attributeOptionCode, $attributeCode, $order)
+    {
+        $attributeOption = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier(sprintf('%s.%s', $attributeCode, $attributeOptionCode));
+
+        assertEquals(
+            $order,
+            $attributeOption->getSortOrder(),
+            sprintf(
+                'Order for attribute option "%s" of attribute "%s" is %s, but %s was expected.',
+                $attributeOptionCode,
+                $attributeCode,
+                $attributeOption->getSortOrder(),
+                $order
+            )
+        );
+    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" association type$/
+     */
+    public function thereShouldBeAAssociationType($associationTypeCode)
+    {
+        $associationType = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.association_type')
+            ->findOneByIdentifier($associationTypeCode);
+
+        assertNotNull(
+            $associationType,
+            sprintf("Association type with code '%s' should exist, but it's not.", $associationTypeCode)
+        );
+    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" attribute group$/
+     */
+    public function thereShouldBeAAttributeGroup($attributeGroupCode)
+    {
+        $attributeGroup = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute_group')
+            ->findOneByIdentifier($attributeGroupCode);
+
+        assertNotNull(
+            $attributeGroup,
+            sprintf("Attribute group with code '%s' should exist, but it's not.", $attributeGroupCode)
+        );
+    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" attribute$/
+     */
+    public function thereShouldBeAAttribute($attributeCode)
+    {
+        $attribute = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute')
+            ->findOneByIdentifier($attributeCode);
+
+        assertNotNull(
+            $attribute,
+            sprintf("Attribute with code '%s' should exist, but it's not.", $attributeCode)
+        );
+    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" datagrid view$/
+     */
+    public function thereShouldBeADatagridView($datagridViewLabel)
+    {
+        $view = $this->kernel
+            ->getContainer()
+            ->get('pim_datagrid.repository.datagrid_view')
+            ->findOneBy(['label' => $datagridViewLabel]);
+
+        assertNotNull(
+            $view,
+            sprintf("Datagrid view with label '%s' should exist, but it's not.", $datagridViewLabel)
+        );
+    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" product$/
+     */
+    public function thereShouldBeAProduct($productIdentifier)
+    {
+        $product = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.product')
+            ->findOneByIdentifier($productIdentifier);
+
+        assertNotNull(
+            $product,
+            sprintf("Product with identifier '%s' should exist, but it's not.", $productIdentifier)
+        );
+    }
+
+    /**
+     * @Then /^there should( not)? be a "([^"]*)" attribute option for attribute "([^"]*)"$/
+     */
+    public function thereShouldNotBeAAttributeOptionForAttribute($not, $attributeOptionCode, $attributeCode)
+    {
+        $attributeOption = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute_option')
+            ->findOneByIdentifier(sprintf('%s.%s', $attributeCode, $attributeOptionCode));
+
+        if ($not) {
+            assertNull(
+                $attributeOption,
+                sprintf("Attribute option with identifier '%s' for attribute '%s' should not exist, but it is.", $attributeOptionCode, $attributeCode)
+            );
+        } else {
+            assertNotNull(
+                $attributeOption,
+                sprintf("Attribute option with identifier '%s' for attribute '%s' should exist, but it's not.", $attributeOptionCode, $attributeCode)
+            );
+        }
+    }
+
+
+    /**
+     * @param string $method
+     * @param string $url
+     */
+    private function doCall($method, $url, $data = [], $content = [], $username = 'Julia')
+    {
+        $this->logIn($username);
+        $this->client->request($method, $url, $data, [], [], json_encode($content));
+
+//        print_r($this->client->getResponse()->getContent());
+//        print_r($this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @param string $username
+     */
+    private function logIn($username = 'Julia')
+    {
+        // http://symfony.com/doc/current/testing/http_authentication.html
+
+        $client = new Client($this->kernel);
+        $client->disableReboot();
+        $client->followRedirects();
+        $this->client = $client;
+
+        $session = $this->client->getContainer()->get('session');
+
+        $user = $this->kernel
+            ->getContainer()
+            ->get('pim_user.repository.user')
+            ->findOneBy(['username' => $username]);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $session->set('_security_main', serialize($token));
+        $session->save();
+
+        $cookie = new Cookie($session->getName(), $session->getId());
+        $this->client->getCookieJar()->set($cookie);
+    }
+}

--- a/features/Context/SecurityContext.php
+++ b/features/Context/SecurityContext.php
@@ -499,6 +499,28 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
         $this->doCall('DELETE', $url);
     }
 
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" group$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheGroup($groupCode)
+    {
+        $routeName = 'pim_enrich_group_remove';
+
+        $group = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.group')
+            ->findOneByIdentifier($groupCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'id' => $group->getId(),
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
+
 
 //    /**
 //     * @When /^I make a direct authenticated POST call on the "([^"]*)" user group with following data:$/
@@ -551,6 +573,19 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
             ->findOneByIdentifier(sprintf('%s.%s', $attributeCode, $attributeOptionCode));
 
         assertEquals($order, $attributeOption->getSortOrder());
+    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" group$/
+     */
+    public function thereShouldBeAGroup($groupCode)
+    {
+        $group = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.group')
+            ->findOneByIdentifier($groupCode);
+
+        assertNotNull($group);
     }
 
     /**

--- a/features/Context/SecurityContext.php
+++ b/features/Context/SecurityContext.php
@@ -449,6 +449,57 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
         $this->doCall('DELETE', $url);
     }
 
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" family$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheFamily($familyCode)
+    {
+        $routeName = 'pim_enrich_family_remove';
+
+        $family = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.family')
+            ->findOneByIdentifier($familyCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'id' => $family->getId(),
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" attribute of family "([^"]*)"$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheAttributeOfFamily($attributeCode, $familyCode)
+    {
+        $routeName = 'pim_enrich_family_removeattribute';
+
+        $attribute = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.attribute')
+            ->findOneByIdentifier($attributeCode);
+
+        $family = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.family')
+            ->findOneByIdentifier($familyCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'familyId' => $family->getId(),
+                'attributeId' => $attribute->getId(),
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+
 //    /**
 //     * @When /^I make a direct authenticated POST call on the "([^"]*)" user group with following data:$/
 //     */
@@ -500,6 +551,37 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
             ->findOneByIdentifier(sprintf('%s.%s', $attributeCode, $attributeOptionCode));
 
         assertEquals($order, $attributeOption->getSortOrder());
+    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" attribute in the "([^"]*)" family$/
+     */
+    public function thereShouldBeAAttributeInTheFamily($attributeCode, $familyCode)
+    {
+        $family = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.family')
+            ->findOneByIdentifier($familyCode);
+
+        $hasAttribute = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.family')
+            ->hasAttribute($family->getId(), $attributeCode);
+
+        assertTrue($hasAttribute);
+    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" family$/
+     */
+    public function thereShouldBeAFamily($familyCode)
+    {
+        $family = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.family')
+            ->findOneByIdentifier($familyCode);
+
+        assertNotNull($family);
     }
 
     /**

--- a/features/Context/SecurityContext.php
+++ b/features/Context/SecurityContext.php
@@ -687,6 +687,46 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
         $this->doCall('DELETE', $url);
     }
 
+    /**
+     * @When /^I make a direct authenticated POST call on the "([^"]*)" variant group to change its "([^"]*)" label to "([^"]*)"$/
+     */
+    public function iMakeADirectAuthenticatedPostCallOnTheVariantGroupToChangeItsLabelTo($variantGroupCode, $localeLabelCode, $labelValue)
+    {
+        $routeName = 'pim_enrich_variant_group_rest_post';
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'code' => $variantGroupCode,
+            ]);
+
+        $this->doCall('POST', $url, [], [
+            'code' => $variantGroupCode,
+            'values' => [],
+            'labels' => [
+                $localeLabelCode => $labelValue
+            ]
+        ]);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" variant group$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheVariantGroup($variantGroupCode)
+    {
+        $routeName = 'pim_enrich_variant_group_rest_remove';
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'code' => $variantGroupCode,
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
+
 //    /**
 //     * @When /^I make a direct authenticated POST call on the "([^"]*)" user group with following data:$/
 //     */
@@ -713,6 +753,34 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
 //        $this->doCall('POST', $url, $params);
 //        var_dump($params);
 //    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" variant group$/
+     */
+    public function thereShouldBeAVariantGroup($variantGroupCode)
+    {
+        $variantGroup = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.group')
+            ->findOneByIdentifier($variantGroupCode);
+
+        assertNotNull($variantGroup);
+    }
+
+    /**
+     * @Then /^the label of variant group "([^"]*)" should be "([^"]*)"$/
+     */
+    public function theLabelOfVariantGroupShouldBe($variantGroupCode, $expectedLabel)
+    {
+        $variantGroup = $this->kernel
+            ->getContainer()
+            ->get('pim_catalog.repository.group')
+            ->findOneByIdentifier($variantGroupCode);
+
+        $label = $variantGroup->getLabel();
+
+        assertEquals($expectedLabel, $label);
+    }
 
     /**
      * @Then /^the category "([^"]*)" should have "([^"]*)" as parent$/

--- a/features/Context/SecurityContext.php
+++ b/features/Context/SecurityContext.php
@@ -2,7 +2,6 @@
 
 namespace Context;
 
-
 use Behat\Behat\Exception\PendingException;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
@@ -1094,9 +1093,6 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
     {
         $this->logIn($username);
         $this->client->request($method, $url, $data, [], [], json_encode($content));
-
-//        print_r($this->client->getResponse()->getContent());
-//        print_r($this->client->getResponse()->getStatusCode());
     }
 
     /**

--- a/features/Context/SecurityContext.php
+++ b/features/Context/SecurityContext.php
@@ -1090,7 +1090,7 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
      * @param string $method
      * @param string $url
      */
-    private function doCall($method, $url, $data = [], $content = [], $username = 'Julia')
+    protected function doCall($method, $url, $data = [], $content = [], $username = 'Julia')
     {
         $this->logIn($username);
         $this->client->request($method, $url, $data, [], [], json_encode($content));
@@ -1102,7 +1102,7 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
     /**
      * @param string $username
      */
-    private function logIn($username = 'Julia')
+    protected function logIn($username = 'Julia')
     {
         // http://symfony.com/doc/current/testing/http_authentication.html
 

--- a/features/Context/SecurityContext.php
+++ b/features/Context/SecurityContext.php
@@ -727,6 +727,50 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
         $this->doCall('DELETE', $url);
     }
 
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" export job profile$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheExportJobProfile($exportJobProfileCode)
+    {
+        $routeName = 'pim_importexport_export_profile_remove';
+
+        $exportJobProfile = $this->kernel
+            ->getContainer()
+            ->get('pim_import_export.repository.job_instance')
+            ->findOneByIdentifier($exportJobProfileCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'id' => $exportJobProfile->getId(),
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
+
+    /**
+     * @When /^I make a direct authenticated DELETE call on the "([^"]*)" import job profile$/
+     */
+    public function iMakeADirectAuthenticatedDeleteCallOnTheImportJobProfile($importJobProfileCode)
+    {
+        $routeName = 'pim_importexport_import_profile_remove';
+
+        $importJobProfile = $this->kernel
+            ->getContainer()
+            ->get('pim_import_export.repository.job_instance')
+            ->findOneByIdentifier($importJobProfileCode);
+
+        $url = $this->kernel
+            ->getContainer()
+            ->get('router')
+            ->generate($routeName, [
+                'id' => $importJobProfile->getId(),
+            ]);
+
+        $this->doCall('DELETE', $url);
+    }
+
 //    /**
 //     * @When /^I make a direct authenticated POST call on the "([^"]*)" user group with following data:$/
 //     */
@@ -753,6 +797,20 @@ class SecurityContext extends RawMinkContext implements KernelAwareInterface
 //        $this->doCall('POST', $url, $params);
 //        var_dump($params);
 //    }
+
+    /**
+     * @Then /^there should be a "([^"]*)" export job profile$/
+     * @Then /^there should be a "([^"]*)" import job profile$/
+     */
+    public function thereShouldBeAExportJobProfile($exportJobProfileCode)
+    {
+        $exportJobProfile = $this->kernel
+            ->getContainer()
+            ->get('pim_import_export.repository.job_instance')
+            ->findOneByIdentifier($exportJobProfileCode);
+
+        assertNotNull($exportJobProfile);
+    }
 
     /**
      * @Then /^there should be a "([^"]*)" variant group$/

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_association_types.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_association_types.feature
@@ -1,0 +1,11 @@
+Feature: Allow only XHR requests for some association types actions
+  In order to protect association types from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some association types actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for association types deletion
+    When I make a direct authenticated DELETE call on the "PACK" association type
+    Then there should be a "PACK" association type

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_association_types.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_association_types.feature
@@ -4,7 +4,7 @@ Feature: Allow only XHR requests for some association types actions
   I need to only do XHR calls for some association types actions
 
   Background:
-    Given a "footwear" catalog configuration
+    Given a "default" catalog configuration
 
   Scenario: Authorize only XHR calls for association types deletion
     When I make a direct authenticated DELETE call on the "PACK" association type

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_attribute_groups.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_attribute_groups.feature
@@ -1,0 +1,18 @@
+Feature: Allow only XHR requests for some attribute groups actions
+  In order to protect attribute groups from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some attribute groups actions
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following attribute group:
+      | code      | label-en_US |
+      | csrf_test | csrf_test   |
+
+  Scenario: Authorize only XHR calls for attribute groups deletion
+    When I make a direct authenticated DELETE call on the "csrf_test" attribute group
+    Then there should be a "csrf_test" attribute group
+
+  Scenario: Authorize only XHR calls for attribute groups attribute deletion
+    When I make a direct authenticated DELETE call on the "price" attribute in the "marketing" attribute group
+    Then there should be a "price" attribute

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_attribute_options.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_attribute_options.feature
@@ -1,0 +1,23 @@
+Feature: Allow only XHR requests for some attribute options actions
+  In order to protect attribute options from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some attribute options actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for attribute options creation
+    When I make a direct authenticated POST call to create a "csrf_test" attribute option for attribute "color"
+    Then there should not be a "csrf_test" attribute option for attribute "color"
+
+  Scenario: Authorize only XHR calls for attribute options update
+    When I make a direct authenticated PUT call to update the "white" attribute option for attribute "color"
+    Then there should be a "white" attribute option for attribute "color"
+
+  Scenario: Authorize only XHR calls for attribute options deletion
+    When I make a direct authenticated DELETE call on the "white" attribute option for attribute "color"
+    Then there should be a "white" attribute option for attribute "color"
+
+  Scenario: Authorize only XHR calls for attribute options sorting
+    When I make a direct authenticated PUT call to sort attribute options of attribute "color"
+    Then the order for attribute options "white" of attribute "color" should be 1

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_attributes.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_attributes.feature
@@ -1,0 +1,11 @@
+Feature: Allow only XHR requests for some attributes actions
+  In order to protect attributes from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some attributes actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for attributes deletion
+    When I make a direct authenticated DELETE call on the "cap_color" attribute
+    Then there should be a "cap_color" attribute

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_category_trees.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_category_trees.feature
@@ -1,0 +1,15 @@
+Feature: Allow only XHR requests for some category trees actions
+  In order to protect category trees from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some category trees actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for category trees move
+    When I make a direct authenticated POST call to move the "sandals" category into the "winter_collection" category
+    Then the category "sandals" should have "summer_collection" as parent
+
+  Scenario: Authorize only XHR calls for category deletion
+    When I make a direct authenticated DELETE call on the "sandals" category
+    Then there should be a "sandals" category

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_channels.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_channels.feature
@@ -1,0 +1,11 @@
+Feature: Allow only XHR requests for some channels actions
+  In order to protect channels from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some channels actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for channels deletion
+    When I make a direct authenticated DELETE call on the "mobile" channel
+    Then there should be a "mobile" channel

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_channels.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_channels.feature
@@ -4,7 +4,7 @@ Feature: Allow only XHR requests for some channels actions
   I need to only do XHR calls for some channels actions
 
   Background:
-    Given a "footwear" catalog configuration
+    Given a "default" catalog configuration
 
   Scenario: Authorize only XHR calls for channels deletion
     When I make a direct authenticated DELETE call on the "mobile" channel

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_comments.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_comments.feature
@@ -1,0 +1,21 @@
+@javascript
+Feature: Allow only XHR requests for some comments actions
+  In order to protect comments from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some comments actions
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following product:
+      | sku        |
+      | high-heels |
+    And the following product comments:
+      | product    | # | author | message                                                        | parent | created_at |
+      | high-heels | 1 | Julia  | Waiting for the confirmation of our manufacturer to update it. | 0      | 29-Aug-14  |
+
+  Scenario: Authorize only XHR calls for comments deletion
+    When I make a direct authenticated DELETE call on the last comment of "high-heels" product
+    And I am logged in as "Julia"
+    And I am on the "high-heels" product page
+    And I open the "Comments" panel
+    Then I should see the text "Waiting for the confirmation of our manufacturer to update it."

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_comments.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_comments.feature
@@ -5,7 +5,7 @@ Feature: Allow only XHR requests for some comments actions
   I need to only do XHR calls for some comments actions
 
   Background:
-    Given a "footwear" catalog configuration
+    Given a "default" catalog configuration
     And the following product:
       | sku        |
       | high-heels |

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_datagrid_views.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_datagrid_views.feature
@@ -1,0 +1,14 @@
+Feature: Allow only XHR requests for some datagrid views actions
+  In order to protect datagrid views from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some datagrid views actions
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following datagrid views:
+      | label     | alias        | columns | filters   |
+      | Sku views | product-grid | sku     | f[sku]=-1 |
+
+  Scenario: Authorize only XHR calls for datagrid views deletion
+    When I make a direct authenticated DELETE call on the "Sku views" datagrid view as "Peter"
+    Then there should be a "Sku views" datagrid view

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_datagrid_views.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_datagrid_views.feature
@@ -4,7 +4,7 @@ Feature: Allow only XHR requests for some datagrid views actions
   I need to only do XHR calls for some datagrid views actions
 
   Background:
-    Given a "footwear" catalog configuration
+    Given a "default" catalog configuration
     And the following datagrid views:
       | label     | alias        | columns | filters   |
       | Sku views | product-grid | sku     | f[sku]=-1 |

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_families.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_families.feature
@@ -1,0 +1,15 @@
+Feature: Allow only XHR requests for some families actions
+  In order to protect families from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some families actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for families deletion
+    When I make a direct authenticated DELETE call on the "boots" family
+    Then there should be a "boots" family
+
+  Scenario: Authorize only XHR calls for families attribute deletion
+    When I make a direct authenticated DELETE call on the "lace_color" attribute of family "boots"
+    Then there should be a "lace_color" attribute in the "boots" family

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_group_types.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_group_types.feature
@@ -1,0 +1,11 @@
+Feature: Allow only XHR requests for some group types actions
+  In order to protect group types from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some group types actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for group types deletion
+    When I make a direct authenticated DELETE call on the "XSELL" group type
+    Then there should be a "XSELL" group type

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_groups.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_groups.feature
@@ -1,0 +1,11 @@
+Feature: Allow only XHR requests for some groups actions
+  In order to protect groups from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some groups actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for groups deletion
+    When I make a direct authenticated DELETE call on the "similar_boots" group
+    Then there should be a "similar_boots" group

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_job_profiles.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_job_profiles.feature
@@ -1,0 +1,15 @@
+Feature: Allow only XHR requests for some job profiles actions
+  In order to protect job profiles from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some job profiles actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for export job profiles deletion
+    When I make a direct authenticated DELETE call on the "csv_footwear_association_type_export" export job profile
+    Then there should be a "csv_footwear_association_type_export" export job profile
+
+  Scenario: Authorize only XHR calls for import job profiles deletion
+    When I make a direct authenticated DELETE call on the "csv_footwear_association_type_import" import job profile
+    Then there should be a "csv_footwear_association_type_import" import job profile

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_mass_actions.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_mass_actions.feature
@@ -1,0 +1,14 @@
+Feature: Allow only XHR requests for some mass actions
+  In order to protect mass actions from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some mass actions
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following product:
+      | sku        |
+      | high-heels |
+
+  Scenario: Authorize only XHR calls for mass actions
+    When I make a direct authenticated GET call to mass delete "high-heels" product
+    Then there should be a "high-heels" product

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_mass_actions.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_mass_actions.feature
@@ -4,7 +4,7 @@ Feature: Allow only XHR requests for some mass actions
   I need to only do XHR calls for some mass actions
 
   Background:
-    Given a "footwear" catalog configuration
+    Given a "default" catalog configuration
     And the following product:
       | sku        |
       | high-heels |

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_notifications.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_notifications.feature
@@ -4,7 +4,7 @@ Feature: Allow only XHR requests for some notifications actions
   I need to only do XHR calls for some notifications actions
 
   Background:
-    Given a "footwear" catalog configuration
+    Given a "default" catalog configuration
 
   Scenario: Authorize only XHR calls for export notifications deletion
     Given there is a notification for user "Julia"

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_notifications.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_notifications.feature
@@ -1,0 +1,12 @@
+Feature: Allow only XHR requests for some notifications actions
+  In order to protect notifications from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some notifications actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for export notifications deletion
+    Given there is a notification for user "Julia"
+    When I make a direct authenticated DELETE call on the last notification of user "Julia"
+    Then there should be 1 notification for user "Julia"

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_products.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_products.feature
@@ -1,0 +1,27 @@
+Feature: Allow only XHR requests for some products actions
+  In order to protect products from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some products actions
+
+  Background:
+    Given a "footwear" catalog configuration
+    And the following products:
+      | sku  | comment         |
+      | test | This is a test. |
+
+  Scenario: Authorize only XHR calls for products creation
+    When I make a direct authenticated POST call to create a "csrf" product in the family "boots"
+    Then there should not be a "csrf" product
+
+  Scenario: Authorize only XHR calls for products update
+    When I make a direct authenticated POST call to disable the "test" product
+    Then product "test" should be enabled
+
+  Scenario: Authorize only XHR calls for products deletion
+    When I make a direct authenticated DELETE call on the "test" product
+    Then there should be a "test" product
+
+  Scenario: Authorize only XHR calls for products attribute deletion
+    When I make a direct authenticated DELETE call on the "test" product to remove the "comment" attribute
+    Then the product "test" should have the following values:
+      | comment   | This is a test. |

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_user_groups.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_user_groups.feature
@@ -1,0 +1,11 @@
+Feature: Allow only XHR requests for some user groups actions
+  In order to protect user groups from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some user groups actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for user groups deletion
+    When I make a direct authenticated DELETE call on the "Redactor" user group
+    Then there should be a "Redactor" user group

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_user_groups.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_user_groups.feature
@@ -4,7 +4,7 @@ Feature: Allow only XHR requests for some user groups actions
   I need to only do XHR calls for some user groups actions
 
   Background:
-    Given a "footwear" catalog configuration
+    Given a "default" catalog configuration
 
   Scenario: Authorize only XHR calls for user groups deletion
     When I make a direct authenticated DELETE call on the "Redactor" user group

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_user_roles.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_user_roles.feature
@@ -1,0 +1,11 @@
+Feature: Allow only XHR requests for some user roles actions
+  In order to protect user roles from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some user roles actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for user roles deletion
+    When I make a direct authenticated DELETE call on the "ROLE_USER" user role
+    Then there should be a "User" user role

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_user_roles.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_user_roles.feature
@@ -4,7 +4,7 @@ Feature: Allow only XHR requests for some user roles actions
   I need to only do XHR calls for some user roles actions
 
   Background:
-    Given a "footwear" catalog configuration
+    Given a "default" catalog configuration
 
   Scenario: Authorize only XHR calls for user roles deletion
     When I make a direct authenticated DELETE call on the "ROLE_USER" user role

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_users.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_users.feature
@@ -1,0 +1,11 @@
+Feature: Allow only XHR requests for some users actions
+  In order to protect users from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some users actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for users deletion
+    When I make a direct authenticated DELETE call on the "Mary" user
+    Then there should be a "Mary" user

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_users.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_users.feature
@@ -4,7 +4,7 @@ Feature: Allow only XHR requests for some users actions
   I need to only do XHR calls for some users actions
 
   Background:
-    Given a "footwear" catalog configuration
+    Given a "default" catalog configuration
 
   Scenario: Authorize only XHR calls for users deletion
     When I make a direct authenticated DELETE call on the "Mary" user

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_variant_group_attributes.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_variant_group_attributes.feature
@@ -1,0 +1,12 @@
+Feature: Allow only XHR requests for some variant group attributes actions
+  In order to protect variant group attributes from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some variant group attributes actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for variant group attributes deletion
+    Given I add the attribute "comment" with value "This is a comment." to the "caterpillar_boots" variant group
+    When I make a direct authenticated DELETE call on the "comment" attribute of the "caterpillar_boots" variant group
+    Then the variant group "caterpillar_boots" should have the "comment" attribute

--- a/features/security/csrf_attacks/allow_only_xhr_requests_for_variant_groups.feature
+++ b/features/security/csrf_attacks/allow_only_xhr_requests_for_variant_groups.feature
@@ -1,0 +1,15 @@
+Feature: Allow only XHR requests for some variant groups actions
+  In order to protect variant groups from CSRF attacks
+  As a developer
+  I need to only do XHR calls for some variant groups actions
+
+  Background:
+    Given a "footwear" catalog configuration
+
+  Scenario: Authorize only XHR calls for variant groups update
+    When I make a direct authenticated POST call on the "caterpillar_boots" variant group to change its "en_US" label to "csrf"
+    Then the label of variant group "caterpillar_boots" should be "Caterpillar boots"
+
+  Scenario: Authorize only XHR calls for variant groups deletion
+    When I make a direct authenticated DELETE call on the "caterpillar_boots" variant group
+    Then there should be a "caterpillar_boots" variant group

--- a/src/Oro/Bundle/UserBundle/Controller/GroupController.php
+++ b/src/Oro/Bundle/UserBundle/Controller/GroupController.php
@@ -9,6 +9,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 class GroupController extends Controller
@@ -51,8 +52,12 @@ class GroupController extends Controller
      *
      * @AclAncestor("pim_user_group_remove")
      */
-    public function deleteAction($id)
+    public function deleteAction(Request $request, $id)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $em = $this->get('doctrine.orm.entity_manager');
         $groupClass = $this->container->getParameter('oro_user.group.entity.class');
         $group = $em->getRepository($groupClass)->find($id);

--- a/src/Oro/Bundle/UserBundle/Controller/RoleController.php
+++ b/src/Oro/Bundle/UserBundle/Controller/RoleController.php
@@ -7,6 +7,7 @@ use Oro\Bundle\UserBundle\Entity\Role;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 class RoleController extends Controller
@@ -43,8 +44,12 @@ class RoleController extends Controller
      *
      * @AclAncestor("pim_user_role_remove")
      */
-    public function deleteAction($id)
+    public function deleteAction(Request $request, $id)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $em = $this->get('doctrine.orm.entity_manager');
         $roleClass = $this->container->getParameter('oro_user.role.entity.class');
         $role = $em->getRepository($roleClass)->find($id);

--- a/src/Oro/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Oro/Bundle/UserBundle/Controller/UserController.php
@@ -14,6 +14,8 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -116,8 +118,12 @@ class UserController extends Controller
      *
      * @AclAncestor("pim_user_user_remove")
      */
-    public function deleteAction($id)
+    public function deleteAction(Request $request, $id)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $tokenStorage = $this->get('security.token_storage')->getToken();
         $currentUser = $tokenStorage ? $tokenStorage->getUser() : null;
         if (is_object($currentUser) && $currentUser->getId() != $id) {

--- a/src/Pim/Bundle/CommentBundle/Controller/CommentController.php
+++ b/src/Pim/Bundle/CommentBundle/Controller/CommentController.php
@@ -6,6 +6,7 @@ use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -60,10 +61,14 @@ class CommentController
      * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     * @return \Symfony\Component\HttpFoundation\JsonResponse|RedirectResponse
      */
     public function deleteAction(Request $request, $id)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $manager = $this->getManagerForClass($this->commentClassName);
         $comment = $manager->find($this->commentClassName, $id);
 

--- a/src/Pim/Bundle/CommentBundle/Controller/CommentController.php
+++ b/src/Pim/Bundle/CommentBundle/Controller/CommentController.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -61,7 +62,7 @@ class CommentController
      * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|RedirectResponse
+     * @return Response
      */
     public function deleteAction(Request $request, $id)
     {

--- a/src/Pim/Bundle/DataGridBundle/Controller/DatagridViewController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/DatagridViewController.php
@@ -9,6 +9,7 @@ use Pim\Bundle\EnrichBundle\Flash\Message;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -161,6 +162,10 @@ class DatagridViewController
      */
     public function removeAction(DatagridView $view)
     {
+        if (!$this->request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         if ($view->getOwner() !== $this->tokenStorage->getToken()->getUser()) {
             throw new DeleteException($this->translator->trans('flash.datagrid view.not removable'));
         }

--- a/src/Pim/Bundle/DataGridBundle/Controller/MassActionController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/MassActionController.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\DataGridBundle\Controller;
 
 use Pim\Bundle\DataGridBundle\Extension\MassAction\MassActionDispatcher;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -38,10 +39,14 @@ class MassActionController
     /**
      * Mass delete action
      *
-     * @return JsonResponse
+     * @return RedirectResponse|JsonResponse
      */
-    public function massActionAction()
+    public function massActionAction(Request $request)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $response = $this->massActionDispatcher->dispatch($this->request);
 
         $data = [

--- a/src/Pim/Bundle/DataGridBundle/Controller/MassActionController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/MassActionController.php
@@ -6,6 +6,7 @@ use Pim\Bundle\DataGridBundle\Extension\MassAction\MassActionDispatcher;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Mass action controller for edit and delete actions
@@ -39,7 +40,7 @@ class MassActionController
     /**
      * Mass delete action
      *
-     * @return RedirectResponse|JsonResponse
+     * @return Response
      */
     public function massActionAction(Request $request)
     {

--- a/src/Pim/Bundle/EnrichBundle/Controller/AssociationTypeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AssociationTypeController.php
@@ -170,6 +170,10 @@ class AssociationTypeController
      */
     public function removeAction(AssociationType $associationType)
     {
+        if (!$this->request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $this->assocTypeRemover->remove($associationType);
 
         if ($this->request->isXmlHttpRequest()) {

--- a/src/Pim/Bundle/EnrichBundle/Controller/AttributeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AttributeController.php
@@ -338,6 +338,10 @@ class AttributeController
      */
     public function removeAction(Request $request, $id)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $attribute = $this->findAttributeOr404($id);
         $this->validateRemoval($attribute);
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/AttributeGroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AttributeGroupController.php
@@ -253,10 +253,14 @@ class AttributeGroupController
      *
      * @AclAncestor("pim_enrich_attributegroup_remove")
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return Response
      */
     public function removeAction(Request $request, AttributeGroup $group)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         if ($group === $this->getDefaultGroup()) {
             throw new DeleteException($this->translator->trans('flash.attribute group.not removed default'));
         }
@@ -343,8 +347,12 @@ class AttributeGroupController
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function removeAttributeAction($groupId, $attributeId)
+    public function removeAttributeAction(Request $request, $groupId, $attributeId)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $group = $this->findAttributeGroupOr404($groupId);
         $attribute = $this->findAttributeOr404($attributeId);
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
@@ -18,6 +18,7 @@ use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -121,12 +122,16 @@ class AttributeOptionController
      * @param Request $request
      * @param int     $attributeId
      *
-     * @return JsonResponse
+     * @return FormInterface|RedirectResponse
      *
      * @AclAncestor("pim_enrich_attribute_edit")
      */
     public function createAction(Request $request, $attributeId)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $attribute = $this->findAttributeOr404($attributeId);
 
         $attributeOption = $this->optionFactory->create();
@@ -144,12 +149,16 @@ class AttributeOptionController
      * @param Request $request
      * @param int     $attributeOptionId
      *
-     * @return JsonResponse
+     * @return FormInterface|RedirectResponse
      *
      * @AclAncestor("pim_enrich_attribute_edit")
      */
     public function updateAction(Request $request, $attributeOptionId)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $attributeOption = $this->findAttributeOptionOr404($attributeOptionId);
 
         //Should be replaced by a paramConverter
@@ -163,12 +172,16 @@ class AttributeOptionController
      *
      * @param int $attributeOptionId
      *
-     * @return JsonResponse
+     * @return JsonResponse|RedirectResponse
      *
      * @AclAncestor("pim_enrich_attribute_edit")
      */
-    public function deleteAction($attributeOptionId)
+    public function deleteAction(Request $request, $attributeOptionId)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $attributeOption = $this->findAttributeOptionOr404($attributeOptionId);
 
         try {
@@ -186,12 +199,16 @@ class AttributeOptionController
      * @param Request $request
      * @param int     $attributeId
      *
-     * @return JsonResponse
+     * @return JsonResponse|RedirectResponse
      *
      * @AclAncestor("pim_enrich_attribute_edit")
      */
     public function updateSortingAction(Request $request, $attributeId)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $attribute = $this->findAttributeOr404($attributeId);
         //Should be replaced by a paramConverter
         $data = json_decode($request->getContent(), true);

--- a/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -172,7 +173,7 @@ class AttributeOptionController
      *
      * @param int $attributeOptionId
      *
-     * @return JsonResponse|RedirectResponse
+     * @return Response
      *
      * @AclAncestor("pim_enrich_attribute_edit")
      */
@@ -199,7 +200,7 @@ class AttributeOptionController
      * @param Request $request
      * @param int     $attributeId
      *
-     * @return JsonResponse|RedirectResponse
+     * @return Response
      *
      * @AclAncestor("pim_enrich_attribute_edit")
      */

--- a/src/Pim/Bundle/EnrichBundle/Controller/CategoryTreeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/CategoryTreeController.php
@@ -140,6 +140,10 @@ class CategoryTreeController extends Controller
      */
     public function moveNodeAction(Request $request)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         if (false === $this->securityFacade->isGranted($this->buildAclName('category_edit'))) {
             throw new AccessDeniedException();
         }
@@ -351,8 +355,12 @@ class CategoryTreeController extends Controller
      *
      * @return Response|RedirectResponse
      */
-    public function removeAction($id)
+    public function removeAction(Request $request, $id)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         if (false === $this->securityFacade->isGranted($this->buildAclName('category_remove'))) {
             throw new AccessDeniedException();
         }

--- a/src/Pim/Bundle/EnrichBundle/Controller/ChannelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/ChannelController.php
@@ -144,6 +144,10 @@ class ChannelController
      */
     public function removeAction(Request $request, Channel $channel)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         // TODO This validation should be moved to a validator and that validation triggered by the remover
         $channelCount = $this->channelRepository->countAll();
         if ($channelCount <= 1) {

--- a/src/Pim/Bundle/EnrichBundle/Controller/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/FamilyController.php
@@ -20,6 +20,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -253,10 +254,14 @@ class FamilyController
      *
      * @AclAncestor("pim_enrich_family_remove")
      *
-     * @return \Symfony\Component\HttpFoundation\Response|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return Response
      */
     public function removeAction($id)
     {
+        if (!$this->request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $family = $this->familyRepository->find($id);
 
         if (null === $family) {
@@ -323,10 +328,14 @@ class FamilyController
      *
      * @throws DeleteException
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return Response
      */
     public function removeAttributeAction($familyId, $attributeId)
     {
+        if (!$this->request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $family = $this->familyRepository->find($familyId);
 
         if (null === $family) {

--- a/src/Pim/Bundle/EnrichBundle/Controller/GroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/GroupController.php
@@ -169,8 +169,12 @@ class GroupController
      *
      * @return Response|RedirectResponse
      */
-    public function removeAction(Group $group)
+    public function removeAction(Request $request, Group $group)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $this->groupRemover->remove($group);
 
         if ($this->request->isXmlHttpRequest()) {

--- a/src/Pim/Bundle/EnrichBundle/Controller/GroupTypeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/GroupTypeController.php
@@ -145,8 +145,12 @@ class GroupTypeController
      *
      * @return Response|RedirectResponse
      */
-    public function removeAction(GroupType $groupType)
+    public function removeAction(Request $request, GroupType $groupType)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         if ($groupType->isVariant()) {
             throw new DeleteException($this->translator->trans('flash.group type.cant remove variant'));
         } elseif (count($groupType->getGroups()) > 0) {

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -19,6 +19,7 @@ use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -163,10 +164,14 @@ class ProductController
     /**
      * @param Request $request
      *
-     * @return JsonResponse
+     * @return JsonResponse|RedirectResponse
      */
     public function createAction(Request $request)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $product = $this->productBuilder->createProduct(
             $request->request->get('identifier'),
             $request->request->get('family', null)
@@ -202,10 +207,14 @@ class ProductController
      * @throws NotFoundHttpException     If product is not found or the user cannot see it
      * @throws AccessDeniedHttpException If the user does not have right to edit the product
      *
-     * @return JsonResponse
+     * @return JsonResponse|RedirectResponse
      */
     public function postAction(Request $request, $id)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $product = $this->findProductOr404($id);
         if ($this->objectFilter->filterObject($product, 'pim.internal_api.product.edit')) {
             throw new AccessDeniedHttpException();
@@ -252,10 +261,14 @@ class ProductController
      *
      * @AclAncestor("pim_enrich_product_remove")
      *
-     * @return JsonResponse
+     * @return JsonResponse|RedirectResponse
      */
-    public function removeAction($id)
+    public function removeAction(Request $request, $id)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $product = $this->findProductOr404($id);
         $this->productRemover->remove($product);
 
@@ -274,10 +287,14 @@ class ProductController
      * @throws AccessDeniedHttpException If the user does not have right to edit the product
      * @throws BadRequestHttpException   If the attribute is not removable
      *
-     * @return JsonResponse
+     * @return JsonResponse|RedirectResponse
      */
-    public function removeAttributeAction($id, $attributeId)
+    public function removeAttributeAction(Request $request, $id, $attributeId)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $product = $this->findProductOr404($id);
         if ($this->objectFilter->filterObject($product, 'pim.internal_api.product.edit')) {
             throw new AccessDeniedHttpException();

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductController.php
@@ -21,6 +21,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -164,7 +165,7 @@ class ProductController
     /**
      * @param Request $request
      *
-     * @return JsonResponse|RedirectResponse
+     * @return Response
      */
     public function createAction(Request $request)
     {
@@ -207,7 +208,7 @@ class ProductController
      * @throws NotFoundHttpException     If product is not found or the user cannot see it
      * @throws AccessDeniedHttpException If the user does not have right to edit the product
      *
-     * @return JsonResponse|RedirectResponse
+     * @return Response
      */
     public function postAction(Request $request, $id)
     {
@@ -261,7 +262,7 @@ class ProductController
      *
      * @AclAncestor("pim_enrich_product_remove")
      *
-     * @return JsonResponse|RedirectResponse
+     * @return Response
      */
     public function removeAction(Request $request, $id)
     {
@@ -287,7 +288,7 @@ class ProductController
      * @throws AccessDeniedHttpException If the user does not have right to edit the product
      * @throws BadRequestHttpException   If the attribute is not removable
      *
-     * @return JsonResponse|RedirectResponse
+     * @return Response
      */
     public function removeAttributeAction(Request $request, $id, $attributeId)
     {

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/VariantGroupAttributeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/VariantGroupAttributeController.php
@@ -10,6 +10,8 @@ use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\GroupInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -59,10 +61,14 @@ class VariantGroupAttributeController
      *
      * @throws NotFoundHttpException If variant group or attribute is not found or the user cannot see it
      *
-     * @return JsonResponse
+     * @return JsonResponse|RedirectResponse
      */
-    public function removeAttributeAction($code, $attributeId)
+    public function removeAttributeAction(Request $request, $code, $attributeId)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $group = $this->findVariantGroupOr404($code);
         $attribute = $this->findAttributeOr404($attributeId);
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/VariantGroupAttributeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/VariantGroupAttributeController.php
@@ -12,6 +12,7 @@ use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -61,7 +62,7 @@ class VariantGroupAttributeController
      *
      * @throws NotFoundHttpException If variant group or attribute is not found or the user cannot see it
      *
-     * @return JsonResponse|RedirectResponse
+     * @return Response
      */
     public function removeAttributeAction(Request $request, $code, $attributeId)
     {

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/VariantGroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/VariantGroupController.php
@@ -12,6 +12,7 @@ use Pim\Bundle\UserBundle\Context\UserContext;
 use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
 use Pim\Component\Catalog\Repository\GroupRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -143,10 +144,14 @@ class VariantGroupController
      * @throws NotFoundHttpException     If product is not found or the user cannot see it
      * @throws AccessDeniedHttpException If the user does not have right to edit the product
      *
-     * @return JsonResponse
+     * @return JsonResponse|RedirectResponse
      */
     public function postAction(Request $request, $code)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $variantGroup = $this->repository->findOneByIdentifier($code);
         if (null === $variantGroup) {
             throw new NotFoundHttpException(sprintf('Variant group with code "%s" not found', $code));
@@ -190,10 +195,14 @@ class VariantGroupController
      *
      * @AclAncestor("pim_enrich_group_remove")
      *
-     * @return JsonResponse
+     * @return JsonResponse|RedirectResponse
      */
-    public function removeAction($code)
+    public function removeAction(Request $request, $code)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $variantGroup = $this->repository->findOneByIdentifier($code);
         if (null === $variantGroup) {
             throw new NotFoundHttpException(sprintf('Variant group with code "%s" not found', $code));

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/VariantGroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/VariantGroupController.php
@@ -14,6 +14,7 @@ use Pim\Component\Catalog\Repository\GroupRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -144,7 +145,7 @@ class VariantGroupController
      * @throws NotFoundHttpException     If product is not found or the user cannot see it
      * @throws AccessDeniedHttpException If the user does not have right to edit the product
      *
-     * @return JsonResponse|RedirectResponse
+     * @return Response
      */
     public function postAction(Request $request, $code)
     {
@@ -195,7 +196,7 @@ class VariantGroupController
      *
      * @AclAncestor("pim_enrich_group_remove")
      *
-     * @return JsonResponse|RedirectResponse
+     * @return Response
      */
     public function removeAction(Request $request, $code)
     {

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobProfileController.php
@@ -315,6 +315,10 @@ class JobProfileController
      */
     public function removeAction(Request $request, $id)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         try {
             $jobInstance = $this->getJobInstance($id);
         } catch (NotFoundHttpException $e) {

--- a/src/Pim/Bundle/NotificationBundle/Controller/NotificationController.php
+++ b/src/Pim/Bundle/NotificationBundle/Controller/NotificationController.php
@@ -9,6 +9,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Notification controller
@@ -106,7 +107,7 @@ class NotificationController
      *
      * @param int $id
      *
-     * @return JsonResponse|RedirectResponse
+     * @return Response
      */
     public function removeAction(Request $request, $id)
     {

--- a/src/Pim/Bundle/NotificationBundle/Controller/NotificationController.php
+++ b/src/Pim/Bundle/NotificationBundle/Controller/NotificationController.php
@@ -7,6 +7,7 @@ use Pim\Bundle\NotificationBundle\Entity\Repository\UserNotificationRepositoryIn
 use Pim\Bundle\UserBundle\Context\UserContext;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -105,10 +106,14 @@ class NotificationController
      *
      * @param int $id
      *
-     * @return JsonResponse
+     * @return JsonResponse|RedirectResponse
      */
-    public function removeAction($id)
+    public function removeAction(Request $request, $id)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $user = $this->userContext->getUser();
 
         if (null !== $user) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

As detected by @BitOne , prior to this PR, it was possible - **as a user logged in the PIM** - to request several endpoints with direct curl call (or other methods, such as using a `src` of an image or a `<form>` element in a page). Example:
```js
productIdsParam = "";

for (i=0; i < 20000; i++) {
    //productIdsParam += "product_" + i + "%2C"; // For 2.0
    productIdsParam += i + "%2C"; // For 1.x

    if (i % 500 == 0) {
        document.write('<img src="'+ targetDomain + '/datagrid/product-grid/massAction/delete?inset=1&values=' + productIdsParam + '" >');
        productIdsParam = "";
    }
}
```

Or 
```html
<html>
<head>
</head>
<body onload='document.getElementById("csrf").submit();'>
<form id="csrf" method="POST" action="http://ref-pim-ee-1-7-orm.akeneo.com/enrich/product/rest/1124">
    <input type="hidden" name="_method" value="DELETE" />
</form>
</body>
</html>
```

According to : https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Protecting_REST_Services:_Use_of_Custom_Request_Headers, one way to fix is that `X-Requested-With: XMLHttpRequest` would need to be checked on the back-end side.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | Y
| Added integration tests           | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo