### PR TITLE
PIM-7130: Fix product update when association type code is an integer

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.X (2018-01-11)
+
+## Bug Fixes
+
+- PIM-7130: Fix product update when association type code is an integer
+
 # 1.7.16 (2018-01-11)
 
 ## Bug Fixes

--- a/src/Pim/Component/Catalog/Updater/Adder/AssociationFieldAdder.php
+++ b/src/Pim/Component/Catalog/Updater/Adder/AssociationFieldAdder.php
@@ -168,6 +168,7 @@ class AssociationFieldAdder extends AbstractFieldAdder
         }
 
         foreach ($data as $assocTypeCode => $items) {
+            $assocTypeCode = (string) $assocTypeCode;
             $this->checkAssociationData($field, $data, $assocTypeCode, $items);
         }
     }

--- a/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
@@ -133,6 +133,7 @@ class AssociationFieldSetter extends AbstractFieldSetter
     protected function setProductsAndGroupsToAssociations(ProductInterface $product, $data)
     {
         foreach ($data as $typeCode => $items) {
+            $typeCode = (string) $typeCode;
             $association = $product->getAssociationForTypeCode($typeCode);
             if (null === $association) {
                 throw InvalidPropertyException::validEntityCodeExpected(
@@ -217,6 +218,7 @@ class AssociationFieldSetter extends AbstractFieldSetter
         }
 
         foreach ($data as $assocTypeCode => $items) {
+            $assocTypeCode = (string) $assocTypeCode;
             $this->checkAssociationData($field, $data, $assocTypeCode, $items);
         }
     }

--- a/src/Pim/Component/Catalog/spec/Updater/Adder/AssociationFieldAdderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Adder/AssociationFieldAdderSpec.php
@@ -165,6 +165,42 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         );
     }
 
+    function it_adds_association_field_even_when_the_association_type_code_is_a_string_representing_an_integer(
+        $productRepository,
+        $groupRepository,
+        $productBuilder,
+        ProductInterface $product,
+        AssociationInterface $assoc666,
+        ProductInterface $assocProductOne,
+        ProductInterface $assocProductTwo,
+        GroupInterface $assocGroupOne,
+        GroupInterface $assocGroupTwo
+    ) {
+        $productBuilder->addMissingAssociations($product)->shouldBeCalled();
+        $product->getAssociationForTypeCode('666')->willReturn($assoc666);
+
+        $productRepository->findOneByIdentifier('assocProductOne')->willReturn($assocProductOne);
+        $productRepository->findOneByIdentifier('assocProductTwo')->willReturn($assocProductTwo);
+
+        $groupRepository->findOneByIdentifier('assocGroupOne')->willReturn($assocGroupOne);
+        $groupRepository->findOneByIdentifier('assocGroupTwo')->willReturn($assocGroupTwo);
+
+        $assoc666->addProduct($assocProductOne)->shouldBeCalled();
+        $assoc666->addProduct($assocProductTwo)->shouldBeCalled();
+        $assoc666->addGroup($assocGroupOne)->shouldBeCalled();
+
+        $this->addFieldData(
+            $product,
+            'associations',
+            [
+                '666' => [
+                    'products' => ['assocProductOne', 'assocProductTwo'],
+                    'groups' => ['assocGroupOne']
+                ],
+            ]
+        );
+    }
+
     function it_fails_if_one_of_the_association_type_code_does_not_exist(
         $productBuilder,
         ProductInterface $product


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Related to https://github.com/akeneo/pim-community-dev/pull/5373

The solution provided is to support the association type having a code which is a string representing an integer (ie, "666").

The standard format representation of the associations goes like:
```
{
   "XSELL": {
       "groups": ["group1", "group2"],
       "products": ["AKN_TS1", "AKN_TSH2"]
   },
   "UPSELL": {
       "groups": ["group3", "group4"],
       "products": ["AKN_TS3", "AKN_TSH4"]
   }
}
```
So in our usecase, when updating a product, the front sends to the back the following representation:
```
{
   "666": {
       "groups": ["group1", "group2"],
       "products": ["AKN_TS1", "AKN_TSH2"]
   },
}
```
When json_decoding it, the representation becomes in PHP:
```
[
   666 => [
       "groups": ["group1", "group2"],
       "products": ["AKN_TS1", "AKN_TSH2"]
   ],
]
```
_(the association code is a `"666"`, json_decode will output it as `666`)_

As the association type `666` is not known, the PIM fails to update the product.

__Solution__:

When iterating over the list of associations, explicitly cast the code to a string. _(implemented)_

__Other solution__:

Add a validation rule to prevent the creation of associations having an integer as a code.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | Ok
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
