### PR TITLE
API-446: Add tests get Product / VariantProduct with association on ProductModel

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Update tests
+
+- API-446: Add tests get Product / VariantProduct with association on ProductModel
+
 # 2.0.13 (2018-01-23)
 
 ## Bug fixes

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
+use PHPUnit\Framework\Assert;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -238,6 +239,229 @@ class GetProductIntegration extends AbstractProductTestCase
         $this->assertCount(2, $content, 'response contains 2 items');
         $this->assertSame(Response::HTTP_NOT_FOUND, $content['code']);
         $this->assertSame('Product "not_found" does not exist.', $content['message']);
+    }
+
+    public function testGetProductWithAssociationOnProductAndProductModel()
+    {
+        $product = $this->get('pim_catalog.repository.product')->findoneByIdentifier('foo');
+
+        $association = $product->getAssociationForTypeCode('X_SELL');
+        $association->addProductModel(
+            $this->get('pim_catalog.repository.product_model')->findoneByIdentifier('bar')
+        );
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+
+        Assert::assertCount(0, $errors);
+
+        $this->get('pim_catalog.saver.product')->save($product);
+
+
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products/foo');
+
+        $standardProduct = [
+            'identifier'    => 'foo',
+            'family'        => 'familyA',
+            'parent'        => null,
+            'groups'        => ['groupA', 'groupB'],
+            'categories'    => ['categoryA1', 'categoryB'],
+            'enabled'       => true,
+            'values'        => [
+                'a_file'                             => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_fileA.txt',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media-files/4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_fileA.txt/download'
+                            ]
+                        ]
+                    ],
+                ],
+                'an_image'                           => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => '1/5/7/5/15757827125efa686c1c0f1e7930ca0c528f1c2c_imageA.jpg',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media-files/1/5/7/5/15757827125efa686c1c0f1e7930ca0c528f1c2c_imageA.jpg/download'
+                            ]
+                        ]
+                    ],
+                ],
+                'a_date'                             => [
+                    ['locale' => null, 'scope' => null, 'data' => '2016-06-13T00:00:00+02:00'],
+                ],
+                'a_metric'                           => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => ['amount' => '987654321987.1234', 'unit' => 'KILOWATT'],
+                    ],
+                ],
+                'a_metric_without_decimal' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => ['amount' => 98, 'unit' => 'CENTIMETER'],
+                    ],
+                ],
+                'a_metric_without_decimal_negative' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => ['amount' => -20, 'unit' => 'CELSIUS'],
+                    ],
+                ],
+                'a_metric_negative'        => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => ['amount' => '-20.5000', 'unit' => 'CELSIUS'],
+                    ],
+                ],
+                'a_multi_select'                     => [
+                    ['locale' => null, 'scope' => null, 'data' => ['optionA', 'optionB']],
+                ],
+                'a_number_float'                     => [
+                    ['locale' => null, 'scope' => null, 'data' => '12.5678'],
+                ],
+                'a_number_float_negative'            => [
+                    ['locale' => null, 'scope' => null, 'data' => '-99.8732'],
+                ],
+                'a_number_integer'                   => [
+                    ['locale' => null, 'scope' => null, 'data' => 42]
+                ],
+                'a_number_integer_negative' => [
+                    ['locale' => null, 'scope' => null, 'data' => -42]
+                ],
+                'a_price'                            => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => [
+                            ['amount' => '56.53', 'currency' => 'EUR'],
+                            ['amount' => '45.00', 'currency' => 'USD'],
+                        ],
+                    ],
+                ],
+                'a_price_without_decimal'            => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => [
+                            ['amount' => 56, 'currency' => 'EUR'],
+                            ['amount' => -45, 'currency' => 'USD'],
+                        ],
+                    ],
+                ],
+                'a_ref_data_multi_select'            => [
+                    ['locale' => null, 'scope' => null, 'data' => ['fabricA', 'fabricB']]
+                ],
+                'a_ref_data_simple_select'           => [
+                    ['locale' => null, 'scope' => null, 'data' => 'colorB'],
+                ],
+                'a_simple_select'                    => [
+                    ['locale' => null, 'scope' => null, 'data' => 'optionB'],
+                ],
+                'a_text'                             => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'this is a text',
+                    ],
+                ],
+                '123'                                => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'a text for an attribute with numerical code',
+                    ],
+                ],
+                'a_text_area'                        => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'this is a very very very very very long  text',
+                    ],
+                ],
+                'a_yes_no'                           => [
+                    ['locale' => null, 'scope' => null, 'data' => true],
+                ],
+                'a_localizable_image'                => [
+                    [
+                        'locale' => 'en_US',
+                        'scope'  => null,
+                        'data'   => '6/2/e/3/62e376e75300d27bfec78878db4d30ff1490bc53_imageB_en_US.jpg',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media-files/6/2/e/3/62e376e75300d27bfec78878db4d30ff1490bc53_imageB_en_US.jpg/download'
+                            ]
+                        ]
+                    ],
+                    [
+                        'locale' => 'fr_FR',
+                        'scope'  => null,
+                        'data'   => '0/f/5/0/0f5058de76f68446bb6b2371f19cd2234b245c00_imageB_fr_FR.jpg',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media-files/0/f/5/0/0f5058de76f68446bb6b2371f19cd2234b245c00_imageB_fr_FR.jpg/download'
+                            ]
+                        ]
+                    ],
+                ],
+                'a_scopable_price'                   => [
+                    [
+                        'locale' => null,
+                        'scope'  => 'ecommerce',
+                        'data'   => [
+                            ['amount' => '15.00', 'currency' => 'EUR'],
+                            ['amount' => '20.00', 'currency' => 'USD'],
+                        ],
+                    ],
+                    [
+                        'locale' => null,
+                        'scope'  => 'tablet',
+                        'data'   => [
+                            ['amount' => '17.00', 'currency' => 'EUR'],
+                            ['amount' => '24.00', 'currency' => 'USD'],
+                        ],
+                    ],
+                ],
+                'a_localized_and_scopable_text_area' => [
+                    [
+                        'locale' => 'en_US',
+                        'scope'  => 'ecommerce',
+                        'data'   => 'a text area for ecommerce in English',
+                    ],
+                    [
+                        'locale' => 'en_US',
+                        'scope'  => 'tablet',
+                        'data'   => 'a text area for tablets in English'
+                    ],
+                    [
+                        'locale' => 'fr_FR',
+                        'scope'  => 'tablet',
+                        'data'   => 'une zone de texte pour les tablettes en français',
+                    ],
+                ],
+            ],
+            'created'       => '2016-06-14T13:12:50+02:00',
+            'updated'       => '2016-06-14T13:12:50+02:00',
+            'associations'  => [
+                'PACK'   => ['groups' => [], 'products' => ['bar', 'baz'], 'product_models' => []],
+                'SUBSTITUTION' => ['groups' => [], 'products' => [], 'product_models' => []],
+                'UPSELL' => ['groups' => ['groupA'], 'products' => [], 'product_models' => []],
+                'X_SELL' => ['groups' => ['groupB'], 'products' => ['bar'], 'product_models' => ['bar']],
+            ]
+        ];
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponse($response, $standardProduct);
     }
 
     /**

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
+use PHPUnit\Framework\Assert;
+use Pim\Component\Catalog\Model\Association;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -105,6 +107,124 @@ class GetVariantProductIntegration extends AbstractProductTestCase
 
         $response = $client->getResponse();
 
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponse($response, $standardVariantProduct);
+    }
+
+    public function testGetVariantProductWithAssociationOnProductAndProductModel()
+    {
+        $product = $this->get('pim_catalog.repository.product')->findoneByIdentifier('biker-jacket-leather-xxs');
+
+        $association = new Association();
+        $association->setAssociationType(
+            $this->get('pim_catalog.repository.association_type')->findoneByIdentifier('PACK')
+        );
+        $association->addProductModel(
+            $this->get('pim_catalog.repository.product_model')->findoneByIdentifier('caelus')
+        );
+        $association->addProduct(
+            $this->get('pim_catalog.repository.product')->findoneByIdentifier('1111111171')
+        );
+        $product->addAssociation($association);
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+
+        Assert::assertCount(0, $errors);
+
+        $this->get('pim_catalog.saver.product')->save($product);
+
+
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products/biker-jacket-leather-xxs');
+
+        $standardVariantProduct = [
+            "identifier"    => "biker-jacket-leather-xxs",
+            "family"        => "clothing",
+            "parent"        => "model-biker-jacket-leather",
+            "groups"        => [],
+            "categories"    => ["master_men_blazers"],
+            "enabled"       => true,
+            "values"        => [
+                "ean"             => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => "1234567890362",
+                    ],
+                ],
+                "size" => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => "xxs",
+                    ],
+                ],
+                "color"            => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => "antique_white",
+                    ],
+                ],
+                "material"   => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => "leather",
+                    ],
+                ],
+                "variation_name"   => [
+                    [
+                        "locale" => "en_US",
+                        "scope"  => null,
+                        "data"   => "Biker jacket leather",
+                    ],
+                ],
+                "name"             => [
+                    [
+                        "locale" => "en_US",
+                        "scope"  => null,
+                        "data"   => "Biker jacket",
+                    ],
+                ],
+                "price"            => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => [
+                            [
+                                "amount"   => null,
+                                "currency" => "EUR",
+                            ],
+                        ],
+                    ],
+                ],
+                "collection"       => [
+                    [
+                        "locale" => null,
+                        "scope"  => null,
+                        "data"   => [
+                            "summer_2017",
+                        ],
+                    ],
+                ],
+                "description"      => [
+                    [
+                        "locale" => "en_US",
+                        "scope"  => "ecommerce",
+                        "data"   => "Biker jacket",
+                    ],
+                ],
+            ],
+            "created"       => "2017-09-19T15:58:19+02:00",
+            "updated"       => "2017-09-19T15:58:19+02:00",
+            'associations'  => [
+                'PACK' => ['groups' => [], 'products' => ['1111111171'], 'product_models' => ['caelus']],
+            ]
+        ];
+
+        $response = $client->getResponse();
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $this->assertResponse($response, $standardVariantProduct);
     }


### PR DESCRIPTION
**Description**
Add phpunit tests on getProduct / getVariantProduct with association on ProductModel

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
