### PR TITLE
API-446: Add tests get Product / VariantProduct with association on ProductModel

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,3 +1,9 @@
+# 2.1.x
+
+## Update tests
+
+- API-446: Add tests get Product / VariantProduct with association on ProductModel
+
 # 2.1.2 (2018-01-23)
 
 ## Web API

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
+use PHPUnit\Framework\Assert;
+use Pim\Component\Catalog\Model\Association;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -15,8 +17,27 @@ class GetVariantProductIntegration extends AbstractProductTestCase
 {
     public function testGetACompleteVariantProduct()
     {
-        $client = $this->createAuthenticatedClient();
+        $product = $this->get('pim_catalog.repository.product')->findoneByIdentifier('biker-jacket-leather-xxs');
 
+        $association = new Association();
+        $association->setAssociationType(
+            $this->get('pim_catalog.repository.association_type')->findoneByIdentifier('PACK')
+        );
+        $association->addProductModel(
+            $this->get('pim_catalog.repository.product_model')->findoneByIdentifier('caelus')
+        );
+        $association->addProduct(
+            $this->get('pim_catalog.repository.product')->findoneByIdentifier('1111111171')
+        );
+        $product->addAssociation($association);
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+
+        Assert::assertCount(0, $errors);
+
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $client = $this->createAuthenticatedClient();
         $client->request('GET', 'api/rest/v1/products/biker-jacket-leather-xxs');
 
         $standardVariantProduct = [
@@ -100,7 +121,9 @@ class GetVariantProductIntegration extends AbstractProductTestCase
             ],
             "created"       => "2017-09-19T15:58:19+02:00",
             "updated"       => "2017-09-19T15:58:19+02:00",
-            "associations"  => [],
+            'associations'  => [
+                'PACK' => ['groups' => [], 'products' => ['1111111171'], 'product_models' => ['caelus']],
+            ]
         ];
 
         $response = $client->getResponse();


### PR DESCRIPTION
**Description**
Add phpunit tests on getProduct / getVariantProduct with association on ProductModel

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
