### PR TITLE
Add symfony/thanks Composer plugin

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - GITHUB-6943: Update the Docker compose template to run Elasticsearch container in development mode (Thanks [aaa2000](https://github.com/aaa2000)!)
+- GITHUB-7538: Add symfony/thanks Composer plugin
 
 ## Bug fixes
 

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         "symfony/swiftmailer-bundle": "3.0.3",
         "symfony/security-acl": "3.0.0",
         "symfony/symfony": "3.4.2",
+        "symfony/thanks": "^1.0",
         "symfony/polyfill-apcu": "1.4.0",
         "twig/extensions": "1.2.0",
         "box/spout": "2.7.2"


### PR DESCRIPTION
# Description

Following a discussion with @nicolas-grekas, it would be nice if Akeneo PIM users could easily thanks the OOS projects being part of Akeneo including himself by sending stars on github. 

![screenshot from 2018-01-25 14-08-20](https://user-images.githubusercontent.com/660091/35389795-551ed772-01d9-11e8-8a5d-7cce6776acfb.png)

Here it is

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | :white_check_mark: 
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

