### PR TITLE
[SLA] PIM-7134: Hardcore detach Version entities too on MongoDB to avoid a Memory Leak

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,6 +6,7 @@
 
 ## Bug Fixes
 
+- PIM-7134: Fix a memory leak when purging version history (MongoDB)
 - PIM-7164: Fix a memory leak on product export caused by associated products not being detached
 
 # 1.7.18 (2018-02-22)

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/Common/Detacher/ObjectDetacher.php
@@ -4,6 +4,7 @@ namespace Akeneo\Bundle\StorageUtilsBundle\Doctrine\Common\Detacher;
 
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Component\Versioning\Model\VersionInterface;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
@@ -47,7 +48,7 @@ class ObjectDetacher implements ObjectDetacherInterface, BulkObjectDetacherInter
 
         if ($objectManager instanceof DocumentManager) {
             $this->doDetach($object);
-            if ($object instanceof ProductInterface) {
+            if ($object instanceof ProductInterface || $object instanceof VersionInterface) {
                 $this->hardcoreDetachForOdmUoW($object);
             }
         } else {

--- a/src/Pim/Bundle/VersioningBundle/Purger/VersionPurger.php
+++ b/src/Pim/Bundle/VersioningBundle/Purger/VersionPurger.php
@@ -146,8 +146,6 @@ class VersionPurger implements VersionPurgerInterface
      * Configure an option resolver with default option values
      *
      * @param OptionsResolver $optionResolver
-     *
-     * @return OptionsResolver
      */
     protected function configureOptions(OptionsResolver $optionResolver)
     {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When running the command `php app/console pim:versioning:purge --more-than-days 7 --no-interaction --force --env=prod` with a LOT of products & versions, there was a memory leak.

Indeed, a lot of `Version` entity were still in memory:

```
## After only 8000 versions processed, already ~1500 were still in memory
+--------------------------------------------+-----------------+-----------------------------+
| Type                                       | Instances Count | Cumulated Self Size (bytes) |
+--------------------------------------------+-----------------+-----------------------------+
| Akeneo\Component\Versioning\Model\Version  | 1490            | 83440                       |
```

Despite the fact that we detach this entity. This is the same problem we encountered with `Products` with https://github.com/akeneo/pim-community-dev/pull/7136 for PIM-6995. Version are still in memory because of the entityMap:

```
+--------------------------------------------------+
| Id: 0xada5e60                                    |
| Type: object                                     |
| Class: Akeneo\Component\Versioning\Model\Version |
| Object Handle: 7781                              |
| Size: 56 B                                       |
| Is root: No                                      |
| Children count: 10                               |
+--------------------------------------------------+
         ^          
         |          
C:7:"MongoId":24:{5a60b5d627ecb5204b8dab00}
         |          
         |          
+----------------------+
| Id: 0x4c9e310        |
| Type: array          |
| Size: 96 B           |
| Is root: No          |
| Children count: 1291 |
+----------------------+
         ^          
         |          
Akeneo\Component\Versioning\Model\Version
         |          
         |          
+-------------------+
| Id: 0x4c9e2b0     |
| Type: array       |
| Size: 96 B        |
| Is root: No       |
| Children count: 1 |
+-------------------+
         ^          
         |          
    identityMap     
         |          
         |          
+----------------------------------------+
| Id: 0x472da90                          |
| Type: object                           |
| Class: Doctrine\ODM\MongoDB\UnitOfWork |
| Object Handle: 1580                    |
| Size: 56 B                             |
| Is root: No                            |
| Children count: 24                     |
+----------------------------------------+
         ^          
         |          
        uow         
         |          
         |          
+--------------------------------------------------------------------------+
| Id: 0x38bb430                                                            |
| Type: object                                                             |
| Class: Pim\Bundle\VersioningBundle\Doctrine\MongoDBODM\VersionRepository |
| Object Handle: 1603                                                      |
| Size: 56 B                                                               |
| Is root: No                                                              |
| Children count: 4                                                        |
+--------------------------------------------------------------------------+
         ^          
         |          
pim_versioning.repository.version
         |          
         |          
+---------------------+
| Id: 0x7f6786e7d640  |
| Type: array         |
| Size: 96 B          |
| Is root: No         |
| Children count: 393 |
+---------------------+
```

**So the fix is already here thanks to @jjanvier , we just have to apply it to `Version` entities, that's what this PR does.**

Once the fix is applied, the memory is stable:
```
## After 180000 versions processed, the number of Version in memory is correct
+--------------------------------------------+-----------------+-----------------------------+
| Type                                       | Instances Count | Cumulated Self Size (bytes) |
+--------------------------------------------+-----------------+-----------------------------+
| Akeneo\Component\Versioning\Model\Version  | 210            | 83440                       |
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added Behats                      | N
| Added integration tests           | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
