### PR TITLE
PIM-7132: Fix "url too long" when doing a mass edit (once and for all)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -239,6 +239,7 @@ stage("Test") {
             "behat-ce": {
                 if (launchBehatTests.equals("yes") && editions.contains("ce")) {
                     queue({
+                        sh (returnStdout: true, script: "mkdir -m 777 -p /home/jenkins/pim/app/build/logs/behat/");
                         def scenariosCE = []
                         for (feature in features) {
                             scenariosCE = (scenariosCE + sh (returnStdout: true, script: "cd /home/jenkins/pim && if [ -e $feature ]; then php ./bin/behat $feature --list-scenarios; fi").tokenize('\n'))
@@ -284,6 +285,7 @@ stage("Test") {
             "behat-ee": {
                 if (launchBehatTests.equals("yes") && editions.contains("ee")) {
                     queue({
+                        sh (returnStdout: true, script: "mkdir -m 777 -p /home/jenkins/pim/app/build/logs/behat/");
                         def scenariosEE = []
                         for (feature in features) {
                             scenariosEE = (scenariosEE + sh (returnStdout: true, script: "cd /home/jenkins/pim && if [ -e $feature ]; then php ./bin/behat $feature --list-scenarios; fi").tokenize('\n'))
@@ -326,6 +328,7 @@ stage("Test") {
             "behat-ce-odm": {
                 if (launchBehatTests.equals("yes") && editions.contains("ceodm")) {
                     queue({
+                        sh (returnStdout: true, script: "mkdir -m 777 -p /home/jenkins/pim/app/build/logs/behat/");
                         def scenariosCE = []
                         for (feature in features) {
                             scenariosCE = (scenariosCE + sh (returnStdout: true, script: "cd /home/jenkins/pim && if [ -e $feature ]; then php ./bin/behat $feature --list-scenarios; fi").tokenize('\n'))
@@ -371,6 +374,7 @@ stage("Test") {
             "behat-ee-odm": {
                 if (launchBehatTests.equals("yes") && editions.contains("eeodm")) {
                     queue({
+                        sh (returnStdout: true, script: "mkdir -m 777 -p /home/jenkins/pim/app/build/logs/behat/");
                         def scenariosEE = []
                         for (feature in features) {
                             scenariosEE = (scenariosEE + sh (returnStdout: true, script: "cd /home/jenkins/pim && if [ -e $feature ]; then php ./bin/behat $feature --list-scenarios; fi").tokenize('\n'))

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,5 +1,9 @@
 # 1.6.x
 
+## Bug fixes
+
+- PIM-7132: Fix "url too long" when doing a mass edit
+
 ## Security fixes
 
 - PIM-7116: Fix multiple CRSF vulnerabilities on several endpoints by allowing only XHR calls (see https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Protecting_REST_Services:_Use_of_Custom_Request_Headers)

--- a/src/Pim/Bundle/DataGridBundle/Adapter/OroToPimGridFilterAdapter.php
+++ b/src/Pim/Bundle/DataGridBundle/Adapter/OroToPimGridFilterAdapter.php
@@ -34,7 +34,7 @@ class OroToPimGridFilterAdapter implements GridFilterAdapterInterface
      */
     public function adapt(Request $request)
     {
-        if (in_array($request->get('gridName'), [self::PRODUCT_GRID_NAME])) {
+        if (self::PRODUCT_GRID_NAME === $request->get('gridName')) {
             $filters = $this->massActionDispatcher->getRawFilters($request);
         } else {
             $items = $this->massActionDispatcher->dispatch($request);

--- a/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Actions/Export/ExportMassAction.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Actions/Export/ExportMassAction.php
@@ -43,6 +43,14 @@ class ExportMassAction extends WidgetMassAction implements ExportMassActionInter
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getExportContext()
+    {
+        return $this->options['context'];
+    }
+
+    /**
      * Add method to assert required route parameters
      */
     protected function assertHasRequiredOptions()
@@ -63,20 +71,12 @@ class ExportMassAction extends WidgetMassAction implements ExportMassActionInter
             if (!isset($this->options['route_parameters'][$requiredRouteParam])) {
                 throw new \LogicException(
                     sprintf(
-                        'There is no route_parameter named "%s" for action "%s"',
+                        'The parameter "%s" for action "%s" is required',
                         $requiredRouteParam,
                         $this->getName()
                     )
                 );
             }
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getExportContext()
-    {
-        return $this->options['context'];
     }
 }

--- a/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Actions/SequentialEdit/SequentialEditAction.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Actions/SequentialEdit/SequentialEditAction.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Pim\Bundle\DataGridBundle\Extension\MassAction\Actions\SequentialEdit;
+
+use Oro\Bundle\DataGridBundle\Extension\Action\ActionConfiguration;
+use Oro\Bundle\DataGridBundle\Extension\Action\Actions\AbstractAction;
+use Oro\Bundle\DataGridBundle\Extension\MassAction\Actions\MassActionInterface;
+
+/**
+ * Sequential edit action
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SequentialEditAction extends AbstractAction implements MassActionInterface
+{
+    /** @var array $requiredOptions */
+    protected $requiredOptions = [];
+
+    /** @var array $requiredRouteParams */
+    protected $requiredRouteParams = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions(ActionConfiguration $options)
+    {
+        $options['frontend_type'] = 'sequential_edit';
+
+        if (empty($options['route'])) {
+            $options['route'] = 'pim_enrich_mass_edit_action_sequential_edit';
+        }
+
+        if (empty($options['handler'])) {
+            $options['handler'] = 'sequential_edit';
+        }
+
+        if (empty($options['context'])) {
+            $options['context'] = [];
+        }
+
+        return parent::setOptions($options);
+    }
+
+    /**
+     * Add method to assert required route parameters
+     */
+    protected function assertHasRequiredOptions()
+    {
+        parent::assertHasRequiredOptions();
+
+        $this->assertRequiredRouteParameters();
+    }
+
+    /**
+     * Check if route parameters are well defined
+     *
+     * @throws \LogicException
+     */
+    protected function assertRequiredRouteParameters()
+    {
+        foreach ($this->requiredRouteParams as $requiredRouteParam) {
+            if (!isset($this->options['route_parameters'][$requiredRouteParam])) {
+                throw new \LogicException(
+                    sprintf(
+                        'There is no route_parameter named "%s" for action "%s"',
+                        $requiredRouteParam,
+                        $this->getName()
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExportContext()
+    {
+        return $this->options['context'];
+    }
+}

--- a/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Actions/SequentialEdit/SequentialEditAction.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/MassAction/Actions/SequentialEdit/SequentialEditAction.php
@@ -64,20 +64,12 @@ class SequentialEditAction extends AbstractAction implements MassActionInterface
             if (!isset($this->options['route_parameters'][$requiredRouteParam])) {
                 throw new \LogicException(
                     sprintf(
-                        'There is no route_parameter named "%s" for action "%s"',
+                        'The parameter "%s" for action "%s" is required',
                         $requiredRouteParam,
                         $this->getName()
                     )
                 );
             }
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getExportContext()
-    {
-        return $this->options['context'];
     }
 }

--- a/src/Pim/Bundle/DataGridBundle/Extension/MassAction/MassActionDispatcher.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/MassAction/MassActionDispatcher.php
@@ -301,7 +301,7 @@ class MassActionDispatcher
      *
      * @return array
      */
-    private function getValues(Request $request)
+    protected function getValues(Request $request)
     {
         $values = $this->getValuesFromRequest($request);
         if (empty($values)) {
@@ -324,7 +324,7 @@ class MassActionDispatcher
      *
      * @return array
      */
-    private function getValuesFromRequest(Request $request)
+    protected function getValuesFromRequest(Request $request)
     {
         $all = $request->request->all();
 

--- a/src/Pim/Bundle/DataGridBundle/Extension/MassAction/MassActionDispatcher.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/MassAction/MassActionDispatcher.php
@@ -144,7 +144,7 @@ class MassActionDispatcher
     {
         $parameters = $this->parametersParser->parse($request);
         $inset = $this->prepareInsetParameter($parameters);
-        $values = $this->prepareValuesParameter($parameters);
+        $values = $this->getValues($request);
         $filters = $this->prepareFiltersParameter($parameters);
 
         $actionName = $request->get('actionName');
@@ -288,5 +288,46 @@ class MassActionDispatcher
         $datagrid = $this->manager->getDatagrid($datagridName);
 
         return $this->getMassActionByName($actionName, $datagrid);
+    }
+
+    /**
+     * @PIM-7132
+     *
+     * Depending on the context:
+     * - the values might be in the request form data (mass edit context)
+     * - The values might be in a URL parameter (quick export)
+     *
+     * @param Request $request
+     *
+     * @return array
+     */
+    private function getValues(Request $request)
+    {
+        $values = $this->getValuesFromRequest($request);
+        if (empty($values)) {
+            $values = $this->prepareValuesParameter($this->parametersParser->parse($request));
+        }
+
+        return $values;
+    }
+
+    /**
+     * @PIM-7132
+     *
+     * We get the values (which are the selected row ids) from the request because the selected ids are passed through
+     * the form data (POST) via a field called 'itemIds' which is hidden and is not part of any form type.
+     *
+     * Prior to this fix, the ids would be passed through query parameters. On submit the form would not be processed
+     * because the URI would be too long.
+     *
+     * @param Request $request
+     *
+     * @return array
+     */
+    private function getValuesFromRequest(Request $request)
+    {
+        $all = $request->request->all();
+
+        return isset($all['itemIds']) ? explode(',', $all['itemIds']) : [];
     }
 }

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/mass_actions.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/mass_actions.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_datagrid.extension.mass_action.type.export.class:                 Pim\Bundle\DataGridBundle\Extension\MassAction\Actions\Export\ExportMassAction
+    pim_datagrid.extension.mass_action.type.sequential_edit.class:        Pim\Bundle\DataGridBundle\Extension\MassAction\Actions\SequentialEdit\SequentialEditAction
     pim_datagrid.extension.mass_action.type.delete.class:                 Pim\Bundle\DataGridBundle\Extension\MassAction\Actions\Ajax\DeleteMassAction
     pim_datagrid.extension.mass_action.handler.edit.class:                Pim\Bundle\DataGridBundle\Extension\MassAction\Handler\EditMassActionHandler
     pim_datagrid.extension.mass_action.handler.export.class:              Pim\Bundle\DataGridBundle\Extension\MassAction\Handler\ExportMassActionHandler
@@ -82,6 +83,12 @@ services:
         scope: prototype
         tags:
             - { name: oro_datagrid.extension.mass_action.type, type: export }
+
+    pim_datagrid.extension.mass_action.type.sequential_edit:
+        class: '%pim_datagrid.extension.mass_action.type.sequential_edit.class%'
+        scope: prototype
+        tags:
+            - { name: oro_datagrid.extension.mass_action.type, type: sequential_edit }
 
     pim_datagrid.extension.mass_action.type.edit:
         class: Pim\Bundle\DataGridBundle\Extension\MassAction\Actions\Redirect\EditMassAction

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
@@ -17,7 +17,7 @@ config:
         oro/datagrid/tab-redirect-action:       pimdatagrid/js/datagrid/action/tab-redirect-action
         pim/datagrid/configure-columns-action:  pimdatagrid/js/datagrid/action/configure-columns-action
         oro/export-widget:                      pimdatagrid/js/datagrid/widget/export-widget
-        oro/datagrid/sequential_edit-action:    pimdatagrid/js/datagrid/widget/sequential_edit-action
+        oro/datagrid/sequential_edit-action:    pimdatagrid/js/datagrid/action/sequential_edit-action
         pim/datagrid/state:                     pimdatagrid/js/datagrid/state
         pim/datagrid/state-listener:            pimdatagrid/js/datagrid/state-listener
         pim/datagrid/column-form-listener:      pimdatagrid/js/datagrid/listener/column-form-listener

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
@@ -17,6 +17,7 @@ config:
         oro/datagrid/tab-redirect-action:       pimdatagrid/js/datagrid/action/tab-redirect-action
         pim/datagrid/configure-columns-action:  pimdatagrid/js/datagrid/action/configure-columns-action
         oro/export-widget:                      pimdatagrid/js/datagrid/widget/export-widget
+        oro/datagrid/sequential_edit-action:    pimdatagrid/js/datagrid/widget/sequential_edit-action
         pim/datagrid/state:                     pimdatagrid/js/datagrid/state
         pim/datagrid/state-listener:            pimdatagrid/js/datagrid/state-listener
         pim/datagrid/column-form-listener:      pimdatagrid/js/datagrid/listener/column-form-listener

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/abstract-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/abstract-action.js
@@ -191,6 +191,11 @@ function($, _, Backbone, routing, Navigation, __, mediator, messenger, error, Mo
             }
             var url = action.getLinkWithParameters(),
                 navigation = Navigation.getInstance();
+
+            /** @PIM-7132: Save the selected items in the localstorage instead of passing them through a URL parameter
+             * to avoid a "URL too long" error. **/
+            action.saveItemIds();
+
             if (navigation) {
                 navigation.processRedirect({
                     fullRedirect: false,
@@ -289,6 +294,8 @@ function($, _, Backbone, routing, Navigation, __, mediator, messenger, error, Mo
                 content: this.messages.confirm_content,
                 okText: this.messages.confirm_ok
             }).on('ok', callback);
-        }
+        },
+
+        saveItemIds: function() {}
     });
 });

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/abstract-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/abstract-action.js
@@ -193,7 +193,7 @@ function($, _, Backbone, routing, Navigation, __, mediator, messenger, error, Mo
                 navigation = Navigation.getInstance();
 
             /** @PIM-7132: Save the selected items in the localstorage instead of passing them through a URL parameter
-             * to avoid a "URL too long" error. **/
+             * to avoid a "URL too long" **/
             action.saveItemIds();
 
             if (navigation) {
@@ -211,15 +211,9 @@ function($, _, Backbone, routing, Navigation, __, mediator, messenger, error, Mo
                 return;
             }
             action.datagrid.showLoading();
-            $.ajax({
-                url: action.getLink(),
-                method: action.getMethod(),
-                data: action.getActionParameters(),
-                context: action,
-                dataType: 'json',
-                error: action._onAjaxError,
-                success: action._onAjaxSuccess
-            });
+            $.post(action.getLinkWithParameters(), {itemIds: action.getSelectedRows().join(',')})
+                .done(action._onAjaxSuccess)
+                .fail(action._onAjaxError);
         },
 
         _onAjaxError: function(jqXHR, textStatus, errorThrown) {

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/abstract-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/abstract-action.js
@@ -212,8 +212,8 @@ function($, _, Backbone, routing, Navigation, __, mediator, messenger, error, Mo
             }
             action.datagrid.showLoading();
             $.post(action.getLinkWithParameters(), {itemIds: action.getSelectedRows().join(',')})
-                .done(action._onAjaxSuccess)
-                .fail(action._onAjaxError);
+                .done(action._onAjaxSuccess.bind(this))
+                .fail(action._onAjaxError.bind(this));
         },
 
         _onAjaxError: function(jqXHR, textStatus, errorThrown) {
@@ -290,6 +290,15 @@ function($, _, Backbone, routing, Navigation, __, mediator, messenger, error, Mo
             }).on('ok', callback);
         },
 
-        saveItemIds: function() {}
+        saveItemIds: function() {},
+
+        getSelectedRows: function() {
+            var selectionState = this.datagrid.getSelectionState();
+            var itemIds = _.map(selectionState.selectedModels, function(model) {
+                return model.get(this.identifierFieldName);
+            }, this);
+
+            return itemIds;
+        }
     });
 });

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/abstract-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/abstract-action.js
@@ -211,7 +211,9 @@ function($, _, Backbone, routing, Navigation, __, mediator, messenger, error, Mo
                 return;
             }
             action.datagrid.showLoading();
-            $.post(action.getLinkWithParameters(), {itemIds: action.getSelectedRows().join(',')})
+
+            var payload = _.extend({itemIds: action.getSelectedRows().join(',')}, action.getActionParameters());
+            $.post(action.getLinkWithParameters(), payload)
                 .done(action._onAjaxSuccess.bind(this))
                 .fail(action._onAjaxError.bind(this));
         },
@@ -290,8 +292,16 @@ function($, _, Backbone, routing, Navigation, __, mediator, messenger, error, Mo
             }).on('ok', callback);
         },
 
+        /**
+         * Saves in the localstorage the list of selected ids in the datagrid.
+         */
         saveItemIds: function() {},
 
+        /**
+         * Returns a list of ids corresponding to the selected rows in the datagrid.
+         *
+         * @returns {Array} an array of string
+         */
         getSelectedRows: function() {
             var selectionState = this.datagrid.getSelectionState();
             var itemIds = _.map(selectionState.selectedModels, function(model) {

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/mass-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/mass-action.js
@@ -89,6 +89,16 @@ function(_, messenger, __, Modal, AbstractAction) {
             return itemIds;
         },
 
+        _handleAjax: function(action) {
+            if (action.dispatched) {
+                return;
+            }
+            action.datagrid.showLoading();
+            $.post(action.getLinkWithParameters(), {itemIds: action.getSelectedRows().join(',')})
+                .done(this._onAjaxSuccess.bind(this))
+                .fail(this._onAjaxError.bind(this));
+        },
+
         /**
          * Get extra parameters (sorters and custom parameters)
          * @param {array}  params
@@ -143,11 +153,6 @@ function(_, messenger, __, Modal, AbstractAction) {
             return result;
         },
 
-        _onAjaxSuccess: function(data, textStatus, jqXHR) {
-            this.datagrid.resetSelectionState();
-            AbstractAction.prototype._onAjaxSuccess.apply(this, arguments);
-        },
-
         /**
          * Get view for confirm modal
          *
@@ -162,7 +167,7 @@ function(_, messenger, __, Modal, AbstractAction) {
         },
 
         saveItemIds: function() {
-            localStorage.setItem('mass_action.'+ this.name +'.itemIds', JSON.stringify(this.getSelectedRows()));
+            localStorage.setItem('mass_action.itemIds', JSON.stringify(this.getSelectedRows()));
         }
     });
 });

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/mass-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/mass-action.js
@@ -55,7 +55,6 @@ function(_, messenger, __, Modal, AbstractAction) {
             }, this);
             var params = {
                 inset: selectionState.inset ? 1 : 0,
-                values: idValues.join(',')
             };
 
             if (selectionState.inset) {
@@ -79,6 +78,15 @@ function(_, messenger, __, Modal, AbstractAction) {
             }
 
             return params;
+        },
+
+        getSelectedRows: function() {
+            var selectionState = this.datagrid.getSelectionState();
+            var itemIds = _.map(selectionState.selectedModels, function(model) {
+                return model.get(this.identifierFieldName);
+            }, this);
+
+            return itemIds;
         },
 
         /**
@@ -151,6 +159,10 @@ function(_, messenger, __, Modal, AbstractAction) {
                 content: this.messages.confirm_content,
                 okText: this.messages.confirm_ok
             }).on('ok', callback);
+        },
+
+        saveItemIds: function() {
+            localStorage.setItem('mass_action.'+ this.name +'.itemIds', JSON.stringify(this.getSelectedRows()));
         }
     });
 });

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/mass-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/mass-action.js
@@ -80,15 +80,6 @@ function(_, messenger, __, Modal, AbstractAction) {
             return params;
         },
 
-        getSelectedRows: function() {
-            var selectionState = this.datagrid.getSelectionState();
-            var itemIds = _.map(selectionState.selectedModels, function(model) {
-                return model.get(this.identifierFieldName);
-            }, this);
-
-            return itemIds;
-        },
-
         _handleAjax: function(action) {
             if (action.dispatched) {
                 return;

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/mass-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/mass-action.js
@@ -80,16 +80,6 @@ function(_, messenger, __, Modal, AbstractAction) {
             return params;
         },
 
-        _handleAjax: function(action) {
-            if (action.dispatched) {
-                return;
-            }
-            action.datagrid.showLoading();
-            $.post(action.getLinkWithParameters(), {itemIds: action.getSelectedRows().join(',')})
-                .done(this._onAjaxSuccess.bind(this))
-                .fail(this._onAjaxError.bind(this));
-        },
-
         /**
          * Get extra parameters (sorters and custom parameters)
          * @param {array}  params
@@ -144,6 +134,11 @@ function(_, messenger, __, Modal, AbstractAction) {
             return result;
         },
 
+        _onAjaxSuccess: function(data, textStatus, jqXHR) {
+            this.datagrid.resetSelectionState();
+            AbstractAction.prototype._onAjaxSuccess.apply(this, arguments);
+        },
+
         /**
          * Get view for confirm modal
          *
@@ -157,6 +152,9 @@ function(_, messenger, __, Modal, AbstractAction) {
             }).on('ok', callback);
         },
 
+        /**
+         * Saves in the localstorage the list of selected ids in the datagrid.
+         */
         saveItemIds: function() {
             localStorage.setItem('mass_action.itemIds', JSON.stringify(this.getSelectedRows()));
         }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/sequential_edit-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/sequential_edit-action.js
@@ -1,6 +1,6 @@
 define(
-    ['jquery', 'underscore', 'backbone', 'oro/navigation',  'routing','oro/messenger', 'oro/datagrid/mass-action'],
-    function ($, _, Backbone, Navigation, Routing, messenger, MassAction) {
+    ['jquery', 'oro/translator', 'underscore', 'backbone', 'oro/navigation',  'routing','oro/messenger', 'oro/datagrid/mass-action'],
+    function ($, _, __, Backbone, Navigation, Routing, messenger, MassAction) {
         'use strict';
 
         return MassAction.extend({
@@ -13,8 +13,7 @@ define(
                 $.post(this.getLinkWithParameters(), {itemIds: this.getSelectedRows().join(',')})
                     .done(function () {
                         var navigation = Navigation.getInstance(),
-                            // url = Routing.generate('pim_enrich_mass_edit_action_sequential_edit_redirect');
-                            url = '/enrich/sequential_edit/redirect';
+                            url = Routing.generate('pim_enrich_mass_edit_action_sequential_edit_redirect');
 
                         navigation.processRedirect({
                             fullRedirect: false,
@@ -24,7 +23,7 @@ define(
                     .error(function (jqXHR) {
                         messenger.notificationFlashMessage(
                             'error',
-                            _.__(jqXHR.responseText)
+                            __(jqXHR.responseText)
                         );
                     });
             }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/widget/export-widget.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/widget/export-widget.js
@@ -12,7 +12,7 @@ define(
             },
 
             run: function () {
-                $.get(this.action.getLinkWithParameters())
+                $.post(this.action.getLinkWithParameters(), {itemIds: this.action.getSelectedRows().join(',')})
                     .done(function () {
                         messenger.notificationFlashMessage(
                             'success',

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/widget/sequential_edit-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/widget/sequential_edit-action.js
@@ -1,0 +1,33 @@
+define(
+    ['jquery', 'underscore', 'backbone', 'oro/navigation',  'routing','oro/messenger', 'oro/datagrid/mass-action'],
+    function ($, _, Backbone, Navigation, Routing, messenger, MassAction) {
+        'use strict';
+
+        return MassAction.extend({
+            initialize: function(options) {
+                MassAction.prototype.initialize.apply(this, arguments);
+                this.route_parameters = { gridName: this.datagrid.name, actionName: this.name };
+            },
+
+            execute: function() {
+                $.post(this.getLinkWithParameters(), {itemIds: this.getSelectedRows().join(',')})
+                    .done(function () {
+                        var navigation = Navigation.getInstance(),
+                            // url = Routing.generate('pim_enrich_mass_edit_action_sequential_edit_redirect');
+                            url = '/enrich/sequential_edit/redirect';
+
+                        navigation.processRedirect({
+                            fullRedirect: false,
+                            location: url
+                        });
+                    })
+                    .error(function (jqXHR) {
+                        messenger.notificationFlashMessage(
+                            'error',
+                            _.__(jqXHR.responseText)
+                        );
+                    });
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/Actions/Export/ExportMassActionSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/Actions/Export/ExportMassActionSpec.php
@@ -20,7 +20,7 @@ class ExportMassActionSpec extends ObjectBehavior
         $options = ActionConfiguration::createNamed('export', []);
 
         $this->shouldThrow(
-            new \LogicException('There is no route_parameter named "_format" for action "export"')
+            new \LogicException('The parameter "_format" for action "export" is required')
         )->duringSetOptions($options);
     }
 
@@ -32,7 +32,7 @@ class ExportMassActionSpec extends ObjectBehavior
         $options = ActionConfiguration::createNamed('export', $params);
 
         $this->shouldThrow(
-            new \LogicException('There is no route_parameter named "_contentType" for action "export"')
+            new \LogicException('The parameter "_contentType" for action "export" is required')
         )->duringSetOptions($options);
     }
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/MassActionDispatcherSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/MassActionDispatcherSpec.php
@@ -97,7 +97,7 @@ class MassActionDispatcherSpec extends ObjectBehavior
                 'actionName' => 'mass_edit_action',
             ],
             [
-                'productIds' => 'id_1,id_2',
+                'itemIds' => 'id_1,id_2',
             ]
         );
 

--- a/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/MassActionDispatcherSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Extension/MassAction/MassActionDispatcherSpec.php
@@ -76,6 +76,87 @@ class MassActionDispatcherSpec extends ObjectBehavior
         $this->dispatch($request)->shouldReturnAnInstanceOf('\Pim\Bundle\DataGridBundle\Extension\MassAction\Handler\MassActionHandlerInterface');
     }
 
+    function it_gets_the_values_from_the_request_form_data(
+        $handlerRegistry,
+        $parametersParser,
+        DatagridInterface $grid,
+        Acceptor $acceptor,
+        MassActionExtension $massActionExtension,
+        MassActionInterface $massActionInterface,
+        QueryBuilder $queryBuilder,
+        DatasourceInterface $datasource,
+        ProductMassActionRepositoryInterface $massActionRepository,
+        MassActionHandlerInterface $massActionHandler
+    ) {
+        $request = new Request(
+            [
+                'inset'      => 'inset',
+                'values'     => [],
+                'gridName'   => 'grid',
+                'massAction' => $massActionInterface,
+                'actionName' => 'mass_edit_action',
+            ],
+            [
+                'productIds' => 'id_1,id_2',
+            ]
+        );
+
+        $parametersParser->parse($request)->willReturn(['inset' => 'inset', 'values' => []]);
+        $datasource->getMassActionRepository()->willReturn($massActionRepository);
+        $massActionRepository->applyMassActionParameters($queryBuilder, 'inset', ['id_1', 'id_2'])->willReturn(null);
+        $massActionExtension->getMassAction('mass_edit_action', $grid)->willReturn($massActionInterface);
+        $acceptor->getExtensions()->willReturn([$massActionExtension]);
+
+        $alias = 'mass_action_alias';
+        $options = new ArrayCollection();
+        $options->offsetSet('handler', $alias);
+        $massActionInterface->getOptions()->willReturn($options);
+        $handlerRegistry->getHandler($alias)->willReturn($massActionHandler);
+        $massActionHandler->handle($grid, $massActionInterface)->willReturn($massActionHandler);
+
+        $this->dispatch($request)->shouldReturnAnInstanceOf('\Pim\Bundle\DataGridBundle\Extension\MassAction\Handler\MassActionHandlerInterface');
+    }
+
+    function it_gets_the_values_from_the_url_parameter_when_the_values_in_the_form_data_are_empty(
+        $handlerRegistry,
+        $parametersParser,
+        DatagridInterface $grid,
+        Acceptor $acceptor,
+        MassActionExtension $massActionExtension,
+        MassActionInterface $massActionInterface,
+        QueryBuilder $queryBuilder,
+        DatasourceInterface $datasource,
+        ProductMassActionRepositoryInterface $massActionRepository,
+        MassActionHandlerInterface $massActionHandler
+    ) {
+        $postParameters = [];
+        $request = new Request(
+            [
+                'inset'      => 'inset',
+                'values'     => 1,
+                'gridName'   => 'grid',
+                'massAction' => $massActionInterface,
+                'actionName' => 'mass_edit_action',
+            ],
+            $postParameters
+        );
+
+        $parametersParser->parse($request)->willReturn(['inset' => 'inset', 'values' => 1]);
+        $datasource->getMassActionRepository()->willReturn($massActionRepository);
+        $massActionRepository->applyMassActionParameters($queryBuilder, 'inset', 1)->willReturn(null);
+        $massActionExtension->getMassAction('mass_edit_action', $grid)->willReturn($massActionInterface);
+        $acceptor->getExtensions()->willReturn([$massActionExtension]);
+
+        $alias = 'mass_action_alias';
+        $options = new ArrayCollection();
+        $options->offsetSet('handler', $alias);
+        $massActionInterface->getOptions()->willReturn($options);
+        $handlerRegistry->getHandler($alias)->willReturn($massActionHandler);
+        $massActionHandler->handle($grid, $massActionInterface)->willReturn($massActionHandler);
+
+        $this->dispatch($request)->shouldReturnAnInstanceOf('\Pim\Bundle\DataGridBundle\Extension\MassAction\Handler\MassActionHandlerInterface');
+    }
+
     function it_throws_an_exception_without_extension($parametersParser, Acceptor $acceptor)
     {
         $request = new Request([

--- a/src/Pim/Bundle/EnrichBundle/Controller/MassEdit/AbstractMassEditController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/MassEdit/AbstractMassEditController.php
@@ -232,7 +232,6 @@ abstract class AbstractMassEditController
         $params = array_merge($params, [
             'gridName'       => $request->get('gridName'),
             'actionName'     => $request->get('actionName'),
-            'values'         => implode(',', $params['values']),
             'filters'        => json_encode($params['filters']),
             'dataLocale'     => $request->get('dataLocale', null),
             'itemsCount'     => $request->get('itemsCount'),

--- a/src/Pim/Bundle/EnrichBundle/Controller/SequentialEditController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/SequentialEditController.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Bundle\EnrichBundle\Controller;
 
-use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\DataGridBundle\Extension\MassAction\MassActionDispatcher;
 use Pim\Bundle\EnrichBundle\Manager\SequentialEditManager;
 use Pim\Bundle\UserBundle\Context\UserContext;
@@ -86,6 +85,18 @@ class SequentialEditController
         );
 
         $this->seqEditManager->save($sequentialEdit);
+
+        return new JsonResponse(
+            [
+                'id'         => current($sequentialEdit->getObjectSet()),
+                'dataLocale' => $request->get('dataLocale'),
+            ]
+        );
+    }
+
+    public function getRedirectAction(Request $request)
+    {
+        $sequentialEdit = $this->seqEditManager->findByUser($this->userContext->getUser());
 
         return new RedirectResponse(
             $this->router->generate(

--- a/src/Pim/Bundle/EnrichBundle/Controller/SequentialEditController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/SequentialEditController.php
@@ -66,7 +66,7 @@ class SequentialEditController
      *
      * @param Request $request
      *
-     * @return RedirectResponse
+     * @return JsonResponse
      */
     public function sequentialEditAction(Request $request)
     {
@@ -94,6 +94,13 @@ class SequentialEditController
         );
     }
 
+    /**
+     * Redirects to the sequential product edit page.
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
     public function getRedirectAction(Request $request)
     {
         $sequentialEdit = $this->seqEditManager->findByUser($this->userContext->getUser());

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -105,11 +105,12 @@ datagrid:
                 launcherOptions:
                     group: bulk_actions
             sequential_edit:
-                type: edit
+                type: sequential_edit
                 acl_resource: pim_enrich_product_edit_attributes
                 label: pim.grid.mass_action.sequential_edit
                 handler: sequential_edit
                 route: pim_enrich_mass_edit_action_sequential_edit
+                frontend_type: sequential_edit
                 launcherOptions:
                     group: bulk_actions
             category_edit:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/sequential_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/sequential_edit.yml
@@ -4,6 +4,12 @@ pim_enrich_mass_edit_action_sequential_edit:
     requirements:
         _method: GET|POST
 
+pim_enrich_mass_edit_action_sequential_edit_redirect:
+    path: /redirect
+    defaults: { _controller: pim_enrich.controller.sequential_edit:getRedirectAction }
+    requirements:
+        _method: GET|POST
+
 pim_enrich_mass_edit_action_sequential_edit_get:
     path: /get.{_format}
     defaults: { _controller: pim_enrich.controller.sequential_edit:getAction, _format: json }

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure.html.twig
@@ -142,7 +142,7 @@
                         $('.confirmation').addClass('hide');
                     });
 
-                    var itemIds = JSON.parse(localStorage.getItem('mass_action.mass_edit.itemIds')).join(',');
+                    var itemIds = JSON.parse(localStorage.getItem('mass_action.itemIds')).join(',');
                     $('input.pim-hidden-form-input[name="itemIds"]').val(itemIds)
                 });
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/MassEditAction/configure.html.twig
@@ -36,15 +36,17 @@
             </div>
         </div>
 
-        <div class="row span12 offset1 buffer-top configuration">
-            {{ elements.link('btn.back', path(backButtonRoute, queryParams), {'class': 'btn-cancel', 'icon': 'chevron-left'}) }}
-            {{ elements.link('btn.next', null, {'class': ['next btn-next', 'btn-primary'], 'icon': 'chevron-right'}) }}
-        </div>
+    <input type="hidden" name="itemIds" value="" class="pim-hidden-form-input" />
 
-        <div class="row offset1 buffer-top confirmation hide">
-            {{ elements.link('btn.cancel', null, {'class': 'cancel btn-cancel', 'icon': 'chevron-left'}) }}
-            {{ elements.submitBtn('btn.confirm', 'ok') }}
-        </div>
+    <div class="row span12 offset1 buffer-top configuration">
+        {{ elements.link('btn.back', path(backButtonRoute, queryParams), {'class': 'btn-cancel', 'icon': 'chevron-left'}) }}
+        {{ elements.link('btn.next', null, {'class': ['next btn-next', 'btn-primary'], 'icon': 'chevron-right'}) }}
+    </div>
+
+    <div class="row offset1 buffer-top confirmation hide">
+        {{ elements.link('btn.cancel', null, {'class': 'cancel btn-cancel', 'icon': 'chevron-left'}) }}
+        {{ elements.submitBtn('btn.confirm', 'ok') }}
+    </div>
 
     {{ form_end(form) }}
 {% endblock %}
@@ -139,6 +141,9 @@
                         $('.configuration').removeClass('hide');
                         $('.confirmation').addClass('hide');
                     });
+
+                    var itemIds = JSON.parse(localStorage.getItem('mass_action.mass_edit.itemIds')).join(',');
+                    $('input.pim-hidden-form-input[name="itemIds"]').val(itemIds)
                 });
             }
         );


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

## Context:
When doing a mass-edit in 1.6 and 1.7 (mass-edit has been reworked in
2.0 <3 @juliensnz), the ids of the products selected in the
datagrid would be passed on all the mass-edit steps through the
URL parameter "values".

When submitting the form to create the mass-edit operation, the form
would be submitted via a POST http verb, but the selected Ids would still be
passed on to the controller using the URI parameter.

This submit action would sometimes not execute because the URL would be
too long.

## Solutions:
**Mass Actions**: (like edit_common_attributes)
Passing the selected Ids from the datagrid to the mass-edit
(without using a url query parameter)

First thing, we need to get rid of the mecanism that passes on the
selected ids to the mass-edit using the URL.

To do so, we will serialize the selected ids in the browser's
localstore prior to go on the mass-edit configuration pages.

Those Ids will stay in the localstorage until the "Configure" step: at
this stage, we will put the Ids in a hidden input in the configure form
to be able to send it to the back-end using form-data.

First part done.

*2nd part*: Sending the selected item ids via POST form data
Instead of passing on the selected ids through an url parameter, we used
a hidden input (see above) in the mass-edit form.

When submitting the form to run the mass-edit, we now need to fetch
the product ids in the right form-data field: this work is mainly done in the
'Pim\Bundle\DataGridBundle\Extension\MassAction\MassActionDispatcher::prepareMassActionParameters`

As this class is also used for the Quick-exports, we need to keep the
old way of getting the value (through a URL parameter) in order to not
break the quick-exports for now.

**Sequential-edit**:
Sequential edit is different. When a user clicks on the sequential edit button, the front-end redirects the user (using the ORO Navigation component) by calling GET the sequential_edit controller.

The controller generates the html content for the seq edit pages and returns it to the component which loads the page.

Problem: the redirect is made using a GET call which is generated inside the ORO Navigation component. There is no way (for now), to pass on to the server the selected IDS via a POST call (having the selected ids in the body of the request) using this component.

Solution: Instead of having one endpoint creating the sequential edit in the back-end and redirecting the user, I created 2 separate endpoints. 
- The first creates the sequential edit action in the back-end (same endpoint as before)
- The second is used to redirect the user to the new page by giving the sequential edit id (/sequential-edit/redirect)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
