### PR TITLE
PIM-7131: Fix mass add product values when number of products selected is greater than batch size

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,8 @@
-# 2.0.X
+# 2.0.x
 
+## Bug fixes
+
+- PIM-7131: Fix mass add product values when number of products selected is greater than batch size
 - PIM-7144: Fix translated label of attribute groups in the product edit form
 
 # 2.0.13 (2018-01-23)

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -139,6 +139,18 @@ class FixturesContext extends BaseFixturesContext
     }
 
     /**
+     * @param int $numberOfProducts
+     *
+     * @Given /^([0-9]+) empty products$/
+     */
+    public function createEmptyProducts(int $numberOfProducts)
+    {
+        for (;$numberOfProducts > 0; $numberOfProducts--) {
+            $this->createProduct(sprintf('product_%s', $numberOfProducts));
+        }
+    }
+
+    /**
      * @param TableNode $table
      *
      * @Given /^the following products?:$/

--- a/features/mass-action/mass_edit_many_products_at_once.feature
+++ b/features/mass-action/mass_edit_many_products_at_once.feature
@@ -1,0 +1,61 @@
+@javascript
+Feature: Mass edit many products at once via a form
+  In order to easily organize many products
+  As a product manager
+  I need to be able to mass edit a selection of products greater than the batch size
+
+  Scenario: Add products to a category
+    Given the "default" catalog configuration
+    And 103 empty products
+    And the following category:
+      | code            | parent  | label-en_US     |
+      | 2018_collection | default | 2018 collection |
+    And I am logged in as "Julia"
+    And I am on the products grid
+    And I sort by "ID" value ascending
+    And I select rows "product_1"
+    And I select all entities
+    And I press the "Bulk actions" button
+    And I choose the "Add to categories" operation
+    And I move on to the choose step
+    And I choose the "Add to categories" operation
+    And I expand the "default" category
+    And I press the "2018 collection" button
+    And I confirm mass edit
+    And I wait for the "add_product_value" job to finish
+    Then I should see the text "COMPLETED"
+    And I should see the text "read 103"
+    And I should see the text "processed 103"
+    And the category of the product "product_1" should be "2018_collection"
+
+  Scenario: Add product models to a category
+    Given the "catalog_modeling" catalog configuration
+    And the following root product models:
+      | code      | family_variant      | description-en_US-ecommerce      |
+      | model-col | clothing_color_size | Magnificent Cult of Luna t-shirt |
+      | model-nin | clothing_size       |                                  |
+    And the following sub product models:
+      | code            | parent    | family_variant      | color | composition             |
+      | model-col-white | model-col | clothing_color_size | white | cotton 90%, viscose 10% |
+    And the following category:
+      | code            | parent | label-en_US     |
+      | custom_category | master | Custom category |
+    And 103 empty products
+    And I am logged in as "Julia"
+    And I am on the products grid
+    And I sort by "ID" value ascending
+    And I select rows "amor"
+    And I select all entities
+    And I press the "Bulk actions" button
+    And I choose the "Add to categories" operation
+    And I move on to the choose step
+    And I choose the "Add to categories" operation
+    And I expand the "master" category
+    And I press the "Custom category" button
+    And I confirm mass edit
+    And I wait for the "add_product_value" job to finish
+    Then I should see the text "COMPLETED"
+    And I should see the text "read 345"
+    And I should see the text "processed 345"
+    And I should see the text "skipped 83"
+    And the category of the product "product_1" should be "custom_category"

--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredProductAndProductModelReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredProductAndProductModelReader.php
@@ -52,6 +52,9 @@ class FilteredProductAndProductModelReader implements
     /** @var CursorInterface */
     private $productsAndProductModels;
 
+    /** @var bool */
+    private $firstRead = true;
+
     /**
      * @param ProductQueryBuilderFactoryInterface $pqbFactory
      * @param ChannelRepositoryInterface          $channelRepository
@@ -185,9 +188,13 @@ class FilteredProductAndProductModelReader implements
         $entity = null;
 
         while ($this->productsAndProductModels->valid()) {
+            if (!$this->firstRead) {
+                $this->productsAndProductModels->next();
+            }
             $entity = $this->productsAndProductModels->current();
-
-            $this->productsAndProductModels->next();
+            if (false === $entity) {
+                return null;
+            }
 
             if ($entity instanceof ProductModelInterface) {
                 if ($this->stepExecution) {
@@ -209,6 +216,7 @@ class FilteredProductAndProductModelReader implements
 
             break;
         }
+        $this->firstRead = false;
 
         return $entity;
     }

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/FilteredProductAndProductModelReaderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/FilteredProductAndProductModelReaderSpec.php
@@ -111,7 +111,7 @@ class FilteredProductAndProductModelReaderSpec extends ObjectBehavior
             }
         );
         $cursor->current()->will(new ReturnPromise($products));
-        $cursor->next()->shouldBeCalled();
+        $cursor->next()->shouldBeCalledTimes(4);
 
         $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(3);
         $metricConverter->convert(Argument::any(), $channel)->shouldBeCalledTimes(3);


### PR DESCRIPTION
When mass editing a number of product greater than the batch size an error was throw
`A new entity was found through the relationship 'Pim\Component\Catalog\Model\Completeness#locale' that was not configured to cascade persist operations for entity: en_US. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example @ManyToOne(..,cascade={"persist"}).`.

With @jjanvier we found that the bug was due to a problem of architecture in our Reader/Writer:
    Info:
- The Cursor used in the Reader loads a page of 50 products during `->next()` if there is no more product left in its current page.
- When the batch size (100) is reached, the Writer clears all repositories and doctrine UOW just after writing in DB.
    Steps
- When initializing the reader, a first page of 50 products is loaded by the Cursor.
- At the 50th products, the Cursor has no more product left and during the call to `->next()` it reloads a new page of 50 products.
- At the 100th products, the Cursor has no more product left and during the call to `->next()` it reloads a new page of 50 products.
    -> So at this moment, we have 100 products in the ItemStep and the 50 next products in the UOW.
- The batch size is reached. The Writer writes and ... TADADA ! The UOW is cleared with our 100 old products that have been write and our 50 next products.

We found a dirty fix: call `->next()` before `->current()` and don't `->next()` the first time we should need it. This results in calling `->next()` AFTER the clear of the UOW and fix the problem.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | OK
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
