### PR TITLE
PIM-7144: Fix translated label of attribute groups in the PEF

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -215,7 +215,7 @@ define(
                                     this.attributeGroupTemplate,
                                     i18n.getLabel(
                                         section.attributeGroup.labels,
-                                        UserContext.get('uiLocale'),
+                                        UserContext.get('catalogLocale'),
                                         section.attributeGroup.code
                                     )
                                 ));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Prior to this fix, the label translated would use the uiLocale, now it
uses the catalogLocale.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
