### PR TITLE
PIM-6367: Refresh all ES indexes in behat

### DIFF
--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -134,7 +134,7 @@ class FixturesContext extends BaseFixturesContext
 
         $this->buildProductHistory($product);
 
-        $this->getElasticsearchProductClient()->refreshIndex();
+        $this->refreshEsIndexes();
 
         return $product;
     }
@@ -254,7 +254,7 @@ class FixturesContext extends BaseFixturesContext
             $uniqueAxesCombinationSet->reset();
 
             $this->refresh($productModel);
-            $this->getContainer()->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+            $this->refreshEsIndexes();
         }
     }
 
@@ -298,7 +298,7 @@ class FixturesContext extends BaseFixturesContext
             $uniqueAxesCombinationSet->reset();
 
             $this->refresh($productModel);
-            $this->getContainer()->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+            $this->refreshEsIndexes();
         }
     }
 
@@ -2369,10 +2369,13 @@ class FixturesContext extends BaseFixturesContext
     }
 
     /**
-     * @return Client
+     * Refresh all the elasticsearch indexes.
      */
-    protected function getElasticsearchProductClient()
+    protected function refreshEsIndexes()
     {
-        return $this->getContainer()->get('akeneo_elasticsearch.client.product');
+        $clients = $this->getMainContext()->getContainer()->get('akeneo_elasticsearch.registry.clients')->getClients();
+        foreach ($clients as $client) {
+            $client->refreshIndex();
+        }
     }
 }


### PR DESCRIPTION
## Description

When creating products or product models for behat tests, only the corresponding Elasticsearch index was refreshed (product index, or product model index), when they should systematically all be refreshed (including the "product and product model" index).

This is needed for an EE pull request, but will be usefull for any behat tests involving products and product models.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
