### PR TITLE
PIM-7142: Enable the creating of ref-data pv with full numerical codes

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -143,12 +143,12 @@ define(
                                 }
 
                                 var choices = _.map($(element).val().split(','), function (choice) {
-                                    var option = _.findWhere(results, {code: choice});
+                                    var option = _.find(results, (elem) => elem.code == choice);
                                     if (option) {
                                         return this.convertBackendItem(option);
                                     }
 
-                                    return _.findWhere(results, {id: choice});
+                                    return _.find(results, (elem) => elem.id == choice);
                                 }.bind(this));
                                 callback(_.compact(choices));
                             }.bind(this));

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -114,10 +114,10 @@ define(
                                 }
 
                                 this.choicePromise.then(function (response) {
-                                    var selected = _.findWhere(response, {code: id});
+                                    var selected = _.find(response, (elem) => elem.code == id);
 
                                     if (!selected) {
-                                        selected = _.findWhere(response.results, {id: id});
+                                        selected = _.find(response.results, (elem) => elem.id == id);
                                     } else {
                                         selected = this.convertBackendItem(selected);
                                     }

--- a/src/Pim/Component/ReferenceData/Factory/Value/ReferenceDataCollectionValueFactory.php
+++ b/src/Pim/Component/ReferenceData/Factory/Value/ReferenceDataCollectionValueFactory.php
@@ -97,10 +97,10 @@ class ReferenceDataCollectionValueFactory implements ValueFactoryInterface
         }
 
         foreach ($data as $key => $value) {
-            if (!is_string($value)) {
+            if (!is_scalar($value)) {
                 throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $attribute->getCode(),
-                    sprintf('array key "%s" expects a string as value, "%s" given', $key, gettype($value)),
+                    sprintf('array key "%s" expects a scalar as value, "%s" given', $key, gettype($value)),
                     static::class,
                     $data
                 );

--- a/src/Pim/Component/ReferenceData/Factory/Value/ReferenceDataValueFactory.php
+++ b/src/Pim/Component/ReferenceData/Factory/Value/ReferenceDataValueFactory.php
@@ -84,8 +84,8 @@ class ReferenceDataValueFactory implements ValueFactoryInterface
             return;
         }
 
-        if (!is_string($data)) {
-            throw InvalidPropertyTypeException::stringExpected(
+        if (!is_scalar($data)) {
+            throw InvalidPropertyTypeException::scalarExpected(
                 $attribute->getCode(),
                 static::class,
                 $data

--- a/src/Pim/Component/ReferenceData/spec/Factory/Value/ReferenceDataCollectionValueFactorySpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Factory/Value/ReferenceDataCollectionValueFactorySpec.php
@@ -99,7 +99,7 @@ class ReferenceDataCollectionValueFactorySpec extends ObjectBehavior
         $productValue->shouldBeEmpty();
     }
 
-    function it_creates_a_reference_data_multi_select_product_value(
+    function it_creates_a_reference_data_multi_select_product_value_with_collection_of_string_as_data(
         $repositoryResolver,
         AttributeInterface $attribute,
         Fabric $silk,
@@ -123,6 +123,39 @@ class ReferenceDataCollectionValueFactorySpec extends ObjectBehavior
             null,
             null,
             ['silk', 'cotton']
+        );
+
+        $productValue->shouldReturnAnInstanceOf(ReferenceDataCollectionValue::class);
+        $productValue->shouldHaveAttribute('reference_data_multi_select_attribute');
+        $productValue->shouldNotBeLocalizable();
+        $productValue->shouldNotBeScopable();
+        $productValue->shouldHaveReferenceData([$silk, $cotton]);
+    }
+
+    function it_creates_a_reference_data_multi_select_product_value_with_collection_of_integers_as_data(
+        $repositoryResolver,
+        AttributeInterface $attribute,
+        Fabric $silk,
+        Fabric $cotton,
+        ReferenceDataRepositoryInterface $referenceDataRepository
+    ) {
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->getCode()->willReturn('reference_data_multi_select_attribute');
+        $attribute->getType()->willReturn('pim_reference_data_catalog_multiselect');
+        $attribute->getBackendType()->willReturn('reference_data_options');
+        $attribute->isBackendTypeReferenceData()->willReturn(true);
+        $attribute->getReferenceDataName()->willReturn('fabrics');
+
+        $repositoryResolver->resolve('fabrics')->willReturn($referenceDataRepository);
+        $referenceDataRepository->findOneBy(['code' => 151])->willReturn($silk);
+        $referenceDataRepository->findOneBy(['code' => 63])->willReturn($cotton);
+
+        $productValue = $this->create(
+            $attribute,
+            null,
+            null,
+            [151, 63]
         );
 
         $productValue->shouldReturnAnInstanceOf(ReferenceDataCollectionValue::class);
@@ -198,7 +231,7 @@ class ReferenceDataCollectionValueFactorySpec extends ObjectBehavior
 
         $exception = InvalidPropertyTypeException::validArrayStructureExpected(
             'reference_data_multi_select_attribute',
-            'array key "foo" expects a string as value, "array" given',
+            'array key "foo" expects a scalar as value, "array" given',
             ReferenceDataCollectionValueFactory::class,
             ['foo' => ['bar']]
         );

--- a/src/Pim/Component/ReferenceData/spec/Factory/Value/ReferenceDataValueFactorySpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Factory/Value/ReferenceDataValueFactorySpec.php
@@ -95,7 +95,7 @@ class ReferenceDataValueFactorySpec extends ObjectBehavior
         $productValue->shouldBeEmpty();
     }
 
-    function it_creates_a_simple_select_reference_data_product_value(
+    function it_creates_a_simple_select_reference_data_product_value_with_a_string_data(
         $repositoryResolver,
         AttributeInterface $attribute,
         Color $color,
@@ -117,6 +117,37 @@ class ReferenceDataValueFactorySpec extends ObjectBehavior
             null,
             null,
             'blue'
+        );
+
+        $productValue->shouldReturnAnInstanceOf(ReferenceDataValue::class);
+        $productValue->shouldHaveAttribute('reference_data_simple_select_attribute');
+        $productValue->shouldNotBeLocalizable();
+        $productValue->shouldNotBeScopable();
+        $productValue->shouldHaveReferenceData($color);
+    }
+
+    function it_creates_a_simple_select_reference_data_product_value_with_an_int_data(
+        $repositoryResolver,
+        AttributeInterface $attribute,
+        Color $color,
+        ReferenceDataRepositoryInterface $referenceDataRepository
+    ) {
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->getCode()->willReturn('reference_data_simple_select_attribute');
+        $attribute->getType()->willReturn('pim_reference_data_catalog_simpleselect');
+        $attribute->getBackendType()->willReturn('reference_data_option');
+        $attribute->isBackendTypeReferenceData()->willReturn(true);
+        $attribute->getReferenceDataName()->willReturn('color');
+
+        $repositoryResolver->resolve('color')->willReturn($referenceDataRepository);
+        $referenceDataRepository->findOneBy(['code' => 172])->willReturn($color);
+
+        $productValue = $this->create(
+            $attribute,
+            null,
+            null,
+            172
         );
 
         $productValue->shouldReturnAnInstanceOf(ReferenceDataValue::class);
@@ -169,7 +200,7 @@ class ReferenceDataValueFactorySpec extends ObjectBehavior
         $attribute->isBackendTypeReferenceData()->willReturn(true);
         $attribute->getReferenceDataName()->willReturn('color');
 
-        $exception = InvalidPropertyTypeException::stringExpected(
+        $exception = InvalidPropertyTypeException::scalarExpected(
             'reference_data_simple_select_attribute',
             ReferenceDataValueFactory::class,
             []


### PR DESCRIPTION
**Context:**
Today, when creating a reference data product value using the
`Pim\Component\ReferenceData\Factory\Value\ReferenceDataValueFactory`,
it is only possible to create the product value by passing-in ref-data
codes that are strings (this is ensured by the factory).

In fact, we also want full numerical codes to be supported.

**Solution:**
In the back-end, allow the ReferecenDataValueFactory and
ReferenceDataCollectionValueFactory to use scalar codes to fetch the
data in order to create the product value.

In the front-end, a quick fix that let the front-end input display the
right reference data label when its code is an integer.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added Behats                      | Todo
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
