### PR TITLE
PIM-6367: Don't add booleans in product builder

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -23,10 +23,11 @@
 
 ### Constructors
 
-- Change the constructor of `Pim\Component\Connector\Processor\Normalization\ProductProcessor` to add `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
-- Change the constructor of `Pim\Component\Connector\Writer\Database\ProductModelDescendantsWriter` to remove `Pim\Component\Catalog\Builder\ProductBuilderInterface`
+- PIM-6367: Change the constructor of `Pim\Component\Connector\Processor\Normalization\ProductProcessor` to add `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
+- PIM-6367: Change the constructor of `Pim\Component\Connector\Writer\Database\ProductModelDescendantsWriter` to remove `Pim\Component\Catalog\Builder\ProductBuilderInterface`
     and to add `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
-- Change the constructor of `Pim\Bundle\DataGridBundle\Datasource\ProductDatasource` to add `Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriber`
+- PIM-6367: Change the constructor of `Pim\Bundle\DataGridBundle\Datasource\ProductDatasource` to add `Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriber`
+- PIM-6367: Change the constructor of `Pim\Component\Catalog\Builder\ProductBuilder` to remove `Pim\Component\Catalog\Manager\AttributeValuesResolverInterface`
 - Change the constructor of `Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber` to add `Akeneo\Component\StorageUtils\Saver\BulkSaverInterface` and `Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface`
 
 ### Services and parameters
@@ -37,3 +38,4 @@
 - PIM-6367: Rename class parameter `pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class` into `pim_catalog.query.elasticsearch.product_and_model_query_builder_factory.class`
 - PIM-6367: Rename class parameter `pim_enrich.query.mass_edit_product_and_product_model_query_builder.class` into `pim_catalog.query.product_and_product_model_query_builder.class`
 - PIM-6367: Rename class parameter `pim_enrich.elasticsearch.cursor_factory.class` into `pim_catalog.elasticsearch.cursor_factory.class`
+- PIM-6367: Remove class parameter `pim_catalog.event_subscriber.product_category.class`

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/AddBooleanValuesSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/AddBooleanValuesSubscriber.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2018 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
+use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Set product values to "false" by default for every boolean attributes in the
+ * product's family or the variant product corresponding attribute set.
+ *
+ * This workaround is due to the UI that does not manage null values for boolean
+ * attributes, only false or true. It avoids to automatically submit boolean
+ * attributes belonging to the product's family in a proposal, even if those
+ * boolean attributes were not modified by the user.
+ *
+ * FIXME - PIM-6056: To remove when the UI will manage null values in boolean attributes
+ *
+ * @author Damien Carcel <damien.carcel@akeneo.com>
+ */
+class AddBooleanValuesSubscriber implements EventSubscriberInterface
+{
+    /** @var AttributeValuesResolverInterface */
+    private $valuesResolver;
+
+    /** @var EntityWithValuesBuilderInterface */
+    private $entityWithValuesBuilder;
+
+    /**
+     * @param AttributeValuesResolverInterface $valuesResolver
+     * @param EntityWithValuesBuilderInterface $entityWithValuesBuilder
+     */
+    public function __construct(
+        AttributeValuesResolverInterface $valuesResolver,
+        EntityWithValuesBuilderInterface $entityWithValuesBuilder
+    ) {
+        $this->valuesResolver = $valuesResolver;
+        $this->entityWithValuesBuilder = $entityWithValuesBuilder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            StorageEvents::PRE_SAVE => 'addBooleanToProduct',
+        ];
+    }
+
+    /**
+     * @param GenericEvent $event
+     */
+    public function addBooleanToProduct(GenericEvent $event): void
+    {
+        $product = $event->getSubject();
+
+        if (!$product instanceof ProductInterface || null !== $product->getId()) {
+            return;
+        }
+
+        $attributes = $this->getAttributes($product);
+
+        if (empty($attributes)) {
+            return;
+        }
+
+        foreach ($attributes as $attribute) {
+            if (AttributeTypes::BOOLEAN === $attribute->getType()) {
+                $requiredValues = $this->valuesResolver->resolveEligibleValues([$attribute]);
+
+                foreach ($requiredValues as $value) {
+                    $originalValue = $product->getValue($attribute->getCode(), $value['locale'], $value['scope']);
+
+                    if (null === $originalValue || null === $originalValue->getData()) {
+                        $this->entityWithValuesBuilder->addOrReplaceValue(
+                            $product,
+                            $attribute,
+                            $value['locale'],
+                            $value['scope'],
+                            false
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param ProductInterface $product
+     *
+     * @return AttributeInterface[]
+     */
+    private function getAttributes(ProductInterface $product): array
+    {
+        if (!$product instanceof VariantProductInterface) {
+            $family = $product->getFamily();
+            if (null === $family) {
+                return [];
+            }
+
+            return $family->getAttributes()->toArray();
+        }
+
+        $level = $product->getVariationLevel();
+        $attributeSet = $product->getFamilyVariant()->getVariantAttributeSet($level);
+
+        return $attributeSet->getAttributes()->toArray();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/builders.yml
@@ -11,7 +11,6 @@ services:
             - '@pim_catalog.repository.family'
             - '@pim_catalog.repository.association_type'
             - '@event_dispatcher'
-            - '@pim_catalog.resolver.attribute_values'
             - '@pim_catalog.builder.entity_with_values'
             - {'product': '%pim_catalog.entity.product.class%', 'association': '%pim_catalog.entity.association.class%'}
 
@@ -22,7 +21,6 @@ services:
             - '@pim_catalog.repository.family'
             - '@pim_catalog.repository.association_type'
             - '@event_dispatcher'
-            - '@pim_catalog.resolver.attribute_values'
             - '@pim_catalog.builder.entity_with_values'
             - {'product': '%pim_catalog.entity.variant_product.class%', 'association': '%pim_catalog.entity.association.class%'}
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -1,5 +1,4 @@
 parameters:
-    pim_catalog.event_subscriber.product_category.class:             Pim\Bundle\CatalogBundle\EventSubscriber\ProductCategorySubscriber
     pim_catalog.event_subscriber.create_attribute_requirement.class: Pim\Bundle\CatalogBundle\EventSubscriber\CreateAttributeRequirementSubscriber
     pim_catalog.event_subscriber.localizable.class: Pim\Bundle\CatalogBundle\EventSubscriber\LocalizableSubscriber
     pim_catalog.event_subscriber.scopable.class: Pim\Bundle\CatalogBundle\EventSubscriber\ScopableSubscriber
@@ -19,6 +18,7 @@ parameters:
     pim_catalog.event_subscriber.remove_attributes_from_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriber
     pim_catalog.event_subscriber.save_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber
     pim_catalog.event_subscriber.add_parent_to_product.class: Pim\Bundle\CatalogBundle\EventSubscriber\AddParentAProductSubscriber
+    pim_catalog.event_subscriber.add_boolean_values.class: Pim\Bundle\CatalogBundle\EventSubscriber\AddBooleanValuesSubscriber
 
 services:
     # Subscribers
@@ -169,5 +169,13 @@ services:
             - '@pim_catalog.saver.family_variant'
             - '@pim_catalog.saver.family_variant'
             - '@akeneo_storage_utils.doctrine.object_detacher'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    pim_catalog.event_subscriber.add_boolean_values:
+        class: '%pim_catalog.event_subscriber.add_boolean_values.class%'
+        arguments:
+            - '@pim_catalog.resolver.attribute_values'
+            - '@pim_catalog.builder.entity_with_values'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/AddBooleanValuesSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/AddBooleanValuesSubscriberSpec.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
+use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\Product;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class AddBooleanValuesSubscriberSpec extends ObjectBehavior
+{
+    function let(
+        AttributeValuesResolverInterface $valuesResolver,
+        EntityWithValuesBuilderInterface $entityWithValuesBuilder
+    ) {
+        $this->beConstructedWith($valuesResolver, $entityWithValuesBuilder);
+    }
+
+    function it_does_not_add_boolean_values_on_an_already_existing_product(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        GenericEvent $event,
+        Product $product
+    ) {
+        $event->getSubject()->willReturn($product);
+
+        $product->getId()->willReturn(42);
+
+        $valuesResolver->resolveEligibleValues(Argument::any())->shouldNotBeCalled();
+        $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addBooleanToProduct($event);
+    }
+
+    function it_does_not_add_boolean_values_on_an_other_entity_than_a_product(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        GenericEvent $event,
+        \stdClass $object
+    ) {
+        $event->getSubject()->willReturn($object);
+
+        $valuesResolver->resolveEligibleValues(Argument::any())->shouldNotBeCalled();
+        $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addBooleanToProduct($event);
+    }
+
+    function it_adds_boolean_value_on_product_if_there_is_a_boolean_attribute_without_data(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        GenericEvent $event,
+        Product $product,
+        FamilyInterface $family,
+        Collection $attributeCollection,
+        AttributeInterface $booleanAttribute,
+        ValueInterface $originalValue
+    ) {
+        $event->getSubject()->willReturn($product);
+
+        $product->getId()->willReturn(null);
+        $product->getFamily()->willReturn($family);
+        $family->getAttributes()->willReturn($attributeCollection);
+        $attributeCollection->toArray()->willReturn([$booleanAttribute]);
+
+        $booleanAttribute->getType()->willReturn(AttributeTypes::BOOLEAN);
+        $booleanAttribute->getCode()->willReturn('a_boolean');
+        $product->getValue('a_boolean', null, null)->willReturn($originalValue);
+        $originalValue->getData()->willReturn(null);
+
+        $valuesResolver->resolveEligibleValues([$booleanAttribute])->willReturn(['locale' => null, 'scope' => null]);
+        $entityWithValuesBuilder->addOrReplaceValue($product, $booleanAttribute, null, null, false)->shouldBeCalled();
+
+        $this->addBooleanToProduct($event);
+    }
+
+    function it_adds_boolean_value_on_product_if_there_is_a_boolean_attribute_without_value(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        GenericEvent $event,
+        Product $product,
+        FamilyInterface $family,
+        Collection $attributeCollection,
+        AttributeInterface $booleanAttribute
+    ) {
+        $event->getSubject()->willReturn($product);
+
+        $product->getId()->willReturn(null);
+        $product->getFamily()->willReturn($family);
+        $family->getAttributes()->willReturn($attributeCollection);
+        $attributeCollection->toArray()->willReturn([$booleanAttribute]);
+
+        $booleanAttribute->getType()->willReturn(AttributeTypes::BOOLEAN);
+        $booleanAttribute->getCode()->willReturn('a_boolean');
+        $product->getValue('a_boolean', null, null)->willReturn(null);
+
+        $valuesResolver->resolveEligibleValues([$booleanAttribute])->willReturn(['locale' => null, 'scope' => null]);
+        $entityWithValuesBuilder->addOrReplaceValue($product, $booleanAttribute, null, null, false)->shouldBeCalled();
+
+        $this->addBooleanToProduct($event);
+    }
+
+    function it_does_not_add_boolean_value_on_product_if_there_is_a_boolean_attribute_with_data(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        GenericEvent $event,
+        Product $product,
+        FamilyInterface $family,
+        Collection $attributeCollection,
+        AttributeInterface $booleanAttribute,
+        ValueInterface $originalValue
+    ) {
+        $event->getSubject()->willReturn($product);
+
+        $product->getId()->willReturn(null);
+        $product->getFamily()->willReturn($family);
+        $family->getAttributes()->willReturn($attributeCollection);
+        $attributeCollection->toArray()->willReturn([$booleanAttribute]);
+
+        $booleanAttribute->getType()->willReturn(AttributeTypes::BOOLEAN);
+        $booleanAttribute->getCode()->willReturn('a_boolean');
+        $product->getValue('a_boolean', null, null)->willReturn($originalValue);
+        $originalValue->getData()->willReturn(false);
+
+        $valuesResolver->resolveEligibleValues([$booleanAttribute])->willReturn(['locale' => null, 'scope' => null]);
+        $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addBooleanToProduct($event);
+    }
+
+    function it_does_not_add_boolean_value_on_product_if_there_is_no_boolean_attribute_in_its_family(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        GenericEvent $event,
+        Product $product,
+        FamilyInterface $family,
+        Collection $attributeCollection,
+        AttributeInterface $numberAttribute
+    ) {
+        $event->getSubject()->willReturn($product);
+
+        $product->getId()->willReturn(null);
+        $product->getFamily()->willReturn($family);
+        $family->getAttributes()->willReturn($attributeCollection);
+        $attributeCollection->toArray()->willReturn([$numberAttribute]);
+
+        $numberAttribute->getType()->willReturn(AttributeTypes::NUMBER);
+
+        $valuesResolver->resolveEligibleValues(Argument::any())->shouldNotBeCalled();
+        $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addBooleanToProduct($event);
+    }
+
+    function it_does_not_add_boolean_values_on_product_if_it_has_no_family(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        GenericEvent $event,
+        Product $product
+    ) {
+        $event->getSubject()->willReturn($product);
+
+        $product->getId()->willReturn(null);
+        $product->getFamily()->willReturn(null);
+
+        $valuesResolver->resolveEligibleValues(Argument::any())->shouldNotBeCalled();
+        $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addBooleanToProduct($event);
+    }
+
+    function it_adds_boolean_value_on_variant_product_if_there_is_a_boolean_attribute_without_data(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        GenericEvent $event,
+        VariantProductInterface $product,
+        FamilyVariantInterface $familyVariant,
+        VariantAttributeSetInterface $attributeSet,
+        Collection $attributeCollection,
+        AttributeInterface $booleanAttribute,
+        ValueInterface $originalValue
+    ) {
+        $event->getSubject()->willReturn($product);
+
+        $product->getId()->willReturn(null);
+        $product->getVariationLevel()->willReturn(1);
+        $product->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getVariantAttributeSet(1)->willReturn($attributeSet);
+        $attributeSet->getAttributes()->willReturn($attributeCollection);
+        $attributeCollection->toArray()->willReturn([$booleanAttribute]);
+
+        $booleanAttribute->getType()->willReturn(AttributeTypes::BOOLEAN);
+        $booleanAttribute->getCode()->willReturn('a_boolean');
+        $product->getValue('a_boolean', null, null)->willReturn($originalValue);
+        $originalValue->getData()->willReturn(null);
+
+        $valuesResolver->resolveEligibleValues([$booleanAttribute])->willReturn(['locale' => null, 'scope' => null]);
+        $entityWithValuesBuilder->addOrReplaceValue($product, $booleanAttribute, null, null, false)->shouldBeCalled();
+
+        $this->addBooleanToProduct($event);
+    }
+
+    function it_adds_boolean_value_on_variant_product_if_there_is_a_boolean_attribute_without_value(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        GenericEvent $event,
+        VariantProductInterface $product,
+        FamilyVariantInterface $familyVariant,
+        VariantAttributeSetInterface $attributeSet,
+        Collection $attributeCollection,
+        AttributeInterface $booleanAttribute
+    ) {
+        $event->getSubject()->willReturn($product);
+
+        $product->getId()->willReturn(null);
+        $product->getVariationLevel()->willReturn(1);
+        $product->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getVariantAttributeSet(1)->willReturn($attributeSet);
+        $attributeSet->getAttributes()->willReturn($attributeCollection);
+        $attributeCollection->toArray()->willReturn([$booleanAttribute]);
+
+        $booleanAttribute->getType()->willReturn(AttributeTypes::BOOLEAN);
+        $booleanAttribute->getCode()->willReturn('a_boolean');
+        $product->getValue('a_boolean', null, null)->willReturn(null);
+
+        $valuesResolver->resolveEligibleValues([$booleanAttribute])->willReturn(['locale' => null, 'scope' => null]);
+        $entityWithValuesBuilder->addOrReplaceValue($product, $booleanAttribute, null, null, false)->shouldBeCalled();
+
+        $this->addBooleanToProduct($event);
+    }
+
+    function it_does_not_add_boolean_value_on_variant_product_if_there_is_a_boolean_attribute_with_data(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        GenericEvent $event,
+        VariantProductInterface $product,
+        FamilyVariantInterface $familyVariant,
+        VariantAttributeSetInterface $attributeSet,
+        Collection $attributeCollection,
+        AttributeInterface $booleanAttribute,
+        ValueInterface $originalValue
+    ) {
+        $event->getSubject()->willReturn($product);
+
+        $product->getId()->willReturn(null);
+        $product->getVariationLevel()->willReturn(1);
+        $product->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getVariantAttributeSet(1)->willReturn($attributeSet);
+        $attributeSet->getAttributes()->willReturn($attributeCollection);
+        $attributeCollection->toArray()->willReturn([$booleanAttribute]);
+
+        $booleanAttribute->getType()->willReturn(AttributeTypes::BOOLEAN);
+        $booleanAttribute->getCode()->willReturn('a_boolean');
+        $product->getValue('a_boolean', null, null)->willReturn($originalValue);
+        $originalValue->getData()->willReturn(false);
+
+        $valuesResolver->resolveEligibleValues([$booleanAttribute])->willReturn(['locale' => null, 'scope' => null]);
+        $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addBooleanToProduct($event);
+    }
+
+    function it_does_not_add_boolean_value_on_variant_product_if_there_is_no_boolean_attribute_in_its_family(
+        $valuesResolver,
+        $entityWithValuesBuilder,
+        GenericEvent $event,
+        VariantProductInterface $product,
+        FamilyVariantInterface $familyVariant,
+        VariantAttributeSetInterface $attributeSet,
+        Collection $attributeCollection,
+        AttributeInterface $numberAttribute
+    ) {
+        $event->getSubject()->willReturn($product);
+
+        $product->getId()->willReturn(null);
+        $product->getVariationLevel()->willReturn(1);
+        $product->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getVariantAttributeSet(1)->willReturn($attributeSet);
+        $attributeSet->getAttributes()->willReturn($attributeCollection);
+        $attributeCollection->toArray()->willReturn([$numberAttribute]);
+
+        $numberAttribute->getType()->willReturn(AttributeTypes::NUMBER);
+
+        $valuesResolver->resolveEligibleValues(Argument::any())->shouldNotBeCalled();
+        $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addBooleanToProduct($event);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
@@ -86,9 +86,7 @@ class BooleanAttributeTypeCompletenessIntegration extends AbstractCompletenessPe
         $this->assertMissingAttributeForProduct($productDataNull, ['a_boolean']);
 
         $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
-        // TODO: This is not as it should be, but inevitable because of PIM-6056
-        // TODO: When PIM-6056 is fixed, we should be able to use "assertNotComplete"
-        $this->assertComplete($productWithoutValues);
+        $this->assertNotComplete($productWithoutValues);
         $this->assertBooleanValueIsFalse($productWithoutValues, 'a_boolean');
     }
 

--- a/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
@@ -4,14 +4,12 @@ namespace spec\Pim\Component\Catalog\Builder;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
-use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
 use Pim\Component\Catalog\Model\Association;
 use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\Product;
 use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\ProductEvents;
 use Pim\Component\Catalog\Repository\AssociationTypeRepositoryInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
@@ -29,7 +27,6 @@ class ProductBuilderSpec extends ObjectBehavior
         FamilyRepositoryInterface $familyRepository,
         AssociationTypeRepositoryInterface $assocTypeRepository,
         EventDispatcherInterface $eventDispatcher,
-        AttributeValuesResolverInterface $valuesResolver,
         EntityWithValuesBuilderInterface $entityWithValuesBuilder
     ) {
         $entityConfig = [
@@ -42,7 +39,6 @@ class ProductBuilderSpec extends ObjectBehavior
             $familyRepository,
             $assocTypeRepository,
             $eventDispatcher,
-            $valuesResolver,
             $entityWithValuesBuilder,
             $entityConfig
         );
@@ -61,8 +57,7 @@ class ProductBuilderSpec extends ObjectBehavior
         $eventDispatcher,
         $entityWithValuesBuilder,
         FamilyInterface $tshirtFamily,
-        AttributeInterface $identifierAttribute,
-        ValueInterface $identifierValue
+        AttributeInterface $identifierAttribute
     ) {
         $attributeRepository->getIdentifier()->willReturn($identifierAttribute);
         $entityWithValuesBuilder->addOrReplaceValue(


### PR DESCRIPTION
## Description

Because of a bug (that will be fixed, one day, in the dedicated card PIM-6056), we have to add all boolean values (to false) when creating a product.

However, this leads to a wrong behavior on variant products, when they don't possess this value, but one of their ancestor has it. In this particular case, we end up with a variant product having this boolean value, and worse having it at `false` even if the parent has it at `true`.

The proposed fix here consists to extract this boolean value adding (in the wait of a real UI fix that will make it useless), to handle variant products properly. It is mandatory that it is done after the update of the product, so we can have access to the family variant of the variant product. In the product builder, the family variant is still not set.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
