### PR TITLE
PIM-6367: Do not add boolean values on product creation anymore

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -23,10 +23,11 @@
 
 ### Constructors
 
-- Change the constructor of `Pim\Component\Connector\Processor\Normalization\ProductProcessor` to add `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
-- Change the constructor of `Pim\Component\Connector\Writer\Database\ProductModelDescendantsWriter` to remove `Pim\Component\Catalog\Builder\ProductBuilderInterface`
+- PIM-6367: Change the constructor of `Pim\Component\Connector\Processor\Normalization\ProductProcessor` to add `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
+- PIM-6367: Change the constructor of `Pim\Component\Connector\Writer\Database\ProductModelDescendantsWriter` to remove `Pim\Component\Catalog\Builder\ProductBuilderInterface`
     and to add `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
-- Change the constructor of `Pim\Bundle\DataGridBundle\Datasource\ProductDatasource` to add `Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriber`
+- PIM-6367: Change the constructor of `Pim\Bundle\DataGridBundle\Datasource\ProductDatasource` to add `Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriber`
+- PIM-6367: Change the constructor of `Pim\Component\Catalog\Builder` to remove `Pim\Component\Catalog\Manager\AttributeValuesResolverInterface`
 - Change the constructor of `Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber` to add `Akeneo\Component\StorageUtils\Saver\BulkSaverInterface` and `Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface`
 
 ### Services and parameters
@@ -37,3 +38,5 @@
 - PIM-6367: Rename class parameter `pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class` into `pim_catalog.query.elasticsearch.product_and_model_query_builder_factory.class`
 - PIM-6367: Rename class parameter `pim_enrich.query.mass_edit_product_and_product_model_query_builder.class` into `pim_catalog.query.product_and_product_model_query_builder.class`
 - PIM-6367: Rename class parameter `pim_enrich.elasticsearch.cursor_factory.class` into `pim_catalog.elasticsearch.cursor_factory.class`
+- PIM-6367: Remove argument `pim_catalog.resolver.attribute_values` from service `pim_catalog.builder.product`
+- PIM-6367: Remove argument `pim_catalog.resolver.attribute_values` from service `pim_catalog.builder.variant_product`

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/builders.yml
@@ -11,7 +11,6 @@ services:
             - '@pim_catalog.repository.family'
             - '@pim_catalog.repository.association_type'
             - '@event_dispatcher'
-            - '@pim_catalog.resolver.attribute_values'
             - '@pim_catalog.builder.entity_with_values'
             - {'product': '%pim_catalog.entity.product.class%', 'association': '%pim_catalog.entity.association.class%'}
 
@@ -22,7 +21,6 @@ services:
             - '@pim_catalog.repository.family'
             - '@pim_catalog.repository.association_type'
             - '@event_dispatcher'
-            - '@pim_catalog.resolver.attribute_values'
             - '@pim_catalog.builder.entity_with_values'
             - {'product': '%pim_catalog.entity.variant_product.class%', 'association': '%pim_catalog.entity.association.class%'}
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
@@ -86,10 +86,7 @@ class BooleanAttributeTypeCompletenessIntegration extends AbstractCompletenessPe
         $this->assertMissingAttributeForProduct($productDataNull, ['a_boolean']);
 
         $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
-        // TODO: This is not as it should be, but inevitable because of PIM-6056
-        // TODO: When PIM-6056 is fixed, we should be able to use "assertNotComplete"
-        $this->assertComplete($productWithoutValues);
-        $this->assertBooleanValueIsFalse($productWithoutValues, 'a_boolean');
+        $this->assertNotComplete($productWithoutValues);
     }
 
     /**

--- a/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
@@ -4,14 +4,12 @@ namespace spec\Pim\Component\Catalog\Builder;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
-use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
 use Pim\Component\Catalog\Model\Association;
 use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\Product;
 use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\ProductEvents;
 use Pim\Component\Catalog\Repository\AssociationTypeRepositoryInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
@@ -29,7 +27,6 @@ class ProductBuilderSpec extends ObjectBehavior
         FamilyRepositoryInterface $familyRepository,
         AssociationTypeRepositoryInterface $assocTypeRepository,
         EventDispatcherInterface $eventDispatcher,
-        AttributeValuesResolverInterface $valuesResolver,
         EntityWithValuesBuilderInterface $entityWithValuesBuilder
     ) {
         $entityConfig = [
@@ -42,7 +39,6 @@ class ProductBuilderSpec extends ObjectBehavior
             $familyRepository,
             $assocTypeRepository,
             $eventDispatcher,
-            $valuesResolver,
             $entityWithValuesBuilder,
             $entityConfig
         );
@@ -61,8 +57,7 @@ class ProductBuilderSpec extends ObjectBehavior
         $eventDispatcher,
         $entityWithValuesBuilder,
         FamilyInterface $tshirtFamily,
-        AttributeInterface $identifierAttribute,
-        ValueInterface $identifierValue
+        AttributeInterface $identifierAttribute
     ) {
         $attributeRepository->getIdentifier()->willReturn($identifierAttribute);
         $entityWithValuesBuilder->addOrReplaceValue(


### PR DESCRIPTION
## Description

### The problem

When a product is created, the product builder automatically set to `false` all boolean values, so we don't end up with a boolean value being null or non existant. According to comment in the code, it was primarily made to fix a bug on proposals.

But this create a wrong behavior on variant product. If you have a boolean attribute on its product model, then a variant product is created, the product builder will set a boolean value for this attribute to the variant product, when it should not.

In the worst case scenario, you can end up with a product model having the value to true, and the variant product to false...

### The solution

The fix here consists in removing this dirty fix, as it is not needed anymore.

The UI works now fine with our new product single storage, and the proposals behave correctly: if a product has a null boolean value, you don't have a `null => false` anymore in the proposal. And if you set the value to true, the proposal show `false => true` as it should.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
