### PR TITLE
PIM-6129 cleaning : Expose the warnings persistance method through an interface to be able to depend on it properly

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -40,3 +40,7 @@
 - PIM-6367: Rename class parameter `pim_enrich.elasticsearch.cursor_factory.class` into `pim_catalog.elasticsearch.cursor_factory.class`
 - PIM-6367: Remove argument `pim_catalog.resolver.attribute_values` from service `pim_catalog.builder.product`
 - PIM-6367: Remove argument `pim_catalog.resolver.attribute_values` from service `pim_catalog.builder.variant_product`
+
+### Interfaces
+
+- Add method `Akeneo\Component\Batch\Job\JobRepositoryInterface::addWarning`

--- a/src/Akeneo/Component/Batch/Job/JobRepositoryInterface.php
+++ b/src/Akeneo/Component/Batch/Job/JobRepositoryInterface.php
@@ -5,6 +5,7 @@ namespace Akeneo\Component\Batch\Job;
 use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Model\Warning;
 
 /**
  * Common interface for Job repositories which should handle how job are stored, updated
@@ -71,4 +72,6 @@ interface JobRepositoryInterface
      * @param array $jobsExecutions
      */
     public function remove(array $jobsExecutions);
+
+    public function addWarning(Warning $warning): void;
 }

--- a/src/Akeneo/Component/Batch/Step/ItemStep.php
+++ b/src/Akeneo/Component/Batch/Step/ItemStep.php
@@ -10,6 +10,7 @@ use Akeneo\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Component\Batch\Item\ItemWriterInterface;
 use Akeneo\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Model\Warning;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -21,17 +22,17 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class ItemStep extends AbstractStep
 {
-    /** @var int */
-    protected $batchSize;
-
     /** @var ItemReaderInterface */
     protected $reader = null;
+
+    /** @var ItemProcessorInterface */
+    protected $processor = null;
 
     /** @var ItemWriterInterface */
     protected $writer = null;
 
-    /** @var ItemProcessorInterface */
-    protected $processor = null;
+    /** @var int */
+    protected $batchSize;
 
     /** @var StepExecution */
     protected $stepExecution = null;
@@ -200,12 +201,14 @@ class ItemStep extends AbstractStep
         $element,
         InvalidItemException $e
     ) {
-        $this->jobRepository->insertWarning(
+        $warning = new Warning(
             $stepExecution,
             $e->getMessage(),
             $e->getMessageParameters(),
             $e->getItem()->getInvalidData()
         );
+
+        $this->jobRepository->addWarning($warning);
 
         $this->dispatchInvalidItemEvent(
             get_class($element),

--- a/src/Akeneo/Component/Batch/spec/Step/ItemStepSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Step/ItemStepSpec.php
@@ -12,6 +12,7 @@ use Akeneo\Component\Batch\Item\ItemWriterInterface;
 use Akeneo\Component\Batch\Job\BatchStatus;
 use Akeneo\Component\Batch\Job\ExitStatus;
 use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Model\Warning;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -25,7 +26,15 @@ class ItemStepSpec extends ObjectBehavior
         ItemProcessorInterface $processor,
         ItemWriterInterface $writer
     ) {
-        $this->beConstructedWith('myname', $dispatcher, $repository, $reader, $processor, $writer, 3);
+        $this->beConstructedWith(
+            'myname',
+            $dispatcher,
+            $repository,
+            $reader,
+            $processor,
+            $writer,
+            3
+        );
     }
 
     function it_executes_with_success(
@@ -100,8 +109,9 @@ class ItemStepSpec extends ObjectBehavior
             new InvalidItemException('my msg', new FileInvalidItem(['r4'], 7))
         );
 
+        $warning = new Warning($execution->getWrappedObject(), 'my msg', [], ['r4']);
         $repository
-            ->insertWarning($execution, 'my msg', [], ['r4'])
+            ->addWarning($warning)
             ->shouldBeCalled();
         $dispatcher->dispatch(Argument::any(), Argument::any())->shouldBeCalled();
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**Problem**
In 1.5.23 @damien-carcel wrote a fix for a memory leak (https://github.com/akeneo/pim-community-dev/pull/6300). The solution was to persist step warnings direcly using the DBAL, and for that he created a dedicated method `insertWarning` in the `DoctrineJobRepository`. But since it was a patch he didn't want to do a BC break, so the method was used by the `ItemStep` without being part of the contract.

**Solution**
As stated in the original PR, the new method should be part of an interface. I added this method in the `JobRepositoryInterface` even if it can feel weird because doing it in a separated interface would imply adding a new dependency to `ItemStep` and rewriting all the step definitions (plus it would be a lot of work for integrators too).
I also renamed the method and reused the `Warning` entity to have a cleaner signature.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
