### PR TITLE
GITHUB-7373: Use a translation instead of hard coded string

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -53,3 +53,7 @@
 ### Interfaces
 
 - Add method `Akeneo\Component\Batch\Job\JobRepositoryInterface::addWarning`
+
+## Have a better UX/UI
+
+- GITHUB-7373: Add translation for 'select action' in mass edit instead of hard coded string 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/mass-edit/form.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/mass-edit/form.html
@@ -67,7 +67,7 @@
         <div class="AknSteps">
             <div class="AknSteps-step<% if (currentStepNumber > 0) { %> AknSteps-step--checked<% } %>">
                 <div class="AknSteps-stepCircle"></div>
-                Select action
+                <%- __('pim_enrich.mass_edit.select_action') %>
             </div>
             <% if (currentStep === 'choose') { %>
             <div class="AknSteps-step AknSteps-step--undefined">

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -1022,6 +1022,7 @@ pim_enrich:
         previous: Back
         cancel: Cancel
         confirm: Confirm
+        select_action: Select action
         product:
             title: Products bulk action
             confirm: "{1}You are about to update a product with the following information, please confirm.|] 1, Inf [You are about to update {{ itemsCount }} products with the following information, please confirm."


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Fix #7373 
Use a translation instead of hard coded string.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
