### PR TITLE
Use correct variant labels when using reference data.

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
@@ -175,6 +175,11 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
                         $valuesForLocale[] = empty($label) ? '[' . $option->getCode() . ']' : $label;
 
                         break;
+                    case AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT:
+                        $option = $value->getData();
+                        $valuesForLocale[] = (string) $option;
+
+                        break;
                     case AttributeTypes::METRIC:
                         $valuesForLocale[] = sprintf(
                             '%s %s',


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When using a simple-select reference data attribute for a variant axis, the attribute's code is used for the attribute value drop down in the product model navigation bar. Use the select labels instead of the select values by casting the reference data options to strings which eventually uses getLabelProperty().