### PR TITLE
PIM-7166: Get field icons on both products and product models

### DIFF
--- a/features/Context/Page/Base/ProductEditForm.php
+++ b/features/Context/Page/Base/ProductEditForm.php
@@ -55,6 +55,18 @@ class ProductEditForm extends Form
     }
 
     /**
+     * @param string $label
+     *
+     * @return NodeElement[]
+     */
+    public function findFieldIcons($label)
+    {
+        $field = $this->findFieldContainer($label);
+
+        return $field->findAll('css', 'i[class*="icon-"]');
+    }
+
+    /**
      * This method allows to fill a field by passing the label
      *
      * @param string  $label

--- a/features/Context/Page/Product/Edit.php
+++ b/features/Context/Page/Product/Edit.php
@@ -253,18 +253,6 @@ class Edit extends ProductEditForm
     }
 
     /**
-     * @param string $label
-     *
-     * @return NodeElement[]
-     */
-    public function findFieldIcons($label)
-    {
-        $field = $this->findFieldContainer($label);
-
-        return $field->findAll('css', 'i[class*="icon-"]');
-    }
-
-    /**
      * @param string $name
      *
      * @return NodeElement[]


### PR DESCRIPTION
## Description

Field icons could currently be only tested on products. This PR allows that both (variant) products and product models can, only by moving a method from a class to the one it inherits from.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
