### PR TITLE
Fix #7614 wrong base_url for js routes when using dev environment

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -29,3 +29,6 @@ oro_assetic:
 
 swiftmailer:
     disable_delivery: true
+
+parameters:
+    router.request_context.base_url: "/app_dev.php"


### PR DESCRIPTION
I guess I found a bug affecting all 2.X versions.

I found the bug while testing some import/export customization where I was using the dev front controller app_dev.php and see who all Ajax request were performed to the prod front controller app.php. In fact all or at least all routes genereated in JS by the FOSJsRoutingBundle are wrong when using the environment.

After debugging I found that the base_url under web/js/routes.js is empty what is ok if you're using prod but it should be app_dev.php when using dev.

This PR fix the problem.
