### PR TITLE
PoC: Remove UI from import tests

### DIFF
--- a/.ci/behat.community.yml
+++ b/.ci/behat.community.yml
@@ -70,6 +70,8 @@ legacy:
                     - 1024
                 - Pim\Behat\Context\JobContext:
                     - 'Context\FeatureContext'
+                - Pim\Behat\Context\ImportFileContext:
+                    - 'Context\FeatureContext'
                 - Pim\Behat\Context\Storage\FileInfoStorage:
                     - 'Context\FeatureContext'
                 - Pim\Behat\Context\Storage\ProductStorage:

--- a/.ci/behat.enterprise.yml
+++ b/.ci/behat.enterprise.yml
@@ -81,6 +81,8 @@ default:
                     - 1024
                 - PimEnterprise\Behat\Context\JobContext:
                     - 'Context\EnterpriseFeatureContext'
+                - Pim\Behat\Context\ImportFileContext:
+                    - 'Context\FeatureContext'
                 - PimEnterprise\Behat\Context\NavigationContext:
                     - 'Context\EnterpriseFeatureContext'
                     - 'http://127.0.0.1/'

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -67,6 +67,8 @@ legacy:
                     - 1024
                 - Pim\Behat\Context\JobContext:
                     - 'Context\FeatureContext'
+                - Pim\Behat\Context\ImportFileContext:
+                    - 'Context\FeatureContext'
                 - Pim\Behat\Context\Storage\FileInfoStorage:
                     - 'Context\FeatureContext'
                 - Pim\Behat\Context\Storage\ProductStorage:

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -24,6 +24,7 @@ use Pim\Behat\Context\Domain\Spread\XlsxFileContext;
 use Pim\Behat\Context\Domain\System\PermissionsContext;
 use Pim\Behat\Context\Domain\TreeContext;
 use Pim\Behat\Context\HookContext;
+use Pim\Behat\Context\ImportFileContext;
 use Pim\Behat\Context\JobContext;
 use Pim\Behat\Context\PimContext;
 use Pim\Behat\Context\Storage\FileInfoStorage;
@@ -106,6 +107,7 @@ class FeatureContext extends PimContext implements KernelAwareContext
         $this->contexts['domain-group'] = $environment->getContext(ProductGroupContext::class);
         $this->contexts['hook'] = $environment->getContext(HookContext::class);
         $this->contexts['job'] = $environment->getContext(JobContext::class);
+        $this->contexts['importFile'] = $environment->getContext(ImportFileContext::class);
         $this->contexts['viewSelector'] = $environment->getContext(ViewSelectorContext::class);
         $this->contexts['storage-product'] = $environment->getContext(ProductStorage::class);
         $this->contexts['storage-file-info'] = $environment->getContext(FileInfoStorage::class);

--- a/features/Pim/Behat/Context/ImportFileContext.php
+++ b/features/Pim/Behat/Context/ImportFileContext.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Pim\Behat\Context;
+
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\JobInstance;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\TableNode;
+use Context\Spin\SpinCapableTrait;
+use PHPUnit\Framework\Assert;
+
+/**
+ * This context aims to contain all methods to the launch of a job.
+ *
+ * When we launch a job, we keep in this context the job instance and execution so that we can
+ * check what happens in a next step (and yes, that means this class is completely stateful).
+ * For instance, we want to check that 1 item has been skipped.
+ *
+ * This also allows to not use several time the same name of a job in the different steps of a use case.
+ * It gives a more natural language.
+ *
+ * In this context, there is no notion of who launched the job. This is made on purpose, don't try to
+ * introduce it later, it makes no sense. The goal is to test the imports coming from an external application,
+ * or required at the setup of the application. Those imports are made by a CLI, not by a human.
+ */
+final class ImportFileContext extends PimContext implements SnippetAcceptingContext
+{
+    use SpinCapableTrait;
+
+    /** @var JobInstance */
+    private $jobInstance;
+
+    /** @var JobExecution */
+    private $jobExecution;
+
+    private const USERNAME_FOR_JOB_LAUNCH = 'admin';
+
+    /**
+     * @When the :entities are imported via the job :jobName
+     */
+    public function entitiesAreImportedViaTheJob($entities, $jobName)
+    {
+        $this->entitiesAreImportedViaTheJobWithOptions($entities, $jobName, new TableNode([]));
+    }
+
+    /**
+     * @When the :entities are imported via the job :jobName with options:
+     */
+    public function entitiesAreImportedViaTheJobWithOptions($entities, $jobName, TableNode $jobOptions)
+    {
+        $newJobOptions = new TableNode(
+            array_merge($jobOptions->getTable(), [['filePath', self::$placeholderValues['%file to import%']]])
+        );
+
+        $this->jobInstance = $this->mainContext->getSubcontext('job')->theFollowingJobConfiguration($jobName, $newJobOptions);
+
+        $user = $this->getFixturesContext()->getUser(self::USERNAME_FOR_JOB_LAUNCH);
+
+        $launcher = $this->mainContext->getContainer()->get('akeneo_batch.launcher.simple_job_launcher');
+        $launcher->launch($this->jobInstance, $user);
+
+        $this->jobExecution = $this->waitForJobToFinish($this->jobInstance);
+    }
+
+    /**
+     * @Then there should be :number product(s) skipped because there is no difference
+     */
+    public function thereShouldBeProductSkippedBecauseThereIsNoDifference($number)
+    {
+        $productsSkipped = array_map(function ($stepExecution) {
+            return $stepExecution->getSummaryInfo('product_skipped_no_diff');
+        }, $this->jobExecution->getStepExecutions()->toArray());
+
+        Assert::assertEquals($productsSkipped[1], $number);
+    }
+
+    private function waitForJobToFinish(JobInstance $jobInstance): JobExecution
+    {
+        $jobInstance->getJobExecutions()->setInitialized(false);
+        $this->getFixturesContext()->refresh($jobInstance);
+        $jobExecution = $jobInstance->getJobExecutions()->last();
+
+        $this->spin(function () use ($jobExecution) {
+            $this->getFixturesContext()->refresh($jobExecution);
+
+            return $jobExecution && !$jobExecution->isRunning();
+        }, sprintf('The job execution of "%s" was too long', $jobInstance->getJobName()));
+
+        return $jobExecution;
+    }
+}

--- a/features/Pim/Behat/Context/JobContext.php
+++ b/features/Pim/Behat/Context/JobContext.php
@@ -71,6 +71,8 @@ class JobContext extends PimContext
 
         $saver = $this->getMainContext()->getContainer()->get('akeneo_batch.saver.job_instance');
         $saver->save($jobInstance);
+
+        return $jobInstance;
     }
 
     /**

--- a/features/import/import_currencies.feature
+++ b/features/import/import_currencies.feature
@@ -1,40 +1,29 @@
-@javascript
-Feature: Import currencies
+Feature: Setup currencies via import
   In order to setup my application
   As an administrator
   I need to be able to import currencies
 
   Scenario: Successfully import new currency in CSV
     Given the "footwear" catalog configuration
-    And I am logged in as "Julia"
     And the following CSV file to import:
       """
       code;activated
       AMD;1
       """
-    And the following job "csv_footwear_currency_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_currency_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_currency_import" job to finish
+    When the currencies are imported via the job csv_footwear_currency_import
     Then there should be the following currencies:
       | code | activated |
       | AMD  | 1         |
 
   Scenario: Successfully update existing currency and add a new one
     Given the "footwear" catalog configuration
-    And I am logged in as "Julia"
     And the following CSV file to import:
       """
       code;activated
       AMD;1
       ARM;0
       """
-    And the following job "csv_footwear_currency_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_currency_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_currency_import" job to finish
+    When the currencies are imported via the job csv_footwear_currency_import
     Then there should be the following currencies:
       | code | activated |
       | AMD  | 1         |

--- a/features/import/product/import_products.feature
+++ b/features/import/product/import_products.feature
@@ -1,15 +1,13 @@
-@javascript
-Feature: Execute a job
-  In order to use existing product information
-  As a product manager
-  I need to be able to import products
+Feature: Import products coming from an external application
+  In order to enrich existing product information
+  As an administrator
+  I need to be able to import products regularly
 
   Background:
     Given the "footwear" catalog configuration
     And the following product groups:
       | code  | label-en_US | type    |
       | CROSS | Bag Cross   | RELATED |
-    And I am logged in as "Julia"
 
   Scenario: Successfully import a csv file of products
     Given the following CSV file to import:
@@ -26,11 +24,7 @@ Feature: Execute a job
       SKU-009;sneakers;;;porttitor;sagittis. Duis gravida. Praesent eu nulla at sem molestie sodales.
       SKU-010;boots;CROSS;sandals;non,;vestibulum nec, euismod in, dolor. Fusce feugiat. Lorem ipsum dolor
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then there should be 10 products
     And the family of the product "SKU-006" should be "boots"
     And product "SKU-007" should be enabled
@@ -49,11 +43,7 @@ Feature: Execute a job
 
       "
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then there should be 1 products
     And the english tablet description of "SKU-001" should be "dictum magna. Ut tincidunt|NL|orci quis lectus.|NL||NL|Nullam suscipit,|NL|est|NL||NL|"
 
@@ -64,11 +54,7 @@ Feature: Execute a job
       SKU-001;boots;;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est
       SKU-001;sneakers;;winter_boots;Donex;Pellentesque habitant morbi tristique senectus et netus et malesuada fames
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then there should be 1 product
     And the english localizable value name of "SKU-001" should be "Donec"
     And the english tablet description of "SKU-001" should be "dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est"
@@ -79,11 +65,7 @@ Feature: Execute a job
       sku;family;groups;categories;name-en_US;description-en_US-tablet;comment
       SKU-001;boots;;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est;This comment should not be imported
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then the product "SKU-001" should not have the following values:
       | comment |
 
@@ -96,17 +78,15 @@ Feature: Execute a job
       sku;family;groups;categories;name-en_US;description-en_US-tablet
       SKU-001;boots;;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then there should be 1 product
     And the english localizable value name of "SKU-001" should be "Donec"
     And the english tablet description of "SKU-001" should be "dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est"
 
+  @javascript
   Scenario: Successfully import products through file upload
-    Given the following CSV file to import:
+    Given I am logged in as "Julia"
+    And the following CSV file to import:
       """
       sku;family;groups;categories;name-en_US;description-en_US-tablet
       SKU-001;boots;;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est
@@ -134,11 +114,7 @@ Feature: Execute a job
       SKU-001;"100 EUR, 90 USD"
       SKU-002;50 EUR
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then there should be 2 products
     And the product "SKU-001" should have the following value:
       | price | 100.00 EUR, 90.00 USD |
@@ -154,11 +130,7 @@ Feature: Execute a job
       sku;price
       SKU-001;"100 EUR, 90 USD"
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then there should be 1 products
     And the product "SKU-001" should have the following value:
       | price | 100.00 EUR, 90.00 USD |
@@ -169,11 +141,7 @@ Feature: Execute a job
       sku;length
       SKU-001;4000 CENTIMETER
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then there should be 1 products
     And the product "SKU-001" should have the following value:
       | length | 4000.0000 CENTIMETER |
@@ -184,11 +152,7 @@ Feature: Execute a job
       sku;length;length-unit
       SKU-001;4000;CENTIMETER
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then there should be 1 products
     And the product "SKU-001" should have the following value:
       | length | 4000.0000 CENTIMETER |
@@ -202,29 +166,21 @@ Feature: Execute a job
       sku;family;categories;name-en_US;description-en_US-tablet
       SKU-001;boots;winter_boots;FooBar;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then there should be 1 product
-    And I should see the text "skipped product (no differences) 1"
+    And there should be 1 product skipped because there is no difference
 
   Scenario: Successfully import products with attributes with full numeric codes
-    And the following family:
+    Given the following family:
       | code      | attributes           |
       | my_family | name,123,description |
-    Given the following CSV file to import:
+    And the following CSV file to import:
       """
       sku;123;family;groups;categories;name-en_US;description-en_US-tablet
       SKU-001;aaa;my_family;;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est
       SKU-002;bbb;my_family;;winter_boots;Donex;Pellentesque habitant morbi tristique senectus et netus et malesuada fames
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then there should be 2 product
     And the product "SKU-001" should have the following values:
       | name-en_US | Donec |
@@ -240,11 +196,7 @@ Feature: Execute a job
       SKU-001;boots
       SKU-002;sneakers
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then there should be 2 products
 
   Scenario: Successfully import a csv file of products without enabled column default yes
@@ -253,7 +205,7 @@ Feature: Execute a job
       | SKU-001 | John Deere | Best of tractors                            | no      |
       | SKU-002 | Class      | Leader in agricultural harvesting equipment | yes     |
       | SKU-003 | Renault    | French Tractors                             | no      |
-    Given the following CSV file to import:
+    And the following CSV file to import:
       """
       sku;name-en_US;description-en_US-tablet
       SKU-001;John Deere;Go fast with John Deere
@@ -261,12 +213,8 @@ Feature: Execute a job
       SKU-003;Renault;French touch for tractors
       SKU-004;New Holland;Faster tractors
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-      | enabled  | yes              |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import with options:
+      | enabled | yes |
     Then there should be 4 products
     And product "SKU-001" should be disabled
     And product "SKU-002" should be enabled
@@ -279,7 +227,7 @@ Feature: Execute a job
       | SKU-001 | John Deere | Best of tractors                            | no      |
       | SKU-002 | Class      | Leader in agricultural harvesting equipment | yes     |
       | SKU-003 | Renault    | French Tractors                             | no      |
-    Given the following CSV file to import:
+    And the following CSV file to import:
       """
       sku;name-en_US;description-en_US-tablet
       SKU-001;John Deere;Go fast with John Deere
@@ -287,20 +235,18 @@ Feature: Execute a job
       SKU-003;Renault;French touch for tractors
       SKU-004;New Holland;Faster tractors
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-      | enabled  | no               |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import with options:
+      | enabled | no |
     Then there should be 4 products
     And product "SKU-001" should be disabled
     And product "SKU-002" should be enabled
     And product "SKU-003" should be disabled
     And product "SKU-004" should be disabled
 
+  @javascript
   Scenario: Successfully import products when category code is integer
-    Given the following products:
+    Given I am logged in as "Julia"
+    And the following products:
       | sku    |
       | jacket |
     And I am on the category "2014_collection" node creation page
@@ -312,15 +258,13 @@ Feature: Execute a job
       sku;categories
       jacket;123
       """
-    And the following job "csv_footwear_product_import" configuration:
-      | filePath | %file to import% |
-    When I am on the "csv_footwear_product_import" import job page
-    And I launch the import job
-    And I wait for the "csv_footwear_product_import" job to finish
+    When the products are imported via the job csv_footwear_product_import
     Then the category of the product "jacket" should be "123"
 
+  @javascript
   Scenario: Successfully import a csv file of products and the completeness should be computed
-    Given the following CSV file to import:
+    Given I am logged in as "Julia"
+    And the following CSV file to import:
       """
       sku;family;groups;categories;name-en_US;description-en_US-tablet;price;size;color
       SKU-001;boots;similar_boots;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est;"100 EUR, 90 USD";40;
@@ -345,8 +289,10 @@ Feature: Execute a job
       | mobile  | en_US  | success | 0              | 100%  |
 
   @jira https://akeneo.atlassian.net/browse/PIM-6085
+  @javascript
   Scenario: Successfully import product associations with modified column name
-    Given the following CSV file to import:
+    Given I am logged in as "Julia"
+    And the following CSV file to import:
       """
       sku;family;groupes;catégories;name-en_US;description-en_US-tablet;price;size;color
       SKU-001;boots;similar_boots;winter_boots;Donec;dictum magna. Ut tincidunt orci quis lectus. Nullam suscipit, est;"100 EUR, 90 USD";40;


### PR DESCRIPTION
## Description

All our import and export Behat currently uses the UI to work.
We log in, configure our job, go to the job page, and click on the "Launch" button of the UI.

This is very time consuming because we boot a browser and Selenium.
This is also useless, as jobs can be launched and tested directly via a CLI.

So, that's the idea of this PR. To test imports/exports via the CLI instead of the UI.
This is not perfect. The ideal would to turn most of those system tests into real acceptance tests. But it's more work. 

**With that simple way of doing, each refactored Behat is twice faster.**

This PR works as is and can be considered as an example to rewrite all other import and export tests.

## About the code 
- we created a new job context, to not pollute the original one. The new one is dedicated to a job you've launched and what you check once the job is finished. It reuses as many code as possible.
- we have a new Gherkin syntax, more natural, to express the fact we import things from a file
