### PR TITLE
Revert strtolower() breaking the API.

### DIFF
--- a/src/Pim/Component/Api/Converter/MeasureFamilyConverter.php
+++ b/src/Pim/Component/Api/Converter/MeasureFamilyConverter.php
@@ -19,7 +19,7 @@ class MeasureFamilyConverter implements ArrayConverterInterface
     public function convert(array $item, array $options = [])
     {
         $convertedItem = [
-            'code'     => strtolower($item['family_code']),
+            'code'     => $item['family_code'],
             'standard' => $item['units']['standard'],
             'units'    => $this->convertUnits($item['units']),
         ];


### PR DESCRIPTION
https://github.com/akeneo/pim-community-dev/commit/cadca92df524ae6a6302ec6f980ce928824348e7#diff-cbad51a55f129ace6efc31ecb41ec3f1R22 refers to a change introduced when adding pagination for API "list" requests in version 2.0. Unfortunately a strtolower() has slipped in there too, which makes the output of the measure-families "list" action incompatible with any measure family properties in other API endpoints. E.g. the API returns a measure family code of "area" while anywhere else I have to use "Area". Thus I can no longer work with measure families returned from the API.