### PR TITLE
PIM-7151: Remove family limit used on export profile

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -6,6 +6,7 @@
 - PIM-7169: Fix a memory leak on product export when having many variant groups
 - PIM-7170: Fix media files unnecessarily generated during quick export
 - PIM-7182: Fix the clean mongodb command for reference data
+- PIM-7151: Fix the family filter display on import/export profile
 
 ## Security fixes
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
@@ -54,6 +54,7 @@ class FamilyController
         $options = $request->query->get('options', ['limit' => 20]);
 
         if ($request->query->has('identifiers')) {
+            $options = $request->query->get('options');
             $options['identifiers'] = explode(',', $request->query->get('identifiers'));
         }
 


### PR DESCRIPTION
**Description**

When you select more than 20 families to export in the Family Field, only 20 are displayed whereas they are all well exported.
Expected behaviour: all selected families should be displayed in the family field.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
