### PR TITLE
[fix] Sort natively columns if localized

### DIFF
--- a/src/Pim/Component/Connector/Writer/File/DefaultColumnSorter.php
+++ b/src/Pim/Component/Connector/Writer/File/DefaultColumnSorter.php
@@ -72,10 +72,14 @@ class DefaultColumnSorter implements ColumnSorterInterface
      */
     protected function compare($a, $b)
     {
-        $a = $this->getColumnCode($a);
-        $b = $this->getColumnCode($b);
+        $ca = $this->getColumnCode($a);
+        $cb = $this->getColumnCode($b);
 
-        return array_search($a, $this->firstDefaultColumns) - array_search($b, $this->firstDefaultColumns);
+        if ($ca == $cb) {
+            return strnatcmp($a, $b);
+        } else {
+            return array_search($a, $this->firstDefaultColumns) - array_search($b, $this->firstDefaultColumns);
+        }
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

DefaultColumnSort has a weird behaviour for label field when this field is translatable

Example: the column sort is really weird for human :
code;label-hu_HU;label-fr_FR;label-it_CH;label-it_IT;label-sl_SI;label-ru_RU;label-pl_PL;label-fr_CH;label-es_ES;label-de_DE;label-de_CH;label-de_AT;label-en_FI;label-en_GB;label-en_US;label-en_SE;label-fr_CA;description-de_AT;description-de_CH;description-de_DE;description-en_FI;description-en_GB;description-en_SE;description-en_US;description-es_ES;description-fr_CA;description-fr_CH;description-fr_FR;description-hu_HU;description-it_CH;description-it_IT;description-pl_PL;description-ru_RU;description-sl_SI


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no
| Added Behats                      | no
| Added integration tests           | no
| Changelog updated                 | no
| Review and 2 GTM                  | no
| Micro Demo to the PO (Story only) | no
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
