### PR TITLE
Add a pim_dev_src_folder_location to avoid to change the std paramete…

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -5,7 +5,6 @@ imports:
     - { resource: '@PimEnrichBundle/Resources/config/pim.yml' }
 
 framework:
-    #esi:             ~
     translator:      { fallback: en }
     secret:          "%secret%"
     router:
@@ -64,3 +63,6 @@ pim_reference_data:
     color:
         class: Acme\Bundle\AppBundle\Entity\Color
         type: simple
+
+parameters:
+    pim_ce_dev_src_folder_location: '%kernel.project_dir%'

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -53,4 +53,4 @@ parameters:
 
     # Files used as configuration for the Elasticsearch index
     elasticsearch_index_configuration_files:
-        - '%kernel.root_dir%/../src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml'
+        - '%pim_ce_dev_src_folder_location%/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml'


### PR DESCRIPTION
…r file each time we release

**Description (for Contributor and Core Developer)**

Each time we release a new version of the PIM, we encounter this bug: akeneo/michel-tag#21 because the pim_parameters file is copied from dev to std. The problem is that the es config file path is relative and is different from dev to std. This PR intend to add a pim_ce_dev_src_folder_location to the container to have always the same path between dev and std.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
