### PR TITLE
[SLA] PIM-7168: fix "status" filter on job tracker datagrid

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -1,3 +1,7 @@
+# 2.1.x
+
+- PIM-7168: Fix "status" filter on job tracker datagrid
+
 # 2.1.4 (2018-02-01)
 
 # 2.1.3 (2018-02-01)

--- a/features/job-tracker/filter_job_executions.feature
+++ b/features/job-tracker/filter_job_executions.feature
@@ -1,0 +1,30 @@
+@javascript
+Feature: Filter jobs execution in job tracker
+  In order to easily find some jobs
+  As a regular user
+  I need to be able to filter the job executions in the job tracker
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7168
+  Scenario Outline: Successfully filter job executions
+    Given a "default" catalog configuration
+    And I am logged in as "Julia"
+    And the following CSV file to import:
+      """
+      sku
+      my_sku
+      """
+    And the following job "csv_default_product_import" configuration:
+      | filePath | %file to import% |
+    And I am on the "csv_default_product_import" export job page
+    And I launch the import job
+    And I wait for the "csv_default_product_import" job to finish
+    And I am on the job tracker page
+    When I show the filter "<filter>"
+    And I filter by "<filter>" with operator "<operator>" and value "<value>"
+    Then the grid should contain <count> elements
+    Then I should see entities <result>
+
+    Examples:
+      | filter | operator    | value     | result                     | count |
+      | status | is equal to | Completed | CSV default product import | 1     |
+      | status | is equal to | Started   |                            | 0     |

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
@@ -62,7 +62,7 @@ datagrid:
                     data_name: j.type
                 status:
                     type:             choice
-                    data_name:        status
+                    data_name:        e.status
                     options:
                         field_options:
                             multiple: true


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

amazing SLA, the filter of the status of the datagrid was not correctly configured.

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
