### PR TITLE
PIM-7165: Add "FamilyVariantInterface::getLevelForAttributeCode"

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -53,3 +53,4 @@
 ### Interfaces
 
 - Add method `Akeneo\Component\Batch\Job\JobRepositoryInterface::addWarning`
+- PIM-7165: Add method `Pim\Component\Catalog\Model\FamilyInterface::getLevelForAttributeCode`

--- a/src/Pim/Component/Catalog/Model/FamilyVariant.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariant.php
@@ -90,7 +90,7 @@ class FamilyVariant implements FamilyVariantInterface
      */
     public function getVariantAttributeSet(int $level): ?VariantAttributeSetInterface
     {
-        if ($level <= 0) {
+        if (0 >= $level) {
             throw new \InvalidArgumentException('The level must be greater than 0');
         }
 
@@ -241,6 +241,40 @@ class FamilyVariant implements FamilyVariantInterface
     public function getTranslationFQCN()
     {
         return FamilyVariantTranslation::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLevelForAttributeCode(string $attributeCode): int
+    {
+        if (!$this->getFamily()->hasAttributeCode($attributeCode)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Impossible to get variation level for attribute "%s", as family "%" does not contain it.',
+                $attributeCode,
+                $this->getFamily()->getCode()
+            ));
+        }
+
+        $level = 0;
+
+        foreach ($this->variantAttributeSets as $attributeSet) {
+            $variantAttributeSetHasAttribute = false;
+
+            foreach ($attributeSet->getAttributes() as $attribute) {
+                if ($attribute->getCode() === $attributeCode) {
+                    $variantAttributeSetHasAttribute = true;
+                    break;
+                }
+            }
+
+            if ($variantAttributeSetHasAttribute) {
+                $level = $attributeSet->getLevel();
+                break;
+            }
+        }
+
+        return $level;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
@@ -80,6 +80,15 @@ interface FamilyVariantInterface extends TranslatableInterface
     public function getNumberOfLevel(): int;
 
     /**
+     * Returns the variant attribute set level in which a given attribute is located.
+     *
+     * @param string $attributeCode
+     *
+     * @return int
+     */
+    public function getLevelForAttributeCode(string $attributeCode): int;
+
+    /**
      * Get available axes attribute types
      *
      * @return array

--- a/src/Pim/Component/Catalog/spec/Model/FamilyVariantSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/FamilyVariantSpec.php
@@ -5,7 +5,10 @@ namespace spec\Pim\Component\Catalog\Model;
 use Akeneo\Component\Localization\Model\TranslatableInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Pim\Bundle\CatalogBundle\Entity\Attribute;
+use Pim\Bundle\CatalogBundle\Entity\Family;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSet;
 use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
 use Pim\Component\Catalog\Model\CommonAttributeCollection;
 use Pim\Component\Catalog\Model\FamilyInterface;
@@ -136,5 +139,72 @@ class FamilyVariantSpec extends ObjectBehavior
         $this->shouldThrow(\InvalidArgumentException::class)->during('getVariantAttributeSet', [
             0,
         ]);
+    }
+
+    function it_throws_an_exception_if_family_variant_does_not_contain_asked_attribute_code()
+    {
+        $attribute = new Attribute();
+        $attribute->setCode('name');
+
+        $family = new Family();
+        $family->addAttribute($attribute);
+        $this->setFamily($family);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during('getLevelForAttributeCode', ['description']);
+    }
+
+    function it_gets_the_attribute_set_level_for_provided_attribute_code()
+    {
+        $name = new Attribute();
+        $name->setCode('name');
+
+        $variantAttributeSet = new VariantAttributeSet();
+        $variantAttributeSet->addAttribute($name);
+        $variantAttributeSet->setLevel(1);
+
+        $family = new Family();
+        $family->addAttribute($name);
+        $this->setFamily($family);
+        $this->addVariantAttributeSet($variantAttributeSet);
+
+        $this->getLevelForAttributeCode('name')->shouldReturn(1);
+    }
+
+    function it_gets_the_attribute_set_level_for_provided_axis_code()
+    {
+        $color = new Attribute();
+        $color->setCode('color');
+
+        $variantAttributeSet = new VariantAttributeSet();
+        $variantAttributeSet->setAxes([$color]);
+        $variantAttributeSet->setLevel(1);
+
+        $family = new Family();
+        $family->addAttribute($color);
+        $this->setFamily($family);
+        $this->addVariantAttributeSet($variantAttributeSet);
+
+        $this->getLevelForAttributeCode('color')->shouldReturn(1);
+    }
+
+    function it_gets_the_attribute_set_level_for_provided_common_attribute_code()
+    {
+        $color = new Attribute();
+        $color->setCode('color');
+
+        $name = new Attribute();
+        $name->setCode('name');
+
+        $variantAttributeSet = new VariantAttributeSet();
+        $variantAttributeSet->setAxes([$color]);
+        $variantAttributeSet->setLevel(1);
+
+        $family = new Family();
+        $family->addAttribute($color);
+        $family->addAttribute($name);
+        $this->setFamily($family);
+        $this->addVariantAttributeSet($variantAttributeSet);
+
+        $this->getLevelForAttributeCode('name')->shouldReturn(0);
     }
 }


### PR DESCRIPTION
## Description

Add a new method in the family variant to know to which variant level an attribute belongs too (if it belongs to the family of the family variant at all).

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
