### PR TITLE
PIM-7170 Fix media files unnecessarily generated during quick export

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -8,6 +8,10 @@
 
 - PIM-7116: Fix multiple CRSF vulnerabilities on several endpoints by allowing only XHR calls (see https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Protecting_REST_Services:_Use_of_Custom_Request_Headers)
 
+## Bug fixes
+
+- PIM-7170: Fix media files unnecessarily generated during quick export
+
 # 1.6.21 (2018-01-11)
 
 ## Bug fixes

--- a/features/mass-action/quick_export_with_media.feature
+++ b/features/mass-action/quick_export_with_media.feature
@@ -57,3 +57,20 @@ Feature: Quick export many products with media from datagrid
     And export directory of "xlsx_product_quick_export" should contain the following media:
       | files/boots/side_view/akeneo.jpg     |
       | files/sneakers/side_view/akeneo2.jpg |
+
+  Scenario: Successfully quick export products with media without selecting the attribute media in the grid
+    Given I am on the products page
+    When I select rows boots, sandals
+    And I press "CSV (Grid context)" on the "Quick Export" dropdown button
+    And I wait for the "csv_product_grid_context_quick_export" quick export to finish
+    And I go on the last executed job resume of "csv_product_grid_context_quick_export"
+    Then I should see the text "COMPLETED"
+    And exported file of "csv_product_grid_context_quick_export" should contain:
+      """
+      sku;enabled;family;groups
+      boots;1;boots;
+      sandals;1;sandals;
+      """
+    And export directory of "csv_product_quick_export" should not contain the following media:
+      | files/boots/side_view/akeneo.jpg     |
+      | files/sneakers/side_view/akeneo2.jpg |


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When a products grid context quick export is performed, the products media files are generated even if no attribute of type media are selected in the grid context.

To fix this bug without doing BC breaks, I added a filter on the product values that are used to fetch the media, to keep only those that are selected from the context.

I didn't add specs because there isn't any for this class, and it no longer exists in 2.0

I did another PR to fix this bug for version 2.0 and beyond.

CI green except failing tests due to CI instability (issue raised). Tests are ok in local: merge.
**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added Behats                      | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
