### PR TITLE
Add slack notification when Ci build is finished

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,6 +9,7 @@ String launchIntegrationTests = "yes"
 String launchBehatTests = "yes"
 String verboseOutputs = "yes"
 String dotsPerLine = "50"
+String slackChannel = ""
 
 stage("Build") {
     milestone 1
@@ -19,7 +20,7 @@ stage("Build") {
                 choice(choices: 'yes\nno', description: 'Run integration tests', name: 'launchIntegrationTests'),
                 choice(choices: 'yes\nno', description: 'Run behat tests', name: 'launchBehatTests'),
                 choice(choices: 'no\nyes', description: 'Enable Verbose mode', name: 'verboseOutputs'),
-                string(defaultValue: '50', description: 'Number of dots per line', name: 'dotsperline'),
+                string(defaultValue: '', description: 'Channel or user to notify (example : "#channel,@user")', name: 'slackChannel'),
                 string(defaultValue: 'ee,ce', description: 'PIM edition the behat tests should run on (comma separated values)', name: 'editions'),
                 string(defaultValue: 'features,vendor/akeneo/pim-community-dev/features', description: 'Behat scenarios to build', name: 'features'),
             ])
@@ -30,7 +31,7 @@ stage("Build") {
             launchIntegrationTests = userInput['launchIntegrationTests']
             launchBehatTests = userInput['launchBehatTests']
             verboseOutputs = userInput['verboseOutputs']
-            dotsPerLine = userInput['dotsperline']
+            slackChannel = userInput['slackChannel']
         }
     }
     milestone 2
@@ -320,6 +321,8 @@ stage("Test") {
                 }
             }
         }
+
+        notifySlack(slackChannel);
     }
 }
 
@@ -432,4 +435,21 @@ def queue(body, scale, edition, verboseOutputs, dotsPerLine) {
 def clearTemplateNames() {
     // see https://issues.jenkins-ci.org/browse/JENKINS-42184
     currentBuild.rawBuild.getAction( PodTemplateAction.class )?.stack?.clear()
+}
+
+def notifySlack(String slackChannel) {
+    if (slackChannel == '') {
+        return;
+    }
+
+    // Null status means success
+    buildStatus = currentBuild.result
+
+    String color = '#42C02D'
+    if (buildStatus != null) {
+        color = '#FF0000'
+    }
+
+    def msg = "<${env.BUILD_URL}|Build finished:> `${env.JOB_NAME}`"
+    slackSend(color: color, message: msg, channel:"${slackChannel}")
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Add a notification in Slack when a build is finished. 

![screen shot 2018-02-14 at 14 03 40](https://user-images.githubusercontent.com/1942439/36205700-e9d3c326-118f-11e8-9039-58ffbaddd285.png)

It's red when it's failing, green when it's ok. There are maybe some edge cases not spotted, so please check your build on the UI for now.

Unfortunately, it's not possible to have the git branch name easily, so it will be the PR name in the notification.
Branch name would imply to do a `curl` to the github API to guess the branch from the PR number. A little bit too much for a notification...

Another thing: the generated link is for the old Jenkins, not blue Ocean. Not very important for now.

As the slack user is different from the github user (and no way to do the mapping easily), you have to fill an text input when configuring the build:
![screen shot 2018-02-14 at 14 07 02](https://user-images.githubusercontent.com/1942439/36205827-61d1111c-1190-11e8-8107-b91ba662dc1f.png)

It's possible to notify several users, several channels, and mix it (as the example above). 
If the field is blank, it does nothing. It's the default behavior. 
So, no change if you don't ant this feature, let it blank.

It's the Slackbot that notify you when you are configuring your Slack username as one of the users/channels to notify. 


Thanks our devops: they did 95% of the job (jenkins plugin configuration).

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added Behats                      | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
