### PR TITLE
Fix ci: regarding the warning: "touch()"

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -239,6 +239,7 @@ stage("Test") {
             "behat-ce": {
                 if (launchBehatTests.equals("yes") && editions.contains("ce")) {
                     queue({
+                        sh (returnStdout: true, script: "mkdir -m 777 -p /home/jenkins/pim/app/build/logs/behat/");
                         def scenariosCE = []
                         for (feature in features) {
                             scenariosCE = (scenariosCE + sh (returnStdout: true, script: "cd /home/jenkins/pim && if [ -e $feature ]; then php ./bin/behat $feature --list-scenarios; fi").tokenize('\n'))
@@ -284,6 +285,7 @@ stage("Test") {
             "behat-ee": {
                 if (launchBehatTests.equals("yes") && editions.contains("ee")) {
                     queue({
+                        sh (returnStdout: true, script: "mkdir -m 777 -p /home/jenkins/pim/app/build/logs/behat/");
                         def scenariosEE = []
                         for (feature in features) {
                             scenariosEE = (scenariosEE + sh (returnStdout: true, script: "cd /home/jenkins/pim && if [ -e $feature ]; then php ./bin/behat $feature --list-scenarios; fi").tokenize('\n'))
@@ -326,6 +328,7 @@ stage("Test") {
             "behat-ce-odm": {
                 if (launchBehatTests.equals("yes") && editions.contains("ceodm")) {
                     queue({
+                        sh (returnStdout: true, script: "mkdir -m 777 -p /home/jenkins/pim/app/build/logs/behat/");
                         def scenariosCE = []
                         for (feature in features) {
                             scenariosCE = (scenariosCE + sh (returnStdout: true, script: "cd /home/jenkins/pim && if [ -e $feature ]; then php ./bin/behat $feature --list-scenarios; fi").tokenize('\n'))
@@ -371,6 +374,7 @@ stage("Test") {
             "behat-ee-odm": {
                 if (launchBehatTests.equals("yes") && editions.contains("eeodm")) {
                     queue({
+                        sh (returnStdout: true, script: "mkdir -m 777 -p /home/jenkins/pim/app/build/logs/behat/");
                         def scenariosEE = []
                         for (feature in features) {
                             scenariosEE = (scenariosEE + sh (returnStdout: true, script: "cd /home/jenkins/pim && if [ -e $feature ]; then php ./bin/behat $feature --list-scenarios; fi").tokenize('\n'))


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The CI uses an extension provided by luigio/fastest to show all the
scenarios of the project.

This extension uses a formatter to show the message which is configured
in the '.ci/behat.community.yml' file with an output_path.

When a path that does not exist is set to this output_path, the
extension cannot create the file to output in resulting in this error.

Fix:
Make sure the path exists prior to list scenarios.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
