### PR TITLE
PIM-7186: Add missing phpdoc

### DIFF
--- a/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariantInterface.php
@@ -84,6 +84,8 @@ interface FamilyVariantInterface extends TranslatableInterface
      *
      * @param string $attributeCode
      *
+     * @throws \InvalidArgumentException
+     *
      * @return int
      */
     public function getLevelForAttributeCode(string $attributeCode): int;


### PR DESCRIPTION
## Description

I forgot a `@throws` in a previous PR, and only saw it during a new EE pull request...

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
