### PR TITLE
PIM-7169: Fix a memory leak on product export

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -3,15 +3,13 @@
 ## Bug fixes
 
 - PIM-7132: Fix "url too long" when doing a mass edit
+- PIM-7169: Fix a memory leak on product export when having many variant groups
+- PIM-7170: Fix media files unnecessarily generated during quick export
 - PIM-7182: Fix the clean mongodb command for reference data
 
 ## Security fixes
 
 - PIM-7116: Fix multiple CRSF vulnerabilities on several endpoints by allowing only XHR calls (see https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Protecting_REST_Services:_Use_of_Custom_Request_Headers)
-
-## Bug fixes
-
-- PIM-7170: Fix media files unnecessarily generated during quick export
 
 # 1.6.21 (2018-01-11)
 

--- a/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
@@ -109,6 +109,10 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
             );
         }
 
+        foreach ($product->getGroups() as $group) {
+            $this->detacher->detach($group);
+        }
+
         $this->detacher->detach($product);
 
         return $productStandard;


### PR DESCRIPTION
## Description

A client has about 150 000 variant groups and when running a product export, we can see a memory leak. The export is running slower and slower.

Benoit investigated the issue and the 1st analysis shows a memory leak on the "ProductTemplate", which is part from Variant Groups.

The fix is to detach groups at the end of `Normalization\ProductProcessor::process`, before detaching the products.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
