### PR TITLE
PIM-7182: Fix CleanMongoDB command

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7132: Fix "url too long" when doing a mass edit
+- PIM-7182: Fix the clean mongodb command for reference data
 
 ## Security fixes
 

--- a/src/Pim/Bundle/CatalogBundle/Command/CleanMongoDBCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/CleanMongoDBCommand.php
@@ -224,7 +224,7 @@ class CleanMongoDBCommand extends ContainerAwareCommand
      * @param array $product
      * @param int   $valueIndex
      *
-     * @return bool
+     * @return array
      */
     protected function checkReferenceDataFields(array $product, $valueIndex)
     {
@@ -245,21 +245,21 @@ class CleanMongoDBCommand extends ContainerAwareCommand
      * @param array   $product
      * @param integer $valueIndex    index of the prodcut value
      *
-     * @return bool whether the reference data exists or not.
+     * @return array
      */
     protected function checkReferenceDataField(array $referenceData, array $product, $valueIndex)
     {
         $referenceDataField = $product['values'][$valueIndex][$referenceData['field']];
 
         if (!is_array($referenceDataField)) {
-            if (null !== $this->findEntity($referenceData['class'], $referenceDataField)) {
+            if (!$this->isReferenceDataExisting($referenceData['class'], $referenceDataField)) {
                 $this->addMissingEntity($referenceData['class'], $referenceDataField);
             }
 
             unset($product['values'][$valueIndex]);
         } else {
             foreach ($referenceDataField as $key => $referenceDataId) {
-                if (null !== $this->findEntity($referenceData['class'], $referenceDataId)) {
+                if (!$this->isReferenceDataExisting($referenceData['class'], $referenceDataId)) {
                     $this->addMissingEntity($referenceData['class'], $referenceDataId);
                 }
 
@@ -295,11 +295,11 @@ class CleanMongoDBCommand extends ContainerAwareCommand
      * @param string $entityClass
      * @param int    $id
      *
-     * @return null|object
+     * @return bool
      */
-    protected function findEntity($entityClass, $id)
+    protected function isReferenceDataExisting($entityClass, $id)
     {
-        return $this->getContainer()->get('doctrine.orm.entity_manager')->find($entityClass, $id);
+        return null !== $this->getContainer()->get('doctrine.orm.entity_manager')->find($entityClass, $id);
     }
 
     /**


### PR DESCRIPTION
An issue has been raised whenever a user would use the CleanMongoDBCommand
with products having reference data.

This command is used to clean the mongoDB when some data (families /
attributes) are not in sync with the Mysql DB (ie, entities have been
deleted from mysql but not in mongodb).

**Problem:**
The command would remove the values of reference data attributes even
when the selected attribute option still existed in mysql.

**Solution:**
This error was due to wrong check in the command. This patch fixes it.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
