### PR TITLE
reset-es-index: Reset Es indexes between tests (behat, integration)

### DIFF
--- a/features/Pim/Behat/Context/HookContext.php
+++ b/features/Pim/Behat/Context/HookContext.php
@@ -10,7 +10,6 @@ use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Testwork\Tester\Result\TestResult;
 use Context\FeatureContext;
-use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
@@ -330,10 +329,11 @@ class HookContext extends PimContext
      */
     private function resetElasticsearchIndex()
     {
-        $esClientProduct = $this->getService('akeneo_elasticsearch.client.product');
-        $esClientProduct->resetIndex();
+        $clientRegistry = $this->getService('akeneo_elasticsearch.registry.clients');
+        $clients = $clientRegistry->getClients();
 
-        $esClientProductAndModel = $this->getService('akeneo_elasticsearch.client.product_and_product_model');
-        $esClientProductAndModel->resetIndex();
+        foreach ($clients as $client) {
+            $client->resetIndex();
+        }
     }
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -48,6 +48,13 @@ abstract class ApiTestCase extends WebTestCase
         $this->testKernel = new \AppKernelTest('test', false);
         $this->testKernel->boot();
 
+        $clientRegistry = $this->get('akeneo_elasticsearch.registry.clients');
+        $clients = $clientRegistry->getClients();
+
+        foreach ($clients as $client) {
+            $client->resetIndex();
+        }
+
         $this->catalog = $this->testKernel->getContainer()->get('akeneo_integration_tests.configuration.catalog');
         $this->testKernel->getContainer()->set('akeneo_integration_tests.catalog.configuration', $this->getConfiguration());
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessLargeAndOrderedListProductIntegration.php
@@ -25,8 +25,6 @@ class SuccessLargeAndOrderedListProductIntegration extends AbstractProductTestCa
     {
         parent::setUp();
 
-        $this->get('akeneo_elasticsearch.client.product')->resetIndex();
-
         $identifiers = [];
         for ($i = 0; $i < $this->getListSize(); $i++) {
             $identifiers[] = 'sku-' . str_pad((string) $i, 4, '0', STR_PAD_LEFT);

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/LargeAndOrderedListProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/LargeAndOrderedListProductModelIntegration.php
@@ -18,8 +18,6 @@ class LargeAndOrderedListProductModelIntegration extends AbstractProductTestCase
     {
         parent::setUp();
 
-        $this->get('akeneo_elasticsearch.client.product_model')->resetIndex();
-
         $data = [];
         for ($i = 0; $i < $this->getListSize(); $i++) {
             $data[] = [

--- a/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -126,9 +126,12 @@ class DatabaseCommand extends ContainerAwareCommand
     {
         $output->writeln('<info>Reset elasticsearch indexes</info>');
 
-        $this->getContainer()->get('akeneo_elasticsearch.client.product')->resetIndex();
-        $this->getContainer()->get('akeneo_elasticsearch.client.product_model')->resetIndex();
-        $this->getContainer()->get('akeneo_elasticsearch.client.product_and_product_model')->resetIndex();
+        $clientRegistry = $this->getContainer()->get('akeneo_elasticsearch.registry.clients');
+        $clients = $clientRegistry->getClients();
+
+        foreach ($clients as $client) {
+            $client->resetIndex();
+        }
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Reset Es indexes between tests (behat, integration), the main goal is to not worry about potential new indexes added in the future 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
