### PR TITLE
Revert "Fix #7614 wrong base_url for js routes when using dev environment"

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -29,6 +29,3 @@ oro_assetic:
 
 swiftmailer:
     disable_delivery: true
-
-parameters:
-    router.request_context.base_url: "/app_dev.php"


### PR DESCRIPTION
It brokes behat environment. Don't know why but it does.

Reverts akeneo/pim-community-dev#7615