### PR TITLE
PIM-7216: Resolve target discriminator map for products

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -57,6 +57,7 @@
 - PIM-7214: Fix a bug that prevents to select multiple items across pages in Products, Family and associations grids
 - PIM-7215: Fix wrong direction of sorting arrow in the grids
 - PIM-7220: Fix the filter "is empty" when the attribute belongs to a family
+- PIM-7216: Allow to easily override Product and VariantProduct classes
 
 # 2.0.17 (2018-03-06)
 

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/MappingsOverrideConfigurator.php
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Doctrine/ORM/MappingsOverrideConfigurator.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\ClassMetadata as OrmClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Pim\Component\Catalog\Model\AbstractProduct;
 
 /**
  * Configure the ORM mappings of the metadata classes.
@@ -40,6 +41,10 @@ class MappingsOverrideConfigurator implements MappingsOverrideConfiguratorInterf
         }
 
         foreach ($mappingOverrides as $override) {
+            if ($metadata->rootEntityName === AbstractProduct::class) {
+                continue;
+            }
+
             if ($override['override'] === $metadata->getName()) {
                 $metadata->isMappedSuperclass = false;
                 $this->setAssociationMappings($metadata, $configuration);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriber.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\Doctrine;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
+use Pim\Component\Catalog\Model\AbstractProduct;
+
+/**
+ * Resolve the discriminator map of the AbstractProduct class
+ * with the concrete Product and VariantProduct entities.
+ * This allows the override of the Product and VariantProduct classes.
+ *
+ * It is important to use "ClassMetadata::setDiscriminatorMap()" method, as this
+ * method will also set the "ClassMetadata::subClasses" field, mandatory to have
+ * a complete mapping with all the fields of both Product and VariantProduct.
+ *
+ * @author    Julien Janvier (julien.janvier@akeneo.com)
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ResolveTargetDiscriminatorMapForProductSubscriber implements EventSubscriber
+{
+    /** @var string */
+    private $productClass;
+
+    /** @var string */
+    private $variantProductClass;
+
+    /**
+     * @param string $productClass
+     * @param string $variantProductClass
+     */
+    public function __construct(string $productClass, string $variantProductClass)
+    {
+        $this->productClass = $productClass;
+        $this->variantProductClass = $variantProductClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubscribedEvents(): array
+    {
+        return [
+            'loadClassMetadata',
+        ];
+    }
+
+    /**
+     * @param LoadClassMetadataEventArgs $args
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $args): void
+    {
+        $classMetadata = $args->getClassMetadata();
+        $className = $classMetadata->getName();
+
+        if (AbstractProduct::class === $className) {
+            $classMetadata->discriminatorMap = [];
+            $classMetadata->setDiscriminatorMap([
+                'product' => $this->productClass,
+                'variant_product' => $this->variantProductClass,
+            ]);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriber.php
@@ -7,6 +7,7 @@ namespace Pim\Bundle\CatalogBundle\Doctrine;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
 use Pim\Component\Catalog\Model\AbstractProduct;
+use Pim\Component\Catalog\Model\Product;
 
 /**
  * Resolve the discriminator map of the AbstractProduct class
@@ -63,6 +64,10 @@ class ResolveTargetDiscriminatorMapForProductSubscriber implements EventSubscrib
                 'product' => $this->productClass,
                 'variant_product' => $this->variantProductClass,
             ]);
+        }
+
+        if (Product::class === $className || is_subclass_of($className, Product::class)) {
+            $classMetadata->discriminatorValue = 'product';
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriber.php
@@ -8,6 +8,7 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
 use Pim\Component\Catalog\Model\AbstractProduct;
 use Pim\Component\Catalog\Model\Product;
+use Pim\Component\Catalog\Model\VariantProduct;
 
 /**
  * Resolve the discriminator map of the AbstractProduct class
@@ -68,6 +69,10 @@ class ResolveTargetDiscriminatorMapForProductSubscriber implements EventSubscrib
 
         if (Product::class === $className || is_subclass_of($className, Product::class)) {
             $classMetadata->discriminatorValue = 'product';
+        }
+
+        if (VariantProduct::class === $className || is_subclass_of($className, VariantProduct::class)) {
+            $classMetadata->discriminatorValue = 'variant_product';
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriber.php
@@ -8,6 +8,7 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
 use Pim\Component\Catalog\Model\AbstractProduct;
 use Pim\Component\Catalog\Model\Product;
+use Pim\Component\Catalog\Model\ProductModel;
 use Pim\Component\Catalog\Model\VariantProduct;
 
 /**
@@ -73,6 +74,10 @@ class ResolveTargetDiscriminatorMapForProductSubscriber implements EventSubscrib
 
         if (VariantProduct::class === $className || is_subclass_of($className, VariantProduct::class)) {
             $classMetadata->discriminatorValue = 'variant_product';
+            unset($classMetadata->associationMappings['parent']['inherited']);
+            unset($classMetadata->associationMappings['parent']['declared']);
+            unset($classMetadata->associationMappings['familyVariant']['inherited']);
+            unset($classMetadata->associationMappings['familyVariant']['declared']);
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -20,6 +20,7 @@ parameters:
     pim_catalog.event_subscriber.save_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber
     pim_catalog.event_subscriber.add_parent_to_product.class: Pim\Bundle\CatalogBundle\EventSubscriber\AddParentAProductSubscriber
     pim_catalog.event_subscriber.add_boolean_values_to_new_product.class: Pim\Bundle\CatalogBundle\EventSubscriber\AddBooleanValuesToNewProductSubscriber
+    pim_catalog.event_subscriber.resolve_target_discriminator_map_for_product: Pim\Bundle\CatalogBundle\Doctrine\ResolveTargetDiscriminatorMapForProductSubscriber
 
 services:
     # Subscribers
@@ -180,3 +181,12 @@ services:
             - '@akeneo_storage_utils.doctrine.object_detacher'
         tags:
             - { name: kernel.event_subscriber }
+
+    pim_catalog.event_subscriber.resolve_target_discriminator_map_for_product:
+        class: '%pim_catalog.event_subscriber.resolve_target_discriminator_map_for_product%'
+        arguments:
+            - '%pim_catalog.entity.product.class%'
+            - '%pim_catalog.entity.variant_product.class%'
+        public: false
+        tags:
+            - { name: doctrine.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/AbstractProduct.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/AbstractProduct.orm.yml
@@ -6,8 +6,8 @@ Pim\Component\Catalog\Model\AbstractProduct:
         name: product_type
         type: string
     discriminatorMap:
-        product: Product
-        variant_product: VariantProduct
+        product: Pim\Component\Catalog\Model\ProductInterface
+        variant_product: Pim\Component\Catalog\Model\VariantProductInterface
     changeTrackingPolicy: DEFERRED_EXPLICIT
     repositoryClass: Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\ProductRepository
     fields:

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriberSpec.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Doctrine;
+
+use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use PhpSpec\Exception\Example\NotEqualException;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AbstractProduct;
+
+class ResolveTargetDiscriminatorMapForProductSubscriberSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('foo', 'bar');
+    }
+
+    function it_resolves_the_discriminator_map_of_the_abstract_product_class(
+        LoadClassMetadataEventArgs $args,
+        ClassMetadata $classMetadata
+    ) {
+        $args->getClassMetadata()->willReturn($classMetadata);
+        $classMetadata->getName()->willReturn(AbstractProduct::class);
+        $classMetadata->setDiscriminatorMap(['product' => 'foo', 'variant_product' => 'bar'])->shouldBeCalled();
+
+        $this->loadClassMetadata($args);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriberSpec.php
@@ -4,9 +4,10 @@ namespace spec\Pim\Bundle\CatalogBundle\Doctrine;
 
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use PhpSpec\Exception\Example\NotEqualException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AbstractProduct;
+use Pim\Component\Catalog\Model\Product;
+use Prophecy\Argument;
 
 class ResolveTargetDiscriminatorMapForProductSubscriberSpec extends ObjectBehavior
 {
@@ -22,6 +23,17 @@ class ResolveTargetDiscriminatorMapForProductSubscriberSpec extends ObjectBehavi
         $args->getClassMetadata()->willReturn($classMetadata);
         $classMetadata->getName()->willReturn(AbstractProduct::class);
         $classMetadata->setDiscriminatorMap(['product' => 'foo', 'variant_product' => 'bar'])->shouldBeCalled();
+
+        $this->loadClassMetadata($args);
+    }
+
+    function it_adds_the_discriminator_value_on_the_product_class(
+        LoadClassMetadataEventArgs $args,
+        ClassMetadata $classMetadata
+    ) {
+        $args->getClassMetadata()->willReturn($classMetadata);
+        $classMetadata->getName()->willReturn(Product::class);
+        $classMetadata->setDiscriminatorMap(Argument::any())->shouldNotBeCalled();
 
         $this->loadClassMetadata($args);
     }

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ResolveTargetDiscriminatorMapForProductSubscriberSpec.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AbstractProduct;
 use Pim\Component\Catalog\Model\Product;
+use Pim\Component\Catalog\Model\VariantProduct;
 use Prophecy\Argument;
 
 class ResolveTargetDiscriminatorMapForProductSubscriberSpec extends ObjectBehavior
@@ -33,6 +34,17 @@ class ResolveTargetDiscriminatorMapForProductSubscriberSpec extends ObjectBehavi
     ) {
         $args->getClassMetadata()->willReturn($classMetadata);
         $classMetadata->getName()->willReturn(Product::class);
+        $classMetadata->setDiscriminatorMap(Argument::any())->shouldNotBeCalled();
+
+        $this->loadClassMetadata($args);
+    }
+
+    function it_adds_the_discriminator_value_on_the_variant_product_class(
+        LoadClassMetadataEventArgs $args,
+        ClassMetadata $classMetadata
+    ) {
+        $args->getClassMetadata()->willReturn($classMetadata);
+        $classMetadata->getName()->willReturn(VariantProduct::class);
         $classMetadata->setDiscriminatorMap(Argument::any())->shouldNotBeCalled();
 
         $this->loadClassMetadata($args);


### PR DESCRIPTION
Today, product and variant product classes are "hardcoded" in the discriminator map of the AbstractProduct mapping (see ).
Which it's impossible to easily override the Product or the VariantProduct classes.

This PR solves this problem.
Therefor, it closes the tickets SDS-2513 and SDS-2496.

**This PR should be reverted on 2.2.**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added legacy Behats               | N
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Y
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
