### PR TITLE
PIM-6329: Remove family variant

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -8,6 +8,7 @@
 
 - PIM-7106: Display the 1st variant product created as product model image
 - PIM-6334: Add support of product model to the export builder
+- PIM-6329: The family variant is now removable from the UI
 
 ## BC breaks
 

--- a/features/family/delete_family_variant.feature
+++ b/features/family/delete_family_variant.feature
@@ -1,0 +1,29 @@
+@javascript
+Feature: Delete a family variant
+  In order to manage families variants in the catalog
+  As an administrator
+  I need to be able to delete family variants
+
+  Background:
+    Given a "catalog_modeling" catalog configuration
+    And I am logged in as "Julia"
+
+  Scenario: Successfully delete a family variant used by product models from the grid
+    Given the following family variants:
+      | code                 | family   | variant-axes_1 | variant-attributes_1 |
+      | empty_family_variant | clothing | color          | description          |
+    And I am on the "Clothing" family page
+    And I visit the "Variants" tab
+    When I click on the "Delete" action of the row which contains "empty_family_variant"
+    And I confirm the deletion
+    Then I should see the flash message "Family variant successfully removed"
+    And I should not see the text "empty_family_variant"
+
+  Scenario: Unsuccessfully delete a family variant used by product models
+    Given I am on the "Clothing" family page
+    And I visit the "Variants" tab
+    When I click on the "Delete" action of the row which contains "Clothing by size"
+    And I confirm the deletion
+    Then I should see the flash message "Cannot remove family variant \"clothing_size\" as it is used by some product models"
+    And I should see the text "Clothing by size"
+

--- a/features/family/delete_family_variant.feature
+++ b/features/family/delete_family_variant.feature
@@ -16,14 +16,12 @@ Feature: Delete a family variant
     And I visit the "Variants" tab
     When I click on the "Delete" action of the row which contains "empty_family_variant"
     And I confirm the deletion
-    Then I should see the flash message "Family variant successfully removed"
-    And I should not see the text "empty_family_variant"
+    Then I should not see the text "empty_family_variant"
 
   Scenario: Unsuccessfully delete a family variant used by product models
     Given I am on the "Clothing" family page
     And I visit the "Variants" tab
     When I click on the "Delete" action of the row which contains "Clothing by size"
     And I confirm the deletion
-    Then I should see the flash message "Cannot remove family variant \"clothing_size\" as it is used by some product models"
     And I should see the text "Clothing by size"
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/CountEntityWithFamilyVariant.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/CountEntityWithFamilyVariant.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Query;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Pim\Component\Catalog\ProductAndProductModel\Query\CountEntityWithFamilyVariantInterface;
+
+/**
+ * Find the number of product and product models count belonging to the given family variant
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CountEntityWithFamilyVariant implements CountEntityWithFamilyVariantInterface
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /**
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * @param FamilyVariantInterface $familyVariant
+     *
+     * @return int
+     */
+    public function belongingToFamilyVariant(FamilyVariantInterface $familyVariant): int
+    {
+        $productModelCount = $this->countProductModels($familyVariant);
+        $productCount = $this->countVariantProducts($familyVariant);
+
+        return $productModelCount + $productCount;
+    }
+
+    /**
+     * @param FamilyVariantInterface $familyVariant
+     *
+     * @return int
+     *
+     * @throws \Doctrine\ORM\NoResultException
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    private function countProductModels(FamilyVariantInterface $familyVariant): int
+    {
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        $productModelCount = $queryBuilder->select('COUNT(pm)')
+            ->from(ProductModelInterface::class, 'pm')
+            ->where('pm.familyVariant = :family_variant_id')
+            ->setParameter(':family_variant_id', $familyVariant->getId())
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $productModelCount;
+    }
+
+    /**
+     * @param FamilyVariantInterface $familyVariant
+     *
+     * @return int
+     *
+     * @throws \Doctrine\ORM\NoResultException
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    private function countVariantProducts(FamilyVariantInterface $familyVariant): int
+    {
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        $productCount = $queryBuilder->select('COUNT(p)')
+            ->from(VariantProductInterface::class, 'p')
+            ->where('p.familyVariant = :family_variant_id')
+            ->setParameter(':family_variant_id', $familyVariant->getId())
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $productCount;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/CountEntityWithFamilyVariant.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/CountEntityWithFamilyVariant.php
@@ -5,8 +5,8 @@ namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Query;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
-use Pim\Component\Catalog\Model\VariantProductInterface;
 use Pim\Component\Catalog\ProductAndProductModel\Query\CountEntityWithFamilyVariantInterface;
 
 /**
@@ -75,7 +75,7 @@ class CountEntityWithFamilyVariant implements CountEntityWithFamilyVariantInterf
     {
         $queryBuilder = $this->entityManager->createQueryBuilder();
         $productCount = $queryBuilder->select('COUNT(p)')
-            ->from(VariantProductInterface::class, 'p')
+            ->from(ProductInterface::class, 'p')
             ->where('p.familyVariant = :family_variant_id')
             ->setParameter(':family_variant_id', $familyVariant->getId())
             ->getQuery()

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
@@ -2,6 +2,7 @@ parameters:
     pim_catalog.doctrine.query.find_variant_product_completeness.class: 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\VariantProductRatio'
     pim_catalog.doctrine.query.complete_filter.class: 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\CompleteFilter'
     pim_catalog.doctrine.query.attribute_is_an_family_variant_axis.class: 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\AttributeIsAFamilyVariantAxis'
+    pim_catalog.doctrine.query.count_entity_with_family_variant.class: 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\CountEntityWithFamilyVariant'
 
 services:
     pim_catalog.doctrine.query.find_variant_product_completeness:
@@ -16,5 +17,10 @@ services:
 
     pim_catalog.doctrine.query.attribute_is_an_family_variant_axis:
         class: '%pim_catalog.doctrine.query.attribute_is_an_family_variant_axis.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'
+
+    pim_catalog.doctrine.query.count_entity_with_family_variant:
+        class: '%pim_catalog.doctrine.query.count_entity_with_family_variant.class%'
         arguments:
             - '@doctrine.orm.entity_manager'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/removers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/removers.yml
@@ -3,6 +3,7 @@ parameters:
     pim_catalog.remover.base_options_resolver.class: Akeneo\Bundle\StorageUtilsBundle\Doctrine\Common\Remover\BaseRemovingOptionsResolver
     pim_catalog.remover.channel.class:               Pim\Bundle\CatalogBundle\Doctrine\Common\Remover\ChannelRemover
     pim_catalog.remover.completeness.class: Pim\Bundle\CatalogBundle\Doctrine\ORM\CompletenessRemover
+    pim_catalog.remover.family_variant.class: Pim\Component\Catalog\Updater\Remover\FamilyVariantRemover
 
 services:
     pim_catalog.remover.group_type:
@@ -94,3 +95,10 @@ services:
 
     pim_catalog.remover.base_options_resolver:
         class: '%pim_catalog.remover.base_options_resolver.class%'
+
+    pim_catalog.remover.family_variant:
+        class: '%pim_catalog.remover.family_variant.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@event_dispatcher'
+            - '@pim_catalog.doctrine.query.count_entity_with_family_variant'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Query/CountEntityWithFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Query/CountEntityWithFamilyVariantIntegration.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Doctrine\Query;
+
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CountEntityWithFamilyVariantIntegration extends TestCase
+{
+    public function testThatItFindsTheNumberOfProductsAndProductModelsHavingAFamilyVariant()
+    {
+        $familyVariant = $this->get('pim_catalog.repository.family_variant')
+            ->findOneByIdentifier('clothing_color_size');
+        $result = $this
+            ->get('pim_catalog.doctrine.query.count_entity_with_family_variant')
+            ->belongingToFamilyVariant($familyVariant);
+        $this->assertEquals(123, $result);
+    }
+
+    public function testThatItFindsNoProductNorProductModelHavingTheFamilyVariant()
+    {
+        $familyVariant = $this->createFamilyVariant([
+            'code'        => 'family_variant_without_products_nor_product_models',
+            'family'      => 'clothing',
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['color'],
+                    'attributes' => ['color', 'variation_name', 'variation_image'],
+                ],
+                [
+                    'level' => 2,
+                    'axes' => ['size'],
+                    'attributes' => ['size', 'ean', 'sku'],
+                ],
+            ]
+        ]);
+        $result = $this
+            ->get('pim_catalog.doctrine.query.count_entity_with_family_variant')
+            ->belongingToFamilyVariant($familyVariant);
+        $this->assertEquals(0, $result);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return FamilyVariantInterface
+     */
+    protected function createFamilyVariant(array $data = []) : FamilyVariantInterface
+    {
+        $family = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update($family, $data);
+        $constraintList = $this->get('validator')->validate($family);
+        $this->assertEquals(0, $constraintList->count());
+        $this->get('pim_catalog.saver.family_variant')->save($family);
+
+        return $family;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/RemoveFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/RemoveFamilyVariantIntegration.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\integration\Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RemoveFamilyVariantIntegration extends TestCase
+{
+    public function testTheFamilyVariantRemovalSuccess(): void
+    {
+        $familyVariant = $this->createDefaultFamilyVariant('my_family_variant');
+        $this->removeFamilyVariant($familyVariant);
+
+        $this->assertNull($this->getFamilyVariant('my_family_variant'));
+    }
+
+    public function testTheFamilyVariantRemovalIsPrevented()
+    {
+        $this->expectException(\LogicException::class);
+        $familyVariant = $this->getFamilyVariant('shoes_size');
+        $this->get('pim_catalog.remover.family_variant')->remove($familyVariant);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useFunctionalCatalog('footwear');
+    }
+
+    /**
+     * Create a family variant with the code family_variant
+     *
+     * @param string $code
+     *
+     * @return FamilyVariantInterface
+     */
+    private function createDefaultFamilyVariant(string $code): FamilyVariantInterface
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
+            'code'                   => $code,
+            'family'                 => 'boots',
+            'labels'                 => [
+                'en_US' => 'My family variant',
+            ],
+            'variant_attribute_sets' => [
+                [
+                    'axes'       => ['color'],
+                    'attributes' => ['weather_conditions', 'rating', 'side_view', 'top_view', 'lace_color'],
+                    'level'      => 1,
+                ],
+                [
+                    'axes'       => ['size'],
+                    'attributes' => ['sku', 'price'],
+                    'level'      => 2,
+                ],
+            ],
+        ]);
+
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+
+        return $familyVariant;
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return null|FamilyVariantInterface
+     */
+    private function getFamilyVariant(string $code): ?FamilyVariantInterface
+    {
+        return $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier($code);
+    }
+
+    /**
+     * @param $familyVariant
+     */
+    private function removeFamilyVariant(FamilyVariantInterface $familyVariant): void
+    {
+        $this->get('pim_catalog.remover.family_variant')->remove($familyVariant);
+    }
+}

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/abstract-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/abstract-action.js
@@ -323,7 +323,7 @@ function($, _, Backbone, routing, router, __, mediator, messenger, error, Dialog
                 return entityHint.replace(/y$/, 'ies');
             }
 
-            return `${entityHint}s`;
+            return `${entityHint.replace('_', ' ')}s`;
         }
     });
 });

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyVariantController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyVariantController.php
@@ -8,6 +8,7 @@ use Akeneo\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Repository\FamilyVariantRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -48,9 +49,7 @@ class FamilyVariantController
     /** @var SaverInterface */
     protected $saver;
 
-    /**
-     * @var null|RemoverInterface
-     */
+    /** @var RemoverInterface */
     private $remover;
 
     /**
@@ -61,7 +60,7 @@ class FamilyVariantController
      * @param ValidatorInterface               $validator
      * @param NormalizerInterface              $constraintViolationNormalizer
      * @param SaverInterface                   $saver
-     * @param RemoverInterface|null            $remover @pull-up: remove null
+     * @param RemoverInterface                 $remover
      */
     public function __construct(
         FamilyVariantRepositoryInterface $familyVariantRepository,
@@ -71,7 +70,7 @@ class FamilyVariantController
         ValidatorInterface $validator,
         NormalizerInterface $constraintViolationNormalizer,
         SaverInterface $saver,
-        RemoverInterface $remover = null
+        RemoverInterface $remover
     ) {
         $this->familyVariantRepository = $familyVariantRepository;
         $this->normalizer = $normalizer;
@@ -136,9 +135,15 @@ class FamilyVariantController
      * @return JsonResponse
      *
      * @throws HttpExceptionInterface
+     *
+     * @AclAncestor("pim_enrich_family_variant_remove")
      */
     public function removeAction(Request $request, $familyVariantCode)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new JsonResponse(['message' => 'An error occurred.', 'global' => true], Response::HTTP_BAD_REQUEST);
+        }
+
         $familyVariant = $this->getFamilyVariant($familyVariantCode);
         try {
             $this->remover->remove($familyVariant);

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
@@ -174,6 +174,10 @@ pim_enrich_family_history:
     type: action
     label: pim_enrich.acl.family.history
     group_name: pim_enrich.acl_group.family
+pim_enrich_family_variant_remove:
+    type: action
+    label: pim_enrich.acl.family_variant.remove
+    group_name: pim_enrich.acl_group.family
 
 # Attribute group
 pim_enrich_attributegroup_index:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -297,6 +297,7 @@ services:
             - '@validator'
             - '@pim_enrich.normalizer.violation'
             - '@pim_catalog.saver.family_variant'
+            - '@pim_catalog.remover.family_variant'
 
     pim_enrich.controller.rest.form_extension:
         class: '%pim_enrich.controller.rest.form_extension.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/family_variant.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/family_variant.yml
@@ -21,6 +21,11 @@ datagrid:
             id: ~
             familyVariantCode: ~
             familyCode: ~
+            delete_link:
+                type: url
+                route: pim_enrich_family_variant_rest_remove
+                params:
+                    - familyVariantCode
         actions:
             edit:
                 launcherOptions:
@@ -31,6 +36,12 @@ datagrid:
                 fetcher:      family-variant
                 form:         pim-family-variant-edit-form
                 rowAction:    true
+            delete:
+                launcherOptions:
+                    className: AknIconButton AknIconButton--small AknIconButton--trash
+                type:  delete
+                label: Delete
+                link:  delete_link
         filters:
             columns:
                 label:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/family_variant.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/family_variant.yml
@@ -42,6 +42,7 @@ datagrid:
                 type:  delete
                 label: Delete
                 link:  delete_link
+                acl_resource: pim_enrich_family_variant_remove
         filters:
             columns:
                 label:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -44,6 +44,8 @@ config:
             url: pim_enrich_channel_rest_remove
         pim/remover/family:
             url: pim_enrich_family_rest_remove
+        pim/remover/family-variant:
+            url: pim_enrich_family_variant_rest_remove
         pim/remover/group:
             url: pim_enrich_group_rest_remove
         pim/remover/product:
@@ -592,6 +594,7 @@ config:
         pim/remover/group-type:          pimenrich/js/remover/group-type-remover
         pim/remover/channel:             pimenrich/js/remover/channel
         pim/remover/family:              pimenrich/js/remover/family
+        pim/remover/family-variant:      pimenrich/js/remover/family-variant
         pim/remover/product:             pimenrich/js/remover/product-remover
         pim/remover/product-model:       pimenrich/js/remover/product-model-remover
         pim/remover/group:               pimenrich/js/remover/group-remover
@@ -663,6 +666,7 @@ config:
         pim/family-variant-edit-form/edit:                                  pimenrich/js/family-variant/form/edit
         pim/family-variant-edit-form/attribute-set:                         pimenrich/js/family-variant/form/attribute-set
         pim/family-variant-edit-form/save:                                  pimenrich/js/family-variant/form/save
+        pim/family-variant-edit-form/delete:                                pimenrich/js/family-variant/form/delete
 
         # Exports
         pim/job-instance-edit-form/save:        pimenrich/js/job/common/edit/save

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/family_variant.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/family_variant.yml
@@ -9,3 +9,10 @@ pim_enrich_family_variant_rest_put:
     requirements:
         identifier: '[a-zA-Z0-9_]+'
     methods: [PUT]
+
+pim_enrich_family_variant_rest_remove:
+    path: /rest/{familyVariantCode}
+    defaults: { _controller: pim_enrich.controller.rest.family_variant:removeAction }
+    requirements:
+        familyVariantCode: '[a-zA-Z0-9_]+'
+    methods: [DELETE]

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/delete.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/delete.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/**
+ * Delete extension for family variants
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(['pim/form/common/delete', 'pim/remover/family-variant'], function (DeleteForm, FamilyVariantRemover) {
+    return DeleteForm.extend({ remover: FamilyVariantRemover });
+});

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/family-variant.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/remover/family-variant.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Module to remove family variant
+ *
+ * @author    Samir Boulil <samir.boulil@gmail.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define([
+        'underscore',
+        'pim/remover/base',
+        'routing'
+    ], function (
+        _,
+        BaseRemover,
+        Routing
+    ) {
+        return _.extend({}, BaseRemover, {
+            /**
+             * {@inheritdoc}
+             */
+            getUrl: function (code) {
+                return Routing.generate(__moduleConfig.url, {code: code});
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -7,6 +7,7 @@ confirmation:
         attribute:        Are you sure you want to delete this attribute?
         attribute_group:  Are you sure you want to delete this attribute group?
         family:           Are you sure you want to delete this family?
+        family_variant:   Are you sure you want to delete this family variant ?
         product:          Are you sure you want to delete this product?
         product_model:    Are you sure you want to delete this product model? All its children, product models and variant products, will be also deleted.
         channel:          Are you sure you want to delete this channel?
@@ -49,6 +50,8 @@ flash:
         removed: Attribute group successfully removed
     family:
         removed: Family successfully removed
+    family_variant:
+        removed: Family variant successfully removed
     product:
         removed: Product successfully removed
     product_model:

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -377,6 +377,7 @@ confirmation:
         attribute group:  Are you sure you want to delete the attribute group %name%?
         category:         Are you sure you want to delete the category %name%?
         family:           Are you sure you want to delete the family %name%?
+        family_variant:   Are you sure you want to delete the family variant %name%?
         product:          Are you sure you want to delete the product %name%?
         group:            Are you sure you want to delete the group %name%?
         group type:       Are you sure you want to delete the group type %name%?

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -213,6 +213,8 @@ pim_enrich:
             edit_attributes: Edit attributes of a family
             remove: Remove a family
             history: View family history
+        family_variant:
+            remove: Remove a family variant
         attribute_group:
             index: List attribute groups
             create: Create an attribute group

--- a/src/Pim/Component/Catalog/ProductAndProductModel/Query/CountEntityWithFamilyVariantInterface.php
+++ b/src/Pim/Component/Catalog/ProductAndProductModel/Query/CountEntityWithFamilyVariantInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Pim\Component\Catalog\ProductAndProductModel\Query;
+
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+
+/**
+ * Find the number of product and product models count belonging to the given family variant
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface CountEntityWithFamilyVariantInterface
+{
+    /**
+     * @param FamilyVariantInterface $familyVariant
+     *
+     * @return int
+     */
+    public function belongingToFamilyVariant(FamilyVariantInterface $familyVariant): int;
+}

--- a/src/Pim/Component/Catalog/Updater/Remover/FamilyVariantRemover.php
+++ b/src/Pim/Component/Catalog/Updater/Remover/FamilyVariantRemover.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Updater\Remover;
+
+use Akeneo\Component\StorageUtils\Event\RemoveEvent;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Util\ClassUtils;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\ProductAndProductModel\Query\CountEntityWithFamilyVariantInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Removes a family variant if there is no entity with family variants already associated with it.
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyVariantRemover implements RemoverInterface
+{
+    /** @var ObjectManager */
+    private $objectManager;
+
+    /** @var EventDispatcherInterface */
+    private $eventDispatcher;
+
+    /** @var CountEntityWithFamilyVariantInterface */
+    private $counter;
+
+    /**
+     * @param ObjectManager                         $objectManager
+     * @param EventDispatcherInterface              $eventDispatcher
+     * @param CountEntityWithFamilyVariantInterface $counter
+     */
+    public function __construct(
+        ObjectManager $objectManager,
+        EventDispatcherInterface $eventDispatcher,
+        CountEntityWithFamilyVariantInterface $counter
+    ) {
+        $this->objectManager = $objectManager;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->counter = $counter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($familyVariant, array $options = []): RemoverInterface
+    {
+        if (!$familyVariant instanceof FamilyVariantInterface) {
+            throw InvalidObjectException::objectExpected(
+                ClassUtils::getClass($familyVariant),
+                FamilyVariantInterface::class
+            );
+        }
+
+        if ($this->hasEntityWithFamilyVariant($familyVariant)) {
+            throw new \LogicException(
+                sprintf(
+                    'Family variant "%s", could not be removed as it is used by some entities with family variants.',
+                    $familyVariant->getCode()
+                )
+            );
+        }
+
+        $this->removeFamilyVariant($familyVariant, $options);
+
+        return $this;
+    }
+
+    /**
+     * @param $familyVariant
+     *
+     * @return bool
+     */
+    private function hasEntityWithFamilyVariant(FamilyVariantInterface $familyVariant): bool
+    {
+        return 0 !== $this->counter->belongingToFamilyVariant($familyVariant);
+    }
+
+    /**
+     * @param FamilyVariantInterface $familyVariant
+     * @param array                  $options
+     */
+    private function removeFamilyVariant(FamilyVariantInterface $familyVariant, array $options): void
+    {
+        $objectId = $familyVariant->getId();
+
+        $options['unitary'] = true;
+
+        $this->eventDispatcher->dispatch(
+            StorageEvents::PRE_REMOVE,
+            new RemoveEvent($familyVariant, $objectId, $options)
+        );
+
+        $this->objectManager->remove($familyVariant);
+        $this->objectManager->flush();
+
+        $this->eventDispatcher->dispatch(
+            StorageEvents::POST_REMOVE,
+            new RemoveEvent($familyVariant, $objectId, $options)
+        );
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Updater/Remover/FamilyVariantRemoverSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/Remover/FamilyVariantRemoverSpec.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Updater\Remover;
+
+use Akeneo\Component\StorageUtils\Event\RemoveEvent;
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Remover\RemoverInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Persistence\ObjectManager;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Exception\InvalidArgumentException;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\ProductAndProductModel\Query\CountEntityWithFamilyVariantInterface;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class FamilyVariantRemoverSpec extends ObjectBehavior
+{
+    function let(
+        ObjectManager $objectManager,
+        EventDispatcherInterface $eventDispatcher,
+        CountEntityWithFamilyVariantInterface $counter
+    ) {
+        $this->beConstructedWith($objectManager, $eventDispatcher, $counter);
+    }
+
+    function it_is_a_remover()
+    {
+        $this->shouldImplement(RemoverInterface::class);
+    }
+
+    function it_removes_family_variant_which_have_no_entity_belonging_to_it(
+        $objectManager,
+        $eventDispatcher,
+        $counter,
+        FamilyVariantInterface $familyVariantToRemove
+    ) {
+        $counter->belongingToFamilyVariant($familyVariantToRemove)->willReturn(0);
+        $familyVariantToRemove->getId()->willReturn(1);
+        $eventDispatcher->dispatch(StorageEvents::PRE_REMOVE, Argument::cetera())->shouldBeCalled();
+        $objectManager->remove($familyVariantToRemove)->shouldBeCalled();
+        $objectManager->flush()->shouldBeCalled();
+        $eventDispatcher->dispatch(StorageEvents::POST_REMOVE, Argument::cetera())->shouldBeCalled();
+
+        $this->remove($familyVariantToRemove, []);
+    }
+
+    function it_throws_an_exception_if_the_family_variant_has_entities_belonging_to_it(
+        $objectManager,
+        $counter,
+        FamilyVariantInterface $familyVariantToRemove
+    ) {
+        $counter->belongingToFamilyVariant($familyVariantToRemove)->willReturn(5);
+        $familyVariantToRemove->getId()->willReturn(1);
+        $familyVariantToRemove->getCode()->willReturn('family_variant');
+        $objectManager->remove($familyVariantToRemove)->shouldNotBeCalled();
+
+        $this->shouldThrow(\LogicException::class)->duringRemove($familyVariantToRemove);
+    }
+
+    function it_throws_an_exception_if_it_is_not_a_family_variant(\stdClass $notAFamilyVariant)
+    {
+        $this->shouldThrow(InvalidObjectException::class)->duringRemove($notAFamilyVariant);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
**Reviewable by commit**

Be able to remove the a family variant if, and only if, there is no product models / variant products belonging to it.

- [x] Add translations in popup
- [x] Add acls

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | Ok
| Added acceptance tests            | -
| Added integration tests           | Ok
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
