### PR TITLE
Make 2.2 the default EE branch on the CI

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -65,7 +65,7 @@ stage("Build") {
             if (editions.contains("ee")) {
                 withBuildNode({
                     checkout([$class: 'GitSCM',
-                        branches: [[name: 'master']],
+                        branches: [[name: '2.2']],
                         userRemoteConfigs: [[credentialsId: 'github-credentials', url: 'https://github.com/akeneo/pim-enterprise-dev.git']]
                     ])
                     // Required to avoid permission error when "composer update"


### PR DESCRIPTION
Today, we can't launch a full CE/EE build when my CE branch is based on E.E

The CI will take EE master as default, which is not what we want.