### PR TITLE
PIM-7164: Detach associated products during export

### DIFF
--- a/.ci/behat.enterprise.yml
+++ b/.ci/behat.enterprise.yml
@@ -2,7 +2,7 @@ default:
     paths:
         features: features
     filters:
-        tags: "~skip&&~skip-pef&&~doc&&~unstable&&~unstable-app&&~deprecated&&~@unstable-app@~ce"
+        tags: "~skip&&~skip-pef&&~doc&&~unstable&&~unstable-app&&~deprecated&&~@unstable-app&&~ce"
     context:
         class: Context\EnterpriseFeatureContext
         parameters:

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,5 +1,9 @@
 # 1.7.18 (2018-02-22)
 
+## Big Fixes
+
+- PIM-7164: Fix a memory leak on product export caused by associated products not being detached
+
 # 1.7.17 (2018-02-01)
 
 ## Bug Fixes

--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,8 +1,10 @@
-# 1.7.18 (2018-02-22)
+# 1.7.x
 
 ## Big Fixes
 
 - PIM-7164: Fix a memory leak on product export caused by associated products not being detached
+
+# 1.7.18 (2018-02-22)
 
 # 1.7.17 (2018-02-01)
 

--- a/src/Pim/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
+++ b/src/Pim/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
@@ -25,6 +25,7 @@ class PimConnectorExtension extends Extension
         $loader->load('analyzers.yml');
         $loader->load('archiving.yml');
         $loader->load('array_converters.yml');
+        $loader->load('detachers.yml');
         $loader->load('factories.yml');
         $loader->load('items.yml');
         $loader->load('jobs.yml');

--- a/src/Pim/Bundle/ConnectorBundle/Doctrine/Common/Detacher/StoredProductDetacher.php
+++ b/src/Pim/Bundle/ConnectorBundle/Doctrine/Common/Detacher/StoredProductDetacher.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Pim\Bundle\ConnectorBundle\Doctrine\Common\Detacher;
+
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * Detach at once products that have been stored for.
+ *
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class StoredProductDetacher implements StoredProductDetacherInterface
+{
+    /** @var ObjectDetacherInterface */
+    protected $objectDetacher;
+
+    /** @var ProductInterface[] */
+    protected $productsToBeDetached = [];
+
+    /**
+     * @param ObjectDetacherInterface $objectDetacher
+     */
+    public function __construct(ObjectDetacherInterface $objectDetacher)
+    {
+        $this->objectDetacher = $objectDetacher;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storeProductToDetach(ProductInterface $product)
+    {
+        $this->productsToBeDetached[] = $product;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function detachStoredProducts()
+    {
+        foreach ($this->productsToBeDetached as $product) {
+            foreach ($product->getAssociations() as $association) {
+                foreach ($association->getProducts() as $associatedProduct) {
+                    $this->detachProductWithGroups($associatedProduct);
+                }
+            }
+
+            $this->detachProductWithGroups($product);
+        }
+
+        $this->productsToBeDetached = [];
+    }
+
+    /**
+     * @param ProductInterface $product
+     */
+    protected function detachProductWithGroups(ProductInterface $product)
+    {
+        foreach ($product->getGroups() as $group) {
+            $this->objectDetacher->detach($group);
+        }
+
+        $this->objectDetacher->detach($product);
+    }
+}

--- a/src/Pim/Bundle/ConnectorBundle/Doctrine/Common/Detacher/StoredProductDetacherInterface.php
+++ b/src/Pim/Bundle/ConnectorBundle/Doctrine/Common/Detacher/StoredProductDetacherInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pim\Bundle\ConnectorBundle\Doctrine\Common\Detacher;
+
+use Pim\Component\Catalog\Model\ProductInterface;
+
+/**
+ * Detach at once products that have been stored for.
+ *
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface StoredProductDetacherInterface
+{
+    /**
+     * Stores the products to be bulk detached.
+     *
+     * @param ProductInterface $product
+     */
+    public function storeProductToDetach(ProductInterface $product);
+
+    /**
+     * Detaches the products that have been stored.
+     */
+    public function detachStoredProducts();
+}

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/detachers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/detachers.yml
@@ -1,0 +1,8 @@
+parameters:
+    pim_connector.detacher.stored_product_detacher.class: Pim\Bundle\ConnectorBundle\Doctrine\Common\Detacher\StoredProductDetacher
+
+services:
+    pim_connector.detacher.stored_product_detacher:
+        class: '%pim_connector.detacher.stored_product_detacher.class%'
+        arguments:
+            - '@akeneo_storage_utils.doctrine.object_detacher'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
@@ -200,6 +200,7 @@ services:
             - '@pim_catalog.builder.product'
             - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_connector.processor.bulk_media_fetcher'
+            - '@pim_connector.detacher.stored_product_detacher'
 
     pim_connector.processor.normalization.variant_group:
         class: '%pim_connector.processor.normalization.variant_group.class%'

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -186,6 +186,7 @@ services:
             - '@pim_catalog.repository.attribute'
             - '@pim_connector.writer.file.media_exporter_path_generator'
             - ['pim_catalog_file', 'pim_catalog_image']
+            - '@pim_connector.detacher.stored_product_detacher'
 
     pim_connector.writer.file.csv_product_quick_export:
         class: '%pim_connector.writer.file.csv_product.class%'
@@ -301,6 +302,7 @@ services:
              - '@pim_catalog.repository.attribute'
              - '@pim_connector.writer.file.media_exporter_path_generator'
              - ['pim_catalog_file', 'pim_catalog_image']
+             - '@pim_connector.detacher.stored_product_detacher'
 
     pim_connector.writer.file.xlsx_product_quick_export:
         class: '%pim_connector.writer.file.xlsx_product.class%'

--- a/src/Pim/Bundle/ConnectorBundle/spec/Doctrine/Common/Detacher/StoredProductDetacherSpec.php
+++ b/src/Pim/Bundle/ConnectorBundle/spec/Doctrine/Common/Detacher/StoredProductDetacherSpec.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace spec\Pim\Bundle\ConnectorBundle\Doctrine\Common\Detacher;
+
+use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AssociationInterface;
+use Pim\Component\Catalog\Model\GroupInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+class StoredProductDetacherSpec extends ObjectBehavior
+{
+    function let(ObjectDetacherInterface $objectDetacher)
+    {
+        $this->beConstructedWith($objectDetacher);
+    }
+
+    function it_detaches_stored_products(
+        $objectDetacher,
+        ProductInterface $productA,
+        ProductInterface $productB
+    ) {
+        $this->storeProductToDetach($productA);
+        $this->storeProductToDetach($productB);
+
+        $productA->getGroups()->willReturn([]);
+        $productA->getAssociations()->willReturn([]);
+        $productB->getGroups()->willReturn([]);
+        $productB->getAssociations()->willReturn([]);
+
+        $objectDetacher->detach($productA)->shouldBeCalled();
+        $objectDetacher->detach($productB)->shouldBeCalled();
+
+        $this->detachStoredProducts([$productA, $productB]);
+    }
+
+    function it_detaches_stored_product_with_groups(
+        $objectDetacher,
+        ProductInterface $product,
+        GroupInterface $groupA,
+        GroupInterface $groupB,
+        Collection $groupCollection,
+        \Iterator $groupIterator
+    ) {
+        $this->storeProductToDetach($product);
+
+        $product->getGroups()->willReturn($groupCollection);
+        $groupCollection->getIterator()->willReturn($groupIterator);
+        $groupIterator->rewind()->shouldBeCalled();
+        $groupIterator->next()->shouldBeCalled();
+        $groupIterator->valid()->willReturn(true, true, false);
+        $groupIterator->current()->willReturn($groupA, $groupB);
+
+        $product->getAssociations()->willReturn([]);
+
+        $objectDetacher->detach($groupA)->shouldBeCalled();
+        $objectDetacher->detach($groupB)->shouldBeCalled();
+        $objectDetacher->detach($product)->shouldBeCalled();
+
+        $this->detachStoredProducts([$product]);
+    }
+
+    function it_detaches_stored_product_with_associated_products(
+        $objectDetacher,
+        ProductInterface $product,
+        ProductInterface $associatedProductA,
+        ProductInterface $associatedProductB,
+        ProductInterface $associatedProductC,
+        AssociationInterface $associationA,
+        AssociationInterface $associationB,
+        Collection $assoCollection,
+        Collection $productCollectionA,
+        Collection $productCollectionB,
+        \Iterator $assoIterator,
+        \Iterator $productIteratorA,
+        \Iterator $productIteratorB
+    ) {
+        $this->storeProductToDetach($product);
+
+        $product->getGroups()->willReturn([]);
+
+        $product->getAssociations()->willReturn($assoCollection);
+        $assoCollection->getIterator()->willReturn($assoIterator);
+        $assoIterator->rewind()->shouldBeCalled();
+        $assoIterator->next()->shouldBeCalled();
+        $assoIterator->valid()->willReturn(true, true, false);
+        $assoIterator->current()->willReturn($associationA, $associationB);
+
+        $associationA->getProducts()->willReturn($productCollectionA);
+        $productCollectionA->getIterator()->willReturn($productIteratorA);
+        $productIteratorA->rewind()->shouldBeCalled();
+        $productIteratorA->next()->shouldBeCalled();
+        $productIteratorA->valid()->willReturn(true, true, false);
+        $productIteratorA->current()->willReturn($associatedProductA, $associatedProductB);
+
+        $associationB->getProducts()->willReturn($productCollectionB);
+        $productCollectionB->getIterator()->willReturn($productIteratorB);
+        $productIteratorB->rewind()->shouldBeCalled();
+        $productIteratorB->next()->shouldBeCalled();
+        $productIteratorB->valid()->willReturn(true, false);
+        $productIteratorB->current()->willReturn($associatedProductC);
+
+        $associatedProductA->getGroups()->willReturn([]);
+        $associatedProductB->getGroups()->willReturn([]);
+        $associatedProductC->getGroups()->willReturn([]);
+
+        $objectDetacher->detach($associatedProductA)->shouldBeCalled();
+        $objectDetacher->detach($associatedProductB)->shouldBeCalled();
+        $objectDetacher->detach($associatedProductC)->shouldBeCalled();
+        $objectDetacher->detach($product)->shouldBeCalled();
+
+        $this->detachStoredProducts([$product]);
+    }
+
+    function it_detaches_stored_product_with_associated_product_having_group(
+        $objectDetacher,
+        ProductInterface $product,
+        ProductInterface $associatedProduct,
+        AssociationInterface $association,
+        GroupInterface $group,
+        Collection $assoCollection,
+        Collection $productCollection,
+        Collection $groupCollection,
+        \Iterator $assoIterator,
+        \Iterator $productIterator,
+        \Iterator $groupIterator
+    ) {
+        $this->storeProductToDetach($product);
+
+        $product->getGroups()->willReturn([]);
+
+        $product->getAssociations()->willReturn($assoCollection);
+        $assoCollection->getIterator()->willReturn($assoIterator);
+        $assoIterator->rewind()->shouldBeCalled();
+        $assoIterator->next()->shouldBeCalled();
+        $assoIterator->valid()->willReturn(true, false);
+        $assoIterator->current()->willReturn($association);
+
+        $association->getProducts()->willReturn($productCollection);
+        $productCollection->getIterator()->willReturn($productIterator);
+        $productIterator->rewind()->shouldBeCalled();
+        $productIterator->next()->shouldBeCalled();
+        $productIterator->valid()->willReturn(true, false);
+        $productIterator->current()->willReturn($associatedProduct);
+
+        $associatedProduct->getGroups()->willReturn($groupCollection);
+        $groupCollection->getIterator()->willReturn($groupIterator);
+        $groupIterator->rewind()->shouldBeCalled();
+        $groupIterator->next()->shouldBeCalled();
+        $groupIterator->valid()->willReturn(true, false);
+        $groupIterator->current()->willReturn($group);
+
+        $objectDetacher->detach($group)->shouldBeCalled();
+        $objectDetacher->detach($associatedProduct)->shouldBeCalled();
+        $objectDetacher->detach($product)->shouldBeCalled();
+
+        $this->detachStoredProducts([$product]);
+    }
+}

--- a/src/Pim/Component/Connector/spec/Processor/Normalization/ProductProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Normalization/ProductProcessorSpec.php
@@ -13,6 +13,7 @@ use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\ConnectorBundle\Doctrine\Common\Detacher\StoredProductDetacherInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\GroupInterface;
@@ -27,7 +28,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class ProductProcessorSpec extends ObjectBehavior
 {
-    function let(
+    function it_is_initializable(
         NormalizerInterface $normalizer,
         ChannelRepositoryInterface $channelRepository,
         AttributeRepositoryInterface $attributeRepository,
@@ -46,31 +47,57 @@ class ProductProcessorSpec extends ObjectBehavior
         );
 
         $this->setStepExecution($stepExecution);
-    }
 
-    function it_is_initializable()
-    {
         $this->shouldHaveType('\Pim\Component\Connector\Processor\Normalization\ProductProcessor');
     }
 
-    function it_is_an_item_processor()
-    {
+    function it_is_an_item_processor(
+        NormalizerInterface $normalizer,
+        ChannelRepositoryInterface $channelRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        ProductBuilderInterface $productBuilder,
+        ObjectDetacherInterface $detacher,
+        BulkMediaFetcher $mediaFetcher,
+        StepExecution $stepExecution
+    ) {
+        $this->beConstructedWith(
+            $normalizer,
+            $channelRepository,
+            $attributeRepository,
+            $productBuilder,
+            $detacher,
+            $mediaFetcher
+        );
+
+        $this->setStepExecution($stepExecution);
+
         $this->shouldImplement('\Akeneo\Component\Batch\Item\ItemProcessorInterface');
     }
 
     function it_processes_product_without_media(
-        $detacher,
-        $normalizer,
-        $channelRepository,
-        $stepExecution,
-        $mediaFetcher,
-        $productBuilder,
-        $attributeRepository,
+        NormalizerInterface $normalizer,
+        ChannelRepositoryInterface $channelRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        ProductBuilderInterface $productBuilder,
+        ObjectDetacherInterface $detacher,
+        BulkMediaFetcher $mediaFetcher,
+        StepExecution $stepExecution,
         ChannelInterface $channel,
         LocaleInterface $locale,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
+        $this->beConstructedWith(
+            $normalizer,
+            $channelRepository,
+            $attributeRepository,
+            $productBuilder,
+            $detacher,
+            $mediaFetcher
+        );
+
+        $this->setStepExecution($stepExecution);
+
         $attributeRepository->findMediaAttributeCodes()->willReturn(['picture']);
 
         $stepExecution->getJobParameters()->willReturn($jobParameters);
@@ -134,13 +161,13 @@ class ProductProcessorSpec extends ObjectBehavior
     }
 
     function it_processes_a_product_with_groups(
-        $detacher,
-        $normalizer,
-        $channelRepository,
-        $stepExecution,
-        $mediaFetcher,
-        $productBuilder,
-        $attributeRepository,
+        NormalizerInterface $normalizer,
+        ChannelRepositoryInterface $channelRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        ProductBuilderInterface $productBuilder,
+        ObjectDetacherInterface $detacher,
+        BulkMediaFetcher $mediaFetcher,
+        StepExecution $stepExecution,
         ChannelInterface $channel,
         LocaleInterface $locale,
         ProductInterface $product,
@@ -150,6 +177,17 @@ class ProductProcessorSpec extends ObjectBehavior
         GroupInterface $groupA,
         GroupInterface $groupB
     ) {
+        $this->beConstructedWith(
+            $normalizer,
+            $channelRepository,
+            $attributeRepository,
+            $productBuilder,
+            $detacher,
+            $mediaFetcher
+        );
+
+        $this->setStepExecution($stepExecution);
+
         $attributeRepository->findMediaAttributeCodes()->willReturn(['picture']);
 
         $stepExecution->getJobParameters()->willReturn($jobParameters);
@@ -221,12 +259,13 @@ class ProductProcessorSpec extends ObjectBehavior
     }
 
     function it_processes_a_product_with_several_media(
-        $detacher,
-        $normalizer,
-        $channelRepository,
-        $stepExecution,
-        $mediaFetcher,
-        $productBuilder,
+        NormalizerInterface $normalizer,
+        ChannelRepositoryInterface $channelRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        ProductBuilderInterface $productBuilder,
+        ObjectDetacherInterface $detacher,
+        BulkMediaFetcher $mediaFetcher,
+        StepExecution $stepExecution,
         ChannelInterface $channel,
         LocaleInterface $locale,
         ProductInterface $product,
@@ -237,6 +276,17 @@ class ProductProcessorSpec extends ObjectBehavior
         ArrayCollection $valuesCollection,
         ExecutionContext $executionContext
     ) {
+        $this->beConstructedWith(
+            $normalizer,
+            $channelRepository,
+            $attributeRepository,
+            $productBuilder,
+            $detacher,
+            $mediaFetcher
+        );
+
+        $this->setStepExecution($stepExecution);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn('/my/path/product.csv');
         $jobParameters->get('filters')->willReturn(
@@ -293,12 +343,13 @@ class ProductProcessorSpec extends ObjectBehavior
     }
 
     function it_throws_an_exception_if_media_of_product_is_not_found(
-        $detacher,
-        $normalizer,
-        $channelRepository,
-        $stepExecution,
-        $mediaFetcher,
-        $productBuilder,
+        NormalizerInterface $normalizer,
+        ChannelRepositoryInterface $channelRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        ProductBuilderInterface $productBuilder,
+        ObjectDetacherInterface $detacher,
+        BulkMediaFetcher $mediaFetcher,
+        StepExecution $stepExecution,
         ChannelInterface $channel,
         LocaleInterface $locale,
         ProductInterface $product,
@@ -309,6 +360,17 @@ class ProductProcessorSpec extends ObjectBehavior
         ArrayCollection $valuesCollection,
         ExecutionContext $executionContext
     ) {
+        $this->beConstructedWith(
+            $normalizer,
+            $channelRepository,
+            $attributeRepository,
+            $productBuilder,
+            $detacher,
+            $mediaFetcher
+        );
+
+        $this->setStepExecution($stepExecution);
+
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn('/my/path/product.csv');
         $jobParameters->get('filters')->willReturn(
@@ -370,5 +432,95 @@ class ProductProcessorSpec extends ObjectBehavior
         $this->process($product)->shouldReturn($productStandard);
 
         $detacher->detach($product)->shouldBeCalled();
+    }
+
+    function it_processes_a_product_using_the_stored_product_detacher(
+        NormalizerInterface $normalizer,
+        ChannelRepositoryInterface $channelRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        ProductBuilderInterface $productBuilder,
+        ObjectDetacherInterface $detacher,
+        BulkMediaFetcher $mediaFetcher,
+        StepExecution $stepExecution,
+        StoredProductDetacherInterface $storedProductDetacher,
+        ChannelInterface $channel,
+        LocaleInterface $locale,
+        ProductInterface $product,
+        JobParameters $jobParameters,
+        Collection $groupCollection
+    ) {
+        $this->beConstructedWith(
+            $normalizer,
+            $channelRepository,
+            $attributeRepository,
+            $productBuilder,
+            $detacher,
+            $mediaFetcher,
+            $storedProductDetacher
+        );
+        $this->setStepExecution($stepExecution);
+
+        $attributeRepository->findMediaAttributeCodes()->willReturn(['picture']);
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filePath')->willReturn('/my/path/product.csv');
+        $jobParameters->get('filters')->willReturn(
+            [
+                'structure' => ['scope' => 'mobile', 'locales' => ['en_US', 'fr_FR']]
+            ]
+        );
+        $jobParameters->has('with_media')->willReturn(true);
+        $jobParameters->get('with_media')->willReturn(false);
+
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getLocales()->willReturn(new ArrayCollection([$locale]));
+        $channel->getCode()->willReturn('foobar');
+        $channel->getLocaleCodes()->willReturn(['en_US', 'de_DE']);
+
+        $productBuilder->addMissingProductValues($product, [$channel], [$locale])->shouldBeCalled();
+
+        $normalizer->normalize($product, 'standard', ['channels' => ['foobar'], 'locales' => ['en_US']])
+            ->willReturn([
+                'enabled'    => true,
+                'categories' => ['cat1', 'cat2'],
+                'values' => [
+                    'picture' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'a/b/c/d/e/f/little_cat.jpg'
+                        ]
+                    ],
+                    'size' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'M'
+                        ]
+                    ]
+                ]
+            ]);
+
+        $mediaFetcher->fetchAll(Argument::cetera())->shouldNotBeCalled();
+        $mediaFetcher->getErrors()->shouldNotBeCalled();
+
+        $product->getGroups()->willReturn($groupCollection);
+
+        $detacher->detach(Argument::any())->shouldNotBeCalled();
+        $storedProductDetacher->storeProductToDetach($product)->shouldBeCalled();
+
+        $this->process($product)->shouldReturn([
+            'enabled'    => true,
+            'categories' => ['cat1', 'cat2'],
+            'values' => [
+                'size' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'M'
+                    ]
+                ]
+            ]
+        ]);
     }
 }

--- a/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
@@ -9,6 +9,7 @@ use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\ConnectorBundle\Doctrine\Common\Detacher\StoredProductDetacherInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Writer\File\FileExporterPathGeneratorInterface;
@@ -31,7 +32,8 @@ class ProductWriterSpec extends ObjectBehavior
         BufferFactory $bufferFactory,
         FlatItemBufferFlusher $flusher,
         AttributeRepositoryInterface $attributeRepository,
-        FileExporterPathGeneratorInterface $fileExporterPath
+        FileExporterPathGeneratorInterface $fileExporterPath,
+        StoredProductDetacherInterface $storedProductDetacher
     ) {
         $this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'spec' . DIRECTORY_SEPARATOR;
         $this->filesystem = new Filesystem();
@@ -43,7 +45,8 @@ class ProductWriterSpec extends ObjectBehavior
             $flusher,
             $attributeRepository,
             $fileExporterPath,
-            ['pim_catalog_file', 'pim_catalog_image']
+            ['pim_catalog_file', 'pim_catalog_image'],
+            $storedProductDetacher
         );
     }
 
@@ -62,6 +65,7 @@ class ProductWriterSpec extends ObjectBehavior
         $attributeRepository,
         $fileExporterPath,
         $bufferFactory,
+        $storedProductDetacher,
         FlatItemBuffer $flatRowBuffer,
         StepExecution $stepExecution,
         JobParameters $jobParameters,
@@ -69,6 +73,8 @@ class ProductWriterSpec extends ObjectBehavior
         JobInstance $jobInstance,
         ExecutionContext $executionContext
     ) {
+        $storedProductDetacher->detachStoredProducts()->shouldBeCalled();
+
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getJobExecution()->willReturn($jobExecution);
@@ -223,6 +229,7 @@ class ProductWriterSpec extends ObjectBehavior
         $attributeRepository,
         $fileExporterPath,
         $bufferFactory,
+        $storedProductDetacher,
         FlatItemBuffer $flatRowBuffer,
         StepExecution $stepExecution,
         JobParameters $jobParameters,
@@ -230,6 +237,8 @@ class ProductWriterSpec extends ObjectBehavior
         JobInstance $jobInstance,
         ExecutionContext $executionContext
     ) {
+        $storedProductDetacher->detachStoredProducts()->shouldBeCalled();
+
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getJobExecution()->willReturn($jobExecution);

--- a/src/Pim/Component/Connector/spec/Writer/File/Xlsx/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Xlsx/ProductWriterSpec.php
@@ -9,6 +9,7 @@ use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\ConnectorBundle\Doctrine\Common\Detacher\StoredProductDetacherInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Writer\File\FileExporterPathGeneratorInterface;
@@ -31,7 +32,8 @@ class ProductWriterSpec extends ObjectBehavior
         BufferFactory $bufferFactory,
         FlatItemBufferFlusher $flusher,
         AttributeRepositoryInterface $attributeRepository,
-        FileExporterPathGeneratorInterface $fileExporterPath
+        FileExporterPathGeneratorInterface $fileExporterPath,
+        StoredProductDetacherInterface $storedProductDetacher
     ) {
         $this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'spec' . DIRECTORY_SEPARATOR;
         $this->filesystem = new Filesystem();
@@ -43,7 +45,8 @@ class ProductWriterSpec extends ObjectBehavior
             $flusher,
             $attributeRepository,
             $fileExporterPath,
-            ['pim_catalog_file', 'pim_catalog_image']
+            ['pim_catalog_file', 'pim_catalog_image'],
+            $storedProductDetacher
         );
     }
 
@@ -62,6 +65,7 @@ class ProductWriterSpec extends ObjectBehavior
         $attributeRepository,
         $fileExporterPath,
         $bufferFactory,
+        $storedProductDetacher,
         FlatItemBuffer $flatRowBuffer,
         StepExecution $stepExecution,
         JobParameters $jobParameters,
@@ -69,6 +73,8 @@ class ProductWriterSpec extends ObjectBehavior
         JobInstance $jobInstance,
         ExecutionContext $executionContext
     ) {
+        $storedProductDetacher->detachStoredProducts()->shouldBeCalled();
+
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getJobExecution()->willReturn($jobExecution);
@@ -226,6 +232,7 @@ class ProductWriterSpec extends ObjectBehavior
         $attributeRepository,
         $fileExporterPath,
         $bufferFactory,
+        $storedProductDetacher,
         FlatItemBuffer $flatRowBuffer,
         StepExecution $stepExecution,
         JobParameters $jobParameters,
@@ -233,6 +240,8 @@ class ProductWriterSpec extends ObjectBehavior
         JobInstance $jobInstance,
         ExecutionContext $executionContext
     ) {
+        $storedProductDetacher->detachStoredProducts()->shouldBeCalled();
+
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getJobExecution()->willReturn($jobExecution);


### PR DESCRIPTION
## Description

There is currently a memory leak on product export, caused by associated products not being detached.
The idea to fix this is to get the associations of an exported product, detach all the products they contain, then finally detach the exported product.

However, there is a problem here: some of the detached associated products could be in the batch too, needing to be exported later. In this case, we would need not to detach them as associated products, but wait they are normalized and passed to the writer, except we cannot predict if an associated product will be in the batch or not.

The solution proposed here is to stop detaching the exported products one by one in the processor, as they are currently, and to store them in a new detacher dedicated to product export. Then the detach itself will be perform from the writer, all the products of the batch at once. This way, we ensure we are not loosing data during the export.

It is hackish and dirty, but it is working. On a data set from a client, with about 4000 products, each with between 400 and 1200 values, the export memory was reaching more than 1 GiB in 20 minutes. Client reported exports of 700 to 900 products in half an hour.

With this fix, memory is stable at 286 MiB, and the export of 7000 products takes 15 minutes.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
