### PR TITLE
Fix tag filtered on EE builds

### DIFF
--- a/.ci/behat.enterprise.yml
+++ b/.ci/behat.enterprise.yml
@@ -2,7 +2,7 @@ default:
     paths:
         features: features
     filters:
-        tags: "~skip&&~skip-pef&&~doc&&~unstable&&~unstable-app&&~deprecated&&~@unstable-app@~ce"
+        tags: "~skip&&~skip-pef&&~doc&&~unstable&&~unstable-app&&~deprecated&&~@unstable-app&&~ce"
     context:
         class: Context\EnterpriseFeatureContext
         parameters:


### PR DESCRIPTION
## Description

This PR fixes an error on the tag list in the `behat.yml` used by the CI on EE builds (launched from a CE PR). The `@ce` tag was not take into accont, running CE behats that should not have been, ending on red builds.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
