### PR TITLE
IM-824: Fix security issue when requesting password

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,6 +1,10 @@
 # 1.7.x
 
-## Big Fixes
+# Improvements
+
+- IM-824: Change message when the user or email is not valid to a more generic message
+
+## Bug Fixes
 
 - PIM-7164: Fix a memory leak on product export caused by associated products not being detached
 

--- a/src/Oro/Bundle/UserBundle/Controller/ResetController.php
+++ b/src/Oro/Bundle/UserBundle/Controller/ResetController.php
@@ -19,6 +19,8 @@ class ResetController extends Controller
 
     /**
      * Request reset user password
+     *
+     * @Template
      */
     public function sendEmailAction()
     {
@@ -26,7 +28,7 @@ class ResetController extends Controller
         $user = $this->get('oro_user.manager')->findUserByUsernameOrEmail($username);
 
         if (null === $user) {
-            return $this->render('OroUserBundle:Reset:request.html.twig', ['invalid_username' => $username]);
+            return [];
         }
 
         if ($user->isPasswordRequestNonExpired($this->container->getParameter('oro_user.reset.ttl'))) {
@@ -61,7 +63,7 @@ class ResetController extends Controller
         $this->get('mailer')->send($message);
         $this->get('oro_user.manager')->updateUser($user);
 
-        return $this->redirect($this->generateUrl('oro_user_reset_check_email'));
+        return [];
     }
 
     /**

--- a/src/Oro/Bundle/UserBundle/Resources/config/navigation.yml
+++ b/src/Oro/Bundle/UserBundle/Resources/config/navigation.yml
@@ -98,7 +98,6 @@ oro_titles:
 
     oro_user_reset_reset: Password Reset
     oro_user_reset_request: Forgot Password
-    oro_user_reset_check_email: Password Reset - Check Email
 
     oro_user_group_create: Create Group
     oro_user_group_update: %%group%% - Edit

--- a/src/Oro/Bundle/UserBundle/Resources/config/oro/routing.yml
+++ b/src/Oro/Bundle/UserBundle/Resources/config/oro/routing.yml
@@ -31,11 +31,6 @@ oro_user_reset_send_email:
     defaults: { _controller: OroUserBundle:Reset:sendEmail }
     methods: [POST]
 
-oro_user_reset_check_email:
-    path: /user/check-email
-    defaults: { _controller: OroUserBundle:Reset:checkEmail }
-    methods: [GET]
-
 oro_user_reset_reset:
     path: /user/reset/{token}
     defaults: { _controller: OroUserBundle:Reset:reset }

--- a/src/Pim/Bundle/UserBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/translations/messages.en.yml
@@ -167,5 +167,5 @@ Username or Email: Username or Email
 Forgot Password: Forgot Password
 Request: Request
 Check Email: Check Email
-password_reset_email_sent: An email has been sent to %email%. It contains a link you must click to reset your password.
+password_reset_email_sent: An email has been sent to the user. It contains a link to reset the password.
 Go to homepage: Go to homepage

--- a/src/Pim/Bundle/UserBundle/Resources/views/Reset/request.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/Reset/request.html.twig
@@ -10,13 +10,6 @@
 
     <form action="{{ path('oro_user_reset_send_email') }}" method="post" class="form-reset">
         <h2 class="AknLogin-subTitle">{{ 'Forgot Password'|trans }}</h2>
-
-        {% if invalid_username is defined %}
-            <div class="AknMessageBox AknMessageBox--error">
-                {{ 'The username or email address "%username%" does not exist.'|trans({ '%username%': invalid_username }) }}
-            </div>
-        {% endif %}
-
         <fieldset>
             <div class="AknLogin-form">
                 <input class="AknLogin-formInput" type="text" name="username" required="required" placeholder="{{ 'Username or Email'|trans }}" autofocus="autofocus"/>

--- a/src/Pim/Bundle/UserBundle/Resources/views/Reset/sendEmail.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/Reset/sendEmail.html.twig
@@ -9,10 +9,8 @@
     </div>
 
     <form action="" class="form-reset">
-        <h2 class="AknLogin-subTitle">{{ 'Check Email'|trans }}</h2>
-
         <div class="AknMessageBox AknMessageBox--apply">
-            {{ 'password_reset_email_sent'|trans({ '%email%': email }) }}
+            {{ 'password_reset_email_sent'|trans }}
         </div>
         <div class="AknForm">
             <a href="{{ path('oro_default') }}" class="AknLogin-link cancel">{{ 'Go to homepage'|trans }}</a>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**Context:**
When a user asks for a new password the pim will show a message to the user indicating the email address the email has been set or tell the user if the username/email is invalid.

**Problem:**
This is a security issue as an attacker can then guess if a username/elam exists or not.

**Solution:**
Print out a standard message, in all cases, saying that an email has been set to the user.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
