### PR TITLE
GITHUB-7709: Fix multiple session save

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7305: Fix memory leak on purge job command
+- GITHUB-7709: Fix multiple session save (thank you so much [muspelheim](https://github.com/muspelheim))
 
 # 2.2.4 (2018-04-26)
 

--- a/src/Pim/Bundle/UserBundle/Context/UserContext.php
+++ b/src/Pim/Bundle/UserBundle/Context/UserContext.php
@@ -113,7 +113,10 @@ class UserContext
             throw new \LogicException('There are no activated locales');
         }
 
-        if (null !== $this->getCurrentRequest() && $this->getCurrentRequest()->hasSession()) {
+        if (null !== $this->getCurrentRequest()
+            && $this->getCurrentRequest()->hasSession()
+            && !$this->getCurrentRequest()->getSession()->has('dataLocale')
+        ) {
             $this->getCurrentRequest()->getSession()->set('dataLocale', $locale->getCode());
             $this->getCurrentRequest()->getSession()->save();
         }

--- a/src/Pim/Bundle/UserBundle/spec/Context/UserContextSpec.php
+++ b/src/Pim/Bundle/UserBundle/spec/Context/UserContextSpec.php
@@ -11,7 +11,6 @@ use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
-use Prophecy\Argument;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -29,7 +28,6 @@ class UserContextSpec extends ObjectBehavior
         LocaleInterface $en,
         LocaleInterface $fr,
         LocaleInterface $de,
-        ChannelInterface $ecommerce,
         ChannelInterface $mobile,
         CategoryInterface $firstTree,
         CategoryInterface $secondTree,
@@ -76,6 +74,7 @@ class UserContextSpec extends ObjectBehavior
     function it_provides_locale_from_the_request_if_it_has_been_set($request, $fr, $session)
     {
         $request->get('dataLocale')->willReturn('fr_FR');
+        $session->has('dataLocale')->willReturn(false);
 
         $session->set('dataLocale', 'fr_FR')->shouldBeCalled();
         $session->save()->shouldBeCalled();
@@ -90,6 +89,7 @@ class UserContextSpec extends ObjectBehavior
     ) {
         $request->get('dataLocale')->willReturn(null);
         $session->get('dataLocale')->willReturn('fr_FR');
+        $session->has('dataLocale')->willReturn(false);
 
         $session->set('dataLocale', 'fr_FR')->shouldBeCalled();
         $session->save()->shouldBeCalled();
@@ -106,6 +106,7 @@ class UserContextSpec extends ObjectBehavior
         $request->get('dataLocale')->willReturn(null);
         $session->get('dataLocale')->willReturn(null);
         $user->getCatalogLocale()->willReturn($de);
+        $session->has('dataLocale')->willReturn(false);
 
         $session->set('dataLocale', 'de_DE')->shouldBeCalled();
         $session->save()->shouldBeCalled();
@@ -121,6 +122,7 @@ class UserContextSpec extends ObjectBehavior
     ) {
         $request->get('dataLocale')->willReturn(null);
         $session->get('dataLocale')->willReturn(null);
+        $session->has('dataLocale')->willReturn(false);
 
         $session->set('dataLocale', 'en_US')->shouldBeCalled();
         $session->save()->shouldBeCalled();
@@ -156,7 +158,7 @@ class UserContextSpec extends ObjectBehavior
         $request->get('dataLocale')->willReturn(null);
         $session->get('dataLocale')->willReturn(null);
         $user->getCatalogLocale()->willReturn(null);
-
+        $session->has('dataLocale')->willReturn(false);
 
         $session->set('dataLocale', 'en_US')->shouldBeCalled();
         $session->save()->shouldBeCalled();


### PR DESCRIPTION
**Description**

PR Related with #7709 

I found a bug with wrong setCookie behavior in `Pim \ Bundle \ UserBundle \ Context \ UserContext` class. method `getCurrentLocale` has had multiple session saving. So this behavior have effect to whole application (`UserContext` used in a bunch of places)

It wrong behavior for application, because doesn't match with [HTTP specification](https://tools.ietf.org/html/rfc6265#section-4.1.1)

`Servers SHOULD NOT include more than one Set-Cookie header field in the same response with the same cookie-name.`

**Dev env BEFORE fix**
![selection_361](https://user-images.githubusercontent.com/1663352/36551351-771142b2-1808-11e8-81b3-acfe0f3d6125.png)

![selection_359](https://user-images.githubusercontent.com/1663352/36551029-b5ab81dc-1807-11e8-9c5c-eaf932364ca7.png)

**Dev env After fix**
![selection_362](https://user-images.githubusercontent.com/1663352/36551374-7fe60058-1808-11e8-994c-08d7def58227.png)

![selection_360](https://user-images.githubusercontent.com/1663352/36551074-d0ae47ee-1807-11e8-95a2-0c99a625828c.png)


**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

P.S: Affected versions atleast 2.0, 2.1, 2.2