### PR TITLE
Fix product import performance by using cached repository

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Improvements
+
+- GITHUB-7730: Improve product and product model import performances by using cached repositories
+
 # 2.0.16 (2018-02-22)
 
 ## Bug fixes

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/processors.yml
@@ -331,12 +331,12 @@ services:
         arguments:
             - '@pim_catalog.repository.family_variant'
             - '@pim_catalog.repository.product_model'
-            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.repository.cached_attribute'
 
     pim_connector.processor.attribute_filter.product:
         class: '%pim_connector.processor.attribute_filter.product.class%'
         arguments:
             - '@pim_catalog.repository.product_model'
-            - '@pim_catalog.repository.family'
+            - '@pim_catalog.repository.cached_family'
             - '@pim_catalog.repository.product'
-            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.repository.cached_attribute'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**Before**:
180 000 query when doing a `pim:install`, more than 80000 requests to get the attributes.
2 minutes to install the catalog (!).

**After**:
80 000 query when doing a `pim:install`.
1m15 to install the catalog.

Free optimisation (37.5%). That's why I think it worths to do it in 2.0 (LTS).

Green CI except unstable test on ACL: https://ci.akeneo.com/blue/organizations/jenkins/akeneo%2Fpim-community-dev/detail/PR-7730/1/tests

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
