### PR TITLE
PIM-7134: Clear repository during version purge

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -8,6 +8,7 @@
 
 - PIM-7188: Avoid duplicate products during import
 - PIM-7164: Fix a memory leak on product export caused by associated products not being detached
+- PIM-7134: Fix a memory leak when purging version history (MongoDB)
 
 # 1.7.18 (2018-02-22)
 

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/VersionRepository.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/MongoDBODM/VersionRepository.php
@@ -73,7 +73,7 @@ class VersionRepository extends DocumentRepository implements VersionRepositoryI
     /**
      * @param array $params
      *
-     * @return \Doctrine\ORM\QueryBuilder
+     * @return \Doctrine\ODM\MongoDB\Query\Builder
      */
     public function createDatagridQueryBuilder(array $params = [])
     {

--- a/src/Pim/Bundle/VersioningBundle/Purger/VersionPurger.php
+++ b/src/Pim/Bundle/VersioningBundle/Purger/VersionPurger.php
@@ -89,6 +89,7 @@ class VersionPurger implements VersionPurgerInterface
                     $this->versionRemover->removeAll($versionsToPurge);
                     $this->objectDetacher->detachAll($versionsToPurge);
                     $versionsToPurge = [];
+                    $this->versionRepository->clear();
                 }
             } else {
                 $this->objectDetacher->detach($version);
@@ -146,8 +147,6 @@ class VersionPurger implements VersionPurgerInterface
      * Configure an option resolver with default option values
      *
      * @param OptionsResolver $optionResolver
-     *
-     * @return OptionsResolver
      */
     protected function configureOptions(OptionsResolver $optionResolver)
     {


### PR DESCRIPTION
## Description

We currently have a memory leak on the version purger in MongoDB. This is probably caused by the same bug in the Doctrine ODM detach method that was already affecting the product, that was fixed in the PR [PIM-6995](https://github.com/akeneo/pim-community-dev/pull/7136).

The same fix was tried on versions [in this PR](https://github.com/akeneo/pim-community-dev/pull/7545), but saddly did not worked: the memory didn't increased, but the versions were no longer removed...

This new PR seems to fix the issue for good: the memory is stable around 110 MiB (tested with the data of the client that raised the bug), and versions are indeed deleted.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
