### PR TITLE
API-547: return 422 instead 403 during product partial update

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Improvements
 
 - GITHUB-7730: Improve product and product model import performances by using cached repositories
+- API-547: return 422 instead 403 during product partial update
 
 ## Bug fixes
 

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -39,7 +39,6 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -425,7 +424,7 @@ class ProductController
                 $exception
             );
         } catch (InvalidArgumentException $exception) {
-            throw new AccessDeniedHttpException($exception->getMessage(), $exception);
+            throw new UnprocessableEntityHttpException($exception->getMessage(), $exception);
         }
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

It's a revert of this previous commit https://github.com/akeneo/pim-community-dev/commit/3e873cf6addeb9a0c9e674c428dd93ac0df0f3c9

We change our mind and prefer uniformity for the API response codes.

No tests to change in CE because it impacts only EE

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
