### PR TITLE
PIM-7167 Slowness when going back to the Product grid when a family is used in the filter

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -8,6 +8,7 @@
 
 - PIM-7199: Display a message when trying to delete the pim identifier attribute
 - PIM-7217: Fix missing and disabled fields in product model import
+- PIM-7167: Fix slowness when going back to the Product grid when a family is used in the filter
 
 # 2.0.16 (2018-02-22)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
@@ -106,7 +106,6 @@ define(
                 } else {
                     this._setInputValue(this.criteriaValueSelectors.value, value.value);
                 }
-                this._setInputValue(this.criteriaValueSelectors.type, value.type);
                 this._highlightDropdown(value.type, '.operator');
 
                 return this;

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
@@ -31,6 +31,10 @@ define(
             events: {
                 'click .AknDropdown-menuLink': '_onSelectOperator'
             },
+            criteriaValueSelectors: {
+                'value': 'input[name="value"]',
+                'operator': '.active .operator_choice'
+            },
 
             initialize: function(options) {
                 _.extend(this.events, TextFilter.prototype.events);
@@ -106,13 +110,14 @@ define(
                 } else {
                     this._setInputValue(this.criteriaValueSelectors.value, value.value);
                 }
+                this.$(this.criteriaValueSelectors.operator).data('value', value.type);
                 this._highlightDropdown(value.type, '.operator');
 
                 return this;
             },
 
             _readDOMValue: function() {
-                var operator = this.emptyChoice ? this.$('.active .operator_choice').data('value') : 'in';
+                var operator = this.emptyChoice ? this.$(this.criteriaValueSelectors.operator).data('value') : 'in';
 
                 return {
                     value: _.contains(['empty', 'not empty'], operator) ? {} : this._getInputValue(this.criteriaValueSelectors.value),


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

On the select2-rest-filter we had an extra call made to retrieve all the options while we already made the call to retrieve only the category selected. So this extra call was unnecessary and it added slowness. For instance, when the client have lot of families and the family filter is used we could see slowness on the product grid loading.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
