### PR TITLE
PIM-7217: [SLA]  Fix missing and disabled fields in product model import

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -7,6 +7,7 @@
 ## Bug fixes
 
 - PIM-7199: Display a message when trying to delete the pim identifier attribute
+- PIM-7217: Fix missing and disabled fields in product model import
 
 # 2.0.16 (2018-02-22)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
@@ -108,6 +108,17 @@ extensions:
             label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
             tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
 
+    pim-job-instance-xlsx-product-model-import-edit-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
+        parent: pim-job-instance-xlsx-product-model-import-edit-global
+        position: 135
+        targetZone: properties
+        config:
+            fieldCode: configuration.decimalSeparator
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
     pim-job-instance-xlsx-product-model-import-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
         parent: pim-job-instance-xlsx-product-model-import-edit-global
@@ -115,7 +126,7 @@ extensions:
         targetZone: properties
         config:
             fieldCode: configuration.dateFormat
-            readOnly: true
+            readOnly: false
             label: pim_enrich.form.job_instance.tab.properties.date_format.title
             tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In the XLSX import profile for product models, the decimal separator field was missing and the date format fields was misconfigured to be readonly, this PR fixes these issues.

Before
![screen shot 2018-03-01 at 11 55 35](https://user-images.githubusercontent.com/1336344/36841165-bf1e7bf8-1d47-11e8-8016-0db644f8885f.png)

After
![screen shot 2018-03-01 at 11 56 03](https://user-images.githubusercontent.com/1336344/36841169-c4689dbe-1d47-11e8-91d4-926cbb047a0f.png)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
