### PR TITLE
[2.1] Mass edit family : Fix warning message instead of fatal errors when we have violations

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Family/SetAttributeRequirements.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Family/SetAttributeRequirements.php
@@ -80,11 +80,7 @@ class SetAttributeRequirements extends AbstractProcessor
         $violations = $this->validator->validate($family);
 
         if (0 !== $violations->count()) {
-            foreach ($violations as $violation) {
-                $errors = sprintf("Family %s: %s\n", (string) $family, $violation->getMessage());
-                $this->stepExecution->addWarning($this->getName(), $errors, [], $family);
-            }
-
+            $this->addWarningMessage($violations, $family);
             $this->stepExecution->incrementSummaryInfo('skipped_families');
             $this->detacher->detach($family);
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description**

When we add an attribute on multiple families and we have violations, there are fatal errors in the call of this line : 
```php
$this->stepExecution->addWarning($this->getName(), $errors, [], $family);
```
The method $this->getName() is undefined
The second argument must be an array instead of a string
The third must implement interface `Akeneo\Component\Batch\Item\InvalidItemInterface 
The fourth don't exist

```php
StepExecution::addWarning($reason, array $reasonParameters, InvalidItemInterface $item)
```
So I replaced this line by the method `AbstractProcessor::addWarningMessage(ConstraintViolationListInterface $violations, $item)` in order to fix this and have this display : 

![screenshot from 2018-03-01 13-54-52](https://user-images.githubusercontent.com/937901/36845814-7967a61e-1d58-11e8-886f-764b02a59366.png)

