### PR TITLE
Fix #7752 wrong position of warning icon

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
@@ -37,10 +37,7 @@
   }
 
   &-iconsContainer {
-    min-width: @AknIconSize + 4px;
     padding-top: 4px;
-    position: absolute;
-    right: -40px;
   }
 
   &-contextContainer {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Changes on Less rules, to display properly the Warning Icon after a field is required.
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
