### PR TITLE
Fix #7760 wrong HTTP status on response

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
@@ -188,7 +188,7 @@ class AttributeOptionController
         try {
             $this->optionRemover->remove($attributeOption);
         } catch (\Exception $e) {
-            return new JsonResponse(['message' => $e->getMessage()], $e->getCode());
+            return new JsonResponse(['message' => $e->getMessage()], Response::HTTP_BAD_REQUEST);
         }
 
         return new JsonResponse();


### PR DESCRIPTION
Use the exception code as HTTP status is wrong since
will produce invalid HTTP responses e.g. a response where
the HTTP status is 0.

The HTTP status should be one of the defined in the following
class Symfony\Component\HttpFoundation\Response as constants.