### PR TITLE
Fixtures builder instances should not be shared

### DIFF
--- a/tests/Integration/IntegrationTestsBundle/Fixture/EntityWithValue/Builder/ProductModel.php
+++ b/tests/Integration/IntegrationTestsBundle/Fixture/EntityWithValue/Builder/ProductModel.php
@@ -155,17 +155,3 @@ final class ProductModel
         return $this;
     }
 }
-
-$this->product = $this->getFromTestContainer('akeneo_integration_tests.catalog.product.builder')
-    ->withIdentifier('my-product')
-    ->withFamily('accessories')
-    ->withValue('color', 'red')
-    ->withValue('description', 'description', 'en_US', 'ecommerce')
-    ->withValue('name', 'name', 'en_US')
-    // The variant product must only have the following values.
-    ->withValue('size', 'l')
-    ->withValue('ean', 'ean')
-    ->withCategories('master_accessories_belts')
-    ->withGroups('related')
-    ->withAssociations('X_SELL', '1111111171')
-    ->build();

--- a/tests/Integration/IntegrationTestsBundle/Resources/config/services.yml
+++ b/tests/Integration/IntegrationTestsBundle/Resources/config/services.yml
@@ -73,6 +73,7 @@ services:
     ### Builder
     akeneo_integration_tests.catalog.product.builder:
         class: 'Akeneo\Test\IntegrationTestsBundle\Fixture\EntityWithValue\Builder\Product'
+        shared: false
         arguments:
             - '@pim_catalog.builder.product'
             - '@pim_catalog.updater.product'
@@ -80,6 +81,7 @@ services:
 
     akeneo_integration_tests.base.product_model.builder:
         class: 'Akeneo\Test\IntegrationTestsBundle\Fixture\EntityBuilder'
+        shared: false
         arguments:
             - '@pim_catalog.factory.product_model'
             - '@pim_catalog.updater.product_model'
@@ -87,6 +89,7 @@ services:
 
     akeneo_integration_tests.catalog.product_model.builder:
         class: 'Akeneo\Test\IntegrationTestsBundle\Fixture\EntityWithValue\Builder\ProductModel'
+        shared: false
         arguments:
             - '@akeneo_integration_tests.base.product_model.builder'
             - '@pim_catalog.repository.product_model'


### PR DESCRIPTION
This fixes a mistake introduced in https://github.com/akeneo/pim-community-dev/pull/7677.
Since builders are stateful and are declared as services, the instances are shared by default. This can lead to weird behaviors like values being shared between two calls.

A "better" solution would be to not declare them as services, but dependencies injection would be another problem at this point.
Relying on the DI is a not perfect but acceptable answer right now.