### PR TITLE
PIM-7069: Fix Channel Export conversion units

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug fixes
+
+- PIM-7069: Fix Channel export regarding conversion_units output
+
 # 1.7.19 (2018-02-27)
 
 ## Improvements

--- a/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/Channel.php
+++ b/src/Pim/Component/Connector/ArrayConverter/StandardToFlat/Channel.php
@@ -21,8 +21,14 @@ class Channel extends AbstractSimpleArrayConverter implements ArrayConverterInte
         switch ($property) {
             case 'locales':
             case 'currencies':
-            case 'conversion_units':
                 $convertedItem[$property] = implode(',', array_filter($data));
+                break;
+            case 'conversion_units':
+                $formattedConvertedUnits = array_map(function ($key) use ($data) {
+                    return sprintf('%s:%s', trim($key), trim($data[$key]));
+                }, array_keys(array_filter($data)));
+
+                $convertedItem[$property] = implode(',', $formattedConvertedUnits);
                 break;
             case 'category_tree':
                 $convertedItem['tree'] = (string) $data;

--- a/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/ChannelSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/StandardToFlat/ChannelSpec.php
@@ -15,7 +15,8 @@ class ChannelSpec extends ObjectBehavior
             'locales'     => '',
             'currencies'  => 'GLD,PST',
             'tree'        => 'master_catalog',
-            'color'       => 'orange'
+            'color'       => 'orange',
+            'conversion_units' => 'weight:KILOGRAM,size:CENTIMETER'
         ];
 
         $item = [
@@ -30,7 +31,11 @@ class ChannelSpec extends ObjectBehavior
                 'PST'
             ],
             'category_tree'   => 'master_catalog',
-            'color'           => 'orange'
+            'color'           => 'orange',
+            'conversion_units' => [
+                'weight' => 'KILOGRAM',
+                'size'   => 'CENTIMETER'
+            ]
         ];
 
         $this->convert($item)->shouldReturn($expected);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

The Channel Export was wrong regarding conversion_units, it converted like that

| conversion_units |
| KILOGRAM, DECIMETER |

instead of:

| conversion_units |
| weight:KILOGRAM, size:DECIMETER |

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
