### PR TITLE
PIM-7214: Select products and families on multiple grid pages

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -9,6 +9,7 @@
 
 - PIM-7118: Fix bug related to product export
 - PIM-7199: Display a message when trying to delete the pim identifier attribute
+- PIM-7214: Fix a bug that prevents to select multiple items across pages in Products, Family and associations grids
 - PIM-7217: Fix missing and disabled fields in product model import
 - PIM-7167: Fix slowness when going back to the Product grid when a family is used in the filter
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Bug fixes
+
+- PIM-7214: Fix a bug that prevents to select multiple items across pages in Products, Family and associations grids
+
 # 2.0.17 (2018-03-06)
 
 ## Improvements
@@ -9,7 +15,6 @@
 
 - PIM-7118: Fix bug related to product export
 - PIM-7199: Display a message when trying to delete the pim identifier attribute
-- PIM-7214: Fix a bug that prevents to select multiple items across pages in Products, Family and associations grids
 - PIM-7217: Fix missing and disabled fields in product model import
 - PIM-7167: Fix slowness when going back to the Product grid when a family is used in the filter
 

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -11,6 +11,7 @@ use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
 use Akeneo\Component\Localization\Localizer\LocalizerInterface;
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Behat\ChainedStepsExtension\Step;
 use Behat\Gherkin\Node\TableNode;
@@ -148,6 +149,25 @@ class FixturesContext extends BaseFixturesContext
         for (;$numberOfProducts > 0; $numberOfProducts--) {
             $this->createProduct(sprintf('product_%s', $numberOfProducts));
         }
+    }
+
+    /**
+     * @param int $numberOfFamilies
+     *
+     * @Given /^([0-9]+) empty families$/
+     */
+    public function createEmptyFamilies(int $numberOfFamilies)
+    {
+        $families = [];
+
+        for (; $numberOfFamilies > 0; $numberOfFamilies--) {
+            $family = $this->getService('pim_catalog.factory.family')->create();
+            $family->setCode(sprintf('family_%s', $numberOfFamilies));
+            $this->validate($family);
+            $families[] = $family;
+        }
+
+        $this->getFamilySaver()->saveAll($families);
     }
 
     /**
@@ -2267,7 +2287,7 @@ class FixturesContext extends BaseFixturesContext
     }
 
     /**
-     * @return SaverInterface
+     * @return SaverInterface|BulkSaverInterface
      */
     protected function getFamilySaver()
     {

--- a/features/family/multiple_page_selection.feature
+++ b/features/family/multiple_page_selection.feature
@@ -1,0 +1,28 @@
+@javascript
+Feature: Select items on several pages
+  In order to enrich several families at once
+  As a product manager
+  I need to be able to select them on multiple pages
+
+  Background:
+    Given the "default" catalog configuration
+    And I am logged in as "Julia"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7214
+  Scenario: Select multiple families on multiple pages
+    Given 30 empty families
+    When I am on the families page
+    And I sort by "Label" value ascending
+    And I select rows [family_1]
+    And I select all visible entities
+    Then I should see the text "25 selected families"
+    When I unselect rows [family_1]
+    Then I should see the text "24 selected families"
+    When I follow "No. 2"
+    And I select rows [family_9]
+    Then I should see the text "25 selected families"
+    When I select all visible entities
+    Then I should see the text "29 selected families"
+    When I follow "No. 1"
+    And I unselect rows [family_2]
+    Then I should see the text "28 selected families"

--- a/features/product/multiple_page_selection.feature
+++ b/features/product/multiple_page_selection.feature
@@ -13,16 +13,16 @@ Feature: Select items on several pages
     Given 30 empty products
     When I am on the products page
     And I sort by "ID" value ascending
-    And I select rows product_1
+    And I select row product_1
     And I select all visible entities
     Then I should see the text "25 selected results"
-    When I unselect rows product_1
+    When I unselect row product_1
     Then I should see the text "24 selected results"
     When I follow "No. 2"
-    And I select rows product_9
+    And I select row product_9
     Then I should see the text "25 selected results"
     When I select all visible entities
     Then I should see the text "29 selected results"
     When I follow "No. 1"
-    And I unselect rows product_2
+    And I unselect row product_11
     Then I should see the text "28 selected results"

--- a/features/product/multiple_page_selection.feature
+++ b/features/product/multiple_page_selection.feature
@@ -1,0 +1,28 @@
+@javascript
+Feature: Select items on several pages
+  In order to enrich several products at once
+  As a product manager
+  I need to be able to select them on multiple pages
+
+  Background:
+    Given the "default" catalog configuration
+    And I am logged in as "Julia"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7214
+  Scenario: Select multiple products on multiple pages
+    Given 30 empty products
+    When I am on the products page
+    And I sort by "ID" value ascending
+    And I select rows product_1
+    And I select all visible entities
+    Then I should see the text "25 selected results"
+    When I unselect rows product_1
+    Then I should see the text "24 selected results"
+    When I follow "No. 2"
+    And I select rows product_9
+    Then I should see the text "25 selected results"
+    When I select all visible entities
+    Then I should see the text "29 selected results"
+    When I follow "No. 1"
+    And I unselect rows product_2
+    Then I should see the text "28 selected results"

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/header-cell/select-all-header-cell.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/header-cell/select-all-header-cell.js
@@ -164,7 +164,7 @@ define(
             if (!this.inset) {
                 this.initialState();
             }
-            this._selectAll();
+            this._selectAllNotSelected();
         },
 
         /**
@@ -173,6 +173,17 @@ define(
          * @private
          */
         _selectAll: function () {
+            this.collection.each(function (model) {
+                model.trigger("backgrid:select", model, true);
+            });
+        },
+
+        /**
+         * Marks all non selected models in collection as selected
+         *
+         * @private
+         */
+        _selectAllNotSelected: function () {
             this.collection.each((model) => {
                 if (!this.isSelectedModel(model)) {
                     model.trigger("backgrid:select", model, true);

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/header-cell/select-all-header-cell.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/header-cell/select-all-header-cell.js
@@ -173,8 +173,10 @@ define(
          * @private
          */
         _selectAll: function () {
-            this.collection.each(function (model) {
-                model.trigger("backgrid:select", model, true);
+            this.collection.each((model) => {
+                if (!this.isSelectedModel(model)) {
+                    model.trigger("backgrid:select", model, true);
+                }
             });
         },
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/row.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/row.js
@@ -42,6 +42,20 @@ function($, _, Backgrid) {
         },
 
         /**
+         * {@inheritdoc}
+         */
+        render: function () {
+            Backgrid.Row.prototype.render.apply(this, arguments);
+
+            const isChecked = this.$el.find('input[type=checkbox]').prop('checked');
+            if (true === isChecked) {
+                this.$el.addClass('AknGrid-bodyRow--selected');
+            }
+
+            return this;
+        },
+
+        /**
          * jQuery event handler for row click, trigger "clicked" event if row element was clicked
          *
          * @param {Event} e

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/mass-actions.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/mass-actions.js
@@ -55,7 +55,6 @@ define(
                     }
 
                     this.collection = collection;
-                    this.count = 0;
                     this.updateView();
                 };
                 this.listenTo(this.getRoot(), 'grid_load:start', setCollection);
@@ -111,7 +110,6 @@ define(
              * Updates the count after clicking in "Select all visible" button
              */
             selectVisible() {
-                this.count = 0;
                 this.collection.trigger('backgrid:selectAllVisible');
 
                 this.updateView();


### PR DESCRIPTION
## Description

In the family and product data grids, when you select items on a page, then change page, the mass action panel disappear, and the selection seems to be lost (see animation just above).

![peek 2018-03-06 16-22](https://user-images.githubusercontent.com/5039018/37040645-a2283de2-215a-11e8-99c8-334debaa4bc0.gif)

In fact, it is not, the datagrid information is still here: you can see it if you come back on the first page and place the cursor above the row you selected, you'll see it is still selected. Only the display of the mass actions is messed up (as you can see above, again).

![peek 2018-03-06 16-23](https://user-images.githubusercontent.com/5039018/37040731-c892cbf0-215a-11e8-8241-d0617d368819.gif)

This PR contains in fact 3 fixes:
- the `count` of the `mass-action` module is not reset anymore when the user change page on the grid,
- in `select-all-header-cell` module, correct class is added on already selected items, so they stay selected when changing page and getting back,
- when selecting "all visibles", only not already selected items are selected (in `row` module), so the counter is not messed up (because of the first fix, if you selected 2 items for instance, then selected all visible ones, meaning 25, you ended up with a counter indicating "27"...).

This is the correct behavior:

![peek 2018-03-06 16-28](https://user-images.githubusercontent.com/5039018/37041020-73bddb0a-215b-11e8-9ec1-996a9a9c279d.gif)

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
