### PR TITLE
PIM-7187: Fix product and product model reader

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/ProductAndProductModelReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/ProductAndProductModelReader.php
@@ -73,6 +73,8 @@ class ProductAndProductModelReader implements
      */
     public function initialize(): void
     {
+        $this->firstRead = true;
+
         $channel = $this->getConfiguredChannel();
         if (null !== $channel) {
             $this->completenessManager->generateMissingForChannel($channel);


### PR DESCRIPTION
## Description

The `ProductAndProductModelReader` is not correctly initialized each time it is used, the `firstRead` property being set to `true` only when the service is instantiated.

This leads to a wrong behavior if the reader is used twice in two steps of the same job (it is the case for mass edits with rule execution in EE): the first entity of the cursor is just skipped.

# Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
