### PR TITLE
PIM-6803: add message when deleting family with family variant

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -5,6 +5,7 @@
 - PIM-7097: Add sticky behaviour to product edit form
 - PIM-7097: Change the loading image
 - PIM-7090: Add completeness filter on product model export builder
+- PIM-6803: Message when delete a family with family variant.
 
 ## BC breaks
 

--- a/features/family/delete_family.feature
+++ b/features/family/delete_family.feature
@@ -16,6 +16,20 @@ Feature: Delete a family
     Then I should be on the families page
     But I should not see family Boots
 
+  Scenario: Failed to delete a family with family variants from the grid
+    Given the following family variants:
+      | code           | family | variant-axes_1 | variant-attributes_1 |
+      | family_variant | boots  | color          | description          |
+    And I am on the families grid
+    When I click on the "Delete" action of the row which contains "Boots"
+    And I confirm the deletion
+    Then I should see a dialog with the following content:
+      | title        | content                                                                |
+      | Delete Error | Can not remove family "boots" because it is linked to family variants. |
+    When I press the "OK" button
+    Then I should be on the families page
+    And I should see family Boots
+
   Scenario: Successfully delete a family from the edit page
     Given I am on the "sneakers" family page
     When I press the secondary action "Delete"

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
@@ -202,6 +202,18 @@ class FamilyController
         }
 
         $family = $this->getFamily($code);
+        if (!$family->getFamilyVariants()->isEmpty()) {
+            return new JsonResponse(
+                [
+                    'message' => sprintf(
+                        'Can not remove family "%s" because it is linked to family variants.',
+                        $family->getCode()
+                    )
+                ],
+                Response::HTTP_UNPROCESSABLE_ENTITY
+            );
+        }
+
         $this->remover->remove($family);
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);


### PR DESCRIPTION
Adds a message when deleting family with family variant instead of nothing + error 500 in js console.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
