### PR TITLE
PIM-7242: bootstrap the backend behind catalog volume monitoring

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -121,6 +121,7 @@ acceptance:
             contexts_services:
                 - test.locale.context
                 - test.channel.context
+                - test.catalog_volume_limits.attribute_per_family_context
             filters:
                 tags: '@acceptance'
     extensions:

--- a/src/Pim/Bundle/AnalyticsBundle/Controller/CatalogVolumeController.php
+++ b/src/Pim/Bundle/AnalyticsBundle/Controller/CatalogVolumeController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Pim\Bundle\AnalyticsBundle\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class CatalogVolumeController extends Controller
+{
+    public function __invoke()
+    {
+        return new JsonResponse($this->get('pim_catalog_volume')());
+    }
+}

--- a/src/Pim/Bundle/AnalyticsBundle/DependencyInjection/PimAnalyticsExtension.php
+++ b/src/Pim/Bundle/AnalyticsBundle/DependencyInjection/PimAnalyticsExtension.php
@@ -31,5 +31,6 @@ class PimAnalyticsExtension extends Extension
         $loader->load('data_collectors.yml');
         $loader->load('twig.yml');
         $loader->load('queries.yml');
+        $loader->load('catalog_volume.yml');
     }
 }

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/config/catalog_volume.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/config/catalog_volume.yml
@@ -1,0 +1,10 @@
+services:
+    pim_catalog_volume:
+        class: Pim\Component\Catalog\VolumeLimits\Application\GetVolumes
+        arguments:
+            - '@pim_catalog_volume.query.attributes_per_family'
+
+    pim_catalog_volume.query.attributes_per_family:
+        class: Pim\Component\Catalog\VolumeLimits\Infra\DBAL\Query\AttributesPerFamily
+        arguments:
+            - '@doctrine.dbal.default_connection'

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/config/routing.yml
@@ -9,3 +9,7 @@ pim_analytics_system_info_index:
 pim_analytics_system_info_download:
     path: /system_info/download
     defaults: { _controller: 'pim_analytics.controller.system_info:indexAction', _format: txt }
+
+pim_analytics_catalog_volume:
+    path: /catalog-volume
+    defaults: { _controller: 'Pim\Bundle\AnalyticsBundle\Controller\CatalogVolumeController' }

--- a/src/Pim/Component/Catalog/VolumeLimits/Application/GetVolumes.php
+++ b/src/Pim/Component/Catalog/VolumeLimits/Application/GetVolumes.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Component\Catalog\VolumeLimits\Application;
+
+use Pim\Component\Catalog\VolumeLimits\Model\Query\AttributesPerFamily;
+
+final class GetVolumes
+{
+    private $attributesPerFamily;
+
+    public function __construct(AttributesPerFamily $attributesPerFamily, array $limits = [])
+    {
+        $this->attributesPerFamily = $attributesPerFamily;
+        $this->limits = $limits;
+    }
+
+    public function __invoke(): iterable
+    {
+        $attributesPerFamily = ($this->attributesPerFamily)();
+
+        return [
+            'attributes_per_family' => [
+                'value' => $attributesPerFamily,
+                'limit_reached' => $attributesPerFamily > ($this->limits['attributes_per_family'] ?? INF),
+                'type' => 'mean_max',
+            ],
+        ];
+    }
+}

--- a/src/Pim/Component/Catalog/VolumeLimits/Infra/DBAL/Query/AttributesPerFamily.php
+++ b/src/Pim/Component/Catalog/VolumeLimits/Infra/DBAL/Query/AttributesPerFamily.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Component\Catalog\VolumeLimits\Infra\DBAL\Query;
+
+use Doctrine\DBAL\Connection;
+use Pim\Component\Catalog\VolumeLimits\Model\Query as Model;
+
+final class AttributesPerFamily implements Model\AttributesPerFamily
+{
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function __invoke(): array
+    {
+        return $this->connection->query(<<<SQL
+            select avg(a.rcount) mean, max(a.rcount) max
+            from (select count(attribute_id) rcount from pim_catalog_family_attribute group by family_id) a
+SQL
+        )->fetch();
+    }
+}

--- a/src/Pim/Component/Catalog/VolumeLimits/Model/Query/AttributesPerFamily.php
+++ b/src/Pim/Component/Catalog/VolumeLimits/Model/Query/AttributesPerFamily.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Component\Catalog\VolumeLimits\Model\Query;
+
+interface AttributesPerFamily
+{
+    public function __invoke(): array;
+}

--- a/tests/Acceptance/CatalogVolumeLimits/AttributePerFamilyContext.php
+++ b/tests/Acceptance/CatalogVolumeLimits/AttributePerFamilyContext.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\Acceptance\CatalogVolumeLimits;
+
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Pim\Component\Catalog\VolumeLimits\Model\Query\AttributesPerFamily;
+use Pim\Component\Catalog\VolumeLimits\Application\GetVolumes;
+use Webmozart\Assert\Assert;
+
+final class AttributePerFamilyContext implements Context, SnippetAcceptingContext
+{
+    private $limits = [];
+
+    /**
+     * @Given a family with :numberOfAttributes attributes
+     */
+    public function aFamilyWithAttributes($numberOfAttributes)
+    {
+        $this->familiesNumbers[] = $numberOfAttributes;
+    }
+
+    /**
+     * @When the administrator user asks for the catalog volume monitoring report
+     */
+    public function theAdministratorUserAsksForTheCatalogVolumeMonitoringReport()
+    {
+        $numbers = [
+            'mean' => array_sum($this->familiesNumbers) / count($this->familiesNumbers),
+            'max' => max($this->familiesNumbers),
+        ];
+        $attributesPerFamily = $this->mockAttributesPerFamilyQuery($numbers);
+
+        $this->getVolumes = new GetVolumes($attributesPerFamily, $this->limits);
+
+        $this->volumes = ($this->getVolumes)();
+    }
+
+    /**
+     * @Then the report returns that the mean number of attributes per family is :number
+     */
+    public function theReportReturnsThatTheMeanNumberOfAttributesPerFamilyIs($number)
+    {
+        Assert::eq($this->volumes['attributes_per_family']['value']['mean'], $number);
+    }
+
+    /**
+     * @Then the report returns that the maximum number of attributes per family is :number
+     */
+    public function theReportReturnsThatTheMaximumNumberOfAttributesPerFamilyIs($number)
+    {
+        Assert::eq($this->volumes['attributes_per_family']['value']['max'], $number);
+    }
+
+    private function mockAttributesPerFamilyQuery($numbers): AttributesPerFamily
+    {
+        return new class($numbers) implements AttributesPerFamily {
+            private $numbers;
+
+            public function __construct(array $numbers)
+            {
+                $this->numbers = $numbers;
+            }
+
+            public function __invoke(): array
+            {
+                return $this->numbers;
+            }
+        };
+    }
+
+    /**
+     * @Given the limit of the number of :what is set to :limit
+     */
+    public function theLimitOfTheNumberOfIsSetTo($what, $limit)
+    {
+        $this->limits[$what] = $limit;
+    }
+
+    /**
+     * @Then the report warns the users that the number of :what is high
+     */
+    public function theReportWarnsTheUsersThatTheNumberIsHigh($what)
+    {
+        Assert::true($this->volumes[$what]['limit_reached']);
+    }
+}

--- a/tests/Acceptance/Resources/config/behat/services.yml
+++ b/tests/Acceptance/Resources/config/behat/services.yml
@@ -49,3 +49,9 @@ services:
             - '@test.currency.builder'
         tags:
             - { name: fob.context_service }
+
+    test.catalog_volume_limits.attribute_per_family_context:
+        class: 'Akeneo\Test\Acceptance\CatalogVolumeLimits\AttributePerFamilyContext'
+        arguments: []
+        tags:
+            - { name: fob.context_service }

--- a/tests/features/scalability/volume-monitoring/monitor_attribute_per_family_volume.feature
+++ b/tests/features/scalability/volume-monitoring/monitor_attribute_per_family_volume.feature
@@ -1,0 +1,20 @@
+Feature: Monitor catalog volume
+  In order to guarantee the performance of the PIM
+  As an administrator user
+  I want to monitor the volume of attributes per family
+
+  @acceptance
+  Scenario: Monitor the number of attributes per family
+    Given a family with 10 attributes
+    And a family with 4 attributes
+    When the administrator user asks for the catalog volume monitoring report
+    Then the report returns that the mean number of attributes per family is 7
+    And the report returns that the maximum number of attributes per family is 10
+
+  @acceptance
+  Scenario: Warn the user administrator when the maximum number of attributes per family is high
+    Given a family with 8 attributes
+    And a family with 2 attributes
+    And the limit of the number of "attributes_per_family" is set to 6
+    When the administrator user asks for the catalog volume monitoring report
+    Then the report warns the users that the number of "attributes_per_family" is high


### PR DESCRIPTION
Related to https://github.com/akeneo/pim-community-dev/pull/7740

I introduced a new context named "Catalog/VolumeLimits" looking like:

```
src/Pim/Component/Catalog/VolumeLimits
├── Application
│   └── GetVolumes.php
├── Infra
│   └── DBAL
│       └── Query
│           └── AttributesPerFamily.php
└── Model
    └── Query
        └── AttributesPerFamily.php

6 directories, 3 files
```

The HTTP layer adapter lies in the AnalyticsBundle at the moment.

Result:

```
 % curl 'http://localhost:8080/app_dev.php/catalog-volume' -H 'Cookie: BAPID=144ir48dtm86lct89deag1ur7a' | jq      

{
  "attributes_per_family": {
    "value": {
      "mean": "13.4118",
      "max": "33"
    },
    "limit_reached": true,
    "type": "mean_max"
  }
}
```



| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | OK
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -


