### PR TITLE
PIM-7215: Fix wrong direction of sorting arrow in the grids

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7214: Fix a bug that prevents to select multiple items across pages in Products, Family and associations grids
+- PIM-7215: Fix wrong direction of sorting arrow in the grids
 
 # 2.0.17 (2018-03-06)
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -156,7 +156,7 @@
     display: inline-block;
   }
 
-  &-headerCell--descending &-caret {
+  &-headerCell--ascending &-caret {
     border-bottom: 4px solid @AknDefaultFontColor;
     border-top: none;
   }


### PR DESCRIPTION
**Description**
The sorting arrows are wrongly displayed in the wrong way, in all grids.
An upward arrow should indicates ascending order and a downward arrow descending order. 

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
