### PR TITLE
Behat chained step extension should be removed :'(

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -93,7 +93,6 @@ legacy:
                 - Pim\Behat\Context\Domain\Enrich\ItemPickerContext:
                     - 'Context\FeatureContext'
     extensions:
-        Behat\ChainedStepsExtension: ~
         Behat\MinkExtension:
             default_session: symfony2
             javascript_session: selenium2


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Chained step is an anti pattern but we still use it! It works because we copy paste the code of a behat extension which are not maintain anymore. Here, I just have removed the extension from the legacy profile. I won't fix all scenario in this PR but we should use it as an inventory. When we will work on a PR that use chained step you should try to rework those step if it possible.

**The main goal:** does not use this extension anymore and remove it from our code base.
