### PR TITLE
PIM-7237: fix integrity constraint violation during import

### DIFF
--- a/.ci/behat.community.yml
+++ b/.ci/behat.community.yml
@@ -88,6 +88,9 @@ default:
                     - 'Context\FeatureContext'
                 - Pim\Behat\Context\Storage\VariantProductStorage:
                     - '@pim_catalog.repository.product'
+                - Pim\Behat\Context\Storage\AttributeOptionStorage:
+                    - '@pim_catalog.repository.attribute_option'
+                    - '@doctrine.orm.default_entity_manager'
     extensions:
         Behat\ChainedStepsExtension: ~
         Behat\MinkExtension:

--- a/.ci/behat.enterprise.yml
+++ b/.ci/behat.enterprise.yml
@@ -98,6 +98,9 @@ default:
                     - 'Context\EnterpriseFeatureContext'
                 - Pim\Behat\Context\Storage\VariantProductStorage:
                     - '@pim_catalog.repository.product'
+                - Pim\Behat\Context\Storage\AttributeOptionStorage:
+                    - '@pim_catalog.repository.attribute_option'
+                    - '@doctrine.orm.default_entity_manager'
     extensions:
         Behat\ChainedStepsExtension: ~
         Behat\MinkExtension:

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,7 @@
 - PIM-7214: Fix a bug that prevents to select multiple items across pages in Products, Family and associations grids
 - PIM-7215: Fix wrong direction of sorting arrow in the grids
 - PIM-7220: Fix the filter "is empty" when the attribute belongs to a family
+- PIM-7237: Fix integrity constraint violation during import
 
 # 2.0.17 (2018-03-06)
 

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -85,6 +85,9 @@ default:
                     - 'Context\FeatureContext'
                 - Pim\Behat\Context\Storage\VariantProductStorage:
                     - '@pim_catalog.repository.product'
+                - Pim\Behat\Context\Storage\AttributeOptionStorage:
+                    - '@pim_catalog.repository.attribute_option'
+                    - '@doctrine.orm.default_entity_manager'
     extensions:
         Behat\ChainedStepsExtension: ~
         Behat\MinkExtension:

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -25,6 +25,7 @@ use Pim\Behat\Context\Domain\TreeContext;
 use Pim\Behat\Context\HookContext;
 use Pim\Behat\Context\JobContext;
 use Pim\Behat\Context\PimContext;
+use Pim\Behat\Context\Storage\AttributeOptionStorage;
 use Pim\Behat\Context\Storage\FileInfoStorage;
 use Pim\Behat\Context\Storage\ProductStorage;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -108,6 +109,7 @@ class FeatureContext extends PimContext implements KernelAwareContext
         $this->contexts['viewSelector'] = $environment->getContext(ViewSelectorContext::class);
         $this->contexts['storage-product'] = $environment->getContext(ProductStorage::class);
         $this->contexts['storage-file-info'] = $environment->getContext(FileInfoStorage::class);
+        $this->contexts['storage-attribute-option'] = $environment->getContext(AttributeOptionStorage::class);
         $this->contexts['attribute-validation'] = $environment->getContext(AttributeValidationContext::class);
         $this->contexts['role'] = $environment->getContext(PermissionsContext::class);
         $this->contexts['export-builder'] = $environment->getContext(ExportBuilderContext::class);

--- a/features/Pim/Behat/Context/Storage/AttributeOptionStorage.php
+++ b/features/Pim/Behat/Context/Storage/AttributeOptionStorage.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Behat\Context\Storage;
+
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Assert;
+use Pim\Bundle\CatalogBundle\Entity\AttributeOption;
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
+
+class AttributeOptionStorage implements Context
+{
+    /** @var IdentifiableObjectRepositoryInterface */
+    private $attributeOptionRepository;
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /**
+     * @param IdentifiableObjectRepositoryInterface $attributeOptionRepository
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(IdentifiableObjectRepositoryInterface $attributeOptionRepository, EntityManagerInterface $entityManager)
+    {
+        $this->attributeOptionRepository = $attributeOptionRepository;
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * @param TableNode $table Must contains columns "attribute" and "code".
+     *
+     * @throws \Exception
+     *
+     * @Then /^there should be the following attribute options:$/
+     */
+    public function thereShouldBeTheFollowingAttributeOptions($table): void
+    {
+        $this->entityManager->clear();
+
+        foreach ($table->getHash() as $attributeOptionData) {
+            $attributeOption = $this->getAttribute($attributeOptionData);
+            unset($attributeOptionData['attribute']);
+            unset($attributeOptionData['code']);
+
+            foreach ($attributeOptionData as $property => $expectedValue) {
+                if (preg_match('/^label-(?<locale>.*)$/', $property, $matches)) {
+                    $this->assertAttributeOptionLabelEqual($expectedValue, $matches['locale'], $attributeOption);
+                } else {
+                    // Implement other properties if needed.
+                    throw new \Exception(sprintf('The property "%s" is not supported', $property));
+                }
+            }
+        }
+    }
+
+    /**
+     * @param array $attributeOptionData
+     *
+     * @throws \Exception If the attribute option does not exist
+     *
+     * @return AttributeOption
+     */
+    private function getAttribute(array $attributeOptionData): AttributeOption
+    {
+        if (!isset($attributeOptionData['attribute'])) {
+            throw new \Exception('You must give the attribute code in the column "attribute"');
+        }
+
+        if (!isset($attributeOptionData['code'])) {
+            throw new \Exception('You must give the option code in the column "code"');
+        }
+
+        $attributeOptionIdentifier = sprintf('%s.%s', $attributeOptionData['attribute'], $attributeOptionData['code']);
+        $attributeOption = $this->attributeOptionRepository->findOneByIdentifier($attributeOptionIdentifier);
+
+        if (null === $attributeOption) {
+            throw new \Exception(sprintf(
+                'There is no option "%s" for the attribute "%s"',
+                $attributeOptionData['code'],
+                $attributeOptionData['attribute']
+            ));
+        }
+
+        return $attributeOption;
+    }
+
+    /**
+     * @param string $expectedLabel
+     * @param string $locale
+     * @param AttributeOptionInterface $attributeOption
+     *
+     * @throws \Exception
+     */
+    private function assertAttributeOptionLabelEqual(string $expectedLabel, string $locale, AttributeOptionInterface $attributeOption): void
+    {
+        $attributeOption->setLocale($locale);
+        $optionValue = $attributeOption->getOptionValue();
+
+        Assert::assertNotNull($optionValue, sprintf(
+            'The option "%s" of the attribute "%s" has no label for the locale "%s"',
+            $attributeOption->getCode(),
+            $attributeOption->getAttribute()->getCode(),
+            $locale
+        ));
+
+        $label = $optionValue->getLabel();
+
+        Assert::assertEquals($expectedLabel, $label, sprintf(
+            'The label "%s" of the option "%s" of the attribute "%s" is not equal to the expected one',
+            $locale,
+            $attributeOption->getCode(),
+            $attributeOption->getAttribute()->getCode()
+        ));
+    }
+}

--- a/features/attribute/option/import_attribute_options.feature
+++ b/features/attribute/option/import_attribute_options.feature
@@ -33,3 +33,20 @@ Feature: Import attribute options
     When I visit the "Product information" group
     And I change the "Manufacturer" to "[Converse]"
     Then I should see the text "[Converse]"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7237
+  Scenario: Successfully create new attribute options with duplicate options codes for the same attribute
+    Given the following CSV file to import:
+      """
+      code;attribute;sort_order;label-en_US
+      new_red;color;0;New Red
+      new_red;color;0;Red is dead
+      """
+    And the following job "csv_footwear_option_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_option_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_option_import" job to finish
+    Then there should be the following attribute options:
+      | attribute | code    | label-en_US |
+      | color     | new_red | Red is dead |

--- a/src/Akeneo/Component/Batch/Event/EventInterface.php
+++ b/src/Akeneo/Component/Batch/Event/EventInterface.php
@@ -26,4 +26,7 @@ interface EventInterface
     const STEP_EXECUTION_ERRORED = 'akeneo_batch.step_execution_errored';
     const STEP_EXECUTION_COMPLETED = 'akeneo_batch.step_execution_completed';
     const INVALID_ITEM = 'akeneo_batch.invalid_item';
+
+    /** Item step events */
+    const ITEM_STEP_AFTER_BATCH = 'akeneo_batch.item_step_after_batch';
 }

--- a/src/Akeneo/Component/Batch/spec/Step/ItemStepSpec.php
+++ b/src/Akeneo/Component/Batch/spec/Step/ItemStepSpec.php
@@ -51,11 +51,13 @@ class ItemStepSpec extends ObjectBehavior
         $processor->process('r2')->shouldBeCalled()->willReturn('p2');
         $processor->process('r3')->shouldBeCalled()->willReturn('p3');
         $writer->write(['p1', 'p2', 'p3'])->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::ITEM_STEP_AFTER_BATCH, Argument::any())->shouldBeCalled();
 
         // second batch
         $processor->process('r4')->shouldBeCalled()->willReturn('p4');
         $processor->process(null)->shouldNotBeCalled();
         $writer->write(['p4'])->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::ITEM_STEP_AFTER_BATCH, Argument::any())->shouldBeCalled();
 
         $execution->getExitStatus()->willReturn($exitStatus);
         $exitStatus->getExitCode()->willReturn(ExitStatus::COMPLETED);
@@ -94,6 +96,7 @@ class ItemStepSpec extends ObjectBehavior
         $processor->process('r2')->shouldBeCalled()->willReturn('p2');
         $processor->process('r3')->shouldBeCalled()->willReturn('p3');
         $writer->write(['p1', 'p2', 'p3'])->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::ITEM_STEP_AFTER_BATCH, Argument::any())->shouldBeCalled();
 
         // second batch
         $processor->process('r4')->shouldBeCalled()->willThrow(

--- a/src/Pim/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
+++ b/src/Pim/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
@@ -38,5 +38,6 @@ class PimConnectorExtension extends Extension
         $loader->load('steps.yml');
         $loader->load('validators.yml');
         $loader->load('writers.yml');
+        $loader->load('event_listeners.yml');
     }
 }

--- a/src/Pim/Bundle/ConnectorBundle/EventListener/ResetProcessedItemsBatchSubscriber.php
+++ b/src/Pim/Bundle/ConnectorBundle/EventListener/ResetProcessedItemsBatchSubscriber.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\ConnectorBundle\EventListener;
+
+use Akeneo\Component\Batch\Event\EventInterface;
+use Akeneo\Component\Batch\Event\StepExecutionEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Reset the processed items saved into the job execution context after each batch executed during a step.
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ResetProcessedItemsBatchSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            EventInterface::ITEM_STEP_AFTER_BATCH => 'resetProcessedItemsBatch',
+        ];
+    }
+
+    public function resetProcessedItemsBatch(StepExecutionEvent $event): void
+    {
+        $event->getStepExecution()->getExecutionContext()->remove('processed_items_batch');
+    }
+}

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/event_listeners.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/event_listeners.yml
@@ -1,0 +1,8 @@
+parameters:
+    pim_connector.reset_processed_items_batch_subscriber.class: Pim\Bundle\ConnectorBundle\EventListener\ResetProcessedItemsBatchSubscriber
+
+services:
+    pim_connector.reset_processed_items_batch_subscriber:
+        class: '%pim_connector.reset_processed_items_batch_subscriber.class%'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/ConnectorBundle/spec/EventListener/ResetProcessedItemsBatchSubscriberSpec.php
+++ b/src/Pim/Bundle/ConnectorBundle/spec/EventListener/ResetProcessedItemsBatchSubscriberSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace spec\Pim\Bundle\ConnectorBundle\EventListener;
+
+use Akeneo\Component\Batch\Event\EventInterface;
+use Akeneo\Component\Batch\Event\StepExecutionEvent;
+use Akeneo\Component\Batch\Item\ExecutionContext;
+use Akeneo\Component\Batch\Model\StepExecution;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ResetProcessedItemsBatchSubscriberSpec extends ObjectBehavior
+{
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_returns_subscribed_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn(
+            [
+                EventInterface::ITEM_STEP_AFTER_BATCH => 'resetProcessedItemsBatch'
+            ]
+        );
+    }
+
+    function it_resets_processed_items_batch_saved_in_the_execution_context(
+        StepExecutionEvent $event,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext
+    ) {
+        $event->getStepExecution()->willReturn($stepExecution);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->remove('processed_items_batch')->shouldBeCalled();
+
+        $this->resetProcessedItemsBatch($event);
+    }
+}

--- a/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/AbstractProcessor.php
@@ -58,20 +58,37 @@ abstract class AbstractProcessor implements StepExecutionAwareInterface
      */
     protected function findObject(IdentifiableObjectRepositoryInterface $repository, array $data)
     {
+        $identifier = $this->getItemIdentifier($repository, $data);
+
+        return $repository->findOneByIdentifier($identifier);
+    }
+
+    /**
+     * Get the identifier of a processed item
+     *
+     * @param IdentifiableObjectRepositoryInterface $repository
+     * @param array                                 $item
+     *
+     * @throws MissingIdentifierException if the processed item doesn't contain the identifier properties
+     *
+     * @return string
+     */
+    protected function getItemIdentifier(IdentifiableObjectRepositoryInterface $repository, array $item)
+    {
         $properties = $repository->getIdentifierProperties();
         $references = [];
         foreach ($properties as $property) {
-            if (!isset($data[$property])) {
+            if (!isset($item[$property])) {
                 throw new MissingIdentifierException(sprintf(
                     'Missing identifier column "%s". Columns found: %s.',
                     $property,
-                    implode(', ', array_keys($data))
+                    implode(', ', array_keys($item))
                 ));
             }
-            $references[] = $data[$property];
+            $references[] = $item[$property];
         }
 
-        return $repository->findOneByIdentifier(implode('.', $references));
+        return implode('.', $references);
     }
 
     /**


### PR DESCRIPTION
**What's the problem?**

When there are two items with the same identifier(s) in an import file that don't exist yet in the PIM, and they're processed in the same batch, then an MySQL error is thrown. 

It doesn't concern products import. The process is different and the duplication problem already handled.
It's about all the import jobs processed in [this generic Processor](https://github.com/akeneo/pim-community-dev/blob/2.0/src/Pim/Component/Connector/Processor/Denormalization/Processor.php)

Indeed, the items are read and processed one by one, but they're written by batch (100 items by default). There's no problem if the duplicate items already exists, they are simply updated twice; but if they don't exist, two distinct entities are created and persisted at the same time with the same identifier(s).

**How to fix that?**

Functionally, the goal is to act as if the duplicated items already exist, and so the last values overwrite the previous ones. (seen with the POs)

The difficulty is to do it without doing any BC-break. 

The idea (thanks to @jjanvier who already worked on that problem, but with another functional goal in the PR #5453) is to keep in memory the created items in the execution context.

To avoid memory issues, the processed items kept in memory are removed between each batch. It's done with a new event and a subscriber. It's not perfect, so if you have another idea I'm a buyer!

It might seem disproportionate to add an event for that, but it will be used to fix the SLA PIM-7240 too (a memory link during import)

**Why did I change the batch behavior in `ItemStep`?**

Now the batch size affects reading and processing items, not only writing. It allows to avoid that the number of processed items kept in memory inflates too much if there are no items to write during a long time (because validation errors per instance). Moreover, it should solve the memory leak when there are too many warnings (for the same reasons)

The counterpart is that it could be more calls to the writer if there are a lot of invalid items in the import file, but it seems acceptable, because it should be uncommon.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
