### PR TITLE
PIM-7112: Fix lock display of image field and multi select field

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -5,6 +5,7 @@
 - PIM-7097: Add sticky behaviour to product edit form
 - PIM-7097: Change the loading image
 - PIM-7090: Add completeness filter on product model export builder
+- PIM-7112: Add lock display on images/assets when user has no edit right.
 
 ## BC breaks
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
@@ -66,7 +66,13 @@
 
    &-list {
      &--disabled {
-       background: @AknDisabledInputColor;
+       background-color: @AknDisabledInputColor;
+       cursor: not-allowed;
+       background-image: url("../../../images/icon-lock.svg");
+       background-repeat: no-repeat;
+       background-position: ~"calc(100% - 12px)" center;
+       padding-right: @AknFormHeight - 4px;
+       color: @AknLightFontColor;
      }
   }
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/MediaField.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/MediaField.less
@@ -17,6 +17,29 @@
     width: 100%;
     height: 100%;
     opacity: 0;
+
+    &--disabled,
+    &[readonly],
+    &[disabled] {
+      cursor: not-allowed;
+
+      & + .AknMediaField-emptyContainer {
+        background: @AknDisabledInputColor;
+        background-image: url("../../../images/icon-lock.svg");
+        background-repeat: no-repeat;
+        background-position: ~"calc(100% - 12px)" center;
+        padding-right: @AknFormHeight - 4px;
+        color: @AknLightFontColor;
+      }
+
+      & ~ .AknMediaField-progress {
+        background: @AknDisabledInputColor;
+        opacity: 1;
+        flex-basis: @AknMicroProgressBarHeight + 5px;
+        margin: 0;
+        border-radius: 0;
+      }
+    }
   }
 
   &-emptyContainer {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -35,7 +35,8 @@
     }
   }
 
-  &.select2-container-disabled .select2-choice {
+  &.select2-container-disabled .select2-choice,
+  &.select2-container-disabled .select2-choices {
     background: @AknDisabledInputColor;
     color: @AknLightFontColor;
     border-color: @AknBorderColor;
@@ -215,7 +216,7 @@
   }
 
   &.select2-container-disabled .select2-choices {
-    background: @AknDisabledInputColor;
+    background-color: @AknDisabledInputColor;
 
     .select2-search-choice {
       padding: 0 8px;


### PR DESCRIPTION
Add a lock display for image and asset in PEF if user has no edit right.
Fix lock display for multiselect.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
