### PR TITLE
PIM-7129: Fix the yaml writer

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7129: Fix repeated content for a Yaml export
 - PIM-7255: Reduce Slowness of the datagrid
 - PIM-7152: Fix errors due to deletion of attributes linked to published products
 - PIM-7214: Fix a bug that prevents to select multiple items across pages in Products, Family and associations grids

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/Writer/YamlWriterIntegration.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/Writer/YamlWriterIntegration.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Pim\Bundle\ConnectorBundle\tests\integration\Export\Writer;
+
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Pim\Component\Connector\ArrayConverter\DummyConverter;
+use Pim\Component\Connector\ArrayConverter\FieldsRequirementChecker;
+use Pim\Component\Connector\Writer\File\Yaml\Writer;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * @author    Anael Chardan <anael.chardan@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class YamlWriterIntegration extends KernelTestCase
+{
+    /** @var Writer */
+    protected $writer;
+
+    /** @var string */
+    protected $filePath;
+
+    /** @var string */
+    protected $header;
+
+    public function setUp()
+    {
+        parent::setUp();
+        static::bootKernel();
+
+        $this->filePath = static::$kernel->getRootDir().'/../var/a_dump.yml';
+        $this->header = 'a_header';
+
+        $jobParameters = new JobParameters(['filePath' => $this->filePath]);
+        $jobExecution = new JobExecution();
+        $jobExecution->setJobParameters($jobParameters);
+        $stepExecution = new StepExecution('a_step', $jobExecution);
+        $this->writer = new Writer(new DummyConverter(new FieldsRequirementChecker()), $this->header);
+        $this->writer->setStepExecution($stepExecution);
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        unlink($this->filePath);
+    }
+
+    public function testItOverwriteTheFileWhenItsFlushed() {
+        $items = $this->itemProviders();
+        $this->writer->write($items);
+        $this->writer->flush();
+        $this->writer->write($items);
+
+        $writtenItems = Yaml::parseFile($this->filePath);
+        $this->assertEquals(count($items), count($writtenItems[$this->header]));
+    }
+
+    public function testItAppendsWithoutCopyingTheHeaderWhenItsNotFlushed() {
+        $items = $this->itemProviders();
+        $secondItems = $this->secondItemsProviders();
+        $this->writer->write($items);
+        $this->writer->write($secondItems);
+
+        //parse file assert that the key is not copied otherwise it would have overwrite a key
+        $writtenItems = Yaml::parseFile($this->filePath);
+        $this->assertEquals(count($items) + count($secondItems), count($writtenItems[$this->header]));
+    }
+
+    private function itemProviders(): array
+    {
+        $letters = range('A', 'Z');
+        $items = [];
+
+        foreach ($letters as $letter) {
+            $items[$letter] = [$letter => $letter];
+        }
+
+        return $items;
+    }
+
+    private function secondItemsProviders(): array
+    {
+        $letters = range('A', 'Z');
+        $items = [];
+
+        foreach ($letters as $letter) {
+            $doubledLetter = $letter.$letter;
+            $items[$doubledLetter] = [$doubledLetter => $doubledLetter];
+        }
+
+        return $items;
+    }
+}


### PR DESCRIPTION
<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

There were two problems:
- First one: 
  The file was never deleted as it was in FILE_APPEND mode, now the Writer is stateful (shame on me) because in case of a batch we need, first to overwrite the file and then append in it.

- Second one:
  During a batch, the header was written each time, but we had this kind of file:
  ```YAML
  rules:
      rule_1: coucou
      rule_100: plop
  rules:
     rule_101: ahahah
  ```
  So when we imported the file only a part of this one was imported, here is where the ugly stuff comes.
  The Yaml is a structured format so we do have to respect it, in order to avoid to repeat the header we had 3 solutions:
     - First one: Write only one time the file when all item would have been processed
           - Pro: The file is written one time only and it respects the structure
           - Cons: The RAM would have been overloaded for sure, the writer is stateful
     - Second one: Load the file, merge with the current batch chunk and overwrite the file
           - Pro: The structure is kept and we remove doubles, the writer is stateless
           - Cons: The RAM and access to the files systems and processing, we load 100, we write 200, we load 200, we write 300 an so one
     - Third one (the chosen one): We write into the file chunk by chunk but we have to remove the header and preserve the indentation to keep a valid YAML.
          - Pro: We do not overload the RAM and we keep the structure
          - Cons: We have to change the string  we write to add the offset indentation and the writer is stateful during a batch 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
