### PR TITLE
PIM-6919: Fix show boolean label for boolean-status-cell

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/boolean-status-cell.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/boolean-status-cell.js
@@ -14,11 +14,10 @@ define(['oro/datagrid/string-cell', 'oro/translator'],
          */
         return StringCell.extend({
             render: function () {
-                const columnValue = this.model.get(this.column.get('name'))
+                const columnValue = this.model.get(this.column.get('name'));
                 const value = this.formatter.fromRaw(columnValue);
-                const valueIsTrue = (value || value === 'true' || value === 1);
-                const label =  valueIsTrue ? '<strong>' + __('Yes') + '</strong>' : __('No');
-                
+                const label = (true === value || 'true' === value || '1' === value) ? '<strong>' + __('Yes') + '</strong>' : __('No');
+
                 this.$el.empty().html(label);
 
                 return this;


### PR DESCRIPTION
**Description**
On EE 2.0, all attributes are indicated as 'smart attributes' on the grid.
Also filter on smart attribute won't work.
==> [PR on EE](https://github.com/akeneo/pim-enterprise-dev/pull/3700)
boolean-status-cell always show "yes" when the value is 0.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | on EE
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
