### PR TITLE
PIM-7152: Fix errors due to deletion of attributes

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7152: Fix errors due to deletion of attributes linked to published products
 - PIM-7214: Fix a bug that prevents to select multiple items across pages in Products, Family and associations grids
 - PIM-7215: Fix wrong direction of sorting arrow in the grids
 - PIM-7220: Fix the filter "is empty" when the attribute belongs to a family

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
@@ -58,11 +58,16 @@ define([
                     url: this.getLink(),
                     wait: true,
                     error: function(element, response) {
+                        let contentType = response.getResponseHeader('content-type');
                         let message = '';
-                        const decodedResponse = JSON.parse(response.responseText);
-                        if (undefined !== decodedResponse.message) {
-                            message = decodedResponse.message
+                        //Need to check if it is a json because the backend can return an error
+                        if (contentType.indexOf("application/json") !== -1) {
+                            const decodedResponse = JSON.parse(response.responseText);
+                            if (undefined !== decodedResponse.message) {
+                                message = decodedResponse.message
+                            }
                         }
+
                         this.getErrorDialog(message).open();
                     }.bind(this),
                     success: function() {

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/edit.yml
@@ -47,7 +47,7 @@ extensions:
                 subTitle: pim_menu.item.attribute
                 content: pim_enrich.confirmation.delete_item
                 success: flash.attribute.removed
-                fail: error.removing.attribute
+                failed: error.removing.attribute
             redirect: pim_enrich_attribute_index
 
     pim-attribute-edit-form-save-buttons:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When deleting an attribute linked to a published product, an exception is thrown here: https://github.com/akeneo/pim-enterprise-dev/blob/2.0/src/PimEnterprise/Bundle/WorkflowBundle/EventSubscriber/PublishedProduct/CheckPublishedProductOnRemovalSubscriber.php#L105

And not catched here: https://github.com/akeneo/pim-community-dev/blob/2.0/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php#L342

Thus, the error is thrown by the server and it is not a JSON one, the javascript has to be aware of that.

See tests in this PR: https://github.com/akeneo/pim-enterprise-dev/pull/3703 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
