### PR TITLE
PIM-7240: Add subscriber to clear the cache between each job step batch

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # 2.0.x
 
+## Bug fixes
+
+- PIM-7240: Add subscriber to clear the cache between each job step batch
+
 # 2.0.19 (2018-03-23)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/ResetUniqueValidationSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/ResetUniqueValidationSubscriber.php
@@ -8,7 +8,7 @@ use Pim\Component\Catalog\Validator\UniqueValuesSet;
 /**
  * The UniqueValueSet class is stateful, and used when you import several product, to check if in the product batch
  * there is no unique identifier issues or unique axis combination issues.
- * This listener listen the StorageEvents::POST_SAVE_ALL to reset the UniqueValueSet information, to be able to
+ * This listener listen the EventInterface::ITEM_STEP_AFTER_BATCH to reset the UniqueValueSet information, to be able to
  * work in another product batch without uniqueness issues.
  *
  * @author    Pierre Allard <pierre.allard@akeneo.com>
@@ -35,9 +35,9 @@ class ResetUniqueValidationSubscriber
 
     /**
      * Reset the Unique Value Set.
-     * Called on StorageEvents::POST_SAVE_ALL
+     * Called on EventInterface::ITEM_STEP_AFTER_BATCH
      */
-    public function onAkeneoStoragePostsaveall()
+    public function onAkeneoBatchItemStepAfterBatch()
     {
         $this->uniqueValueSet->reset();
         $this->uniqueAxesCombinationSet->reset();

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -68,7 +68,7 @@ services:
             - '@pim_catalog.validator.unique_value_set'
             - '@pim_catalog.validator.unique_axes_combination_set'
         tags:
-           - { name: kernel.event_listener, event: akeneo.storage.post_save_all }
+           - { name: kernel.event_listener, event: akeneo_batch.item_step_after_batch }
 
     pim_catalog.event_subscriber.compute_product_raw_values:
         class: '%pim_catalog.event_subscriber.compute_product_raw_values.class%'

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ResetUniqueValidationSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/ResetUniqueValidationSubscriberSpec.php
@@ -23,6 +23,6 @@ class ResetUniqueValidationSubscriberSpec extends ObjectBehavior
         $uniqueValueSet->reset()->shouldBeCalled();
         $uniqueAxesCombinationSet->reset()->shouldBeCalled();
 
-        $this->onAkeneoStoragePostsaveall();
+        $this->onAkeneoBatchItemStepAfterBatch();
     }
 }

--- a/src/Pim/Bundle/ConnectorBundle/EventListener/ClearBatchCacheSubscriber.php
+++ b/src/Pim/Bundle/ConnectorBundle/EventListener/ClearBatchCacheSubscriber.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\ConnectorBundle\EventListener;
+
+use Akeneo\Component\Batch\Event\EventInterface;
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Clear the internal cache between each batch during the execution of an item step.
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ClearBatchCacheSubscriber implements EventSubscriberInterface
+{
+    /** @var CacheClearerInterface */
+    private $cacheClearer;
+
+    /**
+     * @param CacheClearerInterface $cacheClearer
+     */
+    public function __construct(CacheClearerInterface $cacheClearer)
+    {
+        $this->cacheClearer = $cacheClearer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            EventInterface::ITEM_STEP_AFTER_BATCH => 'clearCache',
+        ];
+    }
+
+    public function clearCache(): void
+    {
+        $this->cacheClearer->clear();
+    }
+}

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/event_listeners.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/event_listeners.yml
@@ -1,8 +1,16 @@
 parameters:
     pim_connector.reset_processed_items_batch_subscriber.class: Pim\Bundle\ConnectorBundle\EventListener\ResetProcessedItemsBatchSubscriber
+    pim_connector.clear_batch_cache_subscriber.class: Pim\Bundle\ConnectorBundle\EventListener\ClearBatchCacheSubscriber
 
 services:
     pim_connector.reset_processed_items_batch_subscriber:
         class: '%pim_connector.reset_processed_items_batch_subscriber.class%'
         tags:
             - { name: kernel.event_subscriber }
+
+    pim_connector.clear_batch_cache_subscriber:
+          class: '%pim_connector.clear_batch_cache_subscriber.class%'
+          arguments:
+              - '@pim_connector.doctrine.cache_clearer'
+          tags:
+              - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Family/SetAttributeRequirements.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/MassEdit/Family/SetAttributeRequirements.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Bundle\EnrichBundle\Connector\Processor\MassEdit\Family;
 
+use Akeneo\Component\Batch\Item\DataInvalidItem;
 use Akeneo\Component\StorageUtils\Detacher\ObjectDetacherInterface;
 use Pim\Bundle\EnrichBundle\Connector\Processor\AbstractProcessor;
 use Pim\Component\Catalog\Factory\AttributeRequirementFactory;
@@ -82,7 +83,7 @@ class SetAttributeRequirements extends AbstractProcessor
         if (0 !== $violations->count()) {
             foreach ($violations as $violation) {
                 $errors = sprintf("Family %s: %s\n", (string) $family, $violation->getMessage());
-                $this->stepExecution->addWarning($this->getName(), $errors, [], $family);
+                $this->stepExecution->addWarning($errors, [], new DataInvalidItem($family));
             }
 
             $this->stepExecution->incrementSummaryInfo('skipped_families');

--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredFamilyReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredFamilyReader.php
@@ -19,9 +19,6 @@ class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInt
     /** @var StepExecution */
     protected $stepExecution;
 
-    /** @var bool */
-    protected $isExecuted;
-
     /** @var ArrayCollection */
     protected $families;
 
@@ -34,7 +31,6 @@ class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInt
     public function __construct(FamilyRepositoryInterface $familyRepository)
     {
         $this->familyRepository = $familyRepository;
-        $this->isExecuted = false;
     }
 
     /**
@@ -42,22 +38,20 @@ class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInt
      */
     public function read()
     {
-        $filters = $this->getConfiguredFilters();
-        if (!$this->isExecuted) {
-            $this->isExecuted = true;
+        if (null === $this->families) {
+            $filters = $this->getConfiguredFilters();
             $this->families = $this->getFamilies($filters);
-        }
-
-        $result = $this->families->current();
-
-        if (!empty($result)) {
-            $this->stepExecution->incrementSummaryInfo('read');
-            $this->families->next();
         } else {
-            $result = null;
+            $this->families->next();
         }
 
-        return $result;
+        $family = $this->families->current();
+
+        if (null !== $family) {
+            $this->stepExecution->incrementSummaryInfo('read');
+        }
+
+        return $family;
     }
 
     /**
@@ -75,7 +69,7 @@ class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInt
      *
      * @param array $filters
      *
-     * @return \Doctrine\Common\Collections\ArrayCollection
+     * @return \Generator
      */
     protected function getFamilies(array $filters)
     {
@@ -87,7 +81,13 @@ class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInt
 
         $familiesIds = $filter['value'];
 
-        return new ArrayCollection($this->familyRepository->findByIds($familiesIds));
+        foreach ($familiesIds as $familyId) {
+            $family = $this->familyRepository->find($familyId);
+
+            if (null !== $family) {
+                yield $family;
+            }
+        }
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/FilteredFamilyReaderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/FilteredFamilyReaderSpec.php
@@ -37,8 +37,11 @@ class FilteredFamilyReaderSpec extends ObjectBehavior
         );
 
         $stepExecution->getJobExecution()->willReturn($jobExecution);
-        $families = [$pantFamily, $sockFamily];
-        $familyRepository->findByIds([12, 13, 14])->willReturn($families);
+
+        $familyRepository->find(12)->willReturn($pantFamily);
+        $familyRepository->find(13)->willReturn(null);
+        $familyRepository->find(14)->willReturn($sockFamily);
+
         $stepExecution->incrementSummaryInfo('read')->shouldBeCalled();
 
         $this->setStepExecution($stepExecution);

--- a/src/Pim/Component/Connector/Writer/Database/ProductModelDescendantsWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/ProductModelDescendantsWriter.php
@@ -30,6 +30,8 @@ class ProductModelDescendantsWriter implements ItemWriterInterface, StepExecutio
     /**
      * @param SaverInterface        $descendantsSaver
      * @param CacheClearerInterface $cacheClearer
+     *
+     * @todo @merge Remove $cacheClearer. It's not used anymore.
      */
     public function __construct(
         SaverInterface $descendantsSaver,
@@ -49,10 +51,6 @@ class ProductModelDescendantsWriter implements ItemWriterInterface, StepExecutio
             if (null !== $this->stepExecution) {
                 $this->stepExecution->incrementSummaryInfo('process');
             }
-        }
-
-        if (null !== $this->cacheClearer) {
-            $this->cacheClearer->clear();
         }
     }
 

--- a/src/Pim/Component/Connector/Writer/Database/ProductModelWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/ProductModelWriter.php
@@ -35,6 +35,8 @@ class ProductModelWriter implements ItemWriterInterface, StepExecutionAwareInter
      * @param VersionManager        $versionManager
      * @param BulkSaverInterface    $productModelSaver
      * @param CacheClearerInterface $cacheClearer
+     *
+     * @todo @merge Remove $cacheClearer. It's not used anymore.
      */
     public function __construct(
         VersionManager $versionManager,
@@ -60,7 +62,6 @@ class ProductModelWriter implements ItemWriterInterface, StepExecutionAwareInter
         }
 
         $this->productModelSaver->saveAll($items);
-        $this->cacheClearer->clear();
     }
 
     /**

--- a/src/Pim/Component/Connector/Writer/Database/ProductWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/ProductWriter.php
@@ -38,6 +38,8 @@ class ProductWriter implements ItemWriterInterface, StepExecutionAwareInterface,
      * @param VersionManager        $versionManager
      * @param BulkSaverInterface    $productSaver
      * @param CacheClearerInterface $cacheClearer
+     *
+     * @todo @merge Remove $cacheClearer. It's not used anymore.
      */
     public function __construct(
         VersionManager $versionManager,
@@ -59,7 +61,6 @@ class ProductWriter implements ItemWriterInterface, StepExecutionAwareInterface,
         }
 
         $this->productSaver->saveAll($items);
-        $this->cacheClearer->clear();
     }
 
     /**

--- a/src/Pim/Component/Connector/spec/Writer/Database/ProductModelDescendantsWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/Database/ProductModelDescendantsWriterSpec.php
@@ -24,7 +24,6 @@ class ProductModelDescendantsWriterSpec extends ObjectBehavior
 
     function it_handles_product_model_descendants(
         $descendantsSaver,
-        $cacheClearer,
         $stepExecution,
         ProductModelInterface $productModel1,
         ProductModelInterface $productModel2
@@ -33,8 +32,6 @@ class ProductModelDescendantsWriterSpec extends ObjectBehavior
         $descendantsSaver->save($productModel2)->shouldBeCalled();
 
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalledTimes(2);
-
-        $cacheClearer->clear()->shouldBeCalled();
 
         $this->write([$productModel1, $productModel2]);
     }

--- a/src/Pim/Component/Connector/spec/Writer/Database/ProductModelWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/Database/ProductModelWriterSpec.php
@@ -12,7 +12,6 @@ use Pim\Bundle\VersioningBundle\Manager\VersionManager;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Connector\Writer\Database\ProductModelWriter;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class ProductModelWriterSpec extends ObjectBehavior
 {
@@ -79,25 +78,5 @@ class ProductModelWriterSpec extends ObjectBehavior
         $stepExecution->incrementSummaryInfo('create')->shouldBeCalled();
 
         $this->write([$product1, $product2]);
-    }
-
-    function it_clears_cache(
-        $stepExecution,
-        ProductModelInterface $product1,
-        ProductModelInterface $product2,
-        JobParameters $jobParameters
-    ) {
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('realTimeVersioning')->willReturn(true);
-
-        $items = [$product1, $product2];
-
-        $product1->getId()->willReturn('45');
-        $product2->getId()->willReturn(null);
-
-        $stepExecution->incrementSummaryInfo('create')->shouldBeCalled();
-        $stepExecution->incrementSummaryInfo('process')->shouldBeCalled();
-
-        $this->write($items);
     }
 }

--- a/src/Pim/Component/Connector/spec/Writer/Database/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/Database/ProductWriterSpec.php
@@ -76,24 +76,4 @@ class ProductWriterSpec extends ObjectBehavior
 
         $this->write([$product1, $product2]);
     }
-
-    function it_clears_cache(
-        $stepExecution,
-        ProductInterface $product1,
-        ProductInterface $product2,
-        JobParameters $jobParameters
-    ) {
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('realTimeVersioning')->willReturn(true);
-
-        $items = [$product1, $product2];
-
-        $product1->getId()->willReturn('45');
-        $product2->getId()->willReturn(null);
-
-        $stepExecution->incrementSummaryInfo('create')->shouldBeCalled();
-        $stepExecution->incrementSummaryInfo('process')->shouldBeCalled();
-
-        $this->write($items);
-    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

See the SLA 7237 for more details. In a nutshell, when there are no writing during a product import (and when "Compare values" is enabled) then the cache of the repositories and the UnitOfWork are not cleared.

The goal of this PR is to delegating the responsibility of clearing the UOW and the repositories caches in a dedicated subscriber. 

I had to change `FilteredFamilyReader` because it loaded all the families at once. When the UOW is cleared, all the remaining families (in the next batch loop) were considered as new entities. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
