### PR TITLE
PIM-7239: introduce pim_job_batch_size

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -486,7 +486,7 @@ def withBuildNode(body) {
         podTemplate(label: "build-" + uuid, containers: [
             containerTemplate(name: "docker", image: "paulwoelfel/docker-gcloud:v1.13", ttyEnabled: true, command: 'cat', resourceRequestCpu: '100m', resourceRequestMemory: '200Mi'),
             containerTemplate(name: "php", ttyEnabled: true, command: 'cat', image: "eu.gcr.io/akeneo-ci/httpd-php:5.6", envVars: [envVar(key: "COMPOSER_AUTH", value: "{\"github-oauth\":{\"github.com\": \"$token\"}}")], resourceRequestCpu: '750m', resourceRequestMemory: '2000Mi'),
-            containerTemplate(name: "node", ttyEnabled: true, command: 'cat', image: "node:8", resourceRequestCpu: '750m', resourceRequestMemory: '2000Mi')
+            containerTemplate(name: "node", ttyEnabled: true, command: 'cat', image: "node:8.9", resourceRequestCpu: '750m', resourceRequestMemory: '2000Mi')
         ]) {
             node("build-" + uuid) {
                 dir('/home/jenkins/pim') {

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -72,6 +72,7 @@ services:
             - '@pim_connector.reader.file.csv_product'
             - '@pim_connector.processor.denormalization.product'
             - '@pim_connector.writer.database.product'
+            - '%pim_job_product_batch_size%'
 
     pim_connector.step.csv_product.import_associations:
         class: '%pim_connector.step.item_step.class%'
@@ -216,7 +217,7 @@ services:
             - '@pim_connector.reader.database.product'
             - '@pim_connector.processor.normalization.product'
             - '@pim_connector.writer.file.csv_product'
-            - 10
+            - '%pim_job_product_batch_size%'
 
     pim_connector.step.csv_category.export:
         class: '%pim_connector.step.item_step.class%'
@@ -348,6 +349,7 @@ services:
             - '@pim_connector.reader.file.xlsx_product'
             - '@pim_connector.processor.denormalization.product'
             - '@pim_connector.writer.database.product'
+            - '%pim_job_product_batch_size%'
 
     pim_connector.step.xlsx_product.import_associations:
         class: '%pim_connector.step.item_step.class%'
@@ -496,7 +498,7 @@ services:
             - '@pim_connector.reader.database.product'
             - '@pim_connector.processor.normalization.product'
             - '@pim_connector.writer.file.xlsx_product'
-            - 10
+            - '%pim_job_product_batch_size%'
 
     pim_connector.step.xlsx_category.export:
         class: '%pim_connector.step.item_step.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/pim.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/pim.yml
@@ -19,6 +19,9 @@ imports:
 akeneo_storage_utils:
     storage_driver: '%pim_catalog_product_storage_driver%'
 
+parameters:
+    pim_job_product_batch_size: 10
+
 services:
     oro.cache.abstract:
         abstract:  true

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/steps.yml
@@ -12,7 +12,7 @@ services:
             - '@pim_connector.reader.database.product'
             - '@pim_enrich.connector.processor.quick_export.product'
             - '@pim_connector.writer.file.csv_product_quick_export'
-            - 1000
+            - '%pim_job_product_batch_size%'
 
     # XLSX Quick Export steps -----------------------------------------------------------------------------------------
     pim_enrich.step.xlsx_product.quick_export:
@@ -24,7 +24,7 @@ services:
             - '@pim_connector.reader.database.product'
             - '@pim_enrich.connector.processor.quick_export.product'
             - '@pim_connector.writer.file.xlsx_product_quick_export'
-            - 1000
+            - '%pim_job_product_batch_size%'
 
     # Mass Edit steps -------------------------------------------------------------------------------------------------
     pim_enrich.step.update_product_value.mass_edit:
@@ -36,6 +36,7 @@ services:
             - '@pim_connector.reader.database.product'
             - '@pim_enrich.connector.processor.mass_edit.product.update_value'
             - '@pim_connector.writer.database.product'
+            - '%pim_job_product_batch_size%'
 
     pim_enrich.step.add_product_value.mass_edit:
         class: '%pim_connector.step.item_step.class%'
@@ -46,6 +47,7 @@ services:
             - '@pim_connector.reader.database.product'
             - '@pim_enrich.connector.processor.mass_edit.product.add_value'
             - '@pim_connector.writer.database.product'
+            - '%pim_job_product_batch_size%'
 
     pim_enrich.step.remove_product_value.mass_edit:
         class: '%pim_connector.step.item_step.class%'
@@ -56,6 +58,7 @@ services:
             - '@pim_connector.reader.database.product'
             - '@pim_enrich.connector.processor.mass_edit.product.remove_value'
             - '@pim_connector.writer.database.product'
+            - '%pim_job_product_batch_size%'
 
     pim_enrich.step.edit_common_attributes.mass_edit:
         class: '%pim_connector.step.item_step.class%'
@@ -66,6 +69,7 @@ services:
             - '@pim_connector.reader.database.product'
             - '@pim_enrich.connector.processor.mass_edit.product.edit_common_attributes'
             - '@pim_connector.writer.database.product'
+            - '%pim_job_product_batch_size%'
 
     pim_enrich.step.set_attribute_requirements.mass_edit:
         class: '%pim_connector.step.item_step.class%'
@@ -86,6 +90,7 @@ services:
             - '@pim_enrich.connector.reader.mass_edit.variant_group_product'
             - '@pim_enrich.connector.processor.mass_edit.product.add_to_variant_group'
             - '@pim_connector.writer.database.product'
+            - '%pim_job_product_batch_size%'
 
     # Cleaner steps -------------------------------------------------------------------------------------------------
     pim_enrich.step.clean:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The product size varies a lot between users of the PIM and we cannot have the same value for the batch size for each client. That's why I introduce a new parameter to set the batch size: `pim_job_batch_size`. You need to set it in your config.yml file to be able to override the default value.

```
# app/config/config.yml
parameters:
    pim_job_batch_size: 12
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added legacy Behats               | NA
| Added acceptance tests            | NA
| Added integration tests           | NA
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | NA
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
