### PR TITLE
AOB-100: Apply user timezone on dates in the UI

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -17,6 +17,12 @@
 - AOB-55: Add method `getTimezone` and `setTimezone` to `Pim\Bundle\UserBundle\Entity\UserInterface`
 - PIM-7163: Add `Pim\Bundle\UserBundle\Entity\UserInterface::setPhone` and `Pim\Bundle\UserBundle\Entity\UserInterface::getPhone`
 
+### Constructors
+
+- AOB-100: Change the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\VersioningController` to add `Pim\Bundle\UserBundle\Context\UserContext`
+- AOB-100: Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductModelNormalizer` to add `Pim\Bundle\UserBundle\Context\UserContext`
+- AOB-100: Change the constructor of `Pim\Bundle\LocalizationBundle\Controller\FormatController` to add `Pim\Bundle\UserBundle\Context\UserContext`
+
 ## Migration
 
 - New data has been indexed in Elasticsearch. Please re-index the products and product models by launching the commands `pim:product:index --all -e prod` and `pim:product-model:index --all -e prod`.

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -8,6 +8,7 @@
 - PIM-6803: Message when delete a family with family variant.
 - PIM-7143: Be able to delete products and product models in mass using a backend job
 - PIM-7112: Add lock display on images/assets when user has no edit right.
+- AOB-100: Apply user timezone on dates in the UI
 
 ## BC breaks
 

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -184,6 +184,23 @@ class FixturesContext extends BaseFixturesContext
     }
 
     /**
+     * @Given the :identifier product created at :createdAt
+     */
+    public function theProductCreatedAt(string $identifier, string $createdAt)
+    {
+        $product = $this->createProduct(['sku' => $identifier]);
+
+        $this->getContainer()->get('doctrine')->getConnection()->update(
+            'pim_catalog_product',
+            ['created' => $createdAt],
+            ['id' => $product->getId()]
+        );
+
+        $this->refresh($product);
+        $this->getProductSaver()->save($product);
+    }
+
+    /**
      * @param TableNode $table
      *
      * @Given /^the product?:$/

--- a/features/Context/catalog/default/users.csv
+++ b/features/Context/catalog/default/users.csv
@@ -1,7 +1,7 @@
-username;first_name;last_name;email;password;catalog_default_locale;user_default_locale;catalog_default_scope;default_category_tree;roles;groups;enabled
-admin;John;Doe;admin@example.com;admin;en_US;en_US;ecommerce;default;ROLE_ADMINISTRATOR;IT support;1
-Julia;Julia;Stark;Julia@example.com;Julia;en_US;en_US;ecommerce;default;ROLE_CATALOG_MANAGER;Manager;1
-Peter;Peter;Williams;Peter@example.com;Peter;en_US;en_US;ecommerce;default;ROLE_ADMINISTRATOR;IT support;1
-Mary;Mary;Smith;Mary@example.com;Mary;en_US;en_US;ecommerce;default;ROLE_USER;Redactor;1
-Sandra;Sandra;Harvey;Sandra@example.com;Sandra;en_US;en_US;mobile;default;ROLE_USER;Redactor;1
-Julien;Julien;Février;Julien@example.com;Julien;fr_FR;fr_FR;mobile;default;ROLE_USER;Redactor;1
+username;first_name;last_name;email;password;catalog_default_locale;user_default_locale;catalog_default_scope;default_category_tree;roles;groups;enabled;timezone
+admin;John;Doe;admin@example.com;admin;en_US;en_US;ecommerce;default;ROLE_ADMINISTRATOR;IT support;1;UTC
+Julia;Julia;Stark;Julia@example.com;Julia;en_US;en_US;ecommerce;default;ROLE_CATALOG_MANAGER;Manager;1;America/New_York
+Peter;Peter;Williams;Peter@example.com;Peter;en_US;en_US;ecommerce;default;ROLE_ADMINISTRATOR;IT support;1;UTC
+Mary;Mary;Smith;Mary@example.com;Mary;en_US;en_US;ecommerce;default;ROLE_USER;Redactor;1;UTC
+Sandra;Sandra;Harvey;Sandra@example.com;Sandra;en_US;en_US;mobile;default;ROLE_USER;Redactor;1;UTC
+Julien;Julien;Février;Julien@example.com;Julien;fr_FR;fr_FR;mobile;default;ROLE_USER;Redactor;1;Europe/Paris

--- a/features/product/date.feature
+++ b/features/product/date.feature
@@ -42,5 +42,5 @@ Feature: Check that imported date is properly displayed
       | version | property | before | value       |
       | 2       | SKU      | postit | nice_postit |
       | 1       | SKU      |        | postit      |
-      | 1       | release  |        | 05/01/2014  |
+      | 1       | release  |        | 04/30/2014  |
       | 1       | enabled  |        | 1           |

--- a/features/product/filtering/filter_products_per_date_fields_with_user_timezone.feature
+++ b/features/product/filtering/filter_products_per_date_fields_with_user_timezone.feature
@@ -1,0 +1,21 @@
+@javascript
+Feature: Filter products by date field with user timezone
+  In order to filter products by date
+  As a regular user
+  I need to be able to filter products with user timezone taken into account
+
+  Scenario: Successfully filter products by date attributes with timezone America/New_York
+    Given the "default" catalog configuration
+    And the postit product created at "2018-10-03 01:30:00"
+    And the mug product created at "2018-10-03 05:30:00"
+    And the pen product created at "2018-10-02 23:30:00"
+    When I am logged in as "Julia"
+    And I am on the products grid
+    Then the grid should contain 3 elements
+    And I should see products postit, mug and pen
+    And I should be able to use the following filters:
+      | filter  | operator    | value                     | result         |
+      | created | more than   | 10/02/2018                | mug            |
+      | created | less than   | 10/03/2018                | postit and pen |
+      | created | between     | 10/02/2018 and 10/02/2018 | postit and pen |
+      | created | not between | 10/02/2018 and 10/02/2018 | mug            |

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductDeltaIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductDeltaIntegration.php
@@ -326,7 +326,7 @@ JSON;
     private function getDiscriminantDatetime(): \Datetime
     {
         sleep(1);
-        $datetime = new \DateTime('now');
+        $datetime = new \DateTime('now', new \DateTimeZone('UTC'));
         sleep(1);
 
         return $datetime;

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/DateTimeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/DateTimeFilter.php
@@ -267,9 +267,10 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
     protected function getFormattedDate($field, $value)
     {
         $dateTime = $value;
+        $utcTimeZone = new \DateTimeZone('UTC');
 
         if (!$dateTime instanceof \DateTime) {
-            $dateTime = \DateTime::createFromFormat(static::DATETIME_FORMAT, $dateTime);
+            $dateTime = \DateTime::createFromFormat(static::DATETIME_FORMAT, $dateTime, $utcTimeZone);
 
             if (false === $dateTime || 0 < $dateTime->getLastErrors()['warning_count']) {
                 throw InvalidPropertyException::dateExpected(
@@ -281,7 +282,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
             }
         }
 
-        $dateTime->setTimezone(new \DateTimeZone('UTC'));
+        $dateTime->setTimezone($utcTimeZone);
 
         return $dateTime->format('c');
     }

--- a/src/Pim/Bundle/DashboardBundle/Widget/LastOperationsWidget.php
+++ b/src/Pim/Bundle/DashboardBundle/Widget/LastOperationsWidget.php
@@ -89,8 +89,12 @@ class LastOperationsWidget implements WidgetInterface
                 ->translator
                 ->trans('pim_import_export.batch_status.' . $operation['status']);
             if ($operation['date'] instanceof \DateTime) {
-                $locale = $this->tokenStorage->getToken()->getUser()->getUiLocale()->getCode();
-                $operation['date'] = $this->presenter->present($operation['date'], ['locale' => $locale]);
+                $user = $this->tokenStorage->getToken()->getUser();
+                $locale = $user->getUiLocale()->getCode();
+                $operation['date'] = $this->presenter->present($operation['date'], [
+                    'locale' => $locale,
+                    'timezone' => $user->getTimeZone()
+                ]);
             }
             $operation['canSeeReport'] = !in_array($operation['type'], ['import', 'export']) ||
                 $this->securityFacade->isGranted(sprintf('pim_importexport_%s_execution_show', $operation['type']));

--- a/src/Pim/Bundle/DashboardBundle/spec/Widget/LastOperationsWidgetSpec.php
+++ b/src/Pim/Bundle/DashboardBundle/spec/Widget/LastOperationsWidgetSpec.php
@@ -69,8 +69,9 @@ class LastOperationsWidgetSpec extends ObjectBehavior
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn($user);
         $user->getUiLocale()->willReturn($locale);
+        $user->getTimezone()->willReturn('Pacific/Kiritimati');
         $locale->getCode()->willReturn('fr_FR');
-        $presenter->present($date, ['locale' => 'fr_FR'])->willReturn('01/12/2015');
+        $presenter->present($date, ['locale' => 'fr_FR', 'timezone' => 'Pacific/Kiritimati'])->willReturn('01/12/2015');
 
         $operation['statusLabel'] = 'Completed';
         $operation['date'] = '01/12/2015';

--- a/src/Pim/Bundle/DataGridBundle/Normalizer/DateTimeNormalizer.php
+++ b/src/Pim/Bundle/DataGridBundle/Normalizer/DateTimeNormalizer.php
@@ -46,7 +46,13 @@ class DateTimeNormalizer implements NormalizerInterface
     {
         $stdProductValue = $this->standardNormalizer->normalize($date, 'standard', $context);
 
-        $stdProductValue = $this->presenter->present($stdProductValue, ['locale' => $this->userContext->getUiLocaleCode()]);
+        $stdProductValue = $this->presenter->present(
+            $stdProductValue,
+            [
+                'locale'   => $this->userContext->getUiLocaleCode(),
+                'timezone' => $this->userContext->getUserTimezone(),
+            ]
+        );
 
         return $stdProductValue;
     }

--- a/src/Pim/Bundle/DataGridBundle/spec/Normalizer/DateTimeNormalizerSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Normalizer/DateTimeNormalizerSpec.php
@@ -52,7 +52,14 @@ class DateTimeNormalizerSpec extends ObjectBehavior
 
         $standardNormalizer->normalize($datetime, 'standard', [])->willReturn('2015-01-01T23:50:00+01:00');
         $userContext->getUiLocaleCode()->willReturn('en_US');
-        $presenter->present('2015-01-01T23:50:00+01:00', ['locale' => 'en_US'])->willReturn('01/01/2015');
+        $userContext->getUserTimezone()->willReturn('Pacific/Kiritimati');
+        $presenter->present(
+            '2015-01-01T23:50:00+01:00',
+            [
+                'locale'   => 'en_US',
+                'timezone' => 'Pacific/Kiritimati',
+            ]
+        )->willReturn('01/01/2015');
 
         $this->normalize($datetime, 'datagrid')->shouldReturn('01/01/2015');
     }
@@ -65,7 +72,14 @@ class DateTimeNormalizerSpec extends ObjectBehavior
 
         $standardNormalizer->normalize($datetime, 'standard', [])->willReturn('2014-12-31T18:00:00-05:00');
         $userContext->getUiLocaleCode()->willReturn('en_US');
-        $presenter->present('2014-12-31T18:00:00-05:00', ['locale' => 'en_US'])->willReturn('12/31/2014');
+        $userContext->getUserTimezone()->willReturn('Pacific/Kiritimati');
+        $presenter->present(
+            '2014-12-31T18:00:00-05:00',
+            [
+                'locale'   => 'en_US',
+                'timezone' => 'Pacific/Kiritimati',
+            ]
+        )->willReturn('12/31/2014');
 
         $this->normalize($datetime, 'datagrid')->shouldReturn('12/31/2014');
     }

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/VersioningController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/VersioningController.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\EnrichBundle\Controller\Rest;
 
 use Pim\Bundle\CatalogBundle\Resolver\FQCNResolver;
+use Pim\Bundle\UserBundle\Context\UserContext;
 use Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -25,19 +26,25 @@ class VersioningController
     /** @var NormalizerInterface */
     protected $normalizer;
 
+    /** @var UserContext */
+    protected $userContext;
+
     /**
      * @param VersionRepositoryInterface $versionRepository
      * @param FQCNResolver               $FQCNResolver
      * @param NormalizerInterface        $normalizer
+     * @param UserContext                $userContext
      */
     public function __construct(
         VersionRepositoryInterface $versionRepository,
         FQCNResolver $FQCNResolver,
-        NormalizerInterface $normalizer
+        NormalizerInterface $normalizer,
+        UserContext $userContext
     ) {
         $this->versionRepository = $versionRepository;
         $this->FQCNResolver = $FQCNResolver;
         $this->normalizer = $normalizer;
+        $this->userContext = $userContext;
     }
 
     /**
@@ -53,7 +60,8 @@ class VersioningController
         return new JsonResponse(
             $this->normalizer->normalize(
                 $this->versionRepository->getLogEntries($this->FQCNResolver->getFQCN($entityType), $entityId),
-                'internal_api'
+                'internal_api',
+                ['timezone' => $this->userContext->getUserTimezone()]
             )
         );
     }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -190,8 +190,18 @@ class ProductNormalizer implements NormalizerInterface
         $oldestLog = $this->versionManager->getOldestLogEntry($product);
         $newestLog = $this->versionManager->getNewestLogEntry($product);
 
-        $created = null !== $oldestLog ? $this->versionNormalizer->normalize($oldestLog, 'internal_api') : null;
-        $updated = null !== $newestLog ? $this->versionNormalizer->normalize($newestLog, 'internal_api') : null;
+        $created = null !== $oldestLog ?
+            $this->versionNormalizer->normalize(
+                $oldestLog,
+                'internal_api',
+                ['timezone' => $this->userContext->getUserTimezone()]
+            ) : null;
+        $updated = null !== $newestLog ?
+            $this->versionNormalizer->normalize(
+                $newestLog,
+                'internal_api',
+                ['timezone' => $this->userContext->getUserTimezone()]
+            ) : null;
 
         $scopeCode = $context['channel'] ?? null;
 

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
@@ -59,7 +59,7 @@ class VersionNormalizer implements NormalizerInterface
      */
     public function normalize($version, $format = null, array $context = [])
     {
-        $context = ['locale' => $this->translator->getLocale()];
+        $context = array_merge($context, ['locale' => $this->translator->getLocale()]);
 
         return [
             'id'           => $version->getId(),

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -413,6 +413,7 @@ services:
             - '@pim_versioning.repository.version'
             - '@pim_catalog.resolver.fqcn'
             - '@pim_internal_api_serializer'
+            - '@pim_user.context.user'
 
     pim_enrich.controller.rest.attribute_option:
         class: '%pim_enrich.controller.rest.attribute_option.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -95,6 +95,7 @@ services:
             - '@pim_catalog.product_models.image_as_label'
             - '@pim_enrich.doctrine.query.ascendant_categories'
             - '@pim_enrich.normalizer.incomplete_values'
+            - '@pim_user.context.user'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -6,6 +6,7 @@ use PhpSpec\ObjectBehavior;
 use Pim\Bundle\EnrichBundle\Normalizer\ImageNormalizer;
 use Pim\Bundle\EnrichBundle\Normalizer\VariantNavigationNormalizer;
 use Pim\Bundle\EnrichBundle\Provider\Form\FormProviderInterface;
+use Pim\Bundle\UserBundle\Context\UserContext;
 use Pim\Bundle\VersioningBundle\Manager\VersionManager;
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
@@ -41,7 +42,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         VariantProductRatioInterface $findVariantProductCompleteness,
         ImageAsLabel $imageAsLabel,
         AscendantCategoriesInterface $ascendantCategories,
-        NormalizerInterface $incompleteValuesNormalizer
+        NormalizerInterface $incompleteValuesNormalizer,
+        UserContext $userContext
     ) {
         $this->beConstructedWith(
             $normalizer,
@@ -58,7 +60,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             $findVariantProductCompleteness,
             $imageAsLabel,
             $ascendantCategories,
-            $incompleteValuesNormalizer
+            $incompleteValuesNormalizer,
+            $userContext
         );
     }
 
@@ -82,6 +85,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $imageAsLabel,
         $ascendantCategories,
         $incompleteValuesNormalizer,
+        $userContext,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -94,6 +98,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             'date_format'       => 'dd/MM/yyyy',
             'locale'            => 'en_US',
             'channel'           => 'mobile',
+            'timezone'          => 'Pacific/Kiritimati',
         ];
 
         $productModelNormalized = [
@@ -132,6 +137,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             'picture'             => [['data' => 'a/b/c/my_picture.jpg', 'locale' => null, 'scope' => null]]
         ];
 
+        $userContext->getUserTimezone()->willReturn('Pacific/Kiritimati');
         $normalizer->normalize($productModel, 'standard', $options)->willReturn($productModelNormalized);
         $localizedConverter->convertToLocalizedFormats($productModelNormalized['values'], $options)->willReturn($valuesLocalized);
 
@@ -160,9 +166,11 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productModel->getId()->willReturn(12);
         $productModel->getCode()->willReturn('tshirt_blue');
         $versionManager->getOldestLogEntry($productModel)->willReturn('create_version');
-        $versionNormalizer->normalize('create_version', 'internal_api')->willReturn('normalized_create_version');
+        $versionNormalizer->normalize('create_version', 'internal_api', ['timezone' => 'Pacific/Kiritimati'])
+            ->willReturn('normalized_create_version');
         $versionManager->getNewestLogEntry($productModel)->willReturn('update_version');
-        $versionNormalizer->normalize('update_version', 'internal_api')->willReturn('normalized_update_version');
+        $versionNormalizer->normalize('update_version', 'internal_api', ['timezone' => 'Pacific/Kiritimati'])
+            ->willReturn('normalized_update_version');
 
         $productModel->getFamilyVariant()->willReturn($familyVariant);
         $familyVariant->getFamily()->willReturn($family);
@@ -236,6 +244,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $imageAsLabel,
         $ascendantCategories,
         $incompleteValuesNormalizer,
+        $userContext,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -280,6 +289,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             'picture'             => [['data' => null, 'locale' => null, 'scope' => null]]
         ];
 
+        $userContext->getUserTimezone()->willReturn('UTC');
         $normalizer->normalize($productModel, 'standard', $options)->willReturn($productModelNormalized);
         $localizedConverter->convertToLocalizedFormats($productModelNormalized['values'], $options)->willReturn($valuesLocalized);
 
@@ -301,9 +311,11 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productModel->getId()->willReturn(12);
         $productModel->getCode()->willReturn('tshirt_blue');
         $versionManager->getOldestLogEntry($productModel)->willReturn('create_version');
-        $versionNormalizer->normalize('create_version', 'internal_api')->willReturn('normalized_create_version');
+        $versionNormalizer->normalize('create_version', 'internal_api', ['timezone' => 'UTC'])
+            ->willReturn('normalized_create_version');
         $versionManager->getNewestLogEntry($productModel)->willReturn('update_version');
-        $versionNormalizer->normalize('update_version', 'internal_api')->willReturn('normalized_update_version');
+        $versionNormalizer->normalize('update_version', 'internal_api', ['timezone' => 'UTC'])
+            ->willReturn('normalized_update_version');
 
         $productModel->getFamilyVariant()->willReturn($familyVariant);
         $familyVariant->getFamily()->willReturn($family);
@@ -377,6 +389,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $imageAsLabel,
         $ascendantCategories,
         $incompleteValuesNormalizer,
+        $userContext,
         AttributeInterface $pictureAttribute,
         ProductModelInterface $productModel,
         FamilyVariantInterface $familyVariant,
@@ -427,6 +440,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             'picture'             => [['data' => 'a/b/c/my_picture.jpg', 'locale' => null, 'scope' => null]]
         ];
 
+        $userContext->getUserTimezone()->willReturn('UTC');
         $normalizer->normalize($productModel, 'standard', $options)->willReturn($productModelNormalized);
         $localizedConverter->convertToLocalizedFormats($productModelNormalized['values'], $options)->willReturn($valuesLocalized);
 
@@ -455,9 +469,11 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         $productModel->getId()->willReturn(12);
         $productModel->getCode()->willReturn('tshirt_blue');
         $versionManager->getOldestLogEntry($productModel)->willReturn('create_version');
-        $versionNormalizer->normalize('create_version', 'internal_api')->willReturn('normalized_create_version');
+        $versionNormalizer->normalize('create_version', 'internal_api', ['timezone' => 'UTC'])
+            ->willReturn('normalized_create_version');
         $versionManager->getNewestLogEntry($productModel)->willReturn('update_version');
-        $versionNormalizer->normalize('update_version', 'internal_api')->willReturn('normalized_update_version');
+        $versionNormalizer->normalize('update_version', 'internal_api', ['timezone' => 'UTC'])
+            ->willReturn('normalized_update_version');
 
         $productModel->getFamilyVariant()->willReturn($familyVariant);
         $familyVariant->getFamily()->willReturn($family);

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -2,13 +2,10 @@
 
 namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
 
-use Akeneo\Component\FileStorage\Model\FileInfoInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
-use Pim\Bundle\EnrichBundle\Doctrine\ORM\Query\AscendantCategories;
-use Pim\Bundle\EnrichBundle\Normalizer\FileNormalizer;
 use Pim\Bundle\EnrichBundle\Normalizer\ImageNormalizer;
 use Pim\Bundle\EnrichBundle\Normalizer\VariantNavigationNormalizer;
 use Pim\Bundle\EnrichBundle\Provider\Form\FormProviderInterface;
@@ -146,6 +143,7 @@ class ProductNormalizerSpec extends ObjectBehavior
             'picture'             => [['data' => 'a/b/c/my_picture.jpg', 'locale' => null, 'scope' => null]]
         ];
 
+        $userContext->getUserTimezone()->willReturn('Pacific/Kiritimati');
         $normalizer->normalize($mug, 'standard', $options)->willReturn($productNormalized);
         $localizedConverter->convertToLocalizedFormats($productNormalized['values'], $options)->willReturn($valuesLocalized);
 
@@ -169,9 +167,11 @@ class ProductNormalizerSpec extends ObjectBehavior
         $mug->isVariant()->willReturn(false);
         $mug->getId()->willReturn(12);
         $versionManager->getOldestLogEntry($mug)->willReturn('create_version');
-        $versionNormalizer->normalize('create_version', 'internal_api')->willReturn('normalized_create_version');
+        $versionNormalizer->normalize('create_version', 'internal_api', ['timezone' => 'Pacific/Kiritimati'])
+            ->willReturn('normalized_create_version');
         $versionManager->getNewestLogEntry($mug)->willReturn('update_version');
-        $versionNormalizer->normalize('update_version', 'internal_api')->willReturn('normalized_update_version');
+        $versionNormalizer->normalize('update_version', 'internal_api', ['timezone' => 'Pacific/Kiritimati'])
+            ->willReturn('normalized_update_version');
 
         $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
         $mug->getLabel('en_US', 'mobile')->willReturn('A nice Mug!');
@@ -299,6 +299,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         ];
 
         $mug->isVariant()->willReturn(true);
+        $userContext->getUserTimezone()->willReturn('Pacific/Kiritimati');
         $normalizer->normalize($mug, 'standard', $options)->willReturn($productNormalized);
         $localizedConverter->convertToLocalizedFormats($productNormalized['values'], $options)->willReturn($valuesLocalized);
 
@@ -321,9 +322,11 @@ class ProductNormalizerSpec extends ObjectBehavior
 
         $mug->getId()->willReturn(12);
         $versionManager->getOldestLogEntry($mug)->willReturn('create_version');
-        $versionNormalizer->normalize('create_version', 'internal_api')->willReturn('normalized_create_version');
+        $versionNormalizer->normalize('create_version', 'internal_api', ['timezone' => 'Pacific/Kiritimati'])
+            ->willReturn('normalized_create_version');
         $versionManager->getNewestLogEntry($mug)->willReturn('update_version');
-        $versionNormalizer->normalize('update_version', 'internal_api')->willReturn('normalized_update_version');
+        $versionNormalizer->normalize('update_version', 'internal_api', ['timezone' => 'Pacific/Kiritimati'])
+            ->willReturn('normalized_update_version');
 
         $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
         $mug->getLabel('en_US', 'mobile')->willReturn('A nice Mug!');

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductValue/DateTimeRangeFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductValue/DateTimeRangeFilter.php
@@ -2,7 +2,10 @@
 
 namespace Pim\Bundle\FilterBundle\Filter\ProductValue;
 
+use Oro\Bundle\FilterBundle\Filter\FilterUtility;
 use Oro\Bundle\FilterBundle\Form\Type\Filter\DateRangeFilterType;
+use Pim\Bundle\UserBundle\Context\UserContext;
+use Symfony\Component\Form\FormFactoryInterface;
 
 /**
  * Date time filter
@@ -15,6 +18,16 @@ class DateTimeRangeFilter extends AbstractDateFilter
 {
     const DATETIME_FORMAT = 'Y-m-d H:i:s';
 
+    /** @var UserContext */
+    private $userContext;
+
+    public function __construct(FormFactoryInterface $factory, FilterUtility $util, UserContext $userContext)
+    {
+        parent::__construct($factory, $util);
+
+        $this->userContext = $userContext;
+    }
+
     /**
      * {@inheritdoc}
      *
@@ -22,19 +35,25 @@ class DateTimeRangeFilter extends AbstractDateFilter
      */
     public function parseData($data)
     {
+        $userTimeZone = new \DateTimeZone($this->userContext->getUserTimezone());
+
         switch ($data['type']) {
             case DateRangeFilterType::TYPE_MORE_THAN:
                 $data['value']['start']->setTime(23, 59, 59);
+                $data['values']['start'] = $this->applyTimeZone($userTimeZone, $data['value']['start']);
                 break;
             case DateRangeFilterType::TYPE_LESS_THAN:
                 $data['value']['end']->setTime(0, 0, 0);
+                $data['values']['end'] = $this->applyTimeZone($userTimeZone, $data['value']['end']);
                 break;
             default:
                 if (isset($data['value']['start']) && $data['value']['start'] instanceof \DateTime) {
                     $data['value']['start']->setTime(0, 0, 0);
+                    $data['values']['start'] = $this->applyTimeZone($userTimeZone, $data['value']['start']);
                 }
                 if (isset($data['value']['end']) && $data['value']['end'] instanceof \DateTime) {
                     $data['value']['end']->setTime(23, 59, 59);
+                    $data['values']['end'] = $this->applyTimeZone($userTimeZone, $data['value']['end']);
                 }
         }
 
@@ -47,5 +66,20 @@ class DateTimeRangeFilter extends AbstractDateFilter
     protected function getFormType()
     {
         return DateRangeFilterType::class;
+    }
+
+    /**
+     * @param \DateTimeZone      $userTimeZone
+     * @param \DateTimeInterface $dateTime
+     *
+     * @return \DateTimeInterface
+     */
+    private function applyTimeZone(\DateTimeZone $userTimeZone, \DateTimeInterface $dateTime): \DateTimeInterface
+    {
+        $dateTime->setTimezone(new \DateTimeZone('UTC'));
+        $diffWithUTC = - ($userTimeZone->getOffset($dateTime) / 3600);
+        $dateTime->modify($diffWithUTC . ' hours');
+
+        return $dateTime;
     }
 }

--- a/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
+++ b/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
@@ -82,6 +82,7 @@ services:
         arguments:
             - '@form.factory'
             - '@pim_filter.product_utility'
+            - '@pim_user.context.user'
         tags:
             - { name: oro_filter.extension.orm_filter.filter, type: product_date }
 
@@ -155,6 +156,7 @@ services:
         arguments:
             - '@form.factory'
             - '@pim_filter.product_utility'
+            - '@pim_user.context.user'
         tags:
             - { name: oro_filter.extension.orm_filter.filter, type: product_value_datetime }
 

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/ProductValue/ChoiceFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/ProductValue/ChoiceFilterSpec.php
@@ -108,16 +108,18 @@ class ChoiceFilterSpec extends ObjectBehavior
         Form $form,
         AttributeInterface $attribute,
         $factory,
-        $repository
+        $repository,
+        $userContext
     ) {
         $repository->findOneByCode('data_name_key')->willReturn($attribute);
+        $userContext->getCurrentLocaleCode()->willReturn('en_US');
 
         $factory->create(AjaxChoiceFilterType::class, [], [
             'csrf_protection'   => false,
             'choice_url'        => 'pim_ui_ajaxentity_list',
             'choice_url_params' => [
                 'class'        => 'attributeOptionClass',
-                'dataLocale'   => null,
+                'dataLocale'   => 'en_US',
                 'collectionId' => null,
                 'options'      => [
                     'type' => 'code',

--- a/src/Pim/Bundle/LocalizationBundle/Controller/FormatController.php
+++ b/src/Pim/Bundle/LocalizationBundle/Controller/FormatController.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\LocalizationBundle\Controller;
 use Akeneo\Component\Localization\Factory\DateFactory;
 use Akeneo\Component\Localization\Localizer\LocalizerInterface;
 use Pim\Bundle\EnrichBundle\Resolver\LocaleResolver;
+use Pim\Bundle\UserBundle\Context\UserContext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
@@ -25,6 +26,9 @@ class FormatController
     /** @var LocaleResolver */
     protected $localeResolver;
 
+    /** @var UserContext */
+    protected $userContext;
+
     /** @var array */
     protected $formats;
 
@@ -32,17 +36,20 @@ class FormatController
      * @param DateFactory    $dateFactory
      * @param DateFactory    $datetimeFactory
      * @param LocaleResolver $localeResolver
+     * @param UserContext    $userContext
      * @param array          $formats
      */
     public function __construct(
         DateFactory $dateFactory,
         DateFactory $datetimeFactory,
         LocaleResolver $localeResolver,
+        UserContext $userContext,
         array $formats
     ) {
         $this->dateFactory     = $dateFactory;
         $this->datetimeFactory = $datetimeFactory;
         $this->localeResolver  = $localeResolver;
+        $this->userContext     = $userContext;
         $this->formats         = $formats;
     }
 
@@ -77,6 +84,7 @@ class FormatController
                     'format'        => $timeFormatter->getPattern(),
                     'defaultFormat' => LocalizerInterface::DEFAULT_DATETIME_FORMAT,
                 ],
+                'timezone'       => $this->userContext->getUserTimezone(),
                 'language'       => $locale,
                 '12_hour_format' => false !== strpos($timeFormatter->getPattern(), 'a')
             ]

--- a/src/Pim/Bundle/LocalizationBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/LocalizationBundle/Resources/config/controllers.yml
@@ -15,6 +15,7 @@ services:
             - '@pim_catalog.localization.factory.date'
             - '@pim_catalog.localization.factory.datetime'
             - '@pim_enrich.resolver.locale'
+            - '@pim_user.context.user'
             -
                 decimal_separators: '%pim_catalog.localization.decimal_separators%'
                 date_formats: '%pim_catalog.localization.date_formats%'

--- a/src/Pim/Bundle/UserBundle/Context/UserContext.php
+++ b/src/Pim/Bundle/UserBundle/Context/UserContext.php
@@ -88,7 +88,7 @@ class UserContext
      *
      * @return LocaleInterface
      */
-    public function getCurrentLocale()
+    public function getCurrentLocale(): LocaleInterface
     {
         $locale = $this->getRequestLocale();
 
@@ -126,7 +126,7 @@ class UserContext
      *
      * @return string
      */
-    public function getCurrentLocaleCode()
+    public function getCurrentLocaleCode(): string
     {
         return $this->getCurrentLocale()->getCode();
     }
@@ -136,7 +136,7 @@ class UserContext
      *
      * @return LocaleInterface[]
      */
-    public function getUserLocales()
+    public function getUserLocales(): array
     {
         if ($this->userLocales === null) {
             $this->userLocales = $this->localeRepository->getActivatedLocales();
@@ -150,7 +150,7 @@ class UserContext
      *
      * @return array
      */
-    public function getUserLocaleCodes()
+    public function getUserLocaleCodes(): array
     {
         return array_map(
             function ($locale) {
@@ -165,7 +165,7 @@ class UserContext
      *
      * @return ChannelInterface
      */
-    public function getUserChannel()
+    public function getUserChannel(): ChannelInterface
     {
         $catalogScope = $this->getUserOption('catalogScope');
 
@@ -181,7 +181,7 @@ class UserContext
      *
      * @return string
      */
-    public function getUserChannelCode()
+    public function getUserChannelCode(): string
     {
         return $this->getUserChannel()->getCode();
     }
@@ -191,7 +191,7 @@ class UserContext
      *
      * @return string[]
      */
-    public function getChannelChoicesWithUserChannel()
+    public function getChannelChoicesWithUserChannel(): array
     {
         $channels = $this->channelRepository->findAll();
         $channelChoices = $this->choicesBuilder->buildChoices($channels);
@@ -211,7 +211,7 @@ class UserContext
      *
      * @return CategoryInterface|null
      */
-    public function getUserCategoryTree($relatedEntity)
+    public function getUserCategoryTree($relatedEntity): ?CategoryInterface
     {
         if (static::USER_PRODUCT_CATEGORY_TYPE === $relatedEntity) {
             return $this->getUserProductCategoryTree();
@@ -225,11 +225,28 @@ class UserContext
      *
      * @return CategoryInterface
      */
-    public function getUserProductCategoryTree()
+    public function getUserProductCategoryTree(): CategoryInterface
     {
         $defaultTree = $this->getUserOption('defaultTree');
 
         return $defaultTree ?: current($this->categoryRepository->getTrees());
+    }
+
+    /**
+     * Return the current user's timezone.
+     *
+     * @throws \RuntimeException
+     *
+     * @return string
+     */
+    public function getUserTimezone(): string
+    {
+        $user = $this->getUser();
+        if (null === $user) {
+            throw new \RuntimeException('Impossible to load the current user from context.');
+        }
+
+        return $user->getTimezone();
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The users have now the possibility to set their own timezone (done in https://github.com/akeneo/pim-community-dev/pull/7789).
The second part of this feature is to apply this timezone on dates and datetimes displayed in the UI.
There are still some places where dates are in UTC but the most visible ones are ok (PEF meta, history, last operations, product grid). Another PR will follow. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | Todo
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
