### PR TITLE
PIM-7243: [SLA] issue on currencies in CSV and XLSX product imports

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -9,6 +9,7 @@
 - PIM-7215: Fix wrong direction of sorting arrow in the grids
 - PIM-7220: Fix the filter "is empty" when the attribute belongs to a family
 - PIM-7237: Fix integrity constraint violation during import
+- PIM-7243: Fix issue on currencies in CSV and XLSX product imports
 
 # 2.0.17 (2018-03-06)
 

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldSplitter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldSplitter.php
@@ -62,8 +62,11 @@ class FieldSplitter extends BaseFieldSplitter
     {
         $prices = [];
         if ('' !== $value) {
+            // Strip quotation marks
+            $cleanedValue = preg_replace('/["]/', '', $value);
+
             // Replace commas between prices with semicolons (excluding commas between numbers)
-            $matches = preg_replace('/([a-z]+),/ixm', '\1;', $value);
+            $matches = preg_replace('/([a-z]+),/ixm', '\1;', $cleanedValue);
 
             // Get an array of values by exploding semicolon delimited values
             $prices = explode(';', $matches);

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldSplitter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldSplitter.php
@@ -64,7 +64,7 @@ class FieldSplitter extends BaseFieldSplitter
         if ('' !== $value) {
             preg_match_all('/
                 (?P<prices>
-                    (-?[a-z0-9]+)  # int or blank (if there is no price defined)
+                    (-?[a-z0-9]+|\s)  # int or blank (if there is no price defined)
                     (?:[^0-9]\d+)? # decimal separator and decimal
                     [a-z\s]+       # currency
                 )/ix', $value, $matches);

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldSplitter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldSplitter.php
@@ -62,14 +62,13 @@ class FieldSplitter extends BaseFieldSplitter
     {
         $prices = [];
         if ('' !== $value) {
-            preg_match_all('/
-                (?P<prices>
-                    (-?[a-z0-9]+|\s)  # int or blank (if there is no price defined)
-                    (?:[^0-9]\d+)? # decimal separator and decimal
-                    [a-z\s]+       # currency
-                )/ix', $value, $matches);
+            // Replace commas between prices with semicolons (excluding commas between numbers)
+            $matches = preg_replace('/([a-z]+),/ixm', '\1;', $value);
 
-            if (empty($matches['prices'])) {
+            // Get an array of values by exploding semicolon delimited values
+            $prices = explode(';', $matches);
+
+            if (empty($matches)) {
                 if (!is_array($value)) {
                     return [$value];
                 }
@@ -77,7 +76,7 @@ class FieldSplitter extends BaseFieldSplitter
                 return $value;
             }
 
-            $prices = $matches['prices'];
+
             array_walk($prices, function (&$price) {
                 $price = trim($price);
             });

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldSplitter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/FieldSplitter.php
@@ -65,8 +65,15 @@ class FieldSplitter extends BaseFieldSplitter
             // Strip quotation marks
             $cleanedValue = preg_replace('/["]/', '', $value);
 
-            // Replace commas between prices with semicolons (excluding commas between numbers)
-            $matches = preg_replace('/([a-z]+),/ixm', '\1;', $cleanedValue);
+            // Replace these types of commas with semicolon:
+            // Commas after currency type: 'EUR, ...'
+            // Commas between numbers and currency symbols: '123.00, $199...'
+            // Dots used as separators: '123,100 EUR.199 USD'
+            $matches = preg_replace('/
+                (?:,(?<=[a-z],)
+                |(?=,?\s?\p{Sc}),)
+                |(?:.(?<=[a-z]\.))
+             /ixm', '\1;', $cleanedValue);
 
             // Get an array of values by exploding semicolon delimited values
             $prices = explode(';', $matches);

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/FieldSplitterSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/FieldSplitterSpec.php
@@ -22,6 +22,8 @@ class FieldSplitterSpec extends ObjectBehavior
         $this->splitPrices('120.25 EUR,  gruik#125 USD')->shouldReturn(['120.25 EUR', 'gruik#125 USD']);
         $this->splitPrices('123 EUR, ARS,23423 AUD')->shouldReturn(['123 EUR', 'ARS', '23423 AUD']);
         $this->splitPrices('"100 EUR, 90 USD"')->shouldReturn(['100 EUR', '90 USD']);
+        $this->splitPrices('€125.00,$199.00')->shouldReturn(['€125.00', '$199.00']);
+        $this->splitPrices('125,00 EUR. 199,00 USD')->shouldReturn(['125,00 EUR', '199,00 USD']);
     }
 
     function it_split_collection()

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/FieldSplitterSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/FieldSplitterSpec.php
@@ -20,6 +20,7 @@ class FieldSplitterSpec extends ObjectBehavior
         $this->splitPrices('')->shouldReturn([]);
         $this->splitPrices('invalid')->shouldReturn(['invalid']);
         $this->splitPrices('120.25 EUR,  gruik#125 USD')->shouldReturn(['120.25 EUR', 'gruik#125 USD']);
+        $this->splitPrices('123 EUR, ARS,23423 AUD')->shouldReturn(['123 EUR', 'ARS', '23423 AUD']);
     }
 
     function it_split_collection()

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/FieldSplitterSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/FieldSplitterSpec.php
@@ -21,6 +21,7 @@ class FieldSplitterSpec extends ObjectBehavior
         $this->splitPrices('invalid')->shouldReturn(['invalid']);
         $this->splitPrices('120.25 EUR,  gruik#125 USD')->shouldReturn(['120.25 EUR', 'gruik#125 USD']);
         $this->splitPrices('123 EUR, ARS,23423 AUD')->shouldReturn(['123 EUR', 'ARS', '23423 AUD']);
+        $this->splitPrices('"100 EUR, 90 USD"')->shouldReturn(['100 EUR', '90 USD']);
     }
 
     function it_split_collection()


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes an issue in product import of prices for multiple currencies. 

Previously, in `ArrayConverter/FlatToStandard/Product/FieldSplitter`, price values were split like this:
`123 EUR, ARS,23423 AUD` --> `['123 EUR', 'ARS,23423 AUD']`

This led to a fail in the product import when you have some currencies blank and some filled: 
`values[retail_price].data[3].data: This value should be a valid number.: ARS,23423 AUD`

So users could not override existing values with blank ones if they wished (which is the expected behaviour). I fixed this by updating the FieldSplitter splitPrices method to handle the case where we have blank values before the currency:

`123 EUR, ARS,23423 AUD` --> `['123 EUR', 'ARS', '23423 AUD']` 


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
