### PR TITLE
PIM-6795: add filter to display only attribute at this level

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,1 +1,5 @@
 # 2.3.x
+
+## Improve Julia's experience
+
+- PIM-6795: As Julia, I would like to display only the current level attributes

--- a/features/product-model/edit_product_model_and_filter_attributes.feature
+++ b/features/product-model/edit_product_model_and_filter_attributes.feature
@@ -51,3 +51,20 @@ Feature: Edit product model and filter attributes
     Then I should see the text "Collection"
     But I should not see the text "Size"
     And I should see the text "Model description"
+
+  Scenario: Edit the product model and show only attributes at this level
+    And I am on the "1111111286" product page
+    When I filter attributes with "All level specific attributes"
+    And I visit the "All" group
+    Then I should see the text "EAN"
+    And I should see the text "SKU"
+    And I should see the text "Weight"
+    And I should see the text "Size"
+    But I should not see the text "Supplier"
+    And I should not see the text "ERP name"
+    And I should not see the text "Price"
+    And I should not see the text "Model name"
+    And I should not see the text "Collection"
+    And I should not see the text "Brand"
+    When I filter attributes with "All attributes"
+    Then I should see the text "Collection"

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -252,6 +252,12 @@ extensions:
         parent: pim-product-edit-form-attribute-filter
         position: 110
 
+    pim-product-edit-form-attribute-filter-at-this-level-filter:
+        module: pim/product-edit-form/attribute-filter-at-this-level
+        parent: pim-product-edit-form-attribute-filter
+        targetZone: self
+        position: 120
+
     pim-product-edit-form-copy:
         module: pim/form/common/attributes/copy
         parent: pim-product-edit-form-attributes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -295,3 +295,9 @@ extensions:
         module: pim/product-edit-form/attribute-filter-missing-required
         parent: pim-product-model-edit-form-attribute-filter
         position: 110
+
+    pim-product-model-edit-form-attribute-filter-at-this-level-filter:
+        module: pim/product-edit-form/attribute-filter-at-this-level
+        parent: pim-product-model-edit-form-attribute-filter
+        targetZone: self
+        position: 120

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -687,6 +687,7 @@ config:
         pim/product-edit-form/attribute-filter:                  pimenrich/js/product/form/attribute-filter
         pim/product-edit-form/attribute-filter-all:              pimenrich/js/product/form/attribute-filter-all
         pim/product-edit-form/attribute-filter-missing-required: pimenrich/js/product/form/attribute-filter-missing-required
+        pim/product-edit-form/attribute-filter-at-this-level:    pimenrich/js/product/form/attribute-filter-at-this-level
         pim/product-edit-form/attributes/validation:             pimenrich/js/product/form/attributes/validation
         pim/product-edit-form/attributes/validation-error:       pimenrich/js/product/form/attributes/validation-error
         pim/product-edit-form/attributes/locale-specific:        pimenrich/js/product/form/attributes/locale-specific

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-all.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-all.js
@@ -26,6 +26,13 @@ define(
             },
 
             /**
+             * @returns {Boolean}
+             */
+            isVisible() {
+                return true;
+            },
+
+            /**
              * @param {Object} values
              *
              * @returns {Promise}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-at-this-level.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-at-this-level.js
@@ -1,0 +1,49 @@
+ 'use strict';
+/**
+ * Filter attributes only at this level.
+ *
+ * @author    Julien Sanchez <julien@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+define(
+    ['jquery', 'underscore', 'oro/translator', 'pim/form'],
+    function ($, _, __, BaseForm) {
+        return BaseForm.extend({
+            /**
+             * @returns {String}
+             */
+            getCode() {
+                return 'at-this-level';
+            },
+
+            /**
+             * @returns {String}
+             */
+            getLabel() {
+                return __('pim_enrich.form.product.tab.attributes.attribute_filter.at_this_level');
+            },
+
+            /**
+             * @returns {Boolean}
+             */
+            isVisible() {
+                const meta = this.getFormData().meta;
+
+                return null !== meta.level && meta.level > 0;
+            },
+
+            /**
+             * @param {Object} values
+             *
+             * @returns {Promise}
+             */
+            filterValues(values) {
+                const valuesToFill = _.pick(values, this.getFormData().meta.attributes_for_this_level);
+
+                return $.Deferred().resolve(valuesToFill).promise();
+            }
+        });
+    }
+);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-missing-required.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter-missing-required.js
@@ -40,6 +40,13 @@ define(
             },
 
             /**
+             * @returns {Boolean}
+             */
+            isVisible() {
+                return true;
+            },
+
+            /**
              * @param {Object} values
              *
              * @returns {Promise}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
@@ -43,9 +43,9 @@ define(
                 const currentFilter = this.getCurrentFilter();
 
                 this.$el.html(this.template({
-                    filters: this.getFilters().map((filter) => {
-                        return { code: filter.getCode(), label: filter.getLabel() };
-                    }),
+                    filters: this.getFilters()
+                        .filter(filter => 'function' !== typeof(filter.isVisible) || filter.isVisible())
+                        .map((filter) => ({ code: filter.getCode(), label: filter.getLabel()})),
                     currentFilter: { code: currentFilter.getCode(), label: currentFilter.getLabel() },
                     __: __
                 }));

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -512,6 +512,7 @@ pim_enrich:
                         display: Display
                         all: All attributes
                         missing_required: All missing required attributes
+                        at_this_level: All level specific attributes
                 categories:
                     title: Categories
             panel:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add the filter "All attributes of current level" to product edit form to display only attributes at the current level.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added legacy Behats               | Yes
| Added acceptance tests            | NA
| Added integration tests           | NA
| Changelog updated                 | Yes
| Review and 2 GTM                  | Yes
| Micro Demo to the PO (Story only) | Yes
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
