### PR TITLE
PIM-7244: Fix duplicated entry during products import

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -10,6 +10,7 @@
 - PIM-7220: Fix the filter "is empty" when the attribute belongs to a family
 - PIM-7237: Fix integrity constraint violation during import
 - PIM-7243: Fix issue on currencies in CSV and XLSX product imports
+- PIM-7244: Fix duplicated entry during products import
 
 # 2.0.17 (2018-03-06)
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
@@ -81,6 +81,8 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
             return;
         }
 
+        $products = array_unique($products, SORT_REGULAR);
+
         foreach ($products as $product) {
             $this->validateProduct($product);
         }
@@ -88,7 +90,6 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         $options['unitary'] = false;
 
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($products, $options));
-
 
         foreach ($products as $product) {
             $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When there are duplicate products in an import file and these products are updated (not created) in the same process batch, then it generates a MySQL error on the completeness of the product.

New completeness objects are generated and persisted for each product. When there is a duplicated product, the first completeness objects are replaced by new instances in the product, but they have already been persisted, so Doctrine does two `Insert` statements when `Flush` is called.

The simple way to fix that without changing the completeness re-calculation behavior, is to remove the duplicates. It also has the advantage to prevent other similar problems.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
