### PR TITLE
Fix PEB filter validator

### DIFF
--- a/src/Pim/Component/Connector/Validator/Constraints/FilterDataValidator.php
+++ b/src/Pim/Component/Connector/Validator/Constraints/FilterDataValidator.php
@@ -49,6 +49,7 @@ class FilterDataValidator extends ConstraintValidator
         foreach ($value['data'] as $data) {
             try {
                 $context = isset($data['context']) ? $data['context'] : [];
+                $context['locales'] = isset($value['structure']['locales']) ? $value['structure']['locales'] : [];
                 $pqb->addFilter($data['field'], $data['operator'], $data['value'], $context);
             } catch (PropertyException $exception) {
                 $this->context->buildViolation(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This fixes a weird error when you wanted to validate a product export builder configuration with the filter validator. This validator was not passing the context properly.
 
**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
