### PR TITLE
Reduce slowness due to ES pre-checks

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Improvements
+
+- Remove checks in ES filter before querying
+
 # 2.0.18 (2018-03-20)
 
 ## Bug fixes

--- a/features/family/remove_attribute_from_a_family.feature
+++ b/features/family/remove_attribute_from_a_family.feature
@@ -8,29 +8,19 @@ Feature: Remove attribute from a family
     Given the "catalog_modeling" catalog configuration
     And I am logged in as "Peter"
 
-  Scenario: Successfully remove an attribute from a family and display it as removable from product
-    Given I am on the "accessories" family page
-    And I visit the "Attributes" tab
-    Then I should see attributes "EAN" in group "ERP"
-    When I remove the "material" attribute
-    And I save the family
-    And I should not see the text "There are unsaved changes."
-    Then I should see the flash message "Attribute successfully removed from the family"
-    When I am on the "1111111292" product page
-    Then I should not see the text "Material"
-
-  Scenario: Successfully remove an attribute from a family and it does not appear in the variant product product model edit pages
+  Scenario: Successfully remove an attribute from a family and assert its removal from product, product-model, variant-product
     Given I am on the "accessories" family page
     And I visit the "Attributes" tab
     When I remove the "material" attribute
     And I save the family
-    And I should not see the text "There are unsaved changes."
-    Then I should see the flash message "Attribute successfully removed from the family"
-    When I am on the "model-braided-hat" product model page
-    And I should see the text "Supplier"
-    And I should not see the text "Material"
-    And I am on the "braided-hat-m" product page
-    And I should not see the text "Material"
+    And I wait for the "compute_completeness_of_products_family" job to finish
+    And I wait for the "compute_family_variant_structure_changes" job to finish
+    And I wait for the "compute_product_models_descendants" job to finish
+    Then the product "1111111292" should not have the following values:
+      | material |
+    And the variant product "braided-hat-m" should not have the following values:
+      | material |
+    And the product model "model-braided-hat" should not have the following values "material"
 
   Scenario: Impossible to remove some attributes from a family (used as label, used as image, used as axis)
     Given I am on the "shoes" family page

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/PriceFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/PriceFilter.php
@@ -8,7 +8,6 @@ use Pim\Component\Catalog\Exception\InvalidOperatorException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 
 /**
@@ -41,23 +40,17 @@ use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
  */
 class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInterface
 {
-    /** @var CurrencyRepositoryInterface */
-    protected $currencyRepository;
-
     /**
      * @param AttributeValidatorHelper    $attrValidatorHelper
-     * @param CurrencyRepositoryInterface $currencyRepository
      * @param array                       $supportedAttributeTypes
      * @param array                       $supportedOperators
      */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
-        CurrencyRepositoryInterface $currencyRepository,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
-        $this->currencyRepository = $currencyRepository;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -264,10 +257,7 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
             );
         }
 
-        if ('' === $data['currency'] ||
-            !is_string($data['currency']) ||
-            !in_array($data['currency'], $this->currencyRepository->getActivatedCurrencyCodes())
-        ) {
+        if ('' === $data['currency'] || !is_string($data['currency'])) {
             throw InvalidPropertyException::validEntityCodeExpected(
                 $attribute->getCode(),
                 'currency',

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/AncestorFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/AncestorFilter.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
 
-use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
-use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
 
 /**
  * An ancestor is a product model that is either a parent or a grand parent.
@@ -35,20 +32,14 @@ class AncestorFilter extends AbstractFieldFilter
 {
     private const ANCESTOR_ID_ES_FIELD = 'ancestors.ids';
 
-    /** @var IdentifiableObjectRepositoryInterface */
-    private $productModelRepository;
-
     /**
-     * @param ProductModelRepositoryInterface $productModelRepository
      * @param array                           $supportedFields
      * @param array                           $supportedOperators
      */
     public function __construct(
-        ProductModelRepositoryInterface $productModelRepository,
         array $supportedFields,
         array $supportedOperators
     ) {
-        $this->productModelRepository = $productModelRepository;
         $this->supportedFields = $supportedFields;
         $this->supportedOperators = $supportedOperators;
     }
@@ -101,31 +92,12 @@ class AncestorFilter extends AbstractFieldFilter
      * Checks the value we want to filter on is valid
      *
      * @param $values
-     *
-     * @throws ObjectNotFoundException
      */
     private function checkValues($values): void
     {
         FieldFilterHelper::checkArray(self::ANCESTOR_ID_ES_FIELD, $values, static::class);
         foreach ($values as $value) {
             FieldFilterHelper::checkString(self::ANCESTOR_ID_ES_FIELD, $value, static::class);
-            if (!$this->isValidId($value)) {
-                throw new ObjectNotFoundException(
-                    sprintf('Object "product model" with ID "%s" does not exist', $value)
-                );
-            }
         }
-    }
-
-    /**
-     * @param string $value
-     *
-     * @return bool
-     */
-    private function isValidId(string $value): bool
-    {
-        $id = str_replace('product_model_', '', $value);
-
-        return null !== $this->productModelRepository->findOneBy(['id' => $id]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/FamilyFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/FamilyFilter.php
@@ -3,11 +3,9 @@
 namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
 
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
-use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
 
 /**
  * Family filter for an Elasticsearch query
@@ -18,20 +16,14 @@ use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
  */
 class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
-    /** @var FamilyRepositoryInterface */
-    protected $familyRepository;
-
     /**
-     * @param FamilyRepositoryInterface $familyRepository
      * @param array                     $supportedFields
      * @param array                     $supportedOperators
      */
     public function __construct(
-        FamilyRepositoryInterface $familyRepository,
         array $supportedFields = [],
         array $supportedOperators = []
     ) {
-        $this->familyRepository = $familyRepository;
         $this->supportedFields = $supportedFields;
         $this->supportedOperators = $supportedOperators;
     }
@@ -100,8 +92,6 @@ class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
      *
      * @param string $field
      * @param mixed  $values
-     *
-     * @throws ObjectNotFoundException
      */
     protected function checkValue($field, $values)
     {
@@ -109,12 +99,6 @@ class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         foreach ($values as $value) {
             FieldFilterHelper::checkIdentifier($field, $value, static::class);
-
-            if (null === $this->familyRepository->findOneByIdentifier($value)) {
-                throw new ObjectNotFoundException(
-                    sprintf('Object "family" with code "%s" does not exist', $value)
-                );
-            }
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/GroupFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/GroupFilter.php
@@ -3,11 +3,9 @@
 namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
 
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
-use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Repository\GroupRepositoryInterface;
 
 /**
  * Group filter for an Elasticsearch query
@@ -18,20 +16,14 @@ use Pim\Component\Catalog\Repository\GroupRepositoryInterface;
  */
 class GroupFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
-    /** @var GroupRepositoryInterface */
-    protected $groupRepository;
-
     /**
-     * @param GroupRepositoryInterface $groupRepository
      * @param array                    $supportedFields
      * @param array                    $supportedOperators
      */
     public function __construct(
-        GroupRepositoryInterface $groupRepository,
         array $supportedFields = [],
         array $supportedOperators = []
     ) {
-        $this->groupRepository = $groupRepository;
         $this->supportedFields = $supportedFields;
         $this->supportedOperators = $supportedOperators;
     }
@@ -100,8 +92,6 @@ class GroupFilter extends AbstractFieldFilter implements FieldFilterInterface
      *
      * @param string $field
      * @param mixed  $values
-     *
-     * @throws ObjectNotFoundException
      */
     protected function checkValue($field, $values)
     {
@@ -109,11 +99,6 @@ class GroupFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         foreach ($values as $value) {
             FieldFilterHelper::checkIdentifier($field, $value, static::class);
-            if (null === $this->groupRepository->findOneByIdentifier($value)) {
-                throw new ObjectNotFoundException(
-                    sprintf('Object "groups" with code "%s" does not exist', $value)
-                );
-            }
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/ParentFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/ParentFilter.php
@@ -3,11 +3,9 @@
 namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
 
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
-use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
 
 /**
  * Parent filter for an Elasticsearch query
@@ -18,22 +16,16 @@ use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
  */
 class ParentFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
-    /** @var ProductModelRepositoryInterface */
-    private $productModelRepository;
-
     /**
-     * @param ProductModelRepositoryInterface $productModelRepository
      * @param array                           $supportedFields
      * @param array                           $supportedOperators
      */
     public function __construct(
-        ProductModelRepositoryInterface $productModelRepository,
         array $supportedFields = [],
         array $supportedOperators = []
     ) {
         $this->supportedFields = $supportedFields;
         $this->supportedOperators = $supportedOperators;
-        $this->productModelRepository = $productModelRepository;
     }
 
     /**
@@ -80,19 +72,12 @@ class ParentFilter extends AbstractFieldFilter implements FieldFilterInterface
      *
      * @param string $field
      * @param mixed  $values
-     *
-     * @throws ObjectNotFoundException
      */
     protected function checkValue($field, $values)
     {
         FieldFilterHelper::checkArray($field, $values, static::class);
         foreach ($values as $value) {
             FieldFilterHelper::checkIdentifier($field, $value, static::class);
-            if (null === $this->productModelRepository->findOneByIdentifier($value)) {
-                throw new ObjectNotFoundException(
-                    sprintf('Object "product model" with code "%s" does not exist', $value)
-                );
-            }
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilter.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
 
-use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
-use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
-use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
 
 /**
  * An ancestor is a product model that is either a parent or a grand parent.
@@ -39,26 +35,14 @@ class SelfAndAncestorFilter extends AbstractFieldFilter
 {
     private const ANCESTOR_ID_ES_FIELD = 'ancestors.ids';
 
-    /** @var IdentifiableObjectRepositoryInterface */
-    private $productModelRepository;
-
-    /** @var ProductRepositoryInterface */
-    private $productRepository;
-
     /**
-     * @param ProductModelRepositoryInterface $productModelRepository
-     * @param ProductRepositoryInterface      $productRepository
      * @param array                           $supportedFields
      * @param array                           $supportedOperators
      */
     public function __construct(
-        ProductModelRepositoryInterface $productModelRepository,
-        ProductRepositoryInterface $productRepository,
         array $supportedFields,
         array $supportedOperators
     ) {
-        $this->productModelRepository = $productModelRepository;
-        $this->productRepository = $productRepository;
         $this->supportedFields = $supportedFields;
         $this->supportedOperators = $supportedOperators;
     }
@@ -114,51 +98,12 @@ class SelfAndAncestorFilter extends AbstractFieldFilter
      * Checks the value we want to filter on is valid
      *
      * @param $values
-     *
-     * @throws ObjectNotFoundException
      */
     private function checkValues($values): void
     {
         FieldFilterHelper::checkArray(self::ANCESTOR_ID_ES_FIELD, $values, static::class);
         foreach ($values as $value) {
             FieldFilterHelper::checkString(self::ANCESTOR_ID_ES_FIELD, $value, static::class);
-            if (!$this->isValidProductModelId($value) && !$this->isValidProductId($value)) {
-                throw new ObjectNotFoundException(
-                    sprintf('Object with ID "%s" does not exist as a product nor as a product model', $value)
-                );
-            }
         }
-    }
-
-    /**
-     * @param string $value
-     *
-     * @return bool
-     */
-    private function isValidProductModelId(string $value): bool
-    {
-        if (0 !== strpos($value, 'product_model_')) {
-            return false;
-        }
-
-        $id = str_replace('product_model_', '', $value);
-
-        return null !== $this->productModelRepository->findOneBy(['id' => $id]);
-    }
-
-    /**
-     * @param string $value
-     *
-     * @return bool
-     */
-    private function isValidProductId(string $value): bool
-    {
-        if (0 !== strpos($value, 'product_')) {
-            return false;
-        }
-
-        $id = str_replace('product_', '', $value);
-
-        return null !== $this->productRepository->findOneBy(['id' => $id]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/WithAttributesFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/WithAttributesFilter.php
@@ -3,11 +3,9 @@
 namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
 
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
-use Pim\Component\Catalog\Exception\ObjectNotFoundException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 
 /**
  * Filter that searches Elasticsearch documents containing the given attributes ($value)
@@ -19,20 +17,14 @@ use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
  */
 class WithAttributesFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
-    /** @var AttributeRepositoryInterface */
-    protected $attributeRepository;
-
     /**
-     * @param AttributeRepositoryInterface $attributeRepository
      * @param array                        $supportedFields
      * @param array                        $supportedOperators
      */
     public function __construct(
-        AttributeRepositoryInterface $attributeRepository,
         array $supportedFields = [],
         array $supportedOperators = []
     ) {
-        $this->attributeRepository = $attributeRepository;
         $this->supportedFields = $supportedFields;
         $this->supportedOperators = $supportedOperators;
     }
@@ -79,8 +71,6 @@ class WithAttributesFilter extends AbstractFieldFilter implements FieldFilterInt
      *
      * @param string $field
      * @param mixed  $values
-     *
-     * @throws ObjectNotFoundException
      */
     protected function checkValue($field, $values)
     {
@@ -88,11 +78,6 @@ class WithAttributesFilter extends AbstractFieldFilter implements FieldFilterInt
 
         foreach ($values as $value) {
             FieldFilterHelper::checkIdentifier($field, $value, static::class);
-            if (null === $this->attributeRepository->findOneByIdentifier($value)) {
-                throw new ObjectNotFoundException(
-                    sprintf('Object "attribute" with code "%s" does not exist', $value)
-                );
-            }
         }
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -331,7 +331,6 @@ services:
     pim_catalog.query.elasticsearch.filter.ancestor:
         class: '%pim_catalog.query.elasticsearch.filter.ancestor.class%'
         arguments:
-            - '@pim_catalog.repository.product_model'
             - ['ancestor.id']
             - ['IN', 'NOT IN']
         tags:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -338,8 +338,6 @@ services:
     pim_catalog.query.elasticsearch.filter.self_and_ancestor:
         class: '%pim_catalog.query.elasticsearch.filter.self_and_ancestor.class%'
         arguments:
-            - '@pim_catalog.repository.product_model'
-            - '@pim_catalog.repository.product'
             - ['self_and_ancestor.id']
             - ['IN', 'NOT IN']
         tags:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -408,7 +408,6 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.price.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'
-            - '@pim_catalog.repository.currency'
             - ['pim_catalog_price_collection']
             - ['<', '<=', '=', '!=', '>=', '>', 'EMPTY', 'EMPTY FOR CURRENCY', 'EMPTY ON ALL CURRENCIES', 'NOT EMPTY', 'NOT EMPTY ON AT LEAST ONE CURRENCY', 'NOT EMPTY FOR CURRENCY']
         tags:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -299,7 +299,6 @@ services:
     pim_catalog.query.elasticsearch.filter.with_attributes:
         class: '%pim_catalog.query.elasticsearch.filter.with_attributes.class%'
         arguments:
-            - '@pim_catalog.repository.attribute'
             - ['attributes_for_this_level']
             - ['IN', 'NOT IN']
         tags:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -201,7 +201,6 @@ services:
     pim_catalog.query.elasticsearch.filter.group:
         class: '%pim_catalog.query.elasticsearch.filter.group.class%'
         arguments:
-            - '@pim_catalog.repository.group'
             - ['groups']
             - ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']
         tags:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -310,7 +310,6 @@ services:
     pim_catalog.query.elasticsearch.filter.parent:
         class: '%pim_catalog.query.elasticsearch.filter.parent.class%'
         arguments:
-            - '@pim_catalog.repository.product_model'
             - ['parent']
             - ['IN', 'EMPTY']
         tags:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -191,7 +191,6 @@ services:
     pim_catalog.query.elasticsearch.filter.family:
         class: '%pim_catalog.query.elasticsearch.filter.family.class%'
         arguments:
-            - '@pim_catalog.repository.family'
             - ['family']
             - ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']
         tags:

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/PriceFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/PriceFilterSpec.php
@@ -11,16 +11,14 @@ use Pim\Component\Catalog\Exception\InvalidOperatorException;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
-use Pim\Component\Catalog\Repository\CurrencyRepositoryInterface;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
 
 class PriceFilterSpec extends ObjectBehavior
 {
-    function let(AttributeValidatorHelper $attributeValidatorHelper, CurrencyRepositoryInterface $currencyRepository)
+    function let(AttributeValidatorHelper $attributeValidatorHelper)
     {
         $this->beConstructedWith(
             $attributeValidatorHelper,
-            $currencyRepository,
             ['pim_catalog_price_collection'],
             ['<', '<=', '=', '>=', '>', 'EMPTY', 'NOT EMPTY', '!=']
         );
@@ -71,11 +69,9 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_lower_than(
         $attributeValidatorHelper,
-        $currencyRepository,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
-        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['EUR', 'USD']);
         $price->getCode()->willReturn('a_price');
         $price->getBackendType()->willReturn('prices');
 
@@ -103,11 +99,9 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_lower_or_equal_than(
         $attributeValidatorHelper,
-        $currencyRepository,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
-        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['EUR', 'USD']);
         $price->getCode()->willReturn('a_price');
         $price->getBackendType()->willReturn('prices');
 
@@ -135,11 +129,9 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_equals(
         $attributeValidatorHelper,
-        $currencyRepository,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
-        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['EUR', 'USD']);
         $price->getCode()->willReturn('a_price');
         $price->getBackendType()->willReturn('prices');
 
@@ -167,11 +159,9 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_not_equal(
         $attributeValidatorHelper,
-        $currencyRepository,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
-        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['EUR', 'USD']);
         $price->getCode()->willReturn('a_price');
         $price->getBackendType()->willReturn('prices');
 
@@ -207,11 +197,9 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_greater_or_equal_than(
         $attributeValidatorHelper,
-        $currencyRepository,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
-        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['EUR', 'USD']);
         $price->getCode()->willReturn('a_price');
         $price->getBackendType()->willReturn('prices');
 
@@ -239,11 +227,9 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_greater_than(
         $attributeValidatorHelper,
-        $currencyRepository,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
-        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['EUR', 'USD']);
         $price->getCode()->willReturn('a_price');
         $price->getBackendType()->willReturn('prices');
 
@@ -295,11 +281,9 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_is_empty_for_currency(
         $attributeValidatorHelper,
-        $currencyRepository,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
-        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['EUR', 'USD']);
         $price->getCode()->willReturn('a_price');
         $price->getBackendType()->willReturn('prices');
 
@@ -352,12 +336,9 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_is_not_empty_for_currency(
         $attributeValidatorHelper,
-        $currencyRepository,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
-        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['EUR', 'USD']);
-
         $price->getCode()->willReturn('a_price');
         $price->getBackendType()->willReturn('prices');
 
@@ -460,11 +441,9 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_throws_if_the_currency_is_not_supported(
         $attributeValidatorHelper,
-        $currencyRepository,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
-        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['USD']);
         $price->getCode()->willReturn('a_price');
 
         $attributeValidatorHelper->validateLocale($price, 'en_US')->shouldBeCalled();
@@ -483,19 +462,6 @@ class PriceFilterSpec extends ObjectBehavior
         )->during(
             'addAttributeFilter',
             [$price, Operators::EQUALS, ['amount' => 12], 'en_US', 'ecommerce']
-        );
-
-        $this->shouldThrow(
-            InvalidPropertyException::validEntityCodeExpected(
-                'a_price',
-                'currency',
-                'The currency does not exist',
-                PriceFilter::class,
-                'YEN'
-            )
-        )->during(
-            'addAttributeFilter',
-            [$price, Operators::EQUALS, ['amount' => 12, 'currency' => 'YEN'], 'en_US', 'ecommerce']
         );
 
         $this->shouldThrow(
@@ -592,11 +558,9 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
         $attributeValidatorHelper,
-        $currencyRepository,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
-        $currencyRepository->getActivatedCurrencyCodes()->willReturn(['USD']);
         $price->getCode()->willReturn('a_price');
         $price->getBackendType()->willReturn('prices');
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/AncestorFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/AncestorFilterSpec.php
@@ -15,10 +15,8 @@ use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
 
 class AncestorFilterSpec extends ObjectBehavior
 {
-    public function let(
-        ProductModelRepositoryInterface $productModelRepository
-    ) {
-        $this->beConstructedWith($productModelRepository, ['ancestor.id'], [Operators::IN_LIST, Operators::NOT_IN_LIST]);
+    public function let() {
+        $this->beConstructedWith(['ancestor.id'], [Operators::IN_LIST, Operators::NOT_IN_LIST]);
     }
 
     function it_is_initializable()
@@ -47,7 +45,6 @@ class AncestorFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_in_list(
         SearchQueryBuilder $sqb,
-        $productModelRepository,
         ProductModelInterface $productModel1,
         ProductModelInterface $productModel2
     ) {
@@ -58,9 +55,6 @@ class AncestorFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-
-        $productModelRepository->findOneBy(['id' => 1])->willReturn($productModel1);
-        $productModelRepository->findOneBy(['id' => 2])->willReturn($productModel2);
 
         $this->setQueryBuilder($sqb);
         $this->addFieldFilter(
@@ -73,15 +67,7 @@ class AncestorFilterSpec extends ObjectBehavior
         );
     }
 
-    function it_adds_a_filter_with_operator_not_in_list(
-        SearchQueryBuilder $sqb,
-        $productModelRepository,
-        ProductModelInterface $productModel1,
-        ProductModelInterface $productModel2
-    ) {
-        $productModelRepository->findOneBy(['id' => 1])->willReturn($productModel1);
-        $productModelRepository->findOneBy(['id' => 2])->willReturn($productModel2);
-
+    function it_adds_a_filter_with_operator_not_in_list(SearchQueryBuilder $sqb) {
         $sqb->addMustNot(
             [
                 'terms' => ['ancestors.ids' => ['product_model_1', 'product_model_2']],
@@ -139,22 +125,5 @@ class AncestorFilterSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidPropertyTypeException::arrayExpected('ancestors', AncestorFilter::class, 'wrong_value')
         )->during('addFieldFilter', ['parent', Operators::IN_LIST, 'wrong_value', null, null, []]);
-    }
-
-    function it_throws_an_exception_if_the_value_is_not_a_product_model_id(
-        $productModelRepository,
-        SearchQueryBuilder $sqb
-    ) {
-        $this->setQueryBuilder($sqb);
-
-        $productModelRepository->findOneBy(['id' => 'invalid_identifier'])->willReturn(null);
-
-        $sqb->addFilter()->shouldNotBeCalled();
-
-        $this->shouldThrow(
-            new ObjectNotFoundException(
-                'Object "product model" with ID "invalid_identifier" does not exist'
-            )
-        )->during('addFieldFilter', ['ancestor.id', Operators::IN_LIST, ['invalid_identifier'], null, null, []]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/FamilyFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/FamilyFilterSpec.php
@@ -23,10 +23,9 @@ use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
  */
 class FamilyFilterSpec extends ObjectBehavior
 {
-    function let(FamilyRepositoryInterface $familyRepository)
+    function let()
     {
         $this->beConstructedWith(
-            $familyRepository,
             ['family'],
             ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']
         );
@@ -63,12 +62,9 @@ class FamilyFilterSpec extends ObjectBehavior
     }
 
     function it_adds_a_filter_with_operator_in_list(
-        $familyRepository,
         SearchQueryBuilder $sqb,
         FamilyInterface $family
     ) {
-        $familyRepository->findOneByIdentifier('familyA')->willReturn($family);
-
         $sqb->addFilter(
             [
                 'terms' => [
@@ -82,12 +78,9 @@ class FamilyFilterSpec extends ObjectBehavior
     }
 
     function it_adds_a_filter_with_operator_not_in_list(
-        $familyRepository,
         SearchQueryBuilder $sqb,
         FamilyInterface $family
     ) {
-        $familyRepository->findOneByIdentifier('familyA')->willReturn($family);
-
         $sqb->addMustNot(
             [
                 'terms' => [
@@ -101,11 +94,8 @@ class FamilyFilterSpec extends ObjectBehavior
     }
 
     function it_adds_a_filter_with_operator_is_empty(
-        $familyRepository,
-        SearchQueryBuilder $sqb,
-        FamilyInterface $family
+        SearchQueryBuilder $sqb
     ) {
-        $familyRepository->findOneByIdentifier('familyA')->willReturn($family);
         $sqb->addMustNot(
             [
                 'exists' => ['field' => 'family.code'],
@@ -116,12 +106,7 @@ class FamilyFilterSpec extends ObjectBehavior
         $this->addFieldFilter('family', Operators::IS_EMPTY, ['familyA'], null, null, []);
     }
 
-    function it_adds_a_filter_with_operator_is_not_empty(
-        $familyRepository,
-        SearchQueryBuilder $sqb,
-        FamilyInterface $family
-    ) {
-        $familyRepository->findOneByIdentifier('familyA')->willReturn($family);
+    function it_adds_a_filter_with_operator_is_not_empty(SearchQueryBuilder $sqb) {
         $sqb->addFilter(
             [
                 'exists' => ['field' => 'family.code'],
@@ -205,24 +190,8 @@ class FamilyFilterSpec extends ObjectBehavior
         )->during('addFieldFilter', ['family', Operators::IN_LIST, [false], null, null, []]);
     }
 
-    function it_throws_an_exception_when_the_given_value_is_not_a_known_family(
-        $familyRepository,
-        SearchQueryBuilder $sqb
-    ) {
-        $familyRepository->findOneByIdentifier('UNKNOWN_FAMILY')->willReturn(null);
-        $this->setQueryBuilder($sqb);
-
-        $this->shouldThrow(
-            new ObjectNotFoundException('Object "family" with code "UNKNOWN_FAMILY" does not exist')
-        )->during('addFieldFilter', ['family', Operators::IN_LIST, ['UNKNOWN_FAMILY'], null, null, []]);
-    }
-
-    function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
-        $familyRepository,
-        SearchQueryBuilder $sqb,
-        FamilyInterface $family
-    ) {
-        $familyRepository->findOneByIdentifier('familyA')->willReturn($family);
+    function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(SearchQueryBuilder $sqb)
+    {
         $this->setQueryBuilder($sqb);
 
         $this->shouldThrow(

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/GroupFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/GroupFilterSpec.php
@@ -22,10 +22,9 @@ use Pim\Component\User\Model\GroupInterface;
  */
 class GroupFilterSpec extends ObjectBehavior
 {
-    function let(GroupRepositoryInterface $groupRepository)
+    function let()
     {
         $this->beConstructedWith(
-            $groupRepository,
             ['groups'],
             ['IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']
         );
@@ -61,13 +60,7 @@ class GroupFilterSpec extends ObjectBehavior
         $this->supportsField('a_not_supported_field')->shouldReturn(false);
     }
 
-    function it_adds_a_filter_with_operator_in_list(
-        $groupRepository,
-        GroupInterface $group,
-        SearchQueryBuilder $sqb
-    ) {
-        $groupRepository->findOneByIdentifier('groupsA')->willReturn($group);
-
+    function it_adds_a_filter_with_operator_in_list(SearchQueryBuilder $sqb) {
         $sqb->addFilter(
             [
                 'terms' => [
@@ -81,12 +74,8 @@ class GroupFilterSpec extends ObjectBehavior
     }
 
     function it_adds_a_filter_with_operator_not_in_list(
-        $groupRepository,
-        GroupInterface $group,
         SearchQueryBuilder $sqb
     ) {
-        $groupRepository->findOneByIdentifier('groupsA')->willReturn($group);
-
         $sqb->addMustNot(
             [
                 'terms' => [
@@ -100,10 +89,8 @@ class GroupFilterSpec extends ObjectBehavior
     }
 
     function it_adds_a_filter_with_operator_is_empty(
-        $groupRepository,
         SearchQueryBuilder $sqb
     ) {
-        $groupRepository->findOneByIdentifier()->shouldNotBeCalled();
         $sqb->addMustNot(
             [
                 'exists' => ['field' => 'groups'],
@@ -115,10 +102,8 @@ class GroupFilterSpec extends ObjectBehavior
     }
 
     function it_adds_a_filter_with_operator_is_not_empty(
-        $groupRepository,
         SearchQueryBuilder $sqb
     ) {
-        $groupRepository->findOneByIdentifier()->shouldNotBeCalled();
         $sqb->addFilter(
             [
                 'exists' => ['field' => 'groups'],
@@ -203,26 +188,9 @@ class GroupFilterSpec extends ObjectBehavior
         )->during('addFieldFilter', ['groups', Operators::IN_LIST, [false], null, null, []]);
     }
 
-    function it_throws_an_exception_when_the_given_value_is_not_a_known_group(
-        $groupRepository,
-        SearchQueryBuilder $sqb
-    ) {
-        $groupRepository->findOneByIdentifier('UNKNOWN_GROUP')->willReturn(null);
-
-        $this->setQueryBuilder($sqb);
-
-        $this->shouldThrow(
-            new ObjectNotFoundException('Object "groups" with code "UNKNOWN_GROUP" does not exist')
-        )->during('addFieldFilter', ['groups', Operators::IN_LIST, ['UNKNOWN_GROUP'], null, null, []]);
-    }
-
     function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
-        $groupRepository,
-        GroupInterface $group,
         SearchQueryBuilder $sqb
     ) {
-        $groupRepository->findOneByIdentifier('groupsA')->willReturn($group);
-
         $this->setQueryBuilder($sqb);
 
         $this->shouldThrow(

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/ParentFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/ParentFilterSpec.php
@@ -18,9 +18,9 @@ use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
 
 class ParentFilterSpec extends ObjectBehavior
 {
-    function let(ProductModelRepositoryInterface $productModelRepository)
+    function let()
     {
-        $this->beConstructedWith($productModelRepository, ['parent'], ['EMPTY']);
+        $this->beConstructedWith(['parent'], ['EMPTY']);
     }
 
     function it_is_initializable()
@@ -78,17 +78,5 @@ class ParentFilterSpec extends ObjectBehavior
                 ParentFilter::class
             )
         )->during('addFieldFilter', ['parent', Operators::IN_CHILDREN_LIST, null, null, null, []]);
-    }
-
-    function it_throws_an_exception_if_the_parent_doesn_t_exist(
-        $productModelRepository,
-        SearchQueryBuilder $sqb
-    ) {
-        $this->setQueryBuilder($sqb);
-
-        $productModelRepository->findOneByIdentifier('jambon')->willReturn(null);
-
-        $this->shouldThrow(ObjectNotFoundException::class)
-            ->during('addFieldFilter', ['parent', Operators::IN_LIST, ['jambon'], null, null, []]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/SelfAndAncestorFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/SelfAndAncestorFilterSpec.php
@@ -17,13 +17,8 @@ use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
 
 class SelfAndAncestorFilterSpec extends ObjectBehavior
 {
-    function let(
-        ProductModelRepositoryInterface $productModelRepository,
-        ProductRepositoryInterface $productRepository
-    ) {
+    function let() {
         $this->beConstructedWith(
-            $productModelRepository,
-            $productRepository,
             ['self_and_ancestors.id'],
             ['IN', 'NOT IN']
         );
@@ -55,17 +50,8 @@ class SelfAndAncestorFilterSpec extends ObjectBehavior
     }
 
     function it_adds_a_filter_with_operator_IN(
-        $productModelRepository,
-        $productRepository,
-        SearchQueryBuilder $sqb,
-        ProductModelInterface $productModel,
-        ProductInterface $product
+        SearchQueryBuilder $sqb
     ) {
-        $productModelRepository->findOneBy(['id' => '1'])->shouldNotBeCalled();
-        $productModelRepository->findOneBy(['id' => '2'])->willReturn($productModel);
-        $productRepository->findOneBy(['id' => '1'])->willReturn($product);
-        $productRepository->findOneBy(['id' => '2'])->shouldNotBeCalled();
-
         $sqb->addShould(
             [
                 'terms' => ['id' => ['product_1', 'product_model_2']],
@@ -90,17 +76,8 @@ class SelfAndAncestorFilterSpec extends ObjectBehavior
     }
 
     function it_adds_a_filter_with_operator_NOT_IN(
-        $productModelRepository,
-        $productRepository,
-        SearchQueryBuilder $sqb,
-        ProductModelInterface $productModel,
-        ProductInterface $product
+        SearchQueryBuilder $sqb
     ) {
-        $productModelRepository->findOneBy(['id' => '1'])->shouldNotBeCalled();
-        $productModelRepository->findOneBy(['id' => '2'])->willReturn($productModel);
-        $productRepository->findOneBy(['id' => '1'])->willReturn($product);
-        $productRepository->findOneBy(['id' => '2'])->shouldNotBeCalled();
-
         $sqb->addMustNot(
             [
                 'terms' => ['id' => ['product_1', 'product_model_2']],
@@ -141,19 +118,5 @@ class SelfAndAncestorFilterSpec extends ObjectBehavior
                 SelfAndAncestorFilter::class
             )
         )->during('addFieldFilter', ['self_and_ancestors.id', Operators::IN_CHILDREN_LIST, ['product_1'], null, null, []]);
-    }
-
-    function it_throws_if_the_value_is_not_a_product_id_nor_a_product_model_id(
-        SearchQueryBuilder $sqb
-    ) {
-        $this->setQueryBuilder($sqb);
-        $this->shouldThrow(
-            new ObjectNotFoundException(
-                'Object with ID "not_a_product_id_nor_a_product_model_id" does not exist as a product nor as a product model'
-            )
-        )->during(
-            'addFieldFilter',
-            ['self_and_ancestors.id', Operators::IN_LIST, ['not_a_product_id_nor_a_product_model_id'], null, null, []]
-        );
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/WithAttributesFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/WithAttributesFilterSpec.php
@@ -21,10 +21,9 @@ use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
  */
 class WithAttributesFilterSpec extends ObjectBehavior
 {
-    function let(AttributeRepositoryInterface $attributeRepository)
+    function let()
     {
         $this->beConstructedWith(
-            $attributeRepository,
             ['attributes', 'attributes_for_this_level'],
             ['IN', 'NOT IN']
         );
@@ -56,12 +55,9 @@ class WithAttributesFilterSpec extends ObjectBehavior
     }
 
     function it_adds_a_filter_with_operator_in_list(
-        $attributeRepository,
         SearchQueryBuilder $sqb,
         AttributeInterface $attribute
     ) {
-        $attributeRepository->findOneByIdentifier('attributeA')->willReturn($attribute);
-
         $sqb->addFilter(
             [
                 'terms' => [
@@ -75,12 +71,8 @@ class WithAttributesFilterSpec extends ObjectBehavior
     }
 
     function it_adds_a_filter_with_operator_not_in_list(
-        $attributeRepository,
-        SearchQueryBuilder $sqb,
-        AttributeInterface $attribute
+        SearchQueryBuilder $sqb
     ) {
-        $attributeRepository->findOneByIdentifier('attributeA')->willReturn($attribute);
-
         $sqb->addMustNot(
             [
                 'terms' => [
@@ -139,24 +131,9 @@ class WithAttributesFilterSpec extends ObjectBehavior
         )->during('addFieldFilter', ['attributes', Operators::IN_LIST, [false], null, null, []]);
     }
 
-    function it_throws_an_exception_when_the_given_value_is_not_a_known_family(
-        $attributeRepository,
+    function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
         SearchQueryBuilder $sqb
     ) {
-        $attributeRepository->findOneByIdentifier('UNKNOWN_FAMILY')->willReturn(null);
-        $this->setQueryBuilder($sqb);
-
-        $this->shouldThrow(
-            new ObjectNotFoundException('Object "attribute" with code "UNKNOWN_FAMILY" does not exist')
-        )->during('addFieldFilter', ['attributes', Operators::IN_LIST, ['UNKNOWN_FAMILY'], null, null, []]);
-    }
-
-    function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
-        $attributeRepository,
-        SearchQueryBuilder $sqb,
-        AttributeInterface $attribute
-    ) {
-        $attributeRepository->findOneByIdentifier('attributeA')->willReturn($attribute);
         $this->setQueryBuilder($sqb);
 
         $this->shouldThrow(

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/FamilyFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/FamilyFilterIntegration.php
@@ -71,15 +71,6 @@ class FamilyFilterIntegration extends AbstractProductQueryBuilderTestCase
     }
 
     /**
-     * @expectedException \Pim\Component\Catalog\Exception\ObjectNotFoundException
-     * @expectedExceptionMessage Object "family" with code "UNKNOWN_FAMILY" does not exist
-     */
-    public function testErrorValueNotFound()
-    {
-        $this->executeFilter([['family', Operators::IN_LIST, ['UNKNOWN_FAMILY']]]);
-    }
-
-    /**
      * @expectedException \Pim\Component\Catalog\Exception\UnsupportedFilterException
      * @expectedExceptionMessage Filter on property "family" is not supported or does not support operator "BETWEEN"
      */


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR removes a lot of checks following this one https://github.com/akeneo/pim-community-dev/pull/7821 which removed 
- Check category existence before using them in ES

This PR removes as well:
- Price: Check that currency exists and is active before filtering on them
- Ancestor: A ProductModel Id exists before filtering on them
- Family : Check that families exists before filtering on them
- Group: Check that groups exists before filtering on them
- Parent: Check that a ProductModel id exists before filtering on them
- SelfAndAncestorFilter: Check that a ProductModel id and a Product exist before filtering on them
- WithAttributes: Check that the attributes exists before filtering on them

We did that in order to have feedback on the API in case of querying a non-existent things.
As it is not documented we remove it to  have better performance and to be consistent with the previous PR I made.

The consequencies it is that it will return nothing in case of a wrong queryied value (only in API use case as the other use cases didn't used it)

This impacts the PQB so PO may be aware of that, Nolwenn is Ok for the API.
But import / **rules** etc may be impacted.

In CE the possible points of failure are (I tried to remove the API impacts/ datagrid impacts / and filter where we check before trying to apply a filter) :
- RemoveProductCommand in Catalog
- GroupUpdater
- FilterDataValidator.


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | OK for Nono
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
