### PR TITLE
PIM 7245: initialise the backend of the catalog volume monitoring screen

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -95,6 +95,7 @@ class AppKernel extends Kernel
             new Pim\Bundle\ReferenceDataBundle\PimReferenceDataBundle(),
             new Pim\Bundle\UIBundle\PimUIBundle(),
             new Pim\Bundle\VersioningBundle\PimVersioningBundle(),
+            new Pim\Bundle\CatalogVolumeMonitoringBundle\PimCatalogVolumeMonitoringBundle(),
         ];
     }
 

--- a/app/config/config_acceptance.yml
+++ b/app/config/config_acceptance.yml
@@ -1,3 +1,4 @@
 imports:
     - { resource: config_behat.yml }
     - { resource: ../../tests/back/Acceptance/Resources/config/pim/repositories.yml }
+    - { resource: ../../src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Resources/config/pim/queries.yml }

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -54,3 +54,8 @@ parameters:
     # Files used as configuration for the Elasticsearch index
     elasticsearch_index_configuration_files:
         - '%pim_ce_dev_src_folder_location%/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml'
+
+
+    # these parameters indicate the advisable limitations of the PIM in term of volume
+    # if your volume of data exceeds these limits, it can impact the performance
+    attributes_per_family_limit: 100

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -39,6 +39,9 @@ pim_api:
     resource: "@PimApiBundle/Resources/config/routing.yml"
     prefix: /api
 
+pim_volume_monitoring:
+    resource: "@PimCatalogVolumeMonitoringBundle/Resources/config/routing.yml"
+
 # Oro platform
 
 oro_default:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -121,12 +121,14 @@ acceptance:
             contexts_services:
                 - test.locale.context
                 - test.channel.context
+                - test.catalog_volume_limits.attribute_per_family_context
             filters:
                 tags: '@acceptance'
     extensions:
         FriendsOfBehat\ContextServiceExtension:
            imports:
                - "tests/back/Acceptance/Resources/config/behat/services.yml"
+               - "src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Resources/config/behat/services.yml"
         FriendsOfBehat\CrossContainerExtension: ~
         FriendsOfBehat\SymfonyExtension:
             kernel:

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -123,6 +123,11 @@ suites:
         psr4_prefix: Pim\Component\User
         spec_path: src/Pim/Component/User
         src_path: src/Pim/Component/User
+    CatalogVolumeMonitoring:
+        namespace: Pim\Component\CatalogVolumeMonitoring
+        psr4_prefix: Pim\Component\CatalogVolumeMonitoring
+        spec_path: src/Pim/Component/CatalogVolumeMonitoring
+        src_path: src/Pim/Component/CatalogVolumeMonitoring
 
     ## Pim Bundles
     AnalyticsBundle:
@@ -215,6 +220,11 @@ suites:
         psr4_prefix: Pim\Bundle\VersioningBundle
         spec_path: src/Pim/Bundle/VersioningBundle
         src_path: src/Pim/Bundle/VersioningBundle
+    CatalogVolumeMonitoringBundle:
+        namespace: Pim\Bundle\CatalogVolumeMonitoringBundle
+        psr4_prefix: Pim\Bundle\CatalogVolumeMonitoringBundle
+        spec_path: src/Pim/Bundle/CatalogVolumeMonitoringBundle
+        src_path: src/Pim/Bundle/CatalogVolumeMonitoringBundle
 
     ## Oro bundles
     OroFilterBundle:

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Controller/VolumeMonitoringController.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Controller/VolumeMonitoringController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\Controller;
+
+use Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class VolumeMonitoringController
+{
+    /** @var Normalizer\Volumes */
+    private $volumesNormalizer;
+
+    /**
+     * @param Normalizer\Volumes $volumesNormalizer
+     */
+    public function __construct(Normalizer\Volumes $volumesNormalizer)
+    {
+        $this->volumesNormalizer = $volumesNormalizer;
+    }
+
+    /**
+     * @return Response
+     */
+    public function getVolumesAction(): Response
+    {
+        return new JsonResponse($this->volumesNormalizer->volumes());
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/DependencyInjection/PimCatalogVolumeMonitoringExtension.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/DependencyInjection/PimCatalogVolumeMonitoringExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PimCatalogVolumeMonitoringExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ .'/../Resources/config'));
+        $loader->load('queries.yml');
+        $loader->load('normalizers.yml');
+        $loader->load('controllers.yml');
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/SqlAttributesPerFamily.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/SqlAttributesPerFamily.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SqlAttributesPerFamily implements AverageMaxQuery
+{
+    private const VOLUME_NAME = 'attributes_per_family';
+
+    /** @var Connection */
+    private $connection;
+
+    /** @var int */
+    private $limit;
+
+    /**
+     * @param Connection $connection
+     */
+    public function __construct(Connection $connection, int $limit)
+    {
+        $this->connection = $connection;
+        $this->limit = $limit;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch(): AverageMaxVolumes
+    {
+        $sql = <<<SQL
+            SELECT 
+                CEIL(AVG(a.count_attributes_per_family)) average,
+                MAX(a.count_attributes_per_family) max
+            FROM (
+                SELECT count(attribute_id) count_attributes_per_family 
+                FROM pim_catalog_family_attribute a
+                GROUP BY family_id
+            ) a
+SQL;
+        $result = $this->connection->query($sql)->fetch();
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+
+        return $volume;
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/PimCatalogVolumeMonitoringBundle.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/PimCatalogVolumeMonitoringBundle.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle;
+
+use Akeneo\Bundle\StorageUtilsBundle\AkeneoStorageUtilsBundle;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Pim\Bundle\CatalogBundle\DependencyInjection\Compiler\RegisterSerializerPass;
+use Pim\Bundle\VersioningBundle\DependencyInjection\Compiler\RegisterUpdateGuessersPass;
+use Pim\Bundle\VersioningBundle\DependencyInjection\Compiler\RegisterVersionPurgerAdvisorPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PimCatalogVolumeMonitoringBundle extends Bundle
+{
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/controllers.yml
@@ -1,0 +1,8 @@
+parameters:
+    pim_volume_monitoring.controller.volume_monitoring.class: Pim\Bundle\CatalogVolumeMonitoringBundle\Controller\VolumeMonitoringController
+
+services:
+    pim_volume_monitoring.controller.volume_monitoring:
+        class: '%pim_volume_monitoring.controller.volume_monitoring.class%'
+        arguments:
+            - '@pim_volume_monitoring.volume.normalizer.volumes'

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/normalizers.yml
@@ -1,0 +1,20 @@
+parameters:
+    pim_volume_monitoring.volume.normalizer.average_max_volumes.class: Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer\AverageMaxVolumesNormalizer
+    pim_volume_monitoring.volume.normalizer.count_volume.class: Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer\CountVolumeNormalizer
+    pim_volume_monitoring.volume.normalizer.volumes.class: Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer\Volumes
+
+services:
+    pim_volume_monitoring.volume.normalizer.average_max_volumes:
+        class: '%pim_volume_monitoring.volume.normalizer.average_max_volumes.class%'
+
+    pim_volume_monitoring.volume.normalizer.count_volume:
+        class: '%pim_volume_monitoring.volume.normalizer.count_volume.class%'
+
+    pim_volume_monitoring.volume.normalizer.volumes:
+        class: '%pim_volume_monitoring.volume.normalizer.volumes.class%'
+        arguments:
+            - '@pim_volume_monitoring.volume.normalizer.count_volume'
+            - '@pim_volume_monitoring.volume.normalizer.average_max_volumes'
+            - !tagged pim_volume_monitoring.persistence.count_query
+            - !tagged pim_volume_monitoring.persistence.average_max_query
+

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/queries.yml
@@ -1,0 +1,11 @@
+parameters:
+    pim_volume_monitoring.persistence.query.attributes_per_family.class: Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\SqlAttributesPerFamily
+
+services:
+    pim_volume_monitoring.persistence.query.attributes_per_family:
+        class: '%pim_volume_monitoring.persistence.query.attributes_per_family.class%'
+        arguments:
+            - '@database_connection'
+            - '%attributes_per_family_limit%'
+        tags:
+            - { name: pim_volume_monitoring.persistence.average_max_query }

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/routing.yml
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/routing.yml
@@ -1,0 +1,4 @@
+pim_volume_monitoring_get_volumes:
+    path: /catalog-volume-monitoring/volumes
+    defaults: { _controller: pim_volume_monitoring.controller.volume_monitoring:getVolumesAction, _format: json }
+    methods: [GET]

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Controller/VolumeMonitoringControllerSpec.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Controller/VolumeMonitoringControllerSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Bundle\CatalogVolumeMonitoringBundle\Controller;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\Controller\VolumeMonitoringController;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer\AverageMaxVolumesNormalizer;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer\CountVolumeNormalizer;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer\Volumes;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class VolumeMonitoringControllerSpec extends ObjectBehavior
+{
+    function let(CountVolumeNormalizer $countVolumeNormalizer, AverageMaxVolumesNormalizer $averageMaxVolumesNormalizer)
+    {
+        $countVolumeNormalizer->normalize()->willReturn([]);
+        $averageMaxVolumesNormalizer->normalize()->willReturn([]);
+        $this->beConstructedWith(
+            new Volumes(
+                $countVolumeNormalizer->getWrappedObject(),
+                $averageMaxVolumesNormalizer->getWrappedObject(),
+                [],
+                []
+            )
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(VolumeMonitoringController::class);
+    }
+
+    function it_gets_volumes()
+    {
+        $this->getVolumesAction()->shouldBeLike(new JsonResponse([]));
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/SqlAttributesPerFamilySpec.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/SqlAttributesPerFamilySpec.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\SqlAttributesPerFamily;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+use Prophecy\Argument;
+
+class SqlAttributesPerFamilySpec extends ObjectBehavior
+{
+    function let(Connection $connection)
+    {
+        $this->beConstructedWith($connection, 12);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(SqlAttributesPerFamily::class);
+    }
+
+    function it_is_an_average_ad_max_query()
+    {
+        $this->shouldImplement(AverageMaxQuery::class);
+    }
+
+    function it_gets_average_and_max_volume($connection, Statement $statement)
+    {
+        $connection->query(Argument::type('string'))->willReturn($statement);
+        $statement->fetch()->willReturn(['average' => '4', 'max' => '10']);
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, 12, 'attributes_per_family'));
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/AttributePerFamilyContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/AttributePerFamilyContext.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryAverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer;
+use Webmozart\Assert\Assert;
+
+final class AttributePerFamilyContext implements Context, SnippetAcceptingContext
+{
+    /** @var array */
+    private $limits = [];
+
+    /** @var array */
+    private $familiesNumbers = [];
+
+    /** @var array */
+    private $volumes = [];
+
+    /** @var Normalizer\Volumes */
+    private $volumesNormalizer;
+
+    /** @var InMemoryAverageMaxQuery */
+    private $inMemoryQuery;
+
+    /**
+     * @param Normalizer\Volumes $volumesNormalizer
+     */
+    public function __construct(Normalizer\Volumes $volumesNormalizer, InMemoryAverageMaxQuery $inMemoryQuery)
+    {
+        $this->volumesNormalizer = $volumesNormalizer;
+        $this->inMemoryQuery = $inMemoryQuery;
+    }
+
+    /**
+     * @Given a family with :numberOfAttributes attributes
+     */
+    public function aFamilyWithAttributes(int $numberOfAttributes)
+    {
+        $this->familiesNumbers[] = $numberOfAttributes;
+    }
+
+    /**
+     * @When the administrator user asks for the catalog volume monitoring report
+     */
+    public function theAdministratorUserAsksForTheCatalogVolumeMonitoringReport()
+    {
+        $this->inMemoryQuery->setAverageVolume(array_sum($this->familiesNumbers) / count($this->familiesNumbers));
+        $this->inMemoryQuery->setMaxVolume(max($this->familiesNumbers));
+
+        $this->volumes = $this->volumesNormalizer->volumes();
+    }
+
+    /**
+     * @Then the report returns that the average number of attributes per family is :number
+     */
+    public function theReportReturnsThatTheMeanNumberOfAttributesPerFamilyIs(int $number)
+    {
+        Assert::eq($this->volumes['attributes_per_family']['value']['average'], $number);
+    }
+
+    /**
+     * @Then the report returns that the maximum number of attributes per family is :number
+     */
+    public function theReportReturnsThatTheMaximumNumberOfAttributesPerFamilyIs(int $number)
+    {
+        Assert::eq($this->volumes['attributes_per_family']['value']['max'], $number);
+    }
+
+    /**
+     * @Given the limit of the number of attributes per family is set to :limit
+     */
+    public function theLimitOfTheNumberOfIsSetTo(int $limit)
+    {
+        $this->inMemoryQuery->setLimit($limit);
+    }
+
+    /**
+     * @Then the report warns the users that the number of attributes per family is high
+     */
+    public function theReportWarnsTheUsersThatTheNumberIsHigh()
+    {
+        Assert::true($this->volumes['attributes_per_family']['has_warning']);
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Persistence/Query/InMemory/InMemoryAverageMaxQuery.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Persistence/Query/InMemory/InMemoryAverageMaxQuery.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory;
+
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InMemoryAverageMaxQuery implements AverageMaxQuery
+{
+    /** @var int */
+    private $averageVolume;
+
+    /** @var int */
+    private $maxVolume;
+
+    /** @var int */
+    private $limit;
+
+    /** @var string */
+    private $volumeName;
+
+    /**
+     * @param string $volumeName
+     */
+    public function __construct(string $volumeName)
+    {
+        $this->volumeName = $volumeName;
+        $this->averageVolume = -1;
+        $this->maxVolume = -1;
+        $this->limit = -1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch(): AverageMaxVolumes
+    {
+        return new AverageMaxVolumes($this->maxVolume, $this->averageVolume, $this->limit, $this->volumeName);
+    }
+
+    /**
+     * @param int $averageVolume
+     */
+    public function setAverageVolume(int $averageVolume): void
+    {
+        $this->averageVolume = $averageVolume;
+    }
+
+    /**
+     * @param int $maxVolume
+     */
+    public function setMaxVolume(int $maxVolume): void
+    {
+        $this->maxVolume = $maxVolume;
+    }
+
+    /**
+     * @param int $limit
+     */
+    public function setLimit(int $limit): void
+    {
+        $this->limit = $limit;
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Resources/config/behat/services.yml
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Resources/config/behat/services.yml
@@ -1,0 +1,8 @@
+services:
+    test.catalog_volume_limits.attribute_per_family_context:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context\AttributePerFamilyContext'
+        arguments:
+            - '@__symfony__.pim_volume_monitoring.volume.normalizer.volumes'
+            - '@__symfony__.pim_volume_monitoring.persistence.query.attributes_per_family'
+        tags:
+            - { name: fob.context_service }

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Resources/config/pim/queries.yml
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Resources/config/pim/queries.yml
@@ -1,0 +1,10 @@
+parameters:
+    pim_volume_monitoring.persistence.query.attributes_per_family.class: Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryAverageMaxQuery
+
+services:
+    pim_volume_monitoring.persistence.query.attributes_per_family:
+        class: '%pim_volume_monitoring.persistence.query.attributes_per_family.class%'
+        arguments:
+            - 'attributes_per_family'
+        tags:
+            - { name: pim_volume_monitoring.persistence.average_max_query }

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/SqlAttributesPerFamilyIntegration.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/SqlAttributesPerFamilyIntegration.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Integration\Persistence\Query;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+class SqlAttributesPerFamilyIntegration extends TestCase
+{
+    public function testGetAverageAndMaximumNumberOfAttributesPerFamily()
+    {
+        $query = $this->get('pim_volume_monitoring.persistence.query.attributes_per_family');
+        $this->createFamilyWithAttributes(4);
+        $this->createFamilyWithAttributes(8);
+        $this->createFamilyWithAttributes(2);
+
+        $volume = $query->fetch();
+
+        Assert::assertEquals(8, $volume->getMaxVolume());
+        Assert::assertEquals(5, $volume->getAverageVolume());
+        Assert::assertEquals('attributes_per_family', $volume->getVolumeName());
+        Assert::assertEquals(false, $volume->hasWarning());
+    }
+
+    /**
+     * @param int $numberOfAttributes
+     */
+    private function createFamilyWithAttributes(int $numberOfAttributes): void
+    {
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $family->setCode('family_' . rand());
+
+        $attributes = [];
+        $i = 0;
+        // -1 because sku is automatically added
+        while ($i < $numberOfAttributes -1) {
+            $attribute = $this->get('pim_catalog.factory.attribute')->create();
+            $this->get('pim_catalog.updater.attribute')->update(
+                $attribute,
+                [
+                    'code'     => 'new_attribute_' . rand(),
+                    'type'     => 'pim_catalog_textarea',
+                    'group'    => 'other'
+                ]
+            );
+
+            $errors = $this->get('validator')->validate($attribute);
+            Assert::assertCount(0, $errors);
+
+            $family->addAttribute($attribute);
+            $attributes[] = $attribute;
+
+            $i++;
+        }
+
+        $this->get('pim_catalog.saver.attribute')->saveAll($attributes);
+
+        $errors = $this->get('validator')->validate($family);
+        Assert::assertCount(0, $errors);
+
+        $this->get('pim_catalog.saver.family')->save($family);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/Volume/Normalizer/AverageMaxVolumesNormalizer.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/Volume/Normalizer/AverageMaxVolumesNormalizer.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer;
+
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AverageMaxVolumesNormalizer
+{
+    private const VOLUME_TYPE = 'average_max';
+
+    /**
+     * @param AverageMaxVolumes $data
+     *
+     * @return array
+     */
+    public function normalize(AverageMaxVolumes $data): array
+    {
+        $data = [
+            $data->getVolumeName() => [
+                'value' => [
+                    'average' => $data->getAverageVolume(),
+                    'max' => $data->getMaxVolume(),
+                ],
+                'has_warning' => $data->hasWarning(),
+                'type' => self::VOLUME_TYPE
+            ]
+        ];
+
+        return $data;
+    }
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/Volume/Normalizer/CountVolumeNormalizer.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/Volume/Normalizer/CountVolumeNormalizer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer;
+
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\CountVolume;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CountVolumeNormalizer
+{
+    private const VOLUME_TYPE = 'count';
+    /**
+     * @param CountVolume $data
+     *
+     * @return array
+     */
+    public function normalize(CountVolume $data): array
+    {
+        $data = [
+            $data->getVolumeName() => [
+                'value' => $data->getVolume(),
+                'has_warning' => $data->hasWarning(),
+                'type' => self::VOLUME_TYPE
+            ]
+        ];
+
+        return $data;
+    }
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/Volume/Normalizer/Volumes.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/Volume/Normalizer/Volumes.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer;
+
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\CountQuery;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Volumes
+{
+    /** @var AverageMaxVolumesNormalizer */
+    private $averageMaxVolumesNormalizer;
+
+    /** @var CountVolumeNormalizer */
+    private $countVolumesNormalizer;
+
+    /** @var array */
+    private $countQueries;
+
+    /** @var array */
+    private $averageMaxQueries;
+
+    /**
+     * @param CountVolumeNormalizer       $countVolumesNormalizer
+     * @param AverageMaxVolumesNormalizer $averageMaxVolumesNormalizer
+     * @param CountQuery[]                $countQueries
+     * @param AverageMaxQuery[]           $averageMaxQueries
+     */
+    public function __construct(
+        CountVolumeNormalizer $countVolumesNormalizer,
+        AverageMaxVolumesNormalizer $averageMaxVolumesNormalizer,
+        iterable $countQueries = [],
+        iterable $averageMaxQueries = []
+    ) {
+        $this->countVolumesNormalizer = $countVolumesNormalizer;
+        $this->averageMaxVolumesNormalizer = $averageMaxVolumesNormalizer;
+        $this->countQueries = $countQueries;
+        $this->averageMaxQueries = $averageMaxQueries;
+    }
+
+    /**
+     * Returns an array containing the volume values of the different entities.
+     *
+     * @return array
+     */
+    public function volumes(): array
+    {
+        $data = [];
+
+        foreach ($this->countQueries as $query) {
+            $queryResponse = $query->fetch();
+            $data = array_merge($data, $this->countVolumesNormalizer->normalize($queryResponse));
+        }
+
+        foreach ($this->averageMaxQueries as $query) {
+            $queryResponse = $query->fetch();
+            $data = array_merge($data, $this->averageMaxVolumesNormalizer->normalize($queryResponse));
+        }
+
+        return $data;
+    }
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/Volume/Query/AverageMaxQuery.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/Volume/Query/AverageMaxQuery.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\CatalogVolumeMonitoring\Volume\Query;
+
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface AverageMaxQuery
+{
+    /**
+     * @return AverageMaxVolumes
+     */
+    public function fetch(): AverageMaxVolumes;
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/Volume/Query/CountQuery.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/Volume/Query/CountQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\CatalogVolumeMonitoring\Volume\Query;
+
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\CountVolume;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface CountQuery
+{
+    public function fetch(): CountVolume;
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/Volume/ReadModel/AverageMaxVolumes.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/Volume/ReadModel/AverageMaxVolumes.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel;
+
+/**
+ * Represents the average volume and maximum volume for a given entity.
+ *
+ * For example, the maximum number of attributes per family, among all the families,
+ * and the average number of attributes per family.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AverageMaxVolumes
+{
+    /** @var int */
+    private $maxVolume;
+
+    /** @var int */
+    private $averageVolume;
+
+    /** @var int*/
+    private $limit;
+
+    /** @var string */
+    private $volumeName;
+
+    /**
+     * @param int    $maxVolume
+     * @param int    $averageVolume
+     * @param int    $limit
+     * @param string $volumeName
+     */
+    public function __construct(int $maxVolume, int $averageVolume, int $limit, string $volumeName)
+    {
+        $this->maxVolume = $maxVolume;
+        $this->averageVolume = $averageVolume;
+        $this->limit = $limit;
+        $this->volumeName = $volumeName;
+    }
+
+    public function getMaxVolume(): int
+    {
+        return $this->maxVolume;
+    }
+
+    public function getAverageVolume(): int
+    {
+        return $this->averageVolume;
+    }
+
+    public function getVolumeName(): string
+    {
+        return $this->volumeName;
+    }
+
+    public function hasWarning(): bool
+    {
+        return $this->maxVolume > $this->limit;
+    }
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/Volume/ReadModel/CountVolume.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/Volume/ReadModel/CountVolume.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel;
+
+/**
+ * Represents the volume of an axis of limitation.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CountVolume
+{
+    /** @var int */
+    private $volume;
+
+    /** @var int*/
+    private $limit;
+
+    /** @var string */
+    private $volumeName;
+
+    /**
+     * @param int    $volume
+     * @param int    $limit
+     * @param string $volumeName
+     */
+    public function __construct(int $volume, int $limit, string $volumeName)
+    {
+        $this->volume = $volume;
+        $this->limit = $limit;
+        $this->volumeName = $volumeName;
+    }
+
+    public function getVolume(): int
+    {
+        return $this->volume;
+    }
+
+    public function getVolumeName(): string
+    {
+        return $this->volumeName;
+    }
+
+    public function hasWarning(): bool
+    {
+        return $this->volume > $this->limit;
+    }
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/spec/Volume/Normalizer/AverageMaxVolumesNormalizerSpec.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/spec/Volume/Normalizer/AverageMaxVolumesNormalizerSpec.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer\AverageMaxVolumesNormalizer;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+
+class AverageMaxVolumesNormalizerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AverageMaxVolumesNormalizer::class);
+    }
+
+    function it_normalizes_average_and_max_volumes()
+    {
+        $volumes = new AverageMaxVolumes(10, 6, 14, 'volume_name');
+        $this->normalize($volumes)->shouldReturn([
+            'volume_name' => [
+                'value' => [
+                    'average' => 6,
+                    'max' => 10,
+                ],
+                'has_warning' => false,
+                'type' => 'average_max'
+            ]
+        ]);
+    }
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/spec/Volume/Normalizer/CountVolumeNormalizerSpec.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/spec/Volume/Normalizer/CountVolumeNormalizerSpec.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer\CountVolumeNormalizer;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\CountVolume;
+
+class CountVolumeNormalizerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CountVolumeNormalizer::class);
+    }
+
+    function it_normalizes_count_volume()
+    {
+        $volumes = new CountVolume(10, 8, 'volume_name');
+        $this->normalize($volumes)->shouldReturn([
+            'volume_name' => [
+                'value' => 10,
+                'has_warning' => true,
+                'type' => 'count'
+            ]
+        ]);
+    }
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/spec/Volume/Normalizer/VolumesSpec.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/spec/Volume/Normalizer/VolumesSpec.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer\AverageMaxVolumesNormalizer;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer\CountVolumeNormalizer;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Normalizer\Volumes;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\CountQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\CountVolume;
+
+class VolumesSpec extends ObjectBehavior
+{
+    function let(
+        CountVolumeNormalizer $countVolumeNormalizer,
+        AverageMaxVolumesNormalizer $averageVolumeNormalizer,
+        CountQuery $countQuery1,
+        CountQuery $countQuery2,
+        AverageMaxQuery $averageMaxQuery
+    ) {
+        $this->beConstructedWith(
+            $countVolumeNormalizer,
+            $averageVolumeNormalizer,
+            [$countQuery1, $countQuery2],
+            [$averageMaxQuery]
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(Volumes::class);
+    }
+
+    function it_normalizes_volumes(
+        $countVolumeNormalizer,
+        $averageVolumeNormalizer,
+        $countQuery1,
+        $countQuery2,
+        $averageMaxQuery,
+        CountVolume $countVolume1,
+        CountVolume $countVolume2,
+        AverageMaxVolumes $averageMaxVolumes
+    ) {
+        $countQuery1->fetch()->willReturn($countVolume1);
+        $countQuery2->fetch()->willReturn($countVolume2);
+        $averageMaxQuery->fetch()->willReturn($averageMaxVolumes);
+
+        $countVolumeNormalizer->normalize($countVolume1)->willReturn([
+            'count_volume_1' => [
+                'value' => 10,
+                'has_warning' => true,
+                'type' => 'count'
+            ]
+        ]);
+
+        $countVolumeNormalizer->normalize($countVolume2)->willReturn([
+            'count_volume_2' => [
+                'value' => 12,
+                'has_warning' => false,
+                'type' => 'count'
+            ]
+        ]);
+
+        $averageVolumeNormalizer->normalize($averageMaxVolumes)->willReturn([
+            'average_max_volume' => [
+                'value' => ['average' => 4, 'max' => 10],
+                'has_warning' => false,
+                'type' => 'average_max'
+            ]
+        ]);
+
+        $this->volumes()->shouldReturn([
+            'count_volume_1' => [
+                'value' => 10,
+                'has_warning' => true,
+                'type' => 'count'
+            ],
+            'count_volume_2' => [
+                'value' => 12,
+                'has_warning' => false,
+                'type' => 'count'
+            ],
+            'average_max_volume' => [
+                'value' => ['average' => 4, 'max' => 10],
+                'has_warning' => false,
+                'type' => 'average_max'
+            ],
+        ]);
+    }
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/spec/Volume/ReadModel/AverageMaxVolumesSpec.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/spec/Volume/ReadModel/AverageMaxVolumesSpec.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+
+class AverageMaxVolumesSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(10, 6, 8, 'volume_name');
+    }
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AverageMaxVolumes::class);
+    }
+
+    function it_has_max_volume()
+    {
+        $this->getMaxVolume()->shouldReturn(10);
+    }
+
+    function it_has_average_volume()
+    {
+        $this->getAverageVolume()->shouldReturn(6);
+    }
+
+    function it_has_volume_name()
+    {
+        $this->getVolumeName()->shouldReturn('volume_name');
+    }
+
+    function it_has_warning()
+    {
+        $this->hasWarning()->shouldReturn(true);
+    }
+}

--- a/src/Pim/Component/CatalogVolumeMonitoring/spec/Volume/ReadModel/CountVolumeSpec.php
+++ b/src/Pim/Component/CatalogVolumeMonitoring/spec/Volume/ReadModel/CountVolumeSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\CountVolume;
+
+class CountVolumeSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(10, 6, 'volume_name');
+    }
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CountVolume::class);
+    }
+
+    function it_has_volume()
+    {
+        $this->getVolume()->shouldReturn(10);
+    }
+
+    function it_has_volume_name()
+    {
+        $this->getVolumeName()->shouldReturn('volume_name');
+    }
+
+    function it_has_warning()
+    {
+        $this->hasWarning()->shouldReturn(true);
+    }
+}

--- a/tests/features/volume-monitoring/monitor_attribute_per_family_volume.feature
+++ b/tests/features/volume-monitoring/monitor_attribute_per_family_volume.feature
@@ -1,0 +1,20 @@
+Feature: Monitor catalog volume
+  In order to guarantee the performance of the PIM
+  As an administrator user
+  I want to monitor the volume of attributes per family
+
+  @acceptance
+  Scenario: Monitor the number of attributes per family
+    Given a family with 10 attributes
+    And a family with 4 attributes
+    When the administrator user asks for the catalog volume monitoring report
+    Then the report returns that the average number of attributes per family is 7
+    And the report returns that the maximum number of attributes per family is 10
+
+  @acceptance
+  Scenario: Warn the user administrator when the maximum number of attributes per family is high
+    Given a family with 8 attributes
+    And a family with 2 attributes
+    And the limit of the number of attributes per family is set to 6
+    When the administrator user asks for the catalog volume monitoring report
+    Then the report warns the users that the number of attributes per family is high


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This PR initialise the backend to display the catalog volume in the UI.

I tried to do my best to both respect our conventions but also, change our way to test things.
It uses only unit and acceptance tests for now (and it's fast ;) ).

I decided (after discussing with @aRn0D) to not put tests directly in the "tests/" directory but directly in the bundle (but the scenarios are still at "tests/features".

Same things for fake and tests. The main reason is that's it's a new thing (and not legacy). Also, it will be very quickly a mess to put in "tests/" directory fake adapter and context.

Note: I would personally put our InMemory adapters in our codebase instead of "test" directory for simplicity and clarity. 



<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
