### PR TITLE
PIM-7264: Add validation on import decimal number greater than limit in MySQL

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -5,6 +5,7 @@
 - GITHUB-7507: Fix XLSX product export to allow decimal separator configuration (Thanks [wa-daniel-fahl](https://github.com/wa-daniel-fahl)!
 - PIM-7069: Fix Channel export regarding conversion_units output
 - PIM-7119: Fix missing translation on filters
+- PIM-7264: Fix validation on import decimal number greater than limit in database (MySQL)
 
 # 1.7.19 (2018-02-27)
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -1,4 +1,6 @@
 parameters:
+    product_value_decimal_limit: 9999999999.9999
+
     symfony.validator.recursive.class:                                     Symfony\Component\Validator\Validator\RecursiveValidator
 
     pim_catalog.validator.helper.attribute.class:                          Pim\Component\Catalog\Validator\AttributeValidatorHelper
@@ -36,6 +38,7 @@ parameters:
     pim_catalog.validator.constraint_guesser.currency.class:               Pim\Component\Catalog\Validator\ConstraintGuesser\CurrencyGuesser
     pim_catalog.validator.constraint_guesser.regex.class:                  Pim\Component\Catalog\Validator\ConstraintGuesser\RegexGuesser
     pim_catalog.validator.constraint_guesser.not_decimal.class:            Pim\Component\Catalog\Validator\ConstraintGuesser\NotDecimalGuesser
+    pim_catalog.validator.constraint_guesser.decimal.class:                Pim\Component\Catalog\Validator\ConstraintGuesser\DecimalGuesser
     pim_catalog.validator.constraint_guesser.url.class:                    Pim\Component\Catalog\Validator\ConstraintGuesser\UrlGuesser
     pim_catalog.validator.constraint_guesser.unique_value.class:           Pim\Component\Catalog\Validator\ConstraintGuesser\UniqueValueGuesser
     pim_catalog.validator.constraint_guesser.price_collection.class:       Pim\Component\Catalog\Validator\ConstraintGuesser\PriceCollectionGuesser
@@ -274,6 +277,14 @@ services:
     pim_catalog.validator.constraint_guesser.not_decimal:
         public: false
         class: '%pim_catalog.validator.constraint_guesser.not_decimal.class%'
+        tags:
+            - { name: pim_catalog.constraint_guesser.attribute }
+
+    pim_catalog.validator.constraint_guesser.decimal:
+        public: false
+        class: '%pim_catalog.validator.constraint_guesser.decimal.class%'
+        arguments:
+            - '%product_value_decimal_limit%'
         tags:
             - { name: pim_catalog.constraint_guesser.attribute }
 

--- a/src/Pim/Component/Catalog/Validator/ConstraintGuesser/DecimalGuesser.php
+++ b/src/Pim/Component/Catalog/Validator/ConstraintGuesser/DecimalGuesser.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\ConstraintGuesser;
+
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Validator\ConstraintGuesserInterface;
+use Symfony\Component\Validator\Constraints\LessThan;
+
+/**
+ * Constraint guesser for decimal
+ *
+ * @author    Elodie Raposo <elodie.raposo@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DecimalGuesser implements ConstraintGuesserInterface
+{
+    /**
+     * @var float $limit
+     */
+    private $limit;
+
+    public function __construct($limit)
+    {
+        $this->limit = $limit;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportAttribute(AttributeInterface $attribute)
+    {
+        return $attribute->getType() === AttributeTypes::NUMBER;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessConstraints(AttributeInterface $attribute)
+    {
+        return [new LessThan($this->limit)];
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/DecimalGuesserSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/DecimalGuesserSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\ConstraintGuesser;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Validator\ConstraintGuesserInterface;
+
+class DecimalGuesserSpec extends ObjectBehavior
+{
+    function let($limit)
+    {
+        $this->beConstructedWith($limit);
+    }
+
+    function it_is_an_attribute_constraint_guesser()
+    {
+        $this->shouldImplement(ConstraintGuesserInterface::class);
+    }
+
+    function it_enforces_attribute_type(AttributeInterface $attribute)
+    {
+        $attribute->getType()
+            ->willReturn('pim_catalog_metric');
+        $this->supportAttribute($attribute)
+            ->shouldReturn(false);
+
+        $attribute->getType()
+            ->willReturn('pim_catalog_number');
+        $this->supportAttribute($attribute)
+            ->shouldReturn(true);
+
+        $attribute->getType()
+            ->willReturn('pim_catalog_text');
+        $this->supportAttribute($attribute)
+            ->shouldReturn(false);
+
+        $attribute->getType()
+            ->willReturn('foo');
+        $this->supportAttribute($attribute)
+            ->shouldReturn(false);
+    }
+
+    function it_guesses_decimal(AttributeInterface $attribute)
+    {
+        $constraints = $this->guessConstraints($attribute);
+
+        $constraints->shouldHaveCount(1);
+
+        $constraint = $constraints[0];
+        $constraint->shouldBeAnInstanceOf('Symfony\Component\Validator\Constraints\LessThan');
+    }
+}


### PR DESCRIPTION
**Description**

When importing a product with a very long numeric that is longer than 10 digits (max length in the DB), MySQL will convert the number to the max possible, which is "9999999999.9999" (in the UI you see 9999999999.
As this number is a decimal, if the field is set to not allow decimal, it's not possible to save the product anymore.

Expected behaviour: add a validation on import to not allow number greater than the limit

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
