### PR TITLE
Add duration into the junit report of the behat

### DIFF
--- a/features/Pim/Behat/Extension/PimFormatter/Output/Node/EventListener/JUnitDurationListener.php
+++ b/features/Pim/Behat/Extension/PimFormatter/Output/Node/EventListener/JUnitDurationListener.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Behat\Extension\PimFormatter\Output\Node\EventListener;
+
+use Behat\Behat\EventDispatcher\Event\AfterFeatureTested;
+use Behat\Behat\EventDispatcher\Event\AfterScenarioTested;
+use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
+use Behat\Behat\EventDispatcher\Event\BeforeScenarioTested;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\KeywordNodeInterface;
+use Behat\Gherkin\Node\ScenarioLikeInterface;
+use Behat\Testwork\Counter\Timer;
+use Behat\Testwork\Output\Formatter;
+use Behat\Testwork\Output\Node\EventListener\EventListener;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Allows to display duration in Junit scenario results.
+ *
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class JUnitDurationListener implements EventListener
+{
+    /** @var Timer[] */
+    private $scenarioTimerStore = [];
+
+    /** @var Timer[] */
+    private $featureTimerStore = [];
+
+    /** @var float[] */
+    private $scenarioResultStore = [];
+
+    /** @var float[] */
+    private $featureResultStore = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function listenEvent(Formatter $formatter, Event $event, $eventName)
+    {
+        $this->captureBeforeScenarioEvent($event);
+        $this->captureBeforeFeatureTested($event);
+        $this->captureAfterScenarioEvent($event);
+        $this->captureAfterFeatureEvent($event);
+    }
+
+    /**
+     * @param ScenarioLikeInterface $scenario
+     *
+     * @return float
+     */
+    public function getDuration(ScenarioLikeInterface $scenario): float
+    {
+        $key = $this->getHash($scenario);
+
+        return $this->scenarioResultStore[$key] ?? -1;
+    }
+
+    /**
+     * @param FeatureNode $feature
+     *
+     * @return float
+     */
+    public function getFeatureDuration(FeatureNode $feature): float
+    {
+        $key = $this->getHash($feature);
+
+        return $this->featureResultStore[$key] ?? -1;
+    }
+
+    /**
+     * @param Event $event
+     */
+    private function captureBeforeFeatureTested(Event $event): void
+    {
+        if (!$event instanceof BeforeFeatureTested) {
+            return;
+        }
+        $this->featureTimerStore[$this->getHash($event->getFeature())] = $this->startTimer();
+    }
+
+    /**
+     * @param Event $event
+     */
+    private function captureBeforeScenarioEvent(Event $event): void
+    {
+        if (!$event instanceof BeforeScenarioTested) {
+            return;
+        }
+        $this->scenarioTimerStore[$this->getHash($event->getScenario())] = $this->startTimer();
+    }
+
+    /**
+     * @param Event $event
+     */
+    private function captureAfterScenarioEvent(Event $event): void
+    {
+        if (!$event instanceof AfterScenarioTested) {
+            return;
+        }
+        $key = $this->getHash($event->getScenario());
+        $timer = $this->scenarioTimerStore[$key];
+        if ($timer instanceof Timer) {
+            $timer->stop();
+            $this->scenarioResultStore[$key] = round($timer->getTime(), 3);
+        }
+    }
+
+    /**
+     * @param Event $event
+     */
+    private function captureAfterFeatureEvent(Event $event): void
+    {
+        if (!$event instanceof AfterFeatureTested) {
+            return;
+        }
+        $key = $this->getHash($event->getFeature());
+        $timer = $this->featureTimerStore[$key];
+        if ($timer instanceof Timer) {
+            $timer->stop();
+            $this->featureResultStore[$key] = round($timer->getTime(), 3);
+        }
+    }
+
+    /**
+     * @param KeywordNodeInterface $node
+     *
+     * @return string
+     */
+    private function getHash(KeywordNodeInterface $node): string
+    {
+        return spl_object_hash($node);
+    }
+
+    /**
+     * @return Timer
+     */
+    private function startTimer(): Timer
+    {
+        $timer = new Timer();
+        $timer->start();
+
+        return $timer;
+    }
+}

--- a/features/Pim/Behat/Extension/PimFormatter/Output/Node/Printer/PimScenarioPrinter.php
+++ b/features/Pim/Behat/Extension/PimFormatter/Output/Node/Printer/PimScenarioPrinter.php
@@ -10,6 +10,7 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioLikeInterface;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Tester\Result\TestResult;
+use Pim\Behat\Extension\PimFormatter\Output\Node\EventListener\JUnitDurationListener;
 
 /**
  * Scenario printer of the PIM, for the CI. Instead of displaying the namespace of the scenario,
@@ -32,16 +33,25 @@ final class PimScenarioPrinter
     /** @var JUnitOutlineStoreListener */
     private $outlineStoreListener;
 
+    /** @var JUnitDurationListener */
+    private $durationListener;
+
     /**
      * @param string                    $basePath
      * @param ResultToStringConverter   $resultConverter
      * @param JUnitOutlineStoreListener $outlineListener
+     * @param JUnitDurationListener     $durationListener
      */
-    public function __construct(string $basePath, ResultToStringConverter $resultConverter, JUnitOutlineStoreListener $outlineListener)
-    {
+    public function __construct(
+        string $basePath,
+        ResultToStringConverter $resultConverter,
+        JUnitOutlineStoreListener $outlineListener,
+        JUnitDurationListener $durationListener
+    ) {
         $this->basePath = $basePath;
         $this->resultConverter = $resultConverter;
         $this->outlineStoreListener = $outlineListener;
+        $this->durationListener= $durationListener;
     }
 
     /**
@@ -59,6 +69,7 @@ final class PimScenarioPrinter
         $outputPrinter->addTestcase([
             'name'   => $fileAndLine,
             'status' => $this->resultConverter->convertResultToString($result),
+            'time' => $this->durationListener->getDuration($scenario),
         ]);
     }
 

--- a/features/Pim/Behat/Extension/PimFormatter/ServiceContainer/Formatter/PimFormatterFactory.php
+++ b/features/Pim/Behat/Extension/PimFormatter/ServiceContainer/Formatter/PimFormatterFactory.php
@@ -20,6 +20,7 @@ use Behat\Testwork\Output\Printer\Factory\FilesystemOutputFactory;
 use Behat\Testwork\Output\Printer\JUnitOutputPrinter;
 use Behat\Testwork\Output\ServiceContainer\Formatter\FormatterFactory;
 use Behat\Testwork\Output\ServiceContainer\OutputExtension;
+use Pim\Behat\Extension\PimFormatter\Output\Node\EventListener\JUnitDurationListener;
 use Pim\Behat\Extension\PimFormatter\Output\Node\EventListener\PimFeatureElementListener;
 use Pim\Behat\Extension\PimFormatter\Output\Node\Printer\PimScenarioPrinter;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -93,6 +94,7 @@ final class PimFormatterFactory implements FormatterFactory
             '%paths.base%',
             new Reference(self::RESULT_TO_STRING_CONVERTER_ID),
             new Reference('pim.output.node.listener.junit.outline'),
+            new Reference('pim.output.node.listener.junit.duration')
         ]);
         $container->setDefinition('pim.output.node.printer.pim.scenario', $definition);
 
@@ -110,14 +112,17 @@ final class PimFormatterFactory implements FormatterFactory
     private function loadRootNodeListener(ContainerBuilder $container) : void
     {
         $definition = new Definition(JUnitOutlineStoreListener::class, [
-                new Reference('pim.output.node.printer.junit.suite')
-            ]
-        );
+            new Reference('pim.output.node.printer.junit.suite')
+        ]);
         $container->setDefinition('pim.output.node.listener.junit.outline', $definition);
+
+        $definition = new Definition(JUnitDurationListener::class);
+        $container->setDefinition('pim.output.node.listener.junit.duration', $definition);
 
         $definition = new Definition(ChainEventListener::class, [
             [
                 new Reference('pim.output.node.listener.junit.outline'),
+                new Reference('pim.output.node.listener.junit.duration'),
                 new Definition(PimFeatureElementListener::class, [
                     new Reference('pim.output.node.printer.junit.feature'),
                     new Reference('pim.output.node.printer.pim.scenario'),


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
See https://github.com/Behat/Behat/issues/820

Higlhy inspired from https://github.com/higrow/Behat/commit/eabe3346303034ba9426b84b4791a660abfaf2b5

This PR adds the duration of a behat scenario in the Junit result.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
