### PR TITLE
PIM-7241: Fix memory consumption issue when archiving an import file

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7240: Add subscriber to clear the cache between each job step batch
+- PIM-7241: Fix memory consumption issue when archiving an import file
 
 # 2.0.19 (2018-03-23)
 

--- a/src/Pim/Component/Connector/Archiver/FileReaderArchiver.php
+++ b/src/Pim/Component/Connector/Archiver/FileReaderArchiver.php
@@ -48,13 +48,19 @@ class FileReaderArchiver extends AbstractFilesystemArchiver
             if ($this->isReaderUsable($reader)) {
                 $jobParameters = $jobExecution->getJobParameters();
                 $filePath = $jobParameters->get('filePath');
-                $key = strtr(
+                $archivePath = strtr(
                     $this->getRelativeArchivePath($jobExecution),
                     [
                         '%filename%' => basename($filePath),
                     ]
                 );
-                $this->filesystem->put($key, file_get_contents($filePath));
+
+                $fileResource = fopen($filePath, 'r');
+                $this->filesystem->putStream($archivePath, $fileResource);
+
+                if (is_resource($fileResource)) {
+                    fclose($fileResource);
+                }
             }
         }
     }

--- a/src/Pim/Component/Connector/spec/Archiver/FileReaderArchiverSpec.php
+++ b/src/Pim/Component/Connector/spec/Archiver/FileReaderArchiverSpec.php
@@ -53,13 +53,13 @@ class FileReaderArchiverSpec extends ObjectBehavior
         $jobExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn($pathname);
 
-        $filesystem->put(
+        $filesystem->putStream(
             'type' . DIRECTORY_SEPARATOR .
             'my_job_name' . DIRECTORY_SEPARATOR .
             '12' . DIRECTORY_SEPARATOR .
             'input' . DIRECTORY_SEPARATOR .
             $filename,
-            ''
+            Argument::any()
         )->shouldBeCalled();
 
         $this->archive($jobExecution);
@@ -84,7 +84,7 @@ class FileReaderArchiverSpec extends ObjectBehavior
         $job->getSteps()->willReturn([$step]);
         $step->getReader()->willReturn($reader);
 
-        $filesystem->put(Argument::any())->shouldNotBeCalled();
+        $filesystem->putStream(Argument::any())->shouldNotBeCalled();
 
         $this->archive($jobExecution);
     }
@@ -109,7 +109,7 @@ class FileReaderArchiverSpec extends ObjectBehavior
         $jobInstance->getType()->willReturn('type');
         $job->getSteps()->willReturn([$step]);
 
-        $filesystem->put(Argument::any())->shouldNotBeCalled();
+        $filesystem->putStream(Argument::any())->shouldNotBeCalled();
 
         $this->archive($jobExecution);
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

To archive an import file, its content is loaded in memory using `file_get_contents`. Guess what happens when the file is big...

To fix that I used `putStream` instead of `put` and simply open the import file instead of loading its content. It's not perfect because we shouldn't use any PHP function on a file like that, but it would require too much changements for a simple patch.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
