### PR TITLE
PIM-7257: Add missing translations in product grid

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7240: Add subscriber to clear the cache between each job step batch
+- PIM-7257: Add missing translations in product grid
 - PIM-7241: Fix memory consumption issue when archiving an import file
 
 # 2.0.19 (2018-03-23)

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -535,6 +535,8 @@ Smart:                               Smart
 Useable as grid column:              Usable as grid column
 Useable as grid filter:              Usable in grid
 Family:                              Family
+Image:                               Image
+Variant products:                    Variant products
 Available locales:                   Available locales
 Locale specific:                     Locale specific
 default:                             Default


### PR DESCRIPTION
**Description**

Some attribute's translations are missing in system attributes:

Image
Variant products

![capture du 2018-03-26 14-04-24](https://user-images.githubusercontent.com/34027529/37905310-b89c51f4-30fe-11e8-81c7-3ac835ce1344.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
