### PR TITLE
PIM-6825: fix cancel button redirection on user profile edit

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-6825: Fix cancel button redirection when editing a user
 - GITHUB-7507: Fix XLSX product export to allow decimal separator configuration (Thanks [wa-daniel-fahl](https://github.com/wa-daniel-fahl)!
 - PIM-7069: Fix Channel export regarding conversion_units output
 

--- a/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
@@ -84,7 +84,7 @@
             {% if form.vars.value.id %}
                 {{ elements.link(
                     'Cancel'|trans,
-                    path('oro_user_profile_view', {'id': form.vars.value.id}),
+                    path('oro_user_index'),
                     { icon: 'chevron-left', class:'AknButtonList-item AknButton--grey' }
                 ) }}
             {% endif %}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

**Description (for Contributor and Core Developer)**

Cancel button were always redirecting on Admin user profile, now if you press cancel button when editing a user, it redirect you on the users grid

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
