### PR TITLE
PIM-7259: Remove only attribute's option removed for multi select attribute

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -7,6 +7,7 @@
 - PIM-7241: Fix memory consumption issue when archiving an import file
 - PIM-7256: Add missing filters on product group grid
 - PIM-6945: Fix missing header elements on identifier attribute edit form
+- PIM-7259: Remove only attribute's option removed for multi select attribute
 
 # 2.0.19 (2018-03-23)
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/LoadEntityWithValuesSubscriberIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/LoadEntityWithValuesSubscriberIntegration.php
@@ -70,6 +70,7 @@ class LoadEntityWithValuesSubscriberIntegration extends TestCase
     public function testItDoesNotLoadValuesOfAProductForWhichThereIsARemovedAttributeOptionOfMultiselect()
     {
         $this->removeAttributeOptionFromAttribute('a_multi_select', 'optionA');
+        $this->removeAttributeOptionFromAttribute('a_multi_select', 'optionB');
         $amputatedStandardValues = $this->removeAttributeFromAllStandardValues('a_multi_select');
         $expectedValues = $this->getValuesFromStandardValues(
             $amputatedStandardValues

--- a/src/Pim/Component/Catalog/Exception/InvalidOptionsException.php
+++ b/src/Pim/Component/Catalog/Exception/InvalidOptionsException.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Exception;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
+
+/**
+ * Exception thrown when performing an action on a property with invalid options.
+ *
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InvalidOptionsException extends InvalidPropertyException
+{
+    const VALID_ENTITY_CODE_EXPECTED_CODES = 306;
+
+    /** @var array */
+    private $propertyValues;
+
+    /**
+     * @param string          $propertyName
+     * @param array           $propertyValues
+     * @param string          $className
+     * @param string          $message
+     * @param int             $code
+     * @param \Exception|null $previous
+     */
+    public function __construct(
+        string $propertyName,
+        array $propertyValues,
+        string $className,
+        string $message = '',
+        int $code = 0,
+        \Exception $previous = null
+    ) {
+        parent::__construct($propertyName, implode(', ', $propertyValues), $className, $message, $code, $previous);
+
+        $this->propertyValues = $propertyValues;
+    }
+
+    /**
+     * Build an exception when the data are invalid entity codes.
+     *
+     * @param string $propertyName
+     * @param string $key
+     * @param string $because
+     * @param string $className
+     * @param array  $values
+     *
+     * @return InvalidOptionsException
+     */
+    public static function validEntityListCodesExpected(
+        string $propertyName,
+        string $key,
+        string $because,
+        string $className,
+        array $values
+    ): InvalidOptionsException {
+        $message = 'Property "%s" expects a list of valid %s. %s, "%s" given.';
+        $flatValues = implode(', ', $values);
+
+        return new static(
+            $propertyName,
+            $values,
+            $className,
+            sprintf($message, $propertyName, $key, $because, $flatValues),
+            self::VALID_ENTITY_CODE_EXPECTED_CODES
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return $this->propertyValues;
+    }
+
+    /**
+     * @return string
+     */
+    public function toString(): string
+    {
+        return implode(', ', $this->propertyValues);
+    }
+}

--- a/src/Pim/Component/Catalog/Factory/ValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ValueCollectionFactory.php
@@ -7,6 +7,7 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface;
 use Pim\Component\Catalog\Exception\InvalidAttributeException;
 use Pim\Component\Catalog\Exception\InvalidOptionException;
+use Pim\Component\Catalog\Exception\InvalidOptionsException;
 use Pim\Component\Catalog\Model\ValueCollection;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Psr\Log\LoggerInterface;
@@ -83,6 +84,17 @@ class ValueCollectionFactory implements ValueCollectionFactoryInterface
                                     $e->getPropertyValue()
                                 )
                             );
+                        } catch (InvalidOptionsException $e) {
+                            $this->logger->warning(
+                                sprintf(
+                                    'Tried to load a product value with the options "%s" that do not exist.',
+                                    $e->toString()
+                                )
+                            );
+                            $goodOptions = array_diff($data, $e->toArray());
+                            if (!empty($goodOptions)) {
+                                $values[] = $this->valueFactory->create($attribute, $channelCode, $localeCode, $goodOptions);
+                            }
                         } catch (InvalidAttributeException $e) {
                             $this->logger->warning(
                                 sprintf(

--- a/src/Pim/Component/Catalog/spec/Factory/Value/OptionsValueFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/Value/OptionsValueFactorySpec.php
@@ -6,7 +6,9 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Exception\InvalidOptionsException;
 use Pim\Component\Catalog\Factory\Value\OptionsValueFactory;
+use Pim\Component\Catalog\Factory\Value\OptionValueFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Value\ScalarValue;
@@ -202,7 +204,8 @@ class OptionsValueFactorySpec extends ObjectBehavior
 
     function it_throws_an_exception_if_option_does_not_exist(
         $attributeOptionRepository,
-        AttributeInterface $attribute
+        AttributeInterface $attribute,
+        AttributeOptionInterface $bar
     ) {
         $attribute->isScopable()->willReturn(true);
         $attribute->isLocalizable()->willReturn(true);
@@ -211,19 +214,21 @@ class OptionsValueFactorySpec extends ObjectBehavior
         $attribute->getBackendType()->willReturn('options');
         $attribute->isBackendTypeReferenceData()->willReturn(false);
 
-        $attributeOptionRepository->findOneByIdentifier('multi_select_attribute.foobar')->willReturn(null);
+        $attributeOptionRepository->findOneByIdentifier('multi_select_attribute.bar')->willReturn($bar);
+        $attributeOptionRepository->findOneByIdentifier('multi_select_attribute.foo')->willReturn(null);
+        $attributeOptionRepository->findOneByIdentifier('multi_select_attribute.baz')->willReturn(null);
 
-        $exception = InvalidPropertyException::validEntityCodeExpected(
+        $exception = InvalidOptionsException::validEntityListCodesExpected(
             'multi_select_attribute',
-            'code',
-            'The option does not exist',
+            'codes',
+            'The options do not exist',
             OptionsValueFactory::class,
-            'foobar'
+            ['foo', 'baz']
         );
 
         $this
             ->shouldThrow($exception)
-            ->during('create', [$attribute, 'ecommerce', 'en_US', ['foobar']]);
+            ->during('create', [$attribute, 'ecommerce', 'en_US', ['foo', 'bar', 'baz']]);
     }
 
     public function getMatchers()


### PR DESCRIPTION
When an attribute option was removed and if this option was linked to a value inside a product, instead of just remove this option from values, we were throwing an exception without create values with good options. 

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
