### PR TITLE
PIM-7119: Fix missing translation on filters

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -4,6 +4,7 @@
 
 - GITHUB-7507: Fix XLSX product export to allow decimal separator configuration (Thanks [wa-daniel-fahl](https://github.com/wa-daniel-fahl)!
 - PIM-7069: Fix Channel export regarding conversion_units output
+- PIM-7119: Fix missing translation on filters
 
 # 1.7.19 (2018-02-27)
 

--- a/src/Pim/Bundle/FilterBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/FilterBundle/Resources/translations/messages.en.yml
@@ -11,6 +11,7 @@ oro.filter.form.label_type_equals: is equal to
 oro.filter.form.label_type_start_with: starts with
 oro.filter.form.label_type_end_with: ends with
 oro.filter.form.label_type_empty: is empty
+oro.filter.form.label_type_not_empty: is not empty
 oro.filter.form.label_type_in_list: in list
 oro.filter.form.label_date_type_between: between
 oro.filter.form.label_date_type_not_between: not between


### PR DESCRIPTION
**Description**

Add translation "is not empty" for filters in the grid.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
