### PR TITLE
PIM-7252: add option to do not apply permissions on attribute settings page

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -9,6 +9,7 @@
 - PIM-6945: Fix missing header elements on identifier attribute edit form
 - PIM-7259: Remove only attribute's option removed for multi select attribute
 - PIM-7270: Fix [object Object] empty filter value
+- PIM-7252: Fix permissions on attributes settings page
 
 # 2.0.19 (2018-03-23)
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
@@ -191,16 +191,21 @@ class AttributeController
     /**
      * Get attribute by identifier
      *
-     * @param string $identifier
+     * @param Request $request
+     * @param string  $identifier
+     *
+     * @throws NotFoundHttpException
      *
      * @return JsonResponse
      */
-    public function getAction($identifier)
+    public function getAction(Request $request, $identifier)
     {
         $attribute = $this->attributeRepository->findOneByIdentifier($identifier);
 
-        $attribute = $this->attributeFilter
-            ->filterObject($attribute, 'pim.internal_api.attribute.view') ? null : $attribute;
+        if ($request->query->getBoolean('apply_filters', true)) {
+            $attribute = $this->attributeFilter
+                ->filterObject($attribute, 'pim.internal_api.attribute.view') ? null : $attribute;
+        }
 
         if (null === $attribute) {
             throw new NotFoundHttpException(sprintf('Attribute with code "%s" not found', $identifier));

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/attribute/edit.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/attribute/edit.js
@@ -36,42 +36,44 @@ function (
             fetcherRegistry.getFetcher('locale').clear();
             fetcherRegistry.getFetcher('measure').clear();
 
-            return fetcherRegistry.getFetcher('attribute').fetch(route.params.code, {cached: false})
-                .then((attribute) => {
-                    var label = _.escape(
-                        i18n.getLabel(
-                            attribute.labels,
-                            UserContext.get('catalogLocale'),
-                            attribute.code
-                        )
-                    );
+            return fetcherRegistry.getFetcher('attribute').fetch(route.params.code, {
+                cached: false,
+                apply_filters: false
+            }).then((attribute) => {
+                var label = _.escape(
+                    i18n.getLabel(
+                        attribute.labels,
+                        UserContext.get('catalogLocale'),
+                        attribute.code
+                    )
+                );
 
-                    PageTitle.set({'attribute.label': label});
+                PageTitle.set({'attribute.label': label});
 
-                    var formName = 'pim_catalog_identifier' === attribute.type ?
-                        'pim-attribute-identifier-edit-form' :
-                        'pim-attribute-edit-form';
+                var formName = 'pim_catalog_identifier' === attribute.type ?
+                    'pim-attribute-identifier-edit-form' :
+                    'pim-attribute-edit-form';
 
-                    return FormBuilder.getFormMeta(formName)
-                        .then(FormBuilder.buildForm)
-                        .then((form) => {
-                            form.setType(attribute.type);
+                return FormBuilder.getFormMeta(formName)
+                    .then(FormBuilder.buildForm)
+                    .then((form) => {
+                        form.setType(attribute.type);
 
-                            return form.configure().then(() => {
-                                return form;
-                            });
-                        })
-                        .then((form) => {
-                            this.on('pim:controller:can-leave', function (event) {
-                                form.trigger('pim_enrich:form:can-leave', event);
-                            });
-                            form.setData(attribute);
-                            form.trigger('pim_enrich:form:entity:post_fetch', attribute);
-                            form.setElement(this.$el).render();
-
+                        return form.configure().then(() => {
                             return form;
                         });
-                });
+                    })
+                    .then((form) => {
+                        this.on('pim:controller:can-leave', function (event) {
+                            form.trigger('pim_enrich:form:can-leave', event);
+                        });
+                        form.setData(attribute);
+                        form.trigger('pim_enrich:form:entity:post_fetch', attribute);
+                        form.setElement(this.$el).render();
+
+                        return form;
+                    });
+            });
         }
     });
 });


### PR DESCRIPTION
Today, we use the same route to view an attribute in the PEF (which is in enrich part) and to view an attribute in the settings part. It's a mistake because the behavior is not the same. We need to apply permissions on the enrich part, but not in the settings part. 
As this subject is quite complex and should be rethink/rework, I made the same logic than all other routes (because the same mistake is done on family for instance), that's means: add an option in the URL to define if permissions have to be apply 
 

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
