### PR TITLE
PIM-6945: Fix missing header elements on identifier attribute edit form

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,7 @@
 - PIM-7240: Add subscriber to clear the cache between each job step batch
 - PIM-7241: Fix memory consumption issue when archiving an import file
 - PIM-7256: Add missing filters on product group grid
+- PIM-6945: Fix missing header elements on identifier attribute edit form
 
 # 2.0.19 (2018-03-23)
 

--- a/features/attribute/edit_identifier_attribute.feature
+++ b/features/attribute/edit_identifier_attribute.feature
@@ -10,6 +10,7 @@ Feature: Edit an identifier attribute
 
   Scenario: Successfully display the identifier related fields
     Given I am on the "SKU" attribute page
+    Then I should see the secondary action "Delete"
     Then I should see the Max characters and Validation rule fields
     And the fields Unique, Value per channel and Usable in grid should be disabled
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/identifier/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/identifier/edit.yml
@@ -2,6 +2,22 @@ extensions:
     pim-attribute-identifier-edit-form:
         module: pim/attribute-edit-form
 
+    pim-attribute-identifier-edit-form-breadcrumbs:
+        module: pim/common/breadcrumbs
+        parent: pim-attribute-identifier-edit-form
+        targetZone: breadcrumbs
+        config:
+            tab: pim-menu-settings
+            item: pim-menu-settings-attribute
+
+    pim-attribute-identifier-edit-form-user-navigation:
+        module: pim/menu/user-navigation
+        parent: pim-attribute-identifier-edit-form
+        targetZone: user-menu
+        config:
+            userAccount: pim_menu.user.user_account
+            logout: pim_menu.user.logout
+
     pim-attribute-identifier-edit-form-cache-invalidator:
         module: pim/cache-invalidator
         parent: pim-attribute-identifier-edit-form
@@ -13,18 +29,25 @@ extensions:
         targetZone: title
         position: 90
 
-    pim-attribute-identifier-edit-form-delete:
-        module: pim/attribute-edit-form/delete
+    pim-attribute-identifier-edit-form-secondary-actions:
+        module: pim/form/common/secondary-actions
         parent: pim-attribute-identifier-edit-form
         targetZone: buttons
+        position: 50
+
+    pim-attribute-identifier-edit-form-delete:
+        module: pim/attribute-edit-form/delete
+        parent: pim-attribute-identifier-edit-form-secondary-actions
         position: 100
+        targetZone: secondary-actions
         aclResourceId: pim_enrich_attribute_remove
         config:
             trans:
                 title: confirmation.remove.attribute
+                subTitle: pim_menu.item.attribute
                 content: pim_enrich.confirmation.delete_item
                 success: flash.attribute.removed
-                fail: error.removing.attribute
+                failed: error.removing.attribute
             redirect: pim_enrich_attribute_index
 
     pim-attribute-identifier-edit-form-save-buttons:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes the identifier attribute edit form to add the breadcrumbs, delete secondary action and user section.

Before
![screen shot 2018-03-27 at 15 01 21](https://user-images.githubusercontent.com/1336344/37968981-ed8e66f0-31cf-11e8-9ee6-0973e7ccd589.png)

After
![screen shot 2018-03-27 at 15 01 28](https://user-images.githubusercontent.com/1336344/37968987-f0941c28-31cf-11e8-9659-ce6df6c9170e.png)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
