### PR TITLE
PIM-7253: do not schedule queries to update normalized data for newly created entities

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -31,6 +31,7 @@
 ## Improvements
 
 - IM-824: Change message when the user or email is not valid to a more generic message
+- PIM-7253: Do not schedule mongo queries to update normalizedData for newly created entities
 
 ## Bug Fixes
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/MongoDBODM/UpdateNormalizedProductDataSubscriber.php
@@ -72,10 +72,6 @@ class UpdateNormalizedProductDataSubscriber implements EventSubscriber
         foreach ($uow->getScheduledCollectionUpdates() as $entity) {
             $this->scheduleQueriesAfterUpdate($entity, $uow->getEntityChangeSet($entity));
         }
-
-        foreach ($uow->getScheduledEntityInsertions() as $entity) {
-            $this->scheduleQueriesAfterUpdate($entity, $uow->getEntityChangeSet($entity));
-        }
     }
 
     /**


### PR DESCRIPTION
…  as they cannot appear in the normalizedData anyway.

see https://github.com/akeneo/ElasticSearchBundle/pull/163


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

