### PR TITLE
PIM-7263: Purging command for boolean values on variant products

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -8,6 +8,10 @@
 
 - AOB-101: Apply user timezone on dates in the UI (missing cases)
 
+## Bug fixes
+
+- PIM-7263: Create a purging command (`pim:catalog:remove-wrong-values-on-variant-products`) for boolean values on variant products that should belong to parents
+
 # 2.2.1 (2018-03-22)
 
 # 2.2.0 (2018-03-21)

--- a/src/Pim/Bundle/CatalogBundle/Command/RemoveWrongBooleanValuesOnVariantProductsCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/RemoveWrongBooleanValuesOnVariantProductsCommand.php
@@ -23,12 +23,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class RemoveWrongBooleanValuesOnVariantProductsCommand extends ContainerAwareCommand
 {
-    const PRODUCT_BULK_SIZE = 100;
+    private const PRODUCT_BULK_SIZE = 100;
 
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setHidden(true)
@@ -40,7 +40,7 @@ class RemoveWrongBooleanValuesOnVariantProductsCommand extends ContainerAwareCom
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $output->writeln("<info>Cleaning wrong boolean values on variant products...</info>");
 
@@ -59,7 +59,6 @@ class RemoveWrongBooleanValuesOnVariantProductsCommand extends ContainerAwareCom
                     $this->cleanProductForAttribute($variantProduct, $attribute);
                     $isModified = true;
                 }
-
             }
 
             if ($isModified) {

--- a/src/Pim/Bundle/CatalogBundle/Command/RemoveWrongBooleanValuesOnVariantProductsCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/RemoveWrongBooleanValuesOnVariantProductsCommand.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\Command;
+
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command to fix PIM-7263.
+ *
+ * If some variant products have a some boolean values at their variation level that should belong to their
+ * parents instead, this command will remove these values.
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2018 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class RemoveWrongBooleanValuesOnVariantProductsCommand extends ContainerAwareCommand
+{
+    const PRODUCT_BULK_SIZE = 100;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setHidden(true)
+            ->setName('pim:catalog:remove-wrong-values-on-variant-products')
+            ->setDescription('Remove boolean values on variant products that should belong to their parents')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln("<info>Cleaning wrong boolean values on variant products...</info>");
+
+        $variantProducts = $this->getVariantProducts();
+
+        $totalProducts = 0;
+        $cleanProducts = 0;
+        $productsToSave = [];
+
+        foreach ($variantProducts as $variantProduct) {
+            $totalProducts++;
+            $isModified = false;
+
+            foreach ($variantProduct->getFamily()->getAttributes() as $attribute) {
+                if ($this->isProductImpacted($variantProduct, $attribute)) {
+                    $this->cleanProductForAttribute($variantProduct, $attribute);
+                    $isModified = true;
+                }
+
+            }
+
+            if ($isModified) {
+                $violations = $this->getContainer()->get('pim_catalog.validator.product')->validate($variantProduct);
+
+                if ($violations->count() > 0) {
+                    throw new \LogicException(
+                        sprintf(
+                            'Product "%s" is not valid and cannot be saved',
+                            $variantProduct->getIdentifier()
+                        )
+                    );
+                }
+
+                $productsToSave[] = $variantProduct;
+                $cleanProducts++;
+            }
+
+            if (count($productsToSave) >= self::PRODUCT_BULK_SIZE) {
+                $this->getContainer()->get('pim_catalog.saver.product')->saveAll($productsToSave);
+                $this->getContainer()->get('pim_catalog.elasticsearch.indexer.product')->indexAll($productsToSave);
+
+                $productsToSave = [];
+            }
+        }
+
+        if (!empty($productsToSave)) {
+            $this->getContainer()->get('pim_catalog.saver.product')->saveAll($productsToSave);
+            $this->getContainer()->get('pim_catalog.elasticsearch.indexer.product')->indexAll($productsToSave);
+        }
+
+        $output->writeln(sprintf('<info>%s variant products cleaned (over %s products parsed)</info>', $cleanProducts, $totalProducts));
+    }
+
+    /**
+     * @return CursorInterface
+     */
+    private function getVariantProducts(): CursorInterface
+    {
+        $pqb = $this->getContainer()
+            ->get('pim_catalog.query.product_and_product_model_query_builder_factory')
+            ->create();
+
+        $pqb->addFilter('parent', Operators::IS_NOT_EMPTY, null);
+
+        return $pqb->execute();
+    }
+
+    /**
+     * @param mixed              $variantProduct
+     * @param AttributeInterface $attribute
+     *
+     * @return bool
+     */
+    private function isProductImpacted($variantProduct, AttributeInterface $attribute): bool
+    {
+        if ($attribute->getType() !== AttributeTypes::BOOLEAN) {
+            return false;
+        }
+
+        $familyVariant = $variantProduct->getFamilyVariant();
+        $attributeLevel = $familyVariant->getLevelForAttributeCode($attribute->getCode());
+        $attributeIsOnLastLevel = $attributeLevel === $familyVariant->getNumberOfLevel();
+
+        if ($attributeIsOnLastLevel) {
+            return false;
+        }
+
+        return null !== $variantProduct->getValuesForVariation()->getByCodes($attribute->getCode());
+    }
+
+    /**
+     * @param mixed              $variantProduct
+     * @param AttributeInterface $attribute
+     */
+    private function cleanProductForAttribute($variantProduct, AttributeInterface $attribute): void
+    {
+        $values = $variantProduct->getValues();
+        $values->removeByAttribute($attribute);
+        $variantProduct->setValues($values);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/ParentFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/ParentFilter.php
@@ -68,6 +68,14 @@ class ParentFilter extends AbstractFieldFilter implements FieldFilterInterface
 
                 $this->searchQueryBuilder->addMustNot($clause);
                 break;
+            case Operators::IS_NOT_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $field,
+                    ],
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
             default:
                 throw InvalidOperatorException::notSupported($operator, static::class);
         }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -370,7 +370,7 @@ services:
         arguments:
             - '@pim_catalog.repository.product_model'
             - ['parent']
-            - ['IN', 'EMPTY']
+            - ['IN', 'EMPTY', 'NOT EMPTY']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Command/RemoveWrongBooleanValuesOnVariantProductsCommandSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Command/RemoveWrongBooleanValuesOnVariantProductsCommandSpec.php
@@ -1,0 +1,336 @@
+<?php
+declare(strict_types=1);
+
+namespace spec\Pim\Bundle\CatalogBundle\Command;
+
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ValueCollectionInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+use Prophecy\Argument;
+use Prophecy\Promise\ReturnPromise;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class RemoveWrongBooleanValuesOnVariantProductsCommandSpec extends ObjectBehavior
+{
+    function it_has_a_name()
+    {
+        $this->getName()->shouldReturn('pim:catalog:remove-wrong-values-on-variant-products');
+    }
+
+    function it_is_a_command()
+    {
+        $this->shouldBeAnInstanceOf(ContainerAwareCommand::class);
+    }
+
+    function it_removes_wrong_boolean_values_on_impacted_variant_products(
+        ContainerInterface $container,
+        InputInterface $input,
+        OutputInterface $output,
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $productsCursor,
+        ProductInterface $variantProductImpacted,
+        FamilyInterface $boots,
+        AttributeInterface $booleanAttribute,
+        FamilyVariantInterface $familyVariant,
+        ValueCollectionInterface $valuesForVariation,
+        ValueCollectionInterface $values,
+        ValueInterface $booleanValue,
+        ValidatorInterface $validator,
+        ConstraintViolationListInterface $violationList,
+        BulkSaverInterface $saver,
+        BulkIndexerInterface $indexer
+    ) {
+        $container->get('pim_catalog.query.product_and_product_model_query_builder_factory')->willReturn($pqbFactory);
+        $pqbFactory->create()->willReturn($pqb);
+
+        $pqb->addFilter('parent', Operators::IS_NOT_EMPTY, null)->shouldBeCalled();
+        $pqb->execute()->willReturn($productsCursor);
+
+        $productsCount = count($variantProductImpacted);
+        $productsCursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $productsCursor->current()->will(new ReturnPromise([$variantProductImpacted]));
+        $productsCursor->rewind()->shouldBeCalled();
+        $productsCursor->next()->shouldBeCalled();
+
+        $this->setContainer($container);
+
+        $variantProductImpacted->getFamily()->willReturn($boots);
+        $boots->getAttributes()->willReturn([$booleanAttribute]);
+        $booleanAttribute->getType()->willReturn('pim_catalog_boolean');
+        $booleanAttribute->getCode()->willReturn('bool_attribute');
+
+        $variantProductImpacted->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getLevelForAttributeCode('bool_attribute')->willReturn(0);
+        $familyVariant->getNumberOfLevel()->willReturn(1);
+
+        $variantProductImpacted->getValuesForVariation()->willReturn($valuesForVariation);
+        $valuesForVariation->getByCodes('bool_attribute')->willReturn($booleanValue);
+
+        $variantProductImpacted->getValues()->willReturn($values);
+        $values->removeByAttribute($booleanAttribute)->shouldBeCalled();
+        $variantProductImpacted->setValues($values)->shouldBeCalled();
+
+        $container->get('pim_catalog.validator.product')->willReturn($validator);
+        $validator->validate($variantProductImpacted)->willReturn($violationList);
+        $violationList->count()->willReturn(0);
+
+        $container->get('pim_catalog.saver.product')->willReturn($saver);
+        $saver->saveAll([$variantProductImpacted])->shouldBeCalled();
+        $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($indexer);
+        $indexer->indexAll([$variantProductImpacted])->shouldBeCalled();
+
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+
+        $this->run($input, $output);
+    }
+
+    function it_does_not_update_product_without_boolean_in_their_family(
+        ContainerInterface $container,
+        InputInterface $input,
+        OutputInterface $output,
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $productsCursor,
+        ProductInterface $variantProductNotImpacted,
+        FamilyInterface $boots,
+        AttributeInterface $textAttribute,
+        FamilyVariantInterface $familyVariant
+    ) {
+        $container->get('pim_catalog.query.product_and_product_model_query_builder_factory')->willReturn($pqbFactory);
+        $pqbFactory->create()->willReturn($pqb);
+
+        $pqb->addFilter('parent', Operators::IS_NOT_EMPTY, null)->shouldBeCalled();
+        $pqb->execute()->willReturn($productsCursor);
+
+        $productsCount = count($variantProductNotImpacted);
+        $productsCursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $productsCursor->current()->will(new ReturnPromise([$variantProductNotImpacted]));
+        $productsCursor->rewind()->shouldBeCalled();
+        $productsCursor->next()->shouldBeCalled();
+
+        $this->setContainer($container);
+
+        $variantProductNotImpacted->getFamily()->willReturn($boots);
+        $boots->getAttributes()->willReturn([$textAttribute]);
+        $textAttribute->getType()->willReturn('pim_catalog_text');
+        $textAttribute->getCode()->willReturn('text_attribute');
+
+        $variantProductNotImpacted->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getLevelForAttributeCode('bool_attribute')->willReturn(0);
+        $familyVariant->getNumberOfLevel()->willReturn(1);
+
+        $container->get('pim_catalog.saver.product')->shouldNotBeCalled();
+        $container->get('pim_catalog.elasticsearch.indexer.product')->shouldNotBeCalled();
+
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+
+        $this->run($input, $output);
+    }
+
+    function it_does_not_update_product_if_boolean_is_on_product_level(
+        ContainerInterface $container,
+        InputInterface $input,
+        OutputInterface $output,
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $productsCursor,
+        ProductInterface $variantProductNotImpacted,
+        FamilyInterface $boots,
+        AttributeInterface $booleanAttribute,
+        FamilyVariantInterface $familyVariant,
+        BulkSaverInterface $saver,
+        BulkIndexerInterface $indexer
+    ) {
+        $container->get('pim_catalog.query.product_and_product_model_query_builder_factory')->willReturn($pqbFactory);
+        $pqbFactory->create()->willReturn($pqb);
+
+        $pqb->addFilter('parent', Operators::IS_NOT_EMPTY, null)->shouldBeCalled();
+        $pqb->execute()->willReturn($productsCursor);
+
+        $productsCount = count($variantProductNotImpacted);
+        $productsCursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $productsCursor->current()->will(new ReturnPromise([$variantProductNotImpacted]));
+        $productsCursor->rewind()->shouldBeCalled();
+        $productsCursor->next()->shouldBeCalled();
+
+        $this->setContainer($container);
+
+        $variantProductNotImpacted->getFamily()->willReturn($boots);
+        $boots->getAttributes()->willReturn([$booleanAttribute]);
+        $booleanAttribute->getType()->willReturn('pim_catalog_boolean');
+        $booleanAttribute->getCode()->willReturn('bool_attribute');
+
+        $variantProductNotImpacted->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getLevelForAttributeCode('bool_attribute')->willReturn(1);
+        $familyVariant->getNumberOfLevel()->willReturn(1);
+
+        $container->get('pim_catalog.saver.product')->shouldNotBeCalled($saver);
+        $container->get('pim_catalog.elasticsearch.indexer.product')->shouldNotBeCalled($indexer);
+
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+
+        $this->run($input, $output);
+    }
+
+    function it_does_not_update_product_if_product_does_not_have_any_value_on_this_attribute(
+        ContainerInterface $container,
+        InputInterface $input,
+        OutputInterface $output,
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $productsCursor,
+        ProductInterface $variantProductNotImpacted,
+        FamilyInterface $boots,
+        AttributeInterface $booleanAttribute,
+        FamilyVariantInterface $familyVariant,
+        ValueCollectionInterface $valuesForVariation,
+        BulkSaverInterface $saver,
+        BulkIndexerInterface $indexer
+    ) {
+        $container->get('pim_catalog.query.product_and_product_model_query_builder_factory')->willReturn($pqbFactory);
+        $pqbFactory->create()->willReturn($pqb);
+
+        $pqb->addFilter('parent', Operators::IS_NOT_EMPTY, null)->shouldBeCalled();
+        $pqb->execute()->willReturn($productsCursor);
+
+        $productsCount = count($variantProductNotImpacted);
+        $productsCursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $productsCursor->current()->will(new ReturnPromise([$variantProductNotImpacted]));
+        $productsCursor->rewind()->shouldBeCalled();
+        $productsCursor->next()->shouldBeCalled();
+
+        $this->setContainer($container);
+
+        $variantProductNotImpacted->getFamily()->willReturn($boots);
+        $boots->getAttributes()->willReturn([$booleanAttribute]);
+        $booleanAttribute->getType()->willReturn('pim_catalog_boolean');
+        $booleanAttribute->getCode()->willReturn('bool_attribute');
+
+        $variantProductNotImpacted->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getLevelForAttributeCode('bool_attribute')->willReturn(0);
+        $familyVariant->getNumberOfLevel()->willReturn(1);
+
+        $variantProductNotImpacted->getValuesForVariation()->willReturn($valuesForVariation);
+        $valuesForVariation->getByCodes('bool_attribute')->willReturn(null);
+
+        $container->get('pim_catalog.saver.product')->shouldNotBeCalled($saver);
+        $container->get('pim_catalog.elasticsearch.indexer.product')->shouldNotBeCalled($indexer);
+
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+
+        $this->run($input, $output);
+    }
+
+    function it_throws_an_exception_if_after_being_updated_the_product_is_not_valid(
+        ContainerInterface $container,
+        InputInterface $input,
+        OutputInterface $output,
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $productsCursor,
+        ProductInterface $variantProductImpacted,
+        FamilyInterface $boots,
+        AttributeInterface $booleanAttribute,
+        FamilyVariantInterface $familyVariant,
+        ValueCollectionInterface $valuesForVariation,
+        ValueCollectionInterface $values,
+        ValueInterface $booleanValue,
+        ValidatorInterface $validator,
+        ConstraintViolationListInterface $violationList,
+        BulkSaverInterface $saver,
+        BulkIndexerInterface $indexer
+    ) {
+        $container->get('pim_catalog.query.product_and_product_model_query_builder_factory')->willReturn($pqbFactory);
+        $pqbFactory->create()->willReturn($pqb);
+
+        $pqb->addFilter('parent', Operators::IS_NOT_EMPTY, null)->shouldBeCalled();
+        $pqb->execute()->willReturn($productsCursor);
+
+        $productsCount = count($variantProductImpacted);
+        $productsCursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $productsCursor->current()->will(new ReturnPromise([$variantProductImpacted]));
+        $productsCursor->rewind()->shouldBeCalled();
+
+        $this->setContainer($container);
+
+        $variantProductImpacted->getFamily()->willReturn($boots);
+        $boots->getAttributes()->willReturn([$booleanAttribute]);
+        $booleanAttribute->getType()->willReturn('pim_catalog_boolean');
+        $booleanAttribute->getCode()->willReturn('bool_attribute');
+
+        $variantProductImpacted->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getLevelForAttributeCode('bool_attribute')->willReturn(0);
+        $familyVariant->getNumberOfLevel()->willReturn(1);
+
+        $variantProductImpacted->getValuesForVariation()->willReturn($valuesForVariation);
+        $valuesForVariation->getByCodes('bool_attribute')->willReturn($booleanValue);
+
+        $variantProductImpacted->getValues()->willReturn($values);
+        $values->removeByAttribute($booleanAttribute)->shouldBeCalled();
+        $variantProductImpacted->setValues($values)->shouldBeCalled();
+
+        $container->get('pim_catalog.validator.product')->willReturn($validator);
+        $validator->validate($variantProductImpacted)->willReturn($violationList);
+        $violationList->count()->willReturn(1);
+
+        $container->get('pim_catalog.saver.product')->shouldNotBeCalled($saver);
+        $container->get('pim_catalog.elasticsearch.indexer.product')->shouldNotBeCalled($indexer);
+
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+
+        $variantProductImpacted->getIdentifier()->willReturn('TOTO');
+
+        $this->shouldThrow(\LogicException::class)->during('run', [$input, $output]);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/ParentFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/ParentFilterSpec.php
@@ -60,6 +60,19 @@ class ParentFilterSpec extends ObjectBehavior
         $this->addFieldFilter('parent', Operators::IS_EMPTY, null, null, null, []);
     }
 
+    function it_adds_a_filter_with_operator_is_not_empty(
+        SearchQueryBuilder $sqb
+    ) {
+        $sqb->addFilter(
+            [
+                'exists' => ['field' => 'parent'],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter('parent', Operators::IS_NOT_EMPTY, null, null, null, []);
+    }
+
     function it_throws_an_exception_when_the_search_query_builder_is_not_initialized()
     {
         $this->shouldThrow(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

If variant product has values on boolean attributes that should belong to the parents, this parent will remove those values.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added legacy Behats               | N
| Added acceptance tests            | N
| Added integration tests           | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo