### PR TITLE
PIM-7267: Fix boolean attributes not added to variant product

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -9,6 +9,7 @@
 - PIM-7251: Fix history date on all grids (except product grid)
 - PIM-7275: Fix regression on group products grid filters
 - PIM-6962: Fix breadcrumb links issue after the save on the edit page
+- PIM-7267: Fix boolean attributes not added to variant product
 
 # 2.0.20 (2018-03-29)
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
@@ -68,6 +68,9 @@ JSON;
                 'sku' => [
                     ['locale' => null, 'scope' => null, 'data' => 'product_creation_family'],
                 ],
+                'a_yes_no' => [
+                    ['locale' => null, 'scope' => null, 'data' => false],
+                ]
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductToVariantIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductToVariantIntegration.php
@@ -148,6 +148,14 @@ JSON;
 
     public function testProductHasNoValueForTheVariantAxis()
     {
+        $this->createProductModel(
+            [
+                'code' => 'parent_product_no_value',
+                'family_variant' => 'familyVariantA2',
+                'values'  => []
+            ]
+        );
+
         $this->createProduct('product_no_value', [
             'family' => 'familyA',
             'categories' => ['categoryA2'],
@@ -157,7 +165,7 @@ JSON;
         $data =
 <<<JSON
     {
-        "parent": "amor"
+        "parent": "parent_product_no_value"
     }
 JSON;
 
@@ -172,7 +180,7 @@ JSON;
                 'errors' => [
                     [
                         'property' => 'attribute',
-                        'message' => 'Attribute "a_yes_no" cannot be empty, as it is defined as an axis for this entity'
+                        'message' => 'Attribute "a_simple_select" cannot be empty, as it is defined as an axis for this entity'
                     ]
                 ]
             ],

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/AddBooleanValuesToNewProductSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/AddBooleanValuesToNewProductSubscriber.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Factory\ValueFactory;
+use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * When a new product is created, and before it is saved.
+ * Add a product value "false" for every boolean attributes of the product's family.
+ * For a variant product, only the parent family variant attributes of the related level are taken.
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AddBooleanValuesToNewProductSubscriber implements EventSubscriberInterface
+{
+    /** @var AttributeValuesResolverInterface */
+    private $valuesResolver;
+
+    /** @var ValueFactory */
+    private $productValueFactory;
+
+    /**
+     * @param AttributeValuesResolverInterface $valuesResolver
+     * @param ValueFactory                     $productValueFactory
+     */
+    public function __construct(AttributeValuesResolverInterface $valuesResolver, ValueFactory $productValueFactory)
+    {
+        $this->valuesResolver = $valuesResolver;
+        $this->productValueFactory = $productValueFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [StorageEvents::PRE_SAVE => 'addBooleansDefaultValues'];
+    }
+
+    /**
+     * @param GenericEvent $event
+     */
+    public function addBooleansDefaultValues(GenericEvent $event): void
+    {
+        $product = $event->getSubject();
+
+        if (!$product instanceof ProductInterface || null !== $product->getId()) {
+            return;
+        }
+
+        // TODO @merge Use $product->isVariant() to determine if the product is variant (since 2.2).
+        $booleanAttributes = $product instanceof VariantProductInterface
+            ? $this->getBooleanAttributesFromFamilyVariant($product)
+            : $this->getBooleanAttributesFromFamily($product);
+
+        foreach ($booleanAttributes as $attribute) {
+            $eligibleValues = $this->valuesResolver->resolveEligibleValues([$attribute]);
+
+            foreach ($eligibleValues as $valueData) {
+                $value = $product->getValue($attribute->getCode(), $valueData['locale'], $valueData['scope']);
+
+                if (null === $value) {
+                    $value = $this->productValueFactory->create($attribute, $valueData['scope'], $valueData['locale'], false);
+                    $product->addValue($value);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param ProductInterface $product
+     *
+     * @return \Generator
+     */
+    private function getBooleanAttributesFromFamily(ProductInterface $product): \Generator
+    {
+        $family = $product->getFamily();
+        $familyAttributes = $family instanceof FamilyInterface ? $family->getAttributes() : [];
+
+        foreach ($familyAttributes as $attribute) {
+            if (AttributeTypes::BOOLEAN === $attribute->getType()) {
+                yield $attribute;
+            }
+        }
+    }
+
+    /**
+     * @param VariantProductInterface $product
+     *
+     * @return \Generator
+     *
+     * @todo @merge Replace VariantProductInterface by ProductInterface when merging to 2.2
+     */
+    private function getBooleanAttributesFromFamilyVariant(VariantProductInterface $product): \Generator
+    {
+        $parentProduct = $product->getParent();
+        if (!$parentProduct instanceof ProductModelInterface) {
+            return [];
+        }
+
+        $familyVariant = $parentProduct->getFamilyVariant();
+        if (!$familyVariant instanceof FamilyVariantInterface) {
+            return [];
+        }
+
+        $variationLevel = $product->getVariationLevel();
+        $variantAttributeSet = $familyVariant->getVariantAttributeSet($variationLevel);
+        if (!$variantAttributeSet instanceof VariantAttributeSetInterface) {
+            return [];
+        }
+
+        $attributes = $variantAttributeSet->getAttributes();
+        $axes = $familyVariant->getAxes();
+
+        foreach ($attributes as $attribute) {
+            if (AttributeTypes::BOOLEAN === $attribute->getType() && !$axes->contains($attribute)) {
+                yield $attribute;
+            }
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -19,6 +19,7 @@ parameters:
     pim_catalog.event_subscriber.remove_attributes_from_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\RemoveAttributesFromFamilyVariantsOnFamilyUpdateSubscriber
     pim_catalog.event_subscriber.save_family_variants_on_family_update.class: Pim\Bundle\CatalogBundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber
     pim_catalog.event_subscriber.add_parent_to_product.class: Pim\Bundle\CatalogBundle\EventSubscriber\AddParentAProductSubscriber
+    pim_catalog.event_subscriber.add_boolean_values_to_new_product.class: Pim\Bundle\CatalogBundle\EventSubscriber\AddBooleanValuesToNewProductSubscriber
 
 services:
     # Subscribers
@@ -69,6 +70,14 @@ services:
             - '@pim_catalog.validator.unique_axes_combination_set'
         tags:
            - { name: kernel.event_listener, event: akeneo_batch.item_step_after_batch }
+
+    pim_catalog.event_subscriber.add_boolean_values_to_new_product:
+        class: '%pim_catalog.event_subscriber.add_boolean_values_to_new_product.class%'
+        arguments:
+            - '@pim_catalog.resolver.attribute_values'
+            - '@pim_catalog.factory.value'
+        tags:
+            - { name: kernel.event_subscriber}
 
     pim_catalog.event_subscriber.compute_product_raw_values:
         class: '%pim_catalog.event_subscriber.compute_product_raw_values.class%'

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/AddBooleanValuesToNewProductSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/AddBooleanValuesToNewProductSubscriberSpec.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\EventSubscriber\AddBooleanValuesToNewProductSubscriber;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Factory\ValueFactory;
+use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
+use Pim\Component\Catalog\Model\VariantProductInterface;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class AddBooleanValuesToNewProductSubscriberSpec extends ObjectBehavior
+{
+    function let(AttributeValuesResolverInterface $valuesResolver, ValueFactory $productValueFactory)
+    {
+        $this->beConstructedWith($valuesResolver,  $productValueFactory);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AddBooleanValuesToNewProductSubscriber::class);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldImplement(EventSubscriberInterface::class);
+    }
+
+    function it_does_nothing_if_the_subject_of_the_event_is_not_a_product(
+        GenericEvent $event,
+        AttributeInterface $attribute
+    ) {
+        $event->getSubject()->willReturn($attribute);
+
+        $this->addBooleansDefaultValues($event);
+    }
+
+    function it_does_nothing_if_the_product_already_exist(
+        GenericEvent $event,
+        ProductInterface $product
+    ) {
+        $event->getSubject()->willReturn($product);
+        $product->getId()->willReturn(42);
+
+        $product->addValue(Argument::any())->shouldNotBeCalled();
+
+        $this->addBooleansDefaultValues($event);
+    }
+
+    function it_adds_default_boolean_attribute_values_to_a_new_product(
+        $valuesResolver,
+        $productValueFactory,
+        GenericEvent $event,
+        ProductInterface $product,
+        FamilyInterface $family,
+        AttributeInterface $textAttribute,
+        AttributeInterface $booleanAttribute,
+        ValueInterface $valueEn,
+        ValueInterface $valueFr
+    ) {
+        $event->getSubject()->willReturn($product);
+        $product->getId()->willReturn(null);
+        $product->getFamily()->willReturn($family);
+        $family->getAttributes()->willReturn([$textAttribute, $booleanAttribute]);
+        $textAttribute->getType()->willReturn(AttributeTypes::TEXT);
+        $booleanAttribute->getType()->willReturn(AttributeTypes::BOOLEAN);
+        $booleanAttribute->getCode()->willReturn('is_boolean');
+
+        $valuesResolver->resolveEligibleValues([$booleanAttribute])->willReturn([
+            [
+                'locale' => 'en_US',
+                'scope'  => 'ecommerce',
+            ],
+            [
+                'locale' => 'fr_FR',
+                'scope'  => 'ecommerce',
+            ]
+        ]);
+
+        $product->getValue('is_boolean', 'en_US', 'ecommerce')->willReturn(null);
+        $product->getValue('is_boolean', 'fr_FR', 'ecommerce')->willReturn(null);
+
+        $productValueFactory->create($booleanAttribute, 'ecommerce', 'en_US', false)->willReturn($valueEn);
+        $productValueFactory->create($booleanAttribute, 'ecommerce', 'fr_FR', false)->willReturn($valueFr);
+
+        $product->addValue($valueEn)->shouldBeCalled();
+        $product->addValue($valueFr)->shouldBeCalled();
+
+        $this->addBooleansDefaultValues($event);
+    }
+
+    function it_does_not_replace_boolean_attribute_values_to_a_new_product(
+        $valuesResolver,
+        GenericEvent $event,
+        ProductInterface $product,
+        FamilyInterface $family,
+        AttributeInterface $booleanAttribute,
+        ValueInterface $value
+    ) {
+        $event->getSubject()->willReturn($product);
+        $product->getId()->willReturn(null);
+        $product->getFamily()->willReturn($family);
+        $family->getAttributes()->willReturn([$booleanAttribute]);
+        $booleanAttribute->getType()->willReturn(AttributeTypes::BOOLEAN);
+        $booleanAttribute->getCode()->willReturn('is_boolean');
+
+        $valuesResolver->resolveEligibleValues([$booleanAttribute])->willReturn([
+            [
+                'locale' => 'en_US',
+                'scope'  => 'ecommerce',
+            ]
+        ]);
+
+        $product->getValue('is_boolean', 'en_US', 'ecommerce')->willReturn($value);
+
+        $product->addValue(Argument::any())->shouldNotBeCalled();
+
+        $this->addBooleansDefaultValues($event);
+    }
+
+    function it_adds_only_the_boolean_attributes_of_the_variant_family_to_a_new_variant_product(
+        $valuesResolver,
+        $productValueFactory,
+        GenericEvent $event,
+        VariantProductInterface $variantProduct,
+        ProductModelInterface $parentProduct,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $booleanAttribute,
+        VariantAttributeSetInterface $variantAttributeSet,
+        ValueInterface $value
+    ) {
+        $event->getSubject()->willReturn($variantProduct);
+        $variantProduct->getId()->willReturn(null);
+        $variantProduct->getParent()->willReturn($parentProduct);
+        $variantProduct->getVariationLevel()->willReturn(1);
+        $parentProduct->getFamilyVariant()->willReturn($familyVariant);
+
+        $booleanAttribute->getType()->willReturn(AttributeTypes::BOOLEAN);
+        $booleanAttribute->getCode()->willReturn('is_boolean');
+
+        $familyVariant->getVariantAttributeSet(1)->willReturn($variantAttributeSet);
+        $variantAttributeSet->getAttributes()->willReturn(new ArrayCollection([$booleanAttribute->getWrappedObject()]));
+        $familyVariant->getAxes()->willReturn(new ArrayCollection([]));
+
+        $valuesResolver->resolveEligibleValues([$booleanAttribute])->willReturn([
+            [
+                'locale' => 'en_US',
+                'scope'  => 'ecommerce',
+            ]
+        ]);
+
+        $variantProduct->getValue('is_boolean', 'en_US', 'ecommerce')->willReturn(null);
+        $productValueFactory->create($booleanAttribute, 'ecommerce', 'en_US', false)->willReturn($value);
+
+        $variantProduct->addValue($value)->shouldBeCalled();
+
+        $this->addBooleansDefaultValues($event);
+    }
+
+    function it_does_not_adds_boolean_attributes_defined_as_axis(
+        $valuesResolver,
+        $productValueFactory,
+        GenericEvent $event,
+        VariantProductInterface $variantProduct,
+        ProductModelInterface $parentProduct,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $booleanAttribute,
+        AttributeInterface $booleanAxis,
+        VariantAttributeSetInterface $variantAttributeSet,
+        ValueInterface $value
+    ) {
+        $event->getSubject()->willReturn($variantProduct);
+        $variantProduct->getId()->willReturn(null);
+        $variantProduct->getParent()->willReturn($parentProduct);
+        $variantProduct->getVariationLevel()->willReturn(1);
+        $parentProduct->getFamilyVariant()->willReturn($familyVariant);
+
+        $booleanAttribute->getType()->willReturn(AttributeTypes::BOOLEAN);
+        $booleanAttribute->getCode()->willReturn('is_boolean');
+
+        $booleanAxis->getType()->willReturn(AttributeTypes::BOOLEAN);
+
+        $familyVariant->getVariantAttributeSet(1)->willReturn($variantAttributeSet);
+        $variantAttributeSet->getAttributes()->willReturn(new ArrayCollection([
+            $booleanAttribute->getWrappedObject(),
+            $booleanAxis->getWrappedObject(),
+        ]));
+        $familyVariant->getAxes()->willReturn(new ArrayCollection([$booleanAxis->getWrappedObject()]));
+
+        $valuesResolver->resolveEligibleValues([$booleanAttribute])->willReturn([
+            [
+                'locale' => 'en_US',
+                'scope'  => 'ecommerce',
+            ]
+        ]);
+
+        $variantProduct->getValue('is_boolean', 'en_US', 'ecommerce')->willReturn(null);
+        $productValueFactory->create($booleanAttribute, 'ecommerce', 'en_US', false)->willReturn($value);
+
+        $variantProduct->addValue($value)->shouldBeCalled();
+
+        $this->addBooleansDefaultValues($event);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/AttributeType/BooleanAttributeTypeCompletenessIntegration.php
@@ -86,8 +86,7 @@ class BooleanAttributeTypeCompletenessIntegration extends AbstractCompletenessPe
         $this->assertMissingAttributeForProduct($productDataNull, ['a_boolean']);
 
         $productWithoutValues = $this->createProductWithStandardValues($family, 'product_without_values');
-        // TODO: This is not as it should be, but inevitable because of PIM-6056
-        // TODO: When PIM-6056 is fixed, we should be able to use "assertNotComplete"
+        // @todo @merge : this assertion must not be removed (a mistake has been made in 2.2)
         $this->assertComplete($productWithoutValues);
         $this->assertBooleanValueIsFalse($productWithoutValues, 'a_boolean');
     }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/AddBooleanValuesToNewProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/AddBooleanValuesToNewProductIntegration.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Product;
+
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Test\Integration\Configuration;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+
+/**
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AddBooleanValuesToNewProductIntegration extends TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    public function testBooleanValuesAreAddedToNewProduct(): void
+    {
+        $this->createAttribute([
+            'code'  => 'another_yes_no',
+            'group' => 'attributeGroupA',
+            'type'  => 'pim_catalog_boolean',
+        ]);
+
+        $this->createFamily([
+            'code' => 'family_with_booleans',
+            'attributes' => [
+                'sku',
+                'a_text',
+                'a_yes_no',
+                'another_yes_no'
+            ]
+        ]);
+
+        $product = $this->get('pim_catalog.builder.product')->createProduct('a_new_product', 'family_with_booleans');
+
+        $this->get('pim_catalog.updater.product')->update($product, []);
+        $this->get('pim_catalog.saver.product')->save($product);
+        $this->get('doctrine.orm.entity_manager')->clear();
+
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('a_new_product');
+
+        $this->assertNotNull($product, 'The product has not been created');
+        $this->assertProductHasValue($product, 'a_yes_no', false);
+        $this->assertProductHasValue($product, 'another_yes_no', false);
+    }
+
+    public function testBooleanValuesAreAddedToNewFirstLevelProductVariant(): void
+    {
+        $this->createAttribute([
+            'code'  => 'another_yes_no',
+            'group' => 'attributeGroupA',
+            'type'  => 'pim_catalog_boolean',
+        ]);
+
+        $this->createFamily([
+            'code' => 'family_with_booleans',
+            'attributes' => [
+                'sku',
+                'a_simple_select_color',
+                'a_yes_no',
+                'another_yes_no'
+            ]
+        ]);
+
+        $this->createFamilyVariant([
+            'code'                   => 'family_variant_with_boolean',
+            'family'                 => 'family_with_booleans',
+            'variant_attribute_sets' => [
+                [
+                    'axes'       => ['a_simple_select_color'],
+                    'attributes' => ['another_yes_no'],
+                    'level'      => 1,
+                ],
+                [
+                    'axes'       => [],
+                    'attributes' => [],
+                    'level'      => 2,
+                ]
+            ],
+        ]);
+
+        $this->createProductModel([
+            'code'           => 'product_model_with_boolean',
+            'family_variant' => 'family_variant_with_boolean',
+            'values'         => [
+                'a_simple_select_color' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'blue',
+                    ]
+                ],
+                'a_yes_no'              => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => true,
+                    ]
+                ]
+            ]
+        ]);
+
+        $variantProduct = $this->get('pim_catalog.builder.variant_product')
+            ->createProduct('a_new_variant_product', 'family_with_booleans');
+
+        $this->get('pim_catalog.updater.product')->update($variantProduct, ['parent' => 'product_model_with_boolean']);
+        $this->get('pim_catalog.saver.product')->save($variantProduct);
+        $this->get('doctrine.orm.entity_manager')->clear();
+
+        $variantProduct = $this->get('pim_catalog.repository.product')->findOneByIdentifier('a_new_variant_product');
+
+        $this->assertNotNull($variantProduct, 'The variant product has not been created');
+        $this->assertProductHasValue($variantProduct, 'a_yes_no', true);
+        $this->assertProductHasValue($variantProduct, 'another_yes_no', false);
+    }
+
+    public function testBooleanValuesAreAddedToNewSecondLevelProductVariant(): void
+    {
+        $this->createAttribute([
+            'code'  => 'a_yes_no_level_1',
+            'group' => 'attributeGroupA',
+            'type'  => 'pim_catalog_boolean',
+        ]);
+
+        $this->createAttribute([
+            'code'  => 'a_yes_no_level_2',
+            'group' => 'attributeGroupA',
+            'type'  => 'pim_catalog_boolean',
+        ]);
+
+        $this->createFamily([
+            'code' => 'family_with_booleans',
+            'attributes' => [
+                'sku',
+                'a_simple_select_color',
+                'a_simple_select_size',
+                'a_yes_no',
+                'a_yes_no_level_1',
+                'a_yes_no_level_2',
+
+            ]
+        ]);
+
+        $this->createFamilyVariant([
+            'code'                   => 'family_variant_with_two_levels_booleans',
+            'family'                 => 'family_with_booleans',
+            'variant_attribute_sets' => [
+                [
+                    'axes'       => ['a_simple_select_color'],
+                    'attributes' => ['a_yes_no_level_1'],
+                    'level'      => 1,
+                ],
+                [
+                    'axes'       => ['a_simple_select_size'],
+                    'attributes' => ['a_yes_no_level_2'],
+                    'level'      => 2,
+                ]
+            ],
+        ]);
+
+        $this->createProductModel([
+            'code'           => 'parent_product_model_with_boolean',
+            'family_variant' => 'family_variant_with_two_levels_booleans',
+            'values'         => [
+                'a_simple_select_color' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'blue',
+                    ]
+                ],
+                'a_yes_no'              => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => true,
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->createProductModel([
+            'code'           => 'level_2_product_model_with_boolean',
+            'family_variant' => 'family_variant_with_two_levels_booleans',
+            'parent'         => 'parent_product_model_with_boolean',
+            'values'         => [
+                'a_simple_select_size' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'xl',
+                    ]
+                ],
+                'a_yes_no_level_1'     => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => true,
+                    ]
+                ]
+            ]
+        ]);
+
+        $variantProduct = $this->get('pim_catalog.builder.variant_product')
+            ->createProduct('a_new_variant_product', 'family_with_booleans');
+
+        $this->get('pim_catalog.updater.product')->update($variantProduct, ['parent' => 'level_2_product_model_with_boolean']);
+        $this->get('pim_catalog.saver.product')->save($variantProduct);
+        $this->get('doctrine.orm.entity_manager')->clear();
+
+        $variantProduct = $this->get('pim_catalog.repository.product')->findOneByIdentifier('a_new_variant_product');
+
+        $this->assertNotNull($variantProduct, 'The variant product has not been created');
+        $this->assertProductHasValue($variantProduct, 'a_yes_no', true);
+        $this->assertProductHasValue($variantProduct, 'a_yes_no_level_1', true);
+        $this->assertProductHasValue($variantProduct, 'a_yes_no_level_2', false);
+    }
+
+    /**
+     * @param array $familyData
+     *
+     * @return FamilyInterface
+     */
+    private function createFamily(array $familyData): FamilyInterface
+    {
+        $family = $this->get('pim_catalog.factory.family')->create();
+
+        $this->get('pim_catalog.updater.family')->update($family, $familyData);
+        $this->get('pim_catalog.saver.family')->save($family);
+
+        return $family;
+    }
+
+    /**
+     * @param array $familyData
+     *
+     * @return FamilyVariantInterface
+     */
+    private function createFamilyVariant(array $familyData): FamilyVariantInterface
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, $familyData);
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+
+        return $familyVariant;
+    }
+
+    /**
+     * @param array $attributeData
+     *
+     * @return AttributeInterface
+     */
+    private function createAttribute(array $attributeData): AttributeInterface
+    {
+        $attribute = $this->get('pim_catalog.factory.attribute')->create();
+
+        $this->get('pim_catalog.updater.attribute')->update($attribute, $attributeData);
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        return $attribute;
+    }
+
+    /**
+     * @param array $productModelData
+     *
+     * @return ProductModelInterface
+     */
+    private function createProductModel(array $productModelData): ProductModelInterface
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $productModelData);
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+
+        return $productModel;
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param string           $attributeCode
+     * @param mixed            $expectedValue
+     */
+    private function assertProductHasValue(ProductInterface $product, string $attributeCode, $expectedValue): void
+    {
+        $productValue = $product->getValue($attributeCode);
+
+        $this->assertNotNull($productValue, sprintf(
+            "The product %s doesn't have value for the attribute %s", $product->getIdentifier(), $attributeCode
+        ));
+
+        $this->assertSame($expectedValue, $productValue->getData(), sprintf(
+            "The attribute %s doesn't have the expected value", $attributeCode
+        ));
+    }
+}

--- a/src/Pim/Component/Catalog/Builder/ProductBuilder.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Pim\Component\Catalog\Builder;
 
-use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Manager\AttributeValuesResolverInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\EntityWithValuesInterface;
@@ -55,6 +54,8 @@ class ProductBuilder implements ProductBuilderInterface
      * @param AttributeValuesResolverInterface   $valuesResolver      Attributes values resolver
      * @param EntityWithValuesBuilderInterface   $entityWithValuesBuilder
      * @param array                              $classes             Model classes
+     *
+     * @todo @merge Remove unused parameter $valuesResolver in master
      */
     public function __construct(
         AttributeRepositoryInterface $attributeRepository,
@@ -90,7 +91,6 @@ class ProductBuilder implements ProductBuilderInterface
         if (null !== $familyCode) {
             $family = $this->familyRepository->findOneByIdentifier($familyCode);
             $product->setFamily($family);
-            $this->addBooleanToProduct($product);
         }
 
         $event = new GenericEvent($product);
@@ -135,35 +135,5 @@ class ProductBuilder implements ProductBuilderInterface
         $data
     ) {
         $this->entityWithValuesBuilder->addOrReplaceValue($values, $attribute, $locale, $scope, $data);
-    }
-
-    /**
-     * Set product values to "false" by default for every boolean attributes in the product's family.
-     *
-     * This workaround is due to the UI that does not manage null values for boolean attributes, only false or true.
-     * It avoids to automatically submit boolean attributes belonging to the product's family in a proposal,
-     * even if those boolean attributes were not modified by the user.
-     *
-     * FIXME : To remove when the UI will manage null values in boolean attributes (PIM-6056).
-     *
-     * @param ProductInterface $product
-     */
-    private function addBooleanToProduct(ProductInterface $product)
-    {
-        $family = $product->getFamily();
-
-        if (null === $family) {
-            return;
-        }
-
-        foreach ($family->getAttributes() as $attribute) {
-            if (AttributeTypes::BOOLEAN === $attribute->getType()) {
-                $requiredValues = $this->valuesResolver->resolveEligibleValues([$attribute]);
-
-                foreach ($requiredValues as $value) {
-                    $this->addOrReplaceValue($product, $attribute, $value['locale'], $value['scope'], false);
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

To avoid to handle "three-values" boolean, it had been decided to add default values for boolean attributes when a product is created.

The problem is that for a variant product, all the boolean attributes of the family are added, while only the attributes of the related level of the variant family should be added.

To fix that I choose to extract the boolean adding in a dedicated subscriber listening the event `StorageEvents::PRE_SAVE` . It couldn't be done anymore in `ProductBuilder` because when `ProductBuilder::create` is called for a variant product, the parent is not yet known (it's done in the updater).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
