### PR TITLE
PIM-6962 : Fix breadcrumb links after the save on edit page.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - PIM-7251: Fix history date on all grids (except product grid)
 - PIM-7275: Fix regression on group products grid filters
+- PIM-6962: Fix breadcrumb links issue after the save on the edit page
 
 # 2.0.20 (2018-03-29)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/breadcrumbs.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/breadcrumbs.js
@@ -86,7 +86,11 @@ define([
                         breadcrumbTab: breadcrumbTab,
                         breadcrumbItem: breadcrumbItem
                     }));
+
+                    this.delegateEvents();
                 }.bind(this));
+
+                return this;
             },
 
             /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We had an SLA on the breadcrumbs links doesn't work after the save on the attribute edit page. The problem was due to backbone want to make the click event but the element can't be find as it was render again by the JS after the save.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
