### PR TITLE
[SLA] PIM-7116: Enforce anti-CSRF security on internal API

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Controller/Rest/DatagridViewController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/Rest/DatagridViewController.php
@@ -161,14 +161,21 @@ class DatagridViewController
      * @param Request $request
      * @param string  $alias
      *
-     * @return JsonResponse|BadRequestHttpException|NotFoundHttpException
+     * @throws BadRequestHttpException
+     * @throws NotFoundHttpException
+     *
+     * @return Response
      */
     public function saveAction(Request $request, $alias)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $view = $request->request->get('view', null);
 
         if (null === $view) {
-            return new BadRequestHttpException('Parameter "view" needed in the request.');
+            throw new BadRequestHttpException('Parameter "view" needed in the request.');
         }
 
         if (isset($view['id'])) {
@@ -183,7 +190,7 @@ class DatagridViewController
         }
 
         if (null === $datagridView) {
-            return new NotFoundHttpException();
+            throw new NotFoundHttpException();
         }
 
         $this->updater->update($datagridView, $view);

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AssociationTypeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AssociationTypeController.php
@@ -105,13 +105,18 @@ class AssociationTypeController
 
     /**
      * @param Request $request
+     * @param string  $code
      *
-     * @return JsonResponse
+     * @return Response
      *
      * @AclAncestor("pim_enrich_associationtype_edit")
      */
     public function postAction(Request $request, $code)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $associationType = $this->getAssociationTypeOr404($code);
 
         $data = json_decode($request->getContent(), true);
@@ -142,7 +147,8 @@ class AssociationTypeController
     /**
      * Remove action
      *
-     * @param $code
+     * @param Request $request
+     * @param string  $code
      *
      * @return Response
      *

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ChannelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ChannelController.php
@@ -120,10 +120,14 @@ class ChannelController
      * @throws \LogicException
      * @throws \InvalidArgumentException
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function postAction(Request $request)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $channel = $this->channelFactory->create();
 
         return $this->saveChannel($channel, $request);
@@ -142,10 +146,14 @@ class ChannelController
      * @throws \LogicException
      * @throws \InvalidArgumentException
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function putAction(Request $request, $code)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $channel = $this->getChannel($code);
 
         return $this->saveChannel($channel, $request);
@@ -156,12 +164,11 @@ class ChannelController
      *
      * @AclAncestor("pim_enrich_channel_remove")
      *
-     * @param $code
-     *
-     * @throws HttpExceptionInterface
-     * @throws \InvalidArgumentException
+     * @param Request $request
+     * @param string  $code
      *
      * @return Response
+     * @throws HttpExceptionInterface
      */
     public function removeAction(Request $request, $code)
     {

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/FamilyController.php
@@ -155,10 +155,14 @@ class FamilyController
      * @param Request $request
      * @param string  $code
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function putAction(Request $request, $code)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         if (!$this->securityFacade->isGranted('pim_enrich_family_edit_properties') &&
             !$this->securityFacade->isGranted('pim_enrich_family_edit_attributes')
         ) {

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/GroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/GroupController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/JobInstanceController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/JobInstanceController.php
@@ -161,10 +161,14 @@ class JobInstanceController
      *
      * @AclAncestor("pim_importexport_import_profile_edit")
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function putImportAction(Request $request, $identifier)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         return $this->putAction($request, $identifier);
     }
 
@@ -176,10 +180,14 @@ class JobInstanceController
      *
      * @AclAncestor("pim_importexport_export_profile_edit")
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function putExportAction(Request $request, $identifier)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         return $this->putAction($request, $identifier);
     }
 
@@ -227,10 +235,14 @@ class JobInstanceController
      *
      * @AclAncestor("pim_importexport_import_profile_launch")
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function launchImportAction(Request $request, $code)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         return $this->launchAction($request, $code);
     }
 
@@ -242,10 +254,14 @@ class JobInstanceController
      *
      * @AclAncestor("pim_importexport_export_profile_launch")
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function launchExportAction(Request $request, $code)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         return $this->launchAction($request, $code);
     }
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/MediaController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/MediaController.php
@@ -5,7 +5,9 @@ namespace Pim\Bundle\EnrichBundle\Controller\Rest;
 use Akeneo\Component\FileStorage\PathGeneratorInterface;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -43,10 +45,14 @@ class MediaController
      *
      * @param Request $request
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function postAction(Request $request)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         /** @var \Symfony\Component\HttpFoundation\File\UploadedFile $file */
         $file = $request->files->get('file');
         $violations = $this->validator->validate($file);

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/NavigationHistoryController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/NavigationHistoryController.php
@@ -8,7 +8,9 @@ use Oro\Bundle\NavigationBundle\Entity\NavigationHistoryItem;
 use Oro\Bundle\NavigationBundle\Entity\NavigationItemInterface;
 use Oro\Bundle\NavigationBundle\Entity\Repository\NavigationRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -56,10 +58,14 @@ class NavigationHistoryController
      *
      * @param Request $request
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function postAction(Request $request)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $history = json_decode($request->getContent(), true);
 
         $historyItem = $this->findOrCreate($this->getUser(), $history['url']);

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductCommentController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductCommentController.php
@@ -13,7 +13,9 @@ use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\ProductRepositoryInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -133,10 +135,14 @@ class ProductCommentController
      * @param Request $request
      * @param string  $id
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function postAction(Request $request, $id)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $product = $this->findProductOr404($id);
         $data = json_decode($request->getContent(), true);
         $comment = $this->commentBuilder->buildComment($product, $this->getUser());
@@ -169,10 +175,14 @@ class ProductCommentController
      * @param string  $id
      * @param string  $commentId
      *
-     * @return JsonResponse
+     * @return Response
      */
     public function postReplyAction(Request $request, $id, $commentId)
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $product = $this->findProductOr404($id);
 
         $data = json_decode($request->getContent(), true);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This is a follow-up to the work done on 1.6 (see https://github.com/akeneo/pim-community-dev/pull/7533). This PR add missing checks, particularly on routes that didn't exist in 1.6.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
