### PR TITLE
TIP-850: Define coupling detector rules

### DIFF
--- a/.php_cd_v3.php
+++ b/.php_cd_v3.php
@@ -1,0 +1,51 @@
+<?php
+
+use Akeneo\CouplingDetector\Configuration\Configuration;
+use Akeneo\CouplingDetector\Configuration\DefaultFinder;
+use Akeneo\CouplingDetector\Domain\Rule;
+use Akeneo\CouplingDetector\Domain\RuleInterface;
+
+$finder = new DefaultFinder();
+$finder->notPath('Oro');
+$finder->notPath('Acme');
+$finder->notPath('spec');
+$finder->notPath('tests');
+
+const USER_MANAGEMENT_NAMESPACE = 'Akeneo\UserManagement';
+const PIM_NAMESPACE = 'Akeneo\Pim';
+const PAM_NAMESPACE = 'Akeneo\Pam';
+const MDM_NAMESPACE = 'Akeneo\Mdm';
+const TARGET_MARKET_NAMESPACE = 'Akeneo\TargetMarket';
+
+$rootRules = [
+    new Rule(
+        USER_MANAGEMENT_NAMESPACE,
+        [
+            PIM_NAMESPACE,
+            PAM_NAMESPACE,
+            MDM_NAMESPACE,
+            TARGET_MARKET_NAMESPACE,
+        ],
+        RuleInterface::TYPE_FORBIDDEN
+    ),
+    new Rule(
+        TARGET_MARKET_NAMESPACE,
+        [
+            PIM_NAMESPACE,
+            PAM_NAMESPACE,
+            MDM_NAMESPACE,
+            USER_MANAGEMENT_NAMESPACE,
+        ],
+        RuleInterface::TYPE_FORBIDDEN
+    ),
+    new Rule(MDM_NAMESPACE, [PIM_NAMESPACE], RuleInterface::TYPE_FORBIDDEN),
+    new Rule(
+        PAM_NAMESPACE,
+        [PIM_NAMESPACE, MDM_NAMESPACE],
+        RuleInterface::TYPE_FORBIDDEN
+    ),
+];
+
+$config = new Configuration($rootRules, $finder);
+
+return $config;

--- a/.php_cd_v3.php
+++ b/.php_cd_v3.php
@@ -46,6 +46,22 @@ $rootRules = [
     ),
 ];
 
-$config = new Configuration($rootRules, $finder);
+const PIM_ENRICHMENT = 'Akeneo\Pim\Enrichment';
+const PIM_STRUCTURE = 'Akeneo\Pim\Structure';
+const PIM_SECURITY = 'Akeneo\Pim\Security';
+const PIM_AUTOMATION = 'Akeneo\Pim\Automation';
+const PIM_WORKORG = 'Akeneo\Pim\WorkOrganisation';
+const PIM_WORKORG_TWA = 'Akeneo\Pim\WorkOrganisation\TeamWorkAssistant';
+const PIM_WORKORG_WFL = 'Akeneo\Pim\WorkOrganisation\Workflow';
+
+$pimRules = [
+    new Rule(PIM_STRUCTURE, [PIM_ENRICHMENT, PIM_AUTOMATION, PIM_WORKORG, PIM_SECURITY], RuleInterface::TYPE_FORBIDDEN),
+    new Rule(PIM_ENRICHMENT, [PIM_AUTOMATION, PIM_WORKORG, PIM_SECURITY], RuleInterface::TYPE_FORBIDDEN),
+    new Rule(PIM_WORKORG_TWA, [PIM_WORKORG_WFL, PIM_AUTOMATION], RuleInterface::TYPE_FORBIDDEN),
+    new Rule(PIM_WORKORG_WFL, [PIM_WORKORG_TWA, PIM_AUTOMATION, PIM_STRUCTURE], RuleInterface::TYPE_FORBIDDEN),
+    new Rule(PIM_AUTOMATION, [PIM_WORKORG, PIM_STRUCTURE, PIM_SECURITY], RuleInterface::TYPE_FORBIDDEN),
+];
+
+$config = new Configuration(array_merge($rootRules, $pimRules), $finder);
 
 return $config;

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
     },
     "require-dev": {
         "akeneo/phpspec-skip-example-extension": "2.0.*",
-        "akeneo/php-coupling-detector": "0.2.0",
+        "akeneo/php-coupling-detector": "dev-master",
         "behat/behat": "3.4.3",
         "behat/gherkin":"4.5.1",
         "behat/mink":"1.7.1",


### PR DESCRIPTION
Here is a fist version of the coupling detector rules according to the folder reorganization we "ideally target".
Rules have been defined by forbidding what shouldn't be used in a particular folder. Ideally, we should define the opposite: what a folder should only be able to use. But it's much more complex (as we also have to take into account the external dependencies like Symfony components). This first step will at least allow us to decouple properly the different "big set of features" we have.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
