### PR TITLE
PIM-7275: Fix regression on group products grid filters

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7251: Fix history date on all grids (except product grid)
+- PIM-7275: Fix regression on group products grid filters
 
 # 2.0.20 (2018-03-29)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_group.yml
@@ -5,6 +5,7 @@ datagrid:
             requireJSModules:
                 - pim/datagrid/column-form-listener
                 - oro/datagrid/pagination-input
+                - oro/datafilter-builder
             columnListener:
                 dataField: id
                 columnName: is_checked

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/edit.yml
@@ -142,13 +142,3 @@ extensions:
         config:
             label: 'pim_enrich.form.group.tab.products.title'
             gridId: 'product-group-grid'
-
-    pim-group-edit-form-filters-list:
-        module: oro/datafilter/filters-list
-        parent: pim-group-edit-form-products
-        targetZone: filters
-
-    pim-group-edit-form-filters-manage:
-        module: oro/datafilter/filters-button
-        parent: pim-group-edit-form-products
-        targetZone: filters

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/group/form/products.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/group/form/products.js
@@ -65,9 +65,10 @@ define([
                         this.setData('products', selection);
                     }.bind(this));
 
-                    this.getRoot().on('pim_enrich:form:entity:post_fetch', function () {
-                        this.productGroupGrid.refresh();
-                    }.bind(this));
+                    this.getRoot().on('pim_enrich:form:entity:post_fetch', () => {
+                        const shouldRefresh = this.code === this.getParent().getCurrentTab()
+                        if (shouldRefresh) this.productGroupGrid.refresh();
+                    });
                 }
 
                 this.$el.empty().append(this.productGroupGrid.render().$el);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/grid.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/grid.html
@@ -1,4 +1,3 @@
-<div class="AknFilterBox AknFilterBox--search" data-drop-zone="filters"></div>
 <div class="grid-drop" data-type="datagrid"></div>
 <input type="hidden" id="added_objects"/>
 <input type="hidden" id="removed_objects"/>

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -175,6 +175,6 @@
     background: url("../../../images/icon-filters.svg") no-repeat left 50%;
     flex-grow: 1;
     padding-left: 35px !important; // The padding is updated by JS method.
-    margin-top: 26px;
+    margin-top: 30px;
   }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a regression created in https://github.com/akeneo/pim-community-dev/pull/7877 by using the old datafilter-builder instead of the new filters-list/filters-manage form extensions. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
