### PR TITLE
PIM-7260: Add validation in the 'configure' step of mass edits

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -28,6 +28,7 @@
 - PIM-7259: Remove only attribute's option removed for multi select attribute
 - PIM-7270: Fix [object Object] empty filter value
 - PIM-7252: Fix permissions on attributes settings page
+- PIM-7260: Add form validation in the 'configure' step of mass edits
 
 # 2.0.19 (2018-03-23)
 

--- a/features/mass-action/edit_common_attributes.feature
+++ b/features/mass-action/edit_common_attributes.feature
@@ -49,7 +49,6 @@ Feature: Edit common attributes of many products at once
     When I remove the "Name" attribute
     Then I should not see the "Name" field
     And I should not see a remove link next to the "Name" field
-    And I confirm mass edit
 
   Scenario: Successfully update many text values at once
     Given I am on the products grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/add-to-existing-product-model.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/add-to-existing-product-model.js
@@ -10,12 +10,18 @@
 define(
     [
         'underscore',
+        'oro/translator',
+        'oro/messenger',
         'pim/mass-edit-form/product/operation',
+        'pim/common/property',
         'pim/template/mass-edit/product/add-to-existing-product-model'
     ],
     function (
         _,
+        __,
+        messenger,
         BaseOperation,
+        propertyAccessor,
         template
     ) {
         return BaseOperation.extend({
@@ -69,6 +75,22 @@ define(
                 const action = _.findWhere(this.getFormData().actions, { field: 'productModelCode' });
 
                 return action ? action.value : null;
+            },
+
+            /**
+             * Checks there is one product model selected to go to the next step
+             */
+            validate: function () {
+                const data = this.getFormData();
+                const productModelCode = propertyAccessor.accessProperty(data, 'actions.0.value', null);
+
+                const hasUpdate = null !== productModelCode;
+
+                if (!hasUpdate) {
+                    messenger.notify('error', __('pim_enrich.mass_edit.product.operation.add_to_existing_product_model.no_update'));
+                }
+
+                return $.Deferred().resolve(hasUpdate);
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/add-to-existing-product-model.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/add-to-existing-product-model.js
@@ -9,6 +9,7 @@
  */
 define(
     [
+        'jquery',
         'underscore',
         'oro/translator',
         'oro/messenger',
@@ -17,6 +18,7 @@ define(
         'pim/template/mass-edit/product/add-to-existing-product-model'
     ],
     function (
+        $,
         _,
         __,
         messenger,
@@ -87,7 +89,10 @@ define(
                 const hasUpdate = null !== productModelCode;
 
                 if (!hasUpdate) {
-                    messenger.notify('error', __('pim_enrich.mass_edit.product.operation.add_to_existing_product_model.no_update'));
+                    messenger.notify(
+                        'error',
+                        __('pim_enrich.mass_edit.product.operation.add_to_existing_product_model.no_update')
+                    );
                 }
 
                 return $.Deferred().resolve(hasUpdate);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/add-to-group.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/add-to-group.js
@@ -10,19 +10,23 @@ define(
     [
         'underscore',
         'oro/translator',
+        'oro/messenger',
         'pim/i18n',
         'pim/user-context',
         'pim/mass-edit-form/product/operation',
         'pim/fetcher-registry',
+        'pim/common/property',
         'pim/template/mass-edit/product/add-to-group'
     ],
     function (
         _,
         __,
+        messenger,
         i18n,
         UserContext,
         BaseOperation,
         FetcherRegistry,
+        propertyAccessor,
         template
     ) {
         return BaseOperation.extend({
@@ -102,6 +106,22 @@ define(
                 var action = _.findWhere(this.getFormData().actions, {field: 'groups'})
 
                 return action ? action.value : null;
+            },
+
+            /**
+             * Checks there is at least one group selected to go to the next step
+             */
+            validate: function () {
+                const data = this.getFormData();
+                const categories = propertyAccessor.accessProperty(data, 'actions.0.value', []);
+
+                const hasUpdates = 0 !== categories.length;
+
+                if (!hasUpdates) {
+                    messenger.notify('error', __('pim_enrich.mass_edit.product.operation.add_to_group.no_update'));
+                }
+
+                return $.Deferred().resolve(hasUpdates);
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/add-to-group.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/add-to-group.js
@@ -8,6 +8,7 @@
  */
 define(
     [
+        'jquery',
         'underscore',
         'oro/translator',
         'oro/messenger',
@@ -19,6 +20,7 @@ define(
         'pim/template/mass-edit/product/add-to-group'
     ],
     function (
+        $,
         _,
         __,
         messenger,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/category.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/category.js
@@ -8,6 +8,7 @@
  */
 define(
     [
+        'jquery',
         'underscore',
         'oro/translator',
         'oro/messenger',
@@ -20,6 +21,7 @@ define(
         'pim/template/mass-edit/product/category'
     ],
     function (
+        $,
         _,
         __,
         messenger,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/category.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/category.js
@@ -15,6 +15,7 @@ define(
         'pim/fetcher-registry',
         'pim/mass-edit-form/product/operation',
         'pim/tree/associate',
+        'pim/common/property',
         'pim/template/mass-edit/product/category'
     ],
     function (
@@ -25,6 +26,7 @@ define(
         FetcherRegistry,
         BaseOperation,
         TreeAssociate,
+        propertyAccessor,
         template
     ) {
         return BaseOperation.extend({
@@ -189,6 +191,16 @@ define(
                 }
 
                 return this.categoryCache[id].code;
+            },
+
+            /**
+             * Checks ...
+             */
+            validate: function () {
+                const data = this.getFormData();
+                const categories = propertyAccessor.accessProperty(data, 'actions.0.value', []);
+
+                return $.Deferred().resolve(0 !== categories.length);
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/category.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/category.js
@@ -10,6 +10,7 @@ define(
     [
         'underscore',
         'oro/translator',
+        'oro/messenger',
         'pim/i18n',
         'pim/user-context',
         'pim/fetcher-registry',
@@ -21,6 +22,7 @@ define(
     function (
         _,
         __,
+        messenger,
         i18n,
         UserContext,
         FetcherRegistry,
@@ -126,7 +128,10 @@ define(
              */
             updateModel: function (event) {
                 this.selectedCategories = event.target.value.split(',');
-                this.setValue(_.map(this.selectedCategories, this.getCategoryCode.bind(this)));
+                const selectedCategories = this.selectedCategories
+                    .filter((category) => '' !== category)
+                    .map(this.getCategoryCode.bind(this));
+                this.setValue(selectedCategories);
             },
 
             /**
@@ -194,13 +199,19 @@ define(
             },
 
             /**
-             * Checks ...
+             * Checks there is at least one category selected to go to the next step
              */
             validate: function () {
                 const data = this.getFormData();
                 const categories = propertyAccessor.accessProperty(data, 'actions.0.value', []);
 
-                return $.Deferred().resolve(0 !== categories.length);
+                const hasUpdates = 0 !== categories.length;
+
+                if (!hasUpdates) {
+                    messenger.notify('error', __(`pim_enrich.mass_edit.product.operation.${data.operation}.no_update`));
+                }
+
+                return $.Deferred().resolve(hasUpdates);
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/change-family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/change-family.js
@@ -10,21 +10,17 @@ define(
     [
         'underscore',
         'oro/translator',
-        'oro/messenger',
         'pim/mass-edit-form/product/operation',
         'pim/common/select2/family',
         'pim/template/mass-edit/product/change-family',
-        'pim/common/property',
         'pim/initselect2'
     ],
     function (
         _,
         __,
-        messenger,
         BaseOperation,
         Select2Configurator,
         template,
-        propertyAccessor,
         initSelect2
     ) {
         return BaseOperation.extend({
@@ -88,24 +84,9 @@ define(
              * @return {string}
              */
             getValue: function () {
-                const action = _.findWhere(this.getFormData().actions, {field: 'family'})
+                var action = _.findWhere(this.getFormData().actions, {field: 'family'})
 
                 return action ? action.value : null;
-            },
-
-            /**
-             * Checks there is a one family selected to go to the next step
-             */
-            validate: function () {
-                const data = this.getFormData();
-                const family = propertyAccessor.accessProperty(data, 'actions.0.value', null);
-
-                const hasUpdate = null !== family;
-                if (!hasUpdate) {
-                    messenger.notify('error', __('pim_enrich.mass_edit.product.operation.change_family.no_update'));
-                }
-
-                return $.Deferred().resolve(hasUpdate);
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/change-family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/change-family.js
@@ -10,17 +10,21 @@ define(
     [
         'underscore',
         'oro/translator',
+        'oro/messenger',
         'pim/mass-edit-form/product/operation',
         'pim/common/select2/family',
         'pim/template/mass-edit/product/change-family',
+        'pim/common/property',
         'pim/initselect2'
     ],
     function (
         _,
         __,
+        messenger,
         BaseOperation,
         Select2Configurator,
         template,
+        propertyAccessor,
         initSelect2
     ) {
         return BaseOperation.extend({
@@ -84,9 +88,24 @@ define(
              * @return {string}
              */
             getValue: function () {
-                var action = _.findWhere(this.getFormData().actions, {field: 'family'})
+                const action = _.findWhere(this.getFormData().actions, {field: 'family'})
 
                 return action ? action.value : null;
+            },
+
+            /**
+             * Checks there is a one family selected to go to the next step
+             */
+            validate: function () {
+                const data = this.getFormData();
+                const family = propertyAccessor.accessProperty(data, 'actions.0.value', null);
+
+                const hasUpdate = null !== family;
+                if (!hasUpdate) {
+                    messenger.notify('error', __('pim_enrich.mass_edit.product.operation.change_family.no_update'));
+                }
+
+                return $.Deferred().resolve(hasUpdate);
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/edit-common-attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/edit-common-attributes.js
@@ -11,24 +11,28 @@ define(
         'jquery',
         'underscore',
         'oro/translator',
+        'oro/messenger',
         'routing',
         'pim/mass-edit-form/product/operation',
         'pim/user-context',
         'pim/form-builder',
         'pim/fetcher-registry',
         'pim/i18n',
+        'pim/common/property',
         'pim/template/mass-edit/product/edit-common-attributes'
     ],
     function (
         $,
         _,
         __,
+        messenger,
         Routing,
         BaseOperation,
         UserContext,
         FormBuilder,
         FetcherRegistry,
         i18n,
+        propertyAccessor,
         template
     ) {
         return BaseOperation.extend({
@@ -159,22 +163,31 @@ define(
              * @return {Promise}
              */
             validate: function () {
-                return $.ajax({
-                    method: 'POST',
-                    contentType: 'application/json',
-                    data: JSON.stringify(this.getValue()),
-                    url: Routing.generate('pim_enrich_value_rest_validate')
-                }).then(function (response) {
-                    if (!_.isEmpty(response.values)) {
-                        this.errors = response.values;
+                const data = this.getFormData();
+                const actions = propertyAccessor.accessProperty(data, 'actions.0.normalized_values', {});
 
-                        this.render();
-                    } else {
-                        this.errors = {};
-                    }
+                if (0 === Object.keys(actions).length) {
+                    messenger.notify('error', __('pim_enrich.mass_edit.product.operation.edit_common.no_update'));
 
-                    return _.isEmpty(this.errors);
-                }.bind(this));
+                    return $.Deferred().resolve(false);
+                } else {
+                    return $.ajax({
+                        method: 'POST',
+                        contentType: 'application/json',
+                        data: JSON.stringify(this.getValue()),
+                        url: Routing.generate('pim_enrich_value_rest_validate')
+                    }).then(function (response) {
+                        if (!_.isEmpty(response.values)) {
+                            this.errors = response.values;
+
+                            this.render();
+                        } else {
+                            this.errors = {};
+                        }
+
+                        return _.isEmpty(this.errors);
+                    }.bind(this));
+                }
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/mass-edit/product/category.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/mass-edit/product/category.html
@@ -22,7 +22,7 @@
         <div class="tab-pane active">
             <div id="trees" data-datalocale="<%- locale %>" data-selected-tree="<%- currentTree.id %>">
                 <% _.each(trees, function (tree) { %>
-                    <div class="tree root-unselectable" data-tree-id="<%- tree.id %>">
+                    <div id="root-unselectable" class="tree root-unselectable" data-tree-id="<%- tree.id %>">
                         <div id="tree-<%- tree.id %>" class="buffer-small-left"></div>
                     </div>
                 <% }); %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/categories.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/tab/categories.html
@@ -6,7 +6,7 @@
         <div class="tab-pane active" id="product-categories">
             <div id="trees" data-id="<%- product.meta.id %>" data-datalocale="<%- locale %>" data-selected-tree="<%- trees[0].id %>">
                 <% _.each(trees, function (tree) { %>
-                    <div class="tree root-unselectable" data-tree-id="<%- tree.id %>">
+                    <div id="root-unselectable" class="tree root-unselectable" data-tree-id="<%- tree.id %>">
                         <div id="tree-<%- tree.id %>" class="buffer-small-left"></div>
                     </div>
                 <% }); %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -1043,34 +1043,34 @@ pim_enrich:
                     label: Edit attributes
                     label_count: "{1}Edit attributes of <span class=\"AknFullPage-title--highlight\">1 product</span>|] 1, Inf [Edit attributes of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
                     description: Only the attributes belonging to the families of the selected products will be edited with the following data for the {{ locale }} locale and the {{ scope }} channel.
-                    no_update: There was no update set for the mass edit. Please select an attribute to update with the new value.
+                    no_update: There was no attribute selected to perform the mass-edit. Please select an attribute.
                 change_family:
                     label: Change family
                     label_count: "{1}Change the family of <span class=\"AknFullPage-title--highlight\">1 product</span>|] 1, Inf [Change the family of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
                     description: The family of the selected products will be changed to the chosen family
                     field: Family
-                    no_update: There is no family selected to add the selected entities to.
+                    no_update: There is no family selected to add the selected products to.
                 add_to_group:
                     label: Add to groups
                     label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to groups|] 1, Inf [Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to groups"
                     description: Select the groups in which to add the selected products
                     field: Groups
-                    no_update: There is no group selected to add the selected entities to.
+                    no_update: There is no group selected to add the selected products to.
                 add_to_category:
                     label: Add to categories
                     label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to categories|] 1, Inf [Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to categories"
                     description: The products will be positioned into following categories, the existing placement is kept.
-                    no_update:  There is no category checked to add the selected entities to.
+                    no_update:  There is no category checked to add the selected products to.
                 move_to_category:
                     label: Move between categories
                     label_count: "{1}Move <span class=\"AknFullPage-title--highlight\">1 product</span> between categories|] 1, Inf [Move <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> between categories"
                     description: The products will be positioned into following categories, the existing placement is lost.
-                    no_update: There is no category checked to move the selected entities to.
+                    no_update: There is no category checked to move the selected products to.
                 remove_from_category:
                     label: Remove from categories
                     label_count: "{1}Remove <span class=\"AknFullPage-title--highlight\">1 product</span> from categories|] 1, Inf [Remove <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> from categories"
                     description: The products will be removed from the following categories.
-                    no_update:  There is no category checked to remove the selected entities from.
+                    no_update:  There is no category checked to remove the selected products from.
                 add_to_existing_product_model:
                     label: Add to an existing product model
                     label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to an existing product model|] 1, Inf [Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to an existing product model"

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -1043,32 +1043,39 @@ pim_enrich:
                     label: Edit attributes
                     label_count: "{1}Edit attributes of <span class=\"AknFullPage-title--highlight\">1 product</span>|] 1, Inf [Edit attributes of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
                     description: Only the attributes belonging to the families of the selected products will be edited with the following data for the {{ locale }} locale and the {{ scope }} channel.
+                    no_update: There was no update set for the mass edit. Please select an attribute to update with the new value.
                 change_family:
                     label: Change family
                     label_count: "{1}Change the family of <span class=\"AknFullPage-title--highlight\">1 product</span>|] 1, Inf [Change the family of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
                     description: The family of the selected products will be changed to the chosen family
                     field: Family
+                    no_update: There is no family selected to add the selected entities to.
                 add_to_group:
                     label: Add to groups
                     label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to groups|] 1, Inf [Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to groups"
                     description: Select the groups in which to add the selected products
                     field: Groups
+                    no_update: There is no group selected to add the selected entities to.
                 add_to_category:
                     label: Add to categories
                     label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to categories|] 1, Inf [Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to categories"
                     description: The products will be positioned into following categories, the existing placement is kept.
+                    no_update:  There is no category checked to add the selected entities to.
                 move_to_category:
                     label: Move between categories
                     label_count: "{1}Move <span class=\"AknFullPage-title--highlight\">1 product</span> between categories|] 1, Inf [Move <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> between categories"
                     description: The products will be positioned into following categories, the existing placement is lost.
+                    no_update: There is no category checked to move the selected entities to.
                 remove_from_category:
                     label: Remove from categories
                     label_count: "{1}Remove <span class=\"AknFullPage-title--highlight\">1 product</span> from categories|] 1, Inf [Remove <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> from categories"
                     description: The products will be removed from the following categories.
+                    no_update:  There is no category checked to remove the selected entities from.
                 add_to_existing_product_model:
                     label: Add to an existing product model
                     label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to an existing product model|] 1, Inf [Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to an existing product model"
                     description: The product model selected will gather the products and allows the enrichment of their common properties.
+                    no_update:  There is no product model selected to perform the mass edit.
         family:
             title: Families bulk action
             confirm: "{1}You are about to update a family with the following information, please confirm.|] 1, Inf [You are about to update {{ itemsCount }} families with the following information, please confirm."

--- a/src/Pim/Bundle/EnrichBundle/Twig/CategoryExtension.php
+++ b/src/Pim/Bundle/EnrichBundle/Twig/CategoryExtension.php
@@ -424,7 +424,7 @@ class CategoryExtension extends \Twig_Extension
 
         // set label in bold
         if ($selectedChildren > 0) {
-            $result['data'] = sprintf('<strong>%s</strong>', $result['data']);
+            $result['data'] = sprintf('%s', $result['data']);
         }
 
         return $result;

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
@@ -1,5 +1,12 @@
 @import '../base/variables';
 
+.jstree-icon(@url) {
+  background: url(@url) 50% 50% no-repeat;
+  height: 22px;
+  width: 22px;
+  margin: 0 5px 0 0;
+}
+
 .jstree.jstree-default {
   padding: 0;
 
@@ -8,13 +15,6 @@
     margin-left: -20px;
     overflow: auto;
     max-height: ~"calc(100vh - 223px)";
-
-    .jstree-icon(@url) {
-      background: url(@url) 50% 50% no-repeat;
-      height: 22px;
-      width: 22px;
-      margin: 0 5px 0 0;
-    }
 
     a {
       height: 35px;
@@ -205,8 +205,17 @@
   }
 }
 
-.root-unselectable .jstree-root > a > .jstree-checkbox {
-  display: none;
+#root-unselectable .jstree-root > a {
+  font-weight: normal;
+  color: @AknDarkBlue !important;
+
+  > .jstree-checkbox {
+    display: none;
+  }
+
+  > .jstree-icon {
+    .jstree-icon("../../images/jstree/icon-folders.svg")
+  }
 }
 
 .AknColumnConfigurator-column .jstree.jstree-default {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/pages/Default.less
@@ -25,7 +25,7 @@
 
   &-flashContainer {
     position: fixed;
-    z-index: 15;
+    z-index: 910;
     bottom: @AknFlashMessagesPadding;
     right: @AknFlashMessagesPadding;
   }
@@ -34,7 +34,7 @@
     width: 100%;
     display: flex;
     flex-direction: column-reverse;
-    z-index: 899;
+    z-index: 999;
   }
 
   &-contentWithColumn {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Prior to this PR, there was missing validation when configuring a mass-edit.

For instance, in a "change family" mass-edit we didn't check if the user actually choose a family before running the mass-edit job.

This PR adds those checks for the mass-edits of categories (remove, move, add), groups, edit attributes, family and add to existing product model.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
