### PR TITLE
PIM-6993: Fix to add pagination in list of users in group and roles

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -7,6 +7,7 @@
 ## Bug fixes
 
 - PIM-7251: Fix history date on all grids (except product grid)
+- PIM-6993: Fix pagination on user grid in role and group edition
 - PIM-7275: Fix regression on group products grid filters
 - PIM-6962: Fix breadcrumb links issue after the save on the edit page
 - PIM-7267: Fix boolean attributes not added to variant product

--- a/features/Pim/Behat/Context/Domain/Enrich/GridPaginationContext.php
+++ b/features/Pim/Behat/Context/Domain/Enrich/GridPaginationContext.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Behat\Context\Domain\Enrich;
 
+use Behat\Mink\Exception\ExpectationException;
 use Pim\Behat\Context\PimContext;
 
 /**
@@ -27,6 +28,24 @@ class GridPaginationContext extends PimContext
         if ($pageNumber !== (int) $num) {
             throw  $this->getMainContext()->createExpectationException(
                 sprintf('Expecting page "%s" got "%s" instead', $num, $pageNumber)
+            );
+        }
+    }
+
+    /**
+     * @param int $num
+     *
+     * @throws ExpectationException
+     *
+     * @Then /^the last page number should be (\d+)$/
+     */
+    public function theLastPageShouldBe($num)
+    {
+        $pageNumber = $this->getCurrentPage()->getCurrentGrid()->getLastPage();
+
+        if ($pageNumber !== (int) $num) {
+            throw  $this->getMainContext()->createExpectationException(
+                sprintf('Expecting last page "%s" got "%s" instead', $num, $pageNumber)
             );
         }
     }

--- a/features/Pim/Behat/Decorator/Grid/PaginationDecorator.php
+++ b/features/Pim/Behat/Decorator/Grid/PaginationDecorator.php
@@ -23,6 +23,7 @@ class PaginationDecorator extends ElementDecorator
         'page size button' => '.page-size .AknActionButton',
         'page size list'   => '.page-size .AknDropdown-menu',
         'page size items'  => '.page-size .AknDropdown-menuLink',
+        'pagination last page'   => '.AknGridToolbar-center .AknGridToolbar-actionButton:last-child span',
     ];
 
     /**
@@ -60,6 +61,17 @@ class PaginationDecorator extends ElementDecorator
     {
         preg_match('/^\d+/', $this->getPageSizeButton()->getHtml(), $size);
         return (int) $size[0];
+    }
+
+    /**
+     * Get the Last page
+     *
+     * @return int
+     */
+    public function getLastPage()
+    {
+        preg_match('/^\d+/', $this->getLastPageButton()->getHtml(), $lastPage);
+        return (int) $lastPage[0];
     }
 
     /**
@@ -114,5 +126,17 @@ class PaginationDecorator extends ElementDecorator
         return $this->spin(function () {
             return $this->find('css', $this->selectors['page size button']);
         }, 'Cannot find the change page size button');
+    }
+
+    /**
+     * Get the button element of the last page
+     *
+     * @return NodeElement
+     */
+    protected function getLastPageButton()
+    {
+        return $this->spin(function () {
+            return $this->find('css', $this->selectors['pagination last page']);
+        }, 'Cannot find the button for the last page');
     }
 }

--- a/features/user/edit_user_group_and_role_assignations.feature
+++ b/features/user/edit_user_group_and_role_assignations.feature
@@ -79,3 +79,40 @@ Feature: Edit a user groups and roles
     When I logout
     And I am logged in as "Peter"
     Then I am on the Role index page
+
+  @jira https://akeneo.atlassian.net/browse/PIM-6993
+  Scenario: Successfully show pagination on users grid in group or role page
+    Given the following users:
+      | username | first_name | last_name | email            | password | enabled | roles              | groups  |
+      | antoine  | Antoine    | Doe       | antoine@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | arnaud   | Arnaud     | Doe       | arnaud@doe.com   | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | pascale  | Pascale    | Doe       | pascale@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | helene   | Helene     | Doe       | helene@doe.com   | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | leopold  | Leopold    | Doe       | leopold@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | bernard  | Bernard    | Doe       | bernard@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | maxime   | Maxime     | Doe       | maxime@doe.com   | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | charles  | Charles    | Doe       | charles@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | aurelie  | Aurelie    | Doe       | aurelie@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | remi     | Remi       | Doe       | remi@doe.com     | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | laurent  | Laurent    | Doe       | laurent@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | alex     | Alex       | Doe       | alex@doe.com     | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | emmy     | Emmy       | Doe       | emmy@doe.com     | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | zoe      | Zoe        | Doe       | zoe@doe.com      | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | carole   | Carole     | Doe       | carole@doe.com   | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | mylene   | Mylene     | Doe       | mylene@doe.com   | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | robin    | Robin      | Doe       | robin@doe.com    | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | yvette   | Yvette     | Doe       | yvette@doe.com   | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | tatiana  | Tatiana    | Doe       | tatiana@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | ulric    | Ulric      | Doe       | ulric@doe.com    | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | amandin  | Amandin    | Doe       | amandin@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | lucifer  | Lucifer    | Doe       | lucifer@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | quentin  | Quentin    | Doe       | quentin@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | xavier   | Xavier     | Doe       | xavier@doe.com   | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | valerie  | Valerie    | Doe       | valerie@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+      | wilbert  | Wilbert    | Doe       | wilbert@doe.com  | psswd    | yes     | ROLE_ADMINISTRATOR | manager |
+    When I edit the "Administrator" Role
+    And I visit the "Users" tab
+    Then the last page number should be 2
+    When I edit the "Manager" UserGroup
+    And I visit the "Users" tab
+    Then the last page number should be 2

--- a/src/Pim/Bundle/UserBundle/Resources/config/datagrid/group-user.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/datagrid/group-user.yml
@@ -57,6 +57,7 @@ datagrid:
         options:
             requireJSModules:
               - oro/datagrid/column-form-listener
+              - oro/datagrid/pagination-input
             columnListener:
                 dataField: id
                 columnName: has_group

--- a/src/Pim/Bundle/UserBundle/Resources/config/datagrid/role-user.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/datagrid/role-user.yml
@@ -58,6 +58,7 @@ datagrid:
         options:
             requireJSModules:
               - oro/datagrid/column-form-listener
+              - oro/datagrid/pagination-input
             columnListener:
                 dataField: id
                 columnName: has_role


### PR DESCRIPTION
**Description**
Only 25 users are displayed in the user grid for Role or Group edition, it seems that the pagination is missing.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
