### PR TITLE
PIM-6999: Fix flash message on edit user

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -11,6 +11,7 @@
 - PIM-6962: Fix breadcrumb links issue after the save on the edit page
 - PIM-7267: Fix boolean attributes not added to variant product
 - PIM-7263: (BACKPORT for 2.0) Create a purging command (`pim:catalog:remove-wrong-boolean-values-on-variant-products`) for boolean values on variant products that should belong to parents
+- PIM-6999: Fix flash message on edit user
 
 ## BC breaks
 

--- a/src/Oro/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Oro/Bundle/UserBundle/Controller/UserController.php
@@ -98,7 +98,7 @@ class UserController extends Controller
         if ($this->get('oro_user.form.handler.user')->process($user)) {
             $this->update($user);
 
-            return new RedirectResponse($route);
+            return new JsonResponse('', 204);
         }
 
         return [

--- a/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
@@ -152,3 +152,11 @@
 </div>
 {% endblock %}
 {% endblock %}
+
+{% block content_data %}
+    <script type="text/javascript">
+        require('pim/page-title').set({'user': '{{ form.vars.value.name }}'});
+
+        window.flashMessages = JSON.parse('{{ app.session.flashbag.all|json_encode()|raw }}');
+    </script>
+{% endblock %}


### PR DESCRIPTION
**Description**
Flash message doesn't appear when edit user.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
