### PR TITLE
PIM-7283: Use a more efficient way to count products

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -13,6 +13,7 @@
 - PIM-7267: Fix boolean attributes not added to variant product
 - PIM-7263: (BACKPORT for 2.0) Create a purging command (`pim:catalog:remove-wrong-boolean-values-on-variant-products`) for boolean values on variant products that should belong to parents
 - PIM-6999: Fix flash message on edit user
+- PIM-7283: Fix slowness on count product in categories for the product grid
 
 ## BC breaks
 

--- a/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
+++ b/src/Akeneo/Component/Classification/Repository/CategoryRepositoryInterface.php
@@ -170,4 +170,22 @@ interface CategoryRepositoryInterface extends
      * @return array Multi-dimensional array representing the tree
      */
     public function getFilledTree(CategoryInterface $root, Collection $categories);
+
+    /**
+     * Products count for a category and its children
+     *
+     * @param CategoryInterface $category      Tree root category
+     *
+     * @return int                             Count of products in this category and his children
+     */
+    public function countProductsWithChildren(CategoryInterface $category): int;
+
+    /**
+     * Products count for a category
+     *
+     * @param CategoryInterface $category      Tree root category
+     *
+     * @return int                             Count of products in this category
+     */
+    public function countProducts(CategoryInterface $category): int;
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/repositories.yml
@@ -66,6 +66,8 @@ services:
         arguments: ['%pim_catalog.entity.category.class%']
         tags:
             - { name: 'pim_repository' }
+        calls:
+            - [setTableNameBuilder, ['@akeneo_storage_utils.doctrine.table_name_builder']]
 
     pim_catalog.repository.channel:
         class: '%pim_catalog.repository.channel.class%'

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/Counter/CategoryProductsCounter.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/Counter/CategoryProductsCounter.php
@@ -41,23 +41,10 @@ class CategoryProductsCounter implements CategoryItemsCounterInterface
      */
     public function getItemsCountInCategory(CategoryInterface $category, $inChildren = false, $inProvided = true)
     {
-        $categoryCodes = $inChildren
-            ? $this->categoryRepository->getAllChildrenCodes($category, $inProvided)
-            : [$category->getCode()];
-
-        $options = [
-            'filters' => [
-                [
-                    'field' => 'categories',
-                    'operator' => Operators::IN_LIST,
-                    'value' => $categoryCodes
-                ]
-            ]
-        ];
-
-        $pqb = $this->pqbFactory->create($options);
-        $items = $pqb->execute();
-
-        return $items->count();
+        if ($inChildren) {
+            return $this->categoryRepository->countProductsWithChildren($category);
+        } else {
+            return $this->categoryRepository->countProducts($category);
+        }
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/Counter/CategoryProductsCounterSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/Counter/CategoryProductsCounterSpec.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace spec\Pim\Bundle\EnrichBundle\Doctrine\Counter;
 
 use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
-use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\CategoryInterface;
-use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
-use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
 
 class CategoryProductsCounterSpec extends ObjectBehavior
 {
@@ -22,53 +19,22 @@ class CategoryProductsCounterSpec extends ObjectBehavior
     }
 
     function it_gets_items_count_in_category_without_children(
-        $pqbFactory,
         $categoryRepository,
-        CategoryInterface $category,
-        ProductQueryBuilderInterface $pqb,
-        CursorInterface $cursor
+        CategoryInterface $category
     ) {
-        $category->getCode()->willReturn('short');
-        $categoryRepository->getAllChildrenCodes($category, true)->shouldNotBeCalled();
 
-        $pqbFactory->create([
-            'filters' => [
-                [
-                    'field' => 'categories',
-                    'operator' => Operators::IN_LIST,
-                    'value' => ['short']
-                ]
-            ]
-        ])->willReturn($pqb);
-        $pqb->execute()->willReturn($cursor);
-        $cursor->count()->willReturn(114);
+        $categoryRepository->countProducts($category)->willReturn(114);
+        $categoryRepository->countProductsWithChildren($category)->shouldNotBeCalled();
 
         $this->getItemsCountInCategory($category, false, true)->shouldReturn(114);
     }
 
     function it_gets_items_count_in_category_with_children(
-        $pqbFactory,
         $categoryRepository,
-        CategoryInterface $category,
-        ProductQueryBuilderInterface $pqb,
-        CursorInterface $cursor
+        CategoryInterface $category
     ) {
-        $category->getCode()->willReturn('short');
-        $categoryRepository->getAllChildrenCodes($category, true)->willReturn([
-            'short', 'short_children', 'short_adults'
-        ]);
-
-        $pqbFactory->create([
-            'filters' => [
-                [
-                    'field' => 'categories',
-                    'operator' => Operators::IN_LIST,
-                    'value' => ['short', 'short_children', 'short_adults']
-                ]
-            ]
-        ])->willReturn($pqb);
-        $pqb->execute()->willReturn($cursor);
-        $cursor->count()->willReturn(1220);
+        $categoryRepository->countProducts($category)->shouldNotBeCalled();
+        $categoryRepository->countProductsWithChildren($category)->willReturn(1220);
 
         $this->getItemsCountInCategory($category, true, true)->shouldReturn(1220);
     }


### PR DESCRIPTION
**Description**

Use a more efficient way to count products for the category tree in product grid.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| EE Pull Request                   | [EE - PR](https://github.com/akeneo/pim-enterprise-dev/pull/3796)
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
