### PR TITLE
Add Yaml::PARSE_CONSTANT to allow usage of PHP-Constants

### DIFF
--- a/src/Akeneo/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
@@ -3,7 +3,6 @@
 namespace Akeneo\Bundle\ElasticsearchBundle\IndexConfiguration;
 
 use Symfony\Component\Yaml\Parser;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Elasticsearch configuration loader. Allows to load "index settings", "mappings" and "aliases".
@@ -49,7 +48,7 @@ class Loader
                 );
             }
 
-            $configuration = $yaml->parse(file_get_contents($configurationFile), Yaml::PARSE_CONSTANT);
+            $configuration = $yaml->parse(file_get_contents($configurationFile));
 
             if (isset($configuration['settings'])) {
                 $settings = array_merge_recursive($settings, $configuration['settings']);

--- a/src/Akeneo/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Bundle\ElasticsearchBundle\IndexConfiguration;
 
 use Symfony\Component\Yaml\Parser;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Elasticsearch configuration loader. Allows to load "index settings", "mappings" and "aliases".
@@ -48,7 +49,7 @@ class Loader
                 );
             }
 
-            $configuration = $yaml->parse(file_get_contents($configurationFile));
+            $configuration = $yaml->parse(file_get_contents($configurationFile), Yaml::PARSE_CONSTANT);
 
             if (isset($configuration['settings'])) {
                 $settings = array_merge_recursive($settings, $configuration['settings']);

--- a/src/Akeneo/Bundle/MeasureBundle/DependencyInjection/AkeneoMeasureExtension.php
+++ b/src/Akeneo/Bundle/MeasureBundle/DependencyInjection/AkeneoMeasureExtension.php
@@ -29,9 +29,9 @@ class AkeneoMeasureExtension extends Extension
             if (is_file($file = dirname($reflection->getFilename()).'/Resources/config/measure.yml')) {
                 // merge measures configs
                 if (empty($measuresConfig)) {
-                    $measuresConfig = Yaml::parse(file_get_contents(realpath($file)), Yaml::PARSE_CONSTANT);
+                    $measuresConfig = Yaml::parse(file_get_contents(realpath($file)));
                 } else {
-                    $entities = Yaml::parse(file_get_contents(realpath($file)), Yaml::PARSE_CONSTANT);
+                    $entities = Yaml::parse(file_get_contents(realpath($file)));
                     foreach ($entities['measures_config'] as $family => $familyConfig) {
                         // merge result with already existing family config to add custom units
                         if (isset($measuresConfig['measures_config'][$family])) {

--- a/src/Akeneo/Bundle/MeasureBundle/DependencyInjection/AkeneoMeasureExtension.php
+++ b/src/Akeneo/Bundle/MeasureBundle/DependencyInjection/AkeneoMeasureExtension.php
@@ -29,9 +29,9 @@ class AkeneoMeasureExtension extends Extension
             if (is_file($file = dirname($reflection->getFilename()).'/Resources/config/measure.yml')) {
                 // merge measures configs
                 if (empty($measuresConfig)) {
-                    $measuresConfig = Yaml::parse(file_get_contents(realpath($file)));
+                    $measuresConfig = Yaml::parse(file_get_contents(realpath($file)), Yaml::PARSE_CONSTANT);
                 } else {
-                    $entities = Yaml::parse(file_get_contents(realpath($file)));
+                    $entities = Yaml::parse(file_get_contents(realpath($file)), Yaml::PARSE_CONSTANT);
                     foreach ($entities['measures_config'] as $family => $familyConfig) {
                         // merge result with already existing family config to add custom units
                         if (isset($measuresConfig['measures_config'][$family])) {

--- a/src/Pim/Bundle/DataGridBundle/DependencyInjection/Compiler/ConfigurationPass.php
+++ b/src/Pim/Bundle/DataGridBundle/DependencyInjection/Compiler/ConfigurationPass.php
@@ -40,7 +40,7 @@ class ConfigurationPass implements CompilerPassInterface
             $files = $this->listDatagridFiles($container);
 
             foreach ($files as $file) {
-                $gridConfig = Yaml::parse(file_get_contents($file->getPathName()), Yaml::PARSE_CONSTANT);
+                $gridConfig = Yaml::parse(file_get_contents($file->getPathName()));
                 if (isset($gridConfig[OroConfigurationPass::ROOT_PARAMETER]) &&
                     is_array($gridConfig[OroConfigurationPass::ROOT_PARAMETER])
                 ) {

--- a/src/Pim/Bundle/DataGridBundle/DependencyInjection/Compiler/ConfigurationPass.php
+++ b/src/Pim/Bundle/DataGridBundle/DependencyInjection/Compiler/ConfigurationPass.php
@@ -40,7 +40,7 @@ class ConfigurationPass implements CompilerPassInterface
             $files = $this->listDatagridFiles($container);
 
             foreach ($files as $file) {
-                $gridConfig = Yaml::parse(file_get_contents($file->getPathName()));
+                $gridConfig = Yaml::parse(file_get_contents($file->getPathName()), Yaml::PARSE_CONSTANT);
                 if (isset($gridConfig[OroConfigurationPass::ROOT_PARAMETER]) &&
                     is_array($gridConfig[OroConfigurationPass::ROOT_PARAMETER])
                 ) {

--- a/src/Pim/Bundle/EnrichBundle/DependencyInjection/Compiler/RegisterFormExtensionsPass.php
+++ b/src/Pim/Bundle/EnrichBundle/DependencyInjection/Compiler/RegisterFormExtensionsPass.php
@@ -35,7 +35,7 @@ class RegisterFormExtensionsPass implements CompilerPassInterface
         $files = $this->listConfigFiles($container);
 
         foreach ($files as $file) {
-            $config = Yaml::parse(file_get_contents($file->getPathName()));
+            $config = Yaml::parse(file_get_contents($file->getPathName()), Yaml::PARSE_CONSTANT);
             if (isset($config['extensions']) && is_array($config['extensions'])) {
                 $extensionConfig = array_replace_recursive($extensionConfig, $config['extensions']);
             }

--- a/src/Pim/Bundle/UIBundle/DependencyInjection/PimUIExtension.php
+++ b/src/Pim/Bundle/UIBundle/DependencyInjection/PimUIExtension.php
@@ -49,7 +49,7 @@ class PimUIExtension extends Extension
         foreach ($bundles as $bundle) {
             $reflection = new \ReflectionClass($bundle);
             if (is_file($file = dirname($reflection->getFilename()) . '/Resources/config/placeholders.yml')) {
-                $placeholderData = Yaml::parse(file_get_contents(realpath($file)));
+                $placeholderData = Yaml::parse(file_get_contents(realpath($file)), Yaml::PARSE_CONSTANT);
                 if (isset($placeholderData['placeholders'])) {
                     $placeholders = array_merge_recursive($placeholders, $placeholderData['placeholders']);
                 }

--- a/src/Pim/Bundle/UIBundle/DependencyInjection/PimUIExtension.php
+++ b/src/Pim/Bundle/UIBundle/DependencyInjection/PimUIExtension.php
@@ -49,7 +49,7 @@ class PimUIExtension extends Extension
         foreach ($bundles as $bundle) {
             $reflection = new \ReflectionClass($bundle);
             if (is_file($file = dirname($reflection->getFilename()) . '/Resources/config/placeholders.yml')) {
-                $placeholderData = Yaml::parse(file_get_contents(realpath($file)), Yaml::PARSE_CONSTANT);
+                $placeholderData = Yaml::parse(file_get_contents(realpath($file)));
                 if (isset($placeholderData['placeholders'])) {
                     $placeholders = array_merge_recursive($placeholders, $placeholderData['placeholders']);
                 }

--- a/src/Pim/Bundle/UserBundle/Twig/AclGroupsExtension.php
+++ b/src/Pim/Bundle/UserBundle/Twig/AclGroupsExtension.php
@@ -69,7 +69,7 @@ class AclGroupsExtension extends \Twig_Extension
             $reflection = new \ReflectionClass($class);
             $path = dirname($reflection->getFileName()) . '/Resources/config/acl_groups.yml';
             if (file_exists($path)) {
-                $config = Yaml::parse(file_get_contents($path), Yaml::PARSE_CONSTANT) + $config;
+                $config = Yaml::parse(file_get_contents($path)) + $config;
             }
         }
 

--- a/src/Pim/Bundle/UserBundle/Twig/AclGroupsExtension.php
+++ b/src/Pim/Bundle/UserBundle/Twig/AclGroupsExtension.php
@@ -69,7 +69,7 @@ class AclGroupsExtension extends \Twig_Extension
             $reflection = new \ReflectionClass($class);
             $path = dirname($reflection->getFileName()) . '/Resources/config/acl_groups.yml';
             if (file_exists($path)) {
-                $config = Yaml::parse(file_get_contents($path)) + $config;
+                $config = Yaml::parse(file_get_contents($path), Yaml::PARSE_CONSTANT) + $config;
             }
         }
 

--- a/src/Pim/Bundle/VersioningBundle/DependencyInjection/PimVersioningExtension.php
+++ b/src/Pim/Bundle/VersioningBundle/DependencyInjection/PimVersioningExtension.php
@@ -33,7 +33,7 @@ class PimVersioningExtension extends Extension
         $loader->load('savers.yml');
 
         $file = __DIR__.'/../Resources/config/pim_versioning_entities.yml';
-        $entities = Yaml::parse(file_get_contents(realpath($file)), Yaml::PARSE_CONSTANT);
+        $entities = Yaml::parse(file_get_contents(realpath($file)));
         $container->setParameter('pim_versioning.versionable_entities', $entities['versionable']);
 
         $this->loadSerializerConfig($configs, $container);

--- a/src/Pim/Bundle/VersioningBundle/DependencyInjection/PimVersioningExtension.php
+++ b/src/Pim/Bundle/VersioningBundle/DependencyInjection/PimVersioningExtension.php
@@ -33,7 +33,7 @@ class PimVersioningExtension extends Extension
         $loader->load('savers.yml');
 
         $file = __DIR__.'/../Resources/config/pim_versioning_entities.yml';
-        $entities = Yaml::parse(file_get_contents(realpath($file)));
+        $entities = Yaml::parse(file_get_contents(realpath($file)), Yaml::PARSE_CONSTANT);
         $container->setParameter('pim_versioning.versionable_entities', $entities['versionable']);
 
         $this->loadSerializerConfig($configs, $container);

--- a/src/Pim/Component/Connector/Reader/File/Yaml/Reader.php
+++ b/src/Pim/Component/Connector/Reader/File/Yaml/Reader.php
@@ -127,7 +127,7 @@ class Reader implements ItemReaderInterface, StepExecutionAwareInterface, Flusha
     {
         $jobParameters = $this->stepExecution->getJobParameters();
         $filePath = $jobParameters->get('filePath');
-        $fileData = current(Yaml::parse(file_get_contents($filePath)));
+        $fileData = current(Yaml::parse(file_get_contents($filePath), Yaml::PARSE_CONSTANT));
         if (null === $fileData) {
             return null;
         }


### PR DESCRIPTION
Hello,
this is a proposal and I would like to hear your feedback:

Symfony introduced the ability to use PHP constants in Yaml files in 3.2 and changed the format in 3.4.

https://symfony.com/blog/new-in-symfony-3-2-php-constants-in-yaml-files

By default the `YamlFileLoader` from the Symfony Dependency-Injection parses files using the `Yaml::PARSE_CONSTANT`-flag and therefore allows using PHP constants:

https://github.com/symfony/dependency-injection/blob/master/Loader/YamlFileLoader.php#L621

When I tried to pass a constant to a form-extension directly in the Yaml definition I noticed this isn't possible in Akeneo because the Files aren't loaded with the regarding flag.

My proposal is to add this flag when loading Yaml to allow the developer to use this functionality.
If I've missed anything or if this would be a breaking change please let me know.
