### PR TITLE
PIM-7043 : Fix to add the last page into the pagination only if the total records is under 10000.

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -73,10 +73,6 @@ stage("Build") {
                     sh "mkdir -m 777 vendor"
 
                     container("php") {
-                        sh "composer require --dev --no-update phpspec/phpspec:~3.4.2"
-                        sh "composer require --dev --no-update phpunit/phpunit:~5.7.22"
-                        sh "composer require --dev --no-update sebastian/exporter:~2.0.0"
-                        sh "composer require --dev --no-update liuggio/fastest:~1.4.4"
                         sh "composer update --ansi --optimize-autoloader --no-interaction --no-progress --prefer-dist --no-scripts --ignore-platform-reqs --no-suggest"
 
                         // Required to avoid permission error when "deleteDir()"

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/pagination-input.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/pagination-input.js
@@ -115,6 +115,7 @@ define(
         getPages() {
             const collection = this.collection;
             const state = collection.state;
+            const max_rescore_window = 10000;
 
             let lastPage = state.lastPage ? state.lastPage : state.firstPage;
             lastPage = state.firstPage === 0 ? lastPage : lastPage - 1;
@@ -128,7 +129,10 @@ define(
             for (let i = windowStart; i < windowEnd; i++) {
                 ids.push(i);
             }
-            ids.push(lastPage);
+
+            if (state.totalRecords < max_rescore_window) {
+                ids.push(lastPage);
+            }
 
             return _.uniq(ids);
         },


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When we have more than 10 000 products on the product grid, we couldn't access to the last page.  We got an Elasticsearch error because it has a limitation of 10000 records set by the "max_rescore_window" parameter.

So to solve this problem, we decided to remove the button to access to the last page in the pagination. We know that it doesn't solve completely the problem. The client will get the problem if he want to display the 10000th product and more. However,  he has to go at least on the 400th page to see this error. So we admit that he will probably make a search or filter these products instead to use the pagination.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | Todo
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
