### PR TITLE
PIM-7281: Fix inappropriate calls to the cache clearer

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,3 +1,9 @@
+# 2.2.x
+
+## Bug fixes
+
+- PIM-7281: Fix inappropriate calls to the cache clearer
+
 # 2.2.3 (2018-04-12)
 
 ## BC Breaks

--- a/src/Pim/Bundle/EnrichBundle/Connector/Writer/MassEdit/ProductAndProductModelWriter.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Writer/MassEdit/ProductAndProductModelWriter.php
@@ -44,6 +44,8 @@ class ProductAndProductModelWriter implements ItemWriterInterface, StepExecution
      * @param BulkSaverInterface            $productSaver
      * @param BulkSaverInterface            $productModelSaver
      * @param EntityManagerClearerInterface $cacheClearer
+     *
+     * @todo @merge On master : remove $cacheClearer. It is not used anymore. The cache is now cleared in a dedicated subscriber.
      */
     public function __construct(
         VersionManager $versionManager,
@@ -75,7 +77,6 @@ class ProductAndProductModelWriter implements ItemWriterInterface, StepExecution
 
         $this->productSaver->saveAll($products);
         $this->productModelSaver->saveAll($productModels);
-        $this->cacheClearer->clear();
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Writer/MassEdit/ProductAndProductModelWriterSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Writer/MassEdit/ProductAndProductModelWriterSpec.php
@@ -12,7 +12,6 @@ use PhpSpec\ObjectBehavior;
 use Pim\Bundle\EnrichBundle\Connector\Writer\MassEdit\ProductAndProductModelWriter;
 use Pim\Bundle\VersioningBundle\Manager\VersionManager;
 use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Catalog\Model\ProductModel;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Prophecy\Argument;
 
@@ -95,24 +94,6 @@ class ProductAndProductModelWriterSpec extends ObjectBehavior
 
         $stepExecution->incrementSummaryInfo('create')->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalledTimes(2);
-
-        $this->write($items);
-    }
-
-    function it_clears_cache(
-        $cacheClearer,
-        $stepExecution,
-        ProductInterface $product,
-        ProductModelInterface $productModel,
-        JobParameters $jobParameters
-    ) {
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('realTimeVersioning')->willReturn(true);
-
-        $items = [$product, $productModel];
-
-        $stepExecution->incrementSummaryInfo('create')->shouldBeCalled();
-        $cacheClearer->clear()->shouldBeCalled();
 
         $this->write($items);
     }

--- a/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Normalization/ProductProcessor.php
@@ -55,6 +55,8 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
      * @param BulkMediaFetcher                      $mediaFetcher
      * @param EntityWithFamilyValuesFillerInterface $productValuesFiller
      * @param EntityManagerClearerInterface         $cacheClearer
+     *
+     * @todo @merge On master : remove $cacheClearer. It is not used anymore. The cache is now cleared in a dedicated subscriber.
      */
     public function __construct(
         NormalizerInterface $normalizer,
@@ -115,8 +117,6 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
                 ARRAY_FILTER_USE_KEY
             );
         }
-
-        $this->cacheClearer->clear();
 
         return $productStandard;
     }

--- a/src/Pim/Component/Connector/Writer/Database/ProductWriter.php
+++ b/src/Pim/Component/Connector/Writer/Database/ProductWriter.php
@@ -38,6 +38,8 @@ class ProductWriter implements ItemWriterInterface, StepExecutionAwareInterface,
      * @param VersionManager                $versionManager
      * @param BulkSaverInterface            $productSaver
      * @param EntityManagerClearerInterface $cacheClearer
+     *
+     * @todo @merge On master : remove $cacheClearer. It is not used anymore.
      */
     public function __construct(
         VersionManager $versionManager,

--- a/src/Pim/Component/Connector/spec/Processor/Normalization/ProductProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Normalization/ProductProcessorSpec.php
@@ -113,8 +113,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $mediaFetcher->fetchAll(Argument::cetera())->shouldNotBeCalled();
         $mediaFetcher->getErrors()->shouldNotBeCalled();
 
-        $clearer->clear()->shouldBeCalled();
-
         $this->process($product)->shouldReturn([
             'enabled'    => true,
             'categories' => ['cat1', 'cat2'],
@@ -195,8 +193,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $mediaFetcher->getErrors()->willReturn([]);
 
         $this->process($product)->shouldReturn($productStandard);
-
-        $clearer->clear()->shouldBeCalled();
     }
 
     function it_throws_an_exception_if_media_of_product_is_not_found(
@@ -272,7 +268,5 @@ class ProductProcessorSpec extends ObjectBehavior
         )->shouldBeCalled();
 
         $this->process($product)->shouldReturn($productStandard);
-
-        $clearer->clear()->shouldBeCalled();
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The implementation of the "cache clearer" has been changed, and now the Doctrine UoW is cleared. This as resulted to the bug described in PIM-7281 : the product models exports are broken.

When 2 product models with the same variant family are exported, an error is thrown. The UoW is cleared between each product write, and given that the variant family property in a product model is lazy loaded, Doctrine can't load the variant family of the second product model. 

Since the PR #7815 the calls to clear the cache during jobs executions are done in a subscriber that listen to a new event dispatched from `ItemStep` between each batch. So the fix is just to remove the calls to `EntityManagerClearerInterface::clear` that are still done inside the writers.

Inside a job execution, the cache clearing must be done by batch and not by item, specially when the items are loaded by Doctrine.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
