### PR TITLE
PIM-7299: Add pagination for family variants on several screens

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,11 @@
 
 - PIM-7300: fix the status filter on product grid for products with parent.
 - PIM-7282: Add validation on the code value during the attribute creation to prohibit the "entity_type" value.
+- PIM-7299: Add pagination for family variants on several screens
+
+## BC Breaks
+
+- Changes the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\FamilyVariant` to add `Akeneo\Component\StorageUtils\Repository\SearchableRepositoryInterface`
 
 # 2.0.21 (2018-04-10)
 

--- a/features/Context/Page/Base/Form.php
+++ b/features/Context/Page/Base/Form.php
@@ -998,4 +998,27 @@ class Form extends Base
 
         return !$this->getClosest($button, 'select2-container')->hasClass('select2-container-disabled');
     }
+
+    /**
+     * Finds a select2 field identified by its label
+     *
+     * @param string $label
+     * @return mixed|\Pim\Behat\Decorator\ElementDecorator
+     * @throws TimeoutException
+     */
+    public function findSelect2Field($label)
+    {
+        $select2 = $this->spin(function () use ($label) {
+            $labelElement = $this->extractLabelElement($label);
+            $container = $this->getClosest($labelElement, 'AknFieldContainer');
+            if (null === $container) {
+                return false;
+            }
+
+            return $container->find('css', '.select2-container');
+        }, 'Impossible to find the select2 field');
+        $select2 = $this->decorate($select2, [Select2Decorator::class]);
+
+        return $select2;
+    }
 }

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -2805,27 +2805,17 @@ class WebUser extends PimContext
     /**
      * @param string $field
      *
-     * @When /^I open the (.*) select2 field$/
+     * @When /^I open the (.*) select field$/
      */
-    public function iOpenTheSelect2Field($field)
+    public function iOpenTheSelectField($field)
     {
         $this->getCurrentPage()->findSelect2Field($field)->open();
     }
 
     /**
-     * @param string $field
-     *
-     * @When /^I scroll down the (.*) select2 options$/
+     * @When /^I search "([^"]*)" in the (.*) select field$/
      */
-    public function iScrollDownTheSelect2Options($field)
-    {
-        $this->getCurrentPage()->findSelect2Field($field)->scrollDown();
-    }
-
-    /**
-     * @When /^I search "([^"]*)" in the (.*) select2 field$/
-     */
-    public function iSearchTheSelect2Field($search, $field)
+    public function iSearchTheSelectField($search, $field)
     {
         $this->getCurrentPage()->findSelect2Field($field)->search($search);
     }

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -489,7 +489,7 @@ class WebUser extends PimContext
     public function iConfirmThe()
     {
         $this->getCurrentPage()->confirmDialog();
-        
+
         $this->wait();
     }
 
@@ -2800,6 +2800,34 @@ class WebUser extends PimContext
                 throw $this->createExpectationException('Status switcher should be visible');
             }
         }
+    }
+
+    /**
+     * @param string $field
+     *
+     * @When /^I open the (.*) select2 field$/
+     */
+    public function iOpenTheSelect2Field($field)
+    {
+        $this->getCurrentPage()->findSelect2Field($field)->open();
+    }
+
+    /**
+     * @param string $field
+     *
+     * @When /^I scroll down the (.*) select2 options$/
+     */
+    public function iScrollDownTheSelect2Options($field)
+    {
+        $this->getCurrentPage()->findSelect2Field($field)->scrollDown();
+    }
+
+    /**
+     * @When /^I search "([^"]*)" in the (.*) select2 field$/
+     */
+    public function iSearchTheSelect2Field($search, $field)
+    {
+        $this->getCurrentPage()->findSelect2Field($field)->search($search);
     }
 
     /**

--- a/features/Pim/Behat/Decorator/Field/Select2Decorator.php
+++ b/features/Pim/Behat/Decorator/Field/Select2Decorator.php
@@ -244,6 +244,28 @@ class Select2Decorator extends ElementDecorator
     }
 
     /**
+     * Scrolls down the select2 options; this may trigger a pagination (infinite scroll)
+     */
+    public function scrollDown()
+    {
+        $widget = $this->getWidget();
+        $widgetClasses = '.' . str_replace(' ', '.', $widget->getAttribute('class'));
+
+        $scrollHeight = $this->getSession()->evaluateScript(sprintf(
+            'return $(\'%s .select2-results:visible\').prop(\'scrollHeight\');',
+            $widgetClasses
+        ));
+
+        $this->getSession()->executeScript(
+            sprintf(
+                '$(\'%s .select2-results\').scrollTop(%d);',
+                $widgetClasses,
+                $scrollHeight
+            )
+        );
+    }
+
+    /**
      * Get the current value for the Select2
      *
      * @return string

--- a/features/Pim/Behat/Decorator/Field/Select2Decorator.php
+++ b/features/Pim/Behat/Decorator/Field/Select2Decorator.php
@@ -244,28 +244,6 @@ class Select2Decorator extends ElementDecorator
     }
 
     /**
-     * Scrolls down the select2 options; this may trigger a pagination (infinite scroll)
-     */
-    public function scrollDown()
-    {
-        $widget = $this->getWidget();
-        $widgetClasses = '.' . str_replace(' ', '.', $widget->getAttribute('class'));
-
-        $scrollHeight = $this->getSession()->evaluateScript(sprintf(
-            'return $(\'%s .select2-results:visible\').prop(\'scrollHeight\');',
-            $widgetClasses
-        ));
-
-        $this->getSession()->executeScript(
-            sprintf(
-                '$(\'%s .select2-results\').scrollTop(%d);',
-                $widgetClasses,
-                $scrollHeight
-            )
-        );
-    }
-
-    /**
      * Get the current value for the Select2
      *
      * @return string

--- a/features/category/display_category_history.feature
+++ b/features/category/display_category_history.feature
@@ -33,7 +33,7 @@ Feature: Display the category history
       | 1       | label-en_US | Book category    | now  |
       | 2       | label-en_US | My book category | now  |
 
-  @javascript @jira https://akeneo.atlassian.net/browse/PIM-7279
+  @ce @jira https://akeneo.atlassian.net/browse/PIM-7279
   Scenario: Prevent javascript execution from history tab while updating category label translations
     Given a "default" catalog configuration
     And I am logged in as "Julia"

--- a/features/family/list_family_variant.feature
+++ b/features/family/list_family_variant.feature
@@ -23,8 +23,8 @@ Feature: list family variant
   @jira https://akeneo.atlassian.net/browse/PIM-7299
   Scenario: Successfully show pagination on family variant grid in family edit form
     Given the following family:
-      | code                      | label-en_US       | attributes      |
-      | family_with_many_variants | Many variants     | sku,color,image |
+      | code                      | label-en_US   | attributes      |
+      | family_with_many_variants | Many variants | sku,color,image |
     And the following family variants:
       | code       | family                    | variant-axes_1 | variant-attributes_1 |
       | variant_1  | family_with_many_variants | color          | sku,image            |
@@ -57,7 +57,7 @@ Feature: list family variant
       | variant_28 | family_with_many_variants | color          | sku,image            |
       | variant_29 | family_with_many_variants | color          | sku,image            |
       | variant_30 | family_with_many_variants | color          | sku,image            |
-    When I am on the "Many variants" family page
+    When I am on the "family_with_many_variants" family page
     And I visit the "Variants" tab
     Then the grid should contain 25 elements
     And the last page number should be 2

--- a/features/family/list_family_variant.feature
+++ b/features/family/list_family_variant.feature
@@ -19,3 +19,45 @@ Feature: list family variant
     Then the grid should contain 3 elements
     And I should not see the text "Clothing by material and size"
     And I should see the text "Color, Size"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7299
+  Scenario: Successfully show pagination on family variant grid in family edit form
+    Given the following family:
+      | code                      | label-en_US       | attributes      |
+      | family_with_many_variants | Many variants     | sku,color,image |
+    And the following family variants:
+      | code       | family                    | variant-axes_1 | variant-attributes_1 |
+      | variant_1  | family_with_many_variants | color          | sku,image            |
+      | variant_2  | family_with_many_variants | color          | sku,image            |
+      | variant_3  | family_with_many_variants | color          | sku,image            |
+      | variant_4  | family_with_many_variants | color          | sku,image            |
+      | variant_5  | family_with_many_variants | color          | sku,image            |
+      | variant_6  | family_with_many_variants | color          | sku,image            |
+      | variant_7  | family_with_many_variants | color          | sku,image            |
+      | variant_8  | family_with_many_variants | color          | sku,image            |
+      | variant_9  | family_with_many_variants | color          | sku,image            |
+      | variant_10 | family_with_many_variants | color          | sku,image            |
+      | variant_11 | family_with_many_variants | color          | sku,image            |
+      | variant_12 | family_with_many_variants | color          | sku,image            |
+      | variant_13 | family_with_many_variants | color          | sku,image            |
+      | variant_14 | family_with_many_variants | color          | sku,image            |
+      | variant_15 | family_with_many_variants | color          | sku,image            |
+      | variant_16 | family_with_many_variants | color          | sku,image            |
+      | variant_17 | family_with_many_variants | color          | sku,image            |
+      | variant_18 | family_with_many_variants | color          | sku,image            |
+      | variant_19 | family_with_many_variants | color          | sku,image            |
+      | variant_20 | family_with_many_variants | color          | sku,image            |
+      | variant_21 | family_with_many_variants | color          | sku,image            |
+      | variant_22 | family_with_many_variants | color          | sku,image            |
+      | variant_23 | family_with_many_variants | color          | sku,image            |
+      | variant_24 | family_with_many_variants | color          | sku,image            |
+      | variant_25 | family_with_many_variants | color          | sku,image            |
+      | variant_26 | family_with_many_variants | color          | sku,image            |
+      | variant_27 | family_with_many_variants | color          | sku,image            |
+      | variant_28 | family_with_many_variants | color          | sku,image            |
+      | variant_29 | family_with_many_variants | color          | sku,image            |
+      | variant_30 | family_with_many_variants | color          | sku,image            |
+    When I am on the "Many variants" family page
+    And I visit the "Variants" tab
+    Then the grid should contain 25 elements
+    And the last page number should be 2

--- a/features/family/remove_attribute_from_a_family.feature
+++ b/features/family/remove_attribute_from_a_family.feature
@@ -24,13 +24,13 @@ Feature: Remove attribute from a family
     And I visit the "Attributes" tab
     When I remove the "material" attribute
     And I save the family
-    And I should not see the text "There are unsaved changes."
-    Then I should see the flash message "Attribute successfully removed from the family"
+    Then I should not see the text "There are unsaved changes."
+    And I should see the flash message "Attribute successfully removed from the family"
     When I am on the "model-braided-hat" product model page
-    And I should see the text "Supplier"
-    And I should not see the text "Material"
-    And I am on the "braided-hat-m" product page
-    And I should not see the text "Material"
+    Then I should see the text "Supplier"
+    But I should not see the text "Material"
+    When I am on the "braided-hat-m" product page
+    Then I should not see the Material field
 
   Scenario: Impossible to remove some attributes from a family (used as label, used as image, used as axis)
     Given I am on the "shoes" family page

--- a/features/product-model/create_product_model.feature
+++ b/features/product-model/create_product_model.feature
@@ -130,7 +130,7 @@ Feature: Create a product model
     Then I should see the SKU and Family fields
 
   @jira https://akeneo.atlassian.net/browse/PIM-7299
-  Scenario: Search and paginate family variants in the select2 field
+  Scenario: Search family variants in the product model create form
     Given the following family:
       | code                      | label-en_US   | attributes      |
       | family_with_many_variants | Many variants | sku,color,image |
@@ -169,11 +169,8 @@ Feature: Create a product model
     When I create a product model
     And I fill in the following information in the popin:
       | Family | Many variants |
-    And I open the Variant select2 field
+    And I open the Variant select field
     Then I should see 20 items in the autocomplete
-    When I scroll down the Variant select2 options
-    And I wait 1 seconds
-    Then I should see 30 items in the autocomplete
-    When I search "1" in the Variant select2 field
-    And I wait 1 seconds
-    Then I should see 12 items in the autocomplete
+    And I should not see the choices [variant_23] and [variant_30] in Variant
+    When I search "3" in the Variant select field
+    Then I should see the choices [variant_3], [variant_13], [variant_23] and [variant_30] in Variant

--- a/features/product-model/create_product_model.feature
+++ b/features/product-model/create_product_model.feature
@@ -128,3 +128,52 @@ Feature: Create a product model
     And I am on the products grid
     And I press the "Create product and product models" button
     Then I should see the SKU and Family fields
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7299
+  Scenario: Search and paginate family variants in the select2 field
+    Given the following family:
+      | code                      | label-en_US   | attributes      |
+      | family_with_many_variants | Many variants | sku,color,image |
+    And the following family variants:
+      | code       | family                    | variant-axes_1 | variant-attributes_1 |
+      | variant_1  | family_with_many_variants | color          | sku,image            |
+      | variant_2  | family_with_many_variants | color          | sku,image            |
+      | variant_3  | family_with_many_variants | color          | sku,image            |
+      | variant_4  | family_with_many_variants | color          | sku,image            |
+      | variant_5  | family_with_many_variants | color          | sku,image            |
+      | variant_6  | family_with_many_variants | color          | sku,image            |
+      | variant_7  | family_with_many_variants | color          | sku,image            |
+      | variant_8  | family_with_many_variants | color          | sku,image            |
+      | variant_9  | family_with_many_variants | color          | sku,image            |
+      | variant_10 | family_with_many_variants | color          | sku,image            |
+      | variant_11 | family_with_many_variants | color          | sku,image            |
+      | variant_12 | family_with_many_variants | color          | sku,image            |
+      | variant_13 | family_with_many_variants | color          | sku,image            |
+      | variant_14 | family_with_many_variants | color          | sku,image            |
+      | variant_15 | family_with_many_variants | color          | sku,image            |
+      | variant_16 | family_with_many_variants | color          | sku,image            |
+      | variant_17 | family_with_many_variants | color          | sku,image            |
+      | variant_18 | family_with_many_variants | color          | sku,image            |
+      | variant_19 | family_with_many_variants | color          | sku,image            |
+      | variant_20 | family_with_many_variants | color          | sku,image            |
+      | variant_21 | family_with_many_variants | color          | sku,image            |
+      | variant_22 | family_with_many_variants | color          | sku,image            |
+      | variant_23 | family_with_many_variants | color          | sku,image            |
+      | variant_24 | family_with_many_variants | color          | sku,image            |
+      | variant_25 | family_with_many_variants | color          | sku,image            |
+      | variant_26 | family_with_many_variants | color          | sku,image            |
+      | variant_27 | family_with_many_variants | color          | sku,image            |
+      | variant_28 | family_with_many_variants | color          | sku,image            |
+      | variant_29 | family_with_many_variants | color          | sku,image            |
+      | variant_30 | family_with_many_variants | color          | sku,image            |
+    When I create a product model
+    And I fill in the following information in the popin:
+      | Family | Many variants |
+    And I open the Variant select2 field
+    Then I should see 20 items in the autocomplete
+    When I scroll down the Variant select2 options
+    And I wait 1 seconds
+    Then I should see 30 items in the autocomplete
+    When I search "1" in the Variant select2 field
+    And I wait 1 seconds
+    Then I should see 12 items in the autocomplete

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilyVariantSearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilyVariantSearchableRepository.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository;
+
+use Akeneo\Component\StorageUtils\Repository\SearchableRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyVariantSearchableRepository implements SearchableRepositoryInterface
+{
+    /** @var EntityManagerInterface */
+    protected $entityManager;
+
+    /** @var string */
+    protected $entityName;
+
+    /**
+     * @param EntityManagerInterface $entityManager
+     * @param string $entityName
+     */
+    public function __construct(EntityManagerInterface $entityManager, $entityName)
+    {
+        $this->entityManager = $entityManager;
+        $this->entityName = $entityName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findBySearch($search = null, array $options = [])
+    {
+        $qb = $this->entityManager->createQueryBuilder()->select('fv')->from($this->entityName, 'fv');
+
+        if (null !== $search && '' !== $search) {
+            $qb->where('fv.code like :search')->setParameter('search', '%' . $search . '%');
+            if (isset($options['catalogLocale'])) {
+                $qb->leftJoin('fv.translations', 'fvt');
+                $qb->orWhere('fvt.label like :search AND fvt.locale = :locale');
+                $qb->setParameter('search', '%' . $search . '%');
+                $qb->setParameter('locale', $options['catalogLocale']);
+            }
+        }
+
+        $qb = $this->applyQueryOptions($qb, $options);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @param QueryBuilder $qb
+     * @param array $options
+     *
+     * @return QueryBuilder
+     */
+    protected function applyQueryOptions(QueryBuilder $qb, array $options)
+    {
+        if (isset($options['familyId'])) {
+            $qb->andWhere('fv.family = :familyId');
+            $qb->setParameter('familyId', $options['familyId']);
+        }
+
+        if (isset($options['identifiers']) && is_array($options['identifiers']) && !empty($options['identifiers'])) {
+            $qb->andWhere('f.code in (:codes)');
+            $qb->setParameter('codes', $options['identifiers']);
+        }
+
+        if (isset($options['limit'])) {
+            $qb->setMaxResults((int)$options['limit']);
+            if (isset($options['page'])) {
+                $qb->setFirstResult((int)$options['limit'] * ((int)$options['page'] - 1));
+            }
+        }
+
+        return $qb;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -297,6 +297,7 @@ services:
             - '@validator'
             - '@pim_enrich.normalizer.violation'
             - '@pim_catalog.saver.family_variant'
+            - '@pim_enrich.repository.family_variant.search'
 
     pim_enrich.controller.rest.form_extension:
         class: '%pim_enrich.controller.rest.form_extension.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/family_variant.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/family_variant.yml
@@ -2,6 +2,8 @@ datagrid:
     family-variant-grid:
         options:
             entityHint: family_variant
+            requireJSModules:
+                - oro/datagrid/pagination-input
             locale_parameter: localeCode
             manageFilters: false
         source:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/mass_edit/add_to_existing_product_model.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/mass_edit/add_to_existing_product_model.yml
@@ -20,7 +20,7 @@ extensions:
             fieldName: family_variant
             label: pim_enrich.form.product_model.family_variant
             required: true
-            loadUrl: pim_datagrid_load
+            loadUrl: pim_enrich_family_variant_rest_index
             placeholder: pim_enrich.entity.product.create_popin.labels.family_variant
 
     pim-mass-product-edit-configure-add-to-existing-product-model-product-model:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/create.yml
@@ -42,5 +42,5 @@ extensions:
             fieldName: family_variant
             label: pim_enrich.form.product_model.family_variant
             required: true
-            loadUrl: pim_datagrid_load
+            loadUrl: pim_enrich_family_variant_rest_index
             placeholder: pim_enrich.entity.product.create_popin.labels.family_variant

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/repositories.yml
@@ -1,6 +1,7 @@
 parameters:
     ## Searchable repositories
     pim_enrich.repository.family.search.class:           Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository\FamilySearchableRepository
+    pim_enrich.repository.family_variant.search.class:   Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository\FamilyVariantSearchableRepository
     pim_enrich.repository.attribute.search.class:        Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository\AttributeSearchableRepository
     pim_enrich.repository.attribute_option.search.class: Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository\AttributeOptionSearchableRepository
 
@@ -29,6 +30,12 @@ services:
         arguments:
             - '@doctrine.orm.entity_manager'
             - '%pim_catalog.entity.family.class%'
+
+    pim_enrich.repository.family_variant.search:
+        class: '%pim_enrich.repository.family_variant.search.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '%pim_catalog.entity.family_variant.class%'
 
     pim_enrich.repository.attribute.search:
         class: '%pim_enrich.repository.attribute.search.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/family_variant.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/family_variant.yml
@@ -1,3 +1,8 @@
+pim_enrich_family_variant_rest_index:
+    path: /rest
+    defaults: { _controller: pim_enrich.controller.rest.family_variant:indexAction }
+    methods: [GET]
+
 pim_enrich_family_variant_rest_create:
     path: /rest
     defaults: { _controller: pim_enrich.controller.rest.family_variant:createAction }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/creation/variant.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/creation/variant.js
@@ -61,9 +61,7 @@ function (
                 if (this.getFormData().family) {
                     this.getFamilyIdFromCode(this.getFormData().family).then((familyId) => {
                         this.setChoiceUrl(Routing.generate(this.config.loadUrl, {
-                            alias: 'family-variant-grid',
-                            'family-variant-grid[family_id]': familyId,
-                            'family-variant-grid[localeCode]': UserContext.get('catalogLocale')
+                            'family_id': familyId
                         }));
                         this.readOnly = false;
                         this.setData({[this.fieldName]: null});
@@ -103,29 +101,6 @@ function (
             return FetcherRegistry.getFetcher('family-variant')
                 .fetch(code)
                 .then(familyVariant => familyVariant.labels[UserContext.get('catalogLocale')]);
-        },
-
-        /**
-         * {@inheritdoc}
-         */
-        select2Results(response) {
-            const responseJSON = JSON.parse(response.data);
-            const variantData = responseJSON.data;
-
-            return {
-                more: this.resultsPerPage === Object.keys(variantData).length,
-                results: variantData.map(item => this.convertBackendItem(item))
-            };
-        },
-
-        /**
-         * {@inheritdoc}
-         */
-        convertBackendItem(item) {
-            return {
-                id: item.familyVariantCode,
-                text: item.label
-            };
         },
 
         /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR adds a missing pagination on the Family variant grid in the family edit form, and fixes the search/pagination in the `select2` on the 'create product model' form, as well as the 'add to existing product model' mass action form

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
