### PR TITLE
Introduce the AssociationAwareInterface

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,3 +7,8 @@
 ## Technical improvements
 
 - Add typescript support
+
+## BC Breaks
+
+- Remove methods `getAssociations`, `setAssociations`, `addAssociation`, `removeAssociation`, `getAssociationForType` and `getAssociationForTypeCode` from `Pim\Component\Catalog\Model\ProductInterface`. These methods are now in the `Pim\Component\Catalog\Model\AssociationAwareInterface`.
+- Rename `Pim\Component\Catalog\Model\AssociationInterface` to `Pim\Component\Catalog\Model\ProductAssociationInterface`

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -11,4 +11,6 @@
 ## BC Breaks
 
 - Remove methods `getAssociations`, `setAssociations`, `addAssociation`, `removeAssociation`, `getAssociationForType` and `getAssociationForTypeCode` from `Pim\Component\Catalog\Model\ProductInterface`. These methods are now in the `Pim\Component\Catalog\Model\AssociationAwareInterface`.
-- Rename `Pim\Component\Catalog\Model\AssociationInterface` to `Pim\Component\Catalog\Model\ProductAssociationInterface`
+- Change signature of `Pim\Component\Catalog\Builder\ProductBuilderInterface::addMissingAssociations` which now accepts a `Pim\Component\Catalog\Model\AssociationAwareInterface` instead of a `Pim\Component\Catalog\Model\ProductInterface`
+- Change signature of `Pim\Component\Catalog\Repository\AssociationTypeRepositoryInterface::findMissingAssociationTypes` which now accepts a `Pim\Component\Catalog\Model\AssociationAwareInterface` instead of a `Pim\Component\Catalog\Model\ProductInterface`
+- Change signature of `Pim\Component\Catalog\Model\AssociationInterface::setOwner` which now accepts a `Pim\Component\Catalog\Model\AssociationAwareInterface` instead of a `Pim\Component\Catalog\Model\ProductInterface`

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -30,11 +30,10 @@ use Pim\Bundle\DataGridBundle\Entity\DatagridView;
 use Pim\Bundle\UserBundle\Entity\User;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
-use Pim\Component\Catalog\Model\Association;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
-use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Model\ProductAssociation;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
@@ -1984,7 +1983,7 @@ class FixturesContext extends BaseFixturesContext
                     ->get('pim_catalog.repository.association_type')
                     ->findOneBy(['code' => $row['type']]);
 
-                $association = new Association();
+                $association = new ProductAssociation();
                 $association->setAssociationType($associationType);
                 $owner->addAssociation($association);
             }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
@@ -6,7 +6,7 @@ namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
 use PHPUnit\Framework\Assert;
-use Pim\Component\Catalog\Model\Association;
+use Pim\Component\Catalog\Model\ProductAssociation;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -19,7 +19,7 @@ class GetVariantProductIntegration extends AbstractProductTestCase
     {
         $product = $this->get('pim_catalog.repository.product')->findoneByIdentifier('biker-jacket-leather-xxs');
 
-        $association = new Association();
+        $association = new ProductAssociation();
         $association->setAssociationType(
             $this->get('pim_catalog.repository.association_type')->findoneByIdentifier('PACK')
         );

--- a/src/Pim/Bundle/CatalogBundle/DependencyInjection/Compiler/ResolveDoctrineTargetModelPass.php
+++ b/src/Pim/Bundle/CatalogBundle/DependencyInjection/Compiler/ResolveDoctrineTargetModelPass.php
@@ -20,7 +20,7 @@ class ResolveDoctrineTargetModelPass extends AbstractResolveDoctrineTargetModelP
     {
         return [
             'Symfony\Component\Security\Core\User\UserInterface'             => 'oro_user.entity.class',
-            'Pim\Component\Catalog\Model\AssociationInterface'               => 'pim_catalog.entity.association.class',
+            'Pim\Component\Catalog\Model\ProductAssociationInterface'        => 'pim_catalog.entity.association.class',
             'Pim\Component\Catalog\Model\AssociationTypeInterface'           => 'pim_catalog.entity.association_type.class',
             'Pim\Component\Catalog\Model\AttributeInterface'                 => 'pim_catalog.entity.attribute.class',
             'Pim\Component\Catalog\Model\AttributeOptionInterface'           => 'pim_catalog.entity.attribute_option.class',

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AssociationTypeRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/AssociationTypeRepository.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository;
 
 use Doctrine\ORM\EntityRepository;
-use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\AssociationAwareInterface;
 use Pim\Component\Catalog\Repository\AssociationTypeRepositoryInterface;
 
 /**
@@ -18,11 +18,11 @@ class AssociationTypeRepository extends EntityRepository implements AssociationT
     /**
      * {@inheritdoc}
      */
-    public function findMissingAssociationTypes(ProductInterface $product)
+    public function findMissingAssociationTypes(AssociationAwareInterface $entity)
     {
         $qb = $this->createQueryBuilder('a');
 
-        if ($associations = $product->getAssociations()) {
+        if ($associations = $entity->getAssociations()) {
             $associationTypeIds = $associations->map(
                 function ($association) {
                     return $association->getAssociationType()->getId();

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/entities.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/entities.yml
@@ -3,7 +3,7 @@ parameters:
     pim_catalog.entity.product.class:                      Pim\Component\Catalog\Model\Product
     pim_catalog.entity.product_model.class:                Pim\Component\Catalog\Model\ProductModel
     pim_catalog.entity.product_unique_data.class:          Pim\Component\Catalog\Model\ProductUniqueData
-    pim_catalog.entity.association.class:                  Pim\Component\Catalog\Model\Association
+    pim_catalog.entity.association.class:                  Pim\Component\Catalog\Model\ProductAssociation
     pim_catalog.entity.completeness.class:                 Pim\Component\Catalog\Model\Completeness
     pim_catalog.entity.association_type.class:             Pim\Bundle\CatalogBundle\Entity\AssociationType
     pim_catalog.entity.association_type_translation.class: Pim\Bundle\CatalogBundle\Entity\AssociationTypeTranslation

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.orm.yml
@@ -72,7 +72,7 @@ Pim\Component\Catalog\Model\Product:
                         onDelete: CASCADE
     oneToMany:
         associations:
-            targetEntity: Pim\Component\Catalog\Model\AssociationInterface
+            targetEntity: Pim\Component\Catalog\Model\ProductAssociationInterface
             mappedBy: owner
             cascade:
                 - persist

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductAssociation.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/ProductAssociation.orm.yml
@@ -1,4 +1,4 @@
-Pim\Component\Catalog\Model\Association:
+Pim\Component\Catalog\Model\ProductAssociation:
     type: entity
     table: pim_catalog_association
     changeTrackingPolicy: DEFERRED_EXPLICIT

--- a/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/ProductNormalizerSpec.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
-use Pim\Component\Catalog\Model\Association;
+use Pim\Component\Catalog\Model\ProductAssociation;
 use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
@@ -132,9 +132,9 @@ class ProductNormalizerSpec extends ObjectBehavior
         ProductInterface $product,
         AttributeInterface $skuAttribute,
         ValueInterface $sku,
-        Association $myCrossSell,
+        ProductAssociation $myCrossSell,
         AssociationTypeInterface $crossSell,
-        Association $myUpSell,
+        ProductAssociation $myUpSell,
         AssociationTypeInterface $upSell,
         GroupInterface $associatedGroup1,
         GroupInterface $associatedGroup2,

--- a/src/Pim/Component/Catalog/Builder/ProductBuilder.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilder.php
@@ -2,9 +2,9 @@
 
 namespace Pim\Component\Catalog\Builder;
 
+use Pim\Component\Catalog\Model\AssociationAwareInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\EntityWithValuesInterface;
-use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\ProductEvents;
 use Pim\Component\Catalog\Repository\AssociationTypeRepositoryInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
@@ -95,14 +95,14 @@ class ProductBuilder implements ProductBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function addMissingAssociations(ProductInterface $product)
+    public function addMissingAssociations(AssociationAwareInterface $entity)
     {
-        $missingAssocTypes = $this->assocTypeRepository->findMissingAssociationTypes($product);
+        $missingAssocTypes = $this->assocTypeRepository->findMissingAssociationTypes($entity);
         if (!empty($missingAssocTypes)) {
             foreach ($missingAssocTypes as $associationType) {
                 $association = new $this->associationClass();
                 $association->setAssociationType($associationType);
-                $product->addAssociation($association);
+                $entity->addAssociation($association);
             }
         }
 

--- a/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
+++ b/src/Pim/Component/Catalog/Builder/ProductBuilderInterface.php
@@ -2,8 +2,7 @@
 
 namespace Pim\Component\Catalog\Builder;
 
-use Pim\Component\Catalog\Model\ChannelInterface;
-use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Model\AssociationAwareInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
@@ -30,9 +29,9 @@ interface ProductBuilderInterface extends EntityWithValuesBuilderInterface
     /**
      * Add empty associations for each association types when they don't exist yet
      *
-     * @param ProductInterface $product
+     * @param AssociationAwareInterface $entity
      *
      * @return EntityWithValuesBuilderInterface
      */
-    public function addMissingAssociations(ProductInterface $product);
+    public function addMissingAssociations(AssociationAwareInterface $entity);
 }

--- a/src/Pim/Component/Catalog/Model/AbstractAssociation.php
+++ b/src/Pim/Component/Catalog/Model/AbstractAssociation.php
@@ -20,7 +20,7 @@ abstract class AbstractAssociation implements AssociationInterface
     /** @var AssociationTypeInterface */
     protected $associationType;
 
-    /** @var ProductInterface */
+    /** @var AssociationAwareInterface */
     protected $owner;
 
     /** @var ProductInterface[] */
@@ -74,7 +74,7 @@ abstract class AbstractAssociation implements AssociationInterface
     /**
      * {@inheritdoc}
      */
-    public function setOwner(ProductInterface $owner)
+    public function setOwner(AssociationAwareInterface $owner)
     {
         if (!$this->owner) {
             $this->owner = $owner;

--- a/src/Pim/Component/Catalog/Model/AssociationAwareInterface.php
+++ b/src/Pim/Component/Catalog/Model/AssociationAwareInterface.php
@@ -6,6 +6,8 @@ namespace Pim\Component\Catalog\Model;
 use Doctrine\Common\Collections\Collection;
 
 /**
+ * Interface to implement for any entity that should be aware of any associations attached to it.
+ *
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
  * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/src/Pim/Component/Catalog/Model/AssociationAwareInterface.php
+++ b/src/Pim/Component/Catalog/Model/AssociationAwareInterface.php
@@ -6,7 +6,7 @@ namespace Pim\Component\Catalog\Model;
 use Doctrine\Common\Collections\Collection;
 
 /**
- * Interface to implement for any entity that should be aware of any associations attached to it.
+ * Interface to implement for any entity that should be aware of any associations it is holding.
  *
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
  * @copyright 2018 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Component/Catalog/Model/AssociationAwareInterface.php
+++ b/src/Pim/Component/Catalog/Model/AssociationAwareInterface.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Model;
+
+use Doctrine\Common\Collections\Collection;
+
+interface AssociationAwareInterface
+{
+    /**
+     * Get types of associations
+     *
+     * @return Collection
+     */
+    public function getAssociations();
+
+    /**
+     * Set types of associations
+     *
+     * @param Collection $associations
+     *
+     * @return AssociationAwareInterface
+     */
+    public function setAssociations(Collection $associations);
+
+    /**
+     * Add a type of an association
+     *
+     * @param AssociationInterface $association
+     *
+     * @throws \LogicException
+     *
+     * @return AssociationAwareInterface
+     */
+    public function addAssociation(AssociationInterface $association);
+
+    /**
+     * Remove a type of an association
+     *
+     * @param AssociationInterface $association
+     *
+     * @return AssociationAwareInterface
+     */
+    public function removeAssociation(AssociationInterface $association);
+
+    /**
+     * Get the product association for an Association type
+     *
+     * @param AssociationTypeInterface $type
+     *
+     * @return AssociationInterface|null
+     */
+    public function getAssociationForType(AssociationTypeInterface $type);
+
+    /**
+     * Get the product association for an association type code
+     *
+     * @param string $typeCode
+     *
+     * @return AssociationInterface|null
+     */
+    public function getAssociationForTypeCode($typeCode);
+}

--- a/src/Pim/Component/Catalog/Model/AssociationAwareInterface.php
+++ b/src/Pim/Component/Catalog/Model/AssociationAwareInterface.php
@@ -5,6 +5,11 @@ namespace Pim\Component\Catalog\Model;
 
 use Doctrine\Common\Collections\Collection;
 
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 interface AssociationAwareInterface
 {
     /**

--- a/src/Pim/Component/Catalog/Model/AssociationInterface.php
+++ b/src/Pim/Component/Catalog/Model/AssociationInterface.php
@@ -143,16 +143,16 @@ interface AssociationInterface extends ReferableInterface
     /**
      * Get owner
      *
-     * @return ProductInterface
+     * @return AssociationAwareInterface
      */
     public function getOwner();
 
     /**
      * Set owner
      *
-     * @param ProductInterface $owner
+     * @param AssociationAwareInterface $owner
      *
      * @return AssociationInterface
      */
-    public function setOwner(ProductInterface $owner);
+    public function setOwner(AssociationAwareInterface $owner);
 }

--- a/src/Pim/Component/Catalog/Model/ProductAssociation.php
+++ b/src/Pim/Component/Catalog/Model/ProductAssociation.php
@@ -3,12 +3,12 @@
 namespace Pim\Component\Catalog\Model;
 
 /**
- * Association entity
+ * Product association entity
  *
  * @author    Filips Alpe <filips@akeneo.com>
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Association extends AbstractAssociation
+class ProductAssociation extends AbstractAssociation implements ProductAssociationInterface
 {
 }

--- a/src/Pim/Component/Catalog/Model/ProductAssociationInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductAssociationInterface.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Model;
+
+
+interface ProductAssociationInterface extends AssociationInterface
+{
+}

--- a/src/Pim/Component/Catalog/Model/ProductAssociationInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductAssociationInterface.php
@@ -3,7 +3,11 @@ declare(strict_types=1);
 
 namespace Pim\Component\Catalog\Model;
 
-
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 interface ProductAssociationInterface extends AssociationInterface
 {
 }

--- a/src/Pim/Component/Catalog/Model/ProductInterface.php
+++ b/src/Pim/Component/Catalog/Model/ProductInterface.php
@@ -25,7 +25,8 @@ interface ProductInterface extends
     ReferableInterface,
     CategoryAwareInterface,
     EntityWithFamilyInterface,
-    EntityWithFamilyVariantInterface
+    EntityWithFamilyVariantInterface,
+    AssociationAwareInterface
 {
     /**
      * Get the ID of the product
@@ -101,60 +102,6 @@ interface ProductInterface extends
      * @return array
      */
     public function getGroupCodes();
-
-    /**
-     * Get types of associations
-     *
-     * @return Collection
-     */
-    public function getAssociations();
-
-    /**
-     * Set types of associations
-     *
-     * @param Collection $associations
-     *
-     * @return ProductInterface
-     */
-    public function setAssociations(Collection $associations);
-
-    /**
-     * Add a type of an association
-     *
-     * @param AssociationInterface $association
-     *
-     * @throws \LogicException
-     *
-     * @return ProductInterface
-     */
-    public function addAssociation(AssociationInterface $association);
-
-    /**
-     * Remove a type of an association
-     *
-     * @param AssociationInterface $association
-     *
-     * @return ProductInterface
-     */
-    public function removeAssociation(AssociationInterface $association);
-
-    /**
-     * Get the product association for an Association type
-     *
-     * @param AssociationTypeInterface $type
-     *
-     * @return AssociationInterface|null
-     */
-    public function getAssociationForType(AssociationTypeInterface $type);
-
-    /**
-     * Get the product association for an association type code
-     *
-     * @param string $typeCode
-     *
-     * @return AssociationInterface|null
-     */
-    public function getAssociationForTypeCode($typeCode);
 
     /**
      * Setter for predicate enabled

--- a/src/Pim/Component/Catalog/Repository/AssociationTypeRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/AssociationTypeRepositoryInterface.php
@@ -4,8 +4,8 @@ namespace Pim\Component\Catalog\Repository;
 
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Doctrine\Common\Persistence\ObjectRepository;
+use Pim\Component\Catalog\Model\AssociationAwareInterface;
 use Pim\Component\Catalog\Model\AssociationTypeInterface;
-use Pim\Component\Catalog\Model\ProductInterface;
 
 /**
  * Association repository interface
@@ -19,11 +19,11 @@ interface AssociationTypeRepositoryInterface extends IdentifiableObjectRepositor
     /**
      * Build all association entities not yet linked to a product
      *
-     * @param ProductInterface $product
+     * @param AssociationAwareInterface $entity
      *
      * @return AssociationTypeInterface[]
      */
-    public function findMissingAssociationTypes(ProductInterface $product);
+    public function findMissingAssociationTypes(AssociationAwareInterface $entity);
 
     /**
      * Return the number of association types

--- a/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/AssociationFieldSetter.php
@@ -7,10 +7,9 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Builder\ProductBuilderInterface;
+use Pim\Component\Catalog\Model\AssociationAwareInterface;
 use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\EntityWithValuesInterface;
-use Pim\Component\Catalog\Model\ProductInterface;
-use Pim\Component\Catalog\Model\ProductModelInterface;
 
 /**
  * Sets the association field
@@ -86,8 +85,8 @@ class AssociationFieldSetter extends AbstractFieldSetter
     /**
      * Clear only concerned associations (remove groups and products from existing associations)
      *
-     * @param ProductInterface $product
-     * @param array            $data
+     * @param AssociationAwareInterface $entity
+     * @param array                     $data
      *
      * Expected data input format:
      * {
@@ -103,13 +102,13 @@ class AssociationFieldSetter extends AbstractFieldSetter
      *     },
      * }
      */
-    protected function clearAssociations(ProductInterface $product, array $data = null)
+    protected function clearAssociations(AssociationAwareInterface $entity, array $data = null)
     {
         if (null === $data) {
             return;
         }
 
-        $product->getAssociations()
+        $entity->getAssociations()
             ->filter(function (AssociationInterface $association) use ($data) {
                 return isset($data[$association->getAssociationType()->getCode()]);
             })
@@ -138,25 +137,25 @@ class AssociationFieldSetter extends AbstractFieldSetter
     /**
      * Add missing associations (if association type has been added after the last processing)
      *
-     * @param ProductInterface $product
+     * @param AssociationAwareInterface $entity
      */
-    protected function addMissingAssociations(ProductInterface $product)
+    protected function addMissingAssociations(AssociationAwareInterface $entity)
     {
-        $this->productBuilder->addMissingAssociations($product);
+        $this->productBuilder->addMissingAssociations($entity);
     }
 
     /**
      * Set products and groups to associations
      *
-     * @param ProductInterface $product
+     * @param AssociationAwareInterface $entity
      *
      * @throws InvalidPropertyException
      */
-    protected function setProductsAndGroupsToAssociations(ProductInterface $product, $data)
+    protected function setProductsAndGroupsToAssociations(AssociationAwareInterface $entity, $data)
     {
         foreach ($data as $typeCode => $items) {
             $typeCode = (string) $typeCode;
-            $association = $product->getAssociationForTypeCode($typeCode);
+            $association = $entity->getAssociationForTypeCode($typeCode);
             if (null === $association) {
                 throw InvalidPropertyException::validEntityCodeExpected(
                     'associations',

--- a/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
@@ -4,7 +4,7 @@ namespace spec\Pim\Component\Catalog\Builder;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
-use Pim\Component\Catalog\Model\Association;
+use Pim\Component\Catalog\Model\ProductAssociation;
 use Pim\Component\Catalog\Model\AssociationAwareInterface;
 use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -21,7 +21,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class ProductBuilderSpec extends ObjectBehavior
 {
     const PRODUCT_CLASS = Product::class;
-    const ASSOCIATION_CLASS = Association::class;
+    const ASSOCIATION_CLASS = ProductAssociation::class;
 
     function let(
         AttributeRepositoryInterface $attributeRepository,

--- a/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
+++ b/src/Pim/Component/Catalog/spec/Builder/ProductBuilderSpec.php
@@ -5,6 +5,7 @@ namespace spec\Pim\Component\Catalog\Builder;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Builder\EntityWithValuesBuilderInterface;
 use Pim\Component\Catalog\Model\Association;
+use Pim\Component\Catalog\Model\AssociationAwareInterface;
 use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
@@ -80,8 +81,8 @@ class ProductBuilderSpec extends ObjectBehavior
 
     function it_adds_missing_product_associations(
         $assocTypeRepository,
-        ProductInterface $productOne,
-        ProductInterface $productTwo,
+        AssociationAwareInterface $productOne,
+        AssociationAwareInterface $productTwo,
         AssociationTypeInterface $type
     ) {
         $assocTypeRepository->findMissingAssociationTypes($productOne)->willReturn([$type]);

--- a/src/Pim/Component/Catalog/spec/Model/ProductSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/ProductSpec.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\AttributeTypes;
-use Pim\Component\Catalog\Model\Association;
+use Pim\Component\Catalog\Model\ProductAssociation;
 use Pim\Component\Catalog\Model\AssociationTypeInterface;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\CategoryInterface;
@@ -35,8 +35,8 @@ class ProductSpec extends ObjectBehavior
     }
 
     function it_returns_association_from_an_association_type(
-        Association $assoc1,
-        Association $assoc2,
+        ProductAssociation $assoc1,
+        ProductAssociation $assoc2,
         AssociationTypeInterface $assocType1,
         AssociationTypeInterface $assocType2,
         Collection $associations,
@@ -55,8 +55,8 @@ class ProductSpec extends ObjectBehavior
     }
 
     function it_returns_association_from_an_association_type_code(
-        Association $assoc1,
-        Association $assoc2,
+        ProductAssociation $assoc1,
+        ProductAssociation $assoc2,
         AssociationTypeInterface $assocType1,
         AssociationTypeInterface $assocType2,
         Collection $associations,

--- a/src/Pim/Component/Connector/spec/Writer/Database/ProductAssociationWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/Database/ProductAssociationWriterSpec.php
@@ -7,7 +7,7 @@ use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Model\Association;
+use Pim\Component\Catalog\Model\ProductAssociation;
 use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 
@@ -40,7 +40,7 @@ class ProductAssociationWriterSpec extends ObjectBehavior
         $bulkDetacher->detachAll([$product1, $product2]);
 
         $product1->getId()->willReturn(null);
-        $association1 = new Association();
+        $association1 = new ProductAssociation();
         $product1->getAssociations()->willReturn(new ArrayCollection([$association1]));
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalled();
 


### PR DESCRIPTION
**Prepare product models associations**
This PR is the first preparation step to be able to use associations with product models. To do so, we introduce the `AssociationAwareInterface` to extract the association features from the Product class.

We also rename `Association` into `ProductAssociation`. Do you feel the `ProductModelAssociation` coming? :smiley: 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Updated
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | Yes

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
