### PR TITLE
Improve the performance of the loading of the completeness widget

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Repository/CompletenessRepositorySpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/Repository/CompletenessRepositorySpec.php
@@ -17,7 +17,7 @@ class CompletenessRepositorySpec extends ObjectBehavior
         Statement $statement,
         ClassMetadata $classMetadata
     ) {
-        $connection->prepare(Argument::any())->willReturn($statement);
+        $connection->executeQuery(Argument::any(), ['locale' => 'en_US'])->willReturn($statement);
         $manager->getClassMetadata(Argument::any())->willReturn($classMetadata);
 
         $manager->getConnection()->willReturn($connection);
@@ -29,10 +29,8 @@ class CompletenessRepositorySpec extends ObjectBehavior
         $this->shouldImplement('Pim\Component\Catalog\Repository\CompletenessRepositoryInterface');
     }
 
-    function it_counts_products_per_channels(Statement $statement)
+    function it_counts_products_per_channels($statement)
     {
-        $statement->execute()->willReturn(null);
-
         $statement->fetchAll()->willReturn(
             [
                 ['label' => 'ECommerce', 'total' => 3],
@@ -40,7 +38,7 @@ class CompletenessRepositorySpec extends ObjectBehavior
             ]
         );
 
-        $this->getProductsCountPerChannels(Argument::any())->shouldReturn(
+        $this->getProductsCountPerChannels('en_US')->shouldReturn(
             [
                 ['label' => 'ECommerce', 'total' => 3],
                 ['label' => 'Mobile', 'total' => 2]
@@ -48,10 +46,8 @@ class CompletenessRepositorySpec extends ObjectBehavior
         );
     }
 
-    function it_counts_complete_products_per_channels(Statement $statement)
+    function it_counts_complete_products_per_channels($statement)
     {
-        $statement->execute()->willReturn(null);
-
         $statement->fetchAll()->willReturn(
             [
                 ['locale' => 'en_US', 'label' => 'ECommerce', 'total' => 0],
@@ -60,7 +56,7 @@ class CompletenessRepositorySpec extends ObjectBehavior
             ]
         );
 
-        $this->getCompleteProductsCountPerChannels(Argument::any())->shouldReturn(
+        $this->getCompleteProductsCountPerChannels('en_US')->shouldReturn(
             [
                 ['locale' => 'en_US', 'label' => 'ECommerce', 'total' => 0],
                 ['locale' => 'fr_FR', 'label' => 'ECommerce', 'total' => 1],


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
I already did a PR almost one year ago:
https://github.com/akeneo/pim-community-dev/pull/6204

But I found a better optimisation.

**Before**
7sec on the generated catalog "80%".

**After**
70ms on the generated catalog "80%".

**For fun: before the PIM-6429 (original query)**
1m27 on the generated catalog "80%"

**How**
Delete the `LEFT JOIN` on the completeness table. It was useless and only here in case there is 0 product completed. An INNER JOIN would delete the row and not display the couple channel/locale if we don't change anything. 

So, the trick is to do all the stuff in a subrequest with a JOIN and then doing the LEFT JOIN on the aggregated SUM (which is almost free).

Performance depends of the distributivity of the data. The more you have complete products, the longer this it is to calculate. But it is normal and was the case before.

**Bonus**
It fixes a potential SQL injection as well (I didn't find a way to exploit, so don't worry).


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
