### PR TITLE
PIM-7304 : Fix the SKU filter to be able to be scrollable

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - PIM-7300: fix the status filter on product grid for products with parent.
 - PIM-7282: Add validation on the code value during the attribute creation to prohibit the "entity_type" value.
+- PIM-7304: Fix the SKU filter to be scrollable
 - PIM-7043: Remove the last pagination button if it has more than 10 000 products on the product grid.
 - PIM-7299: Add pagination for family variants on several screens
 
@@ -64,6 +65,7 @@
 - PIM-7214: Fix a bug that prevents to select multiple items across pages in Products, Family and associations grids
 - PIM-7215: Fix wrong direction of sorting arrow in the grids
 - PIM-7220: Fix the filter "is empty" when the attribute belongs to a family
+- PIM-7216: Allow to easily override Product and VariantProduct classes
 
 # 2.0.17 (2018-03-06)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/choice-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/choice-filter.js
@@ -196,6 +196,7 @@ define(
                 width: '290px',
                 formatNoMatches: function() { return ''; }
             });
+            this.$(this.criteriaValueSelectors.value).on('change', () => { this._updateCriteriaSelectorPosition() });
             this.$(this.criteriaValueSelectors.value).addClass('AknTextField--select2');
         },
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -491,6 +491,14 @@
   }
 }
 
+//override for select2 choice filters
+.AknFilterChoice {
+  .select2-choices {
+    overflow: auto;
+    max-height: 250px;
+  }
+}
+
 // Stylize like AknButton
 .aknButtonLike {
   &.select2-container {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -495,7 +495,7 @@
 .AknFilterChoice {
   .select2-choices {
     overflow: auto;
-    max-height: 250px;
+    max-height: 500px;
   }
 }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When we add a long list of values in the SKU filters, we can't see the update button anymore. This is because the popup is too big compare to the window.

So to solved that, I had to fix the max height and add the scroll on the popup. Also, I have to update the position of the popup when we add a value in the select2.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
