### PR TITLE
[SLA] PIM-7313: prevent the same job to be executed by two different daemons due to race condition

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -6,6 +6,7 @@
 - PIM-7282: Add validation on the code value during the attribute creation to prohibit the "entity_type" value.
 - PIM-7043: Remove the last pagination button if it has more than 10 000 products on the product grid.
 - PIM-7299: Add pagination for family variants on several screens
+- PIM-7313: prevent the same job to be executed by two different daemons due to race condition
 
 ## BC Breaks
 
@@ -64,6 +65,7 @@
 - PIM-7214: Fix a bug that prevents to select multiple items across pages in Products, Family and associations grids
 - PIM-7215: Fix wrong direction of sorting arrow in the grids
 - PIM-7220: Fix the filter "is empty" when the attribute belongs to a family
+- PIM-7216: Allow to easily override Product and VariantProduct classes
 
 # 2.0.17 (2018-03-06)
 

--- a/src/Akeneo/Bundle/BatchQueueBundle/Queue/DatabaseJobExecutionQueue.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Queue/DatabaseJobExecutionQueue.php
@@ -25,16 +25,12 @@ class DatabaseJobExecutionQueue implements JobExecutionQueueInterface
     /** Interval in seconds before checking if a new message is in the queue. */
     const QUEUE_CHECK_INTERVAL = 5;
 
-    /** Prefix to add when locking a job execution message in database. */
-    const LOCK_PREFIX = 'akeneo_job_execution_';
-
-    /** @var EntityManagerInterface */
-    private $entityManager;
-
     /** @var JobExecutionMessageRepository */
     private $jobExecutionMessageRepository;
 
     /**
+     * TODO: @merge delete useless entity manager dependency
+     *
      * @param EntityManagerInterface        $entityManager
      * @param JobExecutionMessageRepository $jobExecutionMessageRepository
      */
@@ -42,7 +38,6 @@ class DatabaseJobExecutionQueue implements JobExecutionQueueInterface
         EntityManagerInterface $entityManager,
         JobExecutionMessageRepository $jobExecutionMessageRepository
     ) {
-        $this->entityManager = $entityManager;
         $this->jobExecutionMessageRepository = $jobExecutionMessageRepository;
     }
 
@@ -59,52 +54,17 @@ class DatabaseJobExecutionQueue implements JobExecutionQueueInterface
      */
     public function consume(string $consumer): JobExecutionMessage
     {
-        $hasLock = false;
+        $hasBeenUpdated = false;
 
         do {
             $jobExecutionMessage = $this->jobExecutionMessageRepository->getAvailableJobExecutionMessage();
+
             if (null !== $jobExecutionMessage) {
-                $lock = self::LOCK_PREFIX . $jobExecutionMessage->getJobExecutionId();
-                $hasLock = $this->lock($lock);
+                $jobExecutionMessage->consumedBy($consumer);
+                $hasBeenUpdated = $this->jobExecutionMessageRepository->updateJobExecutionMessage($jobExecutionMessage);
             }
-        } while (!$hasLock && 0 === sleep(self::QUEUE_CHECK_INTERVAL));
-
-        $jobExecutionMessage->consumedBy($consumer);
-
-        $this->jobExecutionMessageRepository->updateJobExecutionMessage($jobExecutionMessage);
-        $this->unlock($lock);
+        } while (!$hasBeenUpdated && 0 === sleep(self::QUEUE_CHECK_INTERVAL));
 
         return $jobExecutionMessage;
-    }
-
-    /**
-     * Try to get an application-level lock.
-     *
-     * @param string $lock
-     *
-     * @return bool return true if lock has been acquired, false otherwise
-     */
-    private function lock(string $lock): bool
-    {
-        $stmt = $this->entityManager->getConnection()->prepare('SELECT GET_LOCK(:lock, 0)');
-        $stmt->bindValue('lock', $lock);
-
-        $stmt->execute();
-        $result = $stmt->fetch();
-
-        return '1' === current($result);
-    }
-
-    /**
-     * Release an application-level lock.
-     *
-     * @param string $lock
-     */
-    private function unlock(string $lock): void
-    {
-        $stmt = $this->entityManager->getConnection()->prepare('SELECT RELEASE_LOCK(:lock)');
-        $stmt->bindValue('lock', $lock);
-
-        $stmt->execute();
     }
 }

--- a/src/Akeneo/Bundle/BatchQueueBundle/Queue/JobExecutionMessageRepository.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Queue/JobExecutionMessageRepository.php
@@ -60,9 +60,14 @@ SQL;
     }
 
     /**
+     * Update a job execution message.
+     * Only an unconsumed job execution message can be updated.
+     *
      * @param JobExecutionMessage $jobExecutionMessage
+     *
+     * @return bool return whether the job has been updated or not
      */
-    public function updateJobExecutionMessage(JobExecutionMessage $jobExecutionMessage)
+    public function updateJobExecutionMessage(JobExecutionMessage $jobExecutionMessage): bool
     {
         $sql = <<<SQL
 UPDATE 
@@ -74,7 +79,8 @@ SET
     q.create_time = :create_time,
     q.updated_time = :updated_time
 WHERE
-    q.id = :id;
+    q.id = :id
+    AND q.consumer IS NULL;
 SQL;
 
         $stmt = $this->entityManager->getConnection()->prepare($sql);
@@ -85,6 +91,8 @@ SQL;
         $stmt->bindValue('updated_time', new \DateTime('now', new \DateTimeZone('UTC')), Type::DATETIME);
         $stmt->bindValue('id', $jobExecutionMessage->getId());
         $stmt->execute();
+
+        return $stmt->rowCount() > 0;
     }
 
     /**

--- a/src/Akeneo/Bundle/BatchQueueBundle/spec/Queue/DatabaseJobExecutionQueueSpec.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/spec/Queue/DatabaseJobExecutionQueueSpec.php
@@ -41,22 +41,13 @@ class DatabaseJobExecutionQueueSpec extends ObjectBehavior
 
     function it_consumes_a_job_execution_message(
         $jobExecutionMessageRepository,
-        $connection,
-        JobExecutionMessage $jobExecutionMessage,
-        Statement $stmt
+        JobExecutionMessage $jobExecutionMessage
     ) {
         $jobExecutionMessageRepository->getAvailableJobExecutionMessage()->willReturn($jobExecutionMessage);
-        $jobExecutionMessageRepository->updateJobExecutionMessage($jobExecutionMessage)->shouldBeCalled();
+        $jobExecutionMessageRepository->updateJobExecutionMessage($jobExecutionMessage)->willReturn(true);
 
-        $jobExecutionMessage->getJobExecutionId()->willReturn(1);
         $jobExecutionMessage->consumedBy('consumer_name')->shouldBeCalled();
 
-        $connection->prepare(Argument::type('string'))->willReturn($stmt);
-        $stmt->bindValue('lock', DatabaseJobExecutionQueue::LOCK_PREFIX . '1')->shouldBeCalled();
-        $stmt->execute()->shouldBeCalled();
-
-        $stmt->fetch()->willReturn(['1']);
-
-        $this->consume('consumer_name');
+        $this->consume('consumer_name')->shouldReturn($jobExecutionMessage);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

A same job can executed by two different daemons, with obvious consequences:
- concurrent INSERT on primary key
- job failing
- etc


In theory, it's impossible to execute the same job by two different daemons, due to a locking strategy that I implemented with the database. 

But it occurs when you have a lot of daemons (for example 10, probability to have the bug increases with the number of daemons). 
Also, it has more chance to occur when you have a lot of "fast" job in the queue, such as "akeneo_batch_job_execution_queue".

The problem is due to the locking strategy that was not robust enough, allowing a race condition to consume a job two times.

**Explication of the race condition:**


- Expected behavior:

| Daemon 1                                 | Daemon 2
| --------------------------------- | ---
| Ask for unconsumed job                       | Ask for unconsumed job
| Answer job 1              | Answer job 1
| Ask lock for job 1           | Ask lock for job 1
| Locked           | Not locked, already lock by process 1
| update job with consumer UUID : job 1 is not considered as unconsumed anymore               | -
| Release lock                  | Ask for another unconsumed job
| execute job 1                 | Answer job 2

But this scenario can occur as well:

| Daemon 1                                 | Daemon 2
| --------------------------------- | ---
| Ask for unconsumed job   | Ask for unconsumed job
| Answer job 1              | Answer job 1
| Ask lock for job 1           | -
| Locked           | -
| update job with consumer UUID : job 1 is not considered as unconsumed anymore               | -
| Release lock                  | -
| **execute job 1**                 | -
| -           | Ask lock for job 1
| -           | Not locked anymore by daemon 1: let's lock it!  
| -           | update job with consumer UUID (and override daemon UUID of process 1)
| -                  | Release lock
| -                 | **execute job 1**

And 🎉, you have two times the same job running.

**How to prevent this**

There are multiple strategies when we talk about locking and queue with Mysql.

1. `SELECT FOR UPDATE`

First one is to use `SELECT FOR UPDATE`. 
But it's dangerous, because you can have what we call `gaps lock` when isolation level is "REPEATBLE READ" (by default on mysql). The consequence is potential dead lock on the table.

https://www.percona.com/blog/2012/03/27/innodbs-gap-locks/
https://www.percona.com/blog/2013/12/12/one-more-innodb-gap-lock-to-avoid/

And that's why Symfony change the isolation level for the session.

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php#L551

2. `GET_LOCK`

You can get a lock on mysql, shared between all the session/connection with a simple `SELECT GET_LOCK("your_lock_name")`.
It's powerful. It works as expected. No gaps lock.

The drawback is that you don't really lock any row (= message of the queue) as with `SELECT FOR UPDATE`.

So, the logic of the lock (the name of the lock, how you lock it, etc) is in your application.
Meaning that if you have multiple applications sharing the same database (ERP is a good example), they have to implement the same logic in the code base to get the lock on a message.

As sharing the database across multiple application is a kind of anti-pattern, and not the case of the PIM, it was the solution I choosed.

It means as well that if you don't lock it correctly, you can have bugs.
And it is the reason of this bug.

It's possible to do a working queue with this lock, and it would be possible to fix the bug with this method. But I found a far better and cleaner solution.

3. `UPDATE` and count row

It's the easier solution to fix this bug and to implement a queue.
You lock a row by updating the message. You can get the number of updated rows with PDO/DBAL. If no row is updated, it means a concurrent consumer has already consumed the message.
So the daemon poll for the next message.

It works as an UPDATE is atomic by using an exclusive lock on the updated row. 
Less code. Less complex. It's a win-win.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
