### PR TITLE
PIM-7312: Fix attribute requirements update for a newly created channel

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -9,6 +9,7 @@
 - PIM-7299: Add pagination for family variants on several screens
 - PIM-7313: prevent the same job to be executed by two different daemons due to race condition
 - PIM-7297: Fix memory leak on completeness purge command
+- PIM-7312: Fix attribute requirements update for a newly created channel
 
 ## BC Breaks
 

--- a/features/family/define_the_attribute_requirement.feature
+++ b/features/family/define_the_attribute_requirement.feature
@@ -56,9 +56,23 @@ Feature: Define the attribute requirement
     And I should not see the text "There are unsaved changes."
     Then I should not see the "rating" attribute
     When I launched the completeness calculator
+    And I wait for the "compute_completeness_of_products_family" job to finish
     When I am on the "BIGBOOTS" product page
     And I visit the "Completeness" column tab
     Then I should see the completeness:
       | channel | locale | state   | missing_values | ratio |
       | mobile  | en_US  | success | 0              | 100%  |
       | tablet  | en_US  | warning | 3              | 62%   |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7312
+  Scenario: Successfully add an attribute requirement for a newly created channel
+    Given the following channel:
+      | code      | label-en_US | currencies | locales | tree            |
+      | ecommerce | Ecommerce   | EUR,USD    | en_US   | 2014_collection |
+    When I visit the "Attributes" tab
+    Then attribute "name" should be required in channels mobile and tablet
+    But attribute "name" should not be required in channel ecommerce
+    When I switch the attribute "name" requirement in channel "ecommerce"
+    And I save the family
+    Then I should not see the text "There are unsaved changes."
+    And attribute "name" should be required in channel ecommerce

--- a/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
@@ -246,7 +246,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
                 $key = array_search($attribute->getCode(), $newRequirements[$channelCode], true);
                 if (false === $key && AttributeTypes::IDENTIFIER !== $attribute->getType()) {
                     $family->removeAttributeRequirement($requirement);
-                } elseif (false !== $key) {
+                } elseif (false !== $key && true === $requirement->isRequired()) {
                     unset($newRequirements[$channelCode][$key]);
                 }
             }
@@ -255,6 +255,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
         foreach ($newRequirements as $channelCode => $requirements) {
             $createdRequirements = $this->createAttributeRequirementsByChannel($family, $requirements, $channelCode);
             foreach ($createdRequirements as $createdRequirement) {
+                $createdRequirement->setRequired(true);
                 $family->addAttributeRequirement($createdRequirement);
             }
         }

--- a/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/FamilyUpdaterSpec.php
@@ -113,6 +113,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
 
         $skuMobileRqrmt->getAttribute()->willReturn($skuAttribute);
         $skuMobileRqrmt->getChannelCode()->willReturn('mobile');
+        $skuMobileRqrmt->isRequired()->willReturn(true);
 
         $skuAttribute->getCode()->willReturn('sku');
         $skuAttribute->getType()->willReturn(AttributeTypes::IDENTIFIER);
@@ -220,8 +221,11 @@ class FamilyUpdaterSpec extends ObjectBehavior
 
         $family->setCode('mycode')->shouldBeCalled();
         $skuEcommerceRqrmt->getChannelCode()->willReturn('ecommerce');
+        $skuEcommerceRqrmt->isRequired()->willReturn(true);
         $skuMobileRqrmt->getChannelCode()->willReturn('mobile');
+        $skuMobileRqrmt->isRequired()->willReturn(true);
         $nameEcommerceRqrmt->getChannelCode()->willReturn('ecommerce');
+        $nameEcommerceRqrmt->isRequired()->willReturn();
 
         $skuMobileRqrmt->getAttribute()->willReturn($skuAttribute);
 
@@ -642,5 +646,71 @@ class FamilyUpdaterSpec extends ObjectBehavior
                 )
             )
             ->during('update', [$family, $data, []]);
+    }
+
+    function it_sets_requirement_as_required_for_a_new_channel
+    (
+        $channelRepository,
+        $attributeRequirementRepo,
+        FamilyInterface $family,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeInterface $skuAttribute,
+        AttributeInterface $nameAttribute,
+        AttributeRequirementInterface $skuNewChannelRqrmt,
+        AttributeRequirementInterface $nameNewChannelRqrmt,
+        ChannelInterface $newChannel
+    ) {
+        $data = [
+            'code'                   => 'mycode',
+            'attribute_requirements' => [
+                'new_channel' => ['name'],
+            ]
+        ];
+
+        $family->getAttributeRequirements()->willReturn([$skuNewChannelRqrmt, $nameNewChannelRqrmt]);
+        $family->getId()->willReturn(1);
+
+        $skuAttribute->getCode()->willReturn('sku');
+        $skuAttribute->getType()->willReturn(AttributeTypes::IDENTIFIER);
+        $skuAttribute->getId()->willReturn(1);
+
+        $nameAttribute->getCode()->willReturn('name');
+        $nameAttribute->getType()->willReturn(AttributeTypes::TEXT);
+        $nameAttribute->getId()->willReturn(2);
+
+        $skuNewChannelRqrmt->getChannelCode()->willReturn('new_channel');
+        $skuNewChannelRqrmt->getAttribute()->willReturn($skuAttribute);
+        $skuNewChannelRqrmt->isRequired()->willReturn(true);
+
+        $nameNewChannelRqrmt->getChannelCode()->willReturn('new_channel');
+        $nameNewChannelRqrmt->getAttribute()->willReturn($nameAttribute);
+        $nameNewChannelRqrmt->isRequired()->willReturn(false);
+
+        $newChannel->getId()->willReturn(44);
+
+        $channelRepository->findOneByIdentifier('new_channel')->willReturn($newChannel);
+        $attributeRepository->findOneByIdentifier('sku')->willReturn($skuAttribute);
+        $attributeRepository->findOneByIdentifier('name')->willReturn($nameAttribute);
+
+        $attributeRequirementRepo->findOneBy(
+            [
+                'attribute' => 1,
+                'channel' => 44,
+                'family' => 1,
+            ]
+        )->willReturn($skuNewChannelRqrmt);
+        $attributeRequirementRepo->findOneBy(
+            [
+                'attribute' => 2,
+                'channel'   => 44,
+                'family'    => 1,
+            ]
+        )->willReturn($nameNewChannelRqrmt);
+
+        $family->setCode('mycode')->shouldBeCalled();
+        $nameNewChannelRqrmt->setRequired(true)->shouldBeCalled();
+        $family->addAttributeRequirement($nameNewChannelRqrmt)->shouldBeCalled();
+
+        $this->update($family, $data);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes an issue when trying to add an attribute requirement for a family, and the attribute requirement already exists but its `required` property is set to `false` (which is the case for newly created channels)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
