### PR TITLE
Only create attribute requirements for identifier on channel creation

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/CreateAttributeRequirementSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/CreateAttributeRequirementSubscriber.php
@@ -4,9 +4,11 @@ namespace Pim\Bundle\CatalogBundle\EventSubscriber;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
-use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Factory\AttributeRequirementFactory;
+use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 
 /**
  * Create attribute requirements for each family attributes after creating a channel
@@ -53,14 +55,18 @@ class CreateAttributeRequirementSubscriber implements EventSubscriber
         }
 
         $entityManager = $event->getEntityManager();
-        $families = $entityManager->getRepository('PimCatalogBundle:Family')->findAll();
+        $families = $entityManager->getRepository(FamilyInterface::class)->findAll();
 
-        foreach ($families as $family) {
-            foreach ($family->getAttributes() as $attribute) {
+        if (count($families)) {
+            /** @var AttributeRepositoryInterface $attributeRepository */
+            $attributeRepository = $entityManager->getRepository(AttributeInterface::class);
+            $identifier = $attributeRepository->getIdentifier();
+
+            foreach ($families as $family) {
                 $requirement = $this->requirementFactory->createAttributeRequirement(
-                    $attribute,
+                    $identifier,
                     $entity,
-                    AttributeTypes::IDENTIFIER === $attribute->getType()
+                    true
                 );
                 $requirement->setFamily($family);
                 $entityManager->persist($requirement);

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/CreateAttributeRequirementSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/CreateAttributeRequirementSubscriberSpec.php
@@ -11,34 +11,14 @@ use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeRequirementInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Prophecy\Argument;
 
 class CreateAttributeRequirementSubscriberSpec extends ObjectBehavior
 {
-    public function let(
-        AttributeRequirementFactory $requirementFactory,
-        LifecycleEventArgs $eventArgs,
-        ChannelInterface $channel,
-        EntityManagerInterface $entityManager,
-        EntityRepository $repository,
-        FamilyInterface $family
-    ) {
+    public function let(AttributeRequirementFactory $requirementFactory)
+    {
         $this->beConstructedWith($requirementFactory);
-
-        $eventArgs->getEntity()
-            ->willReturn($channel);
-
-        $eventArgs->getEntityManager()
-            ->willReturn($entityManager);
-
-        $entityManager->getRepository(Argument::exact('PimCatalogBundle:Family'))
-            ->willReturn($repository);
-
-        $repository->findAll()
-            ->willReturn([$family]);
-
-        $family->getAttributes()
-            ->willReturn([]);
     }
 
     public function it_is_an_event_subscriber()
@@ -53,101 +33,57 @@ class CreateAttributeRequirementSubscriberSpec extends ObjectBehavior
     }
 
     public function it_ignores_non_ChannelInterface_entity(
-        $eventArgs,
-        $entityManager
+        LifecycleEventArgs $eventArgs,
+        EntityManagerInterface $entityManager
     ) {
-        $eventArgs->getEntity()
-            ->willReturn(null)
-            ->shouldBeCalled();
+        $eventArgs->getEntity()->willReturn(null);
+        $eventArgs->getEntityManager()->shouldNotBeCalled();
+        $entityManager->persist(Argument::any())->shouldNotBeCalled();
 
-        $eventArgs->getEntityManager()
-            ->shouldNotBeCalled();
-
-        $entityManager->persist(Argument::any())
-            ->shouldNotBeCalled();
-
-        $this->prePersist($eventArgs)
-            ->shouldReturn(null);
+        $this->prePersist($eventArgs)->shouldReturn(null);
     }
 
     public function it_does_not_create_requirement_without_family(
-        $eventArgs,
-        $entityManager,
-        $repository,
-        $family
+        LifecycleEventArgs $eventArgs,
+        ChannelInterface $channel,
+        EntityManagerInterface $entityManager,
+        EntityRepository $repository
     ) {
-        $eventArgs->getEntityManager()
-            ->shouldBeCalled();
+        $eventArgs->getEntity()->willReturn($channel);
+        $eventArgs->getEntityManager()->willReturn($entityManager);
+        $entityManager->getRepository(FamilyInterface::class)->willReturn($repository);
+        $repository->findAll()->willReturn([]);
 
-        $entityManager->getRepository(Argument::exact('PimCatalogBundle:Family'))
-            ->shouldBeCalled();
-
-        $repository->findAll()
-            ->willReturn([])
-            ->shouldBeCalled();
-
-        $family->getAttributes()
-            ->shouldNotBeCalled();
-
-        $entityManager->persist(Argument::any())
-            ->shouldNotBeCalled();
-
-        $entityManager->persist(Argument::any())
-            ->shouldNotBeCalled();
-
-        $this->prePersist($eventArgs)
-            ->shouldReturn(null);
+        $entityManager->persist(Argument::any())->shouldNotBeCalled();
+        $this->prePersist($eventArgs)->shouldReturn(null);
     }
 
-    public function it_does_not_create_requirements_for_family_without_attributes(
-        $eventArgs,
-        $entityManager,
-        $repository,
-        $family
-    ) {
-        $repository->findAll()
-            ->willReturn([$family])
-            ->shouldBeCalled();
-
-        $family->getAttributes()
-            ->willReturn([])
-            ->shouldBeCalled();
-
-        $entityManager->persist(Argument::any())
-            ->shouldNotBeCalled();
-
-        $this->prePersist($eventArgs)
-            ->shouldReturn(null);
-    }
-
-    public function it_creates_requirements(
+    public function it_creates_requirements_on_identifier_attribute_for_each_family(
         $requirementFactory,
-        $eventArgs,
-        $channel,
-        $entityManager,
-        $family,
-        AttributeInterface $attribute,
+        LifecycleEventArgs $eventArgs,
+        ChannelInterface $channel,
+        EntityManagerInterface $entityManager,
+        EntityRepository $familyRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        FamilyInterface $family,
+        FamilyInterface $otherFamily,
+        AttributeInterface $identifier,
         AttributeRequirementInterface $attributeRequirement
     ) {
-        $family->getAttributes()
-            ->willReturn([$attribute])
-            ->shouldBeCalled();
+        $eventArgs->getEntity()->willReturn($channel);
+        $eventArgs->getEntityManager()->willReturn($entityManager);
 
-        $requirementFactory->createAttributeRequirement(
-            $attribute,
-            $channel,
-            Argument::type('bool')
-        )
-            ->willReturn($attributeRequirement)
-            ->shouldBeCalled();
+        $entityManager->getRepository(FamilyInterface::class)->willReturn($familyRepository);
+        $familyRepository->findAll()->willReturn([$family, $otherFamily]);
+        $entityManager->getRepository(AttributeInterface::class)->willReturn($attributeRepository);
+        $attributeRepository->getIdentifier()->willReturn($identifier);
 
-        $attributeRequirement->setFamily($family)
-            ->shouldBeCalled();
+        $requirementFactory->createAttributeRequirement($identifier, $channel, true)
+            ->willReturn($attributeRequirement)->shouldBeCalledTimes(2);
+        $attributeRequirement->setFamily($family)->shouldBeCalled();
+        $attributeRequirement->setFamily($otherFamily)->shouldBeCalled();
+        $entityManager->persist($attributeRequirement)->shouldBeCalledTimes(2);
 
-        $entityManager->persist(Argument::any())
-            ->shouldBeCalled();
-
-        $this->prePersist($eventArgs)
-            ->shouldReturn(null);
+        $this->prePersist($eventArgs)->shouldReturn(null);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/CreateAttributeRequirementsSubscriberIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/CreateAttributeRequirementsSubscriberIntegration.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\EventSubscriber;
+
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\AttributeRequirementInterface;
+use Pim\Component\Catalog\Model\FamilyInterface;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CreateAttributeRequirementsSubscriberIntegration extends TestCase
+{
+    public function testOnlyCreateAttributeRequirementForIdentifierAttribute()
+    {
+        $channelCode = 'new_cannel';
+        $this->createChannel($channelCode);
+        $families = $this->get('pim_catalog.repository.family')->findAll();
+
+        /** @var FamilyInterface $family */
+        foreach ($families as $family) {
+            $requirements = $this->getRequirementsForChannel($family, $channelCode);
+            $this->assertCount(1, $requirements);
+            $this->assertSame(AttributeTypes::IDENTIFIER, $requirements[0]->getAttribute()->getType());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @param FamilyInterface $family
+     * @param string $channelCode
+     *
+     * @return AttributeRequirementInterface[]
+     */
+    private function getRequirementsForChannel(FamilyInterface $family, string $channelCode): array
+    {
+        $requirements = [];
+        foreach ($family->getAttributeRequirements() as $requirement) {
+            if ($requirement->getChannelCode() === $channelCode) {
+                $requirements[] = $requirement;
+            }
+        }
+
+        return $requirements;
+    }
+
+    /**
+     * @param string $code
+     */
+    private function createChannel(string $code): void
+    {
+        $channel = $this->get('pim_catalog.factory.channel')->create();
+        $this->get('pim_catalog.updater.channel')->update(
+            $channel,
+            [
+                'code' => $code,
+                'currencies' => ['USD', 'EUR'],
+                'locales' => ['en_US'],
+                'category_tree' => 'master',
+            ]
+        );
+        $this->get('pim_catalog.saver.channel')->save($channel);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Currently, when creating a channel, the `Pim\Bundle\CatalogBundle\EventSubscriber\CreateAttributeRequirementSubscriber` creates attribute requirements for every attribute of every family, and sets the `required`property to `true` only for identifier attribute.
This behaviour is quite costly (numerous requests) and useless (AFAIK, the `required` property is not used anywhere, either the AttributeRequirement exists and the attribute is required for the channel/family, or it doesn't exist). Furthermore it can lead to errors (see #8002)

This PR modifies the behaviour of the subscriber by creating requirements only for the `identifier` attribute while creating a channel.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
