### PR TITLE
PIM-7318: correctly detect product models associations

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -38,6 +38,7 @@
 ## Bug fixes
 
 - PIM-7281: Fix inappropriate calls to the cache clearer
+- PIM-7318: correctly detect product models associations
 
 ## Improvements
 

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -201,7 +201,7 @@ class ProductAssociationProcessor extends AbstractProcessor implements ItemProce
         }
 
         foreach ($item['associations'] as $association) {
-            if (!empty($association['products']) || !empty($association['groups'])) {
+            if (!empty($association['products']) || !empty($association['groups']) || !empty($association['product_models'])) {
                 return true;
             }
         }


### PR DESCRIPTION
**Definition Of Done (for Core Developer only)**
If we do not enable the comparison, the `ProductAssociationProcessor` do not detect product models associations.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Yes
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -