### PR TITLE
PIM-7321: prevent concurrent calculation of the completeness 

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -15,6 +15,10 @@
 
 - Changes the constructor of `Pim\Bundle\EnrichBundle\Controller\Rest\FamilyVariant` to add `Akeneo\Component\StorageUtils\Repository\SearchableRepositoryInterface`
 
+## Improvements
+
+- PIM-7321: Prevent concurrent calculation of the completeness
+
 # 2.0.21 (2018-04-10)
 
 ## Improvements

--- a/src/Pim/Bundle/CatalogBundle/Command/CalculateCompletenessCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/CalculateCompletenessCommand.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\CatalogBundle\Command;
 
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -16,6 +17,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class CalculateCompletenessCommand extends ContainerAwareCommand
 {
+    use LockableTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -31,6 +34,12 @@ class CalculateCompletenessCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (!$this->lock()) {
+            $output->writeln(sprintf('The command "%s" is still running in another process.', self::$defaultName));
+
+            return 0;
+        }
+
         $output->writeln("<info>Generating missing completenesses...</info>");
 
         $options = [


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Calculation of the completeness is the origin of a lot of problems with the support, due to multiple cron executed concurrently to calculate it (because the previous one is not finished).
The error is a violation of database integrity.

I know that this fix is not working if the customer is doing the cron across multiple servers, as the locking is with a `flock`.
But the cron of the completeness should be configured on only one server, so it's not really a problem.
It will fix 90% of problems in an easy way.



<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
