### PR TITLE
PIM-7317: Fix iterator misuse in the database product model reader

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -12,6 +12,7 @@
 - PIM-7312: Fix attribute requirements update for a newly created channel
 - PIM-7322: Fix cast of a product model as string to format correctly violations
 - PIM-7320: Fix memory leak on boolean values purge command
+- PIM-7317: Fix iterator misuse in the database product model reader
 
 ## BC Breaks
 

--- a/src/Pim/Component/Connector/Reader/Database/ProductModelReader.php
+++ b/src/Pim/Component/Connector/Reader/Database/ProductModelReader.php
@@ -26,6 +26,9 @@ class ProductModelReader implements ItemReaderInterface, InitializableInterface,
     /** @var CursorInterface */
     protected $productModels;
 
+    /** @var bool */
+    private $firstRead = true;
+
     /**
      * @param ProductQueryBuilderFactoryInterface $pqbFactory
      */
@@ -40,6 +43,7 @@ class ProductModelReader implements ItemReaderInterface, InitializableInterface,
     public function initialize()
     {
         $this->productModels = $this->getProductModelsCursor();
+        $this->firstRead = true;
     }
 
     /**
@@ -50,10 +54,14 @@ class ProductModelReader implements ItemReaderInterface, InitializableInterface,
         $productModel = null;
 
         if ($this->productModels->valid()) {
+            if (!$this->firstRead) {
+                $this->productModels->next();
+            }
             $productModel = $this->productModels->current();
             $this->stepExecution->incrementSummaryInfo('read');
-            $this->productModels->next();
         }
+
+        $this->firstRead = false;
 
         return $productModel;
     }

--- a/src/Pim/Component/Connector/spec/Reader/Database/ProductModelReaderSpec.php
+++ b/src/Pim/Component/Connector/spec/Reader/Database/ProductModelReaderSpec.php
@@ -47,7 +47,7 @@ class ProductModelReaderSpec extends ObjectBehavior
 
         $cursor->valid()->willReturn(true, true, true, false);
         $cursor->current()->willReturn($productModel1, $productModel2, $productModel3);
-        $cursor->next()->shouldBeCalled();
+        $cursor->next()->shouldBeCalledTimes(2);
 
         $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(3);
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since #7815 The UnitOfWork is cleared between each job execution batch. The problem is that there was an error in the database `ProductModelReader` so the items of the next batch were loaded from the database before the last current batch item is processed.

This problem has been fixed for the `ProductReader` in #7641 on 2.2 and brought back to 2.0, but not for the `ProductModelReader` because it doesn't exist on 2.2. So I just report the same fix but on `ProductModelReader`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
