### PR TITLE
PIM-7322: Fix cast of a product model as string to format correctly violations

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -10,6 +10,7 @@
 - PIM-7313: prevent the same job to be executed by two different daemons due to race condition
 - PIM-7297: Fix memory leak on completeness purge command
 - PIM-7312: Fix attribute requirements update for a newly created channel
+- PIM-7322: Fix cast of a product model as string to format correctly violations
 
 ## BC Breaks
 

--- a/src/Pim/Component/Catalog/Model/ProductModel.php
+++ b/src/Pim/Component/Catalog/Model/ProductModel.php
@@ -601,6 +601,14 @@ class ProductModel implements ProductModelInterface
     }
 
     /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->getLabel();
+    }
+
+    /**
      * Does the ancestry of the entity already has the $category?
      *
      * @param CategoryInterface $category

--- a/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
@@ -387,4 +387,25 @@ class ProductModelSpec extends ObjectBehavior
             'otherValue-<all_channels>-<all_locales>' => $otherValue
         ]);
     }
+
+    function it_gets_label_when_casting_object_as_string(
+        FamilyVariantInterface $familyVariant,
+        FamilyInterface $family,
+        AttributeInterface $attributeAsLabel,
+        ValueCollectionInterface $values
+    ) {
+        $familyVariant->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $attributeAsLabel->getCode()->willReturn('name');
+        $attributeAsLabel->isLocalizable()->willReturn(true);
+        $attributeAsLabel->isScopable()->willReturn(false);
+
+        $values->toArray()->willreturn([]);
+
+        $this->setFamilyVariant($familyVariant);
+        $this->setValues($values);
+        $this->setCode('shovel');
+
+        $this->__toString()->shouldReturn('shovel');
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When you have a violation on a product model when applying rules, the product model can not be cast as string:

https://github.com/akeneo/pim-enterprise-dev/blob/2.0/src/PimEnterprise/Component/CatalogRule/Engine/ProductRuleApplier/ProductsValidator.php#L69

It is the case of the product.

So, an exception is thrown:

"CATCHABLE FATAL ERROR: OBJECT OF CLASS PIM\COMPONENT\CATALOG\MODEL\PRODUCTMODEL COULD NOT BE CONVERTED TO STRING"


![screen shot 2018-04-16 at 16 25 35](https://user-images.githubusercontent.com/1942439/39043557-0a407056-448e-11e8-92ea-421183406543.png)



<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
