### PR TITLE
PIM-7305: correct memory leak on purge job command

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,3 +1,9 @@
+# 2.2.x
+
+## Bug fixes
+
+- PIM-7305: Fix memory leak on purge job command
+
 # 2.2.4 (2018-04-26)
 
 ## Bug fixes


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
The command akeneo:batch:purge-job-execution as a memory leak (only a flush in a final execution). 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
