### PR TITLE
PIM-7310 : Fix completeness in rule's conditions

### DIFF
--- a/.ci/behat.enterprise.yml
+++ b/.ci/behat.enterprise.yml
@@ -82,7 +82,7 @@ default:
                 - PimEnterprise\Behat\Context\JobContext:
                     - 'Context\EnterpriseFeatureContext'
                 - Pim\Behat\Context\ImportFileContext:
-                    - 'Context\FeatureContext'
+                    - 'Context\EnterpriseFeatureContext'
                 - PimEnterprise\Behat\Context\NavigationContext:
                     - 'Context\EnterpriseFeatureContext'
                     - 'http://127.0.0.1/'

--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -4,6 +4,10 @@
 
 - PIM-7281: Fix inappropriate calls to the cache clearer
 
+## Improvements
+
+- PIM-7310: Fix completeness filter to have the operators '=', '!=', '<', '>' for the product and product model query builder
+
 # 2.2.3 (2018-04-12)
 
 ## BC Breaks

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CompletenessFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CompletenessFilter.php
@@ -54,6 +54,7 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
         // - All complete:            all_complete == true
         // - At least one incomplete: all_complete == false
         // - All incomplete:          all_incomplete == true
+        // - Equals, Not equal, lower than, and greater than are used to filter variant products on the completeness
         switch ($operator) {
             case Operators::AT_LEAST_COMPLETE:
                 $shouldClauses = [];

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CompletenessFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/CompletenessFilter.php
@@ -126,6 +126,85 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
                 }
                 $this->searchQueryBuilder->addFilter(['bool' => ['must' => $mustClauses]]);
                 break;
+
+            case Operators::EQUALS:
+                $shouldClauses = [];
+
+                foreach ($locales as $locale) {
+                    $field = sprintf('completeness.%s.%s', $channel, $locale);
+                    $clause = [
+                        'term' => [
+                            $field => $value
+                        ]
+                    ];
+
+                    $shouldClauses[] = $clause;
+                }
+
+                $this->searchQueryBuilder->addFilter(['bool' => ['should' => $shouldClauses]]);
+                break;
+
+            case Operators::LOWER_THAN:
+                $shouldClauses = [];
+
+                foreach ($locales as $locale) {
+                    $field = sprintf('completeness.%s.%s', $channel, $locale);
+                    $clause = [
+                        'range' => [
+                            $field => [
+                                'lt' => $value
+                            ]
+                        ]
+                    ];
+
+                    $shouldClauses[] = $clause;
+                }
+                $this->searchQueryBuilder->addFilter(['bool' => ['should' => $shouldClauses]]);
+                break;
+
+            case Operators::GREATER_THAN:
+                $shouldClauses = [];
+
+                foreach ($locales as $locale) {
+                    $field = sprintf('completeness.%s.%s', $channel, $locale);
+                    $clause = [
+                        'range' => [
+                            $field => [
+                                'gt' => $value
+                            ]
+                        ]
+                    ];
+
+                    $shouldClauses[] = $clause;
+                }
+                $this->searchQueryBuilder->addFilter(['bool' => ['should' => $shouldClauses]]);
+                break;
+
+            case Operators::NOT_EQUAL:
+                $filterClauses = [];
+                foreach ($locales as $locale) {
+                    $field = sprintf('completeness.%s.%s', $channel, $locale);
+                    $filterClauses[] = [
+                        'term' => [
+                            $field => $value,
+                        ],
+                    ];
+
+                    $completenessExists = [
+                        'exists' => [
+                            'field' => $field,
+                        ],
+                    ];
+                    $this->searchQueryBuilder->addFilter($completenessExists);
+                }
+                $mustNotClause = [
+                    'bool' => [
+                        'filter' => $filterClauses,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($mustNotClause);
+                break;
+
             default:
                 throw InvalidOperatorException::notSupported($operator, static::class);
         }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -339,6 +339,7 @@ services:
                 - '<'
                 - 'EMPTY'
         tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
 
     pim_catalog.query.elasticsearch.filter.completeness:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -339,7 +339,6 @@ services:
                 - '<'
                 - 'EMPTY'
         tags:
-            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
 
     pim_catalog.query.elasticsearch.filter.completeness:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -351,6 +351,10 @@ services:
                 - 'AT LEAST INCOMPLETE'
                 - 'ALL COMPLETE'
                 - 'ALL INCOMPLETE'
+                - '!='
+                - '='
+                - '>'
+                - '<'
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/CompletenessFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/CompletenessFilterSpec.php
@@ -138,6 +138,82 @@ class CompletenessFilterSpec extends ObjectBehavior
             ->shouldReturn($this);
     }
 
+    function it_adds_an_equal_filter($sqb)
+    {
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['term' => ['completeness.ecommerce.en_US' => 100]],
+                    ],
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->addFieldFilter('completeness', Operators::EQUALS, 100, 'en_US', 'ecommerce', [])
+            ->shouldReturn($this);
+    }
+
+    function it_adds_a_not_equal_filter($sqb)
+    {
+        $sqb
+            ->addFilter(
+                [
+                    'exists' => [
+                        'field' => 'completeness.ecommerce.en_US'
+                    ]
+                ]
+            )
+            ->shouldBeCalled();
+
+        $sqb
+            ->addMustNot(
+                [
+                    'bool' => [
+                        'filter' => [
+                            ['term' => ["completeness.ecommerce.en_US" => 100]],
+                        ],
+                    ]
+                ]
+            )
+            ->shouldBeCalled();
+
+        $this->addFieldFilter('completeness', Operators::NOT_EQUAL, 100, 'en_US', 'ecommerce', [])
+            ->shouldReturn($this);
+    }
+
+    function it_adds_a_lower_than_filter($sqb)
+    {
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['range' => ['completeness.ecommerce.en_US' => ['lt' => 100]]]
+                    ]
+                ]
+            ]
+        )->shouldBeCalled();
+
+        $this->addFieldFilter('completeness', Operators::LOWER_THAN, 100, 'en_US', 'ecommerce', [])
+            ->shouldReturn($this);
+    }
+
+    function it_adds_a_greater_than_filter($sqb)
+    {
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['range' => ['completeness.ecommerce.en_US' => ['gt' => 100]]]
+                    ]
+                ]
+            ]
+        )->shouldBeCalled();
+
+        $this->addFieldFilter('completeness', Operators::GREATER_THAN, 100, 'en_US', 'ecommerce', [])
+            ->shouldReturn($this);
+    }
+
     function it_filters_with_a_non_empty_locale()
     {
         $this->shouldThrow(InvalidPropertyException::class)->during(

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/CompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/CompletenessFilterIntegration.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Filter;
+
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Pim\Bundle\CatalogBundle\tests\assert\AssertEntityWithValues;
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * Test that the right product and product model are found depending
+ *  - the completeness for a variant product
+ *  - the number of complete variant product
+ *
+ * Caution: We use product and product model query builder here
+ *
+ * @author    Arnaud Langlade <arnaud.langlade@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.completeness_filter')
+            ->loadProductModelTree();
+
+        sleep(2);
+    }
+
+    /**
+     * Test the EQUALS filter
+     */
+    public function testOperatorEquals()
+    {
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::EQUALS,
+            100,
+            [
+                'scope' => 'tablet',
+                'locales' => ['fr_FR', 'en_US', 'de_DE']
+            ]
+        ]]);
+        $this->assert($result, ['variant_product_1', 'variant_product_2', 'variant_product_3', 'variant_product_4']);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::EQUALS,
+            100,
+            [
+                'scope' => 'tablet',
+                'locale' => 'en_US'
+            ]
+        ]]);
+        $this->assert($result, ['variant_product_1', 'variant_product_3']);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::EQUALS,
+            100,
+            [
+                'scope' => 'tablet',
+                'locale' => 'fr_FR'
+            ]
+        ]]);
+        $this->assert($result, ['variant_product_2', 'variant_product_3', 'variant_product_4']);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::EQUALS,
+            100,
+            [
+                'scope' => 'tablet',
+                'locale' => 'de_DE'
+            ]
+        ]]);
+        $this->assert($result, []);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::EQUALS,
+            75,
+            [
+                'scope' => 'tablet',
+                'locale' => 'fr_FR'
+            ]
+        ]]);
+        $this->assert($result, ['simple_product', 'variant_product_1']);
+    }
+
+    /**
+     * Test the GREATER filter
+     */
+    public function testOperatorGreaterThan()
+    {
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::GREATER_THAN,
+            100,
+            [
+                'scope' => 'tablet',
+                'locales' => ['fr_FR', 'en_US', 'de_DE']
+            ]
+        ]]);
+        $this->assert($result, []);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::GREATER_THAN,
+            100,
+            [
+                'scope' => 'ecommerce',
+                'locale' => 'en_US'
+            ]
+        ]]);
+        $this->assert($result, []);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::GREATER_THAN,
+            75,
+            [
+                'scope' => 'tablet',
+                'locale' => 'en_US'
+            ]
+        ]]);
+        $this->assert($result, ['variant_product_1', 'variant_product_3']);
+    }
+
+    /**
+     * Test the NOT EQUAL filter
+     */
+    public function testOperatorNotEqual()
+    {
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::NOT_EQUAL,
+            100,
+            [
+                'scope' => 'tablet',
+                'locales' => ['fr_FR', 'en_US', 'de_DE']
+            ]
+        ]]);
+        $this->assert($result, ['variant_product_1', 'variant_product_2', 'variant_product_3', 'variant_product_4', 'simple_product']);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::NOT_EQUAL,
+            50,
+            [
+                'scope' => 'tablet',
+                'locale' => 'en_US'
+            ]
+        ]]);
+        $this->assert($result, ['variant_product_1', 'variant_product_2', 'variant_product_3', 'variant_product_4', 'simple_product']);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::NOT_EQUAL,
+            75,
+            [
+                'scope' => 'tablet',
+                'locale' => 'fr_FR'
+            ]
+        ]]);
+        $this->assert($result, ['variant_product_2', 'variant_product_3', 'variant_product_4']);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::NOT_EQUAL,
+            33,
+            [
+                'scope' => 'ecommerce',
+                'locale' => 'en_US'
+            ]
+        ]]);
+        $this->assert($result, ['variant_product_1', 'variant_product_2', 'variant_product_3', 'variant_product_4', 'simple_product']);
+    }
+
+    /**
+     * Test the LOWER filter
+     */
+    public function testOperatorLowerThan()
+    {
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::LOWER_THAN,
+            100,
+            [
+                'scope' => 'tablet',
+                'locales' => ['fr_FR', 'en_US', 'de_DE']
+            ]
+        ]]);
+        $this->assert($result, ['variant_product_1', 'variant_product_2', 'variant_product_3', 'variant_product_4', 'simple_product']);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::LOWER_THAN,
+            100,
+            [
+                'scope' => 'tablet',
+                'locale' => 'en_US'
+            ]
+        ]]);
+        $this->assert($result, ['variant_product_2', 'variant_product_4', 'simple_product']);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::LOWER_THAN,
+            100,
+            [
+                'scope' => 'tablet',
+                'locale' => 'fr_FR'
+            ]
+        ]]);
+        $this->assert($result, ['variant_product_1', 'simple_product']);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::LOWER_THAN,
+            100,
+            [
+                'scope' => 'ecommerce',
+                'locale' => 'en_US'
+            ]
+        ]]);
+        $this->assert($result, []);
+
+        $result = $this->executeFilter([[
+            'completeness',
+            Operators::LOWER_THAN,
+            75,
+            [
+                'scope' => 'tablet'
+            ]
+        ]]);
+        $this->assert($result, []);
+    }
+
+    /**
+     * All those queries need to be done with product and product model query builder.
+     *
+     * @param array $filters
+     *
+     * @return CursorInterface
+     */
+    protected function executeFilter(array $filters)
+    {
+        $pqb = $this->get('pim_catalog.query.product_and_product_model_query_builder_factory')->create();
+
+        foreach ($filters as $filter) {
+            $context = isset($filter[3]) ? $filter[3] : [];
+            $pqb->addFilter($filter[0], $filter[1], $filter[2], $context);
+        }
+
+        return $pqb->execute();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/CompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/CompletenessFilterIntegration.php
@@ -8,13 +8,11 @@ use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductQueryBuilderTe
 use Pim\Component\Catalog\Query\Filter\Operators;
 
 /**
- * Test that the right product and product model are found depending
- *  - the completeness for a variant product
- *  - the number of complete variant product
+ * Test completeness filter with the operators '=', '!=', '<', '>'.
  *
  * Caution: We use product and product model query builder here
  *
- * @author    Arnaud Langlade <arnaud.langlade@akeneo.com>
+ * @author    Christophe Chausseray <christophe.chausseray@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/CompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/CompletenessFilterIntegration.php
@@ -232,7 +232,8 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
             Operators::LOWER_THAN,
             75,
             [
-                'scope' => 'tablet'
+                'scope' => 'tablet',
+                'locales' => ['fr_FR', 'en_US', 'de_DE']
             ]
         ]]);
         $this->assert($result, []);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We got an SLA that we couldn't have a completeness rule condition with the operator '='
 on the completeness. However in the documentation, we specify that we can add custom rules on the completeness with the operators '=', '!=', '<', '>' (https://docs.akeneo.com/2.2/manipulate_pim_data/rule/general_information_on_rule_format.html#completeness). The completeness filter used on the product and product model index doesn't accept those operators.

To fix it, I added the missing operators on the service declaration of the completeness filter and implemented the ES query for each operator use case.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | Todo
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
