### PR TITLE
PIM-7325: Fix family grid search filter

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -13,6 +13,7 @@
 - PIM-7322: Fix cast of a product model as string to format correctly violations
 - PIM-7320: Fix memory leak on boolean values purge command
 - PIM-7317: Fix iterator misuse in the database product model reader
+- PIM-7325: Fix family grid search filter
 
 ## BC Breaks
 

--- a/features/family/browse_families.feature
+++ b/features/family/browse_families.feature
@@ -57,3 +57,19 @@ Feature: Browse families
     When I select rows caterpillar and dr-martens
     And I press the "Bulk actions" button
     Then I should see the text "Select your action"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7325
+  Scenario: Successfully search families when coming back from a family edit form
+    Given I am on the families grid
+    When I search "Sand"
+    Then the grid should contain 1 element
+    And I should see family Sandals
+    And I click on the "Sandals" row
+    And I wait to be on the "Sandals" family page
+    And I follow the link "Families"
+    Then I should be on the families page
+    And the grid should contain 1 element
+    And I should see family Sandals
+    And I search "e"
+    Then the grid should contain 3 elements
+    And I should see families Heels, LED TVs and Sneakers

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-button.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-button.js
@@ -11,11 +11,13 @@ define(
         FiltersManager
     ) {
         return BaseForm.extend({
+            isLoaded: false,
+
             /**
              * @inheritdoc
              */
             initialize() {
-                mediator.once('datagrid_filters:loaded', this.showFilterManager.bind(this));
+                this.listenTo(mediator, 'datagrid_filters:loaded', this.showFilterManager.bind(this));
 
                 BaseForm.prototype.initialize.apply(this, arguments);
             },
@@ -26,6 +28,11 @@ define(
              * @param {Object} options
              */
             showFilterManager(options) {
+                if (this.isLoaded) {
+                    return;
+                }
+                this.isLoaded = true;
+
                 const filtersList = new FiltersManager(options);
                 this.$el.append(filtersList.render().$el);
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-list.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-list.js
@@ -4,6 +4,7 @@ define(['underscore', 'pim/form', 'oro/mediator', 'oro/tools'],
         return BaseForm.extend({
             options: {},
             filters: [],
+            isLoaded: false,
             className: 'AknFilterBox-list filter-box',
 
             config: {
@@ -22,8 +23,17 @@ define(['underscore', 'pim/form', 'oro/mediator', 'oro/tools'],
              */
             initialize(options) {
                 this.options = options.config;
-                mediator.once('datagrid_collection_set_after', this.loadFilterModules.bind(this));
+
                 BaseForm.prototype.initialize.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            configure: function () {
+                this.listenTo(mediator, 'datagrid_collection_set_after', this.loadFilterModules.bind(this));
+
+                BaseForm.prototype.configure.apply(this, arguments);
             },
 
             /**
@@ -32,6 +42,10 @@ define(['underscore', 'pim/form', 'oro/mediator', 'oro/tools'],
              * @param  {HTMLElement} gridElement Grid element
              */
             loadFilterModules(collection, gridElement) {
+                if (this.isLoaded) {
+                    return;
+                }
+                this.isLoaded = true;
                 this.collection = collection;
                 this.gridElement = gridElement;
                 this.metadata = this.gridElement.data('metadata') || {};


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

This fixes an issue where the family grid search bar was no more usable when coming back from a family edit form.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
