### PR TITLE
Fix default legacy features path for nightly builds

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -3,7 +3,7 @@
 import org.csanchez.jenkins.plugins.kubernetes.pipeline.PodTemplateAction
 
 String[] editions = ["ce"]
-String[] features = ["features"]
+String[] features = ["tests/legacy/features"]
 String launchUnitTests = "yes"
 String launchIntegrationTests = "yes"
 String launchBehatTests = "yes"

--- a/.ci/behat.enterprise.yml
+++ b/.ci/behat.enterprise.yml
@@ -144,17 +144,41 @@ legacy:
         pim:
             output_path: app/build/logs/behat/
 
-
 acceptance:
     suites:
-        acceptance:
+        pim:
             paths:
-                - '%paths.base%/tests/features/'
-                - '%paths.base%/vendor/akeneo/pim-community-dev/tests/features/'
+                - '%paths.base%/tests/features/pim'
+                - '%paths.base%/vendor/akeneo/pim-community-dev/tests/features/pim'
             contexts_services:
                 - test.locale.context
                 - test.channel.context
+            filters:
+                tags: '@acceptance-back'
+        volume-monitoring:
+            paths:
+                - '%paths.base%/tests/features/volume-monitoring'
+                - '%paths.base%/vendor/akeneo/pim-community-dev/tests/features/volume-monitoring'
+            contexts_services:
+                - test.catalog_volume_limits.report_context
                 - test.catalog_volume_limits.attribute_per_family_context
+                - test.catalog_volume_limits.product_context
+                - test.catalog_volume_limits.channel_context
+                - test.catalog_volume_limits.locale_context
+                - test.catalog_volume_limits.scopable_attribute_context
+                - test.catalog_volume_limits.localizable_attribute_context
+                - test.catalog_volume_limits.localizable_and_scopable_attribute_context
+                - test.catalog_volume_limits.family_context
+                - test.catalog_volume_limits.attribute_context
+                - test.catalog_volume_limits.option_per_attribute_context
+                - test.catalog_volume_limits.category_context
+                - test.catalog_volume_limits.category_tree_context
+                - test.catalog_volume_limits.variant_product_context
+                - test.catalog_volume_limits.product_model_context
+                - test.catalog_volume_limits.product_value_context
+                - test.product_asset.asset_context
+                - test.product_asset.asset_category_context
+                - test.product_asset.asset_category_tree_context
             filters:
                 tags: '@acceptance-back'
     extensions:
@@ -163,6 +187,7 @@ acceptance:
                - "tests/back/Acceptance/Resources/config/behat/services.yml"
                - "vendor/akeneo/pim-community-dev/tests/back/Acceptance/Resources/config/behat/services.yml"
                - "vendor/akeneo/pim-community-dev/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Resources/config/behat/services.yml"
+               - "src/PimEnterprise/Bundle/ProductAssetBundle/tests/Acceptance/Resources/config/behat/services.yml"
         FriendsOfBehat\CrossContainerExtension: ~
         FriendsOfBehat\SymfonyExtension:
             kernel:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Fixes the default path for legacy behats in nightly builds.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
