### PR TITLE
PIM-7334: Fix identifier filter with special characters

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7338: Fix attribute groups labels in the grid
+- PIM-7334: Fix identifier filter with special characters
 
 # 2.0.24 (2018-05-16)
 

--- a/features/product/filtering/filter_products.feature
+++ b/features/product/filtering/filter_products.feature
@@ -20,7 +20,7 @@ Feature: Filter products
       | sku    | family    | enabled | name-en_US  | name-fr_FR   | info-en_US-ecommerce    | info-fr_FR-ecommerce     | info-fr_FR-mobile     | image-ecommerce  | image-mobile     |
       | postit | furniture | yes     | Post it     | Etiquette    | My ecommerce info       | Ma info ecommerce        | Ma info mobile        | large.jpeg       | small.jpeg       |
       | book   | library   | no      | Book        | Livre        | My ecommerce book info  | Ma info livre ecommerce  | Ma info livre mobile  | book_large.jpeg  | book_small.jpeg  |
-      | book2  |           | yes     | Book2       | Livre2       | My ecommerce book2 info | Ma info livre2 ecommerce | Ma info livre2 mobile | book2_large.jpeg | book2_small.jpeg |
+      | book/2 |           | yes     | Book2       | Livre2       | My ecommerce book2 info | Ma info livre2 ecommerce | Ma info livre2 mobile | book2_large.jpeg | book2_small.jpeg |
       | 01234  |           | yes     | 01234       | 01234        | My ecommerce 01234 info | Ma info 01234 ecommerce  | Ma info 01234 mobile  |                  |                  |
       | ebook  |           | yes     | eBook       | Ebook        | My ecommerce ebook info | Ma info ebook ecommerce  | Ma info ebook mobile  |                  |                  |
       | chair  | furniture | yes     | Chair/Slash | Chaise/Slash | My ecommerce chair .    | Ma info chaise ecommerce | Ma info chaise mobile |                  |                  |
@@ -29,22 +29,25 @@ Feature: Filter products
   Scenario: Successfully filter products
     Given I am on the products grid
     Then the grid should contain 6 elements
-    And I should see products postit, book, book2, ebook, chair and 01234
+    And I should see products postit, book, book/2, ebook, chair and 01234
     And I should be able to use the following filters:
-      | filter  | operator         | value         | result                                      |
-      | sku     | contains         | book          | book, ebook and book2                       |
-      | name    | contains         | post          | postit                                      |
-      | info    | contains         | book          | book, ebook and book2                       |
-      | enabled |                  | Enabled       | postit, ebook, book2, chair and 01234       |
-      | enabled |                  | Disabled      | book                                        |
-      | sku     | does not contain | book          | postit and chair and 01234                  |
-      | sku     | starts with      | boo           | book and book2                              |
-      | sku     | starts with      | 0             | 01234                                       |
-      | sku     | is equal to      | book          | book                                        |
-      | sku     | in list          | book          | book                                        |
-      | sku     | in list          | postit, book2 | postit and book2                            |
-      | name    | is empty         |               |                                             |
-      | name    | is not empty     |               | postit, book, ebook, book2, chair and 01234 |
+      | filter  | operator         | value         | result                                       |
+      | sku     | contains         | book          | book, ebook and book/2                       |
+      | sku     | contains         | k/            | book/2                                       |
+      | name    | contains         | post          | postit                                       |
+      | info    | contains         | book          | book, ebook and book/2                       |
+      | enabled |                  | Enabled       | postit, ebook, book/2, chair and 01234       |
+      | enabled |                  | Disabled      | book                                         |
+      | sku     | does not contain | book          | postit and chair and 01234                   |
+      | sku     | does not contain | k/2           | postit, book, ebook, chair and 01234         |
+      | sku     | starts with      | boo           | book and book/2                              |
+      | sku     | starts with      | 0             | 01234                                        |
+      | sku     | starts with      | book/         | book/2                                       |
+      | sku     | is equal to      | book          | book                                         |
+      | sku     | in list          | book          | book                                         |
+      | sku     | in list          | postit,book/2 | postit and book/2                            |
+      | name    | is empty         |               |                                              |
+      | name    | is not empty     |               | postit, book, ebook, book/2, chair and 01234 |
 
   Scenario: Successfully hide/show filters
     Given I am on the products grid

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/AbstractAttributeFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/AbstractAttributeFilter.php
@@ -116,24 +116,4 @@ abstract class AbstractAttributeFilter implements AttributeFilterInterface
 
         return 'values.' . $attribute->getCode() . '-' . $attribute->getBackendType() . '.' . $channel . '.' . $locale;
     }
-
-    /**
-     * Escapes particular values prior than doing a search query escaping whitespace or newlines.
-     *
-     * This is useful when using ES 'query_string' clauses in a search query.
-     *
-     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
-     *
-     * TODO: TIP-706 - This may move somewhere else
-     *
-     * @param string $value
-     *
-     * @return string
-     */
-    protected function escapeValue($value)
-    {
-        $regex = '#[-+=|! &(){}\[\]^"~*<>?:/\\\]#';
-
-        return preg_replace($regex, '\\\$0', $value);
-    }
 }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Escaper\QueryString;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
@@ -52,7 +53,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($attribute, $value);
-            $escapedValue = $this->escapeValue($value);
+            $escapedValue = QueryString::escapeValue($value);
         }
 
         $attributePath = $this->getAttributePath($attribute, $locale, $channel);

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/TextFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/TextFilter.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Escaper\QueryString;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Validator\AttributeValidatorHelper;
@@ -52,7 +53,7 @@ class TextFilter extends AbstractAttributeFilter implements AttributeFilterInter
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
             $this->checkValue($attribute, $value);
-            $escapedValue = $this->escapeValue($value);
+            $escapedValue = QueryString::escapeValue($value);
         }
 
         $attributePath = $this->getAttributePath($attribute, $locale, $channel);

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/IdentifierFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/IdentifierFilter.php
@@ -6,6 +6,7 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\AbstractFieldFilter;
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Escaper\QueryString;
 use Pim\Component\Catalog\Query\Filter\AttributeFilterInterface;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
 use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
@@ -123,7 +124,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
                 $clause = [
                     'query_string' => [
                         'default_field' => self::IDENTIFIER_KEY,
-                        'query'         => $value . '*',
+                        'query'         => QueryString::escapeValue($value) . '*',
                     ],
                 ];
                 $this->searchQueryBuilder->addFilter($clause);
@@ -133,7 +134,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
                 $clause = [
                     'query_string' => [
                         'default_field' => self::IDENTIFIER_KEY,
-                        'query'         => '*' . $value . '*',
+                        'query'         => '*' . QueryString::escapeValue($value) . '*',
                     ],
                 ];
                 $this->searchQueryBuilder->addFilter($clause);
@@ -143,7 +144,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
                 $mustNotClause = [
                     'query_string' => [
                         'default_field' => self::IDENTIFIER_KEY,
-                        'query'         => '*' . $value . '*',
+                        'query'         => '*' . QueryString::escapeValue($value) . '*',
                     ],
                 ];
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/IdentifierFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/IdentifierFilterSpec.php
@@ -83,7 +83,7 @@ class IdentifierFilterSpec extends ObjectBehavior
             [
                 'query_string' => [
                     'default_field' => 'identifier',
-                    'query'         => 'sku-*',
+                    'query'         => 'sku\-*',
                 ],
             ]
         )->shouldBeCalled();
@@ -201,7 +201,7 @@ class IdentifierFilterSpec extends ObjectBehavior
             [
                 'query_string' => [
                     'default_field' => 'identifier',
-                    'query'         => 'sku-*',
+                    'query'         => 'sku\-*',
                 ],
             ]
         )->shouldBeCalled();

--- a/src/Pim/Component/Catalog/Query/Escaper/QueryString.php
+++ b/src/Pim/Component/Catalog/Query/Escaper/QueryString.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Pim\Component\Catalog\Query\Escaper;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class QueryString
+{
+    /**
+     * Escapes particular values prior to doing a search query escaping whitespace, newlines or reserved characters.
+     *
+     * This is useful when using ES 'query_string' clauses in a search query.
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    public static function escapeValue(?string $value): string
+    {
+        $regex = '#[-+=|! &(){}\[\]^"~*<>?:/\\\]#';
+
+        return preg_replace($regex, '\\\$0', $value);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

**Description (for Contributor and Core Developer)**

`Pim\Bundle\CatalogBundle\Elasticsearch\Filter\IdentifierFilter` uses ES query_string clauses for `CONTAINS`, `DOES NOT CONTAIN` and `STARTS WITH` operators, so the values have to be escaped (see [elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters))
Fixes #7806 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | Ok
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
