### PR TITLE
PIM-7338: Attribute groups label used catalog locale (not UI locale) in grid

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Bug fixes
+
+- PIM-7338: Fix attribute groups labels in the grid
+
 # 2.0.24 (2018-05-16)
 
 ## Bug fixes

--- a/features/attribute-group/list_attribute_groups.feature
+++ b/features/attribute-group/list_attribute_groups.feature
@@ -103,3 +103,17 @@ Feature: List attribute groups
     Then I should see the text "[attribute_group_1]"
     And I should see the text "[attribute_group_22]"
     And the order of groups should be "[attribute_group_1], [attribute_group_2], [attribute_group_4], [attribute_group_5], [attribute_group_6], [attribute_group_7], [attribute_group_8], [attribute_group_9], [attribute_group_10], [attribute_group_11], [attribute_group_12], [attribute_group_14], [attribute_group_15], [attribute_group_16], [attribute_group_17], [attribute_group_18], [attribute_group_19], [attribute_group_21], [attribute_group_22], [attribute_group_3], [attribute_group_20], [attribute_group_13]"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7338
+  Scenario: Successfully display attribute group labels translated from the catalog locale
+    Given the "footwear" catalog configuration
+    And I am logged in as "Julia"
+    And I am on the "tablet" channel page
+    And I add the "german" locale to the "tablet" channel
+    And I edit the "Julia" user
+    And I visit the "Additional" tab
+    And I fill in the following information:
+      | Catalog locale       | de_DE             |
+    And I save the user
+    When I am on the attribute groups page
+    Then I should see the text "[marketing]"

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute-group/form/list.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute-group/form/list.js
@@ -60,7 +60,7 @@ define([
                 this.$el.html(this.template({
                     attributeGroups: _.sortBy(_.values(this.attributeGroups), 'sort_order'),
                     i18n: i18n,
-                    uiLocale: UserContext.get('uiLocale')
+                    uiLocale: UserContext.get('catalogLocale')
                 }));
 
                 this.$('tbody').sortable({


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The PIM takes the UI locale into account to display the attribute group names and not the catalog locale.
The PIM should display the labels for the catalog locale not the UI locale.

Regression since 1.7.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
