### PR TITLE
PIM-7330: Better validation message on sibling duplicate

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -62,7 +62,7 @@ stage("Build") {
                         containerTemplate(name: "docker", image: "paulwoelfel/docker-gcloud:latest", ttyEnabled: true, command: 'cat', resourceRequestCpu: '100m', resourceRequestMemory: '200Mi')
                     ]) {container('docker') {
                         checkout([$class: 'GitSCM',
-                            branches: [[name: '2.2']],
+                            branches: [[name: '2.3']],
                             userRemoteConfigs: [[credentialsId: 'github-credentials', url: 'https://github.com/akeneo/pim-enterprise-dev.git']]
                         ])
 

--- a/.ci/bin/start-elasticsearch
+++ b/.ci/bin/start-elasticsearch
@@ -2,3 +2,8 @@
 set -eu -o pipefail
 
 su -s /bin/bash -c "/usr/share/elasticsearch/bin/elasticsearch -d -p /var/run/elasticsearch/elasticsearch -Edefault.path.logs=/var/log/elasticsearch -Edefault.path.data=/var/lib/elasticsearch -Edefault.path.conf=/etc/elasticsearch" elasticsearch
+
+while [[ ! $(curl -o /dev/null -sw "%{http_code}\n" 127.0.0.1:9200) =~ (2|3)[0-9]{2} ]]; do
+    printf .
+    sleep 1
+done

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Improve Julia's experience
 
 - PIM-6897: As Julia, I would like to update the family variant labels from the UI
+- PIM-7330: Improve validation message in case of product model or variant product axis values duplication
 
 # 2.3.0-ALPHA1 (2018-04-27)
 

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,11 @@
 - PIM-6897: As Julia, I would like to update the family variant labels from the UI
 - PIM-7330: Improve validation message in case of product model or variant product axis values duplication
 
+## BC Breaks
+
+- Remove public constant `Pim\Component\Catalog\Validator\Constraints\UniqueVariantAxis::DUPLICATE_VALUE_IN_SIBLING`
+- Change the method signature of `Pim\Component\Catalog\Validator\UniqueAxesCombinationSet::addCombination`, this methods does not return anything anymore, but can throw `AlreadyExistingAxisValueCombinationException`
+
 # 2.3.0-ALPHA1 (2018-04-27)
 
 ## Improve Julia's experience
@@ -30,7 +35,9 @@
 - `Pim\Component\Catalog\Model\ProductModelInterface` now implements `Pim\Component\Catalog\Model\AssociationAwareInterface`
 
 ## New jobs
-IMPORTANT: In order for your PIM to work properly, you will need to run the following commands to add the missing job instances.
+
+**IMPORTANT**: In order for your PIM to work properly, you will need to run the following commands to add the missing job instances.
+
 - Add the job instance `add_to_group`: `bin/console akeneo:batch:create-job "Akeneo Mass Edit Connector" "add_to_group" "mass_delete" "add_to_group" '{}' "Mass add product to group" --env=prod`
 
 ## Migrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ENV YARN_CACHE_FOLDER=/tmp/yarn
 ENV BUILD_PACKAGES \
   apt-transport-https \
   autoconf \
-  curl \
   g++ \
   git \
   libcurl4-gnutls-dev \
@@ -62,7 +61,6 @@ RUN apt-get update && apt-get install -y apt-transport-https \
   && docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ \
   && docker-php-ext-install \
   bcmath \
-  curl \
   exif \
   gd \
   intl \

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateListVariantProductIntegration.php
@@ -247,7 +247,7 @@ JSON;
         $expectedContent =
 <<<JSON
 {"line":1,"identifier":"apollon_optionb_true","status_code":204}
-{"line":2,"identifier":"apollon_optionb_new","status_code":422,"message":"Validation failed.","errors":[{"property":"attribute","message":"Cannot set value \"1\" for the attribute axis \"a_yes_no\", as another sibling entity already has this value"}]}
+{"line":2,"identifier":"apollon_optionb_new","status_code":422,"message":"Validation failed.","errors":[{"property":"attribute","message":"Cannot set value \"1\" for the attribute axis \"a_yes_no\" on variant product \"apollon_optionb_new\", as the variant product \"apollon_optionb_true\" already has this value"}]}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
@@ -433,7 +433,7 @@ JSON;
   "errors": [
     {
       "property": "attribute",
-      "message": "Cannot set value \"Option B\" for the attribute axis \"a_simple_select\", as another sibling entity already has this value"
+      "message": "Cannot set value \"Option B\" for the attribute axis \"a_simple_select\" on product model \"sub_product_model\", as the product model \"tshirt_sub_product_model\" already has this value"
     }
   ]
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateListProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateListProductModelIntegration.php
@@ -264,7 +264,7 @@ JSON;
         $expectedContent =
 <<<JSON
 {"line":1,"code":"sub_sweat_option_a","status_code":204}
-{"line":2,"code":"sub_sweat_option_b","status_code":422,"message":"Validation failed.","errors":[{"property":"attribute","message":"Cannot set value \"Option A\" for the attribute axis \"a_simple_select\", as another sibling entity already has this value"}]}
+{"line":2,"code":"sub_sweat_option_b","status_code":422,"message":"Validation failed.","errors":[{"property":"attribute","message":"Cannot set value \"Option A\" for the attribute axis \"a_simple_select\" on product model \"sub_sweat_option_b\", as the product model \"sub_sweat_option_a\" already has this value"}]}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/product-models', [], [], [], $data);

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
@@ -924,7 +924,7 @@ JSON;
     "errors": [
         {
             "property": "attribute",
-            "message": "Cannot set value \"Option B\" for the attribute axis \"a_simple_select\", as another sibling entity already has this value"
+            "message": "Cannot set value \"Option B\" for the attribute axis \"a_simple_select\" on product model \"sub_sweat_bis\", as the product model \"sub_sweat\" already has this value"
         }
     ]
 }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/entity_with_family_variant.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/entity_with_family_variant.yml
@@ -9,7 +9,7 @@ services:
 
     pim_catalog.entity_with_family_variant.check_attribute_editable:
         class: '%pim_catalog.entity_with_family_variant.check_attribute_editable.class%'
-    
+
     pim_catalog.entity_with_family_variant.add_parent_to_product:
         class: '%pim_catalog.entity_with_family_variant.add_parent_to_product.class%'
         arguments:

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
@@ -34,7 +34,8 @@ product_model.family_variant.not_blank.message: The product model family variant
 pim_catalog:
     constraint:
         can_have_family_variant_empty_axis_value: 'Attribute "%attribute%" cannot be empty, as it is defined as an axis for this entity'
-        can_have_family_variant_duplicate_axis_value: 'Cannot set value "%values%" for the attribute axis "%attributes%", as another sibling entity already has this value'
+        product_model_with_same_axis_value_already_exists: 'Cannot set value "%values%" for the attribute axis "%attributes%" on product model "%validated_entity%", as the product model "%sibling_with_same_value%" already has this value'
+        variant_product_with_same_axis_value_already_exists: 'Cannot set value "%values%" for the attribute axis "%attributes%" on variant product "%validated_entity%", as the variant product "%sibling_with_same_value%" already has this value'
         can_have_family_variant_unexpected_attribute: 'Cannot set the property "%attribute%" to this entity as it is not in the attribute set'
         cannot_have_product_model_as_parent: 'The product model "%product_model%" cannot have the product model "%parent_product_model%" as parent'
         cannot_have_parent: 'The product model "%product_model%" cannot have a parent'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateProductModelIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateProductModelIntegration.php
@@ -263,7 +263,7 @@ class CreateProductModelIntegration extends TestCase
         $productModelDuplicate->setParent($productModelParent);
         $errors = $this->get('pim_catalog.validator.product_model')->validate($productModelDuplicate);
         $this->assertEquals(
-            'Cannot set value "[blue]" for the attribute axis "color", as another sibling entity already has this value',
+            'Cannot set value "[blue]" for the attribute axis "color" on product model "product_model_duplicate_code", as the product model "product_model_code" already has this value',
             $errors->get(0)->getMessage()
         );
     }
@@ -321,7 +321,7 @@ class CreateProductModelIntegration extends TestCase
         $productModelDuplicate->setParent($productModelParent);
         $errors = $this->get('pim_catalog.validator.product_model')->validate($productModelDuplicate);
         $this->assertEquals(
-            'Cannot set value "[blue]" for the attribute axis "color", as another sibling entity already has this value',
+            'Cannot set value "[blue]" for the attribute axis "color" on product model "product_model_duplicate_code", as the product model "product_model_code" already has this value',
             $errors->get(0)->getMessage()
         );
     }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateVariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateVariantProductIntegration.php
@@ -58,7 +58,7 @@ class CreateVariantProductIntegration extends TestCase
 
         $this->assertEquals(1, $errors->count());
         $this->assertEquals(
-            'Cannot set value "[m]" for the attribute axis "size", as another sibling entity already has this value',
+            'Cannot set value "[m]" for the attribute axis "size" on variant product "apollon_blue_m_bis", as the variant product "1111111120" already has this value',
             $errors->get(0)->getMessage()
         );
     }
@@ -97,7 +97,7 @@ class CreateVariantProductIntegration extends TestCase
         $errors = $this->get('pim_catalog.validator.product')->validate($variantProduct2);
         $this->assertEquals(1, $errors->count());
         $this->assertEquals(
-            'Cannot set value "[l]" for the attribute axis "size", as another sibling entity already has this value',
+            'Cannot set value "[l]" for the attribute axis "size" on variant product "apollon_blue_l_2", as the variant product "apollon_blue_l_1" already has this value',
             $errors->get(0)->getMessage()
         );
     }

--- a/src/Pim/Component/Catalog/Exception/AlreadyExistingAxisValueCombinationException.php
+++ b/src/Pim/Component/Catalog/Exception/AlreadyExistingAxisValueCombinationException.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Exception;
+
+/**
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AlreadyExistingAxisValueCombinationException extends \Exception
+{
+    /** @var string */
+    private $identifier;
+
+    /** @var string */
+    private $entityClass;
+
+    /** @var string */
+    private $axisCombination;
+
+    /**
+     * @param string $identifier
+     * @param string $entityClass
+     * @param string $axisCombination
+     */
+    public function __construct(string $identifier, string $entityClass, string $axisCombination)
+    {
+        $this->identifier = $identifier;
+        $this->entityClass = $entityClass;
+        $this->axisCombination = $axisCombination;
+
+        parent::__construct($this->createExceptionMessage());
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * @return string
+     */
+    private function createExceptionMessage(): string
+    {
+        return sprintf(
+            'The %s "%s" already have a value for the "%s" axis combination.',
+            $this->entityClass,
+            $this->identifier,
+            $this->axisCombination
+        );
+    }
+}

--- a/src/Pim/Component/Catalog/Exception/AlreadyExistingAxisValueCombinationException.php
+++ b/src/Pim/Component/Catalog/Exception/AlreadyExistingAxisValueCombinationException.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Pim\Component\Catalog\Exception;
 
 /**
+ * This exception is thrown when an entity with family variant uses a combination
+ * of variant axis values that already exists.
+ *
  * @author    Damien Carcel <damien.carcel@akeneo.com>
  * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
@@ -14,44 +17,24 @@ class AlreadyExistingAxisValueCombinationException extends \Exception
     /** @var string */
     private $identifier;
 
-    /** @var string */
-    private $entityClass;
-
-    /** @var string */
-    private $axisCombination;
-
     /**
      * @param string $identifier
-     * @param string $entityClass
-     * @param string $axisCombination
+     * @param string $message
      */
-    public function __construct(string $identifier, string $entityClass, string $axisCombination)
+    public function __construct(string $identifier, string $message)
     {
         $this->identifier = $identifier;
-        $this->entityClass = $entityClass;
-        $this->axisCombination = $axisCombination;
 
-        parent::__construct($this->createExceptionMessage());
+        parent::__construct($message);
     }
 
     /**
+     * Returns the identifier of the entity having an already existing axis value combination.
+     *
      * @return string
      */
     public function getEntityIdentifier(): string
     {
         return $this->identifier;
-    }
-
-    /**
-     * @return string
-     */
-    private function createExceptionMessage(): string
-    {
-        return sprintf(
-            'The %s "%s" already have a value for the "%s" axis combination.',
-            $this->entityClass,
-            $this->identifier,
-            $this->axisCombination
-        );
     }
 }

--- a/src/Pim/Component/Catalog/Model/ProductModel.php
+++ b/src/Pim/Component/Catalog/Model/ProductModel.php
@@ -549,91 +549,11 @@ class ProductModel implements ProductModelInterface
     }
 
     /**
-     * @param EntityWithFamilyVariantInterface $entity
-     * @param ValueCollectionInterface         $valueCollection
-     *
-     * @return ValueCollectionInterface
-     */
-    private function getAllValues(
-        EntityWithFamilyVariantInterface $entity,
-        ValueCollectionInterface $valueCollection
-    ) {
-        $parent = $entity->getParent();
-
-        if (null === $parent) {
-            return $valueCollection;
-        }
-
-        foreach ($parent->getValuesForVariation() as $value) {
-            $valueCollection->add($value);
-        }
-
-        return $this->getAllValues($parent, $valueCollection);
-    }
-
-    /**
-     * @param EntityWithFamilyVariantInterface $entity
-     * @param Collection                       $categoryCollection
-     *
-     * @return Collection
-     */
-    private function getAllCategories(
-        EntityWithFamilyVariantInterface $entity,
-        Collection $categoryCollection
-    ) {
-        $parent = $entity->getParent();
-
-        if (null === $parent) {
-            return $categoryCollection;
-        }
-
-        foreach ($parent->getCategories() as $category) {
-            if (!$categoryCollection->contains($category)) {
-                $categoryCollection->add($category);
-            }
-        }
-
-        return $this->getAllCategories($parent, $categoryCollection);
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFamily(): ?FamilyInterface
     {
         return null !== $this->getFamilyVariant() ? $this->getFamilyVariant()->getFamily() : null;
-    }
-
-    /**
-     * @return string
-     */
-    public function __toString()
-    {
-        return (string) $this->getLabel();
-    }
-
-    /**
-     * Does the ancestry of the entity already has the $category?
-     *
-     * @param CategoryInterface $category
-     *
-     * @return bool
-     */
-    private function hasAncestryCategory(CategoryInterface $category): bool
-    {
-        $parent = $this->getParent();
-        if (null === $parent) {
-            return false;
-        }
-
-        // no need recursion here as getCategories already look in the whole ancestry
-        foreach ($parent->getCategories() as $ancestryCategory) {
-            if ($ancestryCategory->getCode() === $category->getCode()) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -707,5 +627,85 @@ class ProductModel implements ProductModelInterface
         $this->associations = $associations;
 
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->getLabel();
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $entity
+     * @param ValueCollectionInterface         $valueCollection
+     *
+     * @return ValueCollectionInterface
+     */
+    private function getAllValues(
+        EntityWithFamilyVariantInterface $entity,
+        ValueCollectionInterface $valueCollection
+    ) {
+        $parent = $entity->getParent();
+
+        if (null === $parent) {
+            return $valueCollection;
+        }
+
+        foreach ($parent->getValuesForVariation() as $value) {
+            $valueCollection->add($value);
+        }
+
+        return $this->getAllValues($parent, $valueCollection);
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $entity
+     * @param Collection                       $categoryCollection
+     *
+     * @return Collection
+     */
+    private function getAllCategories(
+        EntityWithFamilyVariantInterface $entity,
+        Collection $categoryCollection
+    ) {
+        $parent = $entity->getParent();
+
+        if (null === $parent) {
+            return $categoryCollection;
+        }
+
+        foreach ($parent->getCategories() as $category) {
+            if (!$categoryCollection->contains($category)) {
+                $categoryCollection->add($category);
+            }
+        }
+
+        return $this->getAllCategories($parent, $categoryCollection);
+    }
+
+    /**
+     * Does the ancestry of the entity already has the $category?
+     *
+     * @param CategoryInterface $category
+     *
+     * @return bool
+     */
+    private function hasAncestryCategory(CategoryInterface $category): bool
+    {
+        $parent = $this->getParent();
+        if (null === $parent) {
+            return false;
+        }
+
+        // no need recursion here as getCategories already look in the whole ancestry
+        foreach ($parent->getCategories() as $ancestryCategory) {
+            if ($ancestryCategory->getCode() === $category->getCode()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Pim/Component/Catalog/Repository/EntityWithFamilyVariantRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/EntityWithFamilyVariantRepositoryInterface.php
@@ -16,7 +16,7 @@ interface EntityWithFamilyVariantRepositoryInterface
      *
      * @param EntityWithFamilyVariantInterface $entity
      *
-     * @return array
+     * @return EntityWithFamilyVariantInterface[]
      */
     public function findSiblings(EntityWithFamilyVariantInterface $entity): array;
 }

--- a/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxis.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxis.php
@@ -11,7 +11,8 @@ use Symfony\Component\Validator\Constraint;
  */
 class UniqueVariantAxis extends Constraint
 {
-    public const DUPLICATE_VALUE_IN_SIBLING = 'pim_catalog.constraint.can_have_family_variant_duplicate_axis_value';
+    public const DUPLICATE_VALUE_IN_PRODUCT_MODEL = 'pim_catalog.constraint.product_model_with_same_axis_value_already_exists';
+    public const DUPLICATE_VALUE_IN_VARIANT_PRODUCT = 'pim_catalog.constraint.variant_product_with_same_axis_value_already_exists';
 
     /**
      * {@inheritdoc}

--- a/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxisValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxisValidator.php
@@ -2,9 +2,11 @@
 
 namespace Pim\Component\Catalog\Validator\Constraints;
 
+use Pim\Component\Catalog\Exception\AlreadyExistingAxisValueCombinationException;
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\EntityWithFamilyVariantRepositoryInterface;
 use Pim\Component\Catalog\Validator\UniqueAxesCombinationSet;
 use Symfony\Component\Validator\Constraint;
@@ -22,7 +24,7 @@ class UniqueVariantAxisValidator extends ConstraintValidator
     private $axesProvider;
 
     /** @var EntityWithFamilyVariantRepositoryInterface */
-    private $repository;
+    private $entityWithFamilyVariantRepository;
 
     /** @var UniqueAxesCombinationSet */
     private $uniqueAxesCombinationSet;
@@ -38,7 +40,7 @@ class UniqueVariantAxisValidator extends ConstraintValidator
         UniqueAxesCombinationSet $uniqueAxesCombinationSet
     ) {
         $this->axesProvider = $axesProvider;
-        $this->repository = $repository;
+        $this->entityWithFamilyVariantRepository = $repository;
         $this->uniqueAxesCombinationSet = $uniqueAxesCombinationSet;
     }
 
@@ -65,24 +67,12 @@ class UniqueVariantAxisValidator extends ConstraintValidator
             return;
         }
 
-        $valueAlreadyExists = $this->alreadyExists($entity, $axes);
-        $valueAlreadyProcessed = $this->hasAlreadyValidatedTheSameValue($entity, $axes);
-
-        if ($valueAlreadyExists || $valueAlreadyProcessed) {
-            $axesCodes = implode(',', array_map(function (AttributeInterface $axis) {
-                return $axis->getCode();
-            }, $axes));
-            $duplicateCombination = $this->buildAxesCombination($entity, $axes);
-
-            $this->context->buildViolation(
-                UniqueVariantAxis::DUPLICATE_VALUE_IN_SIBLING,
-                ['%values%' => $duplicateCombination, '%attributes%' => $axesCodes]
-            )->atPath('attribute')->addViolation();
-        }
+        $this->validateValueIsNotAlreadyInDatabase($entity, $axes);
+        $this->validateValueWasNotAlreadyValidated($entity, $axes);
     }
 
     /**
-     * This method builds "combinations" of the given $entityWithValues for its $axes.
+     * This method builds "combinations" of the given $entityWithFamilyVariant for its $axes.
      * A combination is the concatenation of all values for an axis.
      *
      * For example, the axis is made of 2 attributes: color and size.
@@ -91,21 +81,23 @@ class UniqueVariantAxisValidator extends ConstraintValidator
      *
      * This allows use to compare multiple combinations, to look for a potential duplicate.
      *
-     * @param EntityWithFamilyVariantInterface $entityWithValues
+     * @param EntityWithFamilyVariantInterface $entityWithFamilyVariant
      * @param AttributeInterface[]             $axes
      *
      * @return string
      */
-    private function buildAxesCombination(EntityWithFamilyVariantInterface $entityWithValues, array $axes): string
-    {
+    private function buildAxesCombination(
+        EntityWithFamilyVariantInterface $entityWithFamilyVariant,
+        array $axes
+    ): string {
         $combination = [];
 
         foreach ($axes as $axis) {
-            $value = $entityWithValues->getValue($axis->getCode());
+            $value = $entityWithFamilyVariant->getValue($axis->getCode());
             $stringValue = '';
 
             if (null !== $value) {
-                $stringValue = $value->__toString();
+                $stringValue = (string)$value;
             }
 
             $combination[] = $stringValue;
@@ -115,56 +107,122 @@ class UniqueVariantAxisValidator extends ConstraintValidator
     }
 
     /**
-     * This method returns TRUE if there is a duplicate value in siblings of $entity in database, FALSE otherwise
+     * Adds a constraint violation if there is a sibling of "$entity" with the
+     * same axis combination in database.
      *
      * @param EntityWithFamilyVariantInterface $entity
      * @param AttributeInterface[]             $axes
-     *
-     * @return bool
      */
-    private function alreadyExists(EntityWithFamilyVariantInterface $entity, array $axes): bool
+    private function validateValueIsNotAlreadyInDatabase(EntityWithFamilyVariantInterface $entity, array $axes): void
     {
-        $brothers = $this->repository->findSiblings($entity);
+        $siblings = $this->entityWithFamilyVariantRepository->findSiblings($entity);
 
-        if (empty($brothers)) {
-            return false;
+        if (empty($siblings)) {
+            return;
         }
 
-        $brothersCombinations = [];
-        foreach ($brothers as $brother) {
-            $brothersCombinations[] = $this->buildAxesCombination($brother, $axes);
+        $siblingsCombinations = [];
+        foreach ($siblings as $sibling) {
+            $siblingIdentifier = $this->getEntityIdentifier($sibling);
+            $siblingsCombinations[$siblingIdentifier] = $this->buildAxesCombination($sibling, $axes);
         }
 
         $ownCombination = $this->buildAxesCombination($entity, $axes);
 
         if ('' === str_replace(',', '', $ownCombination)) {
-            return false;
+            return;
         }
 
-        return in_array($ownCombination, $brothersCombinations);
+        if (in_array($ownCombination, $siblingsCombinations)) {
+            $alreadyInDatabaseSiblingIdentifier = array_search($ownCombination, $siblingsCombinations);
+
+            $this->addViolation(
+                $axes,
+                $ownCombination,
+                $entity,
+                $alreadyInDatabaseSiblingIdentifier
+            );
+        }
     }
 
     /**
-     * This method returns TRUE if there is a duplicate value in an already parsed entity (so it has to be stateful),
-     * FALSE otherwise
+     * Adds a constraint violation if a sibling of "$entity" with the same axis
+     * combination was already parsed.
+     *
+     * This means "$uniqueAxesCombinationSet" has to be stateful.
      *
      * @param EntityWithFamilyVariantInterface $entity
      * @param AttributeInterface[]             $axes
-     *
-     * @return bool
      */
-    private function hasAlreadyValidatedTheSameValue(EntityWithFamilyVariantInterface $entity, array $axes): bool
+    private function validateValueWasNotAlreadyValidated(EntityWithFamilyVariantInterface $entity, array $axes): void
     {
         if (null === $entity->getParent()) {
-            return false;
+            return;
         }
 
         $combination = $this->buildAxesCombination($entity, $axes);
 
         if ('' === str_replace(',', '', $combination)) {
-            return false;
+            return;
         }
 
-        return false === $this->uniqueAxesCombinationSet->addCombination($entity, $combination);
+        try {
+            $this->uniqueAxesCombinationSet->addCombination($entity, $combination);
+        } catch (AlreadyExistingAxisValueCombinationException $e) {
+            $alreadyValidatedSiblingIdentifier = $e->getEntityIdentifier();
+
+            $this->addViolation(
+                $axes,
+                $combination,
+                $entity,
+                $alreadyValidatedSiblingIdentifier
+            );
+        }
+    }
+
+    /**
+     * @param array                            $axes
+     * @param string                           $combination
+     * @param EntityWithFamilyVariantInterface $entityWithFamilyVariant
+     * @param string                           $siblingIdentifier
+     */
+    private function addViolation(
+        array $axes,
+        string $combination,
+        EntityWithFamilyVariantInterface $entityWithFamilyVariant,
+        string $siblingIdentifier
+    ): void {
+        $axesCodes = implode(',', array_map(
+            function (AttributeInterface $axis) {
+                return $axis->getCode();
+            },
+            $axes
+        ));
+
+        $message = UniqueVariantAxis::DUPLICATE_VALUE_IN_PRODUCT_MODEL;
+        if ($entityWithFamilyVariant instanceof ProductInterface) {
+            $message = UniqueVariantAxis::DUPLICATE_VALUE_IN_VARIANT_PRODUCT;
+        }
+
+        $this->context->buildViolation($message, [
+            '%values%' => $combination,
+            '%attributes%' => $axesCodes,
+            '%validated_entity%' => $this->getEntityIdentifier($entityWithFamilyVariant),
+            '%sibling_with_same_value%' => $siblingIdentifier,
+        ])->atPath('attribute')->addViolation();
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $entity
+     *
+     * @return string
+     */
+    private function getEntityIdentifier(EntityWithFamilyVariantInterface $entity): string
+    {
+        if ($entity instanceof ProductInterface) {
+            return $entity->getIdentifier();
+        }
+
+        return $entity->getCode();
     }
 }

--- a/src/Pim/Component/Catalog/Validator/UniqueAxesCombinationSet.php
+++ b/src/Pim/Component/Catalog/Validator/UniqueAxesCombinationSet.php
@@ -43,23 +43,37 @@ class UniqueAxesCombinationSet
      * this combination.
      *
      * @param EntityWithFamilyVariantInterface $entity
-     * @param string                           $axesCombination
+     * @param string                           $axisValueCombination
      *
      * @throws AlreadyExistingAxisValueCombinationException
      */
-    public function addCombination(EntityWithFamilyVariantInterface $entity, string $axesCombination): void
+    public function addCombination(EntityWithFamilyVariantInterface $entity, string $axisValueCombination): void
     {
         $familyVariantCode = $entity->getFamilyVariant()->getCode();
         $parentCode = $entity->getParent()->getCode();
         $identifier = $this->getEntityIdentifier($entity);
 
-        if (isset($this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axesCombination])) {
-            $cachedIdentifier = $this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axesCombination];
+        if (isset($this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axisValueCombination])) {
+            $cachedIdentifier = $this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axisValueCombination];
             if ($cachedIdentifier !== $identifier) {
+                if ($entity instanceof ProductInterface) {
+                    throw new AlreadyExistingAxisValueCombinationException(
+                        $cachedIdentifier,
+                        sprintf(
+                            'Variant product "%s" already have the "%s" combination of axis values.',
+                            $cachedIdentifier,
+                            $axisValueCombination
+                        )
+                    );
+                }
+
                 throw new AlreadyExistingAxisValueCombinationException(
                     $cachedIdentifier,
-                    get_class($entity),
-                    $axesCombination
+                    sprintf(
+                        'Product model "%s" already have the "%s" combination of axis values.',
+                        $cachedIdentifier,
+                        $axisValueCombination
+                    )
                 );
             }
         }
@@ -72,8 +86,8 @@ class UniqueAxesCombinationSet
             $this->uniqueAxesCombination[$familyVariantCode][$parentCode] = [];
         }
 
-        if (!isset($this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axesCombination])) {
-            $this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axesCombination] = $identifier;
+        if (!isset($this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axisValueCombination])) {
+            $this->uniqueAxesCombination[$familyVariantCode][$parentCode][$axisValueCombination] = $identifier;
         }
     }
 

--- a/src/Pim/Component/Catalog/Value/OptionValue.php
+++ b/src/Pim/Component/Catalog/Value/OptionValue.php
@@ -15,7 +15,7 @@ use Pim\Component\Catalog\Model\AttributeOptionInterface;
  */
 class OptionValue extends AbstractValue implements OptionValueInterface
 {
-    /** @var AttributeOptionInterface[] */
+    /** @var AttributeOptionInterface */
     protected $data;
 
     /**

--- a/src/Pim/Component/Catalog/spec/Exception/AlreadyExistingAxisValueCombinationExceptionSpec.php
+++ b/src/Pim/Component/Catalog/spec/Exception/AlreadyExistingAxisValueCombinationExceptionSpec.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Exception;
+
+use Pim\Component\Catalog\Exception\AlreadyExistingAxisValueCombinationException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class AlreadyExistingAxisValueCombinationExceptionSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('foobar', 'VariantProduct', '[color,size]');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AlreadyExistingAxisValueCombinationException::class);
+    }
+
+    function it_creates_an_exception_message_during_instanciation()
+    {
+        $this->getMessage()->shouldReturn(
+            'The VariantProduct "foobar" already have a value for the "[color,size]" axis combination.'
+        );
+    }
+
+    function it_returns_the_identifier_of_the_entity_that_already_have_the_axis_combination()
+    {
+        $this->getEntityIdentifier()->shouldReturn('foobar');
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Exception/AlreadyExistingAxisValueCombinationExceptionSpec.php
+++ b/src/Pim/Component/Catalog/spec/Exception/AlreadyExistingAxisValueCombinationExceptionSpec.php
@@ -2,15 +2,14 @@
 
 namespace spec\Pim\Component\Catalog\Exception;
 
-use Pim\Component\Catalog\Exception\AlreadyExistingAxisValueCombinationException;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
+use Pim\Component\Catalog\Exception\AlreadyExistingAxisValueCombinationException;
 
 class AlreadyExistingAxisValueCombinationExceptionSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith('foobar', 'VariantProduct', '[color,size]');
+        $this->beConstructedWith('foobar', 'an exception message');
     }
 
     function it_is_initializable()
@@ -18,11 +17,9 @@ class AlreadyExistingAxisValueCombinationExceptionSpec extends ObjectBehavior
         $this->shouldHaveType(AlreadyExistingAxisValueCombinationException::class);
     }
 
-    function it_creates_an_exception_message_during_instanciation()
+    function it_adds_an_exception_message_during_instanciation()
     {
-        $this->getMessage()->shouldReturn(
-            'The VariantProduct "foobar" already have a value for the "[color,size]" axis combination.'
-        );
+        $this->getMessage()->shouldReturn('an exception message');
     }
 
     function it_returns_the_identifier_of_the_entity_that_already_have_the_axis_combination()

--- a/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
@@ -4,7 +4,6 @@ namespace spec\Pim\Component\Catalog\Model;
 
 use Akeneo\Component\Classification\CategoryAwareInterface;
 use Akeneo\Component\Versioning\Model\VersionableInterface;
-use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\CategoryInterface;
@@ -14,10 +13,8 @@ use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModel;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\TimestampableInterface;
-use Pim\Component\Catalog\Model\ValueCollection;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
-use Pim\Component\Connector\ArrayConverter\FlatToStandard\Value;
 
 class ProductModelSpec extends ObjectBehavior
 {

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
@@ -4,10 +4,12 @@ namespace spec\Pim\Component\Catalog\Validator\Constraints;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\EntityWithFamilyVariantRepository;
+use Pim\Component\Catalog\Exception\AlreadyExistingAxisValueCombinationException;
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Validator\Constraints\UniqueVariantAxis;
@@ -61,15 +63,30 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $this->validate($entity, $constraint);
     }
 
+    function it_raises_no_violation_if_the_entity_has_no_parent(
+        $context,
+        FamilyVariantInterface $familyVariant,
+        EntityWithFamilyVariantInterface $entity,
+        UniqueVariantAxis $constraint
+    ) {
+        $entity->getFamilyVariant()->willReturn($familyVariant);
+        $entity->getParent()->willReturn(null);
+
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($entity, $constraint);
+    }
+
     function it_raises_no_violation_if_the_entity_has_no_sibling(
         $context,
         $repository,
         $axesProvider,
         FamilyVariantInterface $familyVariant,
+        ProductModelInterface $parent,
         EntityWithFamilyVariantInterface $entity,
         UniqueVariantAxis $constraint
     ) {
-        $entity->getParent()->willReturn(null);
+        $entity->getParent()->willReturn($parent);
         $axesProvider->getAxes($entity)->willReturn([]);
         $entity->getFamilyVariant()->willReturn($familyVariant);
         $repository->findSiblings($entity)->willReturn([]);
@@ -84,40 +101,74 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $repository,
         $axesProvider,
         FamilyVariantInterface $familyVariant,
+        ProductModelInterface $parent,
         EntityWithFamilyVariantInterface $entity,
         EntityWithFamilyVariantInterface $sibling,
         UniqueVariantAxis $constraint
     ) {
-        $entity->getParent()->willReturn(null);
+        $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
-        $repository->findSiblings($entity)->willReturn([$sibling]);
         $axesProvider->getAxes($entity)->willReturn([]);
+        $repository->findSiblings($entity)->willReturn([$sibling]);
 
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
 
         $this->validate($entity, $constraint);
     }
 
-    function it_raises_no_violation_if_there_is_no_duplicate_in_any_sibling_entity_from_database(
+    function it_raises_no_violation_if_axes_combination_is_empty(
         $context,
         $repository,
         $axesProvider,
         $uniqueAxesCombinationSet,
         FamilyVariantInterface $familyVariant,
-        EntityWithFamilyVariantInterface $entity,
-        EntityWithFamilyVariantInterface $sibling1,
-        EntityWithFamilyVariantInterface $sibling2,
+        ProductModelInterface $parent,
+        ProductModelInterface $entity,
+        ProductModelInterface $sibling1,
+        ProductModelInterface $sibling2,
         AttributeInterface $color,
-        UniqueVariantAxis $constraint,
-        ValueInterface $blue,
-        ValueInterface $red,
-        ValueInterface $yellow
+        ValueInterface $emptyValue,
+        UniqueVariantAxis $constraint
     ) {
-        $entity->getParent()->willReturn(null);
+        $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
-        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
         $axesProvider->getAxes($entity)->willReturn([$color]);
         $color->getCode()->willReturn('color');
+        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
+
+        $entity->getValue('color')->willReturn($emptyValue);
+        $emptyValue->__toString()->willReturn('');
+        $uniqueAxesCombinationSet->addCombination(Argument::any())->shouldNotBeCalled();
+
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($entity, $constraint);
+    }
+
+    function it_raises_no_violation_if_there_is_no_duplicate_in_any_sibling_product_model_from_database(
+        $context,
+        $repository,
+        $axesProvider,
+        $uniqueAxesCombinationSet,
+        FamilyVariantInterface $familyVariant,
+        ProductModelInterface $parent,
+        ProductModelInterface $entity,
+        ProductModelInterface $sibling1,
+        ProductModelInterface $sibling2,
+        AttributeInterface $color,
+        ValueInterface $blue,
+        ValueInterface $red,
+        ValueInterface $yellow,
+        UniqueVariantAxis $constraint
+    ) {
+        $entity->getParent()->willReturn($parent);
+        $entity->getFamilyVariant()->willReturn($familyVariant);
+        $axesProvider->getAxes($entity)->willReturn([$color]);
+        $color->getCode()->willReturn('color');
+
+        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
+        $sibling1->getCode()->willReturn('sibling1');
+        $sibling2->getCode()->willReturn('sibling2');
 
         $entity->getValue('color')->willReturn($blue);
         $sibling1->getValue('color')->willReturn($red);
@@ -127,33 +178,78 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $red->__toString()->willReturn('[red]');
         $yellow->__toString()->willReturn('[yellow]');
 
-        $uniqueAxesCombinationSet->addCombination($entity, Argument::any())->willReturn(true);
+        $uniqueAxesCombinationSet->addCombination($entity, '[blue]')->shouldBeCalled();
 
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
 
         $this->validate($entity, $constraint);
     }
 
-    function it_raises_a_violation_if_there_is_a_duplicate_value_in_any_sibling_entity(
+    function it_raises_no_violation_if_there_is_no_duplicate_in_any_sibling_variant_product_from_database(
         $context,
         $repository,
         $axesProvider,
         $uniqueAxesCombinationSet,
         FamilyVariantInterface $familyVariant,
-        EntityWithFamilyVariantInterface $entity,
-        EntityWithFamilyVariantInterface $sibling1,
-        EntityWithFamilyVariantInterface $sibling2,
+        ProductModelInterface $parent,
+        ProductInterface $entity,
+        ProductInterface $sibling1,
+        ProductInterface $sibling2,
         AttributeInterface $color,
-        UniqueVariantAxis $constraint,
         ValueInterface $blue,
+        ValueInterface $red,
         ValueInterface $yellow,
-        ConstraintViolationBuilderInterface $violation
+        UniqueVariantAxis $constraint
     ) {
-        $entity->getParent()->willReturn(null);
+        $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
-        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
         $axesProvider->getAxes($entity)->willReturn([$color]);
         $color->getCode()->willReturn('color');
+
+        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
+        $sibling1->getIdentifier()->willReturn('sibling1');
+        $sibling2->getIdentifier()->willReturn('sibling2');
+
+        $entity->getValue('color')->willReturn($blue);
+        $sibling1->getValue('color')->willReturn($red);
+        $sibling2->getValue('color')->willReturn($yellow);
+
+        $blue->__toString()->willReturn('[blue]');
+        $red->__toString()->willReturn('[red]');
+        $yellow->__toString()->willReturn('[yellow]');
+
+        $uniqueAxesCombinationSet->addCombination($entity, '[blue]')->shouldBeCalled();
+
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($entity, $constraint);
+    }
+
+    function it_raises_a_violation_if_there_is_a_duplicate_value_in_any_sibling_product_model(
+        $context,
+        $repository,
+        $axesProvider,
+        $uniqueAxesCombinationSet,
+        FamilyVariantInterface $familyVariant,
+        ProductModelInterface $parent,
+        ProductModelInterface $entity,
+        ProductModelInterface $sibling1,
+        ProductModelInterface $sibling2,
+        AttributeInterface $color,
+        ValueInterface $blue,
+        ValueInterface $yellow,
+        UniqueVariantAxis $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $entity->getCode()->willReturn('entity_code');
+        $entity->getParent()->willReturn($parent);
+        $entity->getFamilyVariant()->willReturn($familyVariant);
+        $axesProvider->getAxes($entity)->willReturn([$color]);
+        $color->getCode()->willReturn('color');
+
+        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
+        $sibling1->getCode()->willReturn('sibling1');
+        $sibling2->getCode()->willReturn('sibling2');
 
         $entity->getValue('color')->willReturn($blue);
         $sibling1->getValue('color')->willReturn($blue);
@@ -162,123 +258,298 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $blue->__toString()->willReturn('[blue]');
         $yellow->__toString()->willReturn('[yellow]');
 
+        $uniqueAxesCombinationSet->addCombination($entity, '[blue]')->shouldBeCalled();
+
         $context
             ->buildViolation(
-                UniqueVariantAxis::DUPLICATE_VALUE_IN_SIBLING, [
+                UniqueVariantAxis::DUPLICATE_VALUE_IN_PRODUCT_MODEL,
+                [
                     '%values%' => '[blue]',
                     '%attributes%' => 'color',
+                    '%validated_entity%' => 'entity_code',
+                    '%sibling_with_same_value%' => 'sibling1',
                 ]
             )
             ->willReturn($violation);
         $violation->atPath('attribute')->willReturn($violation);
         $violation->addViolation()->shouldBeCalled();
 
-        $uniqueAxesCombinationSet->addCombination($entity, Argument::any())->willReturn(true);
-
         $this->validate($entity, $constraint);
     }
 
-    function it_raises_a_violation_if_there_is_a_duplicate_value_in_any_sibling_entity_with_multiple_attributes_in_axis(
+    function it_raises_a_violation_if_there_is_a_duplicate_value_in_any_sibling_variant_product(
         $context,
         $repository,
         $axesProvider,
         $uniqueAxesCombinationSet,
         FamilyVariantInterface $familyVariant,
-        EntityWithFamilyVariantInterface $entity,
-        EntityWithFamilyVariantInterface $sibling1,
-        EntityWithFamilyVariantInterface $sibling2,
+        ProductModelInterface $parent,
+        ProductInterface $entity,
+        ProductInterface $sibling1,
+        ProductInterface $sibling2,
         AttributeInterface $color,
-        AttributeInterface $size,
-        UniqueVariantAxis $constraint,
         ValueInterface $blue,
         ValueInterface $yellow,
-        ValueInterface $xl,
+        UniqueVariantAxis $constraint,
         ConstraintViolationBuilderInterface $violation
     ) {
-        $entity->getParent()->willReturn(null);
+        $entity->getIdentifier()->willReturn('entity_identifier');
+        $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
-        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
-        $axesProvider->getAxes($entity)->willReturn([$color, $size]);
+        $axesProvider->getAxes($entity)->willReturn([$color]);
         $color->getCode()->willReturn('color');
-        $size->getCode()->willReturn('size');
+
+        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
+        $sibling1->getIdentifier()->willReturn('sibling1');
+        $sibling2->getIdentifier()->willReturn('sibling2');
 
         $entity->getValue('color')->willReturn($blue);
         $sibling1->getValue('color')->willReturn($blue);
         $sibling2->getValue('color')->willReturn($yellow);
 
+        $blue->__toString()->willReturn('[blue]');
+        $yellow->__toString()->willReturn('[yellow]');
+
+        $uniqueAxesCombinationSet->addCombination($entity, '[blue]')->shouldBeCalled();
+
+        $context
+            ->buildViolation(
+                UniqueVariantAxis::DUPLICATE_VALUE_IN_VARIANT_PRODUCT,
+                [
+                    '%values%' => '[blue]',
+                    '%attributes%' => 'color',
+                    '%validated_entity%' => 'entity_identifier',
+                    '%sibling_with_same_value%' => 'sibling1',
+                ]
+            )
+            ->willReturn($violation);
+        $violation->atPath('attribute')->willReturn($violation);
+        $violation->addViolation()->shouldBeCalled();
+
+        $this->validate($entity, $constraint);
+    }
+
+    function it_raises_a_violation_if_there_is_a_duplicate_value_in_any_sibling_product_model_with_multiple_attributes_in_axis(
+        $context,
+        $repository,
+        $axesProvider,
+        $uniqueAxesCombinationSet,
+        FamilyVariantInterface $familyVariant,
+        ProductModelInterface $parent,
+        ProductModelInterface $entity,
+        ProductModelInterface $sibling1,
+        ProductModelInterface $sibling2,
+        AttributeInterface $color,
+        ValueInterface $blue,
+        ValueInterface $yellow,
+        AttributeInterface $size,
+        ValueInterface $xl,
+        UniqueVariantAxis $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $entity->getCode()->willReturn('entity_code');
+        $entity->getParent()->willReturn($parent);
+        $entity->getFamilyVariant()->willReturn($familyVariant);
+        $axesProvider->getAxes($entity)->willReturn([$color, $size]);
+        $color->getCode()->willReturn('color');
+        $size->getCode()->willReturn('size');
+
+        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
+        $sibling1->getCode()->willReturn('sibling1');
+        $sibling2->getCode()->willReturn('sibling2');
+
+        $entity->getValue('color')->willReturn($blue);
         $entity->getValue('size')->willReturn($xl);
+
+        $sibling1->getValue('color')->willReturn($blue);
         $sibling1->getValue('size')->willReturn($xl);
+
+        $sibling2->getValue('color')->willReturn($yellow);
         $sibling2->getValue('size')->willReturn($xl);
 
         $blue->__toString()->willReturn('[blue]');
         $yellow->__toString()->willReturn('[yellow]');
         $xl->__toString()->willReturn('[xl]');
 
+        $uniqueAxesCombinationSet->addCombination($entity, '[blue],[xl]')->shouldBeCalled();
+
         $context
             ->buildViolation(
-                UniqueVariantAxis::DUPLICATE_VALUE_IN_SIBLING,
+                UniqueVariantAxis::DUPLICATE_VALUE_IN_PRODUCT_MODEL,
                 [
                     '%values%' => '[blue],[xl]',
                     '%attributes%' => 'color,size',
+                    '%validated_entity%' => 'entity_code',
+                    '%sibling_with_same_value%' => 'sibling1',
                 ]
             )
             ->willReturn($violation);
         $violation->atPath('attribute')->willReturn($violation);
         $violation->addViolation()->shouldBeCalled();
 
-        $uniqueAxesCombinationSet->addCombination($entity, Argument::any())->willReturn(true);
-
         $this->validate($entity, $constraint);
     }
 
-    function it_raises_a_violation_if_there_is_a_duplicate_in_the_batch(
+    function it_raises_a_violation_if_there_is_a_duplicate_value_in_any_sibling_variant_product_with_multiple_attributes_in_axis(
         $context,
         $repository,
         $axesProvider,
         $uniqueAxesCombinationSet,
         FamilyVariantInterface $familyVariant,
-        EntityWithFamilyVariantInterface $entity1,
-        EntityWithFamilyVariantInterface $entity2,
         ProductModelInterface $parent,
+        ProductInterface $entity,
+        ProductInterface $sibling1,
+        ProductInterface $sibling2,
         AttributeInterface $color,
-        UniqueVariantAxis $constraint,
         ValueInterface $blue,
+        ValueInterface $yellow,
+        AttributeInterface $size,
+        ValueInterface $xl,
+        UniqueVariantAxis $constraint,
         ConstraintViolationBuilderInterface $violation
     ) {
+        $entity->getIdentifier()->willReturn('entity_identifier');
+        $entity->getParent()->willReturn($parent);
+        $entity->getFamilyVariant()->willReturn($familyVariant);
+        $axesProvider->getAxes($entity)->willReturn([$color, $size]);
         $color->getCode()->willReturn('color');
-        $blue->__toString()->willReturn('[blue]');
+        $size->getCode()->willReturn('size');
 
+        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
+        $sibling1->getIdentifier()->willReturn('sibling1');
+        $sibling2->getIdentifier()->willReturn('sibling2');
+
+        $entity->getValue('color')->willReturn($blue);
+        $entity->getValue('size')->willReturn($xl);
+
+        $sibling1->getValue('color')->willReturn($blue);
+        $sibling1->getValue('size')->willReturn($xl);
+
+        $sibling2->getValue('color')->willReturn($yellow);
+        $sibling2->getValue('size')->willReturn($xl);
+
+        $blue->__toString()->willReturn('[blue]');
+        $yellow->__toString()->willReturn('[yellow]');
+        $xl->__toString()->willReturn('[xl]');
+
+        $uniqueAxesCombinationSet->addCombination($entity, '[blue],[xl]')->shouldBeCalled();
+
+        $context
+            ->buildViolation(
+                UniqueVariantAxis::DUPLICATE_VALUE_IN_VARIANT_PRODUCT,
+                [
+                    '%values%' => '[blue],[xl]',
+                    '%attributes%' => 'color,size',
+                    '%validated_entity%' => 'entity_identifier',
+                    '%sibling_with_same_value%' => 'sibling1',
+                ]
+            )
+            ->willReturn($violation);
+        $violation->atPath('attribute')->willReturn($violation);
+        $violation->addViolation()->shouldBeCalled();
+
+        $this->validate($entity, $constraint);
+    }
+
+    function it_raises_a_violation_if_there_is_a_duplicated_product_model_in_the_batch(
+        $context,
+        $repository,
+        $axesProvider,
+        $uniqueAxesCombinationSet,
+        FamilyVariantInterface $familyVariant,
+        ProductModelInterface $entity1,
+        ProductModelInterface $entity2,
+        ProductModelInterface $parent,
+        AttributeInterface $color,
+        ValueInterface $blue,
+        AlreadyExistingAxisValueCombinationException $exception,
+        UniqueVariantAxis $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
         $entity1->getParent()->willReturn($parent);
         $entity1->getFamilyVariant()->willReturn($familyVariant);
         $repository->findSiblings($entity1)->willReturn([]);
         $axesProvider->getAxes($entity1)->willReturn([$color]);
-        $entity1->getValue('color')->willReturn($blue);
+        $color->getCode()->willReturn('color');
 
+        $entity2->getCode()->willReturn('entity_2');
         $entity2->getParent()->willReturn($parent);
         $entity2->getFamilyVariant()->willReturn($familyVariant);
         $repository->findSiblings($entity2)->willReturn([]);
         $axesProvider->getAxes($entity2)->willReturn([$color]);
-        $entity2->getValue('color')->willReturn($blue);
 
-        $uniqueAxesCombinationSet->addCombination($entity1, '[blue]')->willReturn(true);
-        $uniqueAxesCombinationSet->addCombination($entity2, '[blue]')->willReturn(false);
+        $entity1->getValue('color')->willReturn($blue);
+        $entity2->getValue('color')->willReturn($blue);
+        $blue->__toString()->willReturn('[blue]');
+
+        $uniqueAxesCombinationSet->addCombination($entity2, '[blue]')->willThrow($exception->getWrappedObject());
+        $exception->getEntityIdentifier()->willReturn('entity_1');
 
         $context
             ->buildViolation(
-                UniqueVariantAxis::DUPLICATE_VALUE_IN_SIBLING,
+                UniqueVariantAxis::DUPLICATE_VALUE_IN_PRODUCT_MODEL,
                 [
                     '%values%' => '[blue]',
                     '%attributes%' => 'color',
+                    '%validated_entity%' => 'entity_2',
+                    '%sibling_with_same_value%' => 'entity_1',
                 ]
             )
             ->willReturn($violation);
-
         $violation->atPath('attribute')->willReturn($violation);
         $violation->addViolation()->shouldBeCalled();
 
-        $this->validate($entity1, $constraint);
         $this->validate($entity2, $constraint);
+    }
 
-        $violation->addViolation()->shouldHaveBeenCalled();
+    function it_raises_a_violation_if_there_is_a_duplicated_variant_product_in_the_batch(
+        $context,
+        $repository,
+        $axesProvider,
+        $uniqueAxesCombinationSet,
+        FamilyVariantInterface $familyVariant,
+        ProductInterface $entity1,
+        ProductInterface $entity2,
+        ProductModelInterface $parent,
+        AttributeInterface $color,
+        ValueInterface $blue,
+        AlreadyExistingAxisValueCombinationException $exception,
+        UniqueVariantAxis $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $entity1->getParent()->willReturn($parent);
+        $entity1->getFamilyVariant()->willReturn($familyVariant);
+        $repository->findSiblings($entity1)->willReturn([]);
+        $axesProvider->getAxes($entity1)->willReturn([$color]);
+        $color->getCode()->willReturn('color');
+
+        $entity2->getIdentifier()->willReturn('entity_2');
+        $entity2->getParent()->willReturn($parent);
+        $entity2->getFamilyVariant()->willReturn($familyVariant);
+        $repository->findSiblings($entity2)->willReturn([]);
+        $axesProvider->getAxes($entity2)->willReturn([$color]);
+
+        $entity1->getValue('color')->willReturn($blue);
+        $entity2->getValue('color')->willReturn($blue);
+        $blue->__toString()->willReturn('[blue]');
+
+        $uniqueAxesCombinationSet->addCombination($entity2, '[blue]')->willThrow($exception->getWrappedObject());
+        $exception->getEntityIdentifier()->willReturn('entity_1');
+
+        $context
+            ->buildViolation(
+                UniqueVariantAxis::DUPLICATE_VALUE_IN_VARIANT_PRODUCT,
+                [
+                    '%values%' => '[blue]',
+                    '%attributes%' => 'color',
+                    '%validated_entity%' => 'entity_2',
+                    '%sibling_with_same_value%' => 'entity_1',
+                ]
+            )
+            ->willReturn($violation);
+        $violation->atPath('attribute')->willReturn($violation);
+        $violation->addViolation()->shouldBeCalled();
+
+        $this->validate($entity2, $constraint);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Validator/UniqueAxesCombinationSetSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/UniqueAxesCombinationSetSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Component\Catalog\Validator;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Exception\AlreadyExistingAxisValueCombinationException;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -35,8 +36,8 @@ class UniqueAxesCombinationSetSpec extends ObjectBehavior
         $variantProduct->getParent()->willReturn($productModel);
         $variantProduct->getFamilyVariant()->willReturn($familyVariant);
 
-        $this->addCombination($productModel, '[a_color]')->shouldReturn(true);
-        $this->addCombination($variantProduct, '[a_size]')->shouldReturn(true);
+        $this->addCombination($productModel, '[a_color]');
+        $this->addCombination($variantProduct, '[a_size]');
     }
 
     function it_does_not_add_axes_combinations_twice(
@@ -58,7 +59,10 @@ class UniqueAxesCombinationSetSpec extends ObjectBehavior
         $invalidProductModel->getParent()->willReturn($rootProductModel);
         $invalidProductModel->getFamilyVariant()->willReturn($familyVariant);
 
-        $this->addCombination($productModel, '[a_color]')->shouldReturn(true);
-        $this->addCombination($invalidProductModel, '[a_color]')->shouldReturn(false);
+        $this->addCombination($productModel, '[a_color]');
+
+        $this
+            ->shouldThrow(AlreadyExistingAxisValueCombinationException::class)
+            ->during('addCombination', [$invalidProductModel, '[a_color]']);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Validator/UniqueAxesCombinationSetSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/UniqueAxesCombinationSetSpec.php
@@ -3,12 +3,13 @@
 namespace spec\Pim\Component\Catalog\Validator;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Entity\Attribute;
 use Pim\Component\Catalog\Exception\AlreadyExistingAxisValueCombinationException;
-use Pim\Component\Catalog\Model\FamilyVariantInterface;
-use Pim\Component\Catalog\Model\ProductModelInterface;
-use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\FamilyVariant;
+use Pim\Component\Catalog\Model\Product;
+use Pim\Component\Catalog\Model\ProductModel;
 use Pim\Component\Catalog\Validator\UniqueAxesCombinationSet;
-use Prophecy\Argument;
+use Pim\Component\Catalog\Value\ScalarValue;
 
 class UniqueAxesCombinationSetSpec extends ObjectBehavior
 {
@@ -17,52 +18,108 @@ class UniqueAxesCombinationSetSpec extends ObjectBehavior
         $this->shouldHaveType(UniqueAxesCombinationSet::class);
     }
 
-    function it_adds_axes_combinations(
-        FamilyVariantInterface $familyVariant,
-        ProductModelInterface $rootProductModel,
-        ProductModelInterface $productModel,
-        ProductInterface $variantProduct
-    ) {
-        $familyVariant->getCode()->willReturn('family_variant');
+    function it_adds_combinations_of_axis_values()
+    {
+        $familyVariant = new FamilyVariant();
+        $familyVariant->setCode('family_variant');
 
-        $rootProductModel->getCode()->willReturn('root_product_model');
-        $rootProductModel->getFamilyVariant()->willReturn($familyVariant);
+        $rootProductModel = new ProductModel();
+        $rootProductModel->setCode('root_product_model');
+        $rootProductModel->setFamilyVariant($familyVariant);
 
-        $productModel->getCode()->willReturn('product_model');
-        $productModel->getParent()->willReturn($rootProductModel);
-        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $productModel = new ProductModel();
+        $productModel->setCode('product_model');
+        $productModel->setFamilyVariant($familyVariant);
+        $productModel->setParent($rootProductModel);
 
-        $variantProduct->getIdentifier()->willReturn('variant_product');
-        $variantProduct->getParent()->willReturn($productModel);
-        $variantProduct->getFamilyVariant()->willReturn($familyVariant);
+        $anotherProductModel = new ProductModel();
+        $anotherProductModel->setCode('another_product_model');
+        $anotherProductModel->setFamilyVariant($familyVariant);
+        $anotherProductModel->setParent($rootProductModel);
+
+        $identifierAttribute = new Attribute();
+        $identifierA = new ScalarValue($identifierAttribute, null, null, 'product_a');
+
+        $variantProductA = new Product();
+        $variantProductA->setIdentifier($identifierA);
+        $variantProductA->setFamilyVariant($familyVariant);
+        $variantProductA->setParent($productModel);
+
+        $identifierB = new ScalarValue($identifierAttribute, null, null, 'product_b');
+
+        $variantProductB = new Product();
+        $variantProductB->setIdentifier($identifierB);
+        $variantProductB->setFamilyVariant($familyVariant);
+        $variantProductB->setParent($productModel);
 
         $this->addCombination($productModel, '[a_color]');
-        $this->addCombination($variantProduct, '[a_size]');
+        $this->addCombination($anotherProductModel, '[another_color]');
+        $this->addCombination($variantProductA, '[a_size]');
+        $this->addCombination($variantProductB, '[another_size]');
     }
 
-    function it_does_not_add_axes_combinations_twice(
-        FamilyVariantInterface $familyVariant,
-        ProductModelInterface $rootProductModel,
-        ProductModelInterface $productModel,
-        ProductModelInterface $invalidProductModel
-    ) {
-        $familyVariant->getCode()->willReturn('family_variant');
+    function it_does_not_add_same_combination_of_axis_values_twice_for_product_models()
+    {
+        $familyVariant = new FamilyVariant();
+        $familyVariant->setCode('family_variant');
 
-        $rootProductModel->getCode()->willReturn('root_product_model');
-        $rootProductModel->getFamilyVariant()->willReturn($familyVariant);
+        $rootProductModel = new ProductModel();
+        $rootProductModel->setCode('root_product_model');
+        $rootProductModel->setFamilyVariant($familyVariant);
 
-        $productModel->getCode()->willReturn('product_model');
-        $productModel->getParent()->willReturn($rootProductModel);
-        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $productModel = new ProductModel();
+        $productModel->setCode('valid_product_model');
+        $productModel->setFamilyVariant($familyVariant);
+        $productModel->setParent($rootProductModel);
 
-        $invalidProductModel->getCode()->willReturn('invalid_product_model');
-        $invalidProductModel->getParent()->willReturn($rootProductModel);
-        $invalidProductModel->getFamilyVariant()->willReturn($familyVariant);
+        $invalidProductModel = new ProductModel();
+        $invalidProductModel->setCode('invalid_product_model');
+        $invalidProductModel->setFamilyVariant($familyVariant);
+        $invalidProductModel->setParent($rootProductModel);
 
         $this->addCombination($productModel, '[a_color]');
 
+        $exception = new AlreadyExistingAxisValueCombinationException(
+            'valid_product_model',
+            'Product model "valid_product_model" already have the "[a_color]" combination of axis values.'
+        );
         $this
-            ->shouldThrow(AlreadyExistingAxisValueCombinationException::class)
+            ->shouldThrow($exception)
             ->during('addCombination', [$invalidProductModel, '[a_color]']);
+    }
+
+    function it_does_not_add_same_combination_of_axis_values_twice_for_variant_products()
+    {
+        $familyVariant = new FamilyVariant();
+        $familyVariant->setCode('family_variant');
+
+        $productModel = new ProductModel();
+        $productModel->setCode('root_product_model');
+        $productModel->setFamilyVariant($familyVariant);
+
+        $identifierAttribute = new Attribute();
+        $identifier = new ScalarValue($identifierAttribute, null, null, 'valid_variant_product');
+
+        $variantProduct = new Product();
+        $variantProduct->setIdentifier($identifier);
+        $variantProduct->setFamilyVariant($familyVariant);
+        $variantProduct->setParent($productModel);
+
+        $invalidIdentifier = new ScalarValue($identifierAttribute, null, null, 'invalid_product');
+
+        $invalidVariantProduct = new Product();
+        $invalidVariantProduct->setIdentifier($invalidIdentifier);
+        $invalidVariantProduct->setFamilyVariant($familyVariant);
+        $invalidVariantProduct->setParent($productModel);
+
+        $this->addCombination($variantProduct, '[a_color]');
+
+        $exception = new AlreadyExistingAxisValueCombinationException(
+            'valid_variant_product',
+            'Variant product "valid_variant_product" already have the "[a_color]" combination of axis values.'
+        );
+        $this
+            ->shouldThrow($exception)
+            ->during('addCombination', [$invalidVariantProduct, '[a_color]']);
     }
 }

--- a/tests/legacy/features/import/product_model/import_with_invalid_data.feature
+++ b/tests/legacy/features/import/product_model/import_with_invalid_data.feature
@@ -148,7 +148,7 @@ Feature: Skip invalid product models through CSV
     And I wait for the "csv_catalog_modeling_product_model_import" job to finish
     Then I should see the text "Status: Completed"
     And I should see the text "skipped 1"
-    And I should see the text "Cannot set value \"[blue]\" for the attribute axis \"color\", as another sibling entity already has this value"
+    And I should see the text "Cannot set value \"[blue]\" for the attribute axis \"color\" on product model \"code-003\", as the product model \"code-002\" already has this value"
     And the invalid data file of "csv_catalog_modeling_product_model_import" should contain:
       """
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight

--- a/tests/legacy/features/product-model/add_product_model_children.feature
+++ b/tests/legacy/features/product-model/add_product_model_children.feature
@@ -188,7 +188,7 @@ Feature: Add children to product model
       | Code (required)      | apollon_new_blue |
       | Color (variant axis) | Blue             |
     And I confirm the child creation
-    Then I should see the text "Cannot set value \"Blue\" for the attribute axis \"color\", as another sibling entity already has this value"
+    Then I should see the text "Cannot set value \"Blue\" for the attribute axis \"color\" on product model \"apollon_new_blue\", as the product model \"apollon_blue\" already has this value"
 
   Scenario: I cannot add a variant product with an already existing axis value combination
     Given I am on the "amor" product model page
@@ -196,8 +196,8 @@ Feature: Add children to product model
     And I press the "Add new" button and wait for modal
     Then I should see the text "Add a new Color, Size"
     When I fill in the following child information:
-      | SKU (required)       | apollon_new_blue_xl |
-      | Color (variant axis) | Blue                |
-      | Size (variant axis)  | M                   |
+      | SKU (required)       | apollon_new_blue_m |
+      | Color (variant axis) | Blue               |
+      | Size (variant axis)  | M                  |
     And I confirm the child creation
-    Then I should see the text "Cannot set value \"Blue,M\" for the attribute axis \"color,size\", as another sibling entity already has this value"
+    Then I should see the text "Cannot set value \"Blue,M\" for the attribute axis \"color,size\" on variant product \"apollon_new_blue_m\", as the variant product \"1111111113\" already has this value"


### PR DESCRIPTION
## Description

When changing the parent of a variant product or a product model, or when creating a new one, we need to ensure there is not already an other variant product or product model with the same axis values.

The previous validation message was not explicit enough, as it didn't mention which entities were impacted (updated/created one, nor already existing one).

This PR updates this message, and also makes the distinction between variant products and product models.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | Updated
| Added acceptance tests            | -
| Added integration tests           | Updated
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
