### PR TITLE
PIM-7315 : 500 on "IS EMPTY" operator for the SKU filter

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -4,6 +4,7 @@
 
 - PIM-7358: Cascade remove variant attribute sets when removing a family variant
 - PIM-7367: Fix association of a product and product model with the same identifier
+- PIM-7315: Fix 500 on "IS EMPTY" operator for the SKU filter
 
 ## BC breaks
 

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/IdentifierFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/IdentifierFilter.php
@@ -201,6 +201,14 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
                 $this->searchQueryBuilder->addMustNot($clause);
                 break;
 
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => ['field' => static::IDENTIFIER_KEY],
+                ];
+
+                $this->searchQueryBuilder->addMustNot($clause);
+                break;
+
             default:
                 throw InvalidOperatorException::notSupported($operator, static::class);
         }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -214,7 +214,7 @@ services:
         arguments:
             - ['identifier']
             - ['pim_catalog_identifier']
-            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN']
+            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN', 'EMPTY']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/IdentifierFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/IdentifierFilterSpec.php
@@ -28,7 +28,8 @@ class IdentifierFilterSpec extends ObjectBehavior
                 '=',
                 '!=',
                 'IN LIST',
-                'NOT IN LIST'
+                'NOT IN LIST',
+                'EMPTY'
             ]
         );
     }
@@ -54,12 +55,13 @@ class IdentifierFilterSpec extends ObjectBehavior
                 '=',
                 '!=',
                 'IN LIST',
-                'NOT IN LIST'
+                'NOT IN LIST',
+                'EMPTY'
             ]
 
         );
         $this->supportsOperator('DOES NOT CONTAIN')->shouldReturn(true);
-        $this->supportsOperator('EMPTY')->shouldReturn(false);
+        $this->supportsOperator('IN CHILDREN')->shouldReturn(false);
     }
 
     function it_supports_identifier_field()
@@ -316,6 +318,19 @@ class IdentifierFilterSpec extends ObjectBehavior
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($sku, Operators::NOT_IN_LIST, ['sku-001'], null, null, []);
+    }
+
+    function it_adds_an_attribute_filter_with_operator_empty(SearchQueryBuilder $sqb, AttributeInterface $sku)
+    {
+        $sku->getCode()->willReturn('sku');
+        $sqb->addMustNot(
+            [
+                'exists' => ['field' => 'identifier'],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addAttributeFilter($sku, Operators::IS_EMPTY, 'sku-001', null, null, []);
     }
 
     function it_throws_an_exception_when_the_search_query_builder_is_not_initialized(AttributeInterface $sku)

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/IdentifierFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/IdentifierFilterIntegration.php
@@ -140,6 +140,12 @@ class IdentifierFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
     }
 
+    public function testOperatorIsEmpty()
+    {
+        $result = $this->executeFilter([['identifier', Operators::IS_EMPTY, 'baz']]);
+        $this->assert($result, []);
+    }
+
     /**
      * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
      * @expectedExceptionMessage Property "identifier" expects a string as data, "array" given.


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since we added a parent filter in the 2.1 version, we got the "IS EMPTY" operator on the SKU filter. However, when we try to filter on this operator we get a 500 error. This is because the EMPTY operator wasn't added on the Identifier filter. To make the fix we added this operator.

P.S : The operator "IS EMPTY" shouldn't exist on the SKU filter because we get all the time no result (only products have a sku). So, we will have to create a dedicated filter type for the SKU. It will be done on 2.3 with this bulletproof ticket (https://akeneo.atlassian.net/browse/PIM-7345).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
