### PR TITLE
PIM-7336: Fix setConversionUnits of ChannelUpdater to accept empty value

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug fixes
+
+- PIM-7336: Fix channel update with "do not convert" values for conversion units
+
 # 1.7.21 (2018-04-23)
 
 ## Bug fixes

--- a/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/ChannelUpdater.php
@@ -215,6 +215,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      */
     protected function setConversionUnits(ChannelInterface $channel, $conversionUnits)
     {
+        $conversionUnitsToSave = [];
         foreach ($conversionUnits as $attributeCode => $conversionUnit) {
             $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
 
@@ -237,8 +238,8 @@ class ChannelUpdater implements ObjectUpdaterInterface
                     $conversionUnit
                 );
             }
-
-            $channel->setConversionUnits($conversionUnits);
+            $conversionUnitsToSave[] = $conversionUnit;
         }
+        $channel->setConversionUnits($conversionUnits);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Updater/ChannelUpdaterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Updater/ChannelUpdaterSpec.php
@@ -122,6 +122,65 @@ class ChannelUpdaterSpec extends ObjectBehavior
         $this->update($channel, $values, []);
     }
 
+
+    function it_updates_a_channel_with_conversion_units_empty(
+        $categoryRepository,
+        $localeRepository,
+        $currencyRepository,
+        $attributeRepository,
+        $measureManager,
+        ChannelInterface $channel,
+        CategoryInterface $tree,
+        LocaleInterface $enUS,
+        LocaleInterface $frFR,
+        CurrencyInterface $usd,
+        CurrencyInterface $eur,
+        ChannelTranslationInterface $channelTranslation,
+        AttributeInterface $maximumDiagonalAttribute,
+        AttributeInterface $weightAttribute
+    ) {
+        $values = [
+            'code'             => 'ecommerce',
+            'labels'           => [
+                'fr_FR' => 'Tablette',
+                'en_US' => 'Tablet',
+            ],
+            'locales'          => ['en_US', 'fr_FR'],
+            'currencies'       => ['EUR', 'USD'],
+            'category_tree'    => 'master_catalog',
+            'conversion_units' => [],
+        ];
+
+        $channel->setCode('ecommerce')->shouldBeCalled();
+
+        $categoryRepository->findOneByIdentifier('master_catalog')->willReturn($tree);
+        $channel->setCategory($tree)->shouldBeCalled();
+
+        $localeRepository->findOneByIdentifier('en_US')->willReturn($enUS);
+        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($frFR);
+        $channel->setLocales([$enUS, $frFR])->shouldBeCalled();
+
+        $currencyRepository->findOneByIdentifier('EUR')->willReturn($eur);
+        $currencyRepository->findOneByIdentifier('USD')->willReturn($usd);
+        $channel->setCurrencies([$eur, $usd])->shouldBeCalled();
+
+        $channel->setLocale('en_US')->shouldBeCalled();
+        $channel->setLocale('fr_FR')->shouldBeCalled();
+        $channel->getTranslation()->willReturn($channelTranslation);
+
+        $maximumDiagonalAttribute->getMetricFamily()->willReturn('Length');
+        $weightAttribute->getMetricFamily()->willReturn('Weight');
+
+        $attributeRepository->findOneByIdentifier('maximum_diagonal')->willReturn($maximumDiagonalAttribute);
+        $attributeRepository->findOneByIdentifier('weight')->willReturn($weightAttribute);
+
+        $channelTranslation->setLabel('Tablet');
+        $channelTranslation->setLabel('Tablette');
+        $channel->setConversionUnits([])->shouldBeCalled();
+
+        $this->update($channel, $values, []);
+    }
+
     function it_throws_an_exception_if_category_not_found(
         $categoryRepository,
         $localeRepository,


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When you edit the channel and set a conversion unit to his default value "do not convert", it don't update it (so the previous conversion is still used).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

Phpspec : OK

Tests behat : 
features/import/xlsx/import_channels.feature : OK
features/import/import_channels.feature : OK
features/channel/create_channel.feature: OK
features/channel/edit_channel.feature: OK

Tests integration : 
src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/GetChannelIntegration.php : OK
src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/ListChannelIntegration.php : OK
src/Pim/Bundle/ApiBundle/tests/integration/Security/ChannelAuthorizationIntegration.php : OK