### PR TITLE
PIM-7335: Replace use of Symfony Intl by default \Locale intl php lib

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Bug fixes
+
+- PIM-7335: Fix locale rendering on product form completeness panel
+
 # 2.0.23 (2018-04-30)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/Entity/Locale.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Locale.php
@@ -7,7 +7,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
-use Symfony\Component\Intl\Intl;
 
 /**
  * Locale entity
@@ -180,8 +179,6 @@ class Locale implements LocaleInterface, VersionableInterface
      */
     public function getName()
     {
-        $localeNames = Intl::getLocaleBundle()->getLocaleNames();
-
-        return array_key_exists($this->code, $localeNames) ? $localeNames[$this->code] : null;
+        return \Locale::getDisplayName($this->code);
     }
 }

--- a/src/Pim/Bundle/LocalizationBundle/Twig/LocaleExtension.php
+++ b/src/Pim/Bundle/LocalizationBundle/Twig/LocaleExtension.php
@@ -2,8 +2,6 @@
 
 namespace Pim\Bundle\LocalizationBundle\Twig;
 
-use Symfony\Component\Intl\Intl;
-
 /**
  * Twig extension to present locales
  *
@@ -36,6 +34,6 @@ class LocaleExtension extends \Twig_Extension
             return '';
         }
 
-        return Intl::getLocaleBundle()->getLocaleName($code);
+        return \Locale::getDisplayName($code);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Replace use of Symfony Intl by default \Locale intl php lib, the symfony intl bundle does not contain all locales who are in the default php intl lib such as `en_AE` for English (United Arab Emirates), 
it has been done in the past in other classes like [LocaleNormalizer](https://github.com/akeneo/pim-community-dev/blob/2.0/src/Pim/Bundle/EnrichBundle/Normalizer/LocaleNormalizer.php#L62)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
