### PR TITLE
Update default value for index_hosts

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -10,4 +10,4 @@ parameters:
     product_index_name:                   akeneo_pim_product
     product_model_index_name:             akeneo_pim_product_model
     product_and_product_model_index_name: akeneo_pim_product_and_product_model
-    index_hosts:                          'localhost: 9200'
+    index_hosts:                          'elastic:changeme@localhost: 9200'


### PR DESCRIPTION
hello,

just a little update 

parameters files have  bad values for key `index_hosts`, cause this issue #7440 if you do not read the doc here https://docs.akeneo.com/2.3/install_pim/docker/installation_docker.html#configure-akeneo

