### PR TITLE
API-593: Add possibility to filter a list of product models in the API

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
@@ -321,14 +321,14 @@ class ProductModelController
             $locales = explode(',', $request->query->get('locales'));
             $this->queryParametersChecker->checkLocalesParameters($locales, $channel);
 
-            $normalizerOptions['locales'] = explode(',', $request->query->get('locales'));
+            $normalizerOptions['locales'] = $locales;
         }
 
         if ($request->query->has('attributes')) {
             $attributes = explode(',', $request->query->get('attributes'));
             $this->queryParametersChecker->checkAttributesParameters($attributes);
 
-            $normalizerOptions['attributes'] = explode(',', $request->query->get('attributes'));
+            $normalizerOptions['attributes'] = $attributes;
         }
 
         return $normalizerOptions;
@@ -351,8 +351,7 @@ class ProductModelController
         ?ChannelInterface $channel,
         array $queryParameters,
         array $normalizerOptions
-    )
-    {
+    ) {
         $from = isset($queryParameters['page']) ? ($queryParameters['page'] - 1) * $queryParameters['limit'] : 0;
 
         $pqb = $this->pqbFromSizeFactory->create(['limit' => (int) $queryParameters['limit'], 'from' => (int) $from]);
@@ -383,7 +382,7 @@ class ProductModelController
         try {
             $count = 'true' === $queryParameters['with_count'] ? $productModels->count() : null;
             $paginatedProductModels = $this->offsetPaginator->paginate(
-                $this->normalizer->normalize($productModels, 'external_api'),
+                $this->normalizer->normalize($productModels, 'external_api', $normalizerOptions),
                 $paginationParameters,
                 $count
             );
@@ -528,8 +527,7 @@ class ProductModelController
         ?ChannelInterface $channel,
         array $queryParameters,
         array $normalizerOptions
-    )
-    {
+    ) {
         $pqbOptions = ['limit' => (int) $queryParameters['limit']];
         $searchParameterCrypted = null;
         if (isset($queryParameters['search_after'])) {

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
@@ -579,7 +579,7 @@ class ProductModelController
         ];
 
         $paginatedProductModels = $this->searchAfterPaginator->paginate(
-            $this->normalizer->normalize($productModels, 'standard', $normalizerOptions),
+            $this->normalizer->normalize($productModels, 'external_api', $normalizerOptions),
             $parameters,
             null
         );

--- a/src/Pim/Bundle/ApiBundle/Resources/config/checkers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/checkers.yml
@@ -2,10 +2,25 @@ parameters:
     pim_api.checker.query_parameters.class: Pim\Bundle\ApiBundle\Checker\QueryParametersChecker
 
 services:
-    pim_api.checker.query_parameters:
+    pim_api.checker.query_parameters_locale:
         class: '%pim_api.checker.query_parameters.class%'
         arguments:
             - '@pim_catalog.repository.cached_locale'
             - '@pim_catalog.repository.cached_attribute'
             - '@pim_catalog.repository.cached_category'
-            - ['family', 'enabled', 'groups', 'categories', 'completeness', 'identifier', 'created', 'updated']
+            - ['enabled', 'code']
+    pim_api.checker.query_parameters_product:
+        class: '%pim_api.checker.query_parameters.class%'
+        arguments:
+            - '@pim_catalog.repository.cached_locale'
+            - '@pim_catalog.repository.cached_attribute'
+            - '@pim_catalog.repository.cached_category'
+            - ['family', 'categories', 'completeness', 'identifier', 'created', 'updated']
+
+    pim_api.checker.query_parameters_product_model:
+        class: '%pim_api.checker.query_parameters.class%'
+        arguments:
+            - '@pim_catalog.repository.cached_locale'
+            - '@pim_catalog.repository.cached_attribute'
+            - '@pim_catalog.repository.cached_category'
+            - ['family', 'categories', 'completeness', 'identifier', 'created', 'updated']

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -174,6 +174,8 @@ services:
             - '@pim_catalog.query.product_model_query_builder_from_size_factory'
             - '@pim_catalog.query.product_model_query_builder_search_after_size_factory'
             - '@pim_serializer'
+            - '@pim_api.repository.channel'
+            - '@pim_api.checker.query_parameters'
             - '@pim_api.pagination.parameter_validator'
             - '@pim_api.pagination.offset_hal_paginator'
             - '@pim_api.pagination.search_after_hal_paginator'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -132,7 +132,7 @@ services:
             - '@pim_serializer'
             - '@pim_api.pagination.offset_hal_paginator'
             - '@pim_api.pagination.parameter_validator'
-            - '@pim_api.checker.query_parameters'
+            - '@pim_api.checker.query_parameters_locale'
             - '%pim_api.configuration%'
 
     pim_api.controller.token:
@@ -146,7 +146,7 @@ services:
             - '@pim_catalog.query.product_query_builder_search_after_size_factory'
             - '@pim_serializer'
             - '@pim_api.repository.channel'
-            - '@pim_api.checker.query_parameters'
+            - '@pim_api.checker.query_parameters_product'
             - '@pim_api.repository.attribute'
             - '@pim_api.repository.product'
             - '@pim_api.pagination.offset_hal_paginator'
@@ -175,7 +175,7 @@ services:
             - '@pim_catalog.query.product_model_query_builder_search_after_size_factory'
             - '@pim_serializer'
             - '@pim_api.repository.channel'
-            - '@pim_api.checker.query_parameters'
+            - '@pim_api.checker.query_parameters_product_model'
             - '@pim_api.pagination.parameter_validator'
             - '@pim_api.pagination.offset_hal_paginator'
             - '@pim_api.pagination.search_after_hal_paginator'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
@@ -3,6 +3,7 @@ parameters:
     pim_api.normalizer.exception.violation.class: Pim\Component\Api\Normalizer\Exception\ViolationNormalizer
     pim_api.normalizer.collection.class: Pim\Component\Api\Normalizer\CollectionNormalizer
     pim_api.normalizer.product.class: Pim\Component\Api\Normalizer\ProductNormalizer
+    pim_api.normalizer.product_model.class: Pim\Component\Api\Normalizer\ProductModelNormalizer
     pim_api.normalizer.family.class: Pim\Component\Api\Normalizer\FamilyNormalizer
     pim_api.normalizer.family_variant.class: Pim\Component\Api\Normalizer\FamilyVariantNormalizer
     pim_api.normalizer.category.class: Pim\Component\Api\Normalizer\CategoryNormalizer
@@ -54,7 +55,7 @@ services:
             - { name: pim_serializer.normalizer, priority: 90 }
 
     pim_api.normalizer.product_model:
-        class: 'Pim\Component\Api\Normalizer\ProductModelNormalizer'
+        class: '%pim_api.normalizer.product_model.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product_model'
             - '@pim_api.repository.attribute'

--- a/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
@@ -3,7 +3,6 @@ parameters:
     pim_api.normalizer.exception.violation.class: Pim\Component\Api\Normalizer\Exception\ViolationNormalizer
     pim_api.normalizer.collection.class: Pim\Component\Api\Normalizer\CollectionNormalizer
     pim_api.normalizer.product.class: Pim\Component\Api\Normalizer\ProductNormalizer
-    pim_api.normalizer.product_model.class: Pim\Component\Api\Normalizer\ProductModelNormalizer
     pim_api.normalizer.family.class: Pim\Component\Api\Normalizer\FamilyNormalizer
     pim_api.normalizer.family_variant.class: Pim\Component\Api\Normalizer\FamilyVariantNormalizer
     pim_api.normalizer.category.class: Pim\Component\Api\Normalizer\CategoryNormalizer
@@ -55,7 +54,7 @@ services:
             - { name: pim_serializer.normalizer, priority: 90 }
 
     pim_api.normalizer.product_model:
-        class: '%pim_api.normalizer.product_model.class%'
+        class: 'Pim\Component\Api\Normalizer\ProductModelNormalizer'
         arguments:
             - '@pim_catalog.normalizer.standard.product_model'
             - '@pim_api.repository.attribute'

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
@@ -2,7 +2,9 @@
 
 namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
+use PHPUnit\Framework\Assert;
 use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
@@ -110,7 +112,7 @@ abstract class AbstractProductTestCase extends ApiTestCase
         $expected = json_decode($expected, true);
 
         if (!isset($result['_embedded'])) {
-            \PHPUnit_Framework_Assert::fail($response->getContent());
+            Assert::fail($response->getContent());
         }
 
         foreach ($result['_embedded']['items'] as $index => $product) {

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListProductModelWithCompletenessIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListProductModelWithCompletenessIntegration.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
+
+use Akeneo\Test\Integration\Configuration;
+use Doctrine\Common\Collections\Collection;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+
+/**
+ * @group ce
+ */
+class ListProductModelWithCompletenessIntegration extends AbstractProductTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->createCompleteProductModelAndVariantProduct();
+        $this->createUnCompleteProductModelAndVariantProduct();
+    }
+
+    public function testPaginationWithCompletenessFilter()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $search = '{"completeness":[{"operator":"ALL COMPLETE","scope":"ecommerce", "locales":["en_US"]}]}';
+        $client->request('GET', 'api/rest/v1/product-models?locales=en_US&limit=2&search=' . $search);
+        $searchEncoded = rawurlencode($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self": {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=false&pagination_type=page&limit=2&locales=en_US&search=${searchEncoded}"},
+        "first": {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=false&pagination_type=page&limit=2&locales=en_US&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+		"items": [
+		    {
+		        "_links":{
+		            "self":{
+		                "href": "http:\/\/localhost\/api\/rest\/v1\/product-models\/product_model_complete"
+		            }
+		        },
+		        "code": "product_model_complete",
+		        "parent": null,
+		        "family_variant": "familyVariantA3_by_a_yes_no",
+		        "categories": [],
+		        "values": {
+		            "a_localized_and_scopable_text_area": [
+                        {"locale": "en_US", "scope": "ecommerce", "data": "this is a test"}
+                    ],
+                    "a_simple_select": [
+                        {"locale": null, "scope": null, "data": "optionA"}
+                    ]
+		        },
+		        "created": "2017-03-17T16:11:46+01:00",
+		        "updated": "2017-03-17T16:11:46+01:00",
+		        "associations": {}
+		    }
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function createCompleteProductModelAndVariantProduct(){
+        $this->createFamilyVariant(
+            [
+                'code' => 'familyVariantA3_by_a_yes_no',
+                'family' => 'familyA3',
+                'variant_attribute_sets' => [
+                    [
+                        'level' => 1,
+                        'axes' => ['a_yes_no'],
+                        'attributes' => ['a_yes_no', 'a_text'],
+                    ]
+                ]
+            ]
+        );
+
+        // a product model
+        $this->createProductModel(
+            [
+                'code' => 'product_model_complete',
+                'parent' => '',
+                'family_variant' => 'familyVariantA3_by_a_yes_no',
+                'values'  => [
+                    'a_localized_and_scopable_text_area' => [
+                        [
+                            'locale' => 'en_US',
+                            'scope' => 'ecommerce',
+                            'data' => 'this is a test',
+                        ],
+                    ],
+                    'a_simple_select' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => 'optionA',
+                        ],
+                    ],
+                ]
+            ]
+        );
+
+        // product complete, whatever the scope
+        $this->createVariantProduct('product_complete', [
+            'categories' => ['categoryA', 'categoryB', 'master'],
+            'parent' => 'product_model_complete',
+            'values'     => [
+                'a_yes_no' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => false,
+                    ],
+                ],
+                'sku' => [
+                    ['data' => 'sku-product-complete', 'locale' => null, 'scope' => null]
+                ]
+            ]
+        ]);
+    }
+
+    private function createUncompleteProductModelAndVariantProduct(){
+        $this->createFamilyVariant(
+            [
+                'code' => 'familyVariantA3_by_a_simple_select',
+                'family' => 'familyA3',
+                'variant_attribute_sets' => [
+                    [
+                        'level' => 1,
+                        'axes' => ['a_simple_select'],
+                        'attributes' => ['a_simple_select', 'a_text'],
+                    ]
+                ]
+            ]
+        );
+
+        // a product model
+        $this->createProductModel(
+            [
+                'code' => 'product_model_uncomplete',
+                'parent' => '',
+                'family_variant' => 'familyVariantA3_by_a_simple_select',
+                'values'  => [
+                    'a_localized_and_scopable_text_area' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => null,
+                        ],
+                    ],
+                    'a_yes_no' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => false
+                        ],
+                    ],
+                ]
+            ]
+        );
+
+        // product complete, whatever the scope
+        $this->createVariantProduct('product_uncomplete', [
+            'categories' => ['categoryA', 'categoryB', 'master'],
+            'parent' => 'product_model_uncomplete',
+            'values'     => [
+                'a_simple_select' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'optionB',
+                    ],
+                ],
+                'sku' => [
+                    ['data' => 'sku-product-uncomplete', 'locale' => null, 'scope' => null]
+                ]
+            ]
+        ]);
+    }
+
+
+    /**
+     * @param array  $data
+     *
+     * @return FamilyVariantInterface
+     * @throws \Exception
+     */
+    protected function createFamilyVariant(array $data = []) : FamilyVariantInterface
+    {
+        $family = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update($family, $data);
+        $constraintList = $this->get('validator')->validate($family);
+        $this->assertEquals(0, $constraintList->count());
+        $this->get('pim_catalog.saver.family_variant')->save($family);
+
+        return $family;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -96,7 +96,7 @@ services:
         arguments:
             - '%pim_catalog.query.product_query_builder.class%'
             - '@pim_catalog.repository.attribute'
-            - '@pim_catalog.query.filter.product_registry'
+            - '@pim_catalog.query.filter.product_model_registry'
             - '@pim_catalog.query.sorter.registry'
             - '@pim_catalog.factory.product_model_from_size_cursor'
             - '@pim_catalog.elasticsearch.product_query_builder_from_size_resolver'
@@ -106,7 +106,7 @@ services:
         arguments:
             - '%pim_catalog.query.product_query_builder.class%'
             - '@pim_catalog.repository.attribute'
-            - '@pim_catalog.query.filter.product_registry'
+            - '@pim_catalog.query.filter.product_model_registry'
             - '@pim_catalog.query.sorter.registry'
             - '@pim_catalog.factory.product_model_search_after_size_cursor'
             - '@pim_catalog.elasticsearch.product_query_builder_search_after_resolver'

--- a/src/Pim/Component/Api/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Component/Api/Normalizer/ProductModelNormalizer.php
@@ -14,7 +14,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * @author    Elodie Raposo <elodie.raposo@akeneo.com>
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
  * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -47,28 +47,22 @@ class ProductModelNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($productModel, $format = null, array $context = [])
+    public function normalize($productModel, $format = null, array $context = []): array
     {
         $productModelStandard = $this->productModelNormalizer->normalize($productModel, 'standard', $context);
-        $identifier = $this->attributeRepository->getIdentifierCode();
 
-        if (isset($productModelStandard['values'][$identifier])) {
-            unset($productModelStandard['values'][$identifier]);
-        }
-
+        $mediaAttributeCodes = $this->attributeRepository->getMediaAttributeCodes();
         foreach ($productModelStandard['values'] as $attributeCode => $values) {
             // if $context['attributes'] is defined, returns only these attributes
             if (isset($context['attributes']) && !in_array($attributeCode, $context['attributes'])) {
                 unset($productModelStandard['values'][$attributeCode]);
+            } elseif (in_array($attributeCode, $mediaAttributeCodes)) {
+                $productModelStandard['values'][$attributeCode] = $this->addDownloadLink($values);
             }
         }
 
         if (empty($productModelStandard['values'])) {
             $productModelStandard['values'] = (object) $productModelStandard['values'];
-        }
-
-        if (empty($productModelStandard['associations'])) {
-            $productModelStandard['associations'] = (object) $productModelStandard['associations'];
         }
 
         return $productModelStandard;
@@ -77,8 +71,30 @@ class ProductModelNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ProductModelInterface && 'external_api' === $format;
+    }
+
+    /**
+     * @param array $values
+     *
+     * @return array
+     */
+    protected function addDownloadLink(array $values): array
+    {
+        foreach ($values as $index => $value) {
+            if (null !== $value['data']) {
+                $route = $this->router->generate(
+                    'pim_api_media_file_download',
+                    ['code' => $value['data']],
+                    UrlGeneratorInterface::ABSOLUTE_URL
+                );
+                $download = new Link('download', $route);
+                $values[$index]['_links'] = $download->toArray();
+            }
+        }
+
+        return $values;
     }
 }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Storage/Product/AssociationsNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Storage/Product/AssociationsNormalizerSpec.php
@@ -5,7 +5,6 @@ namespace spec\Pim\Component\Catalog\Normalizer\Storage\Product;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Normalizer\Storage\Product\AssociationsNormalizer;
-use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class AssociationsNormalizerSpec extends ObjectBehavior


### PR DESCRIPTION
**Description**

As Filips, I'd like to get a filtered list of product models
Ex : ?search={"length":[{"operator": ">","value":{"amount":"10","unit":"METER"}}]}

As Filips, I'd like to get a list of product models with filtered product values
Ex : ?channel=ecommerce

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
