### PR TITLE
PIM-7347: Fix completeness for locale specific attributes

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,3 +1,9 @@
+# 2.3.x
+
+## Improve Julia's experience
+
+- PIM-7347: Improve the calculation of the completeness for locale specific attributes.
+
 # 2.3.0-ALPHA2 (2018-06-07)
 
 ## Improve Julia's experience

--- a/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollection.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollection.php
@@ -100,7 +100,7 @@ class IncompleteValueCollection implements \Countable, \IteratorAggregate
      */
     private function buildInternalKey(RequiredValue $requiredValue): string
     {
-        $channelCode = null !== $requiredValue->scope() ? $requiredValue->scope() : '<all_channels>';
+        $channelCode = null !== $requiredValue->channel() ? $requiredValue->channel() : '<all_channels>';
         $localeCode = null !== $requiredValue->locale() ? $requiredValue->locale() : '<all_locales>';
         $key = sprintf('%s-%s-%s', $requiredValue->attribute(), $channelCode, $localeCode);
 

--- a/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollection.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollection.php
@@ -25,11 +25,13 @@ use Doctrine\Common\Collections\Collection;
  */
 class IncompleteValueCollection implements \Countable, \IteratorAggregate
 {
-    /** @var ValueInterface[] */
+    /** @var RequiredValue[] */
     private $values;
 
     /**
-     * @param ValueInterface[] $values
+     * @param RequiredValue[] $values
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(array $values)
     {
@@ -88,9 +90,9 @@ class IncompleteValueCollection implements \Countable, \IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function count()
+    public function count(): int
     {
-        return count($this->values);
+        return \count($this->values);
     }
 
     /**
@@ -100,8 +102,8 @@ class IncompleteValueCollection implements \Countable, \IteratorAggregate
      */
     private function buildInternalKey(RequiredValue $requiredValue): string
     {
-        $channelCode = null !== $requiredValue->channel() ? $requiredValue->channel() : '<all_channels>';
-        $localeCode = null !== $requiredValue->locale() ? $requiredValue->locale() : '<all_locales>';
+        $channelCode = $requiredValue->channel() ?? '<all_channels>';
+        $localeCode = $requiredValue->locale() ?? '<all_locales>';
         $key = sprintf('%s-%s-%s', $requiredValue->attribute(), $channelCode, $localeCode);
 
         return $key;

--- a/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollection.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollection.php
@@ -6,7 +6,6 @@ namespace Pim\Component\Catalog\EntityWithFamily;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Pim\Component\Catalog\Model\ValueInterface;
 
 /**
  * A collection of incomplete values depending on an entity with a family
@@ -43,8 +42,20 @@ class IncompleteValueCollection implements \Countable, \IteratorAggregate
                 );
             }
 
-            $this->values[] = $value;
+            $this->values[$this->buildInternalKey($value)] = $value;
         }
+    }
+
+    /**
+     * Is there already a value with the same attribute, channel and locale than $value?
+     *
+     * @param RequiredValue $value
+     *
+     * @return bool
+     */
+    public function hasSame(RequiredValue $value): bool
+    {
+        return array_key_exists($this->buildInternalKey($value), $this->values);
     }
 
     /**
@@ -57,7 +68,7 @@ class IncompleteValueCollection implements \Countable, \IteratorAggregate
         $attributes = new ArrayCollection();
 
         foreach ($this->values as $value) {
-            $attribute = $value->getAttribute();
+            $attribute = $value->forAttribute();
             if (!$attributes->contains($attribute)) {
                 $attributes->add($attribute);
             }
@@ -80,5 +91,19 @@ class IncompleteValueCollection implements \Countable, \IteratorAggregate
     public function count()
     {
         return count($this->values);
+    }
+
+    /**
+     * @param RequiredValue $requiredValue
+     *
+     * @return string
+     */
+    private function buildInternalKey(RequiredValue $requiredValue): string
+    {
+        $channelCode = null !== $requiredValue->scope() ? $requiredValue->scope() : '<all_channels>';
+        $localeCode = null !== $requiredValue->locale() ? $requiredValue->locale() : '<all_locales>';
+        $key = sprintf('%s-%s-%s', $requiredValue->attribute(), $channelCode, $localeCode);
+
+        return $key;
     }
 }

--- a/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollection.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollection.php
@@ -37,26 +37,14 @@ class IncompleteValueCollection implements \Countable, \IteratorAggregate
         $this->values = [];
 
         foreach ($values as $value) {
-            if (!$value instanceof ValueInterface) {
+            if (!$value instanceof RequiredValue) {
                 throw new \InvalidArgumentException(
-                    'Expected an instance of "Pim\Component\Catalog\Model\ValueInterface".'
+                    'Expected an instance of "Pim\Component\Catalog\EntityWithFamily\RequiredValue".'
                 );
             }
 
-            $this->values[$this->buildInternalKey($value)] = $value;
+            $this->values[] = $value;
         }
-    }
-
-    /**
-     * Is there already a value with the same attribute, channel and locale than $value?
-     *
-     * @param ValueInterface $value
-     *
-     * @return bool
-     */
-    public function hasSame(ValueInterface $value): bool
-    {
-        return array_key_exists($this->buildInternalKey($value), $this->values);
     }
 
     /**
@@ -92,20 +80,5 @@ class IncompleteValueCollection implements \Countable, \IteratorAggregate
     public function count()
     {
         return count($this->values);
-    }
-
-    /**
-     * @param ValueInterface $value
-     *
-     * @return string
-     */
-    private function buildInternalKey(ValueInterface $value): string
-    {
-        $attribute = $value->getAttribute();
-        $channelCode = null !== $value->getScope() ? $value->getScope() : ' < all_channels>';
-        $localeCode = null !== $value->getLocale() ? $value->getLocale() : '<all_locales > ';
-        $key = sprintf('%s-%s-%s', $attribute->getCode(), $channelCode, $localeCode);
-
-        return $key;
     }
 }

--- a/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollectionFactory.php
@@ -70,13 +70,12 @@ class IncompleteValueCollectionFactory
      * @return bool
      */
     private function isValueMissingOrEmpty(
-        ValueInterface $value,
+        RequiredValue $value,
         ChannelInterface $channel,
         LocaleInterface $locale,
         EntityWithValuesInterface $entityWithValues
     ) {
-        $values = $entityWithValues->getValues();
-        $actualValue = $values->getSame($value);
+        $actualValue = $entityWithValues->getValues()->getByKey($value->getValueKey());
 
         if (null === $actualValue) {
             return true;

--- a/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollectionFactory.php
@@ -75,7 +75,12 @@ class IncompleteValueCollectionFactory
         LocaleInterface $locale,
         EntityWithValuesInterface $entityWithValues
     ) {
-        $actualValue = $entityWithValues->getValues()->getByKey($value->getValueKey());
+        $actualValue = $value->valueFromEntity()(
+            $entityWithValues,
+            $value->getAttribute(),
+            $value->getScope(),
+            $value->getLocale()
+        );
 
         if (null === $actualValue) {
             return true;

--- a/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollectionFactory.php
@@ -62,7 +62,7 @@ class IncompleteValueCollectionFactory
     }
 
     /**
-     * @param ValueInterface            $value
+     * @param ValueInterface            $requiredValue
      * @param ChannelInterface          $channel
      * @param LocaleInterface           $locale
      * @param EntityWithValuesInterface $entityWithValues
@@ -70,16 +70,15 @@ class IncompleteValueCollectionFactory
      * @return bool
      */
     private function isValueMissingOrEmpty(
-        RequiredValue $value,
+        RequiredValue $requiredValue,
         ChannelInterface $channel,
         LocaleInterface $locale,
         EntityWithValuesInterface $entityWithValues
     ) {
-        $actualValue = $value->valueFromEntity()(
-            $entityWithValues,
-            $value->getAttribute(),
-            $value->getScope(),
-            $value->getLocale()
+        $actualValue = $entityWithValues->getValues()->getByCodes(
+            $requiredValue->forAttributeCode(),
+            $requiredValue->forScope(),
+            $requiredValue->forLocale($locale)
         );
 
         if (null === $actualValue) {

--- a/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollectionFactory.php
@@ -62,7 +62,7 @@ class IncompleteValueCollectionFactory
     }
 
     /**
-     * @param ValueInterface            $requiredValue
+     * @param RequiredValue             $requiredValue
      * @param ChannelInterface          $channel
      * @param LocaleInterface           $locale
      * @param EntityWithValuesInterface $entityWithValues
@@ -76,9 +76,9 @@ class IncompleteValueCollectionFactory
         EntityWithValuesInterface $entityWithValues
     ) {
         $actualValue = $entityWithValues->getValues()->getByCodes(
-            $requiredValue->forAttributeCode(),
-            $requiredValue->forScope(),
-            $requiredValue->forLocale($locale)
+            $requiredValue->attribute(),
+            $requiredValue->scope(),
+            $requiredValue->locale()
         );
 
         if (null === $actualValue) {

--- a/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/IncompleteValueCollectionFactory.php
@@ -77,7 +77,7 @@ class IncompleteValueCollectionFactory
     ) {
         $actualValue = $entityWithValues->getValues()->getByCodes(
             $requiredValue->attribute(),
-            $requiredValue->scope(),
+            $requiredValue->channel(),
             $requiredValue->locale()
         );
 

--- a/src/Pim/Component/Catalog/EntityWithFamily/RequiredValue.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/RequiredValue.php
@@ -25,16 +25,30 @@ use Pim\Component\Catalog\Model\ValueInterface;
  */
 class RequiredValue extends AbstractValue implements ValueInterface
 {
+    /** @var string */
+    private $valueKey;
+
     /**
      * @param AttributeInterface $attribute
      * @param string             $channel
      * @param string             $locale
+     * @param string             $valueKey
      */
-    public function __construct(AttributeInterface $attribute, string $channel = null, string $locale = null)
-    {
+    public function __construct(
+        AttributeInterface $attribute,
+        string $channel = null,
+        string $locale = null,
+        string $valueKey = null
+    ) {
         $this->setAttribute($attribute);
         $this->setScope($channel);
         $this->setLocale($locale);
+        $this->valueKey = $valueKey;
+    }
+
+    public function getValueKey(): string
+    {
+        return $this->valueKey;
     }
 
     /**

--- a/src/Pim/Component/Catalog/EntityWithFamily/RequiredValue.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/RequiredValue.php
@@ -25,30 +25,30 @@ use Pim\Component\Catalog\Model\ValueInterface;
  */
 class RequiredValue extends AbstractValue implements ValueInterface
 {
-    /** @var string */
-    private $valueKey;
+    /** @var \Closure  */
+    private $valueGetter;
 
     /**
      * @param AttributeInterface $attribute
      * @param string             $channel
      * @param string             $locale
-     * @param string             $valueKey
+     * @param string             $valueGetter
      */
     public function __construct(
         AttributeInterface $attribute,
         string $channel = null,
         string $locale = null,
-        string $valueKey = null
+        \Closure $valueGetter = null
     ) {
         $this->setAttribute($attribute);
         $this->setScope($channel);
         $this->setLocale($locale);
-        $this->valueKey = $valueKey;
+        $this->valueGetter = $valueGetter;
     }
 
-    public function getValueKey(): string
+    public function valueFromEntity(): \Closure
     {
-        return $this->valueKey;
+        return $this->valueGetter;
     }
 
     /**

--- a/src/Pim/Component/Catalog/EntityWithFamily/RequiredValue.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/RequiredValue.php
@@ -10,7 +10,7 @@ use Pim\Component\Catalog\Model\LocaleInterface;
 
 /**
  * A required value is the translation of the attribute requirements
- * {@see Pim\Component\Catalog\Model\AttributeRequirementInterface} in terms of values.
+ * {@see Pim\Component\Catalog\Model\AttributeRequirementInterface}.
  *
  * Therefore a required value contains no data. It simply expresses the fact that for instance:
  *  - a "sku" is required on all channels and all locales
@@ -18,6 +18,21 @@ use Pim\Component\Catalog\Model\LocaleInterface;
  *  - a name is required on all channels and the locale "en_US"
  *  - a price is required on the channel "ecommerce" and all locales
  *  - ...
+ *
+ * This object gives you the information of the requirement in the matrix: attribute, channel, locale.
+ * that's why the functions forAttribute, forScope and ForLocale always return an object.
+ *
+ * It also helps you how to retrieve the corresponding value in a value collection.
+ * For instance, if the attribute is not scopable and not localizable. if we try to compute the completeness on the
+ * channel 'ecommerce' and locale 'fr_FR' for this attribute.
+ * - forScope will return the channel ecommerde
+ * - forLocale will return the locale fr_FR
+ * the information of the matrix, and
+ * - scope() will return null
+ * - locale('fr_FR') will return null
+ *
+ * This way, we decouple what is the required value in the matrix, from the way we retrieve it in the value collection
+ * (depending on the attribute's settings).
  *
  * @author    Julien Janvier <j.janvier@gmail.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -49,17 +64,26 @@ class RequiredValue
         $this->locale = $locale;
     }
 
-    public function getAttribute(): AttributeInterface
+    /**
+     * @return AttributeInterface
+     */
+    public function forAttribute(): AttributeInterface
     {
         return $this->attribute;
     }
 
-    public function getScope(): ChannelInterface
+    /**
+     * @return ChannelInterface
+     */
+    public function forScope(): ChannelInterface
     {
         return $this->channel;
     }
 
-    public function getLocale(): LocaleInterface
+    /**
+     * @return LocaleInterface
+     */
+    public function forLocale(): LocaleInterface
     {
         return $this->locale;
     }
@@ -67,7 +91,7 @@ class RequiredValue
     /**
      * @return string
      */
-    public function forAttributeCode(): string
+    public function attribute(): string
     {
         return $this->attribute->getCode();
     }
@@ -75,23 +99,18 @@ class RequiredValue
     /**
      * @return null|string
      */
-    public function forScope(): ?string
+    public function scope(): ?string
     {
         return $this->attribute->isScopable() ? $this->channel->getCode() : null;
     }
 
     /**
+     * @param LocaleInterface $locale
+     *
      * @return null|string
      */
-    public function forLocale(LocaleInterface $locale): ?string
+    public function locale(): ?string
     {
-        if (!$this->attribute->isLocalizable() &&
-            $this->attribute->isLocaleSpecific() &&
-            $this->attribute->hasLocaleSpecific($locale)
-        ) {
-            return null;
-        }
-
-        return $this->locale->getCode();
+        return $this->attribute->isLocalizable() ? $this->locale->getCode() : null;
     }
 }

--- a/src/Pim/Component/Catalog/EntityWithFamily/RequiredValue.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/RequiredValue.php
@@ -20,19 +20,26 @@ use Pim\Component\Catalog\Model\LocaleInterface;
  *  - ...
  *
  * This object gives you the information of the requirement in the matrix: attribute, channel, locale.
- * that's why the functions forAttribute, forScope and ForLocale always return an object.
+ * that's why the functions forAttribute, forChannel and ForLocale always return an object representing the value in those
+ * axis.
  *
- * It also helps you how to retrieve the corresponding value in a value collection.
- * For instance, if the attribute is not scopable and not localizable. if we try to compute the completeness on the
+ * It also helps to retrieve the corresponding value in a value collection:
+ *
+ * For instance, if the attribute 'description' is not scopable and not localizable and we try to compute the completeness on the
  * channel 'ecommerce' and locale 'fr_FR' for this attribute.
- * - forScope will return the channel ecommerde
- * - forLocale will return the locale fr_FR
- * the information of the matrix, and
- * - scope() will return null
- * - locale('fr_FR') will return null
  *
- * This way, we decouple what is the required value in the matrix, from the way we retrieve it in the value collection
- * (depending on the attribute's settings).
+ * - forAttribute() will return the attribute description object
+ * - forChannel() will return the channel ecommerce object
+ * - forLocale() will return the locale fr_FR object
+ *
+ * However, to retrieve the corresponding value in the value collection, we will use:
+ * - attribute() will return the code of the description attribute 'description'
+ * - channel() will return null (because the attribute is note scopable)
+ * - locale() will return null (because the attribute is not localizable)
+ *
+ * This way, the required value holds two kind of information:
+ * - The attribute, channel, locale for which this required value is relevant (using the for* functions)
+ * - the way we retrieve it in the value collection (depending on the attribute's settings).
  *
  * @author    Julien Janvier <j.janvier@gmail.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -41,13 +48,13 @@ use Pim\Component\Catalog\Model\LocaleInterface;
 class RequiredValue
 {
     /** @var AttributeInterface */
-    private $attribute;
+    private $forAttribute;
 
     /** @var ChannelInterface */
-    private $channel;
+    private $forChannel;
 
     /** @var LocaleInterface */
-    private $locale;
+    private $forLocale;
 
     /**
      * @param AttributeInterface $attribute
@@ -59,9 +66,9 @@ class RequiredValue
         ChannelInterface $channel,
         LocaleInterface $locale
     ) {
-        $this->attribute = $attribute;
-        $this->channel = $channel;
-        $this->locale = $locale;
+        $this->forAttribute = $attribute;
+        $this->forChannel = $channel;
+        $this->forLocale = $locale;
     }
 
     /**
@@ -69,15 +76,15 @@ class RequiredValue
      */
     public function forAttribute(): AttributeInterface
     {
-        return $this->attribute;
+        return $this->forAttribute;
     }
 
     /**
      * @return ChannelInterface
      */
-    public function forScope(): ChannelInterface
+    public function forChannel(): ChannelInterface
     {
-        return $this->channel;
+        return $this->forChannel;
     }
 
     /**
@@ -85,7 +92,7 @@ class RequiredValue
      */
     public function forLocale(): LocaleInterface
     {
-        return $this->locale;
+        return $this->forLocale;
     }
 
     /**
@@ -93,24 +100,22 @@ class RequiredValue
      */
     public function attribute(): string
     {
-        return $this->attribute->getCode();
+        return $this->forAttribute->getCode();
     }
 
     /**
      * @return null|string
      */
-    public function scope(): ?string
+    public function channel(): ?string
     {
-        return $this->attribute->isScopable() ? $this->channel->getCode() : null;
+        return $this->forAttribute->isScopable() ? $this->forChannel->getCode() : null;
     }
 
     /**
-     * @param LocaleInterface $locale
-     *
      * @return null|string
      */
     public function locale(): ?string
     {
-        return $this->attribute->isLocalizable() ? $this->locale->getCode() : null;
+        return $this->forAttribute->isLocalizable() ? $this->forLocale->getCode() : null;
     }
 }

--- a/src/Pim/Component/Catalog/EntityWithFamily/RequiredValue.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/RequiredValue.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Pim\Component\Catalog\EntityWithFamily;
 
-use Pim\Component\Catalog\Model\AbstractValue;
 use Pim\Component\Catalog\Model\AttributeInterface;
-use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
 
 /**
  * A required value is the translation of the attribute requirements
@@ -23,47 +23,75 @@ use Pim\Component\Catalog\Model\ValueInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class RequiredValue extends AbstractValue implements ValueInterface
+class RequiredValue
 {
-    /** @var \Closure  */
-    private $valueGetter;
+    /** @var AttributeInterface */
+    private $attribute;
+
+    /** @var ChannelInterface */
+    private $channel;
+
+    /** @var LocaleInterface */
+    private $locale;
 
     /**
      * @param AttributeInterface $attribute
-     * @param string             $channel
-     * @param string             $locale
-     * @param string             $valueGetter
+     * @param ChannelInterface   $channel
+     * @param LocaleInterface    $locale
      */
     public function __construct(
         AttributeInterface $attribute,
-        string $channel = null,
-        string $locale = null,
-        \Closure $valueGetter = null
+        ChannelInterface $channel,
+        LocaleInterface $locale
     ) {
-        $this->setAttribute($attribute);
-        $this->setScope($channel);
-        $this->setLocale($locale);
-        $this->valueGetter = $valueGetter;
+        $this->attribute = $attribute;
+        $this->channel = $channel;
+        $this->locale = $locale;
     }
 
-    public function valueFromEntity(): \Closure
+    public function getAttribute(): AttributeInterface
     {
-        return $this->valueGetter;
+        return $this->attribute;
+    }
+
+    public function getScope(): ChannelInterface
+    {
+        return $this->channel;
+    }
+
+    public function getLocale(): LocaleInterface
+    {
+        return $this->locale;
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
-    public function getData()
+    public function forAttributeCode(): string
     {
-        return null;
+        return $this->attribute->getCode();
     }
 
     /**
-     * {@inheritdoc}
+     * @return null|string
      */
-    public function __toString()
+    public function forScope(): ?string
     {
-        return null;
+        return $this->attribute->isScopable() ? $this->channel->getCode() : null;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function forLocale(LocaleInterface $locale): ?string
+    {
+        if (!$this->attribute->isLocalizable() &&
+            $this->attribute->isLocaleSpecific() &&
+            $this->attribute->hasLocaleSpecific($locale)
+        ) {
+            return null;
+        }
+
+        return $this->locale->getCode();
     }
 }

--- a/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollection.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollection.php
@@ -81,6 +81,10 @@ class RequiredValueCollection implements \Countable, \IteratorAggregate
                     return false;
                 }
 
+                if ($attribute->isLocaleSpecific() && !$attribute->hasLocaleSpecific($locale)) {
+                    return false;
+                }
+
                 return true;
             }
         );

--- a/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollection.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollection.php
@@ -81,7 +81,7 @@ class RequiredValueCollection implements \Countable, \IteratorAggregate
                     return false;
                 }
 
-                if ($attribute->isLocaleSpecific() && !$attribute->hasLocaleSpecific($locale)) {
+                if ($attribute->isLocaleSpecific() && (!$attribute->hasLocaleSpecific($locale) || $value->getLocale() !== $locale->getCode())) {
                     return false;
                 }
 

--- a/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollection.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollection.php
@@ -72,7 +72,7 @@ class RequiredValueCollection implements \Countable, \IteratorAggregate
             function (RequiredValue $requiredValue) use ($channel, $locale) {
                 $attribute = $requiredValue->forAttribute();
 
-                if ($attribute->isScopable() && $requiredValue->forScope()->getCode() !== $channel->getCode()) {
+                if ($attribute->isScopable() && $requiredValue->forChannel()->getCode() !== $channel->getCode()) {
                     return false;
                 }
 
@@ -116,7 +116,7 @@ class RequiredValueCollection implements \Countable, \IteratorAggregate
      */
     private function buildInternalKey(RequiredValue $requiredValue): string
     {
-        $channelCode = null !== $requiredValue->scope() ? $requiredValue->scope() : '<all_channels>';
+        $channelCode = null !== $requiredValue->channel() ? $requiredValue->channel() : '<all_channels>';
         $localeCode = null !== $requiredValue->locale() ? $requiredValue->locale() : '<all_locales>';
         $key = sprintf('%s-%s-%s', $requiredValue->attribute(), $channelCode, $localeCode);
 

--- a/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollectionFactory.php
@@ -38,12 +38,16 @@ class RequiredValueCollectionFactory
                     $channel = $attributeRequirement->getChannel();
 
                     $attribute = $attributeRequirement->getAttribute();
+                    $channelCode = $attribute->isScopable() ? $channel->getCode() : null;
+                    $localeCode = $attribute->isLocalizable() ? $locale->getCode() : null;
+
                     if ($attribute->isLocaleSpecific() && !$attribute->hasLocaleSpecific($locale)) {
                         continue;
                     }
 
-                    $channelCode = $attribute->isScopable() ? $channel->getCode() : null;
-                    $localeCode = $attribute->isLocalizable() ? $locale->getCode() : null;
+                    if ($attribute->isLocaleSpecific() && $attribute->hasLocaleSpecific($locale)) {
+                        $localeCode = $locale->getCode();
+                    }
 
                     $requiredValues[] = new RequiredValue($attribute, $channelCode, $localeCode);
                 }

--- a/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollectionFactory.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\FamilyInterface;
+use Pim\Component\Catalog\Model\ValueCollection;
 
 /**
  * Simple factory of a "required value" collection.
@@ -40,16 +41,18 @@ class RequiredValueCollectionFactory
                     $attribute = $attributeRequirement->getAttribute();
                     $channelCode = $attribute->isScopable() ? $channel->getCode() : null;
                     $localeCode = $attribute->isLocalizable() ? $locale->getCode() : null;
+                    $valueKey = ValueCollection::generateKey($attribute->getCode(), $channelCode, $localeCode);
 
                     if ($attribute->isLocaleSpecific() && !$attribute->hasLocaleSpecific($locale)) {
                         continue;
                     }
 
-                    if ($attribute->isLocaleSpecific() && $attribute->hasLocaleSpecific($locale)) {
+                    if (!$attribute->isLocalizable() && $attribute->isLocaleSpecific() && $attribute->hasLocaleSpecific($locale)) {
                         $localeCode = $locale->getCode();
+                        $valueKey = ValueCollection::generateKey($attribute->getCode(), $channelCode, null);
                     }
 
-                    $requiredValues[] = new RequiredValue($attribute, $channelCode, $localeCode);
+                    $requiredValues[] = new RequiredValue($attribute, $channelCode, $localeCode, $valueKey);
                 }
             }
         }

--- a/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/EntityWithFamily/RequiredValueCollectionFactory.php
@@ -38,23 +38,13 @@ class RequiredValueCollectionFactory
         foreach ($this->filterRequirementsByChannel($family, $channel) as $attributeRequirement) {
             foreach ($attributeRequirement->getChannel()->getLocales() as $locale) {
                 if ($attributeRequirement->isRequired()) {
-                    $channel = $attributeRequirement->getChannel();
-
                     $attribute = $attributeRequirement->getAttribute();
-                    $channelCode = $attribute->isScopable() ? $channel->getCode() : null;
-                    $localeCode = $attribute->isLocalizable() ? $locale->getCode() : null;
-                    $getter = $this->simpleValueGetter();
 
                     if ($attribute->isLocaleSpecific() && !$attribute->hasLocaleSpecific($locale)) {
                         continue;
                     }
 
-                    if (!$attribute->isLocalizable() && $attribute->isLocaleSpecific() && $attribute->hasLocaleSpecific($locale)) {
-                        $localeCode = $locale->getCode();
-                        $getter = $this->localeSpecficGetter();
-                    }
-
-                    $requiredValues[] = new RequiredValue($attribute, $channelCode, $localeCode, $getter);
+                    $requiredValues[] = new RequiredValue($attribute, $attributeRequirement->getChannel(), $locale);
                 }
             }
         }
@@ -80,33 +70,5 @@ class RequiredValueCollectionFactory
         }
 
         return $requirements;
-    }
-
-    protected function simpleValueGetter(): \Closure
-    {
-        return function (
-            EntityWithValuesInterface $entityWithValues,
-            AttributeInterface $attribute,
-            $channelCode,
-            $localeCode
-        ) {
-            $requiredValue = new RequiredValue($attribute, $channelCode, $localeCode);
-
-            return $entityWithValues->getValues()->getSame($requiredValue);
-        };
-    }
-
-    protected function localeSpecficGetter(): \Closure
-    {
-        return function (
-            EntityWithValuesInterface $entityWithValues,
-            AttributeInterface $attribute,
-            $channelCode,
-            $localeCode
-        ) {
-            $requiredValue = new RequiredValue($attribute, $channelCode, null);
-
-            return $entityWithValues->getValues()->getSame($requiredValue);
-        };
     }
 }

--- a/src/Pim/Component/Catalog/Model/AbstractValue.php
+++ b/src/Pim/Component/Catalog/Model/AbstractValue.php
@@ -107,7 +107,7 @@ abstract class AbstractValue implements ValueInterface
      */
     protected function setLocale($locale)
     {
-        if ($locale && $this->getAttribute() && !$this->getAttribute()->isLocalizable()) {
+        if ($this->isProductValueNotLocalizableNeitherLocaleSpecific($locale)) {
             $attributeCode = $this->getAttribute()->getCode();
             throw new \LogicException(
                 "The product value cannot be localized, see attribute '".$attributeCode."' configuration"
@@ -115,5 +115,18 @@ abstract class AbstractValue implements ValueInterface
         }
 
         $this->locale = $locale;
+    }
+
+    /**
+     * @param string $locale
+     *
+     * @return bool
+     */
+    protected function isProductValueNotLocalizableNeitherLocaleSpecific($locale): bool
+    {
+        return $locale
+            && null !== $this->getAttribute()
+            && !$this->getAttribute()->isLocalizable()
+            && !$this->getAttribute()->isLocaleSpecific();
     }
 }

--- a/src/Pim/Component/Catalog/Model/AbstractValue.php
+++ b/src/Pim/Component/Catalog/Model/AbstractValue.php
@@ -107,7 +107,12 @@ abstract class AbstractValue implements ValueInterface
      */
     protected function setLocale($locale)
     {
-        if ($this->isProductValueNotLocalizableNeitherLocaleSpecific($locale)) {
+        $isProductValueNotLocalizableNeitherLocaleSpecific = $locale
+            && null !== $this->getAttribute()
+            && !$this->getAttribute()->isLocalizable()
+            && !$this->getAttribute()->isLocaleSpecific();
+
+        if ($isProductValueNotLocalizableNeitherLocaleSpecific) {
             $attributeCode = $this->getAttribute()->getCode();
             throw new \LogicException(
                 "The product value cannot be localized, see attribute '".$attributeCode."' configuration"
@@ -115,18 +120,5 @@ abstract class AbstractValue implements ValueInterface
         }
 
         $this->locale = $locale;
-    }
-
-    /**
-     * @param string $locale
-     *
-     * @return bool
-     */
-    protected function isProductValueNotLocalizableNeitherLocaleSpecific($locale): bool
-    {
-        return $locale
-            && null !== $this->getAttribute()
-            && !$this->getAttribute()->isLocalizable()
-            && !$this->getAttribute()->isLocaleSpecific();
     }
 }

--- a/src/Pim/Component/Catalog/Model/ValueCollection.php
+++ b/src/Pim/Component/Catalog/Model/ValueCollection.php
@@ -182,10 +182,9 @@ class ValueCollection implements ValueCollectionInterface
      */
     public function getSame(ValueInterface $value)
     {
-        $channelCode = null !== $value->getScope() ? $value->getScope() : '<all_channels>';
-        $localeCode = null !== $value->getLocale() ? $value->getLocale() : '<all_locales>';
+        $key = self::generateKey($value->getAttribute()->getCode(), $value->getScope(), $value->getLocale());
 
-        return $this->getByCodes($value->getAttribute()->getCode(), $channelCode, $localeCode);
+        return $this->getByKey($key);
     }
 
     /**
@@ -201,9 +200,7 @@ class ValueCollection implements ValueCollectionInterface
      */
     public function getByCodes($attributeCode, $channelCode = null, $localeCode = null)
     {
-        $channelCode = null !== $channelCode ? $channelCode : '<all_channels>';
-        $localeCode = null !== $localeCode ? $localeCode : '<all_locales>';
-        $key = sprintf('%s-%s-%s', $attributeCode, $channelCode, $localeCode);
+        $key = self::generateKey($attributeCode, $channelCode, $localeCode);
 
         return $this->getByKey($key);
     }
@@ -238,9 +235,7 @@ class ValueCollection implements ValueCollectionInterface
     public function add(ValueInterface $value)
     {
         $attribute = $value->getAttribute();
-        $channelCode = null !== $value->getScope() ? $value->getScope() : '<all_channels>';
-        $localeCode = null !== $value->getLocale() ? $value->getLocale() : '<all_locales>';
-        $key = sprintf('%s-%s-%s', $attribute->getCode(), $channelCode, $localeCode);
+        $key = self::generateKey($value->getAttribute()->getCode(), $value->getScope(), $value->getLocale());
 
         if (isset($this->values[$key])) {
             return false;
@@ -318,5 +313,21 @@ class ValueCollection implements ValueCollectionInterface
         $filteredValues = array_filter($this->values, $filterBy);
 
         return new self($filteredValues);
+    }
+
+    /**
+     * @param string $attributeCode
+     * @param string $channelCode
+     * @param string $localeCode
+     *
+     * @return string
+     */
+    public static function generateKey(string $attributeCode, ?string $channelCode, ?string $localeCode): string
+    {
+        $channelCode = null !== $channelCode ? $channelCode : '<all_channels>';
+        $localeCode = null !== $localeCode ? $localeCode : '<all_locales>';
+        $key = sprintf('%s-%s-%s', $attributeCode, $channelCode, $localeCode);
+
+        return $key;
     }
 }

--- a/src/Pim/Component/Catalog/Model/ValueCollection.php
+++ b/src/Pim/Component/Catalog/Model/ValueCollection.php
@@ -182,7 +182,7 @@ class ValueCollection implements ValueCollectionInterface
      */
     public function getSame(ValueInterface $value)
     {
-        $key = self::generateKey($value->getAttribute()->getCode(), $value->getScope(), $value->getLocale());
+        $key = $this->generateKey($value->getAttribute()->getCode(), $value->getScope(), $value->getLocale());
 
         return $this->getByKey($key);
     }
@@ -200,7 +200,7 @@ class ValueCollection implements ValueCollectionInterface
      */
     public function getByCodes($attributeCode, $channelCode = null, $localeCode = null)
     {
-        $key = self::generateKey($attributeCode, $channelCode, $localeCode);
+        $key = $this->generateKey($attributeCode, $channelCode, $localeCode);
 
         return $this->getByKey($key);
     }
@@ -235,7 +235,7 @@ class ValueCollection implements ValueCollectionInterface
     public function add(ValueInterface $value)
     {
         $attribute = $value->getAttribute();
-        $key = self::generateKey($value->getAttribute()->getCode(), $value->getScope(), $value->getLocale());
+        $key = $this->generateKey($value->getAttribute()->getCode(), $value->getScope(), $value->getLocale());
 
         if (isset($this->values[$key])) {
             return false;
@@ -322,7 +322,7 @@ class ValueCollection implements ValueCollectionInterface
      *
      * @return string
      */
-    public static function generateKey(string $attributeCode, ?string $channelCode, ?string $localeCode): string
+    private function generateKey(string $attributeCode, ?string $channelCode, ?string $localeCode): string
     {
         $channelCode = null !== $channelCode ? $channelCode : '<all_channels>';
         $localeCode = null !== $localeCode ? $localeCode : '<all_locales>';

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/IncompleteValueCollectionFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/IncompleteValueCollectionFactorySpec.php
@@ -80,24 +80,24 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         $requiredValuesForChannelAndLocaleIterator->next()->shouldBeCalled();
 
         $requiredValue1->forAttribute()->willReturn($price);
-        $requiredValue1->forScope()->willReturn($ecommerce);
+        $requiredValue1->forChannel()->willReturn($ecommerce);
         $requiredValue1->forLocale()->willReturn($en_US);
         $requiredValue1->attribute()->willReturn('price');
-        $requiredValue1->scope()->willReturn('ecommerce');
+        $requiredValue1->channel()->willReturn('ecommerce');
         $requiredValue1->locale()->willReturn(null);
 
         $requiredValue2->forAttribute()->willReturn($description);
-        $requiredValue2->forScope()->willReturn('ecommerce');
+        $requiredValue2->forChannel()->willReturn('ecommerce');
         $requiredValue2->forLocale()->willReturn('en_US');
         $requiredValue2->attribute()->willReturn('description');
-        $requiredValue2->scope()->willReturn('ecommerce');
+        $requiredValue2->channel()->willReturn('ecommerce');
         $requiredValue2->locale()->willReturn('en_US');
 
         $requiredValue3->forAttribute()->willReturn($name);
-        $requiredValue3->forScope()->willReturn($en_US);
+        $requiredValue3->forChannel()->willReturn($en_US);
         $requiredValue3->forLocale()->willReturn('en_US');
         $requiredValue3->attribute()->willReturn('name');
-        $requiredValue3->scope()->willReturn(null);
+        $requiredValue3->channel()->willReturn(null);
         $requiredValue3->locale()->willReturn('en_US');
 
         $product->getValues()->willReturn($productValues);
@@ -135,10 +135,10 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         $requiredValuesForChannelAndLocaleIterator->next()->shouldBeCalled();
 
         $requiredValue->forAttribute()->willReturn($price);
-        $requiredValue->forScope()->willReturn('ecommerce');
+        $requiredValue->forChannel()->willReturn('ecommerce');
         $requiredValue->forLocale()->willReturn($en_US);
         $requiredValue->attribute()->willReturn('price');
-        $requiredValue->scope()->willReturn('ecommerce');
+        $requiredValue->channel()->willReturn('ecommerce');
         $requiredValue->locale()->willReturn(null);
 
         $product->getValues()->willReturn($productValues);
@@ -171,10 +171,10 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         $requiredValuesForChannelAndLocaleIterator->next()->shouldBeCalled();
 
         $requiredValue->forAttribute()->willReturn($price);
-        $requiredValue->forScope()->willReturn('ecommerce');
+        $requiredValue->forChannel()->willReturn('ecommerce');
         $requiredValue->forLocale()->willReturn($en_US);
         $requiredValue->attribute()->willReturn('price');
-        $requiredValue->scope()->willReturn('ecommerce');
+        $requiredValue->channel()->willReturn('ecommerce');
         $requiredValue->locale()->willReturn(null);
 
         $product->getValues()->willReturn($productValues);
@@ -208,10 +208,10 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         $requiredValuesForChannelAndLocaleIterator->next()->shouldBeCalled();
 
         $requiredValue->forAttribute()->willReturn($price);
-        $requiredValue->forScope()->willReturn('ecommerce');
+        $requiredValue->forChannel()->willReturn('ecommerce');
         $requiredValue->forLocale()->willReturn($en_US);
         $requiredValue->attribute()->willReturn('price');
-        $requiredValue->scope()->willReturn('ecommerce');
+        $requiredValue->channel()->willReturn('ecommerce');
         $requiredValue->locale()->willReturn(null);
 
         $product->getValues()->willReturn($productValues);

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/IncompleteValueCollectionFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/IncompleteValueCollectionFactorySpec.php
@@ -5,6 +5,7 @@ namespace spec\Pim\Component\Catalog\EntityWithFamily;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Completeness\Checker\ValueCompleteCheckerInterface;
 use Pim\Component\Catalog\EntityWithFamily\IncompleteValueCollectionFactory;
+use Pim\Component\Catalog\EntityWithFamily\RequiredValue;
 use Pim\Component\Catalog\EntityWithFamily\RequiredValueCollection;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
@@ -61,9 +62,9 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         RequiredValueCollection $requiredValues,
         RequiredValueCollection $requiredValuesForChannelAndLocale,
         \Iterator $requiredValuesForChannelAndLocaleIterator,
-        ValueInterface $requiredValue1,
-        ValueInterface $requiredValue2,
-        ValueInterface $requiredValue3,
+        RequiredValue $requiredValue1,
+        RequiredValue $requiredValue2,
+        RequiredValue $requiredValue3,
         ValueInterface $productValue1,
         ValueInterface $productValue3
     ) {
@@ -78,22 +79,31 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         );
         $requiredValuesForChannelAndLocaleIterator->next()->shouldBeCalled();
 
-        $requiredValue1->getAttribute()->willReturn($price);
-        $requiredValue1->getScope()->willReturn('ecommerce');
-        $requiredValue1->getLocale()->willReturn(null);
+        $requiredValue1->forAttribute()->willReturn($price);
+        $requiredValue1->forScope()->willReturn($ecommerce);
+        $requiredValue1->forLocale()->willReturn($en_US);
+        $requiredValue1->attribute()->willReturn('price');
+        $requiredValue1->scope()->willReturn('ecommerce');
+        $requiredValue1->locale()->willReturn(null);
 
-        $requiredValue2->getAttribute()->willReturn($description);
-        $requiredValue2->getScope()->willReturn('ecommerce');
-        $requiredValue2->getLocale()->willReturn('en_US');
+        $requiredValue2->forAttribute()->willReturn($description);
+        $requiredValue2->forScope()->willReturn('ecommerce');
+        $requiredValue2->forLocale()->willReturn('en_US');
+        $requiredValue2->attribute()->willReturn('description');
+        $requiredValue2->scope()->willReturn('ecommerce');
+        $requiredValue2->locale()->willReturn('en_US');
 
-        $requiredValue3->getAttribute()->willReturn($name);
-        $requiredValue3->getScope()->willReturn(null);
-        $requiredValue3->getLocale()->willReturn('en_US');
+        $requiredValue3->forAttribute()->willReturn($name);
+        $requiredValue3->forScope()->willReturn($en_US);
+        $requiredValue3->forLocale()->willReturn('en_US');
+        $requiredValue3->attribute()->willReturn('name');
+        $requiredValue3->scope()->willReturn(null);
+        $requiredValue3->locale()->willReturn('en_US');
 
         $product->getValues()->willReturn($productValues);
-        $productValues->getSame($requiredValue1)->willReturn($productValue1);
-        $productValues->getSame($requiredValue2)->willReturn(null);
-        $productValues->getSame($requiredValue3)->willReturn($productValue3);
+        $productValues->getByCodes('price', 'ecommerce', null)->willReturn($productValue1);
+        $productValues->getByCodes('description', 'ecommerce', 'en_US')->willReturn(null);
+        $productValues->getByCodes('name', null, 'en_US')->willReturn($productValue3);
 
         $completeValueChecker->isComplete($productValue1, $ecommerce, $en_US)->willReturn(true);
         $completeValueChecker->isComplete($productValue3, $ecommerce, $en_US)->willReturn(false);
@@ -114,7 +124,7 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         RequiredValueCollection $requiredValues,
         RequiredValueCollection $requiredValuesForChannelAndLocale,
         \Iterator $requiredValuesForChannelAndLocaleIterator,
-        ValueInterface $requiredValue,
+        RequiredValue $requiredValue,
         ValueInterface $productValue
     ) {
         $requiredValues->filterByChannelAndLocale($ecommerce, $en_US)->willReturn($requiredValuesForChannelAndLocale);
@@ -124,12 +134,15 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         $requiredValuesForChannelAndLocaleIterator->current()->willReturn($requiredValue);
         $requiredValuesForChannelAndLocaleIterator->next()->shouldBeCalled();
 
-        $requiredValue->getAttribute()->willReturn($price);
-        $requiredValue->getScope()->willReturn('ecommerce');
-        $requiredValue->getLocale()->willReturn(null);
+        $requiredValue->forAttribute()->willReturn($price);
+        $requiredValue->forScope()->willReturn('ecommerce');
+        $requiredValue->forLocale()->willReturn($en_US);
+        $requiredValue->attribute()->willReturn('price');
+        $requiredValue->scope()->willReturn('ecommerce');
+        $requiredValue->locale()->willReturn(null);
 
         $product->getValues()->willReturn($productValues);
-        $productValues->getSame($requiredValue)->willReturn($productValue);
+        $productValues->getByCodes('price', 'ecommerce', null)->willReturn($productValue);
 
         $completeValueChecker->isComplete($productValue, $ecommerce, $en_US)->willReturn(false);
 
@@ -148,7 +161,7 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         RequiredValueCollection $requiredValues,
         RequiredValueCollection $requiredValuesForChannelAndLocale,
         \Iterator $requiredValuesForChannelAndLocaleIterator,
-        ValueInterface $requiredValue
+        RequiredValue $requiredValue
     ) {
         $requiredValues->filterByChannelAndLocale($ecommerce, $en_US)->willReturn($requiredValuesForChannelAndLocale);
         $requiredValuesForChannelAndLocale->getIterator()->willReturn($requiredValuesForChannelAndLocaleIterator);
@@ -157,12 +170,15 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         $requiredValuesForChannelAndLocaleIterator->current()->willReturn($requiredValue);
         $requiredValuesForChannelAndLocaleIterator->next()->shouldBeCalled();
 
-        $requiredValue->getAttribute()->willReturn($price);
-        $requiredValue->getScope()->willReturn('ecommerce');
-        $requiredValue->getLocale()->willReturn(null);
+        $requiredValue->forAttribute()->willReturn($price);
+        $requiredValue->forScope()->willReturn('ecommerce');
+        $requiredValue->forLocale()->willReturn($en_US);
+        $requiredValue->attribute()->willReturn('price');
+        $requiredValue->scope()->willReturn('ecommerce');
+        $requiredValue->locale()->willReturn(null);
 
         $product->getValues()->willReturn($productValues);
-        $productValues->getSame($requiredValue)->willReturn(null);
+        $productValues->getByCodes('price', 'ecommerce', null)->willReturn(null);
 
         $completeValueChecker->isComplete(Argument::cetera())->shouldNotBeCalled();
 
@@ -181,7 +197,7 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         RequiredValueCollection $requiredValues,
         RequiredValueCollection $requiredValuesForChannelAndLocale,
         \Iterator $requiredValuesForChannelAndLocaleIterator,
-        ValueInterface $requiredValue,
+        RequiredValue $requiredValue,
         ValueInterface $productValue
     ) {
         $requiredValues->filterByChannelAndLocale($ecommerce, $en_US)->willReturn($requiredValuesForChannelAndLocale);
@@ -191,12 +207,15 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         $requiredValuesForChannelAndLocaleIterator->current()->willReturn($requiredValue);
         $requiredValuesForChannelAndLocaleIterator->next()->shouldBeCalled();
 
-        $requiredValue->getAttribute()->willReturn($price);
-        $requiredValue->getScope()->willReturn('ecommerce');
-        $requiredValue->getLocale()->willReturn(null);
+        $requiredValue->forAttribute()->willReturn($price);
+        $requiredValue->forScope()->willReturn('ecommerce');
+        $requiredValue->forLocale()->willReturn($en_US);
+        $requiredValue->attribute()->willReturn('price');
+        $requiredValue->scope()->willReturn('ecommerce');
+        $requiredValue->locale()->willReturn(null);
 
         $product->getValues()->willReturn($productValues);
-        $productValues->getSame($requiredValue)->willReturn($productValue);
+        $productValues->getByCodes('price', 'ecommerce', null)->willReturn($productValue);
 
         $completeValueChecker->isComplete($productValue, $ecommerce, $en_US)->willReturn(true);
 

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/IncompleteValueCollectionSpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/IncompleteValueCollectionSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Catalog\EntityWithFamily;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\EntityWithFamily\IncompleteValueCollection;
+use Pim\Component\Catalog\EntityWithFamily\RequiredValue;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
@@ -20,12 +21,12 @@ class IncompleteValueCollectionSpec extends ObjectBehavior
         ChannelInterface $print,
         LocaleInterface $en_US,
         LocaleInterface $fr_FR,
-        ValueInterface $value1,
-        ValueInterface $value2,
-        ValueInterface $value3,
-        ValueInterface $value4,
-        ValueInterface $value5,
-        ValueInterface $value6
+        RequiredValue $value1,
+        RequiredValue $value2,
+        RequiredValue $value3,
+        RequiredValue $value4,
+        RequiredValue $value5,
+        RequiredValue $value6
     ) {
         $length->isUnique()->willReturn(false);
         $price->isUnique()->willReturn(false);
@@ -51,28 +52,47 @@ class IncompleteValueCollectionSpec extends ObjectBehavior
         $en_US->getCode()->willReturn('en_US');
         $fr_FR->getCode()->willReturn('fr_FR');
 
-        $value1->getAttribute()->willReturn($length);
-        $value2->getAttribute()->willReturn($price);
-        $value3->getAttribute()->willReturn($description);
-        $value4->getAttribute()->willReturn($description);
-        $value5->getAttribute()->willReturn($description);
-        $value6->getAttribute()->willReturn($releaseDate);
+        $value1->forAttribute()->willReturn($length);
+        $value2->forAttribute()->willReturn($price);
+        $value3->forAttribute()->willReturn($description);
+        $value4->forAttribute()->willReturn($description);
+        $value5->forAttribute()->willReturn($description);
+        $value6->forAttribute()->willReturn($releaseDate);
 
-        $value1->getScope()->willReturn(null);
-        $value2->getScope()->willReturn(null);
-        $value3->getScope()->willReturn('ecommerce');
-        $value4->getScope()->willReturn('ecommerce');
-        $value5->getScope()->willReturn('print');
-        $value6->getScope()->willReturn(null);
+        $value1->forScope()->willReturn($ecommerce);
+        $value2->forScope()->willReturn($ecommerce);
+        $value3->forScope()->willReturn($ecommerce);
+        $value4->forScope()->willReturn($print);
+        $value5->forScope()->willReturn($print);
+        $value6->forScope()->willReturn($print);
 
-        $value1->getLocale()->willReturn(null);
-        $value2->getLocale()->willReturn(null);
-        $value3->getLocale()->willReturn('en_US');
-        $value4->getLocale()->willReturn('fr_FR');
-        $value5->getLocale()->willReturn('en_US');
-        $value6->getLocale()->willReturn(null);
+        $value1->forLocale()->willReturn($en_US);
+        $value2->forLocale()->willReturn($en_US);
+        $value3->forLocale()->willReturn($en_US);
+        $value4->forLocale()->willReturn($fr_FR);
+        $value5->forLocale()->willReturn($fr_FR);
+        $value6->forLocale()->willReturn($fr_FR);
 
-        $value6->getData()->willReturn('2016-09-12');
+        $value1->attribute()->willReturn('length');
+        $value2->attribute()->willReturn('price');
+        $value3->attribute()->willReturn('description');
+        $value4->attribute()->willReturn('description');
+        $value5->attribute()->willReturn('description');
+        $value6->attribute()->willReturn('release_date');
+
+        $value1->scope()->willReturn(null);
+        $value2->scope()->willReturn(null);
+        $value3->scope()->willReturn('ecommerce');
+        $value4->scope()->willReturn('ecommerce');
+        $value5->scope()->willReturn('print');
+        $value6->scope()->willReturn(null);
+
+        $value1->locale()->willReturn(null);
+        $value2->locale()->willReturn('en_US');
+        $value3->locale()->willReturn('en_US');
+        $value4->locale()->willReturn('fr_FR');
+        $value5->locale()->willReturn('fr_FR');
+        $value6->locale()->willReturn(null);
 
         $this->beConstructedWith([$value1, $value2, $value3, $value4, $value5, $value6]);
     }

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/IncompleteValueCollectionSpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/IncompleteValueCollectionSpec.php
@@ -59,12 +59,12 @@ class IncompleteValueCollectionSpec extends ObjectBehavior
         $value5->forAttribute()->willReturn($description);
         $value6->forAttribute()->willReturn($releaseDate);
 
-        $value1->forScope()->willReturn($ecommerce);
-        $value2->forScope()->willReturn($ecommerce);
-        $value3->forScope()->willReturn($ecommerce);
-        $value4->forScope()->willReturn($print);
-        $value5->forScope()->willReturn($print);
-        $value6->forScope()->willReturn($print);
+        $value1->forChannel()->willReturn($ecommerce);
+        $value2->forChannel()->willReturn($ecommerce);
+        $value3->forChannel()->willReturn($ecommerce);
+        $value4->forChannel()->willReturn($print);
+        $value5->forChannel()->willReturn($print);
+        $value6->forChannel()->willReturn($print);
 
         $value1->forLocale()->willReturn($en_US);
         $value2->forLocale()->willReturn($en_US);
@@ -80,12 +80,12 @@ class IncompleteValueCollectionSpec extends ObjectBehavior
         $value5->attribute()->willReturn('description');
         $value6->attribute()->willReturn('release_date');
 
-        $value1->scope()->willReturn(null);
-        $value2->scope()->willReturn(null);
-        $value3->scope()->willReturn('ecommerce');
-        $value4->scope()->willReturn('ecommerce');
-        $value5->scope()->willReturn('print');
-        $value6->scope()->willReturn(null);
+        $value1->channel()->willReturn(null);
+        $value2->channel()->willReturn(null);
+        $value3->channel()->willReturn('ecommerce');
+        $value4->channel()->willReturn('ecommerce');
+        $value5->channel()->willReturn('print');
+        $value6->channel()->willReturn(null);
 
         $value1->locale()->willReturn(null);
         $value2->locale()->willReturn('en_US');

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionFactorySpec.php
@@ -17,6 +17,7 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
         AttributeInterface $sku,
         AttributeInterface $price,
         AttributeInterface $description,
+        AttributeInterface $image,
         ChannelInterface $ecommerce,
         ChannelInterface $print,
         LocaleInterface $en_US,
@@ -25,6 +26,7 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
         $sku->getCode()->willReturn('sku');
         $price->getCode()->willReturn('price');
         $description->getCode()->willReturn('description');
+        $image->getCode()->willReturn('image');
         $ecommerce->getCode()->willReturn('ecommerce');
         $print->getCode()->willReturn('print');
         $en_US->getCode()->willReturn('en_US');
@@ -42,6 +44,7 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
         $sku,
         $description,
         $price,
+        $image,
         $ecommerce,
         $print,
         FamilyInterface $family,
@@ -50,10 +53,12 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
         AttributeRequirementInterface $requirement3,
         AttributeRequirementInterface $requirement4,
         AttributeRequirementInterface $requirement5,
+        AttributeRequirementInterface $requirement6,
         ValueInterface $expectedValue1,
         ValueInterface $expectedValue2,
         ValueInterface $expectedValue3,
-        ValueInterface $expectedValue4
+        ValueInterface $expectedValue4,
+        ValueInterface $expectedValue5
     ) {
         $expectedValue1->getAttribute()->willReturn($sku);
         $expectedValue1->getScope()->willReturn(null);
@@ -71,7 +76,11 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
         $expectedValue4->getScope()->willReturn(null);
         $expectedValue4->getLocale()->willReturn(null);
 
-        $family->getAttributeRequirements()->willReturn([$requirement1, $requirement2, $requirement3, $requirement4, $requirement5]);
+        $expectedValue5->getAttribute()->willReturn($image);
+        $expectedValue5->getScope()->willReturn(null);
+        $expectedValue5->getLocale()->willReturn('fr_FR');
+
+        $family->getAttributeRequirements()->willReturn([$requirement1, $requirement2, $requirement3, $requirement4, $requirement5, $requirement6]);
 
         $ecommerce->getLocales()->willReturn([$en_US, $fr_FR]);
         $print->getLocales()->willReturn([$en_US]);
@@ -85,6 +94,11 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
         $price->isScopable()->willReturn(false);
         $price->isLocalizable()->willReturn(false);
         $price->isLocaleSpecific()->willReturn(false);
+        $image->isScopable()->willReturn(false);
+        $image->isLocalizable()->willReturn(false);
+        $image->isLocaleSpecific()->willReturn(true);
+        $image->hasLocaleSpecific($fr_FR)->willReturn(true);
+        $image->hasLocaleSpecific($en_US)->willReturn(false);
 
         $requirement1->getAttribute()->willReturn($sku);
         $requirement1->getChannel()->willReturn($ecommerce);
@@ -106,11 +120,16 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
         $requirement5->getChannel()->willReturn($print);
         $requirement5->isRequired()->willReturn(true);
 
+        $requirement6->getAttribute()->willReturn($image);
+        $requirement6->getChannel()->willReturn($ecommerce);
+        $requirement6->isRequired()->willReturn(true);
+
         $expectedRequiredValuesEcommerce = $this->forChannel($family, $ecommerce);
-        $expectedRequiredValuesEcommerce->count()->shouldReturn(3);
+        $expectedRequiredValuesEcommerce->count()->shouldReturn(4);
         $expectedRequiredValuesEcommerce->hasSame($expectedValue1)->shouldReturn(true);
         $expectedRequiredValuesEcommerce->hasSame($expectedValue2)->shouldReturn(true);
         $expectedRequiredValuesEcommerce->hasSame($expectedValue3)->shouldReturn(true);
+        $expectedRequiredValuesEcommerce->hasSame($expectedValue5)->shouldReturn(true);
 
         $expectedRequiredValuesPrint = $this->forChannel($family, $print);
         $expectedRequiredValuesPrint->count()->shouldReturn(1);

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionFactorySpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Component\Catalog\EntityWithFamily;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\EntityWithFamily\RequiredValue;
 use Pim\Component\Catalog\EntityWithFamily\RequiredValueCollectionFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeRequirementInterface;
@@ -54,31 +55,46 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
         AttributeRequirementInterface $requirement4,
         AttributeRequirementInterface $requirement5,
         AttributeRequirementInterface $requirement6,
-        ValueInterface $expectedValue1,
-        ValueInterface $expectedValue2,
-        ValueInterface $expectedValue3,
-        ValueInterface $expectedValue4,
-        ValueInterface $expectedValue5
+        RequiredValue $expectedRequiredValue1,
+        RequiredValue $expectedRequiredValue2,
+        RequiredValue $expectedRequiredValue3,
+        RequiredValue $expectedRequiredValue4,
+        RequiredValue $expectedRequiredValue5
     ) {
-        $expectedValue1->getAttribute()->willReturn($sku);
-        $expectedValue1->getScope()->willReturn(null);
-        $expectedValue1->getLocale()->willReturn(null);
+        $expectedRequiredValue1->forAttribute()->willReturn($sku);
+        $expectedRequiredValue1->forScope()->willReturn($ecommerce);
+        $expectedRequiredValue1->forLocale()->willReturn($en_US);
+        $expectedRequiredValue1->attribute()->willReturn('sku');
+        $expectedRequiredValue1->scope()->willReturn(null);
+        $expectedRequiredValue1->locale()->willReturn(null);
 
-        $expectedValue2->getAttribute()->willReturn($description);
-        $expectedValue2->getScope()->willReturn('ecommerce');
-        $expectedValue2->getLocale()->willReturn('en_US');
+        $expectedRequiredValue2->forAttribute()->willReturn($description);
+        $expectedRequiredValue2->forScope()->willReturn($ecommerce);
+        $expectedRequiredValue2->forLocale()->willReturn($en_US);
+        $expectedRequiredValue2->attribute()->willReturn('description');
+        $expectedRequiredValue2->scope()->willReturn('ecommerce');
+        $expectedRequiredValue2->locale()->willReturn('en_US');
 
-        $expectedValue3->getAttribute()->willReturn($description);
-        $expectedValue3->getScope()->willReturn('ecommerce');
-        $expectedValue3->getLocale()->willReturn('fr_FR');
+        $expectedRequiredValue3->forAttribute()->willReturn($description);
+        $expectedRequiredValue3->forScope()->willReturn($ecommerce);
+        $expectedRequiredValue3->forLocale()->willReturn($fr_FR);
+        $expectedRequiredValue3->attribute()->willReturn('description');
+        $expectedRequiredValue3->scope()->willReturn('ecommerce');
+        $expectedRequiredValue3->locale()->willReturn('fr_FR');
 
-        $expectedValue4->getAttribute()->willReturn($price);
-        $expectedValue4->getScope()->willReturn(null);
-        $expectedValue4->getLocale()->willReturn(null);
+        $expectedRequiredValue4->forAttribute()->willReturn($price);
+        $expectedRequiredValue4->forScope()->willReturn($ecommerce);
+        $expectedRequiredValue4->forLocale()->willReturn($en_US);
+        $expectedRequiredValue4->attribute()->willReturn('price');
+        $expectedRequiredValue4->scope()->willReturn(null);
+        $expectedRequiredValue4->locale()->willReturn(null);
 
-        $expectedValue5->getAttribute()->willReturn($image);
-        $expectedValue5->getScope()->willReturn(null);
-        $expectedValue5->getLocale()->willReturn('fr_FR');
+        $expectedRequiredValue5->forAttribute()->willReturn($image);
+        $expectedRequiredValue5->forScope()->willReturn($ecommerce);
+        $expectedRequiredValue5->forLocale()->willReturn($fr_FR);
+        $expectedRequiredValue5->attribute()->willReturn('image');
+        $expectedRequiredValue5->scope()->willReturn(null);
+        $expectedRequiredValue5->locale()->willReturn(null);
 
         $family->getAttributeRequirements()->willReturn([$requirement1, $requirement2, $requirement3, $requirement4, $requirement5, $requirement6]);
 
@@ -126,13 +142,13 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
 
         $expectedRequiredValuesEcommerce = $this->forChannel($family, $ecommerce);
         $expectedRequiredValuesEcommerce->count()->shouldReturn(4);
-        $expectedRequiredValuesEcommerce->hasSame($expectedValue1)->shouldReturn(true);
-        $expectedRequiredValuesEcommerce->hasSame($expectedValue2)->shouldReturn(true);
-        $expectedRequiredValuesEcommerce->hasSame($expectedValue3)->shouldReturn(true);
-        $expectedRequiredValuesEcommerce->hasSame($expectedValue5)->shouldReturn(true);
+        $expectedRequiredValuesEcommerce->hasSame($expectedRequiredValue1)->shouldReturn(true);
+        $expectedRequiredValuesEcommerce->hasSame($expectedRequiredValue2)->shouldReturn(true);
+        $expectedRequiredValuesEcommerce->hasSame($expectedRequiredValue3)->shouldReturn(true);
+        $expectedRequiredValuesEcommerce->hasSame($expectedRequiredValue5)->shouldReturn(true);
 
         $expectedRequiredValuesPrint = $this->forChannel($family, $print);
         $expectedRequiredValuesPrint->count()->shouldReturn(1);
-        $expectedRequiredValuesPrint->hasSame($expectedValue4)->shouldReturn(true);
+        $expectedRequiredValuesPrint->hasSame($expectedRequiredValue4)->shouldReturn(true);
     }
 }

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionFactorySpec.php
@@ -62,38 +62,38 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
         RequiredValue $expectedRequiredValue5
     ) {
         $expectedRequiredValue1->forAttribute()->willReturn($sku);
-        $expectedRequiredValue1->forScope()->willReturn($ecommerce);
+        $expectedRequiredValue1->forChannel()->willReturn($ecommerce);
         $expectedRequiredValue1->forLocale()->willReturn($en_US);
         $expectedRequiredValue1->attribute()->willReturn('sku');
-        $expectedRequiredValue1->scope()->willReturn(null);
+        $expectedRequiredValue1->channel()->willReturn(null);
         $expectedRequiredValue1->locale()->willReturn(null);
 
         $expectedRequiredValue2->forAttribute()->willReturn($description);
-        $expectedRequiredValue2->forScope()->willReturn($ecommerce);
+        $expectedRequiredValue2->forChannel()->willReturn($ecommerce);
         $expectedRequiredValue2->forLocale()->willReturn($en_US);
         $expectedRequiredValue2->attribute()->willReturn('description');
-        $expectedRequiredValue2->scope()->willReturn('ecommerce');
+        $expectedRequiredValue2->channel()->willReturn('ecommerce');
         $expectedRequiredValue2->locale()->willReturn('en_US');
 
         $expectedRequiredValue3->forAttribute()->willReturn($description);
-        $expectedRequiredValue3->forScope()->willReturn($ecommerce);
+        $expectedRequiredValue3->forChannel()->willReturn($ecommerce);
         $expectedRequiredValue3->forLocale()->willReturn($fr_FR);
         $expectedRequiredValue3->attribute()->willReturn('description');
-        $expectedRequiredValue3->scope()->willReturn('ecommerce');
+        $expectedRequiredValue3->channel()->willReturn('ecommerce');
         $expectedRequiredValue3->locale()->willReturn('fr_FR');
 
         $expectedRequiredValue4->forAttribute()->willReturn($price);
-        $expectedRequiredValue4->forScope()->willReturn($ecommerce);
+        $expectedRequiredValue4->forChannel()->willReturn($ecommerce);
         $expectedRequiredValue4->forLocale()->willReturn($en_US);
         $expectedRequiredValue4->attribute()->willReturn('price');
-        $expectedRequiredValue4->scope()->willReturn(null);
+        $expectedRequiredValue4->channel()->willReturn(null);
         $expectedRequiredValue4->locale()->willReturn(null);
 
         $expectedRequiredValue5->forAttribute()->willReturn($image);
-        $expectedRequiredValue5->forScope()->willReturn($ecommerce);
+        $expectedRequiredValue5->forChannel()->willReturn($ecommerce);
         $expectedRequiredValue5->forLocale()->willReturn($fr_FR);
         $expectedRequiredValue5->attribute()->willReturn('image');
-        $expectedRequiredValue5->scope()->willReturn(null);
+        $expectedRequiredValue5->channel()->willReturn(null);
         $expectedRequiredValue5->locale()->willReturn(null);
 
         $family->getAttributeRequirements()->willReturn([$requirement1, $requirement2, $requirement3, $requirement4, $requirement5, $requirement6]);

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionSpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionSpec.php
@@ -16,6 +16,7 @@ class RequiredValueCollectionSpec extends ObjectBehavior
         AttributeInterface $price,
         AttributeInterface $description,
         AttributeInterface $releaseDate,
+        AttributeInterface $image,
         ChannelInterface $ecommerce,
         ChannelInterface $print,
         LocaleInterface $en_US,
@@ -25,28 +26,50 @@ class RequiredValueCollectionSpec extends ObjectBehavior
         ValueInterface $value3,
         ValueInterface $value4,
         ValueInterface $value5,
-        ValueInterface $value6
+        ValueInterface $value6,
+        ValueInterface $value7
     ) {
         $length->isUnique()->willReturn(false);
         $price->isUnique()->willReturn(false);
         $description->isUnique()->willReturn(false);
         $releaseDate->isUnique()->willReturn(true);
+        $image->isUnique()->willReturn(false);
 
         $length->isScopable()->willReturn(false);
         $price->isScopable()->willReturn(false);
         $description->isScopable()->willReturn(true);
         $releaseDate->isScopable()->willReturn(false);
+        $image->isScopable()->willReturn(false);
 
         $length->isLocalizable()->willReturn(false);
         $price->isLocalizable()->willReturn(false);
         $description->isLocalizable()->willReturn(true);
         $releaseDate->isLocalizable()->willReturn(false);
+        $image->isLocalizable()->willReturn(false);
+
+        $length->isLocaleSpecific()->willReturn(false);
+        $price->isLocaleSpecific()->willReturn(false);
+        $description->isLocaleSpecific()->willReturn(false);
+        $releaseDate->isLocaleSpecific()->willReturn(false);
+        $image->isLocaleSpecific()->willReturn(true);
+
+        $length->hasLocaleSpecific($fr_FR)->willReturn(false);
+        $length->hasLocaleSpecific($en_US)->willReturn(false);
+        $price->hasLocaleSpecific($fr_FR)->willReturn(false);
+        $price->hasLocaleSpecific($en_US)->willReturn(false);
+        $description->hasLocaleSpecific($fr_FR)->willReturn(false);
+        $description->hasLocaleSpecific($en_US)->willReturn(false);
+        $releaseDate->hasLocaleSpecific($fr_FR)->willReturn(false);
+        $releaseDate->hasLocaleSpecific($en_US)->willReturn(false);
+        $image->hasLocaleSpecific($fr_FR)->willReturn(true);
+        $image->hasLocaleSpecific($en_US)->willReturn(false);
 
         $length->getCode()->willReturn('length');
         $price->getCode()->willReturn('price');
         $description->getCode()->willReturn('description');
         $ecommerce->getCode()->willReturn('ecommerce');
         $releaseDate->getCode()->willReturn('release_date');
+        $image->getCode()->willReturn('image');
         $print->getCode()->willReturn('print');
         $en_US->getCode()->willReturn('en_US');
         $fr_FR->getCode()->willReturn('fr_FR');
@@ -57,6 +80,7 @@ class RequiredValueCollectionSpec extends ObjectBehavior
         $value4->getAttribute()->willReturn($description);
         $value5->getAttribute()->willReturn($description);
         $value6->getAttribute()->willReturn($releaseDate);
+        $value7->getAttribute()->willReturn($image);
 
         $value1->getScope()->willReturn(null);
         $value2->getScope()->willReturn(null);
@@ -64,6 +88,7 @@ class RequiredValueCollectionSpec extends ObjectBehavior
         $value4->getScope()->willReturn('ecommerce');
         $value5->getScope()->willReturn('print');
         $value6->getScope()->willReturn(null);
+        $value7->getScope()->willReturn(null);
 
         $value1->getLocale()->willReturn(null);
         $value2->getLocale()->willReturn(null);
@@ -71,10 +96,11 @@ class RequiredValueCollectionSpec extends ObjectBehavior
         $value4->getLocale()->willReturn('fr_FR');
         $value5->getLocale()->willReturn('en_US');
         $value6->getLocale()->willReturn(null);
+        $value7->getLocale()->willReturn('fr_FR');
 
         $value6->getData()->willReturn('2016-09-12');
 
-        $this->beConstructedWith([$value1, $value2, $value3, $value4, $value5, $value6]);
+        $this->beConstructedWith([$value1, $value2, $value3, $value4, $value5, $value6, $value7]);
     }
 
     function it_is_initializable()
@@ -84,7 +110,7 @@ class RequiredValueCollectionSpec extends ObjectBehavior
 
     function it_count_values()
     {
-        $this->count()->shouldReturn(6);
+        $this->count()->shouldReturn(7);
     }
 
     function it_provides_an_iterator()
@@ -92,18 +118,35 @@ class RequiredValueCollectionSpec extends ObjectBehavior
         $this->getIterator()->shouldReturnAnInstanceOf('\ArrayIterator');
     }
 
-    function it_filters_by_channel_and_locale($value1, $value2, $value4, $value6, ChannelInterface $ecommerce, LocaleInterface $frFR)
-    {
+    function it_filters_by_channel_and_locale(
+        $value1,
+        $value2,
+        $value4,
+        $value6,
+        $value7,
+        $fr_FR,
+        $en_US,
+        ChannelInterface $ecommerce
+    ) {
         $ecommerce->getCode()->willReturn('ecommerce');
-        $frFR->getCode()->willReturn('fr_FR');
 
-        $filteredValues = $this->filterByChannelAndLocale($ecommerce, $frFR);
+        $filteredValues = $this->filterByChannelAndLocale($ecommerce, $fr_FR);
+
+        $filteredValues->shouldHaveType(RequiredValueCollection::class);
+        $filteredValues->count()->shouldReturn(5);
+        $filteredValues->hasSame($value1)->shouldReturn(true);
+        $filteredValues->hasSame($value2)->shouldReturn(true);
+        $filteredValues->hasSame($value4)->shouldReturn(true);
+        $filteredValues->hasSame($value6)->shouldReturn(true);
+        $filteredValues->hasSame($value7)->shouldReturn(true);
+
+        $filteredValues = $this->filterByChannelAndLocale($ecommerce, $en_US);
 
         $filteredValues->shouldHaveType(RequiredValueCollection::class);
         $filteredValues->count()->shouldReturn(4);
         $filteredValues->hasSame($value1)->shouldReturn(true);
         $filteredValues->hasSame($value2)->shouldReturn(true);
-        $filteredValues->hasSame($value4)->shouldReturn(true);
         $filteredValues->hasSame($value6)->shouldReturn(true);
+        $filteredValues->hasSame($value7)->shouldReturn(false);
     }
 }

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionSpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionSpec.php
@@ -82,13 +82,13 @@ class RequiredValueCollectionSpec extends ObjectBehavior
         $value6->forAttribute()->willReturn($releaseDate);
         $value7->forAttribute()->willReturn($image);
 
-        $value1->forScope()->willReturn($ecommerce);
-        $value2->forScope()->willReturn($ecommerce);
-        $value3->forScope()->willReturn($ecommerce);
-        $value4->forScope()->willReturn($ecommerce);
-        $value5->forScope()->willReturn($print);
-        $value6->forScope()->willReturn($print);
-        $value7->forScope()->willReturn($print);
+        $value1->forChannel()->willReturn($ecommerce);
+        $value2->forChannel()->willReturn($ecommerce);
+        $value3->forChannel()->willReturn($ecommerce);
+        $value4->forChannel()->willReturn($ecommerce);
+        $value5->forChannel()->willReturn($print);
+        $value6->forChannel()->willReturn($print);
+        $value7->forChannel()->willReturn($print);
 
         $value1->forLocale()->willReturn($fr_FR);
         $value2->forLocale()->willReturn($fr_FR);
@@ -106,13 +106,13 @@ class RequiredValueCollectionSpec extends ObjectBehavior
         $value6->attribute()->willReturn('release_date');
         $value7->attribute()->willReturn('image');
 
-        $value1->scope()->willReturn(null);
-        $value2->scope()->willReturn(null);
-        $value3->scope()->willReturn('ecommerce');
-        $value4->scope()->willReturn('ecommerce');
-        $value5->scope()->willReturn('print');
-        $value6->scope()->willReturn(null);
-        $value7->scope()->willReturn(null);
+        $value1->channel()->willReturn(null);
+        $value2->channel()->willReturn(null);
+        $value3->channel()->willReturn('ecommerce');
+        $value4->channel()->willReturn('ecommerce');
+        $value5->channel()->willReturn('print');
+        $value6->channel()->willReturn(null);
+        $value7->channel()->willReturn(null);
 
         $value1->locale()->willReturn(null);
         $value2->locale()->willReturn(null);

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionSpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueCollectionSpec.php
@@ -3,11 +3,11 @@
 namespace spec\Pim\Component\Catalog\EntityWithFamily;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\EntityWithFamily\RequiredValue;
 use Pim\Component\Catalog\EntityWithFamily\RequiredValueCollection;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
-use Pim\Component\Catalog\Model\ValueInterface;
 
 class RequiredValueCollectionSpec extends ObjectBehavior
 {
@@ -21,13 +21,13 @@ class RequiredValueCollectionSpec extends ObjectBehavior
         ChannelInterface $print,
         LocaleInterface $en_US,
         LocaleInterface $fr_FR,
-        ValueInterface $value1,
-        ValueInterface $value2,
-        ValueInterface $value3,
-        ValueInterface $value4,
-        ValueInterface $value5,
-        ValueInterface $value6,
-        ValueInterface $value7
+        RequiredValue $value1,
+        RequiredValue $value2,
+        RequiredValue $value3,
+        RequiredValue $value4,
+        RequiredValue $value5,
+        RequiredValue $value6,
+        RequiredValue $value7
     ) {
         $length->isUnique()->willReturn(false);
         $price->isUnique()->willReturn(false);
@@ -74,31 +74,53 @@ class RequiredValueCollectionSpec extends ObjectBehavior
         $en_US->getCode()->willReturn('en_US');
         $fr_FR->getCode()->willReturn('fr_FR');
 
-        $value1->getAttribute()->willReturn($length);
-        $value2->getAttribute()->willReturn($price);
-        $value3->getAttribute()->willReturn($description);
-        $value4->getAttribute()->willReturn($description);
-        $value5->getAttribute()->willReturn($description);
-        $value6->getAttribute()->willReturn($releaseDate);
-        $value7->getAttribute()->willReturn($image);
+        $value1->forAttribute()->willReturn($length);
+        $value2->forAttribute()->willReturn($price);
+        $value3->forAttribute()->willReturn($description);
+        $value4->forAttribute()->willReturn($description);
+        $value5->forAttribute()->willReturn($description);
+        $value6->forAttribute()->willReturn($releaseDate);
+        $value7->forAttribute()->willReturn($image);
 
-        $value1->getScope()->willReturn(null);
-        $value2->getScope()->willReturn(null);
-        $value3->getScope()->willReturn('ecommerce');
-        $value4->getScope()->willReturn('ecommerce');
-        $value5->getScope()->willReturn('print');
-        $value6->getScope()->willReturn(null);
-        $value7->getScope()->willReturn(null);
+        $value1->forScope()->willReturn($ecommerce);
+        $value2->forScope()->willReturn($ecommerce);
+        $value3->forScope()->willReturn($ecommerce);
+        $value4->forScope()->willReturn($ecommerce);
+        $value5->forScope()->willReturn($print);
+        $value6->forScope()->willReturn($print);
+        $value7->forScope()->willReturn($print);
 
-        $value1->getLocale()->willReturn(null);
-        $value2->getLocale()->willReturn(null);
-        $value3->getLocale()->willReturn('en_US');
-        $value4->getLocale()->willReturn('fr_FR');
-        $value5->getLocale()->willReturn('en_US');
-        $value6->getLocale()->willReturn(null);
-        $value7->getLocale()->willReturn('fr_FR');
+        $value1->forLocale()->willReturn($fr_FR);
+        $value2->forLocale()->willReturn($fr_FR);
+        $value4->forLocale()->willReturn($fr_FR);
+        $value3->forLocale()->willReturn($en_US);
+        $value5->forLocale()->willReturn($en_US);
+        $value6->forLocale()->willReturn($en_US);
+        $value7->forLocale()->willReturn($en_US);
 
-        $value6->getData()->willReturn('2016-09-12');
+        $value1->attribute()->willReturn('length');
+        $value2->attribute()->willReturn('price');
+        $value3->attribute()->willReturn('description');
+        $value4->attribute()->willReturn('description');
+        $value5->attribute()->willReturn('description');
+        $value6->attribute()->willReturn('release_date');
+        $value7->attribute()->willReturn('image');
+
+        $value1->scope()->willReturn(null);
+        $value2->scope()->willReturn(null);
+        $value3->scope()->willReturn('ecommerce');
+        $value4->scope()->willReturn('ecommerce');
+        $value5->scope()->willReturn('print');
+        $value6->scope()->willReturn(null);
+        $value7->scope()->willReturn(null);
+
+        $value1->locale()->willReturn(null);
+        $value2->locale()->willReturn(null);
+        $value3->locale()->willReturn('en_US');
+        $value4->locale()->willReturn('fr_FR');
+        $value5->locale()->willReturn('en_US');
+        $value6->locale()->willReturn(null);
+        $value7->locale()->willReturn('fr_FR');
 
         $this->beConstructedWith([$value1, $value2, $value3, $value4, $value5, $value6, $value7]);
     }
@@ -133,12 +155,11 @@ class RequiredValueCollectionSpec extends ObjectBehavior
         $filteredValues = $this->filterByChannelAndLocale($ecommerce, $fr_FR);
 
         $filteredValues->shouldHaveType(RequiredValueCollection::class);
-        $filteredValues->count()->shouldReturn(5);
+        $filteredValues->count()->shouldReturn(4);
         $filteredValues->hasSame($value1)->shouldReturn(true);
         $filteredValues->hasSame($value2)->shouldReturn(true);
         $filteredValues->hasSame($value4)->shouldReturn(true);
         $filteredValues->hasSame($value6)->shouldReturn(true);
-        $filteredValues->hasSame($value7)->shouldReturn(true);
 
         $filteredValues = $this->filterByChannelAndLocale($ecommerce, $en_US);
 

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueSpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueSpec.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\EntityWithFamily;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\EntityWithFamily\RequiredValue;
+use Pim\Component\Catalog\Model\AttributeInterface;
+
+class RequiredValueSpec extends ObjectBehavior
+{
+    function it_creates_a_non_scopable_non_localizable_non_locale_specific_required_value(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attribute_code');
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(false);
+
+        $this->shouldNotThrow(\Exception::class)
+            ->during('__construct', [$attribute, null, null]);
+    }
+
+    function it_creates_a_scopable_non_localizable_non_locale_specific_required_value(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attribute_code');
+        $attribute->isScopable()->willReturn(true);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(false);
+
+        $this->shouldNotThrow(\Exception::class)
+            ->during('__construct', [$attribute, 'channel', null]);
+    }
+
+    function it_creates_a_localizable_non_scopable_non_locale_specific_required_value(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attribute_code');
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(true);
+        $attribute->isLocaleSpecific()->willReturn(false);
+
+        $this->shouldNotThrow(\Exception::class)
+            ->during('__construct', [$attribute, null, 'fr_FR']);
+    }
+
+    function it_creates_a_locale_specific_non_scopable_non_localizable_required_value(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attribute_code');
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(true);
+
+        $this->shouldNotThrow(\Exception::class)
+            ->during('__construct', [$attribute, null, 'fr_FR']);
+    }
+
+    function it_does_not_create_a_non_scopable_required_value_with_a_channel(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attribute_code');
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(false);
+
+        $this->shouldThrow(new \LogicException('The product value cannot be scoped, see attribute \'attribute_code\' configuration'))
+            ->during('__construct', [$attribute, 'channel', null]);
+    }
+
+    function it_does_not_create_a_required_value_with_a_locale_if_the_attribute_is_not_localizable_nor_locale_specific(
+        AttributeInterface $attribute
+    ) {
+        $attribute->getCode()->willReturn('attribute_code');
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(false);
+
+        $this->shouldThrow(new \LogicException(
+            "The product value cannot be localized, see attribute 'attribute_code' configuration"
+        ))->during('__construct', [$attribute, null, 'fr_FR']);
+    }
+
+    function it_does_not_set_the_locale_if_the_attribute_is_not_locale_specific(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attribute_code');
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(false);
+
+        $this->shouldThrow(new \LogicException(
+            "The product value cannot be localized, see attribute 'attribute_code' configuration"
+        ))->during('__construct', [$attribute, null, 'fr_FR']);
+    }
+
+    function let(AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attribute_required');
+        $attribute->isScopable()->willReturn(true);
+        $attribute->isLocalizable()->willReturn(true);
+        $attribute->isLocaleSpecific()->willReturn(false);
+        $this->beConstructedWith($attribute, 'ecommerce', 'fr_FR');
+    }
+
+    function it_returns_a_null_data()
+    {
+        $this->getData()->shouldReturn(null);
+    }
+
+    function it_returns_the_attribute($attribute)
+    {
+        $this->getAttribute()->shouldReturn($attribute);
+    }
+
+    function it_returns_the_scope()
+    {
+        $this->getScope()->shouldReturn('ecommerce');
+    }
+
+    function it_returns_the_locale()
+    {
+        $this->getLocale()->shouldReturn('fr_FR');
+    }
+
+    function it_is_comparable_to_another_required_value(RequiredValue $sameValue, RequiredValue $anotherValue)
+    {
+        $sameValue->getData()->willReturn(null);
+        $sameValue->getScope()->willReturn('ecommerce');
+        $sameValue->getLocale()->willReturn('fr_FR');
+
+        $anotherValue->getData()->willReturn('value');
+        $anotherValue->getScope()->willReturn('print');
+        $anotherValue->getLocale()->willReturn('en_US');
+
+        $this->isEqual($sameValue)->shouldReturn(true);
+        $this->isEqual($anotherValue)->shouldReturn(false);
+    }
+
+}

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueSpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueSpec.php
@@ -3,132 +3,94 @@
 namespace spec\Pim\Component\Catalog\EntityWithFamily;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\EntityWithFamily\RequiredValue;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
 
 class RequiredValueSpec extends ObjectBehavior
 {
-    function it_creates_a_non_scopable_non_localizable_non_locale_specific_required_value(AttributeInterface $attribute)
-    {
-        $attribute->getCode()->willReturn('attribute_code');
-        $attribute->isScopable()->willReturn(false);
-        $attribute->isLocalizable()->willReturn(false);
-        $attribute->isLocaleSpecific()->willReturn(false);
-
-        $this->shouldNotThrow(\Exception::class)
-            ->during('__construct', [$attribute, null, null]);
-    }
-
-    function it_creates_a_scopable_non_localizable_non_locale_specific_required_value(AttributeInterface $attribute)
-    {
-        $attribute->getCode()->willReturn('attribute_code');
-        $attribute->isScopable()->willReturn(true);
-        $attribute->isLocalizable()->willReturn(false);
-        $attribute->isLocaleSpecific()->willReturn(false);
-
-        $this->shouldNotThrow(\Exception::class)
-            ->during('__construct', [$attribute, 'channel', null]);
-    }
-
-    function it_creates_a_localizable_non_scopable_non_locale_specific_required_value(AttributeInterface $attribute)
-    {
-        $attribute->getCode()->willReturn('attribute_code');
-        $attribute->isScopable()->willReturn(false);
-        $attribute->isLocalizable()->willReturn(true);
-        $attribute->isLocaleSpecific()->willReturn(false);
-
-        $this->shouldNotThrow(\Exception::class)
-            ->during('__construct', [$attribute, null, 'fr_FR']);
-    }
-
-    function it_creates_a_locale_specific_non_scopable_non_localizable_required_value(AttributeInterface $attribute)
-    {
-        $attribute->getCode()->willReturn('attribute_code');
-        $attribute->isScopable()->willReturn(false);
-        $attribute->isLocalizable()->willReturn(false);
-        $attribute->isLocaleSpecific()->willReturn(true);
-
-        $this->shouldNotThrow(\Exception::class)
-            ->during('__construct', [$attribute, null, 'fr_FR']);
-    }
-
-    function it_does_not_create_a_non_scopable_required_value_with_a_channel(AttributeInterface $attribute)
-    {
-        $attribute->getCode()->willReturn('attribute_code');
-        $attribute->isScopable()->willReturn(false);
-        $attribute->isLocalizable()->willReturn(false);
-        $attribute->isLocaleSpecific()->willReturn(false);
-
-        $this->shouldThrow(new \LogicException('The product value cannot be scoped, see attribute \'attribute_code\' configuration'))
-            ->during('__construct', [$attribute, 'channel', null]);
-    }
-
-    function it_does_not_create_a_required_value_with_a_locale_if_the_attribute_is_not_localizable_nor_locale_specific(
-        AttributeInterface $attribute
+    function let(
+        AttributeInterface $attribute,
+        ChannelInterface $channel,
+        LocaleInterface $locale
     ) {
         $attribute->getCode()->willReturn('attribute_code');
-        $attribute->isScopable()->willReturn(false);
-        $attribute->isLocalizable()->willReturn(false);
-        $attribute->isLocaleSpecific()->willReturn(false);
-
-        $this->shouldThrow(new \LogicException(
-            "The product value cannot be localized, see attribute 'attribute_code' configuration"
-        ))->during('__construct', [$attribute, null, 'fr_FR']);
-    }
-
-    function it_does_not_set_the_locale_if_the_attribute_is_not_locale_specific(AttributeInterface $attribute)
-    {
-        $attribute->getCode()->willReturn('attribute_code');
-        $attribute->isScopable()->willReturn(false);
-        $attribute->isLocalizable()->willReturn(false);
-        $attribute->isLocaleSpecific()->willReturn(false);
-
-        $this->shouldThrow(new \LogicException(
-            "The product value cannot be localized, see attribute 'attribute_code' configuration"
-        ))->during('__construct', [$attribute, null, 'fr_FR']);
-    }
-
-    function let(AttributeInterface $attribute)
-    {
-        $attribute->getCode()->willReturn('attribute_required');
-        $attribute->isScopable()->willReturn(true);
-        $attribute->isLocalizable()->willReturn(true);
-        $attribute->isLocaleSpecific()->willReturn(false);
-        $this->beConstructedWith($attribute, 'ecommerce', 'fr_FR');
-    }
-
-    function it_returns_a_null_data()
-    {
-        $this->getData()->shouldReturn(null);
+        $channel->getCode()->willReturn('channel');
+        $locale->getCode()->willReturn('locale');
+        $this->beConstructedWith($attribute, $channel, $locale);
     }
 
     function it_returns_the_attribute($attribute)
     {
-        $this->getAttribute()->shouldReturn($attribute);
+        $this->forAttribute()->shouldReturn($attribute);
     }
 
-    function it_returns_the_scope()
+    function it_returns_the_scope($channel)
     {
-        $this->getScope()->shouldReturn('ecommerce');
+        $this->forScope()->shouldReturn($channel);
     }
 
-    function it_returns_the_locale()
+    function it_returns_the_locale($locale)
     {
-        $this->getLocale()->shouldReturn('fr_FR');
+        $this->forLocale()->shouldReturn($locale);
     }
 
-    function it_is_comparable_to_another_required_value(RequiredValue $sameValue, RequiredValue $anotherValue)
-    {
-        $sameValue->getData()->willReturn(null);
-        $sameValue->getScope()->willReturn('ecommerce');
-        $sameValue->getLocale()->willReturn('fr_FR');
+    function it_helps_to_retrieve_the_value_when_the_attribute_is_non_scopable_non_localizable_non_locale_specific(
+        $attribute,
+        $locale
+    ) {
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(false);
 
-        $anotherValue->getData()->willReturn('value');
-        $anotherValue->getScope()->willReturn('print');
-        $anotherValue->getLocale()->willReturn('en_US');
-
-        $this->isEqual($sameValue)->shouldReturn(true);
-        $this->isEqual($anotherValue)->shouldReturn(false);
+        $this->attribute()->shouldReturn('attribute_code');
+        $this->scope()->shouldReturn(null);
+        $this->locale($locale)->shouldReturn(null);
     }
 
+    function it_helps_to_retrive_the_when_the_attribute_is_scopable_non_localizable_non_locale_specific(
+        $attribute,
+        $locale
+    ) {
+        $attribute->getCode()->willReturn('attribute_code');
+        $attribute->isScopable()->willReturn(true);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(false);
+
+        $this->attribute()->shouldReturn('attribute_code');
+        $this->scope()->shouldReturn('channel');
+        $this->locale($locale)->shouldReturn(null);
+    }
+
+    function it_helps_to_retrive_the_when_the_attribute_is_localizable_non_scopable_non_locale_specific(
+        $attribute,
+        $locale
+    ) {
+        $attribute->getCode()->willReturn('attribute_code');
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(true);
+        $attribute->isLocaleSpecific()->willReturn(false);
+
+        $this->attribute()->shouldReturn('attribute_code');
+        $this->scope()->shouldReturn(null);
+        $this->locale($locale)->shouldReturn('locale');
+    }
+
+    function it_helps_to_retrive_the_when_the_locale_specific_non_scopable_non_localizable(
+        $attribute,
+        $locale,
+        LocaleInterface $anotherLocale
+    ) {
+        $attribute->getCode()->willReturn('attribute_code');
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->isLocaleSpecific()->willReturn(true);
+        $attribute->hasLocaleSpecific($locale)->willReturn(true);
+        $attribute->hasLocaleSpecific($anotherLocale)->willReturn(false);
+
+        $this->attribute()->shouldReturn('attribute_code');
+        $this->scope()->shouldReturn(null);
+        $this->locale($locale)->shouldReturn(null);
+        $this->locale($anotherLocale)->shouldReturn(null);
+    }
 }

--- a/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueSpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamily/RequiredValueSpec.php
@@ -27,7 +27,7 @@ class RequiredValueSpec extends ObjectBehavior
 
     function it_returns_the_scope($channel)
     {
-        $this->forScope()->shouldReturn($channel);
+        $this->forChannel()->shouldReturn($channel);
     }
 
     function it_returns_the_locale($locale)
@@ -44,7 +44,7 @@ class RequiredValueSpec extends ObjectBehavior
         $attribute->isLocaleSpecific()->willReturn(false);
 
         $this->attribute()->shouldReturn('attribute_code');
-        $this->scope()->shouldReturn(null);
+        $this->channel()->shouldReturn(null);
         $this->locale($locale)->shouldReturn(null);
     }
 
@@ -58,7 +58,7 @@ class RequiredValueSpec extends ObjectBehavior
         $attribute->isLocaleSpecific()->willReturn(false);
 
         $this->attribute()->shouldReturn('attribute_code');
-        $this->scope()->shouldReturn('channel');
+        $this->channel()->shouldReturn('channel');
         $this->locale($locale)->shouldReturn(null);
     }
 
@@ -72,7 +72,7 @@ class RequiredValueSpec extends ObjectBehavior
         $attribute->isLocaleSpecific()->willReturn(false);
 
         $this->attribute()->shouldReturn('attribute_code');
-        $this->scope()->shouldReturn(null);
+        $this->channel()->shouldReturn(null);
         $this->locale($locale)->shouldReturn('locale');
     }
 
@@ -89,7 +89,7 @@ class RequiredValueSpec extends ObjectBehavior
         $attribute->hasLocaleSpecific($anotherLocale)->willReturn(false);
 
         $this->attribute()->shouldReturn('attribute_code');
-        $this->scope()->shouldReturn(null);
+        $this->channel()->shouldReturn(null);
         $this->locale($locale)->shouldReturn(null);
         $this->locale($anotherLocale)->shouldReturn(null);
     }

--- a/src/Pim/Component/Catalog/spec/Validator/UniqueAxesCombinationSetSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/UniqueAxesCombinationSetSpec.php
@@ -38,6 +38,7 @@ class UniqueAxesCombinationSetSpec extends ObjectBehavior
         $anotherProductModel->setParent($rootProductModel);
 
         $identifierAttribute = new Attribute();
+        $identifierAttribute->setCode('sku');
         $identifierA = new ScalarValue($identifierAttribute, null, null, 'product_a');
 
         $variantProductA = new Product();
@@ -98,6 +99,7 @@ class UniqueAxesCombinationSetSpec extends ObjectBehavior
         $productModel->setFamilyVariant($familyVariant);
 
         $identifierAttribute = new Attribute();
+        $identifierAttribute->setCode('sku');
         $identifier = new ScalarValue($identifierAttribute, null, null, 'valid_variant_product');
 
         $variantProduct = new Product();

--- a/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
+++ b/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
@@ -44,7 +44,9 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
     function it_finds_a_product_by_identifier()
     {
         $product = new Product();
-        $product->setIdentifier(new ScalarValue(new Attribute(), '', '', 'a-product'));
+        $attribute = new Attribute();
+        $attribute->setCode('my_attribute');
+        $product->setIdentifier(new ScalarValue($attribute, '', '', 'a-product'));
         $this->beConstructedWith([$product->getIdentifier() => $product]);
 
         $this->findOneByIdentifier('a-product')->shouldReturn($product);
@@ -58,7 +60,9 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
     function it_saves_a_product()
     {
         $product = new Product();
-        $product->setIdentifier(new ScalarValue(new Attribute(), '', '', 'a-product'));
+        $attribute = new Attribute();
+        $attribute->setCode('my_attribute');
+        $product->setIdentifier(new ScalarValue($attribute, '', '', 'a-product'));
 
         $this->save($product)->shouldReturn(null);
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
**Context:**

The calculation of the completeness of products is a two step process.

It basically starts in this class: `Pim\Component\Catalog\Completeness\CompletenessCalculator::Calculate`

**1. Build the list of required values based on the attribute requirements.**

Based on the attribute requirements of the family, we generate a
`Pim\Component\Catalog\EntityWithFamily\RequiredValueCollection`, which holds a list of `\Pim\Component\Catalog\EntityWithFamily\RequiredValue`.

Basically, this object holds a reference for each required value for:
- An attribute
- A channel
- A locale

Important note:

Conviniently, this RequiredValue extends `Pim\Component\Catalog\Model\ValueInterface` which
gives us the opportunity to get the value of a product based on this
object with
```
$productValueCollection->getSame($requiredValue); // the actual value
```

**2. Use the required values and the values of the product to generate**
completeness.

In
`Pim\Component\Catalog\EntityWithFamily\IncompleteValueCollectionFactory`, we use
this list of RequiredValues to find the value for a given product using
the *ValueCollection::getSame method* and test if it's complete or not.

And that's it!

**Problem: Let there be non-localizable locale specific attributes**

The coupling between a required value (the information it holds) and the
fact that we can directly use this object to retrieve the data from the
product value collection becomes an issue when the locale specific values comes
in.

Let's say we have:
- An attribute "description" which is localeSpecific on
'en_US' and 'fr_FR'.
- A family "camcorders" with two attributes: "sku", "description"
required on all channels
- A product "webcam" with the following values:
```
| sku | description |
| 001 | ""          |
```

Now, when we generate the required values in the first step for this family, we get
something like this:
```
[
  'requiredValue1' => [
      'attribute' => 'description',
      'locale' => 'fr_FR',
      'scope' => null
  ],
  'requiredValue2' => [
      'attribute' => 'description',
      'locale' => 'en_US',
      'scope' => null
  ]
]
```

In the second step, we try to check if the values of the products are
complete or not, we try to get the value using:

```
$myWebcapProduct->getSame($requiredValue1); // => returns null
$myWebcapProduct->getSame($requiredValue2); // => returns null
```

indeed, the value collection cannot return it's data for the attribute
'description' on the locale 'fr_FR' or 'en_US' because it is not localizable!

Internally, in the value collection of the product they are indexed
using the keys:
'description-<all_channels>-<all_locales>' and not 'description-<all_channels>-fr_FR' nor
'description-<all_channels>-en_US'.

That's why we need to decouple the required value structure and the way
the value of the products are retrieved.

**Solution:**

The solution I suggest involves 2 things:
- Redesign of the RequiredValue object which should contain the information about the attribute requirements (attribute, channel, locale) as well as the information needed to retrieve the value from the product value collection (depending on the products).
- Take into account locale specific attributes when building the incompleteRequiredValueCollection.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
