### PR TITLE
Spring cleaning - Burn "I should see the flash message" from all behat steps

### DIFF
--- a/features/Context/AssertionContext.php
+++ b/features/Context/AssertionContext.php
@@ -248,27 +248,11 @@ class AssertionContext extends PimContext
     }
 
     /**
-     * @deprecated This function was disabled because it generates too many failing tests. Warning, some tests are
-     * always using it, and it checks nothing at all.
-     *
-     * @param $text
-     *
      * @Then /^I should see the flash message "(.*)"$/
      */
     public function iShouldSeeTheFlashMessage($text)
     {
-        return;
-
-        $this->spin(function () use ($text) {
-            $flashes = $this->getCurrentPage()->findAll('css', '.flash-messages-holder > div');
-            foreach ($flashes as $flash) {
-                if (false !== strpos($flash->getText(), $text)) {
-                    return true;
-                }
-            }
-
-            return null;
-        }, sprintf('Can not find flash message with text "%s"', $text));
+        Throw new \Exception('Do not use this legacy function.');
     }
 
     /**

--- a/features/association-type/display_association_type_history.feature
+++ b/features/association-type/display_association_type_history.feature
@@ -29,7 +29,7 @@ Feature: Display the association type history
     And I fill in the following information:
       | English (United States) | <script>document.getElementById('top-page').classList.add('foo');</script> |
     And I save the association type
-    Then I should see the flash message "Association type successfully updated."
+    Then I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then I should not see a "#top-page.foo" element
     And I should see history:

--- a/features/attribute-group/delete_attribute_group.feature
+++ b/features/attribute-group/delete_attribute_group.feature
@@ -18,17 +18,14 @@ Feature: Attribute group creation
   Scenario: Successfully delete an attribute group
     Given I am on the "sizes" attribute group page
     When I press the secondary action "Delete"
-    And I confirm the deletion
-    Then I should see the flash message "Attribute group successfully removed"
+    Then I confirm the deletion
 
   Scenario: Fail to delete an attribute group that contains attributes
     Given I am on the "colors" attribute group page
     When I press the secondary action "Delete"
-    And I confirm the deletion
-    Then I should see the flash message "Attribute group containing attributes cannot be removed. Please remove its attributes prior to delete it."
+    Then I confirm the deletion
 
   Scenario: Fail to delete the attribute "other"
     Given I am on the "other" attribute group page
     When I press the secondary action "Delete"
-    And I confirm the deletion
-    Then I should see the flash message "Attribute group \"other\" cannot be removed."
+    Then I confirm the deletion

--- a/features/attribute-group/display_attribute_group_history.feature
+++ b/features/attribute-group/display_attribute_group_history.feature
@@ -15,7 +15,7 @@ Feature: Display the attribute group history
     Given I am on the attribute group creation page
     And I change the Code to "Technical"
     And I save the group
-    And I should see the flash message "Attribute group successfully created"
+    Then I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then there should be 1 update
     And I should see history:
@@ -25,7 +25,7 @@ Feature: Display the attribute group history
     And I fill in the following information:
       | English (United States) | My technical group |
     And I save the group
-    And I should see the flash message "Attribute group successfully updated"
+    Then I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then there should be 2 updates
     And I should see history:
@@ -36,7 +36,7 @@ Feature: Display the attribute group history
     When I visit the "Attributes" tab
     And I add available attributes SKU, Description
     And I save the group
-    And I should see the flash message "Attribute group successfully updated"
+    Then I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then there should be 3 updates
     And I should see history:
@@ -49,7 +49,7 @@ Feature: Display the attribute group history
     And I remove the "Description" attribute
     And I confirm the deletion
     And I save the group
-    And I should see the flash message "Attribute group successfully updated"
+    Then I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then there should be 4 updates
     And I should see history:
@@ -65,7 +65,7 @@ Feature: Display the attribute group history
     And I fill in the following information:
       | English (United States) | <script>document.getElementById('top-page').classList.add('foo');</script> |
     And I save the attribute group
-    Then I should see the flash message "Attribute group successfully updated."
+    Then I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then I should not see a "#top-page.foo" element
     And I should see history:

--- a/features/attribute/create_text_attribute.feature
+++ b/features/attribute/create_text_attribute.feature
@@ -15,7 +15,7 @@ Feature: Create an attribute
       | Code            | short_description |
       | Attribute group | Other             |
     And I save the attribute
-    Then I should see the flash message "Attribute successfully created"
+    Then I should not see the text "There are unsaved changes."
 
   Scenario: Fail to create a text attribute with an invalid code
     Given I change the Code to an invalid value

--- a/features/attribute/display_attribute_history.feature
+++ b/features/attribute/display_attribute_history.feature
@@ -45,7 +45,7 @@ Feature: Display the attribute history
     And I fill in the following information:
       | English (United States) | <script>document.getElementById('top-page').classList.add('foo');</script> |
     And I save the attribute
-    Then I should see the flash message "Attribute successfully updated."
+    Then I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then I should not see a "#top-page.foo" element
     And I should see history:

--- a/features/attribute/option/create_attribute_options.feature
+++ b/features/attribute/option/create_attribute_options.feature
@@ -25,7 +25,7 @@ Feature: Create attribute options
       | green |
     Then I should see the text "green"
     When I save the attribute
-    Then I should see the flash message "Attribute successfully updated"
+    Then I should not see the text "There are unsaved changes."
     And I should see the text "green"
 
   @jira https://akeneo.atlassian.net/browse/PIM-6033

--- a/features/attribute/option/delete_attribute_options.feature
+++ b/features/attribute/option/delete_attribute_options.feature
@@ -14,7 +14,7 @@ Feature: Delete attribute options
       | Attribute group | Other |
     And I save the attribute
     When I visit the "Options" tab
-    Then I should see the flash message "Attribute successfully created"
+    Then I should not see the text "There are unsaved changes."
     And I check the "Sort automatically options by alphabetical order" switch
 
   @jira https://akeneo.atlassian.net/browse/PIM-2166

--- a/features/attribute/option/edit_attribute_options_02.feature
+++ b/features/attribute/option/edit_attribute_options_02.feature
@@ -14,7 +14,7 @@ Feature: Edit attribute options
       | Attribute group | Other |
     And I save the attribute
     And I visit the "Options" tab
-    Then I should see the flash message "Attribute successfully created"
+    Then I should not see the text "There are unsaved changes."
 
   Scenario: Successfully cancel while editing some attribute options
     Given I check the "Sort automatically options by alphabetical order" switch

--- a/features/category/display_category_history.feature
+++ b/features/category/display_category_history.feature
@@ -41,7 +41,7 @@ Feature: Display the category history
     And I fill in the following information:
       | English (United States) | <script>document.getElementById('top-page').classList.add('foo');</script> |
     And I save the category
-    Then I should see the flash message "Category successfully updated."
+    Then I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then I should not see a "#top-page.foo" element
     And I should see history:

--- a/features/category/edit_a_category.feature
+++ b/features/category/edit_a_category.feature
@@ -15,7 +15,7 @@ Feature: Edit a category
     When I fill in the following information:
       | English (United States) | My sandals |
     And I save the category
-    Then I should see the flash message "Category successfully updated"
+    Then I should not see the text "There are unsaved changes."
     And I should be on the category "sandals" edit page
     And I should see the text "My sandals"
 

--- a/features/category/remove_a_category.feature
+++ b/features/category/remove_a_category.feature
@@ -17,7 +17,6 @@ Feature: Remove a category
     When I press the secondary action "Delete"
     And I confirm the deletion
     Then I should be on the category "summer_collection" edit page
-    And I should see the flash message "Category successfully removed"
     And I should not see the "Sandals" category under the "summer_collection" category
 
   @skip
@@ -26,7 +25,6 @@ Feature: Remove a category
     When I press the secondary action "Delete"
     And I confirm the deletion
     Then I should be on the category "2014_collection" edit page
-    And I should see the flash message "Category successfully removed"
     And I should not see "Winter collection"
 
   @unstable
@@ -35,7 +33,6 @@ Feature: Remove a category
     When I press the secondary action "Delete"
     And I confirm the deletion
     Then I should be on the category "winter_collection" edit page
-    And I should see the flash message "Category successfully removed"
     When I expand the "winter_collection" category
     Then I should not see "Winter boots"
     When I edit the "caterpillar_2" product
@@ -51,9 +48,8 @@ Feature: Remove a category
     When I press the secondary action "Delete"
     And I confirm the deletion
     Then I should be on the category "2014_collection" edit page
-    And I should see the flash message "Category successfully removed"
-    Then I should not see "Winter collection"
-    And I should not see "Winter boots"
+    And I should not see "Winter collection"
+    Then I should not see "Winter boots"
 
   Scenario: Remove a category tree
     Given the following category:
@@ -64,7 +60,6 @@ Feature: Remove a category
     When I press the secondary action "Delete"
     And I confirm the deletion
     Then I should be redirected on the category tree creation page
-    And I should see the flash message "Tree successfully removed"
 
   Scenario: Cancel the removal of a category
     Given I am on the "sandals" category page

--- a/features/channel/delete_channel.feature
+++ b/features/channel/delete_channel.feature
@@ -13,14 +13,12 @@ Feature: Delete a channel
     And I should see channels Tablet and Mobile
     When I click on the "Delete" action of the row which contains "Tablet"
     And I confirm the deletion
-    Then I should see the flash message "Channel successfully removed"
-    And the grid should contain 1 element
+    Then the grid should contain 1 element
     And I should not see channel Tablet
 
   Scenario: Successfully delete a channel
     Given I am on the "mobile" channel page
     When I press the secondary action "Delete"
     And I confirm the deletion
-    Then I should see the flash message "Channel successfully removed"
-    And the grid should contain 1 element
+    Then the grid should contain 1 element
     And I should not see channel Mobile

--- a/features/channel/display_channel_history.feature
+++ b/features/channel/display_channel_history.feature
@@ -34,7 +34,7 @@ Feature: Display the channel history
     And I fill in the following information:
       | English (United States) | <script>document.getElementById('top-page').classList.add('foo');</script> |
     And I save the channel
-    Then I should see the flash message "Channel successfully updated."
+    Then I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then I should not see a "#top-page.foo" element
     And I should see history:

--- a/features/datagrid/datagrid_views.feature
+++ b/features/datagrid/datagrid_views.feature
@@ -23,7 +23,6 @@ Feature: Datagrid views
     And I create the view:
       | new-view-label | Sneakers only |
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully created"
     And I should see the text "Sneakers only"
     And I should see products purple-sneakers and black-sneakers
     But I should not see product black-boots
@@ -43,7 +42,6 @@ Feature: Datagrid views
     And I create the view:
       | new-view-label | Some shoes |
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully created"
     And I should see the text "Some shoes"
     And I should see product black-boots
     But I should not see products purple-sneakers and black-sneakers
@@ -63,7 +61,6 @@ Feature: Datagrid views
     And I create the view:
       | new-view-label | Some shoes |
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully created"
     And I should see the text "Some shoes"
     When I display the columns SKU, Name, Family and Manufacturer
     Then I should see the text "Nike"
@@ -80,14 +77,12 @@ Feature: Datagrid views
     And I create the view:
       | new-view-label | Boots only |
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully created"
     And I should see the text "Boots only"
     And I should see product black-boots
     But I should not see products purple-sneakers and black-sneakers
     When I delete the view
     And I confirm the deletion
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully removed"
     And I should see the text "Default view"
     But I should not see "Boots only"
     And I should see products black-boots, purple-sneakers and black-sneakers
@@ -98,7 +93,6 @@ Feature: Datagrid views
     And I create the view:
       | new-view-label | Boots only |
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully created"
     And I should see the text "Boots only"
     And I should see product black-boots
     But I should not see products purple-sneakers and black-sneakers
@@ -117,7 +111,6 @@ Feature: Datagrid views
     And I create the view:
       | new-view-label | Sneakers only |
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully created"
     When I am on the User profile show page
     And I press the "Edit" button
     Then I should see the text "Edit user - Mary Smith"
@@ -156,7 +149,6 @@ Feature: Datagrid views
     And I create the view:
       | new-view-label | Sneakers only |
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully created"
     When I am on the User profile show page
     And I press the "Edit" button
     Then I should see the text "Edit user - Mary Smith"
@@ -171,7 +163,6 @@ Feature: Datagrid views
     When I delete the view
     And I confirm the deletion
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully removed"
     And I should see the text "Default view"
     And I should not see the text "Sneakers only"
 
@@ -182,7 +173,6 @@ Feature: Datagrid views
     When I create the view:
       | new-view-label | With name |
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully created"
     When I am on the my account page
     And I press the "Edit" button
     And I visit the "Additional" tab
@@ -216,7 +206,6 @@ Feature: Datagrid views
     And I create the view:
       | new-view-label | Mobile only |
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully created"
     And I should see the text "Mobile only"
     And I should see the text "Mobile"
 
@@ -226,7 +215,6 @@ Feature: Datagrid views
     And I create the view:
       | new-view-label | Boots only |
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully created"
     When I logout
     And I am logged in as "Julia"
     And I am on the my account page
@@ -245,7 +233,6 @@ Feature: Datagrid views
     And I delete the view
     And I confirm the deletion
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully removed"
     And I should see the text "Default view"
     When I logout
     And I am logged in as "Julia"
@@ -264,7 +251,6 @@ Feature: Datagrid views
     And I create the view:
       | new-view-label | Empty family |
     Then I should be on the products page
-    And I should see the flash message "Datagrid view successfully created"
     And I refresh current page
     And I apply the "Empty family" view
     Then I should see the text "Family is empty"

--- a/features/export/delete_an_export.feature
+++ b/features/export/delete_an_export.feature
@@ -14,8 +14,7 @@ Feature: Delete export
   Scenario: Successfully delete an export job from the export grid
     Given I delete the "CSV footwear product export" job
     When I confirm the deletion
-    Then I should see the flash message "Export profile successfully removed"
-    And the grid should contain 21 elements
+    Then the grid should contain 21 elements
     And I should not see export profile "CSV footwear product export"
 
   Scenario: Successfully cancel the deletion of an export job
@@ -28,6 +27,5 @@ Feature: Delete export
     Given I am on the "csv_footwear_product_export" import job edit page
     When I press the secondary action "Delete"
     And I confirm the deletion
-    Then I should see the flash message "Job instance successfully removed"
-    And the grid should contain 21 elements
+    Then the grid should contain 21 elements
     And I should not see export profile "CSV footwear product export"

--- a/features/family/define_the_attribute_requirement.feature
+++ b/features/family/define_the_attribute_requirement.feature
@@ -20,7 +20,6 @@ Feature: Define the attribute requirement
     Given I visit the "Attributes" tab
     And I switch the attribute "rating" requirement in channel "mobile"
     And I save the family
-    And I should see the flash message "Family successfully updated"
     And I should not see the text "There are unsaved changes."
     And I visit the "Attributes" tab
     Then attribute "rating" should be required in channels mobile and tablet
@@ -29,7 +28,6 @@ Feature: Define the attribute requirement
     Given I visit the "Attributes" tab
     And I switch the attribute "description" requirement in channel "tablet"
     And I save the family
-    And I should see the flash message "Family successfully updated"
     And I should not see the text "There are unsaved changes."
     And I visit the "Attributes" tab
     Then attribute "description" should not be required in channels mobile and tablet
@@ -49,7 +47,6 @@ Feature: Define the attribute requirement
     And I visit the "Attributes" tab
     And I switch the attribute "rating" requirement in channel "mobile"
     And I save the family
-    And I should see the flash message "Family successfully updated"
     And I should not see the text "There are unsaved changes."
     When I remove the "rating" attribute
     And I save the family

--- a/features/family/display_family_history.feature
+++ b/features/family/display_family_history.feature
@@ -20,7 +20,6 @@ Feature: Display the family history
     And I fill in the following information in the popin:
       | Code | Flyer |
     And I press the "Save" button
-    And I should see the flash message "Family successfully created"
     And I should not see the text "There are unsaved changes."
     And I am on the "Flyer" family page
     When I visit the "History" tab
@@ -32,7 +31,6 @@ Feature: Display the family history
     And I fill in the following information:
       | English (United States) | Fly |
     And I press the "Save" button
-    And I should see the flash message "Family successfully updated"
     And I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then there should be 2 updates

--- a/features/family/remove_attribute_from_a_family.feature
+++ b/features/family/remove_attribute_from_a_family.feature
@@ -14,8 +14,7 @@ Feature: Remove attribute from a family
     Then I should see attributes "EAN" in group "ERP"
     When I remove the "material" attribute
     And I save the family
-    And I should not see the text "There are unsaved changes."
-    Then I should see the flash message "Attribute successfully removed from the family"
+    Then I should not see the text "There are unsaved changes."
     When I am on the "1111111292" product page
     Then I should not see the text "Material"
 
@@ -25,7 +24,6 @@ Feature: Remove attribute from a family
     When I remove the "material" attribute
     And I save the family
     Then I should not see the text "There are unsaved changes."
-    And I should see the flash message "Attribute successfully removed from the family"
     When I am on the "model-braided-hat" product model page
     Then I should see the text "Supplier"
     But I should not see the text "Material"
@@ -37,12 +35,9 @@ Feature: Remove attribute from a family
     And I visit the "Attributes" tab
     And I scroll down
     When I remove the "variation_name" attribute
-    Then I should see the flash message "Cannot remove attribute used as label"
-    When I remove the "variation_image" attribute
-    Then I should see the flash message "Cannot remove used as the main picture"
-    When I remove the "size" attribute
-    Then I should see the flash message "Cannot remove this attribute used as a variant axis in a family variant"
-    And I should see the text "size"
+    And I remove the "variation_image" attribute
+    And I remove the "size" attribute
+    Then I should see the text "size"
 
   Scenario: Successfully remove an attribute from a family removes it from the family variants.
     Given I am on the "shoes" family page

--- a/features/import/check_mime_type_before_import.feature
+++ b/features/import/check_mime_type_before_import.feature
@@ -21,5 +21,4 @@ Feature:
       | Groups column     | grp      |
     And I press the "Save" button
     When I am on the "csv_footwear_product_import" import job page
-    And I upload and import an invalid file "akeneo2.jpg"
-    Then I should see the flash message "The file extension is not allowed (allowed extensions: csv, zip)."
+    Then I upload and import an invalid file "akeneo2.jpg"

--- a/features/import/delete_an_import.feature
+++ b/features/import/delete_an_import.feature
@@ -13,8 +13,7 @@ Feature: Delete import
   Scenario: Successfully delete a CSV import job from the jobs page
     Given I delete the "CSV footwear product import" job
     When I confirm the deletion
-    Then I should see the flash message "Import profile successfully removed"
-    And the grid should contain 24 elements
+    Then the grid should contain 24 elements
     And I should not see import profile "CSV footwear product import"
 
   Scenario: Successfully cancel the deletion of a CSV import job
@@ -27,8 +26,7 @@ Feature: Delete import
     Given I am on the "csv_footwear_product_import" import job edit page
     When I press the secondary action "Delete"
     And I confirm the deletion
-    Then I should see the flash message "Job instance successfully removed"
-    And the grid should contain 24 elements
+    Then the grid should contain 24 elements
     And I should not see import profile "CSV footwear product import"
 
   @github https://github.com/akeneo/pim-community-dev/issues/6414
@@ -42,6 +40,5 @@ Feature: Delete import
     And I press the "Save" button
     And I press the secondary action "Delete"
     And I confirm the deletion
-    Then I should see the flash message "Import profile successfully removed"
     When I am on the imports page
     Then the grid should contain 25 elements

--- a/features/import/upload_and_import_products_with_media.feature
+++ b/features/import/upload_and_import_products_with_media.feature
@@ -50,4 +50,3 @@ Feature: Upload and import products with media
       """
     And I am on the "xlsx_footwear_product_import" import job page
     When I upload and import the file "%file to import%"
-    Then I should see the flash message "The file extension is not allowed (allowed extensions: xlsx, zip)."

--- a/features/locale/change_user_locale.feature
+++ b/features/locale/change_user_locale.feature
@@ -14,7 +14,7 @@ Feature: Change user locale
     And I fill in the following information:
      | UI locale | French (France) |
     And I save the user
-    Then I should see the flash message "Utilisateur enregistré"
+    Then I should not see the text "There are unsaved changes."
     And I should see the text "Langue de l'interface"
 
   Scenario: Successfully change Mary's locale
@@ -23,7 +23,7 @@ Feature: Change user locale
     And I fill in the following information:
      | UI locale | French (France) |
     And I save the user
-    Then I should see the flash message "User saved"
+    Then I should not see the text "There are unsaved changes."
     Then I should not see the text "Collecter"
 
   Scenario: Should only see translated locales

--- a/features/product/edit_product_and_action.feature
+++ b/features/product/edit_product_and_action.feature
@@ -20,7 +20,7 @@ Feature: Product edition clicking on another action
     And I fill in the following information:
       | Price | foo EUR |
     When I save the product
-    Then I should see the flash message "The product could not be updated."
+    Then I should not see the text "There are unsaved changes."
     When I click on the Akeneo logo
     Then I should see "You will lose changes to the product if you leave the page." in popup
 

--- a/features/product/edit_product_with_localizable_and_scopable_attribute_options.feature
+++ b/features/product/edit_product_with_localizable_and_scopable_attribute_options.feature
@@ -39,7 +39,7 @@ Feature: Edit a product with localizable and scopable attribute options
     Then the field Simple should display the Print scope label
     And I change the Simple to "US1"
     When I save the product
-    Then I should see the flash message "Product successfully updated"
+    Then I should not see the text "There are unsaved changes."
     Given I switch the scope to "ecommerce"
     Then the field Simple should display the Ecommerce scope label
     And I change the Simple to "US2"
@@ -59,7 +59,7 @@ Feature: Edit a product with localizable and scopable attribute options
     And I switch the locale to "de_DE"
     And I change the Multi to "DE3, DE2"
     When I save the product
-    Then I should see the flash message "Product successfully updated"
+    Then I should not see the text "There are unsaved changes."
     When I switch the scope to "ecommerce"
     And I switch the locale to "en_US"
     Then I should see the text "US1 US3"

--- a/features/product/enabling.feature
+++ b/features/product/enabling.feature
@@ -13,13 +13,11 @@ Feature: Enable and disable a product
     Given an enabled "boat" product
     When I am on the "boat" product page
     And I disable the product
-    Then I should see the flash message "Product successfully updated"
-    And product "boat" should be disabled
+    Then product "boat" should be disabled
 
   @ce
   Scenario: Successfully enable a product
     Given a disabled "boat" product
     When I am on the "boat" product page
     And I enable the product
-    Then I should see the flash message "Product successfully updated"
-    And product "boat" should be enabled
+    Then product "boat" should be enabled

--- a/features/product/join_an_image_to_a_product.feature
+++ b/features/product/join_an_image_to_a_product.feature
@@ -17,7 +17,7 @@ Feature: Join an image to a product
   @ce
   Scenario: Successfully leave the image empty
     When I save the product
-    Then I should see the flash message "Product successfully updated"
+    Then I should not see the text "There are unsaved changes."
 
   Scenario: Successfully upload an image
     When I attach file "akeneo.jpg" to "Visual"

--- a/features/product/toggle_status_product.feature
+++ b/features/product/toggle_status_product.feature
@@ -19,9 +19,7 @@ Feature: Toggle status of a product
     Then the row "CD player" should contain:
       | column | value    |
       | status | DISABLED |
-    And I should see the flash message "Product has been disabled"
     When I click on the "Toggle status" action of the row which contains "CD player"
     Then the row "CD player" should contain:
       | column | value   |
       | status | ENABLED |
-    And I should see the flash message "Product has been enabled"

--- a/features/reference-data/attribute/add_attribute.feature
+++ b/features/reference-data/attribute/add_attribute.feature
@@ -15,7 +15,7 @@ Feature: Add attribute options
       | Reference data type | color   |
       | Attribute group     | Other   |
     When I save the attribute
-    Then I should see the flash message "Attribute successfully created"
+    Then I should not see the text "There are unsaved changes."
 
   Scenario: Successfully create a multiple reference data
     Given I create a "Reference data multi select" attribute
@@ -24,4 +24,4 @@ Feature: Add attribute options
       | Reference data type | fabric  |
       | Attribute group     | Other   |
     When I save the attribute
-    Then I should see the flash message "Attribute successfully created"
+    Then I should not see the text "There are unsaved changes."

--- a/features/reference-data/attribute/display_attribute_history.feature
+++ b/features/reference-data/attribute/display_attribute_history.feature
@@ -19,12 +19,11 @@ Feature: Display the attribute history
       | Reference data type | color   |
       | Attribute group     | Other   |
     And I save the attribute
-    Then I should see the flash message "Attribute successfully created"
+    Then I should not see the text "There are unsaved changes."
     And I should not see the text "There are unsaved changes."
     When I change the "Attribute group" to "Technical"
     And I save the attribute
-    Then I should see the flash message "Attribute successfully updated"
-    And I should not see the text "There are unsaved changes."
+    Then I should not see the text "There are unsaved changes."
     When I visit the "History" tab
     Then there should be 2 update
     And I should see history:

--- a/features/user/edit_my_account.feature
+++ b/features/user/edit_my_account.feature
@@ -12,7 +12,7 @@ Feature: Change my profile
     Given I edit the "admin" user
     When I attach file "akeneo.jpg" to "Avatar"
     And I save the user
-    Then I should see the flash message "User saved"
+    Then I should not see the text "There are unsaved changes."
     And I should not see the default avatar
 
   @jira https://akeneo.atlassian.net/browse/PIM-6258
@@ -24,7 +24,7 @@ Feature: Change my profile
     And I am on the User profile edit page
     When I attach file "akeneo.jpg" to "Avatar"
     And I save the user
-    Then I should see the flash message "User saved"
+    Then I should not see the text "There are unsaved changes."
 
   @jira https://akeneo.atlassian.net/browse/PIM-6894
   Scenario: Successfully update my password with any characters

--- a/features/user/edit_user.feature
+++ b/features/user/edit_user.feature
@@ -14,7 +14,7 @@ Feature: Edit a user
       | First name | John  |
       | Last name  | Smith |
     And I save the user
-    Then I should see the flash message "User saved"
+    Then I should not see the text "There are unsaved changes."
     And I should see the text "John Smith"
 
   Scenario: Successfully edit and apply user preferences
@@ -26,7 +26,7 @@ Feature: Edit a user
       | Default tree         | 2015 collection   |
       | Product grid filters | SKU, Name, Family |
     And I save the user
-    Then I should see the flash message "User saved"
+    Then I should not see the text "There are unsaved changes."
     When I am on the products grid
     And I open the category tree
     Then I should see the text "Kollektion"

--- a/features/user/update_user_preferences.feature
+++ b/features/user/update_user_preferences.feature
@@ -44,8 +44,7 @@ Feature: Update user preferences
     And I visit the "Additional" tab
     And I change the "Catalog locale" to "fr_FR"
     And I save the user
-    Then I should see the flash message "User saved"
-    And I should not see the text "There are unsaved changes."
+    Then I should not see the text "There are unsaved changes."
     When I visit the "Additional" tab
     Then I should see the text "Catalog locale"
     And I should see the text "fr_FR"


### PR DESCRIPTION
**Time to clean our own shit**

Remove Old Behat Legacy step "I should see the flash message"  where code of function was a `return;` since many time...

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
