### PR TITLE
PIM-7337: fix completeness popup when no label on attribute

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,7 @@
+# 2.0.x
+
+- PIM-7337: Fix completeness popup when no label on attribute
+
 # 2.0.24 (2018-05-16)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-completeness.js
@@ -12,6 +12,7 @@ define(
         'underscore',
         'oro/translator',
         'pim/form',
+        'pim/i18n',
         'pim/user-context',
         'pim/template/product/form/product-completeness'
     ],
@@ -19,6 +20,7 @@ define(
         _,
         __,
         BaseForm,
+        i18n,
         UserContext,
         template
     ) {
@@ -82,7 +84,8 @@ define(
                         completenesses: this.getCurrentCompletenesses(options.scope),
                         badgeClass: this.getBadgeClass(options),
                         currentLocale: options.locale,
-                        missingValues: 'pim_enrich.form.product.panel.completeness.missing_values'
+                        missingValues: 'pim_enrich.form.product.panel.completeness.missing_values',
+                        i18n: i18n
                     }));
                 } else {
                     // We drop the element for design issues, to avoid blank spaces.

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/product-completeness.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/product-completeness.html
@@ -23,7 +23,7 @@
                         <% _.each(completeness.missing, function (attribute, i) { %>
                             <% if (0 !== i) { %> | <% } %>
                             <span class="AknCompletenessPanel-highlight missing-attribute" data-attribute="<%- attribute.code %>" data-locale="<%- locale %>">
-                                <%- attribute.labels[currentLocale] %>
+                                <%- i18n.getLabel(attribute.labels, currentLocale, attribute.code) %>
                             </span>
                         <% }) %>
                     </div>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Nobody complained since 2.0 so maybe that's not that important to test. I can add one if needed

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added legacy Behats               | NA
| Added acceptance tests            | NA
| Added integration tests           | NA
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
