### PR TITLE
PIM-7351: Fix boolean values display in product PDF

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,7 @@
 - PIM-7338: Fix attribute groups labels in the grid
 - PIM-7334: Fix identifier filter with special characters
 - PIM-7337: Fix completeness popup when no label on attribute
+- PIM-7351: Fix boolean values display in product PDF
 
 # 2.0.24 (2018-05-16)
 

--- a/features/family/remove_attribute_from_a_family.feature
+++ b/features/family/remove_attribute_from_a_family.feature
@@ -26,10 +26,11 @@ Feature: Remove attribute from a family
     And I save the family
     Then I should not see the text "There are unsaved changes."
     And I should see the flash message "Attribute successfully removed from the family"
-    When I am on the "model-braided-hat" product model page
+    And I wait for the "compute_product_models_descendants" job to finish
+    And I am on the "model-braided-hat" product model page
     Then I should see the text "Supplier"
     But I should not see the text "Material"
-    When I am on the "braided-hat-m" product page
+    And I am on the "braided-hat-m" product page
     Then I should not see the Material field
 
   Scenario: Impossible to remove some attributes from a family (used as label, used as image, used as axis)

--- a/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
+++ b/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
@@ -120,6 +120,9 @@
                                     <div class="right-column">
                                         {% if 'pim_catalog_textarea' == attribute.type and attribute.isWysiwygEnabled %}
                                             {{ content|raw }}
+                                        {% elseif 'pim_catalog_boolean' == attribute.type %}
+                                            {# @todo @merge: refactor on master - use new translation keys #}
+                                            {{ (content.data ? 'Yes' : 'No')|trans([], null, locale) }}
                                         {% else %}
                                             {{ content }}
                                         {% endif %}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Boolean values set to false used to not be displayed at all in PDF exports, and `true` was rendered as `1`. This PR allows rendering boolean values as translated "Yes" or "No" in PDF exports

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
