### PR TITLE
PimConnectorBundle: optimize product read

### DIFF
--- a/src/Pim/Component/Connector/Reader/Database/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/Database/ProductReader.php
@@ -86,6 +86,11 @@ class ProductReader implements ItemReaderInterface, InitializableInterface, Step
 
         $this->firstRead = true;
     }
+    
+    protected function getConfiguredChannel()
+    {
+        return $this->configuredChannel;
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Pim/Component/Connector/Reader/Database/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/Database/ProductReader.php
@@ -46,6 +46,9 @@ class ProductReader implements ItemReaderInterface, InitializableInterface, Step
 
     /** @var bool */
     private $firstRead = true;
+    
+    /** @var ChannelInterface|null */
+    private $configuredChannel;
 
     /**
      * @param ProductQueryBuilderFactoryInterface $pqbFactory
@@ -73,13 +76,13 @@ class ProductReader implements ItemReaderInterface, InitializableInterface, Step
      */
     public function initialize()
     {
-        $channel = $this->getConfiguredChannel();
-        if (null !== $channel && $this->generateCompleteness) {
-            $this->completenessManager->generateMissingForChannel($channel);
+        $this->configuredChannel = $this->getConfiguredChannel();
+        if (null !== $this->configuredChannel && $this->generateCompleteness) {
+            $this->completenessManager->generateMissingForChannel($this->configuredChannel);
         }
 
         $filters = $this->getConfiguredFilters();
-        $this->products = $this->getProductsCursor($filters, $channel);
+        $this->products = $this->getProductsCursor($filters, $this->configuredChannel);
 
         $this->firstRead = true;
     }
@@ -99,11 +102,8 @@ class ProductReader implements ItemReaderInterface, InitializableInterface, Step
             $this->stepExecution->incrementSummaryInfo('read');
         }
 
-        if (null !== $product) {
-            $channel = $this->getConfiguredChannel();
-            if (null !== $channel) {
-                $this->metricConverter->convert($product, $channel);
-            }
+        if (null !== $product && null !== $this->configuredChannel) {
+            $this->metricConverter->convert($product, $this->configuredChannel);
         }
 
         $this->firstRead = false;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Channel fetch was executed on each product read. As the exports are limited to one channel at a time, the case where it is required should not appear and as the fetch is already done in the `initialize()` stage. We now store this info at this moment and use the stored channel instance from this point on each read.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
