### PR TITLE
PIM-7366 Use CHILDREN operators instead of redoing it

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7400: Fix 'ensure-indexes' timeout command
+- PIM-7366: Fix performance issue related to reloading of selected category children ids on the grid
 
 # 1.7.22 (2018-06-05)
 

--- a/src/Pim/Bundle/FilterBundle/Filter/CategoryFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/CategoryFilter.php
@@ -113,8 +113,7 @@ class CategoryFilter extends NumberFilter
     {
         $tree = $this->categoryRepo->find($data['treeId']);
         if ($tree) {
-            $categoryCodes = $this->getAllChildrenCodes($tree);
-            $this->util->applyFilter($ds, 'categories', 'NOT IN', $categoryCodes);
+            $this->util->applyFilter($ds, 'categories', 'NOT IN CHILDREN', [$tree->getCode()]);
 
             return true;
         }
@@ -140,12 +139,10 @@ class CategoryFilter extends NumberFilter
 
         if ($category) {
             if ($data['includeSub']) {
-                $categoryCodes = $this->getAllChildrenCodes($category);
+                $this->util->applyFilter($ds, 'categories', 'IN CHILDREN', [$category->getCode()]);
             } else {
-                $categoryCodes = [];
+                $this->util->applyFilter($ds, 'categories', 'IN', [$category->getCode()]);
             }
-            $categoryCodes[] = $category->getCode();
-            $this->util->applyFilter($ds, 'categories', 'IN', $categoryCodes);
 
             return true;
         }
@@ -157,8 +154,9 @@ class CategoryFilter extends NumberFilter
      * Get children category codes
      *
      * @param CategoryInterface $category
-     *
      * @return string[]
+     *
+     * @deprecated Not used anymore internally. If needed, use directly the categoryRepo service
      */
     protected function getAllChildrenCodes(CategoryInterface $category)
     {

--- a/src/Pim/Bundle/FilterBundle/spec/Filter/CategoryFilterSpec.php
+++ b/src/Pim/Bundle/FilterBundle/spec/Filter/CategoryFilterSpec.php
@@ -35,10 +35,9 @@ class CategoryFilterSpec extends ObjectBehavior
         FilterDatasourceAdapterInterface $datasource,
         CategoryInterface $tree
     ) {
-        $tree->getId()->willReturn(1);
+        $tree->getCode()->willReturn('my_tree');
         $categoryRepo->find(1)->willReturn($tree);
-        $categoryRepo->getAllChildrenCodes($tree)->willReturn(['bar', 'baz']);
-        $utility->applyFilter($datasource, 'categories', 'NOT IN', ['bar', 'baz'])->shouldBeCalled();
+        $utility->applyFilter($datasource, 'categories', 'NOT IN CHILDREN', ['my_tree'])->shouldBeCalled();
 
         $this->apply($datasource, ['value' => ['categoryId' => -1, 'treeId' => 1]]);
     }
@@ -64,10 +63,8 @@ class CategoryFilterSpec extends ObjectBehavior
     ) {
         $categoryRepo->find(42)->willReturn($category);
         $category->getCode()->willReturn('foo');
-        $categoryRepo->find(42)->willReturn($category);
-        $categoryRepo->getAllChildrenCodes($category)->willReturn(['bar', 'baz']);
 
-        $utility->applyFilter($datasource, 'categories', 'IN', ['bar', 'baz', 'foo'])->shouldBeCalled();
+        $utility->applyFilter($datasource, 'categories', 'IN CHILDREN', ['foo'])->shouldBeCalled();
 
         $this->apply($datasource, ['value' => ['categoryId' => 42], 'type' => true]);
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

PIM-7366: Avoid loading children by code then reloading all ids from the codes.

This does a little bit of cleanup as well, as we properly use the right filter's operator instead
of reinventing it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Done
| Added legacy Behats               | N.A.
| Added acceptance tests            | N.A.
| Added integration tests           | N.A.
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
