### PR TITLE
PIM-7358: Cascade remove variant attribute sets when removing a family variant

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/FamilyVariant.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/FamilyVariant.orm.yml
@@ -32,13 +32,16 @@ Pim\Component\Catalog\Model\FamilyVariant:
                 joinColumns:
                     family_variant_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     variant_attribute_sets_id:
                         referencedColumnName: id
                         unique: true
+                        onDelete: CASCADE
             cascade:
                 - persist
                 - detach
+                - remove
 
     manyToOne:
         family:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/VariantAttributeSet.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/VariantAttributeSet.orm.yml
@@ -21,6 +21,7 @@ Pim\Component\Catalog\Model\VariantAttributeSet:
                 joinColumns:
                     variant_attribute_set_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     attributes_id:
                         referencedColumnName: id
@@ -32,6 +33,7 @@ Pim\Component\Catalog\Model\VariantAttributeSet:
                 joinColumns:
                     variant_attribute_set_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     axes_id:
                         referencedColumnName: id

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Family/RemoveFamilyVariantIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Family/RemoveFamilyVariantIntegration.php
@@ -7,6 +7,7 @@ namespace tests\integration\Pim\Bundle\CatalogBundle\EventSubscriber;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
+use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
 
 /**
  * @author    Samir Boulil <samir.boulil@akeneo.com>
@@ -18,9 +19,17 @@ class RemoveFamilyVariantIntegration extends TestCase
     public function testTheFamilyVariantRemovalSuccess(): void
     {
         $familyVariant = $this->createDefaultFamilyVariant('my_family_variant');
-        $this->removeFamilyVariant($familyVariant);
 
+        $variantAttributeSetIds = [];
+        foreach ($familyVariant->getVariantAttributeSets() as $variantAttributeSet) {
+            $variantAttributeSetIds[] = $variantAttributeSet->getId();
+        }
+
+        $this->removeFamilyVariant($familyVariant);
         $this->assertNull($this->getFamilyVariant('my_family_variant'));
+
+        $attributeSetRepo = $this->get('doctrine.orm.entity_manager')->getRepository(VariantAttributeSetInterface::class);
+        $this->assertCount(0, $attributeSetRepo->findBy(['id' => $variantAttributeSetIds]));
     }
 
     public function testTheFamilyVariantRemovalIsPrevented()

--- a/upgrades/schema/Version_2_2_20180523125419.php
+++ b/upgrades/schema/Version_2_2_20180523125419.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add CASCADE DELETE on pim_catalog_family_variant_attribute_set related foreign keys
+ */
+class Version_2_2_20180523125419 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE pim_catalog_family_variant_has_variant_attribute_sets DROP FOREIGN KEY FK_1F4DC7028A37AD0');
+        $this->addSql('ALTER TABLE pim_catalog_family_variant_has_variant_attribute_sets DROP FOREIGN KEY FK_1F4DC702D8404D');
+        $this->addSql('ALTER TABLE pim_catalog_family_variant_has_variant_attribute_sets ADD CONSTRAINT FK_1F4DC7028A37AD0 FOREIGN KEY (family_variant_id) REFERENCES pim_catalog_family_variant (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE pim_catalog_family_variant_has_variant_attribute_sets ADD CONSTRAINT FK_1F4DC702D8404D FOREIGN KEY (variant_attribute_sets_id) REFERENCES pim_catalog_family_variant_attribute_set (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE pim_catalog_variant_attribute_set_has_attributes DROP FOREIGN KEY FK_E9C4264A11D06F0E');
+        $this->addSql('ALTER TABLE pim_catalog_variant_attribute_set_has_attributes ADD CONSTRAINT FK_E9C4264A11D06F0E FOREIGN KEY (variant_attribute_set_id) REFERENCES pim_catalog_family_variant_attribute_set (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE pim_catalog_variant_attribute_set_has_axes DROP FOREIGN KEY FK_6965051E11D06F0E');
+        $this->addSql('ALTER TABLE pim_catalog_variant_attribute_set_has_axes ADD CONSTRAINT FK_6965051E11D06F0E FOREIGN KEY (variant_attribute_set_id) REFERENCES pim_catalog_family_variant_attribute_set (id) ON DELETE CASCADE');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

As of version 2.2, it is possible to remove family variants. Problem was, related entities (variant attribute sets) were not removed, hence preventing from e.g removing an attribute, even if it was not used as an axis anymore.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | OK
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
