### PR TITLE
PIM-7370 - Sort filters on group and role grids are not consistent

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -5,6 +5,7 @@
 - PIM-7336: Fix channel update with "do not convert" values for conversion units
 - PIM-7385: Fix memory leak on purge job command
 - PIM-7375: Fix metric unit values on export/import with empty values
+- PIM-7370: disable multisorting on group/user and role/user grid for a better sort experience
 
 # 1.7.21 (2018-04-23)
 

--- a/src/Pim/Bundle/UserBundle/Resources/config/datagrid/group-user.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/datagrid/group-user.yml
@@ -45,13 +45,11 @@ datagrid:
                     type: string
                     data_name: u.lastName
         sorters:
-            multiple_sorting: true
             columns:
                 has_group:
                     data_name: has_group
             default:
                 has_group: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_DESC'
-                lastName: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_ASC'
 
         options:
             requireJSModules:

--- a/src/Pim/Bundle/UserBundle/Resources/config/datagrid/role-user.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/datagrid/role-user.yml
@@ -45,14 +45,11 @@ datagrid:
                     type: string
                     data_name: u.email
         sorters:
-            multiple_sorting: true
             columns:
                 has_role:
                     data_name: has_role
-
             default:
                 has_role: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_DESC'
-                lastName: '%oro_datagrid.extension.orm_sorter.class%::DIRECTION_ASC'
 
         options:
             requireJSModules:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The multiple sorting into grid is a weird experience of sorting, not very natural. 

We remove this sorting option into the "System / Users Management / Groups / Users" grid and "System / Users Management / Roles / Users" grid and use a natural column by column sorting.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
