### PR TITLE
WIP : Form Feature - Display information on the form extensions as html comment

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form.js
@@ -235,6 +235,9 @@ define(
                         'zone "' + extension.targetZone + '" does not exist');
                 }
 
+                zone.appendChild(document.createComment('FORM - extension: "' + extension.code + '" in: "' +
+                    this.code + '": ' + 'zone: "' + extension.targetZone + '"'));
+
                 zone.appendChild(extension.el);
 
                 extension.render();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This pull request is an idea I think should be implemented in Akeneo. When working on a page it's quite hard to pinpoint which form extension is displaying a certain part of the page. 

The idea is to simply add a comment displaying information that makes it very easy to find the extension responsible for displaying a particular section.

![image](https://user-images.githubusercontent.com/3658513/40432484-1b6080de-5eaa-11e8-934f-5c91b484d0e7.png)

Ideally it should only show in dev, but the pull request is here to introduce the idea. 

_On the same subject it would be great to be able to extend existing forms instead of recreating everything. Looking at the code it doesen't look that complicated  to put in place._ 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
