### PR TITLE
PIM-7373 Avoid deleting and reinsert all attributes relation at family save

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,8 @@
+# 1.7.x
+
+## Bug fixes
+ - PIM-7373: Fix deletion and reinsertion of all attributes relations at family save time
+
 # 1.7.23 (2018-06-25)
 
 ## Bug fixes

--- a/features/export/product-export-builder/export_products_by_families.feature
+++ b/features/export/product-export-builder/export_products_by_families.feature
@@ -91,10 +91,10 @@ Feature: Export products according to their families
   Scenario: Display default messages when no family are selected
     Given the following job "csv_footwear_product_export" configuration:
       | filePath | %tmp%/product_export/product_export.csv |
-    When I am on the "csv_footwear_product_export" export job edit page
+    When I am on the "csv_footwear_product_export" export job page
     And I visit the "Content" tab
     Then the export content field "family" should contain "No condition on families"
-    When I am on the "csv_footwear_product_export" export job page
+    When I am on the "csv_footwear_product_export" export job edit page
     And I visit the "Content" tab
     Then the export content field "family" should contain "No condition on families"
 

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/guessers.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/guessers.yml
@@ -54,5 +54,10 @@ services:
         tags:
             - { name: pim_versioning.update_guesser }
 
+    pim_versioning.update_guesser.family_attribute_requirement:
+        class: Pim\Bundle\VersioningBundle\UpdateGuesser\FamilyAttributeRequirementUpdateGuesser
+        tags:
+            - { name: pim_versioning.update_guesser }
+
     pim_versioning.update_guesser.chained:
         class: '%pim_versioning.update_guesser.chained.class%'

--- a/src/Pim/Bundle/VersioningBundle/UpdateGuesser/FamilyAttributeRequirementUpdateGuesser.php
+++ b/src/Pim/Bundle/VersioningBundle/UpdateGuesser/FamilyAttributeRequirementUpdateGuesser.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Pim\Bundle\VersioningBundle\UpdateGuesser;
+
+use Doctrine\ORM\EntityManager;
+use Pim\Bundle\CatalogBundle\Entity\AttributeRequirement;
+
+/**
+ * Guess update on family attribute requirements.
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyAttributeRequirementUpdateGuesser implements UpdateGuesserInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportAction($action)
+    {
+        return $action === UpdateGuesserInterface::ACTION_UPDATE_ENTITY
+            || $action === UpdateGuesserInterface::ACTION_DELETE;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessUpdates(EntityManager $em, $entity, $action)
+    {
+        $updatedEntities = [];
+
+        if ($entity instanceof AttributeRequirement) {
+            $updatedEntities[] = $entity->getFamily();
+        }
+
+        return $updatedEntities;
+    }
+}

--- a/src/Pim/Bundle/VersioningBundle/spec/UpdateGuesser/FamilyAttributeRequirementUpdateGuesserSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/UpdateGuesser/FamilyAttributeRequirementUpdateGuesserSpec.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace spec\Pim\Bundle\VersioningBundle\UpdateGuesser;
+
+use Doctrine\ORM\EntityManager;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Entity\AttributeRequirement;
+use Pim\Bundle\CatalogBundle\Entity\Family;
+use Pim\Bundle\VersioningBundle\UpdateGuesser\UpdateGuesserInterface;
+
+class FamilyAttributeRequirementUpdateGuesserSpec extends ObjectBehavior
+{
+    function it_is_an_update_guesser()
+    {
+        $this->shouldImplement(UpdateGuesserInterface::class);
+    }
+
+    function it_supports_update_action()
+    {
+        $this->supportAction(UpdateGuesserInterface::ACTION_UPDATE_ENTITY)->shouldReturn(true);
+        $this->supportAction('foo')->shouldReturn(false);
+    }
+
+    function it_supports_delete_action()
+    {
+        $this->supportAction(UpdateGuesserInterface::ACTION_DELETE)->shouldReturn(true);
+    }
+
+    function it_guesses_family_update_when_an_attribute_requirement_is_added(
+        EntityManager $em,
+        AttributeRequirement $attributeRequirement,
+        Family $family
+    )
+    {
+        $attributeRequirement->getFamily()->willReturn($family);
+
+        $this->guessUpdates($em, $attributeRequirement, UpdateGuesserInterface::ACTION_UPDATE_ENTITY)
+            ->shouldReturn([$family]);
+    }
+
+    function it_guesses_family_update_when_an_attribute_requirement_is_removed(
+        EntityManager $em,
+        AttributeRequirement $attributeRequirement,
+        Family $family
+    )
+    {
+        $attributeRequirement->getFamily()->willReturn($family);
+
+        $this->guessUpdates($em, $attributeRequirement, UpdateGuesserInterface::ACTION_DELETE)
+            ->shouldReturn([$family]);
+    }
+
+    function it_returns_no_pending_updates_if_not_given_an_attribute_requirement(EntityManager $em)
+    {
+        $this->guessUpdates($em, new Family(), UpdateGuesserInterface::ACTION_UPDATE_ENTITY)
+            ->shouldReturn([]);
+    }
+}

--- a/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
@@ -336,12 +336,25 @@ class FamilyUpdater implements ObjectUpdaterInterface
      */
     protected function addAttributes(FamilyInterface $family, array $data)
     {
+        $currentAttributeCodes = [];
+        $wantedAttributeCodes = array_values($data);
+
         foreach ($family->getAttributes() as $attribute) {
-            if (AttributeTypes::IDENTIFIER !== $attribute->getType()) {
-                $family->removeAttribute($attribute);
+            $currentAttributeCodes[] = $attribute->getCode();
+        }
+
+        $attributeCodesToRemove = array_diff($currentAttributeCodes, $wantedAttributeCodes);
+        $attributeCodesToAdd = array_diff($wantedAttributeCodes, $currentAttributeCodes);
+
+        foreach ($family->getAttributes() as $attribute) {
+            if (in_array($attribute->getCode(), $attributeCodesToRemove)) {
+                if (AttributeTypes::IDENTIFIER !== $attribute->getType()) {
+                    $family->removeAttribute($attribute);
+                }
             }
         }
-        foreach ($data as $attributeCode) {
+
+        foreach ($attributeCodesToAdd as $attributeCode) {
             if (null !== $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode)) {
                 $family->addAttribute($attribute);
             } else {


### PR DESCRIPTION
This PR avoid generating lots of DELETE and INSERT queries by removing or adding only attributes that have been removed or added to the family at save time.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Done
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
