### PR TITLE
Fix CI build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm
+FROM php:7.1.16-fpm
 
 ENV COMPOSER_CACHE_DIR=/tmp/composer/cache
 ENV YARN_CACHE_FOLDER=/tmp/yarn


### PR DESCRIPTION
## Description

Our CI is using `php:7.1-fpm` image from the Docker library. This night, the image was updated from Debian Jessie to Stretch, removing some usefull tools from it, and making our build fail.

This PR fixes the base image to `php:7.1.16-fpm` so we are sure this won't happen again.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
