### PR TITLE
PIM-7364: use catalog locale to display categories tree

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/category.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/category.js
@@ -84,7 +84,7 @@ define(
 
                         this.$el.html(this.template({
                             i18n: i18n,
-                            locale: UserContext.get('uiLocale'),
+                            locale: UserContext.get('catalogLocale'),
                             trees: trees,
                             currentTree: _.findWhere(trees, {code: this.currentTree}),
                             selectedCategories: this.selectedCategories


### PR DESCRIPTION
Currently, the user ui (interface) locale is used to display the category tree. We must use the catalog locale for this tree.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
