### PR TITLE
PIM-7362: Fix error to save and detach at batch size

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,7 @@
+# 2.0.*
+
+- PIM-7362: Fix Completeness computing from family keeping in account batch size to free the memory
+
 # 2.0.25 (2018-05-21)
 
 ## Bug fixes

--- a/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamilyTasklet.php
+++ b/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamilyTasklet.php
@@ -112,7 +112,7 @@ class ComputeCompletenessOfProductsFamilyTasklet implements TaskletInterface
         foreach ($productToSave as $product) {
             $productBatch[] = $product;
 
-            if (self::BATCH_SIZE === $productBatch) {
+            if (self::BATCH_SIZE === count($productBatch)) {
                 $this->bulkProductSaver->saveAll($productBatch);
                 $this->bulkObjectDetacher->detachAll($productBatch);
 


### PR DESCRIPTION
Fix memory leak on completeness.
Batch size is not taken into account as the assertion is wrong.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
