### PR TITLE
Fix tests on product model export with association

### DIFF
--- a/tests/legacy/features/Context/FixturesContext.php
+++ b/tests/legacy/features/Context/FixturesContext.php
@@ -2064,9 +2064,12 @@ class FixturesContext extends BaseFixturesContext
     }
 
     /**
+     * @param ProductInterface $owner
+     * @param TableNode        $values
+     *
      * @Given /^the following associations for the (product "([^"]+)"):$/
      */
-    public function theFollowingAssociationsForTheProduct(ProductInterface $owner, $id, TableNode $values)
+    public function theFollowingAssociationsForTheProduct(ProductInterface $owner, TableNode $values)
     {
         $rows = $values->getHash();
 
@@ -2092,9 +2095,12 @@ class FixturesContext extends BaseFixturesContext
     }
 
     /**
+     * @param ProductModelInterface $owner
+     * @param TableNode             $values
+     *
      * @Given /^the following associations for the (product model "([^"]+)"):$/
      */
-    public function theFollowingAssociationsForTheProductModel(ProductModelInterface $owner, $code, TableNode $values)
+    public function theFollowingAssociationsForTheProductModel(ProductModelInterface $owner, TableNode $values)
     {
         $rows = $values->getHash();
 
@@ -2113,6 +2119,8 @@ class FixturesContext extends BaseFixturesContext
 
             $association->addProduct($this->getProduct($row['products']));
         }
+        $missingAssociationAdder = $this->getContainer()->get('pim_catalog.association.missing_association_adder');
+        $missingAssociationAdder->addMissingAssociations($owner);
 
         $this->getProductModelSaver()->save($owner);
     }

--- a/tests/legacy/features/export/product_model/csv/export_product_models.feature
+++ b/tests/legacy/features/export/product_model/csv/export_product_models.feature
@@ -10,23 +10,23 @@ Feature: Export variant products through CSV export
 
   Scenario: Export product models through CSV
     Given the following associations for the product model "amor":
-      | type   | products    |
-      | X_SELL | 1111111175  |
-      | X_SELL | 1111111176  |
-      | UPSELL | 1111111177  |
+      | type   | products   |
+      | X_SELL | 1111111175 |
+      | X_SELL | 1111111176 |
+      | UPSELL | 1111111177 |
     And the following associations for the product model "plain":
-      | type   | products    |
-      | X_SELL | 1111111175  |
+      | type   | products   |
+      | X_SELL | 1111111175 |
     And the following associations for the product model "plain_red":
-      | type   | products    |
-      | X_SELL | 1111111176  |
+      | type   | products   |
+      | X_SELL | 1111111176 |
     And I am on the "csv_product_model_export" export job page
     And I launch the export job
     And I wait for the "csv_product_model_export" job to finish
     Then exported file of "csv_product_model_export" should contain the lines:
-    """
-    code;family_variant;parent;categories;brand;care_instructions;collection;color;composition;description-en_US-ecommerce;erp_name-en_US;eu_shoes_size;image;keywords-en_US;material;meta_description-en_US;meta_title-en_US;name-en_US;notice;price-EUR;price-USD;size;sole_composition;supplier;top_composition;UPSELL-groups;UPSELL-products;UPSELL-product_models;variation_image;variation_name-en_US;wash_temperature;weight;weight-unit;X_SELL-groups;X_SELL-products;X_SELL-product_models
-    amor;clothing_colorsize;;master_men_blazers,supplier_zaro;;;summer_2016;;;"Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR";Amor;;;;;;;"Heritage jacket navy";;999.00;;;;zaro;;;1111111177;;;;800;;;;1111111175,1111111176;
-    plain_red;clothing_color_size;plain;tshirts;;;summer_2017;red;;;Plain;;;;;;;plain;;;;;;;;;;;files/plain_red/variation_image/plain_red.jpg;"Plain red ";;;;;1111111176,1111111175;
-    plain;clothing_color_size;;tshirts;;;summer_2017;;;;Plain;;;;;;;plain;;;;;;;;;;;;;;;;;1111111175;
-    """
+      """
+      code;family_variant;parent;categories;brand;care_instructions;collection;color;composition;description-en_US-ecommerce;erp_name-en_US;eu_shoes_size;image;keywords-en_US;material;meta_description-en_US;meta_title-en_US;name-en_US;notice;PACK-groups;PACK-products;PACK-product_models;price-EUR;price-USD;size;sole_composition;SUBSTITUTION-groups;SUBSTITUTION-products;SUBSTITUTION-product_models;supplier;top_composition;UPSELL-groups;UPSELL-products;UPSELL-product_models;variation_image;variation_name-en_US;wash_temperature;weight;weight-unit;X_SELL-groups;X_SELL-products;X_SELL-product_models
+      amor;clothing_colorsize;;master_men_blazers,supplier_zaro;;;summer_2016;;;"Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR";Amor;;;;;;;"Heritage jacket navy";;;;;999.00;;;;;;;zaro;;;1111111177;;;;800;;;;1111111175,1111111176;
+      plain_red;clothing_color_size;plain;tshirts;;;summer_2017;red;;;Plain;;;;;;;plain;;;;;;;;;;;;;;;;;files/plain_red/variation_image/plain_red.jpg;"Plain red ";;;;;1111111176,1111111175;
+      plain;clothing_color_size;;tshirts;;;summer_2017;;;;Plain;;;;;;;plain;;;;;;;;;;;;;;;;;;;;;;;1111111175;
+      """

--- a/tests/legacy/features/export/product_model/xlsx/export_product_models.feature
+++ b/tests/legacy/features/export/product_model/xlsx/export_product_models.feature
@@ -10,21 +10,21 @@ Feature: Export variant products through XLSX export
 
   Scenario: Export product models through XLSX
     Given the following associations for the product model "amor":
-      | type   | products    |
-      | X_SELL | 1111111175  |
-      | X_SELL | 1111111176  |
-      | UPSELL | 1111111177  |
+      | type   | products   |
+      | X_SELL | 1111111175 |
+      | X_SELL | 1111111176 |
+      | UPSELL | 1111111177 |
     And the following associations for the product model "plain":
-      | type   | products    |
-      | X_SELL | 1111111175  |
+      | type   | products   |
+      | X_SELL | 1111111175 |
     And the following associations for the product model "plain_red":
-      | type   | products    |
-      | X_SELL | 1111111176  |
+      | type   | products   |
+      | X_SELL | 1111111176 |
     And I am on the "xlsx_summer_2016_models_export" export job page
     And I launch the export job
     And I wait for the "xlsx_summer_2016_models_export" job to finish
     Then exported xlsx file of "xlsx_summer_2016_models_export" should contain the lines:
-    |code|family_variant|parent|categories|brand|care_instructions|collection|color|composition|description-en_US-ecommerce|erp_name-en_US|eu_shoes_size|image|keywords-en_US|material|meta_description-en_US|meta_title-en_US|name-en_US|notice|price-EUR|price-USD|size|sole_composition|supplier|top_composition|UPSELL-groups|UPSELL-products|UPSELL-product_models|variation_image|variation_name-en_US|wash_temperature|weight|weight-unit|X_SELL-groups|X_SELL-products|X_SELL-product_models|
-    |amor|clothing_colorsize||master_men_blazers,supplier_zaro|||summer_2016|||Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR|Amor|||||||Heritage jacket navy||999.00||||zaro|||1111111177||||800||||1111111175,1111111176||
-    |plain_red|clothing_color_size|plain|tshirts|||summer_2017|red|||Plain|||||||plain|||||||||||files/plain_red/variation_image/plain_red.jpg|"Plain red "|||||1111111176,1111111175||
-    |plain|clothing_color_size||tshirts|||summer_2017||||Plain|||||||plain|||||||||||||||||1111111175||
+      | code      | family_variant      | parent | categories                       | brand | care_instructions | collection  | color | composition | description-en_US-ecommerce                                                                                                                                                                                                       | erp_name-en_US | eu_shoes_size | image | keywords-en_US | material | meta_description-en_US | meta_title-en_US | name-en_US             | notice | PACK-groups | PACK-products | PACK-product_models | price-EUR | price-USD | size | sole_composition | SUBSTITUTION-groups | SUBSTITUTION-products | SUBSTITUTION-product_models | supplier | top_composition | UPSELL-groups | UPSELL-products | UPSELL-product_models | variation_image                               | variation_name-en_US | wash_temperature | weight | weight-unit | X_SELL-groups | X_SELL-products       | X_SELL-product_models |
+      | amor      | clothing_colorsize  |        | master_men_blazers,supplier_zaro |       |                   | summer_2016 |       |             | "Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR" | Amor           |               |       |                |          |                        |                  | "Heritage jacket navy" |        |             |               |                     | 999.00    |           |      |                  |                     |                       |                             | zaro     |                 |               | 1111111177      |                       |                                               |                      | 800              |        |             |               | 1111111175,1111111176 |                       |
+      | plain_red | clothing_color_size | plain  | tshirts                          |       |                   | summer_2017 | red   |             |                                                                                                                                                                                                                                   | Plain          |               |       |                |          |                        |                  | plain                  |        |             |               |                     |           |           |      |                  |                     |                       |                             |          |                 |               |                 |                       | files/plain_red/variation_image/plain_red.jpg | "Plain red "         |                  |        |             |               | 1111111176,1111111175 |                       |
+      | plain     | clothing_color_size |        | tshirts                          |       |                   | summer_2017 |       |             |                                                                                                                                                                                                                                   | Plain          |               |       |                |          |                        |                  | plain                  |        |             |               |                     |           |           |      |                  |                     |                       |                             |          |                 |               |                 |                       |                                               |                      |                  |        |             |               | 1111111175            |                       |


### PR DESCRIPTION
## Description

After a mess with CI - rebase - CI - rebase again … (you know what I mean), two behats were broken, but only on EE, not CE. This was caused by empty variations being generated differently in CE and EE (because of permissions in EE) from our behat fixtures (not a real-use PIM issue).

This PR fixes those two scenarios.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
