### PR TITLE
No ligature on lato font

### DIFF
--- a/src/Pim/Bundle/UIBundle/Resources/public/less/base/general.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/base/general.less
@@ -37,6 +37,7 @@ body {
   color: @AknDefaultFontColor;
   font-family: @AknDefaultFont;
   font-size: @AknDefaultFontSize;
+  font-variant-ligatures: no-common-ligatures;
   background-color: white;
   line-height: 20px;
   min-width: 980px;


### PR DESCRIPTION
Before:
<img width="137" alt="capture d ecran 2018-05-24 a 20 22 49" src="https://user-images.githubusercontent.com/17061942/40504043-56e22086-5f90-11e8-98ce-0a4adfa14f50.png">

After:
<img width="148" alt="capture d ecran 2018-05-24 a 20 22 36" src="https://user-images.githubusercontent.com/17061942/40504039-52c93bb0-5f90-11e8-9fe3-1e7f7eb33bfb.png">

_(Note the "fi" difference)_

