### PR TITLE
[PIM-854] Structure EnrichBundle translations, step 1

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -1,7 +1,7 @@
 pim_title:
-    pim_user_index:                  Users
-    pim_user_role_index:             Roles
-    pim_user_group_index:            User groups
+    pim_user_index: Users
+    pim_user_role_index: Roles
+    pim_user_group_index: User groups
     oro_config_configuration_system: Configuration
 
     pim_user_view: 'User {{ username }} | View'
@@ -23,15 +23,14 @@ pim_title:
     pim_user_group_create: 'Groups | Create'
     pim_user_group_update: 'Group {{ group }} | Edit'
 
-# TODO Move this
-pim_enrich:
+pim_user_management:
     entity:
         user:
             page_title:
                 index: "] -Inf, 1] {{ count }} user|] 1, Inf [{{ count }} users"
-        user_role:
+        role:
             page_title:
                 index: "] -Inf, 1] {{ count }} role|] 1, Inf [{{ count }} roles"
-        user_group:
+        group:
             page_title:
                 index: "] -Inf, 1] {{ count }} group|] 1, Inf [{{ count }} groups"

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -22,3 +22,16 @@ pim_title:
 
     pim_user_group_create: 'Groups | Create'
     pim_user_group_update: 'Group {{ group }} | Edit'
+
+# TODO Move this
+pim_enrich:
+    entity:
+        user:
+            page_title:
+                index: "] -Inf, 1] {{ count }} user|] 1, Inf [{{ count }} users"
+        user_role:
+            page_title:
+                index: "] -Inf, 1] {{ count }} role|] 1, Inf [{{ count }} roles"
+        user_group:
+            page_title:
+                index: "] -Inf, 1] {{ count }} group|] 1, Inf [{{ count }} groups"

--- a/src/Oro/Bundle/ConfigBundle/Resources/config/form_extensions.yml
+++ b/src/Oro/Bundle/ConfigBundle/Resources/config/form_extensions.yml
@@ -56,4 +56,4 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.product.title
+            entity: pim_enrich.entity.product.label

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/jsmessages.en_US.yml
@@ -103,7 +103,7 @@ batch_jobs:
         label: Product import in XLSX
         import.label: Product import
     xlsx_product_model_import:
-        label: Product model import in XSLX
+        label: Product model import in XLSX
         import_product_model_descendants.label: Compute product model descendants
     xlsx_group_export:
         label: Group export in XLSX

--- a/src/Pim/Bundle/DashboardBundle/Resources/translations/messages.en_US.yml
+++ b/src/Pim/Bundle/DashboardBundle/Resources/translations/messages.en_US.yml
@@ -6,16 +6,5 @@ pim_dashboard:
             title: Completeness Over Channels and Locales
         last_operations:
             title: Last operations
-            empty: No operations found
             status: Status
-            date: Date
             type: Type
-            "profile name": Profile name
-            details: Details
-            job_type:
-                import: Import
-                export: Export
-                mass_edit: Mass edit
-                quick_export: Quick export
-                compute_product_models_descendants: Compute product models descendants
-                mass_delete: Mass delete products

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
@@ -71,7 +71,7 @@ define([
                         this.getErrorDialog(message).open();
                     }.bind(this),
                     success: function() {
-                        var messageText = __('flash.' + this.getEntityCode() + '.removed');
+                        var messageText = __('pim_enrich.entity.' + this.getEntityCode() + '.flash.delete.success');
                         messenger.notify('success', messageText);
                         userContext.initialize();
 
@@ -107,7 +107,10 @@ define([
                 if (!this.errorModal) {
                     this.errorModal = new Modal({
                         title: __('pim_datagrid.delete_error.title'),
-                        content: '' === message ? __('error.removing.' + this.getEntityHint()) : message,
+                        content:
+                            '' === message ?
+                            __('pim_enrich.entity.' + this.getEntityHint() + '.flash.delete.fail') :
+                            message,
                         cancelText: false
                     });
                 }

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/grid.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/grid.js
@@ -362,7 +362,9 @@ define(
              */
             getDefaultNoDataOptions() {
                 const entityHint = (this.entityHint || __('pim_datagrid.entity_hint')).toLowerCase();
-                let key = 'pim_datagrid.' + (_.isEmpty(this.collection.state.filters) ? 'no_entities' : 'no_results');
+                let key = _.isEmpty(this.collection.state.filters) ?
+                    'pim_datagrid.no_entities' :
+                    'pim_datagrid.no_results';
 
                 if (Translator.has('jsmessages:' + key + '.' + entityHint)) {
                     key += '.' + entityHint;

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/api_connection/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/api_connection/create.yml
@@ -6,7 +6,7 @@ extensions:
                title: pim_common.create
                subTitle: pim_menu.item.api_connection
            picture: illustrations/Api.svg
-           successMessage: pim_enrich.entity.api_connection.flash.create.successd
+           successMessage: pim_enrich.entity.api_connection.flash.create.success
            postUrl: pim_enrich_api_connection_rest_create
            editRoute: pim_enrich_api_connection_index
            gridName: api-connection-grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/api_connection/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/api_connection/create.yml
@@ -6,7 +6,7 @@ extensions:
                title: pim_common.create
                subTitle: pim_menu.item.api_connection
            picture: illustrations/Api.svg
-           successMessage: pim_enrich.entity.api_connection.message.created
+           successMessage: pim_enrich.entity.api_connection.flash.create.successd
            postUrl: pim_enrich_api_connection_rest_create
            editRoute: pim_enrich_api_connection_index
            gridName: api-connection-grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/api_connection/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/api_connection/index.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-api-connection-index
         targetZone: title
         config:
-            title: pim_enrich.index.api_connection.title
+            title: pim_enrich.entity.api_connection.page_title.index
 
     pim-api-connection-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/association_type/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/association_type/create.yml
@@ -6,7 +6,7 @@ extensions:
                 title: pim_common.create
                 subTitle: pim_menu.item.association_type
             picture: illustrations/Association-types.svg
-            successMessage: pim_enrich.entity.association_type.message.created
+            successMessage: pim_enrich.entity.association_type.flash.create.success
             editRoute: pim_enrich_associationtype_edit
             postUrl: pim_enrich_associationtype_rest_create
             routerKey: code

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/association_type/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/association_type/edit.yml
@@ -79,7 +79,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.association_type.title
+            entity: pim_enrich.entity.association_type.label
 
     pim-association-type-edit-form-properties-tab:
         module: pim/common/tab

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/association_type/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/association_type/edit.yml
@@ -52,8 +52,8 @@ extensions:
                 title: confirmation.remove.association_type
                 subTitle: pim_menu.item.association_type
                 content: pim_common.confirm_deletion
-                success: flash.association_type.removed
-                fail: error.removing.association_type
+                success: pim_enrich.entity.association_type.flash.delete.success
+                fail: pim_enrich.entity.association_type.flash.delete.fail
             redirect: pim_enrich_associationtype_index
 
     pim-association-type-edit-form-save-buttons:
@@ -68,9 +68,9 @@ extensions:
         targetZone: buttons
         position: 0
         config:
-            updateSuccessMessage: pim_enrich.entity.association_type.info.update_successful
-            updateFailureMessage: pim_enrich.entity.association_type.info.update_failed
-            notReadyMessage: pim_enrich.entity.association_type.info.field_not_ready
+            updateSuccessMessage: pim_enrich.entity.association_type.flash.update.success
+            updateFailureMessage: pim_enrich.entity.association_type.flash.update.fail
+            notReadyMessage: pim_enrich.entity.association_type.flash.update.fields_not_ready
             url: pim_enrich_associationtype_rest_post
 
     pim-association-type-edit-form-state:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/association_type/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/association_type/index.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-association-type-index
         targetZone: title
         config:
-            title: pim_enrich.index.association_type.title
+            title: pim_enrich.entity.association_type.page_title.index
 
     pim-association-type-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/boolean.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/boolean.yml
@@ -11,7 +11,7 @@ extensions:
         position: 70
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-edit-form-boolean-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 80
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-edit-form-boolean-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,5 +29,5 @@ extensions:
         position: 90
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/create.yml
@@ -41,9 +41,9 @@ extensions:
         targetZone: buttons
         position: 0
         config:
-            updateSuccessMessage: pim_enrich.entity.attribute.info.update_successful
-            updateFailureMessage: pim_enrich.entity.attribute.info.update_failed
-            notReadyMessage: pim_enrich.entity.attribute.info.field_not_ready
+            updateSuccessMessage: pim_enrich.entity.attribute.flash.update.success
+            updateFailureMessage: pim_enrich.entity.attribute.flash.update.fail
+            notReadyMessage: pim_enrich.entity.attribute.flash.update.fields_not_ready
             url: pim_enrich_attribute_rest_create
             method: PUT
             redirectAfter: pim_enrich_attribute_edit

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/create.yml
@@ -56,7 +56,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.attribute.title
+            entity: pim_enrich.entity.attribute.label
 
     pim-attribute-create-form-form-tabs:
         module: pim/form/common/form-tabs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/create.yml
@@ -87,7 +87,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.common
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.common
                 dropZone: content
 
     pim-attribute-create-form-properties-common-code:
@@ -118,7 +118,7 @@ extensions:
         aclResourceId: pim_enrich_attributegroup_add_attribute
         config:
             fieldName: group
-            label: pim_enrich.form.attribute.tab.properties.label.group
+            label: pim_enrich.entity.attribute.property.group.label
             required: true
 
     pim-attribute-create-form-properties-common-unique:
@@ -128,7 +128,7 @@ extensions:
         position: 120
         config:
             fieldName: unique
-            label: pim_enrich.form.attribute.tab.properties.label.unique
+            label: pim_enrich.entity.attribute.property.unique
             activeForTypes: [pim_catalog_number, pim_catalog_text]
 
     pim-attribute-create-form-properties-common-scopable:
@@ -138,7 +138,7 @@ extensions:
         position: 130
         config:
             fieldName: scopable
-            label: pim_enrich.form.attribute.tab.properties.label.scopable
+            label: pim_enrich.entity.attribute.property.scopable
 
     pim-attribute-create-form-properties-common-localizable:
         module: pim/attribute-edit-form/properties/localizable
@@ -147,7 +147,7 @@ extensions:
         position: 140
         config:
             fieldName: localizable
-            label: pim_enrich.form.attribute.tab.properties.label.localizable
+            label: pim_enrich.entity.attribute.property.localizable
 
     pim-attribute-create-form-properties-type-specific:
         module: pim/attribute-edit-form/type-specific-form

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/date.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/date.yml
@@ -11,7 +11,7 @@ extensions:
         position: 70
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-edit-form-date-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 80
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-edit-form-date-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 90
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
     pim-attribute-form-date-validation-params:
         module: pim/common/simple-view
@@ -39,7 +39,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.validation
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.validation
                 dropZone: content
 
     pim-attribute-form-date-validation-params-date-min:
@@ -49,7 +49,7 @@ extensions:
         position: 100
         config:
             fieldName: date_min
-            label: pim_enrich.form.attribute.tab.properties.label.date_min
+            label: pim_enrich.entity.attribute.property.date_min
 
     pim-attribute-form-date-validation-params-date-max:
         module: pim/form/common/fields/date
@@ -58,4 +58,4 @@ extensions:
         position: 110
         config:
             fieldName: date_max
-            label: pim_enrich.form.attribute.tab.properties.label.date_max
+            label: pim_enrich.entity.attribute.property.date_max

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/edit.yml
@@ -76,7 +76,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.attribute.title
+            entity: pim_enrich.entity.attribute.label
 
     pim-attribute-edit-form-form-tabs:
         module: pim/form/common/form-tabs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/edit.yml
@@ -46,8 +46,8 @@ extensions:
                 title: confirmation.remove.attribute
                 subTitle: pim_common.attributes
                 content: pim_common.confirm_deletion
-                success: flash.attribute.removed
-                failed: error.removing.attribute
+                success: pim_enrich.entity.attribute.flash.delete.success
+                failed: pim_enrich.entity.attribute.flash.delete.fail
             redirect: pim_enrich_attribute_index
 
     pim-attribute-edit-form-save-buttons:
@@ -62,9 +62,9 @@ extensions:
         targetZone: buttons
         position: 0
         config:
-            updateSuccessMessage: pim_enrich.entity.attribute.info.update_successful
-            updateFailureMessage: pim_enrich.entity.attribute.info.update_failed
-            notReadyMessage: pim_enrich.entity.attribute.info.field_not_ready
+            updateSuccessMessage: pim_enrich.entity.attribute.flash.update.success
+            updateFailureMessage: pim_enrich.entity.attribute.flash.update.fail
+            notReadyMessage: pim_enrich.entity.attribute.flash.update.fields_not_ready
             url: pim_enrich_attribute_rest_post
             redirectAfter: pim_enrich_attribute_edit
             identifierParamName: code

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/edit.yml
@@ -44,7 +44,7 @@ extensions:
         config:
             trans:
                 title: confirmation.remove.attribute
-                subTitle: pim_common.attributes
+                subTitle: pim_enrich.entity.attribute.plural_label
                 content: pim_common.confirm_deletion
                 success: pim_enrich.entity.attribute.flash.delete.success
                 failed: pim_enrich.entity.attribute.flash.delete.fail
@@ -107,7 +107,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.common
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.common
                 dropZone: content
 
     pim-attribute-edit-form-properties-common-code:
@@ -139,7 +139,7 @@ extensions:
         aclResourceId: pim_enrich_attributegroup_add_attribute
         config:
             fieldName: group
-            label: pim_enrich.form.attribute.tab.properties.label.group
+            label: pim_enrich.entity.attribute.property.group.label
             required: true
 
     pim-attribute-edit-form-properties-common-unique:
@@ -149,7 +149,7 @@ extensions:
         position: 120
         config:
             fieldName: unique
-            label: pim_enrich.form.attribute.tab.properties.label.unique
+            label: pim_enrich.entity.attribute.property.unique
             readOnly: true
 
     pim-attribute-edit-form-properties-common-scopable:
@@ -159,7 +159,7 @@ extensions:
         position: 130
         config:
             fieldName: scopable
-            label: pim_enrich.form.attribute.tab.properties.label.scopable
+            label: pim_enrich.entity.attribute.property.scopable
             readOnly: true
 
     pim-attribute-edit-form-properties-common-localizable:
@@ -169,7 +169,7 @@ extensions:
         position: 140
         config:
             fieldName: localizable
-            label: pim_enrich.form.attribute.tab.properties.label.localizable
+            label: pim_enrich.entity.attribute.property.localizable
             readOnly: true
 
     pim-attribute-edit-form-properties-type-specific:
@@ -186,7 +186,7 @@ extensions:
         targetZone: container
         position: 110
         config:
-            label: pim_enrich.form.attribute.tab.choices.title
+            label: pim_enrich.entity.attribute.tab.choices.title
             activeForTypes: [pim_catalog_multiselect, pim_catalog_simpleselect]
 
     pim-attribute-edit-form-choices-auto-sorting:
@@ -196,7 +196,7 @@ extensions:
         position: 100
         config:
             fieldName: auto_option_sorting
-            label: pim_enrich.form.attribute.tab.properties.label.auto_option_sorting
+            label: pim_enrich.entity.attribute.property.auto_option_sorting
             defaultValue: null
 
     pim-attribute-edit-form-choices-options-grid:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/file.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/file.yml
@@ -11,7 +11,7 @@ extensions:
         position: 70
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-edit-form-file-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 80
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-edit-form-file-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 90
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
     pim-attribute-form-file-validation-params:
         module: pim/common/simple-view
@@ -39,7 +39,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.validation
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.validation
                 dropZone: content
 
     pim-attribute-form-file-validation-params-max-file-size:
@@ -49,7 +49,7 @@ extensions:
         position: 100
         config:
             fieldName: max_file_size
-            label: pim_enrich.form.attribute.tab.properties.label.max_file_size
+            label: pim_enrich.entity.attribute.property.max_file_size
 
     pim-attribute-form-file-validation-params-allowed-extensions:
         module: pim/form/common/fields/select
@@ -58,7 +58,7 @@ extensions:
         position: 110
         config:
             fieldName: allowed_extensions
-            label: pim_enrich.form.attribute.tab.properties.label.allowed_extensions
+            label: pim_enrich.entity.attribute.property.allowed_extensions
             choices: '%pim_catalog_file_allowed_extensions%'
             isMultiple: true
             defaultValue: []

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/identifier.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/identifier.yml
@@ -11,7 +11,7 @@ extensions:
         position: 90
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
             readOnly: true
             defaultValue: true
 
@@ -22,7 +22,7 @@ extensions:
         position: 100
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
             readOnly: true
 
     pim-attribute-identifier-form-validation-params:
@@ -33,7 +33,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.validation
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.validation
                 dropZone: content
 
     pim-attribute-identifier-form-validation-params-max-characters:
@@ -43,7 +43,7 @@ extensions:
         position: 100
         config:
             fieldName: max_characters
-            label: pim_enrich.form.attribute.tab.properties.label.max_characters
+            label: pim_enrich.entity.attribute.property.max_characters
 
     pim-attribute-identifier-form-validation-params-validation-rule:
         module: pim/form/common/fields/select
@@ -52,9 +52,9 @@ extensions:
         position: 110
         config:
             fieldName: validation_rule
-            label: pim_enrich.form.attribute.tab.properties.label.validation_rule
+            label: pim_enrich.entity.attribute.property.validation_rule.label
             choices:
-                regexp: pim_enrich.entity.attribute.validation_rule.regexp
+                regexp: pim_enrich.entity.attribute.property.validation_rule.regexp
 
     pim-attribute-identifier-form-validation-params-validation-regexp:
         module: pim/attribute-edit-form/properties/validation-regexp
@@ -63,4 +63,4 @@ extensions:
         position: 120
         config:
             fieldName: validation_regexp
-            label: pim_enrich.form.attribute.tab.properties.label.validation_regexp
+            label: pim_enrich.entity.attribute.property.validation_regexp

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/image.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/image.yml
@@ -11,7 +11,7 @@ extensions:
         position: 70
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-edit-form-image-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 80
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-edit-form-image-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 90
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
     pim-attribute-form-image-validation-params:
         module: pim/common/simple-view
@@ -39,7 +39,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.validation
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.validation
                 dropZone: content
 
     pim-attribute-form-image-validation-params-max-file-size:
@@ -49,7 +49,7 @@ extensions:
         position: 100
         config:
             fieldName: max_file_size
-            label: pim_enrich.form.attribute.tab.properties.label.max_file_size
+            label: pim_enrich.entity.attribute.property.max_file_size
 
     pim-attribute-form-image-validation-params-allowed-extensions:
         module: pim/form/common/fields/select
@@ -58,7 +58,7 @@ extensions:
         position: 110
         config:
             fieldName: allowed_extensions
-            label: pim_enrich.form.attribute.tab.properties.label.allowed_extensions
+            label: pim_enrich.entity.attribute.property.allowed_extensions
             choices: '%pim_catalog_image_allowed_extensions%'
             isMultiple: true
             defaultValue: []

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/index.yml
@@ -65,5 +65,5 @@ extensions:
         position: 100
         aclResourceId: pim_enrich_attribute_create
         config:
-            buttonTitle: pim_enrich.index.attribute.create_btn
-            modalTitle: pim_enrich.index.attribute.modal_title
+            buttonTitle: pim_enrich.entity.attribute.create.create_btn
+            modalTitle: pim_enrich.entity.attribute.property.type.choose

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/index.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-attribute-index
         targetZone: title
         config:
-            title: pim_enrich.index.attribute.title
+            title: pim_enrich.entity.attribute.page_title.index
 
     pim-attribute-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/metric/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/metric/create.yml
@@ -11,7 +11,7 @@ extensions:
         position: 70
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-edit-form-metric-create-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 80
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-edit-form-metric-create-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 90
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
     pim-attribute-form-metric-create-type-specific-params:
         module: pim/common/simple-view
@@ -39,7 +39,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.type_specific
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.type_specific
                 dropZone: content
 
     pim-attribute-form-metric-create-type-specific-params-metric-family:
@@ -49,7 +49,7 @@ extensions:
         position: 100
         config:
             fieldName: metric_family
-            label: pim_enrich.form.attribute.tab.properties.label.metric_family
+            label: pim_enrich.entity.attribute.property.metric_family.label
             required: true
 
     pim-attribute-form-metric-create-type-specific-params-default-metric-unit:
@@ -59,7 +59,7 @@ extensions:
         position: 110
         config:
             fieldName: default_metric_unit
-            label: pim_enrich.form.attribute.tab.properties.label.default_metric_unit
+            label: pim_enrich.entity.attribute.property.default_metric_unit.label
             required: true
 
     pim-attribute-form-metric-create-validation-params:
@@ -70,7 +70,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.validation
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.validation
                 dropZone: content
 
     pim-attribute-form-metric-create-validation-params-negative-allowed:
@@ -80,7 +80,7 @@ extensions:
         position: 100
         config:
             fieldName: negative_allowed
-            label: pim_enrich.form.attribute.tab.properties.label.negative_allowed
+            label: pim_enrich.entity.attribute.property.negative_allowed
             defaultValue: true
 
     pim-attribute-form-metric-create-validation-params-decimals-allowed:
@@ -90,7 +90,7 @@ extensions:
         position: 110
         config:
             fieldName: decimals_allowed
-            label: pim_enrich.form.attribute.tab.properties.label.decimals_allowed
+            label: pim_enrich.entity.attribute.property.decimals_allowed
             defaultValue: true
 
     pim-attribute-form-metric-create-validation-params-number-min:
@@ -100,7 +100,7 @@ extensions:
         position: 120
         config:
             fieldName: number_min
-            label: pim_enrich.form.attribute.tab.properties.label.number_min
+            label: pim_enrich.entity.attribute.property.number_min
 
     pim-attribute-form-metric-create-validation-params-number-max:
         module: pim/form/common/fields/text
@@ -109,4 +109,4 @@ extensions:
         position: 130
         config:
             fieldName: number_max
-            label: pim_enrich.form.attribute.tab.properties.label.number_max
+            label: pim_enrich.entity.attribute.property.number_max

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/metric/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/metric/edit.yml
@@ -11,7 +11,7 @@ extensions:
         position: 70
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-edit-form-metric-edit-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 80
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-edit-form-metric-edit-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 90
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
     pim-attribute-form-metric-edit-type-specific-params:
         module: pim/common/simple-view
@@ -39,7 +39,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.type_specific
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.type_specific
                 dropZone: content
 
     pim-attribute-form-metric-edit-type-specific-params-metric-family:
@@ -49,7 +49,7 @@ extensions:
         position: 100
         config:
             fieldName: metric_family
-            label: pim_enrich.form.attribute.tab.properties.label.metric_family
+            label: pim_enrich.entity.attribute.property.metric_family.label
             readOnly: true
             required: true
 
@@ -60,7 +60,7 @@ extensions:
         position: 110
         config:
             fieldName: default_metric_unit
-            label: pim_enrich.form.attribute.tab.properties.label.default_metric_unit
+            label: pim_enrich.entity.attribute.property.default_metric_unit.label
             required: true
 
     pim-attribute-form-metric-edit-validation-params:
@@ -71,7 +71,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.validation
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.validation
                 dropZone: content
 
     pim-attribute-form-metric-edit-validation-params-negative-allowed:
@@ -81,7 +81,7 @@ extensions:
         position: 100
         config:
             fieldName: negative_allowed
-            label: pim_enrich.form.attribute.tab.properties.label.negative_allowed
+            label: pim_enrich.entity.attribute.property.negative_allowed
 
     pim-attribute-form-metric-edit-validation-params-decimals-allowed:
         module: pim/form/common/fields/boolean
@@ -90,7 +90,7 @@ extensions:
         position: 110
         config:
             fieldName: decimals_allowed
-            label: pim_enrich.form.attribute.tab.properties.label.decimals_allowed
+            label: pim_enrich.entity.attribute.property.decimals_allowed
 
     pim-attribute-form-metric-edit-validation-params-number-min:
         module: pim/form/common/fields/text
@@ -99,7 +99,7 @@ extensions:
         position: 120
         config:
             fieldName: number_min
-            label: pim_enrich.form.attribute.tab.properties.label.number_min
+            label: pim_enrich.entity.attribute.property.number_min
 
     pim-attribute-form-metric-edit-validation-params-number-max:
         module: pim/form/common/fields/text
@@ -108,4 +108,4 @@ extensions:
         position: 130
         config:
             fieldName: number_max
-            label: pim_enrich.form.attribute.tab.properties.label.number_max
+            label: pim_enrich.entity.attribute.property.number_max

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/number.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/number.yml
@@ -11,7 +11,7 @@ extensions:
         position: 70
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-edit-form-number-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 80
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-edit-form-number-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 90
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
     pim-attribute-form-number-validation-params:
         module: pim/common/simple-view
@@ -39,7 +39,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.validation
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.validation
                 dropZone: content
 
     pim-attribute-form-number-validation-params-negative-allowed:
@@ -49,7 +49,7 @@ extensions:
         position: 100
         config:
             fieldName: negative_allowed
-            label: pim_enrich.form.attribute.tab.properties.label.negative_allowed
+            label: pim_enrich.entity.attribute.property.negative_allowed
             defaultValue: true
 
     pim-attribute-form-number-validation-params-decimals-allowed:
@@ -59,7 +59,7 @@ extensions:
         position: 110
         config:
             fieldName: decimals_allowed
-            label: pim_enrich.form.attribute.tab.properties.label.decimals_allowed
+            label: pim_enrich.entity.attribute.property.decimals_allowed
             defaultValue: true
 
     pim-attribute-form-number-validation-params-number-min:
@@ -69,7 +69,7 @@ extensions:
         position: 120
         config:
             fieldName: number_min
-            label: pim_enrich.form.attribute.tab.properties.label.number_min
+            label: pim_enrich.entity.attribute.property.number_min
 
     pim-attribute-form-number-validation-params-number-max:
         module: pim/form/common/fields/text
@@ -78,4 +78,4 @@ extensions:
         position: 130
         config:
             fieldName: number_max
-            label: pim_enrich.form.attribute.tab.properties.label.number_max
+            label: pim_enrich.entity.attribute.property.number_max

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/price.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/price.yml
@@ -11,7 +11,7 @@ extensions:
         position: 70
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-edit-form-price-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 80
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-edit-form-price-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 90
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
     pim-attribute-form-price-validation-params:
         module: pim/common/simple-view
@@ -39,7 +39,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.validation
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.validation
                 dropZone: content
 
     pim-attribute-form-price-validation-params-decimals-allowed:
@@ -49,7 +49,7 @@ extensions:
         position: 100
         config:
             fieldName: decimals_allowed
-            label: pim_enrich.form.attribute.tab.properties.label.decimals_allowed
+            label: pim_enrich.entity.attribute.property.decimals_allowed
             defaultValue: true
 
     pim-attribute-form-price-validation-params-number-min:
@@ -59,7 +59,7 @@ extensions:
         position: 110
         config:
             fieldName: number_min
-            label: pim_enrich.form.attribute.tab.properties.label.number_min
+            label: pim_enrich.entity.attribute.property.number_min
 
     pim-attribute-form-price-validation-params-number-max:
         module: pim/form/common/fields/text
@@ -68,4 +68,4 @@ extensions:
         position: 120
         config:
             fieldName: number_max
-            label: pim_enrich.form.attribute.tab.properties.label.number_max
+            label: pim_enrich.entity.attribute.property.number_max

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/select.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/select.yml
@@ -11,7 +11,7 @@ extensions:
         position: 70
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-edit-form-select-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 80
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-edit-form-select-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 90
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
     pim-attribute-form-select-type-specific-params:
         module: pim/common/simple-view
@@ -39,7 +39,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.type_specific
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.type_specific
                 dropZone: content
 
     pim-attribute-form-select-type-specific-params-minimum-input-length:
@@ -49,4 +49,4 @@ extensions:
         position: 100
         config:
             fieldName: minimum_input_length
-            label: pim_enrich.form.attribute.tab.properties.label.minimum_input_length
+            label: pim_enrich.entity.attribute.property.minimum_input_length

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/text.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/text.yml
@@ -11,7 +11,7 @@ extensions:
         position: 70
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-edit-form-text-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 80
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-edit-form-text-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 90
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
     pim-attribute-form-text-validation-params:
         module: pim/common/simple-view
@@ -39,7 +39,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.validation
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.validation
                 dropZone: content
 
     pim-attribute-form-text-validation-params-max-characters:
@@ -49,7 +49,7 @@ extensions:
         position: 100
         config:
             fieldName: max_characters
-            label: pim_enrich.form.attribute.tab.properties.label.max_characters
+            label: pim_enrich.entity.attribute.property.max_characters
 
     pim-attribute-form-text-validation-params-validation-rule:
         module: pim/form/common/fields/select
@@ -58,11 +58,11 @@ extensions:
         position: 110
         config:
             fieldName: validation_rule
-            label: pim_enrich.form.attribute.tab.properties.label.validation_rule
+            label: pim_enrich.entity.attribute.property.validation_rule.label
             choices:
-                email: pim_enrich.entity.attribute.validation_rule.email
-                regexp: pim_enrich.entity.attribute.validation_rule.regexp
-                url: pim_enrich.entity.attribute.validation_rule.url
+                email: pim_enrich.entity.attribute.property.validation_rule.email
+                regexp: pim_enrich.entity.attribute.property.validation_rule.regexp
+                url: pim_enrich.entity.attribute.property.validation_rule.url
 
     pim-attribute-form-text-validation-params-validation-regexp:
         module: pim/attribute-edit-form/properties/validation-regexp
@@ -71,4 +71,4 @@ extensions:
         position: 120
         config:
             fieldName: validation_regexp
-            label: pim_enrich.form.attribute.tab.properties.label.validation_regexp
+            label: pim_enrich.entity.attribute.property.validation_regexp

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/textarea.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute/textarea.yml
@@ -11,7 +11,7 @@ extensions:
         position: 70
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-edit-form-textarea-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 80
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-edit-form-textarea-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 90
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
     pim-attribute-form-textarea-type-specific-params:
         module: pim/common/simple-view
@@ -39,7 +39,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.type_specific
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.type_specific
                 dropZone: content
 
     pim-attribute-form-textarea-type-specific-params-wysiwyg-enabled:
@@ -49,7 +49,7 @@ extensions:
         position: 100
         config:
             fieldName: wysiwyg_enabled
-            label: pim_enrich.form.attribute.tab.properties.label.wysiwyg_enabled
+            label: pim_enrich.entity.attribute.property.wysiwyg_enabled
 
     pim-attribute-form-textarea-validation-params:
         module: pim/common/simple-view
@@ -59,7 +59,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.validation
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.validation
                 dropZone: content
 
     pim-attribute-form-textarea-validation-params-max-characters:
@@ -69,4 +69,4 @@ extensions:
         position: 100
         config:
             fieldName: max_characters
-            label: pim_enrich.form.attribute.tab.properties.label.max_characters
+            label: pim_enrich.entity.attribute.property.max_characters

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/create.yml
@@ -44,7 +44,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.attribute_group.title
+            entity: pim_enrich.entity.attribute_group.label
 
     pim-attribute-group-create-form-properties-tab:
         module: pim/common/tab

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/create.yml
@@ -31,9 +31,9 @@ extensions:
         targetZone: buttons
         position: 0
         config:
-            updateSuccessMessage: pim_enrich.entity.attribute_group.info.update_successful
-            updateFailureMessage: pim_enrich.entity.attribute_group.info.update_failed
-            notReadyMessage: pim_enrich.entity.attribute_group.info.field_not_ready
+            updateSuccessMessage: pim_enrich.entity.attribute_group.flash.update.success
+            updateFailureMessage: pim_enrich.entity.attribute_group.flash.update.fail
+            notReadyMessage: pim_enrich.entity.attribute_group.flash.update.fields_not_ready
             url: pim_enrich_attributegroup_rest_create
             method: PUT
             redirectAfter: pim_enrich_attributegroup_edit

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/edit.yml
@@ -153,9 +153,9 @@ extensions:
             title: pim_common.attributes
             otherGroup: other
             confirmation:
-                title: pim_enrich.confirmation.remove_item
+                title: confirmation.remove.alternative_title
                 subTitle: pim_common.attribute_groups
-                message: pim_enrich.confirmation.delete.attribute_group
+                message: confirmation.remove.attribute_from_group
                 buttonText: pim_common.remove
             removeAttributeACL: pim_enrich_attributegroup_remove_attribute
             addAttributeACL: pim_enrich_attributegroup_add_attribute

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/edit.yml
@@ -52,8 +52,8 @@ extensions:
                 title: confirmation.remove.attribute_group
                 subTitle: pim_common.attribute_groups
                 content: pim_common.confirm_deletion
-                success: flash.attribute_group.removed
-                fail: error.removing.attribute_group
+                success: pim_enrich.entity.attribute_group.flash.delete.success
+                fail: pim_enrich.entity.attribute_group.flash.delete.fail
             redirect: pim_enrich_attributegroup_index
 
     pim-attribute-group-edit-form-save-buttons:
@@ -68,9 +68,9 @@ extensions:
         targetZone: buttons
         position: 0
         config:
-            updateSuccessMessage: pim_enrich.entity.attribute_group.info.update_successful
-            updateFailureMessage: pim_enrich.entity.attribute_group.info.update_failed
-            notReadyMessage: pim_enrich.entity.attribute_group.info.field_not_ready
+            updateSuccessMessage: pim_enrich.entity.attribute_group.flash.update.success
+            updateFailureMessage: pim_enrich.entity.attribute_group.flash.update.fail
+            notReadyMessage: pim_enrich.entity.attribute_group.flash.update.fields_not_ready
             url: pim_enrich_attributegroup_rest_post
 
     pim-attribute-group-edit-form-state:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/edit.yml
@@ -50,7 +50,7 @@ extensions:
         config:
             trans:
                 title: confirmation.remove.attribute_group
-                subTitle: pim_common.attribute_groups
+                subTitle: pim_enrich.entity.attribute_group.plural_label
                 content: pim_common.confirm_deletion
                 success: pim_enrich.entity.attribute_group.flash.delete.success
                 fail: pim_enrich.entity.attribute_group.flash.delete.fail
@@ -150,11 +150,11 @@ extensions:
         targetZone: container
         position: 120
         config:
-            title: pim_common.attributes
+            title: pim_enrich.entity.attribute.plural_label
             otherGroup: other
             confirmation:
                 title: confirmation.remove.alternative_title
-                subTitle: pim_common.attribute_groups
+                subTitle: pim_enrich.entity.attribute_group.plural_label
                 message: confirmation.remove.attribute_from_group
                 buttonText: pim_common.remove
             removeAttributeACL: pim_enrich_attributegroup_remove_attribute

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/edit.yml
@@ -79,7 +79,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.attribute_group.title
+            entity: pim_enrich.entity.attribute_group.label
 
     pim-attribute-group-edit-form-created:
         module: pim/form/common/meta/created

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/index.yml
@@ -9,7 +9,7 @@ extensions:
         parent: pim-attribute-group-index
         targetZone: title
         config:
-            title: pim_common.attribute_groups
+            title: pim_enrich.entity.attribute_group.plural_label
             countable: false
 
     pim-attribute-group-index-user-navigation:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/create.yml
@@ -39,7 +39,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_common.channel
+            entity: pim_enrich.entity.channel.uppercase_label
 
     pim-channel-create-form-properties-tab:
         module: pim/common/tab

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/edit.yml
@@ -76,7 +76,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.channel.uppercase_label
+            entity: pim_enrich.entity.channel.label
 
     pim-channel-edit-form-properties-tab:
         module: pim/common/tab

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/edit.yml
@@ -52,8 +52,8 @@ extensions:
                 title: confirmation.remove.channel
                 subTitle: pim_menu.item.channel
                 content: pim_common.confirm_deletion
-                success: flash.channel.removed
-                fail: error.removing.channel
+                success: pim_enrich.entity.channel.flash.delete.success
+                fail: pim_enrich.entity.channel.flash.delete.fail
             redirect: pim_enrich_channel_index
 
     pim-channel-edit-form-save-buttons:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/edit.yml
@@ -76,7 +76,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_common.channel
+            entity: pim_enrich.entity.channel.uppercase_label
 
     pim-channel-edit-form-properties-tab:
         module: pim/common/tab

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/index.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-channel-index
         targetZone: title
         config:
-            title: pim_enrich.index.channel.title
+            title: pim_enrich.entity.channel.page_title.index
 
     pim-channel-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/common/menu.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/common/menu.yml
@@ -74,7 +74,7 @@ extensions:
         targetZone: mainMenu
         aclResourceId: pim_enrich_product_index
         config:
-            title: pim_common.products
+            title: pim_enrich.entity.product.plural_label
             iconModifier: iconProduct
             to: pim_enrich_product_index
 
@@ -123,7 +123,7 @@ extensions:
         aclResourceId: pim_enrich_attributegroup_index
         position: 100
         config:
-            title: pim_common.attribute_groups
+            title: pim_enrich.entity.attribute_group.plural_label
             to: pim_enrich_attributegroup_index
 
     pim-menu-settings-attribute:
@@ -134,7 +134,7 @@ extensions:
         # position: 110
         position: 0
         config:
-            title: pim_common.attributes
+            title: pim_enrich.entity.attribute.plural_label
             to: pim_enrich_attribute_index
 
     pim-menu-settings-product-category:
@@ -143,7 +143,7 @@ extensions:
         aclResourceId: pim_enrich_product_category_list
         position: 120
         config:
-            title: pim_common.categories
+            title: pim_enrich.entity.category.plural_label
             to: pim_enrich_categorytree_index
 
     pim-menu-settings-family:
@@ -197,7 +197,7 @@ extensions:
         aclResourceId: pim_enrich_locale_index
         position: 190
         config:
-            title: pim_common.locales
+            title: pim_enrich.entity.locale.plural_label
             to: pim_enrich_locale_index
 
     pim-menu-settings-channel:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/currency/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/currency/index.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-currency-index
         targetZone: title
         config:
-            title: pim_enrich.index.currency.title
+            title: pim_enrich.entity.currency.page_title.index
 
     pim-currency-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/export/create-profile.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/export/create-profile.yml
@@ -37,5 +37,5 @@ extensions:
         config:
           type: export
           identifier: job_name
-          label: pim_enrich.form.job_instance.meta.job
+          label: pim_import_export.form.job_instance.meta.job
           url: pim_enrich_job_instance_rest_jobs_get

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/export/index-profile.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/export/index-profile.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-export-profile-index
         targetZone: title
         config:
-            title: pim_enrich.entity.export_profile.page_title.index
+            title: pim_import_export.entity.export_profile.page_title.index
 
     pim-export-profile-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/export/index-profile.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/export/index-profile.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-export-profile-index
         targetZone: title
         config:
-            title: pim_enrich.index.export_profiles.title
+            title: pim_enrich.entity.export_profile.page_title.index
 
     pim-export-profile-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/create.yml
@@ -6,7 +6,7 @@ extensions:
                 title: pim_common.create
                 subTitle: pim_menu.item.family
             picture: illustrations/Family.svg
-            successMessage: pim_enrich.entity.family.message.created
+            successMessage: pim_enrich.entity.family.flash.create.success
             editRoute: pim_enrich_family_edit
             postUrl: pim_enrich_family_rest_create
             routerKey: code

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
@@ -208,9 +208,9 @@ extensions:
         config:
             label: pim_common.label
             confirmation:
-                title: pim_enrich.confirmation.remove_item
+                title: confirmation.remove.alternative_title
                 subTitle: pim_common.attributes
-                message: pim_enrich.confirmation.delete.attribute_from_family
+                message: confirmation.remove.attribute_from_family
                 buttonText: pim_common.remove
 
     pim-family-edit-form-variant:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
@@ -74,7 +74,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.family.title
+            entity: pim_enrich.entity.family.label
 
     pim-family-edit-form-properties-tab:
         module: pim/common/tab

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
@@ -52,8 +52,8 @@ extensions:
                 title: confirmation.remove.family
                 subTitle: pim_menu.item.family
                 content: pim_common.confirm_deletion
-                success: flash.family.removed
-                fail: error.removing.family
+                success: pim_enrich.entity.family.flash.delete.success
+                fail: pim_enrich.entity.family.flash.delete.fail
             redirect: pim_enrich_family_index
 
     pim-family-edit-form-save-buttons:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
@@ -155,7 +155,7 @@ extensions:
         targetZone: container
         position: 150
         config:
-            label: 'pim_common.attributes'
+            label: 'pim_enrich.entity.attribute.plural_label'
 
     pim-family-edit-form-attributes-toolbar:
         module: pim/family-edit-form/attributes/toolbar
@@ -209,7 +209,7 @@ extensions:
             label: pim_common.label
             confirmation:
                 title: confirmation.remove.alternative_title
-                subTitle: pim_common.attributes
+                subTitle: pim_enrich.entity.attribute.plural_label
                 message: confirmation.remove.attribute_from_family
                 buttonText: pim_common.remove
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/index.yml
@@ -52,7 +52,7 @@ extensions:
         parent: pim-family-index
         targetZone: bottom-panel
         config:
-            label: pim_datagrid.mass_edit.selected.family
+            label: pim_datagrid.mass_action.selected.family
 
     pim-family-index-actions-panel:
         module: oro/datagrid/actions-panel

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/index.yml
@@ -27,7 +27,7 @@ extensions:
         parent: pim-family-index
         targetZone: title
         config:
-            title: pim_enrich.index.family.title
+            title: pim_enrich.entity.family.page_title.index
 
     pim-family-breadcrumbs:
         module: pim/common/breadcrumbs
@@ -52,7 +52,7 @@ extensions:
         parent: pim-family-index
         targetZone: bottom-panel
         config:
-            label: pim_enrich.entity.family.selected
+            label: pim_datagrid.mass_edit.selected.family
 
     pim-family-index-actions-panel:
         module: oro/datagrid/actions-panel

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family_variant/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family_variant/edit.yml
@@ -13,48 +13,13 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.family_variant.title
-
-    pim-family-variant-edit-form-tabs:
-        module: pim/form/common/form-tabs
-        parent: pim-family-variant-edit-form
-        targetZone: content
-        position: 90
-        config:
-            centered: true
-
-    pim-family-variant-edit-form-attribute-set-tab:
-        module: pim/common/tab
-        parent: pim-family-variant-edit-form-tabs
-        targetZone: container
-        position: 100
-        config:
-            label: 'pim_enrich.form.family_variant.tab.attributes.title'
-
-    pim-family-variant-edit-form-labels-tab:
-        module: pim/common/tab
-        parent: pim-family-variant-edit-form-tabs
-        targetZone: container
-        position: 110
-        config:
-            label: 'pim_enrich.form.family_variant.tab.labels.title'
+            entity: pim_enrich.entity.family_variant.label
 
     pim-family-variant-edit-form-attribute-set:
         module: pim/family-variant-edit-form/attribute-set
-        parent: pim-family-variant-edit-form-attribute-set-tab
-        targetZone: self
-
-    pim-family-variant-edit-form-labels-container:
-        module: pim/family-variant-edit-form/labels-container
-        parent: pim-family-variant-edit-form-labels-tab
-        targetZone: self
-
-    pim-family-variant-edit-form-labels-translation:
-        module: pim/common/properties/translation
-        parent: pim-family-variant-edit-form-labels-container
-        targetZone: fields
-        config:
-            fieldBaseId: 'pim_enrich_family_variant_form_label_'
+        parent: pim-family-variant-edit-form
+        targetZone: content
+        position: 100
 
     pim-family-variant-edit-form-save-buttons:
         module: pim/form/common/save-buttons

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family_variant/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family_variant/edit.yml
@@ -15,11 +15,47 @@ extensions:
         config:
             entity: pim_enrich.entity.family_variant.label
 
-    pim-family-variant-edit-form-attribute-set:
+    pim-family-variant-edit-form-tabs:
+        module: pim/form/common/form-tabs
         module: pim/family-variant-edit-form/attribute-set
         parent: pim-family-variant-edit-form
         targetZone: content
+        position: 90
+        config:
+            centered: true
+
+    pim-family-variant-edit-form-attribute-set-tab:
+        module: pim/common/tab
+        parent: pim-family-variant-edit-form-tabs
+        targetZone: container
         position: 100
+        config:
+            label: 'pim_enrich.form.family_variant.tab.attributes.title'
+
+    pim-family-variant-edit-form-labels-tab:
+        module: pim/common/tab
+        parent: pim-family-variant-edit-form-tabs
+        targetZone: container
+        position: 110
+        config:
+            label: 'pim_enrich.form.family_variant.tab.labels.title'
+
+    pim-family-variant-edit-form-attribute-set:
+        module: pim/family-variant-edit-form/attribute-set
+        parent: pim-family-variant-edit-form-attribute-set-tab
+        targetZone: self
+
+    pim-family-variant-edit-form-labels-container:
+        module: pim/family-variant-edit-form/labels-container
+        parent: pim-family-variant-edit-form-labels-tab
+        targetZone: self
+
+    pim-family-variant-edit-form-labels-translation:
+        module: pim/common/properties/translation
+        parent: pim-family-variant-edit-form-labels-container
+        targetZone: fields
+        config:
+            fieldBaseId: 'pim_enrich_family_variant_form_label_'
 
     pim-family-variant-edit-form-save-buttons:
         module: pim/form/common/save-buttons

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/create.yml
@@ -6,7 +6,7 @@ extensions:
                 title: pim_common.create
                 subTitle: pim_menu.item.group
             picture: illustrations/Groups.svg
-            successMessage: pim_enrich.entity.group.message.created
+            successMessage: pim_enrich.entity.group.flash.create.success
             editRoute: pim_enrich_group_edit
             postUrl: pim_enrich_group_rest_create
             routerKey: code

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/edit.yml
@@ -82,7 +82,7 @@ extensions:
         targetZone: meta
         position: 110
         config:
-            productCountLabel: pim_common.products
+            productCountLabel: pim_enrich.entity.product.plural_label
 
     pim-group-edit-form-properties-tab:
         module: pim/common/tab
@@ -140,5 +140,5 @@ extensions:
         targetZone: container
         position: 80
         config:
-            label: 'pim_common.products'
+            label: 'pim_enrich.entity.product.plural_label'
             gridId: 'product-group-grid'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/edit.yml
@@ -74,7 +74,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.group.title
+            entity: pim_enrich.entity.group.label
 
     pim-group-edit-form-product-count:
         module: pim/group-edit-form/meta/product-count

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/edit.yml
@@ -52,8 +52,8 @@ extensions:
                 title: confirmation.remove.group
                 subTitle: pim_menu.item.group
                 content: pim_common.confirm_deletion
-                success: flash.group.removed
-                fail: error.removing.group
+                success: pim_enrich.entity.group.flash.delete.success
+                fail: pim_enrich.entity.group.flash.delete.fail
             redirect: pim_enrich_group_index
 
     pim-group-edit-form-save-buttons:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group/index.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-group-index
         targetZone: title
         config:
-            title: pim_enrich.index.group.title
+            title: pim_enrich.entity.group.page_title.index
 
     pim-group-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group_type/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group_type/create.yml
@@ -6,7 +6,7 @@ extensions:
                title: pim_common.create
                subTitle: pim_menu.item.group_type
            picture: illustrations/Groups.svg
-           successMessage: pim_enrich.entity.group_type.message.created
+           successMessage: pim_enrich.entity.group_type.flash.create.success
            editRoute: pim_enrich_grouptype_edit
            postUrl: pim_enrich_grouptype_rest_create
            routerKey: code

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group_type/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group_type/edit.yml
@@ -79,7 +79,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.group_type.title
+            entity: pim_enrich.entity.group_type.label
 
     pim-group-type-edit-form-properties-tab:
         module: pim/common/tab

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group_type/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group_type/edit.yml
@@ -52,8 +52,8 @@ extensions:
                 title: confirmation.remove.group_type
                 subTitle: pim_menu.item.group_type
                 content: pim_common.confirm_deletion
-                success: flash.group_type.removed
-                fail: error.removing.group_type
+                success: pim_enrich.entity.group_type.flash.delete.success
+                fail: pim_enrich.entity.group_type.flash.delete.fail
             redirect: pim_enrich_grouptype_index
 
     pim-group-type-edit-form-save-buttons:
@@ -68,9 +68,9 @@ extensions:
         targetZone: buttons
         position: 0
         config:
-            updateSuccessMessage: pim_enrich.entity.group_type.info.update_successful
-            updateFailureMessage: pim_enrich.entity.group_type.info.update_failed
-            notReadyMessage: pim_enrich.entity.group_type.info.field_not_ready
+            updateSuccessMessage: pim_enrich.entity.group_type.flash.update.success
+            updateFailureMessage: pim_enrich.entity.group_type.flash.update.fail
+            notReadyMessage: pim_enrich.entity.group_type.flash.update.fields_not_ready
             url: pim_enrich_grouptype_rest_post
 
     pim-group-type-edit-form-state:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group_type/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/group_type/index.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-group-type-index
         targetZone: title
         config:
-            title: pim_enrich.index.grouptype.title
+            title: pim_enrich.entity.group_type.page_title.index
 
     pim-group-type-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/import/create-profile.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/import/create-profile.yml
@@ -37,5 +37,5 @@ extensions:
         config:
             type: import
             identifier: job_name
-            label: pim_enrich.form.job_instance.meta.job
+            label: pim_import_export.form.job_instance.meta.job
             url: pim_enrich_job_instance_rest_jobs_get

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/import/index-profile.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/import/index-profile.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-import-profile-index
         targetZone: title
         config:
-            title: pim_enrich.entity.import_profile.page_title.index
+            title: pim_import_export.entity.import_profile.page_title.index
 
     pim-import-profile-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/import/index-profile.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/import/index-profile.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-import-profile-index
         targetZone: title
         config:
-            title: pim_enrich.index.import_profiles.title
+            title: pim_enrich.entity.import_profile.page_title.index
 
     pim-import-profile-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_execution.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_execution.yml
@@ -43,7 +43,7 @@ extensions:
         position: 50
         config:
             buttonClass: AknDropdown-menuLink
-            label: pim_enrich.form.job_execution.button.show_profile.title
+            label: pim_import_export.form.job_execution.button.show_profile.title
             route: pim_importexport_import_profile_edit
 
     pim-job-execution-form-download-log:
@@ -52,7 +52,7 @@ extensions:
         targetZone: secondary-actions
         position: 90
         config:
-            label: pim_enrich.form.job_execution.button.download_log.title
+            label: pim_import_export.form.job_execution.button.download_log.title
             iconName: download-alt
             isVisiblePath: meta.logExists
             url: pim_importexport_export_execution_download_log

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
@@ -159,7 +159,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 
@@ -183,7 +183,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-csv-base-export-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
@@ -94,8 +94,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-base-export-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -105,8 +105,8 @@ extensions:
         config:
             fieldCode: configuration.delimiter
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
+            label: pim_import_export.form.job_instance.tab.properties.delimiter.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-base-export-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -116,8 +116,8 @@ extensions:
         config:
             fieldCode: configuration.enclosure
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+            label: pim_import_export.form.job_instance.tab.properties.enclosure.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-base-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -127,8 +127,8 @@ extensions:
         config:
             fieldCode: configuration.withHeader
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+            label: pim_import_export.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-csv-base-export-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
@@ -159,7 +159,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
@@ -183,7 +183,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-csv-base-export-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_export_show.yml
@@ -30,7 +30,7 @@ extensions:
         targetZone: meta
         position: 110
         config:
-            label: pim_enrich.form.job_instance.button.export.title
+            label: pim_import_export.form.job_instance.button.export.title
             route: pim_enrich_job_instance_rest_export_launch
             identifier:
                 path: code
@@ -60,7 +60,7 @@ extensions:
         parent: pim-job-instance-csv-base-export-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-csv-base-export-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
@@ -94,8 +94,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -105,8 +105,8 @@ extensions:
         config:
             fieldCode: configuration.uploadAllowed
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
+            label: pim_import_export.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-csv-base-import-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -116,8 +116,8 @@ extensions:
         config:
             fieldCode: configuration.delimiter
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
+            label: pim_import_export.form.job_instance.tab.properties.delimiter.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-base-import-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -127,8 +127,8 @@ extensions:
         config:
             fieldCode: configuration.enclosure
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+            label: pim_import_export.form.job_instance.tab.properties.enclosure.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-base-import-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
@@ -158,7 +158,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
@@ -158,7 +158,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 
@@ -182,7 +182,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-csv-base-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
@@ -182,7 +182,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-csv-base-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
@@ -37,20 +37,20 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 40
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
 
     pim-job-instance-csv-base-import-show-file-path:
         module: pim/job/common/file-path
         parent: pim-job-instance-csv-base-import-show-launch-switcher-item
         config:
-            label: pim_enrich.form.job_instance.file_path
+            label: pim_import_export.form.job_instance.file_path
 
     pim-job-instance-csv-base-import-show-import-button:
         module: pim/job/common/edit/launch
         parent: pim-job-instance-csv-base-import-show-file-path
         targetZone: buttons
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -63,7 +63,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
-            label: pim_enrich.form.job_instance.button.import.upload_file
+            label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-csv-base-import-show-upload:
         module: pim/job/common/edit/upload
@@ -77,7 +77,7 @@ extensions:
         parent: pim-job-instance-csv-base-import-show-upload-switcher-item
         position: 60
         config:
-            label: pim_enrich.form.job_instance.button.import.upload
+            label: pim_import_export.form.job_instance.button.import.upload
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -88,7 +88,7 @@ extensions:
         parent: pim-job-instance-csv-base-import-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-csv-base-import-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
@@ -208,7 +208,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 
@@ -232,7 +232,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-csv-product-export-edit-content-structure-scope:
         module: pim/job/product/edit/content/structure/scope

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
@@ -208,7 +208,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
@@ -232,7 +232,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-csv-product-export-edit-content-structure-scope:
         module: pim/job/product/edit/content/structure/scope

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
@@ -62,7 +62,7 @@ extensions:
         targetZone: container
         position: 130
         config:
-            tabTitle: pim_enrich.form.job_instance.tab.content.title
+            tabTitle: pim_import_export.form.job_instance.tab.content.title
             tabCode: pim-job-instance-content
 
     pim-job-instance-csv-product-export-edit-history:
@@ -104,8 +104,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-product-export-edit-properties-decimal-separator:
         module: pim/job/common/edit/field/decimal-separator
@@ -115,8 +115,8 @@ extensions:
         config:
             fieldCode: configuration.decimalSeparator
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+            label: pim_import_export.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-csv-product-export-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -126,8 +126,8 @@ extensions:
         config:
             fieldCode: configuration.dateFormat
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+            label: pim_import_export.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-csv-product-export-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -137,8 +137,8 @@ extensions:
         config:
             fieldCode: configuration.delimiter
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
+            label: pim_import_export.form.job_instance.tab.properties.delimiter.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-product-export-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -148,8 +148,8 @@ extensions:
         config:
             fieldCode: configuration.enclosure
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+            label: pim_import_export.form.job_instance.tab.properties.enclosure.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-product-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -159,8 +159,8 @@ extensions:
         config:
             fieldCode: configuration.withHeader
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+            label: pim_import_export.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-csv-product-export-edit-properties-with-media:
         module: pim/job/common/edit/field/switch
@@ -170,8 +170,8 @@ extensions:
         config:
             fieldCode: configuration.with_media
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
+            label: pim_import_export.form.job_instance.tab.properties.with_media.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.with_media.help
 
     pim-job-instance-csv-product-export-edit-content-structure:
         module: pim/job/product/edit/content/structure

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
@@ -30,7 +30,7 @@ extensions:
         targetZone: meta
         position: 110
         config:
-            label: pim_enrich.form.job_instance.button.export.title
+            label: pim_import_export.form.job_instance.button.export.title
             route: pim_enrich_job_instance_rest_export_launch
             identifier:
                 path: code
@@ -60,7 +60,7 @@ extensions:
         parent: pim-job-instance-csv-product-export-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-csv-product-export-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
@@ -246,7 +246,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 
@@ -270,7 +270,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-csv-product-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
@@ -246,7 +246,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
@@ -93,8 +93,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-product-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -104,8 +104,8 @@ extensions:
         config:
             fieldCode: configuration.uploadAllowed
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
+            label: pim_import_export.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.upload_allowed.help
             readOnly: false
 
     pim-job-instance-csv-product-import-edit-properties-delimiter:
@@ -116,8 +116,8 @@ extensions:
         config:
             fieldCode: configuration.delimiter
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
+            label: pim_import_export.form.job_instance.tab.properties.delimiter.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-product-import-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -127,8 +127,8 @@ extensions:
         config:
             fieldCode: configuration.enclosure
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+            label: pim_import_export.form.job_instance.tab.properties.enclosure.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-product-import-edit-properties-decimal-separator:
         module: pim/job/common/edit/field/decimal-separator
@@ -138,8 +138,8 @@ extensions:
         config:
             fieldCode: configuration.decimalSeparator
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+            label: pim_import_export.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-csv-product-import-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -149,8 +149,8 @@ extensions:
         config:
             fieldCode: configuration.dateFormat
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+            label: pim_import_export.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-csv-product-import-edit-properties-enabled:
         module: pim/job/common/edit/field/switch
@@ -160,8 +160,8 @@ extensions:
         config:
             fieldCode: configuration.enabled
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
+            label: pim_import_export.form.job_instance.tab.properties.enabled.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enabled.help
 
     pim-job-instance-csv-product-import-edit-properties-categories-column:
         module: pim/job/common/edit/field/text
@@ -171,8 +171,8 @@ extensions:
         config:
             fieldCode: configuration.categoriesColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.categories_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
+            label: pim_import_export.form.job_instance.tab.properties.categories_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.categories_column.help
 
     pim-job-instance-csv-product-import-edit-properties-family-column:
         module: pim/job/common/edit/field/text
@@ -182,8 +182,8 @@ extensions:
         config:
             fieldCode: configuration.familyColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.family_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.family_column.help
+            label: pim_import_export.form.job_instance.tab.properties.family_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.family_column.help
 
     pim-job-instance-csv-product-import-edit-properties-groups-column:
         module: pim/job/common/edit/field/text
@@ -193,8 +193,8 @@ extensions:
         config:
             fieldCode: configuration.groupsColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.groups_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
+            label: pim_import_export.form.job_instance.tab.properties.groups_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.groups_column.help
 
     pim-job-instance-csv-product-import-edit-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
@@ -204,8 +204,8 @@ extensions:
         config:
             fieldCode: configuration.enabledComparison
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled_comparison.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled_comparison.help
+            label: pim_import_export.form.job_instance.tab.properties.enabled_comparison.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enabled_comparison.help
 
     pim-job-instance-csv-product-import-edit-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
@@ -215,8 +215,8 @@ extensions:
         config:
             fieldCode: configuration.realTimeVersioning
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
+            label: pim_import_export.form.job_instance.tab.properties.real_time_versioning.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.real_time_versioning.help
 
     pim-job-instance-csv-product-import-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
@@ -270,7 +270,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-csv-product-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
@@ -37,20 +37,20 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 40
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
 
     pim-job-instance-csv-product-import-show-file-path:
         module: pim/job/common/file-path
         parent: pim-job-instance-csv-product-import-show-launch-switcher-item
         config:
-            label: pim_enrich.form.job_instance.file_path
+            label: pim_import_export.form.job_instance.file_path
 
     pim-job-instance-csv-product-import-show-import-button:
         module: pim/job/common/edit/launch
         parent: pim-job-instance-csv-product-import-show-file-path
         targetZone: buttons
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -63,7 +63,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
-            label: pim_enrich.form.job_instance.button.import.upload_file
+            label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-csv-product-import-show-upload:
         module: pim/job/common/edit/upload
@@ -77,7 +77,7 @@ extensions:
         parent: pim-job-instance-csv-product-import-show-upload-switcher-item
         position: 60
         config:
-            label: pim_enrich.form.job_instance.button.import.upload
+            label: pim_import_export.form.job_instance.button.import.upload
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -88,7 +88,7 @@ extensions:
         parent: pim-job-instance-csv-product-import-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-csv-product-import-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
@@ -62,7 +62,7 @@ extensions:
         targetZone: container
         position: 125
         config:
-            tabTitle: pim_enrich.form.job_instance.tab.content.title
+            tabTitle: pim_import_export.form.job_instance.tab.content.title
             tabCode: pim-job-instance-content
 
     pim-job-instance-csv-product-model-export-edit-history:
@@ -104,8 +104,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-product-model-export-edit-properties-decimal-separator:
         module: pim/job/common/edit/field/decimal-separator
@@ -115,8 +115,8 @@ extensions:
         config:
             fieldCode: configuration.decimalSeparator
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+            label: pim_import_export.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-csv-product-model-export-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -126,8 +126,8 @@ extensions:
         config:
             fieldCode: configuration.dateFormat
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+            label: pim_import_export.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-csv-product-model-export-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -137,8 +137,8 @@ extensions:
         config:
             fieldCode: configuration.delimiter
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
+            label: pim_import_export.form.job_instance.tab.properties.delimiter.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-product-model-export-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -148,8 +148,8 @@ extensions:
         config:
             fieldCode: configuration.enclosure
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+            label: pim_import_export.form.job_instance.tab.properties.enclosure.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-product-model-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -159,8 +159,8 @@ extensions:
         config:
             fieldCode: configuration.withHeader
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+            label: pim_import_export.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-csv-product-model-export-edit-properties-with-media:
         module: pim/job/common/edit/field/switch
@@ -170,8 +170,8 @@ extensions:
         config:
             fieldCode: configuration.with_media
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
+            label: pim_import_export.form.job_instance.tab.properties.with_media.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.with_media.help
 
     pim-job-instance-csv-product-model-export-edit-content-structure:
         module: pim/job/product/edit/content/structure

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
@@ -232,7 +232,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-csv-product-model-export-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
@@ -208,7 +208,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 
@@ -232,7 +232,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-csv-product-model-export-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
@@ -208,7 +208,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_show.yml
@@ -30,7 +30,7 @@ extensions:
         targetZone: meta
         position: 110
         config:
-            label: pim_enrich.form.job_instance.button.export.title
+            label: pim_import_export.form.job_instance.button.export.title
             route: pim_enrich_job_instance_rest_export_launch
             identifier:
                 path: code
@@ -60,7 +60,7 @@ extensions:
         parent: pim-job-instance-csv-product-model-export-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-csv-product-model-export-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
@@ -234,7 +234,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
@@ -93,8 +93,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-csv-product-model-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -104,8 +104,8 @@ extensions:
         config:
             fieldCode: configuration.uploadAllowed
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
+            label: pim_import_export.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-csv-product-model-import-edit-properties-delimiter:
         module: pim/job/common/edit/field/text
@@ -115,8 +115,8 @@ extensions:
         config:
             fieldCode: configuration.delimiter
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.delimiter.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
+            label: pim_import_export.form.job_instance.tab.properties.delimiter.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.delimiter.help
 
     pim-job-instance-csv-product-model-import-edit-properties-enclosure:
         module: pim/job/common/edit/field/text
@@ -126,8 +126,8 @@ extensions:
         config:
             fieldCode: configuration.enclosure
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enclosure.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+            label: pim_import_export.form.job_instance.tab.properties.enclosure.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enclosure.help
 
     pim-job-instance-csv-product-model-import-edit-properties-decimal-separator:
         module: pim/job/common/edit/field/decimal-separator
@@ -137,8 +137,8 @@ extensions:
         config:
             fieldCode: configuration.decimalSeparator
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+            label: pim_import_export.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-csv-product-model-import-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -148,8 +148,8 @@ extensions:
         config:
             fieldCode: configuration.dateFormat
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+            label: pim_import_export.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-csv-product-model-import-edit-properties-enabled:
         module: pim/job/common/edit/field/switch
@@ -159,8 +159,8 @@ extensions:
         config:
             fieldCode: configuration.enabled
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
+            label: pim_import_export.form.job_instance.tab.properties.enabled.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enabled.help
 
     pim-job-instance-csv-product-model-import-edit-properties-categories-column:
         module: pim/job/common/edit/field/text
@@ -170,8 +170,8 @@ extensions:
         config:
             fieldCode: configuration.categoriesColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.categories_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
+            label: pim_import_export.form.job_instance.tab.properties.categories_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.categories_column.help
 
     pim-job-instance-csv-product-model-import-edit-properties-family-variant-column:
         module: pim/job/common/edit/field/text
@@ -181,8 +181,8 @@ extensions:
         config:
             fieldCode: configuration.familyVariantColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.family_variant_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.family_variant_column.help
+            label: pim_import_export.form.job_instance.tab.properties.family_variant_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.family_variant_column.help
 
     pim-job-instance-csv-product-model-import-edit-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
@@ -192,8 +192,8 @@ extensions:
         config:
             fieldCode: configuration.enabledComparison
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled_comparison.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled_comparison.help
+            label: pim_import_export.form.job_instance.tab.properties.enabled_comparison.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enabled_comparison.help
 
     pim-job-instance-csv-product-model-import-edit-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
@@ -203,8 +203,8 @@ extensions:
         config:
             fieldCode: configuration.realTimeVersioning
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
+            label: pim_import_export.form.job_instance.tab.properties.real_time_versioning.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.real_time_versioning.help
 
     pim-job-instance-csv-product-model-import-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
@@ -258,7 +258,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-csv-product-model-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
@@ -234,7 +234,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 
@@ -258,7 +258,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-csv-product-model-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
@@ -37,20 +37,20 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 40
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
 
     pim-job-instance-csv-product-model-import-show-file-path:
         module: pim/job/common/file-path
         parent: pim-job-instance-csv-product-model-import-show-launch-switcher-item
         config:
-            label: pim_enrich.form.job_instance.file_path
+            label: pim_import_export.form.job_instance.file_path
 
     pim-job-instance-csv-product-model-import-show-import-button:
         module: pim/job/common/edit/launch
         parent: pim-job-instance-csv-product-model-import-show-file-path
         targetZone: buttons
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -63,7 +63,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
-            label: pim_enrich.form.job_instance.button.import.upload_file
+            label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-csv-product-model-import-show-upload:
         module: pim/job/common/edit/upload
@@ -75,7 +75,7 @@ extensions:
         parent: pim-job-instance-csv-product-model-import-show-upload-switcher-item
         position: 60
         config:
-            label: pim_enrich.form.job_instance.button.import.upload
+            label: pim_import_export.form.job_instance.button.import.upload
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -86,7 +86,7 @@ extensions:
         parent: pim-job-instance-csv-product-model-import-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-csv-product-model-import-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
@@ -172,7 +172,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-xlsx-base-export-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
@@ -94,8 +94,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-base-export-edit-properties-lines-per-file:
         module: pim/job/common/edit/field/text
@@ -105,8 +105,8 @@ extensions:
         config:
             fieldCode: configuration.linesPerFile
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.lines_per_file.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.lines_per_file.help
+            label: pim_import_export.form.job_instance.tab.properties.lines_per_file.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.lines_per_file.help
 
     pim-job-instance-xlsx-base-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -116,8 +116,8 @@ extensions:
         config:
             fieldCode: configuration.withHeader
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+            label: pim_import_export.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-xlsx-base-export-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
@@ -148,7 +148,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
@@ -148,7 +148,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 
@@ -172,7 +172,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-xlsx-base-export-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
@@ -30,7 +30,7 @@ extensions:
         targetZone: meta
         position: 110
         config:
-            label: pim_enrich.form.job_instance.button.export.title
+            label: pim_import_export.form.job_instance.button.export.title
             route: pim_enrich_job_instance_rest_export_launch
             identifier:
                 path: code
@@ -60,7 +60,7 @@ extensions:
         parent: pim-job-instance-xlsx-base-export-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-xlsx-base-export-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
@@ -136,7 +136,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 
@@ -160,7 +160,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-xlsx-base-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
@@ -94,8 +94,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -105,8 +105,8 @@ extensions:
         config:
             fieldCode: configuration.uploadAllowed
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
+            label: pim_import_export.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-xlsx-base-import-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
@@ -136,7 +136,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
@@ -160,7 +160,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-xlsx-base-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
@@ -37,19 +37,19 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 40
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
 
     pim-job-instance-xlsx-base-import-show-file-path:
         module: pim/job/common/file-path
         parent: pim-job-instance-xlsx-base-import-show-launch-switcher-item
         config:
-            label: pim_enrich.form.job_instance.file_path
+            label: pim_import_export.form.job_instance.file_path
 
     pim-job-instance-xlsx-base-import-show-import-button:
         module: pim/job/common/edit/launch
         parent: pim-job-instance-xlsx-base-import-show-file-path
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -62,7 +62,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
-            label: pim_enrich.form.job_instance.button.import.upload_file
+            label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-xlsx-base-import-show-upload:
         module: pim/job/common/edit/upload
@@ -76,7 +76,7 @@ extensions:
         parent: pim-job-instance-xlsx-base-import-show-upload-switcher-item
         position: 60
         config:
-            label: pim_enrich.form.job_instance.button.import.upload
+            label: pim_import_export.form.job_instance.button.import.upload
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -87,7 +87,7 @@ extensions:
         parent: pim-job-instance-xlsx-base-import-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-xlsx-base-import-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
@@ -62,7 +62,7 @@ extensions:
         targetZone: container
         position: 140
         config:
-            tabTitle: pim_enrich.form.job_instance.tab.content.title
+            tabTitle: pim_import_export.form.job_instance.tab.content.title
             tabCode: pim-job-instance-content
 
     pim-job-instance-xlsx-product-export-edit-history:
@@ -104,8 +104,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-product-export-edit-properties-decimal-separator:
         module: pim/job/common/edit/field/decimal-separator
@@ -115,8 +115,8 @@ extensions:
         config:
             fieldCode: configuration.decimalSeparator
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+            label: pim_import_export.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-xlsx-product-export-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -126,8 +126,8 @@ extensions:
         config:
             fieldCode: configuration.dateFormat
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+            label: pim_import_export.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-xlsx-product-export-edit-properties-lines-per-file:
         module: pim/job/common/edit/field/text
@@ -137,8 +137,8 @@ extensions:
         config:
             fieldCode: configuration.linesPerFile
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.lines_per_file.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.lines_per_file.help
+            label: pim_import_export.form.job_instance.tab.properties.lines_per_file.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.lines_per_file.help
 
     pim-job-instance-xlsx-product-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -148,8 +148,8 @@ extensions:
         config:
             fieldCode: configuration.withHeader
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+            label: pim_import_export.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-xlsx-product-export-edit-properties-with-media:
         module: pim/job/common/edit/field/switch
@@ -159,8 +159,8 @@ extensions:
         config:
             fieldCode: configuration.with_media
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
+            label: pim_import_export.form.job_instance.tab.properties.with_media.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.with_media.help
 
     pim-job-instance-xlsx-product-export-edit-content-structure:
         module: pim/job/product/edit/content/structure

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
@@ -221,7 +221,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-xlsx-product-export-edit-content-structure-scope:
         module: pim/job/product/edit/content/structure/scope

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
@@ -197,7 +197,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 
@@ -221,7 +221,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-xlsx-product-export-edit-content-structure-scope:
         module: pim/job/product/edit/content/structure/scope

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
@@ -197,7 +197,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
@@ -30,7 +30,7 @@ extensions:
         targetZone: meta
         position: 110
         config:
-            label: pim_enrich.form.job_instance.button.export.title
+            label: pim_import_export.form.job_instance.button.export.title
             route: pim_enrich_job_instance_rest_export_launch
             identifier:
                 path: code
@@ -60,7 +60,7 @@ extensions:
         parent: pim-job-instance-xlsx-product-export-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-xlsx-product-export-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
@@ -94,8 +94,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-product-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -105,8 +105,8 @@ extensions:
         config:
             fieldCode: configuration.uploadAllowed
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
+            label: pim_import_export.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-xlsx-product-import-edit-properties-decimal-separator:
         module: pim/job/common/edit/field/decimal-separator
@@ -116,8 +116,8 @@ extensions:
         config:
             fieldCode: configuration.decimalSeparator
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+            label: pim_import_export.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-xlsx-product-import-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -127,8 +127,8 @@ extensions:
         config:
             fieldCode: configuration.dateFormat
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+            label: pim_import_export.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-xlsx-product-import-edit-properties-enabled:
         module: pim/job/common/edit/field/switch
@@ -138,8 +138,8 @@ extensions:
         config:
             fieldCode: configuration.enabled
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
+            label: pim_import_export.form.job_instance.tab.properties.enabled.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enabled.help
 
     pim-job-instance-xlsx-product-import-edit-properties-categories-column:
         module: pim/job/common/edit/field/text
@@ -149,8 +149,8 @@ extensions:
         config:
             fieldCode: configuration.categoriesColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.categories_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
+            label: pim_import_export.form.job_instance.tab.properties.categories_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.categories_column.help
 
     pim-job-instance-xlsx-product-import-edit-properties-family-column:
         module: pim/job/common/edit/field/text
@@ -160,8 +160,8 @@ extensions:
         config:
             fieldCode: configuration.familyColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.family_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.family_column.help
+            label: pim_import_export.form.job_instance.tab.properties.family_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.family_column.help
 
     pim-job-instance-xlsx-product-import-edit-properties-groups-column:
         module: pim/job/common/edit/field/text
@@ -171,8 +171,8 @@ extensions:
         config:
             fieldCode: configuration.groupsColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.groups_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.groups_column.help
+            label: pim_import_export.form.job_instance.tab.properties.groups_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.groups_column.help
 
     pim-job-instance-xlsx-product-import-edit-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
@@ -182,8 +182,8 @@ extensions:
         config:
             fieldCode: configuration.enabledComparison
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled_comparison.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled_comparison.help
+            label: pim_import_export.form.job_instance.tab.properties.enabled_comparison.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enabled_comparison.help
 
     pim-job-instance-xlsx-product-import-edit-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
@@ -193,8 +193,8 @@ extensions:
         config:
             fieldCode: configuration.realTimeVersioning
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
+            label: pim_import_export.form.job_instance.tab.properties.real_time_versioning.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.real_time_versioning.help
 
     pim-job-instance-xlsx-product-import-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
@@ -248,7 +248,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-xlsx-product-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
@@ -224,7 +224,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
@@ -224,7 +224,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 
@@ -248,7 +248,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-xlsx-product-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
@@ -37,19 +37,19 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 40
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
 
     pim-job-instance-xlsx-product-import-show-file-path:
         module: pim/job/common/file-path
         parent: pim-job-instance-xlsx-product-import-show-launch-switcher-item
         config:
-            label: pim_enrich.form.job_instance.file_path
+            label: pim_import_export.form.job_instance.file_path
 
     pim-job-instance-xlsx-product-import-show-import-button:
         module: pim/job/common/edit/launch
         parent: pim-job-instance-xlsx-product-import-show-file-path
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -62,7 +62,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
-            label: pim_enrich.form.job_instance.button.import.upload_file
+            label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-xlsx-product-import-show-upload:
         module: pim/job/common/edit/upload
@@ -75,7 +75,7 @@ extensions:
         parent: pim-job-instance-xlsx-product-import-show-upload-switcher-item
         position: 60
         config:
-            label: pim_enrich.form.job_instance.button.import.upload
+            label: pim_import_export.form.job_instance.button.import.upload
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -86,7 +86,7 @@ extensions:
         parent: pim-job-instance-xlsx-product-import-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-xlsx-product-import-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
@@ -62,7 +62,7 @@ extensions:
         targetZone: container
         position: 125
         config:
-            tabTitle: pim_enrich.form.job_instance.tab.content.title
+            tabTitle: pim_import_export.form.job_instance.tab.content.title
             tabCode: pim-job-instance-content
 
     pim-job-instance-xlsx-product-model-export-edit-history:
@@ -104,8 +104,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-product-model-export-edit-properties-decimal-separator:
         module: pim/job/common/edit/field/decimal-separator
@@ -115,8 +115,8 @@ extensions:
         config:
             fieldCode: configuration.decimalSeparator
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+            label: pim_import_export.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-xlsx-product-model-export-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -126,8 +126,8 @@ extensions:
         config:
             fieldCode: configuration.dateFormat
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+            label: pim_import_export.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-xlsx-product-model-export-edit-properties-lines-per-file:
         module: pim/job/common/edit/field/text
@@ -137,8 +137,8 @@ extensions:
         config:
             fieldCode: configuration.linesPerFile
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.lines_per_file.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.lines_per_file.help
+            label: pim_import_export.form.job_instance.tab.properties.lines_per_file.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.lines_per_file.help
 
     pim-job-instance-xlsx-product-model-export-edit-properties-with-header:
         module: pim/job/common/edit/field/switch
@@ -148,8 +148,8 @@ extensions:
         config:
             fieldCode: configuration.withHeader
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_header.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+            label: pim_import_export.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.with_header.help
 
     pim-job-instance-xlsx-product-model-export-edit-properties-with-media:
         module: pim/job/common/edit/field/switch
@@ -159,8 +159,8 @@ extensions:
         config:
             fieldCode: configuration.with_media
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.with_media.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
+            label: pim_import_export.form.job_instance.tab.properties.with_media.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.with_media.help
 
     pim-job-instance-xlsx-product-model-export-edit-content-structure:
         module: pim/job/product/edit/content/structure

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
@@ -197,7 +197,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 
@@ -221,7 +221,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-xlsx-product-model-export-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
@@ -197,7 +197,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
@@ -221,7 +221,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-xlsx-product-model-export-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_show.yml
@@ -30,7 +30,7 @@ extensions:
         targetZone: meta
         position: 110
         config:
-            label: pim_enrich.form.job_instance.button.export.title
+            label: pim_import_export.form.job_instance.button.export.title
             route: pim_enrich_job_instance_rest_export_launch
             identifier:
                 path: code
@@ -60,7 +60,7 @@ extensions:
         parent: pim-job-instance-xlsx-product-model-export-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-xlsx-product-model-export-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
@@ -213,7 +213,7 @@ extensions:
             trans:
                 title: confirmation.remove.export_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
@@ -94,8 +94,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-xlsx-product-model-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -105,8 +105,8 @@ extensions:
         config:
             fieldCode: configuration.uploadAllowed
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
+            label: pim_import_export.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-xlsx-product-model-import-edit-properties-decimal-separator:
         module: pim/job/common/edit/field/decimal-separator
@@ -116,8 +116,8 @@ extensions:
         config:
             fieldCode: configuration.decimalSeparator
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+            label: pim_import_export.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.decimal_separator.help
 
     pim-job-instance-xlsx-product-model-import-edit-properties-date-format:
         module: pim/job/product/edit/field/date-format
@@ -127,8 +127,8 @@ extensions:
         config:
             fieldCode: configuration.dateFormat
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.date_format.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+            label: pim_import_export.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.date_format.help
 
     pim-job-instance-xlsx-product-model-import-edit-properties-enabled:
         module: pim/job/common/edit/field/switch
@@ -138,8 +138,8 @@ extensions:
         config:
             fieldCode: configuration.enabled
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled.help
+            label: pim_import_export.form.job_instance.tab.properties.enabled.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enabled.help
 
     pim-job-instance-xlsx-product-model-import-edit-properties-categories-column:
         module: pim/job/common/edit/field/text
@@ -149,8 +149,8 @@ extensions:
         config:
             fieldCode: configuration.categoriesColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.categories_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.categories_column.help
+            label: pim_import_export.form.job_instance.tab.properties.categories_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.categories_column.help
 
     pim-job-instance-xlsx-product-model-import-edit-properties-family-variant-column:
         module: pim/job/common/edit/field/text
@@ -160,8 +160,8 @@ extensions:
         config:
             fieldCode: configuration.familyVariantColumn
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.family_variant_column.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.family_variant_column.help
+            label: pim_import_export.form.job_instance.tab.properties.family_variant_column.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.family_variant_column.help
 
     pim-job-instance-xlsx-product-model-import-edit-properties-enabled-comparison:
         module: pim/job/common/edit/field/switch
@@ -171,8 +171,8 @@ extensions:
         config:
             fieldCode: configuration.enabledComparison
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.enabled_comparison.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.enabled_comparison.help
+            label: pim_import_export.form.job_instance.tab.properties.enabled_comparison.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.enabled_comparison.help
 
     pim-job-instance-xlsx-product-model-import-edit-properties-real-time-versioning:
         module: pim/job/common/edit/field/switch
@@ -182,8 +182,8 @@ extensions:
         config:
             fieldCode: configuration.realTimeVersioning
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.real_time_versioning.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.real_time_versioning.help
+            label: pim_import_export.form.job_instance.tab.properties.real_time_versioning.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.real_time_versioning.help
 
     pim-job-instance-xlsx-product-model-import-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
@@ -237,7 +237,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-xlsx-product-model-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
@@ -213,7 +213,7 @@ extensions:
             trans:
                 title: confirmation.remove.export_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 
@@ -237,7 +237,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-xlsx-product-model-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
@@ -37,19 +37,19 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 40
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
 
     pim-job-instance-xlsx-product-model-import-show-file-path:
         module: pim/job/common/file-path
         parent: pim-job-instance-xlsx-product-model-import-show-launch-switcher-item
         config:
-            label: pim_enrich.form.job_instance.file_path
+            label: pim_import_export.form.job_instance.file_path
 
     pim-job-instance-xlsx-product-model-import-show-import-button:
         module: pim/job/common/edit/launch
         parent: pim-job-instance-xlsx-product-model-import-show-file-path
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -62,7 +62,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
-            label: pim_enrich.form.job_instance.button.import.upload_file
+            label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-xlsx-product-model-import-show-upload:
         module: pim/job/common/edit/upload
@@ -73,7 +73,7 @@ extensions:
         parent: pim-job-instance-xlsx-product-model-import-show-upload-switcher-item
         position: 60
         config:
-            label: pim_enrich.form.job_instance.button.import.upload
+            label: pim_import_export.form.job_instance.button.import.upload
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -84,7 +84,7 @@ extensions:
         parent: pim-job-instance-xlsx-product-model-import-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-xlsx-product-model-import-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
@@ -94,8 +94,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-yml-base-export-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
@@ -150,7 +150,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-yml-base-export-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
@@ -126,7 +126,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 
@@ -150,7 +150,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-yml-base-export-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
@@ -126,7 +126,7 @@ extensions:
                 title: confirmation.remove.export_profile
                 subTitle: pim_menu.item.export_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_export_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
@@ -30,7 +30,7 @@ extensions:
         targetZone: meta
         position: 110
         config:
-            label: pim_enrich.form.job_instance.button.export.title
+            label: pim_import_export.form.job_instance.button.export.title
             route: pim_enrich_job_instance_rest_export_launch
             identifier:
                 path: code
@@ -60,7 +60,7 @@ extensions:
         parent: pim-job-instance-yml-base-export-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-yml-base-export-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
@@ -136,7 +136,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: flash.job_instance.removed
+                success: pim_enrich.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
@@ -94,8 +94,8 @@ extensions:
         config:
             fieldCode: configuration.filePath
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.file_path.help
+            label: pim_import_export.form.job_instance.tab.properties.file_path.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
 
     pim-job-instance-yml-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/switch
@@ -105,8 +105,8 @@ extensions:
         config:
             fieldCode: configuration.uploadAllowed
             readOnly: false
-            label: pim_enrich.form.job_instance.tab.properties.upload_allowed.title
-            tooltip: pim_enrich.form.job_instance.tab.properties.upload_allowed.help
+            label: pim_import_export.form.job_instance.tab.properties.upload_allowed.title
+            tooltip: pim_import_export.form.job_instance.tab.properties.upload_allowed.help
 
     pim-job-instance-yml-base-import-edit-label:
         module: pim/job/common/edit/label

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
@@ -160,7 +160,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_import_export.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.label
 
     pim-job-instance-yml-base-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
@@ -136,7 +136,7 @@ extensions:
             trans:
                 title: confirmation.remove.import_profile
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.job_instance.flash.delete.success
+                success: pim_import_export.entity.job_instance.flash.delete.success
                 failed: error.removing.job_instance
             redirect: pim_importexport_import_profile_index
 
@@ -160,7 +160,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.job_instance.title
+            entity: pim_import_export.entity.job_instance.title
 
     pim-job-instance-yml-base-import-edit-validation:
         module: pim/job/common/edit/validation

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
@@ -37,20 +37,20 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 40
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
 
     pim-job-instance-yml-base-import-show-file-path:
         module: pim/job/common/file-path
         parent: pim-job-instance-yml-base-import-show-launch-switcher-item
         config:
-            label: pim_enrich.form.job_instance.file_path
+            label: pim_import_export.form.job_instance.file_path
 
     pim-job-instance-yml-base-import-show-import-button:
         module: pim/job/common/edit/launch
         parent: pim-job-instance-yml-base-import-show-file-path
         targetZone: buttons
         config:
-            label: pim_enrich.form.job_instance.button.import.launch
+            label: pim_import_export.form.job_instance.button.import.launch
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -63,7 +63,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
-            label: pim_enrich.form.job_instance.button.import.upload_file
+            label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-yml-base-import-show-upload:
         module: pim/job/common/edit/upload
@@ -77,7 +77,7 @@ extensions:
         parent: pim-job-instance-yml-base-import-show-upload-switcher-item
         position: 60
         config:
-            label: pim_enrich.form.job_instance.button.import.upload
+            label: pim_import_export.form.job_instance.button.import.upload
             route: pim_enrich_job_instance_rest_import_launch
             identifier:
                 path: code
@@ -88,7 +88,7 @@ extensions:
         parent: pim-job-instance-yml-base-import-show
         targetZone: content
         config:
-            title: pim_enrich.form.job_instance.subsection.last_executions
+            title: pim_import_export.form.job_instance.subsection.last_executions
 
     pim-job-instance-yml-base-import-show-grid:
         module: pim/job/common/grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/locale/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/locale/index.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-locale-index
         targetZone: title
         config:
-            title: pim_enrich.index.locale.title
+            title: pim_enrich.entity.locale.page_title.index
 
     pim-locale-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/mass_edit/add_to_existing_product_model.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/mass_edit/add_to_existing_product_model.yml
@@ -7,7 +7,7 @@ extensions:
         config:
             fieldName: family
             required: true
-            label: pim_enrich.entity.product.meta.family.title
+            label: pim_enrich.entity.family.uppercase_label
             choiceRoute: pim_enrich_family_index_get_variants
             placeholder: pim_enrich.entity.product.create_popin.labels.family
 
@@ -30,7 +30,7 @@ extensions:
         position: 40
         config:
             fieldName: product_model
-            label: pim_enrich.product_model.uppercase_label
+            label: pim_enrich.entity.product_model.uppercase_label
             required: true
             choiceRoute: pim_enrich_product_model_family_variant_leaf
             placeholder: pim_enrich.entity.product_model.choose

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/mass_edit/add_to_existing_product_model.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/mass_edit/add_to_existing_product_model.yml
@@ -30,7 +30,7 @@ extensions:
         position: 40
         config:
             fieldName: product_model
-            label: pim_enrich.form.product_model.product_model
+            label: pim_enrich.product_model.uppercase_label
             required: true
             choiceRoute: pim_enrich_product_model_family_variant_leaf
-            placeholder: pim_enrich.form.product_model.choose_product_model
+            placeholder: pim_enrich.entity.product_model.choose

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/process_tracker/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/process_tracker/index.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-process-index
         targetZone: title
         config:
-            title: pim_enrich.index.process_tracker.title
+            title: pim_enrich.entity.job_execution.page_title.index
 
     pim-process-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/create.yml
@@ -4,7 +4,7 @@ extensions:
        config:
            labels:
                title: pim_common.create
-               subTitle: pim_common.products
+               subTitle: pim_enrich.entity.product.plural_label
            picture: illustrations/Product.svg
            successMessage: pim_enrich.entity.product.flash.create.success
            editRoute: pim_enrich_product_edit

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/create.yml
@@ -25,5 +25,5 @@ extensions:
         position: 20
         config:
             fieldName: family
-            label: pim_enrich.entity.family.label
+            label: pim_enrich.entity.family.uppercase_label
             choiceRoute: pim_enrich_family_rest_index

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/create.yml
@@ -25,5 +25,5 @@ extensions:
         position: 20
         config:
             fieldName: family
-            label: pim_enrich.entity.family.title
+            label: pim_enrich.entity.family.label
             choiceRoute: pim_enrich_family_rest_index

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/create.yml
@@ -6,7 +6,7 @@ extensions:
                title: pim_common.create
                subTitle: pim_common.products
            picture: illustrations/Product.svg
-           successMessage: pim_enrich.entity.product.message.created
+           successMessage: pim_enrich.entity.product.flash.create.success
            editRoute: pim_enrich_product_edit
            postUrl: pim_enrich_product_rest_create
 
@@ -25,5 +25,5 @@ extensions:
         position: 20
         config:
             fieldName: family
-            label: pim_enrich.entity.product.meta.family.title
+            label: pim_enrich.entity.family.title
             choiceRoute: pim_enrich_family_rest_index

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -229,6 +229,7 @@ extensions:
         position: 130
         config:
             aclAddAssociations: pim_enrich_associations_edit
+            datagridName: 'association-product-grid'
 
     pim-product-edit-form-attribute-group-selector:
         module: pim/form/common/attributes/attribute-group-selector

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -176,7 +176,7 @@ extensions:
         position: 90
         config:
             label: pim_common.created
-            labelBy: pim_enrich.entity.product.meta.created_by
+            labelBy: pim_common.by
 
     pim-product-edit-form-updated:
         module: pim/product-edit-form/meta/updated
@@ -185,7 +185,7 @@ extensions:
         position: 100
         config:
             label: pim_enrich.entity.product.meta.updated
-            labelBy: pim_enrich.entity.product.meta.updated_by
+            labelBy: pim_common.by
 
     pim-product-edit-form-groups:
         module: pim/product-edit-form/meta/groups
@@ -229,7 +229,6 @@ extensions:
         position: 130
         config:
             aclAddAssociations: pim_enrich_associations_edit
-            datagridName: 'association-product-grid'
 
     pim-product-edit-form-attribute-group-selector:
         module: pim/form/common/attributes/attribute-group-selector

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -47,7 +47,7 @@ extensions:
         targetZone: column
         config:
           stateCode: product_edit_form
-          navigationTitle: pim_enrich.entity.product.navigation
+          navigationTitle: pim_menu.navigation.product
 
     pim-product-edit-form-column-tabs-navigation:
         module: pim/form/common/column-tabs-navigation
@@ -55,7 +55,7 @@ extensions:
         targetZone: navigation
         position: 10
         config:
-          title: pim_enrich.entity.product.navigation
+          title: pim_menu.navigation.product
 
     pim-product-edit-form-meta:
         module: pim/form/common/meta
@@ -63,7 +63,7 @@ extensions:
         targetZone: bottom
         position: 10
         config:
-            label: pim_enrich.entity.product.infos
+            label: pim_enrich.entity.product.meta.infos
 
     pim-product-edit-form-column-tabs:
         module: pim/form/common/column-tabs
@@ -141,7 +141,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.product.title
+            entity: pim_enrich.entity.product.label
 
     pim-product-edit-form-family:
         module: pim/product-edit-form/meta/family

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -106,8 +106,8 @@ extensions:
                 title: confirmation.remove.product
                 subTitle: pim_common.products
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.product.info.deletion_successful
-                fail: pim_enrich.entity.product.info.deletion_failed
+                success: pim_enrich.entity.product.flash.delete.success
+                fail: pim_enrich.entity.product.flash.delete.fail
             redirect: pim_enrich_product_index
 
     pim-product-edit-form-download-pdf:
@@ -203,7 +203,7 @@ extensions:
             removeAttributeRoute: pim_enrich_product_remove_attribute_rest
             removeAttributeACL: pim_enrich_product_remove_attribute
             tabTitle: pim_common.attributes
-            deletionFailed: pim_enrich.form.product.flash.attribute_deletion_error
+            deletionFailed: pim_enrich.entity.attribute.flash.delete.fail
 
     pim-product-edit-form-completeness:
         module: pim/product-edit-form/completeness

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -104,7 +104,7 @@ extensions:
         config:
             trans:
                 title: confirmation.remove.product
-                subTitle: pim_common.products
+                subTitle: pim_enrich.entity.product.plural_label
                 content: pim_common.confirm_deletion
                 success: pim_enrich.entity.product.flash.delete.success
                 fail: pim_enrich.entity.product.flash.delete.fail
@@ -202,7 +202,7 @@ extensions:
         config:
             removeAttributeRoute: pim_enrich_product_remove_attribute_rest
             removeAttributeACL: pim_enrich_product_remove_attribute
-            tabTitle: pim_common.attributes
+            tabTitle: pim_enrich.entity.attribute.plural_label
             deletionFailed: pim_enrich.entity.attribute.flash.delete.fail
 
     pim-product-edit-form-completeness:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/index.yml
@@ -30,7 +30,7 @@ extensions:
         parent: pim-product-index
         targetZone: title
         config:
-            title: pim_enrich.entity.product.index_title
+            title: pim_enrich.entity.product.page_title.index
 
     pim-product-index-left-column:
         module: pim/form/common/column
@@ -38,7 +38,7 @@ extensions:
         targetZone: column
         config:
           stateCode: product_index
-          navigationTitle: pim_enrich.entity.product.navigation
+          navigationTitle: pim_menu.navigation.product
 
     pim-product-index-column-inner:
         module: pim/common/simple-view
@@ -68,7 +68,7 @@ extensions:
                     aclResourceId: pim_enrich_product_create
                 create-product-model:
                     form: pim-product-model-create-modal
-                    title: pim_enrich.entity.product_model.create_popin.type
+                    title: pim_enrich.entity.product_model.uppercase_label
                     icon: icon-model
                     aclResourceId: pim_enrich_product_model_create
 
@@ -115,7 +115,7 @@ extensions:
         parent: pim-product-index
         targetZone: bottom-panel
         config:
-            label: pim_enrich.entity.product.selected
+            label: pim_datagrid.mass_edit.selected.product
 
     pim-product-index-grid-filters-manage:
         module: oro/datafilter/filters-button

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/index.yml
@@ -63,7 +63,7 @@ extensions:
             choices:
                 create-product:
                     form: pim-product-create-modal
-                    title: pim_enrich.entity.product.create_popin.type
+                    title: pim_enrich.entity.product.uppercase_label
                     icon: icon-product
                     aclResourceId: pim_enrich_product_create
                 create-product-model:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/index.yml
@@ -115,7 +115,7 @@ extensions:
         parent: pim-product-index
         targetZone: bottom-panel
         config:
-            label: pim_datagrid.mass_edit.selected.product
+            label: pim_datagrid.mass_action.selected.product
 
     pim-product-index-grid-filters-manage:
         module: oro/datafilter/filters-button

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/create.yml
@@ -29,7 +29,7 @@ extensions:
         config:
             fieldName: family
             required: true
-            label: pim_enrich.entity.product.meta.family.title
+            label: pim_enrich.entity.family.uppercase_label
             choiceRoute: pim_enrich_family_index_get_variants
             placeholder: pim_enrich.entity.product.create_popin.labels.family
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/create.yml
@@ -7,7 +7,7 @@ extensions:
                subTitle: pim_common.products
                content: pim_enrich.entity.product_model.create_popin.content
            picture: illustrations/Product-model.svg
-           successMessage: pim_enrich.entity.product_model.info.create_successful
+           successMessage: pim_enrich.entity.product_model.flash.create.success
            editRoute: pim_enrich_product_model_edit
            postUrl: pim_enrich_product_model_rest_create
            excludedProperties: [ family ]

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/create.yml
@@ -4,7 +4,7 @@ extensions:
        config:
            labels:
                title: pim_enrich.entity.product_model.create_popin.title
-               subTitle: pim_common.products
+               subTitle: pim_enrich.entity.product.plural_label
                content: pim_enrich.entity.product_model.create_popin.content
            picture: illustrations/Product-model.svg
            successMessage: pim_enrich.entity.product_model.flash.create.success

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -100,8 +100,8 @@ extensions:
                 title: confirmation.remove.product_model
                 subTitle: pim_common.products_model
                 content: pim_common.confirm_deletion
-                success: pim_enrich.entity.product_model.info.deletion_successful
-                fail: pim_enrich.entity.product_model.info.deletion_failed
+                success: pim_enrich.entity.product_model.flash.delete.success
+                fail: pim_enrich.entity.product_model.flash.delete.fail
             redirect: pim_enrich_product_index
 
     pim-product-model-edit-form-save-buttons:
@@ -164,7 +164,7 @@ extensions:
             removeAttributeRoute: pim_enrich_product_remove_attribute_rest
             removeAttributeACL: pim_enrich_product_remove_attribute
             tabTitle: pim_common.attributes
-            deletionFailed: pim_enrich.form.product.flash.attribute_deletion_error
+            deletionFailed: pim_enrich.entity.attribute.flash.delete.fail
 
     pim-product-model-edit-form-categories:
         module: pim/product-edit-form/categories

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -47,7 +47,7 @@ extensions:
         targetZone: column
         config:
           stateCode: product_edit_form
-          navigationTitle: pim_enrich.entity.product.navigation
+          navigationTitle: pim_menu.navigation.product
 
     pim-product-model-edit-form-column-tabs-navigation:
         module: pim/form/common/column-tabs-navigation
@@ -55,7 +55,7 @@ extensions:
         targetZone: navigation
         position: 10
         config:
-          title: pim_enrich.entity.product.navigation
+          title: pim_menu.navigation.product
 
     pim-product-model-edit-form-meta:
         module: pim/form/common/meta
@@ -63,7 +63,7 @@ extensions:
         targetZone: bottom
         position: 10
         config:
-            label: pim_enrich.entity.product.infos
+            label: pim_enrich.entity.product.meta.infos
 
     pim-product-model-edit-form-column-tabs:
         module: pim/form/common/column-tabs
@@ -122,7 +122,7 @@ extensions:
         targetZone: state
         position: 900
         config:
-            entity: pim_enrich.entity.product.title
+            entity: pim_enrich.entity.product.label
 
     pim-product-model-edit-form-family:
         module: pim/product-edit-form/meta/family

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -170,7 +170,7 @@ extensions:
         module: pim/product-edit-form/categories
         parent: pim-product-model-edit-form-column-tabs
         targetZone: container
-        aclResourceId: pim_enrich_product_categories_view #TODO
+        aclResourceId: pim_enrich_product_model_categories_view
         position: 100
         config:
             tabCode: pim-product-edit-form-categories

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -143,7 +143,7 @@ extensions:
         position: 90
         config:
             label: pim_common.created
-            labelBy: pim_enrich.entity.product.meta.created_by
+            labelBy: pim_common.by
 
     pim-product-model-edit-form-updated:
         module: pim/product-edit-form/meta/updated
@@ -152,7 +152,7 @@ extensions:
         position: 100
         config:
             label: pim_enrich.entity.product.meta.updated
-            labelBy: pim_enrich.entity.product.meta.updated_by
+            labelBy: pim_common.by
 
     pim-product-model-edit-form-attributes:
         module: pim/product-edit-form/attributes
@@ -170,7 +170,7 @@ extensions:
         module: pim/product-edit-form/categories
         parent: pim-product-model-edit-form-column-tabs
         targetZone: container
-        aclResourceId: pim_enrich_product_model_categories_view
+        aclResourceId: pim_enrich_product_categories_view #TODO
         position: 100
         config:
             tabCode: pim-product-edit-form-categories

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -98,7 +98,7 @@ extensions:
         config:
             trans:
                 title: confirmation.remove.product_model
-                subTitle: pim_common.products_model
+                subTitle: pim_enrich.entity.product.plural_label_model
                 content: pim_common.confirm_deletion
                 success: pim_enrich.entity.product_model.flash.delete.success
                 fail: pim_enrich.entity.product_model.flash.delete.fail
@@ -163,7 +163,7 @@ extensions:
         config:
             removeAttributeRoute: pim_enrich_product_remove_attribute_rest
             removeAttributeACL: pim_enrich_product_remove_attribute
-            tabTitle: pim_common.attributes
+            tabTitle: pim_enrich.entity.attribute.plural_label
             deletionFailed: pim_enrich.entity.attribute.flash.delete.fail
 
     pim-product-model-edit-form-categories:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-group.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-user-group-index
         targetZone: title
         config:
-            title: pim_enrich.entity.user_group.page_title.index
+            title: pim_user_management.entity.group.page_title.index
 
     pim-user-group-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-group.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-user-group-index
         targetZone: title
         config:
-            title: pim_enrich.index.user_group.title
+            title: pim_enrich.entity.user_group.page_title.index
 
     pim-user-group-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-role.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-role.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-user-role-index
         targetZone: title
         config:
-            title: pim_enrich.entity.user_role.page_title.index
+            title: pim_user_management.entity.role.page_title.index
 
     pim-user-role-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-role.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-role.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-user-role-index
         targetZone: title
         config:
-            title: pim_enrich.index.user_role.title
+            title: pim_enrich.entity.user_role.page_title.index
 
     pim-user-role-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-user.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-user.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-user-index
         targetZone: title
         config:
-            title: pim_enrich.entity.user.page_title.index
+            title: pim_user_management.entity.user.page_title.index
 
     pim-user-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-user.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/user/index-user.yml
@@ -24,7 +24,7 @@ extensions:
         parent: pim-user-index
         targetZone: title
         config:
-            title: pim_enrich.index.user.title
+            title: pim_enrich.entity.user.page_title.index
 
     pim-user-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute-option/create.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute-option/create.js
@@ -59,7 +59,7 @@ define(
                             modal.close();
                             messenger.notify(
                                 'success',
-                                _.__('pim_enrich.form.attribute_option.flash.option_created')
+                                _.__('pim_enrich.entity.attribute_option.flash.create.success')
                             );
                             deferred.resolve(option);
                         }).fail(function (xhr) {
@@ -74,7 +74,7 @@ define(
                             } else {
                                 messenger.notify(
                                     'error',
-                                    _.__('pim_enrich.form.attribute_option.flash.error_creating_option')
+                                    _.__('pim_enrich.entity.attribute_option.flash.create.fail')
                                 );
                             }
                         }.bind(this));

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute/form/properties/default-metric-unit.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute/form/properties/default-metric-unit.js
@@ -56,7 +56,7 @@ function (
                 choices: this.formatChoices(this.measures[metricFamily].units),
                 multiple: false,
                 labels: {
-                    defaultLabel: __('pim_enrich.form.attribute.tab.properties.default_label.default_metric_unit')
+                    defaultLabel: __('pim_enrich.entity.attribute.property.default_metric_unit.choose')
                 }
             }));
         },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute/form/properties/group.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute/form/properties/group.js
@@ -59,7 +59,7 @@ function (
                 i18n: i18n,
                 locale: UserContext.get('catalogLocale'),
                 labels: {
-                    defaultLabel: __('pim_enrich.form.attribute.tab.properties.default_label.group')
+                    defaultLabel: __('pim_enrich.entity.attribute.property.group.choose')
                 }
             }));
         },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute/form/properties/metric-family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute/form/properties/metric-family.js
@@ -54,7 +54,7 @@ function (
                 choices: this.formatChoices(this.measures),
                 multiple: false,
                 labels: {
-                    defaultLabel: __('pim_enrich.form.attribute.tab.properties.default_label.metric_family')
+                    defaultLabel: __('pim_enrich.entity.attribute.property.metric_family.choose')
                 }
             }));
         },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute/form/properties/type.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute/form/properties/type.js
@@ -33,7 +33,7 @@ function (
         renderInput: function (templateContext) {
             var value = this.getFormData()[this.fieldName];
             var choices = {};
-            choices[value] = __('pim_enrich.entity.attribute.type.' + value);
+            choices[value] = __('pim_enrich.entity.attribute.property.type.' + value);
 
             return this.template(_.extend(templateContext, {
                 value: value,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/channel/form/properties/general/locales.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/channel/form/properties/general/locales.js
@@ -57,7 +57,7 @@ define([
                     this.$el.html(this.template({
                         currentLocales: this.getFormData().locales,
                         locales: locales,
-                        label: __('pim_common.locales'),
+                        label: __('pim_enrich.entity.locale.plural_label'),
                         requiredLabel: __('pim_enrich.form.required'),
                         errors: this.getParent().getValidationErrorsForField('locales')
                     }));

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/channel/form/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/channel/form/save.js
@@ -35,10 +35,10 @@ define(
         router
     ) {
         return BaseSave.extend({
-            updateSuccessMessage: __('pim_enrich.entity.channel.info.update_successful'),
-            updateFailureMessage: __('pim_enrich.entity.channel.info.update_failed'),
-            createSuccessMessage: __('pim_enrich.entity.channel.info.create_successful'),
-            createFailureMessage: __('pim_enrich.entity.channel.info.create_failed'),
+            updateSuccessMessage: __('pim_enrich.entity.channel.flash.update.success'),
+            updateFailureMessage: __('pim_enrich.entity.channel.flash.update.fail'),
+            createSuccessMessage: __('pim_enrich.entity.channel.flash.create.success'),
+            createFailureMessage: __('pim_enrich.entity.channel.flash.create.fail'),
 
             /**
              * {@inheritdoc}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/column-list-view.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/column-list-view.js
@@ -121,7 +121,7 @@ define([
                 this.template({
                     title: __('pim_datagrid.column_configurator.title'),
                     description: __('pim_datagrid.column_configurator.description'),
-                    attributeGroupsLabel: __('pim_common.attribute_groups'),
+                    attributeGroupsLabel: __('pim_enrich.entity.attribute_group.plural_label'),
                     groups:  groups,
                     columns: this.collection.toJSON()
                 })

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/channel/edit.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/channel/edit.js
@@ -19,7 +19,7 @@ define(
              */
             renderForm: function (route) {
                 if (undefined === route.params.code) {
-                    var label = 'pim_enrich.entity.channel.title.create';
+                    var label = 'pim_enrich.entity.channel.label.create';
 
                     return createForm.call(
                         this,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/front.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/front.js
@@ -13,7 +13,7 @@ define(['oro/translator', 'pim/controller/base', 'pim/error'], function (__, Bas
                     const message = response &&
                         response.responseJSON ?
                         response.responseJSON.message :
-                        __('error.common');
+                        __('pim_enrich.entity.fallback.generic_error');
                     const status = response && response.status ? response.status : 500;
 
                     const errorView = new Error(message, status);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/save.js
@@ -18,7 +18,7 @@ define(
         'pim/field-manager',
         'pim/i18n',
         'pim/user-context',
-        'oro/mediator'
+        'pim/mediator'
     ],
     function (
         $,
@@ -33,8 +33,8 @@ define(
         mediator
     ) {
         return BaseSave.extend({
-            updateSuccessMessage: __('pim_enrich.entity.family_variant.info.update_successful'),
-            updateFailureMessage: __('pim_enrich.entity.family_variant.info.update_failed'),
+            updateSuccessMessage: __('pim_enrich.entity.family_variant.flash.update.success'),
+            updateFailureMessage: __('pim_enrich.entity.family_variant.flash.update.fail'),
 
             /**
              * {@inheritdoc}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/save.js
@@ -18,7 +18,7 @@ define(
         'pim/field-manager',
         'pim/i18n',
         'pim/user-context',
-        'pim/mediator'
+        'oro/mediator'
     ],
     function (
         $,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -265,7 +265,7 @@ define([
                 if (attributeAsLabel === attributeToRemove) {
                     Messenger.notify(
                         'error',
-                        __('pim_enrich.entity.family.info.cant_remove_attribute_as_label')
+                        __('pim_enrich.entity.family.flash.update.can_remove_attribute_as_label')
                     );
 
                     return false;
@@ -273,14 +273,14 @@ define([
                 } else if (attributeAsImage === attributeToRemove) {
                     Messenger.notify(
                         'error',
-                        __('pim_enrich.entity.family.info.cant_remove_attribute_as_image')
+                        __('pim_enrich.entity.family.flash.update.cant_remove_attribute_as_image')
                     );
 
                     return false;
                 } else if (_.contains(attributesUsedAsAxis, attributeToRemove)) {
                     Messenger.notify(
                         'error',
-                        __('pim_enrich.entity.family.info.cant_remove_attribute_used_as_axis')
+                        __('pim_enrich.entity.family.flash.update.cant_remove_attribute_used_as_axis')
                     );
 
                     return false;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/save.js
@@ -32,8 +32,8 @@ define(
         UserContext
     ) {
         return BaseSave.extend({
-            updateSuccessMessage: __('pim_enrich.entity.family.info.update_successful'),
-            updateFailureMessage: __('pim_enrich.entity.family.info.update_failed'),
+            updateSuccessMessage: __('pim_enrich.entity.family.flash.update.success'),
+            updateFailureMessage: __('pim_enrich.entity.family.flash.update.fail'),
 
             /**
              * {@inheritdoc}
@@ -57,7 +57,7 @@ define(
                     messenger.notify(
                         'error',
                         __(
-                            'pim_enrich.entity.family.info.field_not_ready',
+                            'pim_enrich.entity.family.flash.update.fields_not_ready',
                             {'fields': fieldLabels.join(', ')}
                         )
                     );

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant.js
@@ -71,7 +71,7 @@ define(
                     .then((familyVariant) => {
                         messenger.notify(
                             'success',
-                            _.__('pim_enrich.form.pim_enrich.entity.family_variant.flash.create.success')
+                            _.__('pim_enrich.entity.family_variant.flash.create.success')
                         );
                         this.getRoot().trigger('pim_enrich.entity.family.family_variant.post_create', familyVariant);
                     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant.js
@@ -71,7 +71,7 @@ define(
                     .then((familyVariant) => {
                         messenger.notify(
                             'success',
-                            _.__('pim_enrich.form.family.tab.variant.flash.family_variant_created')
+                            _.__('pim_enrich.form.pim_enrich.entity.family_variant.flash.create.success')
                         );
                         this.getRoot().trigger('pim_enrich.entity.family.family_variant.post_create', familyVariant);
                     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -298,7 +298,7 @@ define(
                 var fields = FieldManager.getFields();
 
                 Dialog.confirm(
-                    __('pim_enrich.confirmation.delete.attribute'),
+                    __('confirmation.remove.attribute_from_product'),
                     __('pim_common.confirm_deletion'),
                     function () {
                         FetcherRegistry.getFetcher('attribute').fetch(attributeCode).then(function (attribute) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/create-button.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/create-button.js
@@ -119,7 +119,7 @@ define(
                     if (attributeTypesMap.hasOwnProperty(key)) {
                         sortedAttributeTypesByLabel.push({
                             code: key,
-                            label: __('pim_enrich.entity.attribute.type.' + attributeTypesMap[key])
+                            label: __('pim_enrich.entity.attribute.property.type.' + attributeTypesMap[key])
                         });
                     }
                 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/creation/modal.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/creation/modal.js
@@ -173,7 +173,7 @@ define(
                     }
 
                     this.validationErrors = response.responseJSON ?
-                        this.normalize(response.responseJSON) : [{message: __('error.common')}];
+                        this.normalize(response.responseJSON) : [{message: __('pim_enrich.entity.fallback.generic_error')}];
                     this.render();
                 }.bind(this))
                 .always(() => loadingMask.remove());

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/creation/modal.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/creation/modal.js
@@ -173,7 +173,9 @@ define(
                     }
 
                     this.validationErrors = response.responseJSON ?
-                        this.normalize(response.responseJSON) : [{message: __('pim_enrich.entity.fallback.generic_error')}];
+                        this.normalize(response.responseJSON) : [{
+                            message: __('pim_enrich.entity.fallback.generic_error')
+                        }];
                     this.render();
                 }.bind(this))
                 .always(() => loadingMask.remove());

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/delete.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/delete.js
@@ -56,8 +56,8 @@ define(
                     trans: {
                         title: 'confirmation.remove.item',
                         content: 'pim_common.confirm_deletion',
-                        success: 'flash.item.removed',
-                        fail: 'error.removing.item',
+                        success: 'pim_enrich.entity.fallback.flash.delete.success',
+                        fail: 'pim_enrich.entity.fallback.flash.delete.error',
                         subTitle: '',
                         buttonText: 'pim_common.delete'
                     },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/save.js
@@ -24,8 +24,8 @@ define(
     ) {
         return BaseForm.extend({
             loadingMask: null,
-            updateFailureMessage: __('pim_enrich.entity.info.update_failed'),
-            updateSuccessMessage: __('pim_enrich.entity.info.update_successful'),
+            updateFailureMessage: __('pim_enrich.entity.fallback.flash.update.fail'),
+            updateSuccessMessage: __('pim_enrich.entity.fallback.flash.update.success'),
             label: __('pim_common.save'),
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/secondary-actions.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/secondary-actions.js
@@ -35,7 +35,7 @@ define(
 
                 if (!_.isEmpty(this.extensions)) {
                     this.$el.html(this.template({
-                        titleLabel: __('pim_enrich.navigation.other_actions')
+                        titleLabel: __('pim_datagrid.actions.other')
                     }));
 
                     this.renderExtensions();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/state.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/state.js
@@ -37,8 +37,8 @@ define(
              */
             initialize: function (meta) {
                 this.config = _.extend({}, {
-                    confirmationMessage: 'pim_enrich.confirmation.discard_changes',
-                    confirmationTitle: 'pim_enrich.confirmation.leave',
+                    confirmationMessage: 'confirmation.discard_changes',
+                    confirmationTitle: 'confirmation.leave',
                     message: 'pim_enrich.info.entity.updated'
                 }, meta.config);
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/group/form/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/group/form/save.js
@@ -31,8 +31,8 @@ define(
         UserContext
     ) {
         return BaseSave.extend({
-            updateSuccessMessage: __('pim_enrich.entity.group.info.update_successful'),
-            updateFailureMessage: __('pim_enrich.entity.group.info.update_failed'),
+            updateSuccessMessage: __('pim_enrich.entity.group.flash.update.success'),
+            updateFailureMessage: __('pim_enrich.entity.group.flash.update.fail'),
 
             /**
              * {@inheritdoc}
@@ -55,7 +55,7 @@ define(
 
                     messenger.notify(
                         'error',
-                        __('pim_enrich.entity.group.info.field_not_ready', {'fields': fieldLabels.join(', ')})
+                        __('pim_enrich.entity.group.flash.update.fields_not_ready', {'fields': fieldLabels.join(', ')})
                     );
 
                     return;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/label.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/label.js
@@ -17,7 +17,7 @@ define(
              * @return {String}
              */
             getLabel: function () {
-                var prefix = __('pim_enrich.form.job_instance.title.' + this.getFormData().type);
+                var prefix = __('pim_import_export.form.job_instance.title.' + this.getFormData().type);
 
                 return prefix + ' - ' + this.getFormData().label;
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/label.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/label.js
@@ -10,14 +10,13 @@ define(
     ['pim/form/common/label', 'oro/translator'],
     function (BaseLabel, __) {
         return BaseLabel.extend({
-
             /**
              * Provide the object label
              *
              * @return {String}
              */
             getLabel: function () {
-                var prefix = __('pim_import_export.form.job_instance.title.' + this.getFormData().type);
+                const prefix = __('pim_import_export.entity.' + this.getFormData().type + '.uppercase_label');
 
                 return prefix + ' - ' + this.getFormData().label;
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/label.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/label.js
@@ -16,7 +16,8 @@ define(
              * @return {String}
              */
             getLabel: function () {
-                const prefix = __('pim_import_export.entity.' + this.getFormData().type + '.uppercase_label');
+                // The key is for example 'pim_import_export.entity.import_profile.uppercase_label'
+                const prefix = __('pim_import_export.entity.' + this.getFormData().type + '_profile.uppercase_label');
 
                 return prefix + ' - ' + this.getFormData().label;
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/launch.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/launch.js
@@ -63,7 +63,7 @@ define(
                         router.redirect(response.redirectUrl);
                     })
                     .fail(function () {
-                        messenger.notify('error', __('pim_enrich.form.job_instance.fail.launch'));
+                        messenger.notify('error', __('pim_import_export.form.job_instance.fail.launch'));
                     });
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/save.js
@@ -33,8 +33,8 @@ define(
         router
     ) {
         return BaseSave.extend({
-            updateSuccessMessage: __('pim_enrich.entity.job_instance.info.update_successful'),
-            updateFailureMessage: __('pim_enrich.entity.job_instance.info.update_failed'),
+            updateSuccessMessage: __('pim_enrich.entity.job_instance.flash.update.success'),
+            updateFailureMessage: __('pim_enrich.entity.job_instance.flash.update.fail'),
 
             /**
              * {@inheritdoc}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/save.js
@@ -33,8 +33,8 @@ define(
         router
     ) {
         return BaseSave.extend({
-            updateSuccessMessage: __('pim_enrich.entity.job_instance.flash.update.success'),
-            updateFailureMessage: __('pim_enrich.entity.job_instance.flash.update.fail'),
+            updateSuccessMessage: __('pim_import_export.entity.job_instance.flash.update.success'),
+            updateFailureMessage: __('pim_import_export.entity.job_instance.flash.update.fail'),
 
             /**
              * {@inheritdoc}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/upload-launch.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/upload-launch.js
@@ -55,7 +55,7 @@ define(
                         router.redirect(response.redirectUrl);
                     })
                     .fail(() => {
-                        messenger.notify('error', __('pim_enrich.form.job_instance.fail.launch'));
+                        messenger.notify('error', __('pim_import_export.form.job_instance.fail.launch'));
                     })
                     .always(router.hideLoadingMask());
                 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/label.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/label.js
@@ -18,7 +18,7 @@ define(
              */
             getLabel: function () {
                 var jobInstance = this.getFormData().jobInstance;
-                var prefix = __('pim_enrich.form.job_execution.title.details');
+                var prefix = __('pim_import_export.form.job_execution.title.details');
 
                 return prefix + ' - ' + jobInstance.label + ' [' + jobInstance.code + ']';
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/product/edit/content/structure/attributes-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/product/edit/content/structure/attributes-selector.js
@@ -85,7 +85,7 @@ define(
                         attributeCount: attributeCount,
                         currentGroup: this.currentGroup,
                         selectedAttributes: selectedAttributes,
-                        title: __('pim_common.attributes'),
+                        title: __('pim_enrich.entity.attribute.plural_label'),
                         description: __('pim_enrich.export.product.filter.attributes_selector.description')
                     }));
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/product/edit/content/structure/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/product/edit/content/structure/attributes.js
@@ -63,7 +63,7 @@ define(
                     this.template({
                         __: __,
                         isEditable: this.isEditable(),
-                        titleEdit: __('pim_common.attributes'),
+                        titleEdit: __('pim_enrich.entity.attribute.plural_label'),
                         labelEdit: __('pim_common.edit'),
                         labelInfo: __(
                             'pim_enrich.export.product.filter.attributes.label',

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/change-family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/change-family.js
@@ -43,7 +43,7 @@ define(
                 this.$el.html(this.template({
                     readOnly: this.readOnly,
                     value: this.getValue(),
-                    label: __('pim_enrich.mass_edit.product.operation.change_family.field')
+                    label: __('pim_enrich.entity.family.title')
                 }));
 
                 var options = Select2Configurator.getConfig(this.getValue());

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/change-family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/change-family.js
@@ -43,7 +43,7 @@ define(
                 this.$el.html(this.template({
                     readOnly: this.readOnly,
                     value: this.getValue(),
-                    label: __('pim_enrich.entity.family.label')
+                    label: __('pim_enrich.entity.family.uppercase_label')
                 }));
 
                 var options = Select2Configurator.getConfig(this.getValue());

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/change-family.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/change-family.js
@@ -43,7 +43,7 @@ define(
                 this.$el.html(this.template({
                     readOnly: this.readOnly,
                     value: this.getValue(),
-                    label: __('pim_enrich.entity.family.title')
+                    label: __('pim_enrich.entity.family.label')
                 }));
 
                 var options = Select2Configurator.getConfig(this.getValue());

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -178,7 +178,7 @@ define(
                 } else {
                     Dialog.alert(
                         __('alert.attribute_option.error_occured_during_submission'),
-                        __('error.saving.attribute_option')
+                        __('pim_enrich.entity.attribute_option.flash.update.fail')
                     );
                 }
             },
@@ -413,7 +413,7 @@ define(
                             message = response.responseText;
                         }
 
-                        Dialog.alert(message, __('error.removing.attribute_option'));
+                        Dialog.alert(message, __('pim_enrich.entity.attribute_option.flash.delete.fail'));
                     }.bind(this)
                 });
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -137,7 +137,7 @@ define(
                     function () {
                         this.parent.deleteItem(this);
                     }.bind(this),
-                    __('pim_common.attributes')
+                    __('pim_enrich.entity.attribute.plural_label')
                 );
             },
             updateItem: function () {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -109,8 +109,8 @@ define(
                 if (!this.model.id || this.dirty) {
                     if (this.dirty) {
                         Dialog.confirm(
-                            __('confirm.attribute_option.cancel_edition_on_new_option_text'),
-                            __('confirm.attribute_option.cancel_edition_on_new_option_title'),
+                            __('confirmation.cancel.message'),
+                            __('confirmation.cancel.title'),
                             function () {
                                 this.showReadableItem(this);
                                 if (!this.model.id) {
@@ -132,8 +132,8 @@ define(
                 var itemCode = this.el.firstChild.innerText;
 
                 Dialog.confirmDelete(
-                    __('pim_enrich.item.delete.confirm.content', {'itemName': itemCode}),
-                    __('pim_enrich.item.delete.confirm.title', {'itemName': itemCode}),
+                    __('confirmation.remove.item_placeholder', {'itemName': itemCode}),
+                    __('confirmation.remove.title', {'itemName': itemCode}),
                     function () {
                         this.parent.deleteItem(this);
                     }.bind(this),

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-item-tableview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-item-tableview.js
@@ -105,7 +105,7 @@ define(
                             message = response.responseText;
                         }
 
-                        Dialog.alert(message, __('pim_enrich.item.list.delete.error'));
+                        Dialog.alert(message, __('error.removing.item'));
                     }.bind(this)
                 });
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-item-tableview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-item-tableview.js
@@ -105,7 +105,7 @@ define(
                             message = response.responseText;
                         }
 
-                        Dialog.alert(message, __('error.removing.item'));
+                        Dialog.alert(message, __('pim_enrich.entity.fallback.flash.delete.error'));
                     }.bind(this)
                 });
             },

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-item-view.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-item-view.js
@@ -33,8 +33,8 @@ define(
             },
             deleteItem: function () {
                 Dialog.confirm(
-                    __('pim_enrich.item.delete.confirm.content', {'itemName': this.itemName}),
-                    __('pim_enrich.item.delete.confirm.title', {'itemName': this.itemName}),
+                    __('confirmation.remove.item_placeholder', {'itemName': this.itemName}),
+                    __('confirmation.remove.title', {'itemName': this.itemName}),
                     function () {
                         this.parent.deleteItem(this);
                     }.bind(this)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/save.js
@@ -29,8 +29,8 @@ define(
         UserContext
     ) {
         return BaseSave.extend({
-            updateSuccessMessage: __('pim_enrich.entity.product_model.info.update_successful'),
-            updateFailureMessage: __('pim_enrich.entity.product_model.info.update_failed'),
+            updateSuccessMessage: __('pim_enrich.entity.product_model.flash.update.success'),
+            updateFailureMessage: __('pim_enrich.entity.product_model.flash.update.fail'),
 
             configure: function () {
                 this.listenTo(this.getRoot(), 'pim_enrich:form:update-association', this.save);
@@ -61,7 +61,7 @@ define(
 
                     messenger.notify(
                         'error',
-                        __('pim_enrich.entity.product_model.info.field_not_ready', {'fields': fieldLabels.join(', ')})
+                        __('pim_enrich.entity.product_model.flash.update.fields_not_ready', {'fields': fieldLabels.join(', ')})
                     );
 
                     return;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product-model/form/save.js
@@ -61,7 +61,9 @@ define(
 
                     messenger.notify(
                         'error',
-                        __('pim_enrich.entity.product_model.flash.update.fields_not_ready', {'fields': fieldLabels.join(', ')})
+                        __('pim_enrich.entity.product_model.flash.update.fields_not_ready', {
+                            'fields': fieldLabels.join(', ')
+                        })
                     );
 
                     return;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/media-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/media-field.js
@@ -58,7 +58,7 @@ define([
             updateModel: function () {
                 if (!this.isReady()) {
                     Dialog.alert(_.__(
-                        'pim_enrich.entity.product.info.already_in_upload',
+                        'pim_enrich.entity.product.flash.update.already_in_upload',
                         {'locale': this.context.locale, 'scope': this.context.scope}
                     ));
                 }
@@ -101,7 +101,7 @@ define([
                 .fail(function (xhr) {
                     var message = xhr.responseJSON && xhr.responseJSON.message ?
                         xhr.responseJSON.message :
-                        _.__('pim_enrich.entity.product.error.upload');
+                        _.__('pim_enrich.entity.product.flash.update.file_upload');
                     messenger.enqueueMessage('error', message);
                 })
                 .always(function () {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/categories.js
@@ -81,7 +81,7 @@ define(
                 this.trigger('tab:register', {
                     code: (undefined === this.config.tabCode) ? this.code : this.config.tabCode,
                     isVisible: this.isVisible.bind(this),
-                    label: __('pim_common.categories')
+                    label: __('pim_enrich.entity.category.plural_label')
                 });
 
                 this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', function (localeEvent) {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/creation/identifier.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/creation/identifier.js
@@ -40,7 +40,7 @@ define([
 
                 return this;
             }.bind(this)).fail(() => {
-                this.$el.html(this.errorTemplate({message: __('error.creating.product')}));
+                this.$el.html(this.errorTemplate({message: __('pim_enrich.entity.product.flash.create.fail')}));
             });
         }
     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/locale-switcher.js
@@ -80,7 +80,7 @@ define(
                                 i18n: i18n,
                                 displayInline: this.displayInline,
                                 displayLabel: this.displayLabel,
-                                label: __('pim_enrich.entity.product.meta.locale')
+                                label: __('pim_enrich.entity.locale.uppercase_locale')
                             })
                         );
                         this.delegateEvents();

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/save.js
@@ -63,7 +63,9 @@ define(
 
                     messenger.notify(
                         'error',
-                        __('pim_enrich.entity.product.flash.update.fields_not_ready', {'fields': fieldLabels.join(', ')})
+                        __('pim_enrich.entity.product.flash.update.fields_not_ready', {
+                            'fields': fieldLabels.join(', ')
+                        })
                     );
 
                     return;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/save.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/save.js
@@ -31,8 +31,8 @@ define(
         UserContext
     ) {
         return BaseSave.extend({
-            updateSuccessMessage: __('pim_enrich.entity.product.info.update_successful'),
-            updateFailureMessage: __('pim_enrich.entity.product.info.update_failed'),
+            updateSuccessMessage: __('pim_enrich.entity.product.flash.update.success'),
+            updateFailureMessage: __('pim_enrich.entity.product.flash.update.fail'),
 
             configure: function () {
                 this.listenTo(this.getRoot(), 'pim_enrich:form:change-family:after', this.save);
@@ -63,7 +63,7 @@ define(
 
                     messenger.notify(
                         'error',
-                        __('pim_enrich.entity.product.info.field_not_ready', {'fields': fieldLabels.join(', ')})
+                        __('pim_enrich.entity.product.flash.update.fields_not_ready', {'fields': fieldLabels.join(', ')})
                     );
 
                     return;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/scope-switcher.js
@@ -88,7 +88,7 @@ define(
                                 i18n: i18n,
                                 displayInline: this.displayInline,
                                 displayLabel: this.displayLabel,
-                                label: __('pim_common.channel')
+                                label: __('pim_enrich.entity.channel.uppercase_label')
                             })
                         );
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
@@ -48,7 +48,7 @@ define(
              */
             render() {
                 this.$el.html(this.template({
-                    label: __('pim_enrich.entity.category.label').toUpperCase(),
+                    label: __('pim_enrich.entity.category.uppercase_label'),
                     isOpen: this.isOpen,
                     categoryLabel: this.categoryLabel,
                     treeLabel: this.treeLabel

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
@@ -48,7 +48,7 @@ define(
              */
             render() {
                 this.$el.html(this.template({
-                    label: __('pim_enrich.entity.product.category'),
+                    label: __('pim_enrich.entity.category.label').toUpperCase(),
                     isOpen: this.isOpen,
                     categoryLabel: this.categoryLabel,
                     treeLabel: this.treeLabel

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/locale-switcher.js
@@ -69,7 +69,7 @@ define(
                 }
 
                 this.$el.empty().append(this.template({
-                    localeLabel: __('pim_enrich.entity.locale.label').toUpperCase(),
+                    localeLabel: __('pim_enrich.entity.locale.uppercase_label'),
                     locales: this.locales,
                     currentLocale,
                     i18n,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/locale-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/locale-switcher.js
@@ -69,7 +69,7 @@ define(
                 }
 
                 this.$el.empty().append(this.template({
-                    localeLabel: __('pim_enrich.entity.product.locale'),
+                    localeLabel: __('pim_enrich.entity.locale.label').toUpperCase(),
                     locales: this.locales,
                     currentLocale,
                     i18n,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/router.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/router.js
@@ -96,7 +96,7 @@ define(
                     if (controller.aclResourceId && !securityContext.isGranted(controller.aclResourceId)) {
                         this.hideLoadingMask();
 
-                        return this.displayErrorPage(__('pim_enrich.error.http.403'), '403');
+                        return this.displayErrorPage(__('error.exception.forbidden'), '403');
                     }
 
                     controller.el = $view;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-group/tab/attribute.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-group/tab/attribute.html
@@ -27,7 +27,7 @@
                                 </span>
                             </td>
                             <td class="AknGrid-bodyCell"><%- i18n.getLabel(attribute.labels, UserContext.get('uiLocale'), attribute.code) %></td>
-                            <td class="AknGrid-bodyCell"><%- __('pim_enrich.entity.attribute.type.' + attribute.type) %></td>
+                            <td class="AknGrid-bodyCell"><%- __('pim_enrich.entity.attribute.property.type.' + attribute.type) %></td>
                             <td class="AknGrid-bodyCell">
                                 <input type="checkbox" disabled="disabled"<%- attribute.scopable ? ' checked="checked"' : '' %>>
                             </td>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-option/index.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-option/index.html
@@ -11,7 +11,7 @@
                 <%- locale %>
             </th>
         <% }); %>
-        <th class="AknGrid-headerCell AknGrid-headerCell--right"><%- _.__('pim_enrich.entity.attribute_option.actions') %></th>
+        <th class="AknGrid-headerCell AknGrid-headerCell--right"><%- _.__('pim_common.actions') %></th>
     </tr>
 </thead>
 <tbody></tbody>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/error/error.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/error/error.html
@@ -2,7 +2,7 @@
     <img src="/bundles/pimui/images/illustration-error-<%- statusCode >= 400 && statusCode < 500 ? '404' : '503' %>.svg"/>
     <span class="AknInfoBlock-errorNumber AknInfoBlock-errorNumber--<%- statusCode >= 400 && statusCode < 500 ? '400' : '500' %>"><%- statusCode %></span>
     <h1>
-        <%- _.__('pim_enrich.error.exception.title', {'status_code': statusCode}) %>
+        <%- _.__('error.exception', {'status_code': statusCode}) %>
     </h1>
     <div class="AknMessageBox AknMessageBox--danger AknMessageBox--centered"><%- message %></div>
 </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/common/edit/meta.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/common/edit/meta.html
@@ -1,1 +1,1 @@
-<span class="AknTitleContainer-metaItem"><%- __('pim_enrich.form.job_instance.meta.job') %>: <%- jobInstance.code %> | <%- __('pim_enrich.form.job_instance.meta.connector') %>: <%- jobInstance.connector %></span>
+<span class="AknTitleContainer-metaItem"><%- __('pim_import_export.form.job_instance.meta.job') %>: <%- jobInstance.code %> | <%- __('pim_import_export.form.job_instance.meta.connector') %>: <%- jobInstance.connector %></span>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/attributes-selector.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/attributes-selector.html
@@ -5,7 +5,7 @@
     <%- description %>
 </div>
 <div class="AknColumnConfigurator-column attribute-groups">
-    <header class="AknColumnConfigurator-columnHeader"><%- __('pim_common.attribute_groups') %></header>
+    <header class="AknColumnConfigurator-columnHeader"><%- __('pim_enrich.entity.attribute_group.plural_label') %></header>
     <div data-scroll-container="attribute-groups" class="AknColumnConfigurator-listContainer">
         <ul class="AknVerticalList">
             <li class="AknVerticalList-item AknVerticalList-item--selectable <%- null === currentGroup ? 'selected active' : '' %>" data-attribute-group-code=""><%- __('pim_enrich.export.product.filter.attributes_selector.all_group') %></li>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/attributes.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/attributes.html
@@ -1,5 +1,5 @@
 <div class="AknFieldContainer-header">
-    <label class="AknFieldContainer-label control-label required" for="pim_enrich.export.product.filter.attributes"><%- __('pim_common.attributes') %></label>
+    <label class="AknFieldContainer-label control-label required" for="pim_enrich.export.product.filter.attributes"><%- __('pim_enrich.entity.attribute.plural_label') %></label>
 </div>
 <div class="AknFieldContainer-inputContainer">
     <div class="AknTextField <%- !isEditable ? 'AknTextField--disabled' : 'AknTextField--withRightButton' %>">

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/locales.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/locales.html
@@ -1,6 +1,6 @@
 <div class="AknFieldContainer-header">
     <label class="AknFieldContainer-label control-label required" for="pim_enrich.export.product.filter.locales">
-        <%- __('pim_common.locales') %> <em><%- __('pim_enrich.form.required') %></em>
+        <%- __('pim_enrich.entity.locale.plural_label') %> <em><%- __('pim_enrich.form.required') %></em>
     </label>
 </div>
 <div class="AknFieldContainer-inputContainer">

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/scope.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/scope.html
@@ -1,6 +1,6 @@
 <div class="AknFieldContainer-header">
     <label class="AknFieldContainer-label control-label required" for="pim_enrich.export.product.filter.channel">
-        <%- __('pim_common.channel') %> <em><%- __('pim_enrich.form.required') %></em>
+        <%- __('pim_enrich.entity.channel.uppercase_label') %> <em><%- __('pim_enrich.form.required') %></em>
     </label>
 </div>
 <div class="AknFieldContainer-inputContainer">

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family/tab/variants/add-variant-form-header.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family/tab/variants/add-variant-form-header.html
@@ -1,3 +1,3 @@
-<div class="AknFullPage-subTitle"><%- __('pim_enrich.entity.family.label') %> <%- familyName %></div>
+<div class="AknFullPage-subTitle"><%- __('pim_enrich.entity.family.uppercase_label') %> <%- familyName %></div>
 <div class="AknFullPage-title"><%- __('pim_enrich.entity.family.variant.create_label') %></div>
 <div class="AknFullPage-description"><%- __('pim_enrich.entity.family.variant.create_description') %></div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family/tab/variants/add-variant-form-header.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family/tab/variants/add-variant-form-header.html
@@ -1,3 +1,3 @@
-<div class="AknFullPage-subTitle"><%- __('pim_enrich.entity.family.title') %> <%- familyName %></div>
+<div class="AknFullPage-subTitle"><%- __('pim_enrich.entity.family.label') %> <%- familyName %></div>
 <div class="AknFullPage-title"><%- __('pim_enrich.entity.family.variant.create_label') %></div>
 <div class="AknFullPage-description"><%- __('pim_enrich.entity.family.variant.create_description') %></div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/job-execution/auto-refresh.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/job-execution/auto-refresh.html
@@ -2,5 +2,5 @@
      class="AknButtonList-item <%- loadingShown ? '': 'AknButtonList-item--transparent' %>"/>
 <a class="AknButtonList-item AknButton <%- refreshBtnShown ? '': 'AknButtonList-item--transparent' %>"
    title="Refresh">
-    <%- __('pim_enrich.form.job_execution.refreshBtn.title')%>
+    <%- __('pim_import_export.form.job_execution.refreshBtn.title')%>
 </a>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/job-execution/summary-table.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/job-execution/summary-table.html
@@ -1,17 +1,17 @@
 <div class="AknGridContainer grid-container">
     <table class="AknGrid AknGrid--unclickable grid job-execution" id="job-execution">
         <thead>
-        <th class="AknGrid-headerCell"><%- transAndUpperCase('pim_enrich.form.job_execution.summary.header.step')%></th>
+        <th class="AknGrid-headerCell"><%- transAndUpperCase('pim_import_export.form.job_execution.summary.header.step')%></th>
         <th class="AknGrid-headerCell"><%- transAndUpperCase('pim_common.status')%></th>
-        <th class="AknGrid-headerCell"><%- transAndUpperCase('pim_enrich.form.job_execution.summary.header.summary')%></th>
-        <th class="AknGrid-headerCell"><%- transAndUpperCase('pim_enrich.form.job_execution.summary.header.start')%></th>
-        <th class="AknGrid-headerCell"><%- transAndUpperCase('pim_enrich.form.job_execution.summary.header.end')%></th>
+        <th class="AknGrid-headerCell"><%- transAndUpperCase('pim_import_export.form.job_execution.summary.header.summary')%></th>
+        <th class="AknGrid-headerCell"><%- transAndUpperCase('pim_import_export.form.job_execution.summary.header.start')%></th>
+        <th class="AknGrid-headerCell"><%- transAndUpperCase('pim_import_export.form.job_execution.summary.header.end')%></th>
         </thead>
         <tbody>
         <% if (!stepExecutions) { %>
         <tr class="AknGrid-bodyRow">
             <td class="AknGrid-bodyCell AknGrid-bodyCell--full" colspan="5">
-                <%- __('pim_enrich.form.job_execution.summary.fetching')%>
+                <%- __('pim_import_export.form.job_execution.summary.fetching')%>
             </td>
         </tr>
         <% } else { %>
@@ -40,7 +40,7 @@
                 <tr class="AknGrid-bodyRow warning">
                     <td class="AknGrid-bodyCell AknGrid-bodyCell--full" colspan="5">
                         <div class="AknMessageBox AknMessageBox--warning">
-                            <span class="AknMessageBox-title title"><%- __('pim_enrich.form.job_execution.summary.warning')%></span>
+                            <span class="AknMessageBox-title title"><%- __('pim_import_export.form.job_execution.summary.warning')%></span>
                             <ul class="AknMessageBox-list">
                                 <% _.each(warning.reason.split("\n"), function(warningItem) { %>
                                     <% if (warningItem) { %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/history.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/history.html
@@ -7,7 +7,7 @@
                 <th class="AknGrid-headerCell author"><%- _.__('pim_enrich.entity.product.history.author') %></th>
                 <th class="AknGrid-headerCell loggedAt"><%- _.__('pim_enrich.entity.product.history.logged_at') %></th>
                 <th class="AknGrid-headerCell changes"><%- _.__('pim_enrich.entity.product.history.modified') %></th>
-                <% if (hasAction) { %><th class="AknGrid-headerCell actions"><%- _.__('pim_enrich.entity.product.history.actions') %></th><% } %>
+                <% if (hasAction) { %><th class="AknGrid-headerCell actions"><%- _.__('pim_common.actions') %></th><% } %>
             </tr>
         </thead>
         <tbody>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/family.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/family.html
@@ -1,2 +1,2 @@
-<div class="AknColumn-subtitle"><%- _.__('pim_enrich.entity.product.meta.family.title')%></div>
+<div class="AknColumn-subtitle"><%- _.__('pim_enrich.entity.family.title')%></div>
 <div class="AknColumn-value product-family" data-drop-zone="buttons"><%- familyLabel %></div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/family.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/family.html
@@ -1,2 +1,2 @@
-<div class="AknColumn-subtitle"><%- _.__('pim_enrich.entity.family.label')%></div>
+<div class="AknColumn-subtitle"><%- _.__('pim_enrich.entity.family.uppercase_label')%></div>
 <div class="AknColumn-value product-family" data-drop-zone="buttons"><%- familyLabel %></div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/family.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/meta/family.html
@@ -1,2 +1,2 @@
-<div class="AknColumn-subtitle"><%- _.__('pim_enrich.entity.family.title')%></div>
+<div class="AknColumn-subtitle"><%- _.__('pim_enrich.entity.family.label')%></div>
 <div class="AknColumn-value product-family" data-drop-zone="buttons"><%- familyLabel %></div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/sequential-edit.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/sequential-edit.html
@@ -8,7 +8,7 @@
 <span class="AknSequentialEdit-progress AknProgress--info AknProgress progress progress-bar">
     <div class="AknProgress-bar bar" style="width: <%- ratio %>%;">
     <% if (ratio < 30) { %></div>&nbsp;&nbsp;<% } %>
-    <%- currentIndex %> / <%- objectCount %> <%- _.__('pim_common.products') %>
+    <%- currentIndex %> / <%- objectCount %> <%- _.__('pim_enrich.entity.product.plural_label') %>
     <% if (ratio >= 30) { %></div><% } %>
 </span>
 <% if (nextObject) { %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product_model/add-child/header.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product_model/add-child/header.html
@@ -1,2 +1,2 @@
-<div class="AknFullPage-subTitle"><%- __('pim_enrich.entity.product_model.title') %></div>
+<div class="AknFullPage-subTitle"><%- __('pim_enrich.entity.product_model.plural_label') %></div>
 <div class="AknFullPage-title"><%- __('pim_enrich.entity.product_model.add_child.create_label', { axes: axes }) %></div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
@@ -34,6 +34,7 @@ pim_common:
     not_available: N/A
     now: Now
     ok: OK
+    permissions: Permissions
     previous: Previous
     properties: Properties
     products: Products

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
@@ -125,63 +125,7 @@ pim_datagrid:
             hint: There are no associated products
             subHint: 'Click on the button "Add associations" to associate this product'
 
-flash:
-    item:
-        removed: Item successfully removed
-    association_type:
-        removed: Association type successfully removed
-    attribute:
-        removed: Attribute successfully removed
-    attribute_group:
-        removed: Attribute group successfully removed
-    family:
-        removed: Family successfully removed
-    family_variant:
-        removed: Family variant successfully removed
-    product:
-        removed: Product successfully removed
-    product_model:
-        removed: Product model successfully removed
-    channel:
-        removed: Channel successfully removed
-    group:
-        removed: Group successfully removed
-    group_type:
-        removed: Group type successfully removed
-    import profile:
-        removed: Import profile successfully removed
-    export profile:
-        removed: Export profile successfully removed
-    user:
-        removed: User successfully removed
-    role:
-        removed: Role successfully removed
-    job_instance:
-        removed: Job instance successfully removed
-    api_connection:
-        removed: API connection successfully revoked
-
 error:
-    common: An error occured
-    creating:
-        product: No attribute is configured as a product identifier or you don't have the rights to edit it.
-    removing:
-        item:             Cannot delete this item
-        association_type: Cannot delete this association type
-        attribute:        Cannot delete this attribute
-        family:           Cannot delete this family
-        product:          Cannot delete this product
-        channel:          Cannot delete this channel
-        group:            Cannot delete this group
-        group type:       Cannot delete this group type
-        import profile:   Cannot delete this import profile
-        export profile:   Cannot delete this export profile
-        user:             Cannot delete this user
-        role:             Cannot delete this role
-        attribute_option: Error during deletion of the attribute option
-    saving:
-        attribute_option: Cannot save attribute option
-        export_profile: Cannot save export profile. Please check that all filters are well filled
     exception: Oh snap! A {{ status_code }} error occured...
     forbidden: Forbidden. You are not allowed to access this page
 
@@ -194,10 +138,30 @@ alert:
 
 pim_enrich:
     entity:
-        info:
-            update_failed: Update failed
-            update_successful: Successfully updated
+        fallback:
+            flash:
+                generic_error: An error occured
+                update:
+                    fail: Update failed
+                    success: Successfully updated
+                delete:
+                    fail: Cannot delete this item
+                    success: Item successfully removed
+
         product:
+            flash:
+                update:
+                    success: Product successfully updated.
+                    fail: The product could not be updated.
+                    fields_not_ready: "The product cannot be saved right now. The following fields are not ready: {{ fields }}"
+                    already_in_upload: A file is already in upload for this attribute in the locale "{{ locale }}" and scope "{{ scope }}"
+                    file_upload: An error occured during the file upload
+                delete:
+                    success: Product successfully deleted.
+                    fail: The product could not be deleted.
+                create:
+                    success: Product successfully created
+                    fail: No attribute is configured as a product identifier or you don't have the rights to edit it.
             navigation: Product navigation
             infos: Product infos
             index_title: "] -Inf, 1] {{ count }} result|] 1, Inf [{{ count }} results"
@@ -223,19 +187,8 @@ pim_enrich:
                 old_value: Old value
                 new_value: New value
                 actions: Actions
-            info:
-                deletion_successful: Product successfully deleted.
-                deletion_failed: The product could not be deleted.
-                update_successful: Product successfully updated.
-                update_failed: The product could not be updated.
-                field_not_ready: "The product cannot be saved right now. The following fields are not ready: {{ fields }}"
-                already_in_upload: A file is already in upload for this attribute in the locale "{{ locale }}" and scope "{{ scope }}"
-            error:
-                upload: An error occured during the file upload
             meta:
                 updated: Last update
-                family:
-                    title: Family
                 family_variant:
                     title: Variant
                 groups:
@@ -262,23 +215,25 @@ pim_enrich:
                 labels:
                     family: Choose a family
                     family_variant: Choose a family variant
-            message:
-                created: Product successfully created
             completeness: Complete
             sequential_edit:
                 item_limit: Only first 1000 items shown in this sequential edit ({{ count }} selected)
                 empty: Your selection is empty, please change your search criteria
+
         product_model:
+            flash:
+                create:
+                    success: Product model successfully created
+                update:
+                    success: Product model successfully updated. The completeness of its variant products will be recalculated.
+                    fail: The product model could not be updated.
+                    fields_not_ready: "The product model cannot be saved right now. The following fields are not ready: {{ fields }}"
+                delete:
+                    success: Product model successfully deleted.
             create_popin:
                 type: Product model
                 title: Create a product model
                 content: A product model gathers variant products and eases the enrichment of their common properties.
-            info:
-                create_successful: Product model successfully created
-                update_successful: Product model successfully updated. The completeness of its variant products will be recalculated.
-                deletion_successful: Product model successfully deleted.
-                update_failed: The product model could not be updated.
-                field_not_ready: "The product model cannot be saved right now. The following fields are not ready: {{ fields }}"
             read_only_parent_attribute_from_common: This attribute can be updated in the common attributes.
             read_only_parent_attribute_from_model: "This attribute can be updated in the attributes by {{ axes }}"
             variant_axis: Variant axis
@@ -288,47 +243,60 @@ pim_enrich:
                 create_label: "Add a new {{ axes }}"
                 fields:
                     required_label: (variant axis)
+
         association_type:
-            info:
-                deletion_successful: Association type successfully deleted.
-                deletion_failed: Association type could not be deleted.
-                update_successful: Association type successfully updated.
-                update_failed: The association type could not be updated.
-                field_not_ready: "The association type cannot be saved right now. The following fields are not ready: {{ fields }}"
+            flash:
+                update:
+                    success: Association type successfully updated.
+                    fail: The association type could not be updated.
+                    fields_not_ready: "The association type cannot be saved right now. The following fields are not ready: {{ fields }}"
+                create:
+                    success: Association type successfully created
+                delete:
+                    success: Association type successfully removed
+                    fail: Cannot delete this association type
             title: association type
-            message:
-                created: Association type successfully created
+
         group_type:
-            info:
-                deletion_successful: Group type successfully deleted.
-                deletion_failed: Group type could not be deleted.
-                update_successful: Group type successfully updated.
-                update_failed: The group type could not be updated.
-                field_not_ready: "The group type cannot be saved right now. The following fields are not ready: {{ fields }}"
+            flash:
+                update:
+                    success: Group type successfully updated.
+                    fail: The group type could not be updated.
+                    fields_not_ready: "The group type cannot be saved right now. The following fields are not ready: {{ fields }}"
+                create:
+                    success: Group type successfully created
+                delete:
+                    success: Group type successfully removed
+                    fail: Cannot delete this group type
             title: group type
-            message:
-                created: Group type successfully created
+
         channel:
-            info:
-                deletion_successful: Channel successfully deleted.
-                deletion_failed: Channel could not be deleted.
-                update_successful: Channel successfully updated.
-                update_failed: The channel could not be updated.
-                create_successful: Channel successfully created.
-                create_failed: The channel could not be created.
-                field_not_ready: "The channel cannot be saved right now. The following fields are not ready: {{ fields }}"
+            flash:
+                update:
+                    success: Channel successfully updated.
+                    fail: The channel could not be updated.
+                create:
+                    success: Channel successfully created.
+                    fail: The channel could not be created.
+                delete:
+                    success: Channel successfully removed
+                    fail: Cannot delete this channel
         family:
-            title: family
+            flash:
+                update:
+                    success: Family successfully updated.
+                    fail: An error occured during family update.
+                    cant_remove_attribute_as_label: Cannot remove attribute used as label
+                    cant_remove_attribute_as_image: Cannot remove attribute used as the main picture
+                    cant_remove_attribute_used_as_axis: Cannot remove this attribute used as a variant axis in a family variant
+                    fields_not_ready: "The family cannot be saved right now. The following fields are not ready: {{ fields }}"
+                create:
+                    success: Family successfully created
+                delete:
+                    success: Family successfully removed
+                    fail: Cannot delete this family
+            title: Family
             selected: selected families
-            info:
-                update_successful: Family successfully updated.
-                update_failed: An error occured during family update.
-                cant_remove_attribute_as_label: Cannot remove attribute used as label
-                cant_remove_attribute_as_image: Cannot remove attribute used as the main picture
-                attribute_edit_permission_is_not_granted: You have no rights to edit family's attributes
-                cant_remove_attribute_used_as_axis: Cannot remove this attribute used as a variant axis in a family variant
-            message:
-                created: Family successfully created
             variant:
                 common:
                     title: Common attributes
@@ -346,35 +314,57 @@ pim_enrich:
                 confirm_attribute_removal:
                     title: Confirm remove of attributes
                     message: By removing these attributes you will put them back in the common attributes of the family variant and remove the values from the variant products
+
         family_variant:
-            info:
-                update_successful: Family variant successfully updated. The products with variants will be updated with your changes.
+            flash:
+                update:
+                    success: Family variant successfully updated. The products with variants will be updated with your changes.
+                    fail: The family variant could not be updated.
+                create:
+                    success: Family variant successfully created
+
         attribute_option:
+            flash:
+                create:
+                    success: Attribute option successfully created
+                    fail: An error ocurred when trying to create the attribute option
+                update:
+                    fail: Cannot save attribute option
+                delete:
+                    fail: Error during deletion of the attribute option
             actions: Actions
+
         group:
+            flash:
+                update:
+                    success: Group successfully updated.
+                    fail: The group could not be updated.
+                    fields_not_ready: "The group cannot be saved right now. The following fields are not ready: {{ fields }}"
+                create:
+                    success: Group successfully created
+                delete:
+                    success: Group successfully removed
+                    fail: Cannot delete this group
             title: Group
-            info:
-                deletion_successful: Group successfully deleted.
-                deletion_failed: Group could not be deleted.
-                update_successful: Group successfully updated.
-                update_failed: The group could not be updated.
-                field_not_ready: "The group cannot be saved right now. The following fields are not ready: {{ fields }}"
-            message:
-                created: Group successfully created
+
         job_instance:
+            flash:
+                update:
+                    success: The job profile has been successfully updated.
+                    fail: The job profile could not be updated.
+                delete:
+                    success: Job instance successfully removed
             title: job profile
-            info:
-                update_failed: The job profile could not be updated.
-                update_successful: The job profile has been successfully updated.
+
         attribute:
-            info:
-                deletion_successful: Attribute successfully deleted.
-                deletion_failed: The attribute could not be deleted.
-                update_successful: Attribute successfully updated.
-                update_failed: The attribute could not be updated.
-                create_successful: Attribute successfully created.
-                create_failed: The attribute could not be created.
-                field_not_ready: "The attribute cannot be saved right now. The following fields are not ready: {{ fields }}"
+            flash:
+                update:
+                    success: Attribute successfully updated.
+                    fail: The attribute could not be updated.
+                    fields_not_ready: "The attribute cannot be saved right now. The following fields are not ready: {{ fields }}"
+                delete:
+                    success: Attribute successfully removed
+                    fail: Cannot delete this attribute
             scopable: Scopable
             type:
                 pim_catalog_identifier:             Identifier
@@ -396,13 +386,22 @@ pim_enrich:
                 regexp: Regular expression
                 url: URL
             title: attribute
+
         attribute_group:
-            info:
-                update_failed: Attribute group could not be updated
-                update_successful: Attribute group successfully updated
+            flash:
+                update:
+                    success: Attribute group successfully updated
+                    fail: Attribute group could not be updated
+                    fields_not_ready: "The attribute group cannot be saved right now. The following fields are not ready: {{ fields }}"
+                delete:
+                    success: Attribute group successfully removed
+                    fail: Cannot delete this attribute group
+
         api_connection:
-            message:
-                created: API connection successfully created
+            flash:
+                create:
+                    success: API connection successfully created
+
     info:
         entity:
             updated: There are unsaved changes.
@@ -467,8 +466,6 @@ pim_enrich:
                     keep_attributes:  No attributes will be removed.
                     change_family_to: Change the family to
                     empty_selection:  Choose a family
-            flash:
-                attribute_deletion_error: An error occured during the attribute deletion
             mass_edit:
                 select_attributes: Select attributes
                 select: Select
@@ -496,8 +493,6 @@ pim_enrich:
                     required_label: Required
                 variant:
                     title: Variants
-                    flash:
-                        family_variant_created: Family variant successfully created
         family_variant:
             tab:
                 attributes:
@@ -505,9 +500,6 @@ pim_enrich:
                 labels:
                     title: Label translations
         attribute_option:
-            flash:
-                option_created: Attribute option successfully created
-                error_creating_option: An error ocurred when trying to create the attribute option
             add_option_modal:
                 title: Add attribute option
             add_option: Add an option
@@ -835,7 +827,6 @@ pim_enrich:
                     label: Change family
                     label_count: "{1}Change the family of <span class=\"AknFullPage-title--highlight\">1 product</span>|] 1, Inf [Change the family of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
                     description: The family of the selected products will be changed to the chosen family
-                    field: Family
                 add_to_group:
                     label: Add to groups
                     label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to groups|] 1, Inf [Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to groups"

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
@@ -1,4 +1,5 @@
 pim_common:
+    actions: Actions
     add: Add
     add_attributes: Add attributes
     after: After
@@ -79,11 +80,8 @@ confirmation:
         channel: Are you sure you want to delete this channel?
         group: Are you sure you want to delete this group?
         group_type: Are you sure you want to delete this group type?
-        import_profile: Are you sure you want to delete this import profile?
-        export_profile: Are you sure you want to delete this export profile?
         user: Are you sure you want to delete this user?
         role: Are you sure you want to delete this role?
-        job_instance: Are you sure you want to delete this job instance?
         api_connection: Are you sure you want to revoke this API connection? All API calls made through this connection will now throw an error.
         products_and_product_models: Are you sure you want to delete the selected products and product models? All the product models' children will be also deleted.
     leave: Are you sure you want to leave this page?
@@ -111,6 +109,9 @@ pim_datagrid:
         mass_edit: Bulk actions
         sequential_edit: Sequential edit
         mass_delete: Mass delete
+        selected:
+            family: selected families
+            product: selected results
     view_selector:
         view: Views
     actions:
@@ -149,6 +150,7 @@ pim_enrich:
                     success: Item successfully removed
 
         product:
+            label: product
             flash:
                 update:
                     success: Product successfully updated.
@@ -162,16 +164,11 @@ pim_enrich:
                 create:
                     success: Product successfully created
                     fail: No attribute is configured as a product identifier or you don't have the rights to edit it.
-            navigation: Product navigation
-            infos: Product infos
-            index_title: "] -Inf, 1] {{ count }} result|] 1, Inf [{{ count }} results"
-            title: product
-            locale: Locale
-            category: Category
+            page_title:
+                index: "] -Inf, 1] {{ count }} result|] 1, Inf [{{ count }} results"
             subTitle: Create product
             modalTitle: Select your action
             filters: Filters
-            selected: selected results
             common: Common
             btn:
                 enabled: Enabled
@@ -186,8 +183,8 @@ pim_enrich:
                 modified: Modified
                 old_value: Old value
                 new_value: New value
-                actions: Actions
             meta:
+                infos: Product infos
                 updated: Last update
                 family_variant:
                     title: Variant
@@ -221,6 +218,9 @@ pim_enrich:
                 empty: Your selection is empty, please change your search criteria
 
         product_model:
+            label: product model
+            uppercase_label: Product model
+            plural_label: Product models
             flash:
                 create:
                     success: Product model successfully created
@@ -230,14 +230,13 @@ pim_enrich:
                     fields_not_ready: "The product model cannot be saved right now. The following fields are not ready: {{ fields }}"
                 delete:
                     success: Product model successfully deleted.
+            choose: Choose a product model
             create_popin:
-                type: Product model
                 title: Create a product model
                 content: A product model gathers variant products and eases the enrichment of their common properties.
             read_only_parent_attribute_from_common: This attribute can be updated in the common attributes.
             read_only_parent_attribute_from_model: "This attribute can be updated in the attributes by {{ axes }}"
             variant_axis: Variant axis
-            title: product models
             add_child:
                 create: Add new
                 create_label: "Add a new {{ axes }}"
@@ -245,6 +244,7 @@ pim_enrich:
                     required_label: (variant axis)
 
         association_type:
+            label: association type
             flash:
                 update:
                     success: Association type successfully updated.
@@ -255,9 +255,11 @@ pim_enrich:
                 delete:
                     success: Association type successfully removed
                     fail: Cannot delete this association type
-            title: association type
+            page_title:
+                index: "] -Inf, 1] {{ count }} association type|] 1, Inf [{{ count }} association types"
 
         group_type:
+            label: group type
             flash:
                 update:
                     success: Group type successfully updated.
@@ -268,9 +270,11 @@ pim_enrich:
                 delete:
                     success: Group type successfully removed
                     fail: Cannot delete this group type
-            title: group type
+            page_title:
+                index: "] -Inf, 1] {{ count }} group type|] 1, Inf [{{ count }} group types"
 
         channel:
+            label: channel
             flash:
                 update:
                     success: Channel successfully updated.
@@ -281,7 +285,11 @@ pim_enrich:
                 delete:
                     success: Channel successfully removed
                     fail: Cannot delete this channel
+            page_title:
+                index: "] -Inf, 1] {{ count }} channel|] 1, Inf [{{ count }} channels"
+
         family:
+            label: family
             flash:
                 update:
                     success: Family successfully updated.
@@ -295,8 +303,8 @@ pim_enrich:
                 delete:
                     success: Family successfully removed
                     fail: Cannot delete this family
-            title: Family
-            selected: selected families
+            page_title:
+                index: "] -Inf, 1] {{ count }} family|] 1, Inf [{{ count }} families"
             variant:
                 common:
                     title: Common attributes
@@ -316,6 +324,7 @@ pim_enrich:
                     message: By removing these attributes you will put them back in the common attributes of the family variant and remove the values from the variant products
 
         family_variant:
+            label: family variant
             flash:
                 update:
                     success: Family variant successfully updated. The products with variants will be updated with your changes.
@@ -332,9 +341,9 @@ pim_enrich:
                     fail: Cannot save attribute option
                 delete:
                     fail: Error during deletion of the attribute option
-            actions: Actions
 
         group:
+            label: Group
             flash:
                 update:
                     success: Group successfully updated.
@@ -345,18 +354,11 @@ pim_enrich:
                 delete:
                     success: Group successfully removed
                     fail: Cannot delete this group
-            title: Group
-
-        job_instance:
-            flash:
-                update:
-                    success: The job profile has been successfully updated.
-                    fail: The job profile could not be updated.
-                delete:
-                    success: Job instance successfully removed
-            title: job profile
+            page_title:
+                index: "] -Inf, 1] {{ count }} group|] 1, Inf [{{ count }} groups"
 
         attribute:
+            label: attribute
             flash:
                 update:
                     success: Attribute successfully updated.
@@ -365,6 +367,8 @@ pim_enrich:
                 delete:
                     success: Attribute successfully removed
                     fail: Cannot delete this attribute
+            page_title:
+                index: "] -Inf, 1] {{ count }} attribute|] 1, Inf [{{ count }} attributes"
             scopable: Scopable
             type:
                 pim_catalog_identifier:             Identifier
@@ -385,9 +389,9 @@ pim_enrich:
                 email: E-mail
                 regexp: Regular expression
                 url: URL
-            title: attribute
 
         attribute_group:
+            label: attribute group
             flash:
                 update:
                     success: Attribute group successfully updated
@@ -401,6 +405,23 @@ pim_enrich:
             flash:
                 create:
                     success: API connection successfully created
+            page_title:
+                index: "] -Inf, 1] {{ count }} API connection|] 1, Inf [{{ count }} API connections"
+
+        locale:
+            label: locale
+            page_title:
+                index: "] -Inf, 1] {{ count }} locale|] 1, Inf [{{ count }} locales"
+        category:
+            label: category
+
+        currency:
+            page_title:
+                index: "] -Inf, 1] {{ count }} currency|] 1, Inf [{{ count }} currencies"
+
+        job_execution:
+            page_title:
+                index: "] -Inf, 1] {{ count }} operation|] 1, Inf [{{ count }} operations"
 
     info:
         entity:
@@ -408,12 +429,9 @@ pim_enrich:
     form:
         required: (required)
         product_model:
-            choose_product_model: Choose a product model
-            choose_variant: Choose a variant
             complete_variant_product: variant product
             complete_variant_products: variant products
             family_variant: Variant
-            product_model: Product model
             flash:
                 product_model_added: Product model successfully added to the product model
                 variant_product_added: Variant product successfully added to the product model
@@ -514,99 +532,9 @@ pim_enrich:
         common:
             tab:
                 attributes:
-                    btn:
-                        add_attributes: Add attributes
                     info:
                         search_attributes: Search...
                         no_available_attributes: There are no more attributes to add
-        job_execution:
-            title.details:    Execution details
-            refreshBtn.title: Refresh
-            button:
-                show_profile.title: Show profile
-                download_log.title: Download log
-                download_file.title: Download generated file
-                download_archive.title: Downlaod generated archive
-            summary:
-                fetching:        Collecting data about job execution...
-                warning:         Warning
-                header.step:     Step
-                header.warnings: Warnings
-                header.summary:  Summary
-                header.start:    Start
-                header.end:      End
-        job_instance:
-            fail:
-                launch: Failed to launch the job profile. Make sure it is valid and that you have right to launch it.
-                save: Failed to save the job profile. Make sure that you have right to edit it.
-            title:
-                import: Import profile
-                export: Export profile
-            button:
-                export.title: Export now
-                import.launch: Import now
-                import.upload: Upload and import now
-                import.upload_file: Upload a file
-            meta:
-                job: Job
-                connector: Connector
-            subsection:
-                last_executions: Last executions
-            tab:
-                content:
-                    title: Content
-                properties:
-                    decimal_separator:
-                        title: Decimal separator
-                        help: Determine the decimal separator
-                    date_format:
-                        title: Date format
-                        help: Determine the format of date fields
-                    file_path:
-                        title: File path
-                        help: Where to write the generated file on the file system
-                    delimiter:
-                        title: Delimiter
-                        help: One character used to set the field delimiter
-                    enclosure:
-                        title: Enclosure
-                        help: One character used to set the field enclosure
-                    with_header:
-                        title: With header
-                        help: Whether or not to print the column name
-                    with_media:
-                        title: Export files and images
-                        help: Whether or not to export product files and images
-                    lines_per_file:
-                        title: Number of lines per file
-                        help: Define the limit number of lines per file
-                    upload_allowed:
-                        title: Allow file upload
-                        help: Whether or not to allow uploading the file directly
-                    categories_column:
-                        title: Categories column
-                        help: Name of the categories column
-                    escape:
-                        title: Escape
-                        help: One character used to set the field escape
-                    family_column:
-                        title: Family column
-                        help: Name of the family column
-                    groups_column:
-                        title: Groups column
-                        help: Name of the groups column
-                    enabled:
-                        title: Enable the product
-                        help: Whether or not imported product should be enabled
-                    enabled_comparison:
-                        title: Compare values
-                        help: Enable the comparison between original values and imported values. Can speed up import if imported values are very similar to original values
-                    real_time_versioning:
-                        title: Real time history update
-                        help: Means that the product history is automatically updated, can be switched off to improve performances
-                    family_variant_column:
-                        title: Family variant column
-            file_path: File path
         attribute:
             meta:
                 updated: Last update
@@ -741,56 +669,33 @@ pim_enrich:
             description: Only the attributes belonging to the families of the selected products will be edited with the following data for the <span class="highlight">{{ locale }}</span> locale and the <span class="highlight">{{ channel }}</span> channel.
     index:
         association_type:
-            title:      "] -Inf, 1] {{ count }} association type|] 1, Inf [{{ count }} association types"
             create_btn: Create association type
         import_profiles:
-            title:      "] -Inf, 1] {{ count }} import profile|] 1, Inf [{{ count }} import profiles"
             create_btn: Create import profile
             list:       Select a job
             message:
                 created: Import profile successfully created
-        import_history:
-            title:      Import reports
         group:
-            title:       "] -Inf, 1] {{ count }} group|] 1, Inf [{{ count }} groups"
             create_btn: Create group
         export_profiles:
-            title:      "] -Inf, 1] {{ count }} export profile|] 1, Inf [{{ count }} export profiles"
             create_btn: Create export profile
             message:
                 created: Export profile successfully created
-        export_history:
-            title:      Export reports
         family:
-            title:       "] -Inf, 1] {{ count }} family|] 1, Inf [{{ count }} families"
             create_btn: Create family
         grouptype:
-            title:       "] -Inf, 1] {{ count }} group type|] 1, Inf [{{ count }} group types"
             create_btn: Create group type
-        currency:
-            title:      "] -Inf, 1] {{ count }} currency|] 1, Inf [{{ count }} currencies"
-        locale:
-            title:      "] -Inf, 1] {{ count }} locale|] 1, Inf [{{ count }} locales"
         user:
-            title:      "] -Inf, 1] {{ count }} user|] 1, Inf [{{ count }} users"
             create_btn: Create user
         user_role:
-            title:      "] -Inf, 1] {{ count }} role|] 1, Inf [{{ count }} roles"
             create_btn: Create role
         user_group:
-            title:      "] -Inf, 1] {{ count }} group|] 1, Inf [{{ count }} groups"
             create_btn: Create group
-        process_tracker:
-            title:      "] -Inf, 1] {{ count }} operation|] 1, Inf [{{ count }} operations"
         channel:
-            title:      "] -Inf, 1] {{ count }} channel|] 1, Inf [{{ count }} channels"
             create_btn: Create channel
         attribute:
-            title:       "] -Inf, 1] {{ count }} attribute|] 1, Inf [{{ count }} attributes"
             create_btn:  Create attribute
             modal_title: Choose the attribute type
-        api_connection:
-            title:       "] -Inf, 1] {{ count }} API connection|] 1, Inf [{{ count }} API connections"
     mass_edit:
         product:
             title: Products bulk action
@@ -961,6 +866,7 @@ pim_menu:
         system: System navigation
         user: Users management navigation
         settings: Settings navigation
+        product: Product navigation
 
     user:
         logout: Logout
@@ -1018,10 +924,10 @@ batch_jobs:
         label: Set attributes requirements
         perform.label: Set attributes requirements
     xlsx_product_grid_context_quick_export:
-        quick_export.label: Xlsx product grid context quick export
+        quick_export.label: XLSX product grid context quick export
         quick_export_product_model.label: XSLX product model grid context quick export
-        perform.label: Xlsx product grid context quick export
+        perform.label: XLSX product grid context quick export
     xlsx_product_quick_export:
-        quick_export.label: Xlsx product quick export
+        quick_export.label: XLSX product quick export
         quick_export_product_model.label: XSLX product model quick export
-        perform.label: Xlsx product quick export
+        perform.label: XLSX product quick export

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
@@ -1,3 +1,29 @@
+#Global structure of translation files
+#
+#pim_bundle_name:
+#    entity:
+#        entity_name:
+#            label: entity
+#            uppercase_label: Entity
+#            plural_label: Entities
+#            flash:
+#                update:
+#                    fail: Update failed
+#                    success: Entity Successfully updated
+#                delete:
+#                    fail: Cannot delete this entity
+#                    success: Entity successfully removed
+#                create:
+#                    fail: Can not create this entity
+#                    success: Entity successfully created
+#            page_title:
+#                index: "]-Inf, 1]1 entity|]1, Inf[{{ count }} entities"
+#            property:
+#                field_name: Field name
+#                complex_field:
+#                    label: Field name
+#                    choose: Choose a field name
+
 pim_common:
     actions: Actions
     add: Add
@@ -6,13 +32,9 @@ pim_common:
     all: All
     and: and
     apply: Apply
-    attributes: Attributes
-    attribute_groups: Attribute groups
     before: Before
     by: by
     cancel: Cancel
-    categories: Categories
-    channel: Channel
     code: Code
     confirm: Confirm
     confirm_deletion: Confirm deletion
@@ -28,7 +50,6 @@ pim_common:
     label_translations: Label translations
     less_than: Less than
     loading: Loading...
-    locales: Locales
     more_than: More than
     next: Next
     "no": "No"
@@ -39,7 +60,6 @@ pim_common:
     permissions: Permissions
     previous: Previous
     properties: Properties
-    products: Products
     save: Save
     status: Status
     to: to
@@ -99,8 +119,8 @@ pim_datagrid:
     mass_action:
         delete:
             confirm_content: Are you sure you want to delete the selected products?
-            success:         Selected products successfully deleted.
-            error:           Error ocurred when trying to delete selected products, please try again.
+            success: Selected products successfully deleted.
+            error: Error ocurred when trying to delete selected products, please try again.
         quick_export:
             csv_all: CSV (All attributes)
             csv_grid_context: CSV (Grid context)
@@ -151,6 +171,8 @@ pim_enrich:
 
         product:
             label: product
+            uppercase_label: Product
+            plural_label: Products
             flash:
                 update:
                     success: Product successfully updated.
@@ -194,7 +216,6 @@ pim_enrich:
                         title: Group {{ group }}
                         view_group: View group
                         more_products: '{{ count }} more products...'
-                locale: Locale
             copy:
                 select: Select
                 all_visible: All visible
@@ -208,7 +229,6 @@ pim_enrich:
             media:
                 upload: Drag and drop to upload or click here
             create_popin:
-                type: Product
                 labels:
                     family: Choose a family
                     family_variant: Choose a family variant
@@ -276,6 +296,7 @@ pim_enrich:
 
         channel:
             label: channel
+            uppercase_label: Channel
             flash:
                 update:
                     success: Channel successfully updated.
@@ -361,6 +382,7 @@ pim_enrich:
 
         attribute:
             label: attribute
+            plural_label: Attributes
             flash:
                 update:
                     success: Attribute successfully updated.
@@ -371,29 +393,73 @@ pim_enrich:
                     fail: Cannot delete this attribute
             page_title:
                 index: "] -Inf, 1] {{ count }} attribute|] 1, Inf [{{ count }} attributes"
-            scopable: Scopable
-            type:
-                pim_catalog_identifier:             Identifier
-                pim_catalog_text:                   Text
-                pim_catalog_textarea:               Text Area
-                pim_catalog_number:                 Number
-                pim_catalog_price_collection:       Price
-                pim_catalog_multiselect:            Multi select
-                pim_catalog_simpleselect:           Simple select
-                pim_catalog_file:                   File
-                pim_catalog_image:                  Image
-                pim_catalog_boolean:                "Yes/No"
-                pim_catalog_date:                   Date
-                pim_catalog_metric:                 Metric
-                pim_reference_data_simpleselect:    Reference data simple select
-                pim_reference_data_multiselect:     Reference data multi select
-            validation_rule:
-                email: E-mail
-                regexp: Regular expression
-                url: URL
+            property:
+                allowed_extensions: Allowed extensions
+                auto_option_sorting: Sort automatically options by alphabetical order
+                available_locales: Available locales
+                date_max: Max date
+                date_min: Min date
+                decimals_allowed: Decimal values allowed
+                default_metric_unit:
+                    label: Default metric unit
+                    choose: Choose a unit
+                group:
+                    label: Attribute group
+                    choose: Choose the attribute group
+                is_locale_specific: Locale specific
+                localizable: Value per locale
+                max_characters: Max characters
+                max_file_size: Max file size (MB)
+                metric_family:
+                    label: Metric family
+                    choose: Choose a family
+                minimum_input_length: Minimum length for autocompletion
+                negative_allowed: Negative values allowed
+                number_max: Max number
+                number_min: Min number
+                reference_data_name:
+                    label: Reference data type
+                    choose: Choose the reference data type
+                scopable: Value per channel
+                type:
+                    choose: Choose the attribute type
+                    pim_catalog_identifier: Identifier
+                    pim_catalog_text: Text
+                    pim_catalog_textarea: Text Area
+                    pim_catalog_number: Number
+                    pim_catalog_price_collection: Price
+                    pim_catalog_multiselect: Multi select
+                    pim_catalog_simpleselect: Simple select
+                    pim_catalog_file: File
+                    pim_catalog_image: Image
+                    pim_catalog_boolean: "Yes/No"
+                    pim_catalog_date: Date
+                    pim_catalog_metric: Metric
+                    pim_reference_data_simpleselect: Reference data simple select
+                    pim_reference_data_multiselect: Reference data multi select
+                unique: Unique value
+                useable_as_grid_filter: Usable in grid
+                validation_regexp: Regular expression
+                validation_rule:
+                    label: Validation rule
+                    email: E-mail
+                    regexp: Regular expression
+                    url: URL
+                wysiwyg_enabled: Rich text editor enabled
+            tab:
+                properties:
+                    section:
+                        common: General parameters
+                        type_specific: Type specific parameters
+                        validation: Validation parameters
+                choices:
+                    title: Options
+            create:
+                create_btn: Create attribute
 
         attribute_group:
             label: attribute group
+            plural_label: Attribute groups
             flash:
                 update:
                     success: Attribute group successfully updated
@@ -416,12 +482,14 @@ pim_enrich:
         locale:
             label: locale
             uppercase_label: Locale
+            plural_label: Locales
             page_title:
                 index: "] -Inf, 1] {{ count }} locale|] 1, Inf [{{ count }} locales"
 
         category:
             label: category
             uppercase_label: Category
+            plural_label: Categories
 
         currency:
             page_title:
@@ -543,47 +611,6 @@ pim_enrich:
                     info:
                         search_attributes: Search...
                         no_available_attributes: There are no more attributes to add
-        attribute:
-            meta:
-                updated: Last update
-            tab:
-                properties:
-                    section:
-                        common: General parameters
-                        type_specific: Type specific parameters
-                        validation: Validation parameters
-                    label:
-                        allowed_extensions: Allowed extensions
-                        auto_option_sorting: Sort automatically options by alphabetical order
-                        available_locales: Available locales
-                        date_max: Max date
-                        date_min: Min date
-                        decimals_allowed: Decimal values allowed
-                        default_metric_unit: Default metric unit
-                        group: Attribute group
-                        is_locale_specific: Locale specific
-                        localizable: Value per locale
-                        max_characters: Max characters
-                        max_file_size: Max file size (MB)
-                        metric_family: Metric family
-                        minimum_input_length: Minimum length for autocompletion
-                        negative_allowed: Negative values allowed
-                        number_max: Max number
-                        number_min: Min number
-                        reference_data_name: Reference data type
-                        scopable: Value per channel
-                        unique: Unique value
-                        useable_as_grid_filter: Usable in grid
-                        validation_regexp: Regular expression
-                        validation_rule: Validation rule
-                        wysiwyg_enabled: Rich text editor enabled
-                    default_label:
-                        default_metric_unit: Choose a unit
-                        group: Choose the attribute group
-                        metric_family: Choose a family
-                        reference_data_name: Choose the reference data type
-                choices:
-                    title: Options
         mass_edit:
             family:
                 attributes:
@@ -701,9 +728,6 @@ pim_enrich:
             create_btn: Create group
         channel:
             create_btn: Create channel
-        attribute:
-            create_btn:  Create attribute
-            modal_title: Choose the attribute type
     mass_edit:
         product:
             title: Products bulk action

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
@@ -230,6 +230,7 @@ pim_enrich:
                     fields_not_ready: "The product model cannot be saved right now. The following fields are not ready: {{ fields }}"
                 delete:
                     success: Product model successfully deleted.
+                    fail: Cannot delete this product model
             choose: Choose a product model
             create_popin:
                 title: Create a product model
@@ -290,6 +291,7 @@ pim_enrich:
 
         family:
             label: family
+            uppercase_label: Family
             flash:
                 update:
                     success: Family successfully updated.
@@ -405,15 +407,21 @@ pim_enrich:
             flash:
                 create:
                     success: API connection successfully created
+                delete:
+                    success: API connection successfully revoked
+                    fail: Cannot revoke this API connection
             page_title:
                 index: "] -Inf, 1] {{ count }} API connection|] 1, Inf [{{ count }} API connections"
 
         locale:
             label: locale
+            uppercase_label: Locale
             page_title:
                 index: "] -Inf, 1] {{ count }} locale|] 1, Inf [{{ count }} locales"
+
         category:
             label: category
+            uppercase_label: Category
 
         currency:
             page_title:
@@ -925,9 +933,9 @@ batch_jobs:
         perform.label: Set attributes requirements
     xlsx_product_grid_context_quick_export:
         quick_export.label: XLSX product grid context quick export
-        quick_export_product_model.label: XSLX product model grid context quick export
+        quick_export_product_model.label: XLSX product model grid context quick export
         perform.label: XLSX product grid context quick export
     xlsx_product_quick_export:
         quick_export.label: XLSX product quick export
-        quick_export_product_model.label: XSLX product model quick export
+        quick_export_product_model.label: XLSX product model quick export
         perform.label: XLSX product quick export

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
@@ -8,6 +8,7 @@ pim_common:
     attributes: Attributes
     attribute_groups: Attribute groups
     before: Before
+    by: by
     cancel: Cancel
     categories: Categories
     channel: Channel
@@ -61,24 +62,35 @@ pim_common:
 
 confirmation:
     remove:
-        item:             Are you sure you want to delete this item?
+        title: Delete this {{ itemName }}
+        alternative_title: Confirm removal
+        item: Are you sure you want to delete this item?
+        item_placeholder: Are you sure you want to delete this {{ itemName }}? It is not possible to undo this action.
         association_type: Are you sure you want to delete this association type?
-        attribute:        Are you sure you want to delete this attribute?
-        attribute_group:  Are you sure you want to delete this attribute group?
-        family:           Are you sure you want to delete this family?
-        family_variant:   Are you sure you want to delete this family variant ?
-        product:          Are you sure you want to delete this product?
-        product_model:    Are you sure you want to delete this product model? All its children, product models and variant products, will be also deleted.
-        channel:          Are you sure you want to delete this channel?
-        group:            Are you sure you want to delete this group?
-        group_type:       Are you sure you want to delete this group type?
-        import_profile:   Are you sure you want to delete this import profile?
-        export_profile:   Are you sure you want to delete this export profile?
-        user:             Are you sure you want to delete this user?
-        role:             Are you sure you want to delete this role?
-        job_instance:     Are you sure you want to delete this job instance?
-        api_connection:   Are you sure you want to revoke this API connection? All API calls made through this connection will now throw an error.
+        attribute: Are you sure you want to delete this attribute?
+        attribute_from_family: Are you sure you want to delete this attribute from the family?
+        attribute_from_group: Are you sure you want to remove the attribute {{ attribute }} from this attribute group?
+        attribute_from_product: Are you sure you want to delete this attribute from the product?
+        attribute_group: Are you sure you want to delete this attribute group?
+        family: Are you sure you want to delete this family?
+        family_variant: Are you sure you want to delete this family variant?
+        product: Are you sure you want to delete this product?
+        product_model: Are you sure you want to delete this product model? All its children, product models and variant products, will be also deleted.
+        channel: Are you sure you want to delete this channel?
+        group: Are you sure you want to delete this group?
+        group_type: Are you sure you want to delete this group type?
+        import_profile: Are you sure you want to delete this import profile?
+        export_profile: Are you sure you want to delete this export profile?
+        user: Are you sure you want to delete this user?
+        role: Are you sure you want to delete this role?
+        job_instance: Are you sure you want to delete this job instance?
+        api_connection: Are you sure you want to revoke this API connection? All API calls made through this connection will now throw an error.
         products_and_product_models: Are you sure you want to delete the selected products and product models? All the product models' children will be also deleted.
+    leave: Are you sure you want to leave this page?
+    discard_changes: You will lose changes to the {{ entity }} if you leave the page.
+    cancel:
+        title: Cancel modification
+        message: Warning, you will lose unsaved data. Are you sure you want to cancel modification on this new option?
 
 pim_datagrid:
     mass_action_group:
@@ -107,6 +119,7 @@ pim_datagrid:
         delete_product: Delete the product
         change_status: Change status
         toggle_status: Toggle status
+        other: Other actions
     empty_results:
         associated_product:
             hint: There are no associated products
@@ -169,6 +182,8 @@ error:
     saving:
         attribute_option: Cannot save attribute option
         export_profile: Cannot save export profile. Please check that all filters are well filled
+    exception: Oh snap! A {{ status_code }} error occured...
+    forbidden: Forbidden. You are not allowed to access this page
 
 alert:
     attribute_option:
@@ -177,23 +192,7 @@ alert:
     session_storage:
         not_available: Your web browser does not seems compatible with sessionStorage. Please contact your administrator
 
-confirm:
-    attribute_option:
-        cancel_edition_on_new_option_text: Warning, you will lose unsaved data. Are you sure you want to cancel modification on this new option?
-        cancel_edition_on_new_option_title: Cancel modification
-
 pim_enrich:
-    item:
-        list:
-            delete.error: Error during item deletion
-        delete:
-            confirm.content: Are you sure you want to delete this {{ itemName }}? It is not possible to undo this action
-            confirm.title: Delete this {{ itemName }}
-
-    navigation:
-        link:
-            back_to_grid: Back to grid
-        other_actions: Other actions
     entity:
         info:
             update_failed: Update failed
@@ -234,8 +233,6 @@ pim_enrich:
             error:
                 upload: An error occured during the file upload
             meta:
-                created_by: By
-                updated_by: By
                 updated: Last update
                 family:
                     title: Family
@@ -325,7 +322,6 @@ pim_enrich:
             selected: selected families
             info:
                 update_successful: Family successfully updated.
-                create_successful: Channel successfully created.
                 update_failed: An error occured during family update.
                 cant_remove_attribute_as_label: Cannot remove attribute used as label
                 cant_remove_attribute_as_image: Cannot remove attribute used as the main picture
@@ -407,22 +403,9 @@ pim_enrich:
         api_connection:
             message:
                 created: API connection successfully created
-    confirmation:
-        leave:           Are you sure you want to leave this page?
-        discard_changes: You will lose changes to the {{ entity }} if you leave the page.
-        remove_item:     Confirm removal
-        delete:
-            attribute: Are you sure you want to delete this attribute from the product?
-            attribute_group: Are you sure you want to remove the attribute {{ attribute }} from this attribute group?
     info:
-        not_applicable: N/A
         entity:
             updated: There are unsaved changes.
-    error:
-        upload: An error occured during the upload of the file
-    alert:
-        not_allowed: Forbidden. You are not allowed to access this page
-        error_occured: An error occured during the loading of the page
     form:
         required: (required)
         product_model:
@@ -634,9 +617,7 @@ pim_enrich:
             file_path: File path
         attribute:
             meta:
-                created_by: by
                 updated: Last update
-                updated_by: by
             tab:
                 properties:
                     section:
@@ -901,13 +882,6 @@ pim_enrich:
                     label: Set attributes requirements
                     description: The following attributes requirements will be applied to the selected families
                     label_count: "{1}Set attributes requirements of <span class=\"AknFullPage-title--highlight\">1 family</span>|] 1, Inf [Set attributes requirements of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} families</span>"
-
-pim_enrich:
-    error:
-        exception:
-            title: Oh snap! A {{ status_code }} error occured...
-        http:
-            403: Forbidden. You are not allowed to access this page
 
 # Page titles
 pim_title:

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_US.yml
@@ -902,10 +902,12 @@ pim_enrich:
                     description: The following attributes requirements will be applied to the selected families
                     label_count: "{1}Set attributes requirements of <span class=\"AknFullPage-title--highlight\">1 family</span>|] 1, Inf [Set attributes requirements of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} families</span>"
 
-pim_enrich.error:
-    exception.title: Oh snap! A {{ status_code }} error occured...
-    http:
-        403: Forbidden. You are not allowed to access this page
+pim_enrich:
+    error:
+        exception:
+            title: Oh snap! A {{ status_code }} error occured...
+        http:
+            403: Forbidden. You are not allowed to access this page
 
 # Page titles
 pim_title:
@@ -975,7 +977,6 @@ pim_menu:
         group: Groups
         group_type: Group types
         product_model: Product Models
-        published_product: Published Products
         export_history: Exports history
         export_profile: Export profiles
         import_history: Imports history
@@ -1009,93 +1010,53 @@ pim_notification:
 
 # Background jobs & steps labels
 batch_jobs:
-    add_product_value:
-        label: Add product value
-        perform.label: Add product value
-    update_product_value:
-        label: Update product value
-        perform.label: Update product value
+    add_association:
+        label: Associate to products
+        perform.label: Associate to products
     add_attribute_value:
         label: Add attributes value
         perform.label: Add attributes value
+    add_product_value:
+        label: Add product value
+        perform.label: Add product value
+    add_to_category:
+        label: Add to category
+        perform.label: Add to category
+    add_to_existing_product_model:
+        label: Add to an existing product model
+        perform.label: Add to an existing product model
+    csv_product_grid_context_quick_export:
+        quick_export.label: Csv product grid context quick export
+        quick_export_product_model.label: CSV product model grid context quick export
+        perform.label: Csv product grid context quick export
+    csv_product_quick_export:
+        quick_export.label: Csv product quick export
+        quick_export_product_model.label: CSV product model quick export
+        perform.label: Csv product quick export
+    delete_products_and_product_models:
+        delete_products_and_product_models.label: Mass delete products
     edit_common_attributes:
         label: Edit attributes
         perform.label: Edit attributes
         clean.label: Clean files for attributes
         cleaner.label: Clean files for attributes
-    add_to_category:
-        label: Add to category
-        perform.label: Add to category
     move_to_category:
         label: Move to category
         perform.label: Move to category
-    remove_from_category:
-        label: Remove from category
-        perform.label: Remove from category
-    add_association:
-        label: Associate to products
-        perform.label: Associate to products
-    add_to_existing_product_model:
-        label: Add to an existing product model
-        perform.label: Add to an existing product model
-    set_attribute_requirements:
-        label: Set attributes requirements
-        perform.label: Set attributes requirements
-    csv_product_quick_export:
-        quick_export.label: Csv product quick export
-        perform.label: Csv product quick export
-    csv_product_grid_context_quick_export:
-        quick_export.label: Csv product grid context quick export
-        perform.label: Csv product grid context quick export
-    xlsx_product_quick_export:
-        quick_export.label: Xlsx product quick export
-        perform.label: Xlsx product quick export
-    xlsx_product_grid_context_quick_export:
-        quick_export.label: Xlsx product grid context quick export
-        perform.label: Xlsx product grid context quick export
-    delete_products_and_product_models:
-        delete_products_and_product_models.label: Mass delete products
-    add_product_value:
-        label: Add product value
-        perform.label: Add product value
     update_product_value:
         label: Update product value
         perform.label: Update product value
-    edit_common_attributes:
-        label: Edit attributes
-        perform.label: Edit attributes
-        cleaner.label: Clean files for attributes
-    add_to_category:
-        label: Add to category
-        perform.label: Add to category
-    move_to_category:
-        label: Move to category
-        perform.label: Move to category
     remove_from_category:
         label: Remove from category
         perform.label: Remove from category
-    add_association:
-        label: Associate to products
-        perform.label: Associate to products
-    add_to_existing_product_model:
-        label: Add to an existing product model
-        perform.label: Add to an existing product model
     set_attribute_requirements:
         label: Set attributes requirements
         perform.label: Set attributes requirements
-    csv_product_quick_export:
-        quick_export.label: CSV product quick export
-        quick_export_product_model.label: CSV product model quick export
-        perform.label: CSV product quick export
-    csv_product_grid_context_quick_export:
-        quick_export.label: CSV product grid context quick export
-        quick_export_product_model.label: CSV product model grid context quick export
-        perform.label: CSV product grid context quick export
-    xlsx_product_quick_export:
-        quick_export.label: XSLX product quick export
-        quick_export_product_model.label: XSLX product model quick export
-        perform.label: XSLX product quick export
     xlsx_product_grid_context_quick_export:
-        quick_export.label: XSLX product grid context quick export
+        quick_export.label: Xlsx product grid context quick export
         quick_export_product_model.label: XSLX product model grid context quick export
-        perform.label: XSLX product grid context quick export
+        perform.label: Xlsx product grid context quick export
+    xlsx_product_quick_export:
+        quick_export.label: Xlsx product quick export
+        quick_export_product_model.label: XSLX product model quick export
+        perform.label: Xlsx product quick export

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.fr_FR.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.fr_FR.yml
@@ -362,6 +362,49 @@ pim_enrich:
         update_failed: Le profil n'a pas pu être mis à jour.
         update_successful: Le profil a été mis à jour avec succès.
     attribute:
+      label: Attribut
+      uppercase_label: Attribut
+      plural_label: Attributs
+      property:
+        allowed_extensions: Extensions autorisées
+        auto_option_sorting: Trier automatiquement les options par ordre alphabétique
+        available_locales: Locales disponibles
+        date_max: Date maxi
+        date_min: Date mini
+        decimals_allowed: Valeurs décimales autorisées
+        default_metric_unit.label: Unité de mesure par défaut
+        group.label: Groupe d'attributs
+        is_locale_specific: Spécifique à une locale
+        localizable: Valeur par locale
+        max_characters: Nombre maximum de caractères
+        max_file_size: Taille de fichier maximale (MB)
+        metric_family.label: Type de mesure
+        minimum_input_length: Longueur minimale pour l’auto-complétion
+        negative_allowed: Valeurs négatives autorisées
+        number_max: Nombre max
+        number_min: Nombre min
+        reference_data_name.label: Type de données de référence
+        scopable: Valeur par canal
+        unique: Valeur unique
+        useable_as_grid_filter: Utilisable sur la grille
+        validation_regexp: Expression régulière
+        validation_rule: Règle de validation
+        wysiwyg_enabled: Éditeur de texte enrichi activé
+        type:
+          pim_catalog_identifier: Identifiant
+          pim_catalog_text: Texte
+          pim_catalog_textarea: Zone de texte
+          pim_catalog_number: Nombre
+          pim_catalog_price_collection: Prix
+          pim_catalog_multiselect: Liste à choix multiples
+          pim_catalog_simpleselect: Liste à choix unique
+          pim_catalog_file: Fichier
+          pim_catalog_image: Image
+          pim_catalog_boolean: "Oui / Non"
+          pim_catalog_date: Date
+          pim_catalog_metric: Unité de mesure
+          pim_reference_data_simpleselect: Liste à choix unique de données référentielles
+          pim_reference_data_multiselect: Liste à choix multiples de données référentielles
       info:
         deletion_successful: Attribut supprimé avec succès.
         deletion_failed: L'attribut n'a pas pu être supprimé.
@@ -371,21 +414,6 @@ pim_enrich:
         create_failed: L'attribut n'a pas pu être créé.
         field_not_ready: "L'attribut ne peut être sauvé dès maintenant. Les champs suivants ne sont pas prêts : {{ fields }}"
       scopable: Décliné par canal
-      type:
-        pim_catalog_identifier: Identifiant
-        pim_catalog_text: Texte
-        pim_catalog_textarea: Zone de texte
-        pim_catalog_number: Nombre
-        pim_catalog_price_collection: Prix
-        pim_catalog_multiselect: Liste à choix multiples
-        pim_catalog_simpleselect: Liste à choix unique
-        pim_catalog_file: Fichier
-        pim_catalog_image: Image
-        pim_catalog_boolean: "Oui / Non"
-        pim_catalog_date: Date
-        pim_catalog_metric: Unité de mesure
-        pim_reference_data_simpleselect: Liste à choix unique de données référentielles
-        pim_reference_data_multiselect: Liste à choix multiples de données référentielles
       validation_rule:
         email: E-mail
         regexp: Expression régulière

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en_US.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en_US.yml
@@ -9,6 +9,7 @@ pim_common:
     updated: Updated
     create: Create
     permissions: Permissions
+    properties: Properties
 
 pim_enrich:
     # Attribute

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en_US.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en_US.yml
@@ -8,6 +8,7 @@ pim_common:
     created: Created
     updated: Updated
     create: Create
+    permissions: Permissions
 
 pim_enrich:
     # Attribute
@@ -36,7 +37,6 @@ pim_enrich:
     locale:
         tab:
             property.title: Properties
-            permission.title: Permissions
     # Mass edit operations
     mass_edit_action:
         limit_exceeded: Please choose less than %limit% items to edit

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -18,19 +18,21 @@ pim_connector:
 pim_import_export:
     entity:
         job_instance:
+            label: job profile
             flash:
                 update:
                     success: The job profile has been successfully updated.
                     fail: The job profile could not be updated.
                 delete:
                     success: Job instance successfully removed
-            title: job profile
 
         import_profile:
+            uppercase_label: Import profile
             page_title:
                 index: "] -Inf, 1] {{ count }} import profile|] 1, Inf [{{ count }} import profiles"
 
         export_profile:
+            uppercase_label: Export profile
             page_title:
                 index: "] -Inf, 1] {{ count }} export profile|] 1, Inf [{{ count }} export profiles"
 
@@ -56,9 +58,6 @@ pim_import_export:
             fail:
                 launch: Failed to launch the job profile. Make sure it is valid and that you have right to launch it.
                 save: Failed to save the job profile. Make sure that you have right to edit it.
-            title:
-                import: Import profile
-                export: Export profile
             button:
                 export.title: Export now
                 import.launch: Import now
@@ -131,7 +130,6 @@ confirmation:
         export_profile: Are you sure you want to delete this export profile?
         job_instance: Are you sure you want to delete this job instance?
 
-# Page titles
 pim_title:
     pim_importexport_export_profile_index:   Export profiles management
     pim_importexport_export_profile_edit:    Export profile {{ job.label }} | Edit

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -26,18 +26,10 @@ pim_import_export:
                     success: Job instance successfully removed
             title: job profile
 
-confirmation:
-    remove:
-        import_profile: Are you sure you want to delete this import profile?
-        export_profile: Are you sure you want to delete this export profile?
-        job_instance: Are you sure you want to delete this job instance?
-
-# TODO Update the main key
-pim_enrich:
-    entity:
         import_profile:
             page_title:
                 index: "] -Inf, 1] {{ count }} import profile|] 1, Inf [{{ count }} import profiles"
+
         export_profile:
             page_title:
                 index: "] -Inf, 1] {{ count }} export profile|] 1, Inf [{{ count }} export profiles"
@@ -59,6 +51,7 @@ pim_enrich:
                 header.summary:  Summary
                 header.start:    Start
                 header.end:      End
+
         job_instance:
             fail:
                 launch: Failed to launch the job profile. Make sure it is valid and that you have right to launch it.
@@ -131,6 +124,12 @@ pim_enrich:
                     family_variant_column:
                         title: Family variant column
             file_path: File path
+
+confirmation:
+    remove:
+        import_profile: Are you sure you want to delete this import profile?
+        export_profile: Are you sure you want to delete this export profile?
+        job_instance: Are you sure you want to delete this job instance?
 
 # Page titles
 pim_title:

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -15,6 +15,123 @@ pim_connector:
             validation:
                 not_blank: One locale must be selected, please choose a locale to export.
 
+pim_import_export:
+    entity:
+        job_instance:
+            flash:
+                update:
+                    success: The job profile has been successfully updated.
+                    fail: The job profile could not be updated.
+                delete:
+                    success: Job instance successfully removed
+            title: job profile
+
+confirmation:
+    remove:
+        import_profile: Are you sure you want to delete this import profile?
+        export_profile: Are you sure you want to delete this export profile?
+        job_instance: Are you sure you want to delete this job instance?
+
+# TODO Update the main key
+pim_enrich:
+    entity:
+        import_profile:
+            page_title:
+                index: "] -Inf, 1] {{ count }} import profile|] 1, Inf [{{ count }} import profiles"
+        export_profile:
+            page_title:
+                index: "] -Inf, 1] {{ count }} export profile|] 1, Inf [{{ count }} export profiles"
+
+    form:
+        job_execution:
+            title.details:    Execution details
+            refreshBtn.title: Refresh
+            button:
+                show_profile.title: Show profile
+                download_log.title: Download log
+                download_file.title: Download generated file
+                download_archive.title: Downlaod generated archive
+            summary:
+                fetching:        Collecting data about job execution...
+                warning:         Warning
+                header.step:     Step
+                header.warnings: Warnings
+                header.summary:  Summary
+                header.start:    Start
+                header.end:      End
+        job_instance:
+            fail:
+                launch: Failed to launch the job profile. Make sure it is valid and that you have right to launch it.
+                save: Failed to save the job profile. Make sure that you have right to edit it.
+            title:
+                import: Import profile
+                export: Export profile
+            button:
+                export.title: Export now
+                import.launch: Import now
+                import.upload: Upload and import now
+                import.upload_file: Upload a file
+            meta:
+                job: Job
+                connector: Connector
+            subsection:
+                last_executions: Last executions
+            tab:
+                content:
+                    title: Content
+                properties:
+                    decimal_separator:
+                        title: Decimal separator
+                        help: Determine the decimal separator
+                    date_format:
+                        title: Date format
+                        help: Determine the format of date fields
+                    file_path:
+                        title: File path
+                        help: Where to write the generated file on the file system
+                    delimiter:
+                        title: Delimiter
+                        help: One character used to set the field delimiter
+                    enclosure:
+                        title: Enclosure
+                        help: One character used to set the field enclosure
+                    with_header:
+                        title: With header
+                        help: Whether or not to print the column name
+                    with_media:
+                        title: Export files and images
+                        help: Whether or not to export product files and images
+                    lines_per_file:
+                        title: Number of lines per file
+                        help: Define the limit number of lines per file
+                    upload_allowed:
+                        title: Allow file upload
+                        help: Whether or not to allow uploading the file directly
+                    categories_column:
+                        title: Categories column
+                        help: Name of the categories column
+                    escape:
+                        title: Escape
+                        help: One character used to set the field escape
+                    family_column:
+                        title: Family column
+                        help: Name of the family column
+                    groups_column:
+                        title: Groups column
+                        help: Name of the groups column
+                    enabled:
+                        title: Enable the product
+                        help: Whether or not imported product should be enabled
+                    enabled_comparison:
+                        title: Compare values
+                        help: Enable the comparison between original values and imported values. Can speed up import if imported values are very similar to original values
+                    real_time_versioning:
+                        title: Real time history update
+                        help: Means that the product history is automatically updated, can be switched off to improve performances
+                    family_variant_column:
+                        title: Family variant column
+            file_path: File path
+
 # Page titles
 pim_title:
     pim_importexport_export_profile_index:   Export profiles management

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.fr_FR.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.fr_FR.yml
@@ -24,3 +24,11 @@ pim_title:
   pim_importexport_import_profile_show: Profil d'import {{ job.label }} | Visualisation
   pim_importexport_import_execution_index: Historique d'exécution des imports
   pim_importexport_import_execution_show: Executions d'imports | Détails
+
+
+pim_import_export:
+    form:
+        job_instance:
+            tab:
+                content:
+                    title: Contenu

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/form_extensions/attribute/reference_data_multi.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/form_extensions/attribute/reference_data_multi.yml
@@ -11,7 +11,7 @@ extensions:
         position: 60
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-form-ref-data-multi-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 70
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-reference-data-multi-form-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 80
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
 
     pim-attribute-form-ref-data-multi-type-specific-params:
@@ -40,7 +40,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.type_specific
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.type_specific
                 dropZone: content
 
     pim-attribute-form-ref-data-multi-type-specific-params-ref-data-name:
@@ -50,5 +50,5 @@ extensions:
         position: 100
         config:
             fieldName: reference_data_name
-            label: pim_enrich.form.attribute.tab.properties.label.reference_data_name
+            label: pim_enrich.entity.attribute.property.reference_data_name.label
             refDataType: multi

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/form_extensions/attribute/reference_data_simple.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/form_extensions/attribute/reference_data_simple.yml
@@ -11,7 +11,7 @@ extensions:
         position: 60
         config:
             fieldName: useable_as_grid_filter
-            label: pim_enrich.form.attribute.tab.properties.label.useable_as_grid_filter
+            label: pim_enrich.entity.attribute.property.useable_as_grid_filter
 
     pim-attribute-form-ref-data-simple-is-locale-specific:
         module: pim/attribute-edit-form/properties/is-locale-specific
@@ -20,7 +20,7 @@ extensions:
         position: 70
         config:
             fieldName: is_locale_specific
-            label: pim_enrich.form.attribute.tab.properties.label.is_locale_specific
+            label: pim_enrich.entity.attribute.property.is_locale_specific
 
     pim-attribute-reference-data-simpleselect-form-available-locales:
         module: pim/attribute-edit-form/properties/available-locales
@@ -29,7 +29,7 @@ extensions:
         position: 80
         config:
             fieldName: available_locales
-            label: pim_enrich.form.attribute.tab.properties.label.available_locales
+            label: pim_enrich.entity.attribute.property.available_locales
 
     pim-attribute-form-ref-data-simple-type-specific-params:
         module: pim/common/simple-view
@@ -39,7 +39,7 @@ extensions:
         config:
             template: pim/template/form/tab/section
             templateParams:
-                sectionTitle: pim_enrich.form.attribute.tab.properties.section.type_specific
+                sectionTitle: pim_enrich.entity.attribute.tab.properties.section.type_specific
                 dropZone: content
 
     pim-attribute-form-ref-data-simple-type-specific-params-ref-data-name:
@@ -49,5 +49,5 @@ extensions:
         position: 100
         config:
             fieldName: reference_data_name
-            label: pim_enrich.form.attribute.tab.properties.label.reference_data_name
+            label: pim_enrich.entity.attribute.property.reference_data_name.label
             refDataType: simple

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/public/js/attribute/form/properties/ref-data-name.js
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/public/js/attribute/form/properties/ref-data-name.js
@@ -60,7 +60,7 @@ function (
                 choices: this.formatChoices(this.refData),
                 multiple: false,
                 labels: {
-                    defaultLabel: __('pim_enrich.form.attribute.tab.properties.default_label.reference_data_name')
+                    defaultLabel: __('pim_enrich.entity.attribute.property.reference_data_name.choose')
                 }
             }));
         },

--- a/tests/legacy/features/Pim/Behat/Extension/PimFormatter/PimFormatterExtension.php
+++ b/tests/legacy/features/Pim/Behat/Extension/PimFormatter/PimFormatterExtension.php
@@ -17,7 +17,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class PimFormatterExtension implements ExtensionInterface
 {
-
     /**
      * {@inheritdoc}
      */

--- a/tests/legacy/features/export/configure_export_products_with_media.feature
+++ b/tests/legacy/features/export/configure_export_products_with_media.feature
@@ -8,7 +8,7 @@ Feature: Configure export of products media
     Given a "footwear" catalog configuration
     And the following jobs:
       | connector             | type   | alias               | code                | label                        |
-      | Akeneo XLSX Connector | export | xlsx_product_export | xlsx_product_export | XSLX footwear product export |
+      | Akeneo XLSX Connector | export | xlsx_product_export | xlsx_product_export | XLSX footwear product export |
     And the following products:
       | sku           | name-en_US    | price-EUR | size | color | side_view             | family | categories        |
       | gothic_boot_1 | Gothic Boot A | 19.99     | 35   | black | %fixtures%/akeneo.jpg | boots  | winter_collection |

--- a/tests/legacy/features/export/xlsx/export_options.feature
+++ b/tests/legacy/features/export/xlsx/export_options.feature
@@ -1,5 +1,5 @@
 @javascript
-Feature: Export options in XSLX
+Feature: Export options in XLSX
   In order to be able to access and modify options data outside PIM
   As a product manager
   I need to be able to export options in XLSX

--- a/tests/legacy/features/import/product_model/create_import_profile.feature
+++ b/tests/legacy/features/import/product_model/create_import_profile.feature
@@ -20,12 +20,12 @@ Feature: Create product models through CSV import
     And I visit the "Global settings" tab
     And I should see the Family variant fields
 
-  Scenario: Peter creates a new XSLX import profile to import products models
+  Scenario: Peter creates a new XLSX import profile to import products models
     Given I create a new import
     When I fill in the following information in the popin:
       | Code  | product_model_import         |
-      | Label | Product model import in XSLX |
-      | Job   | Product model import in XSLX |
+      | Label | Product model import in XLSX |
+      | Job   | Product model import in XLSX |
     And I press the "Save" button
     Then I should not see the text "There are unsaved changes"
     And I visit the "Global settings" tab

--- a/tests/legacy/features/mass-action/quick_export.feature
+++ b/tests/legacy/features/mass-action/quick_export.feature
@@ -69,7 +69,7 @@ Feature: Quick export many products from datagrid
       sneakers;bbb;summer_collection;white;;1;sneakers;;;;Sneakers;50;60;;;42;;
       """
 
-  Scenario: Successfully quick export selected products as a XSLX file
+  Scenario: Successfully quick export selected products as a XLSX file
     Given I am on the products grid
     When I select rows boots, sneakers
     And I press "Excel (All attributes)" on the "Quick Export" dropdown button

--- a/tests/legacy/features/mass-action/quick_export_grid_context.feature
+++ b/tests/legacy/features/mass-action/quick_export_grid_context.feature
@@ -36,7 +36,7 @@ Feature: Quick export products according to the product grid context
     pump;blue;;;;Pump;15;20;41
     """
 
-  Scenario: Successfully quick export products from grid context as a XSLX file
+  Scenario: Successfully quick export products from grid context as a XLSX file
     Given I am on the products grid
     And I display the columns SKU, Name, Label, Family, Color, Complete, Groups, Price, Size, Created at, Updated at, Description and Weight
     And I select rows boots, sneakers, pump

--- a/tests/legacy/features/mass-action/quick_export_with_media.feature
+++ b/tests/legacy/features/mass-action/quick_export_with_media.feature
@@ -49,7 +49,7 @@ Feature: Quick export many products with media from datagrid
       | files/boots/side_view/akeneo.jpg     |
       | files/sneakers/side_view/akeneo2.jpg |
 
-  Scenario: Successfully quick export products and media as a XSLX file
+  Scenario: Successfully quick export products and media as a XLSX file
     Given I am on the products grid
     When I select rows boots, sneakers
     And I press "Excel (All attributes)" on the "Quick Export" dropdown button

--- a/tests/legacy/features/product/history/display_history.feature
+++ b/tests/legacy/features/product/history/display_history.feature
@@ -104,7 +104,7 @@ Feature: Display the product history
       | 4       | Length unit |       | now  |
 
   @jira https://akeneo.atlassian.net/browse/PIM-3628
-  Scenario: Update product history when updating product media
+    Scenario: Update product history when updating product media
     Given a "footwear" catalog configuration
     And I am logged in as "Julia"
     And I am on the products grid

--- a/tests/legacy/features/product/history/display_history.feature
+++ b/tests/legacy/features/product/history/display_history.feature
@@ -104,7 +104,7 @@ Feature: Display the product history
       | 4       | Length unit |       | now  |
 
   @jira https://akeneo.atlassian.net/browse/PIM-3628
-    Scenario: Update product history when updating product media
+  Scenario: Update product history when updating product media
     Given a "footwear" catalog configuration
     And I am logged in as "Julia"
     And I am on the products grid


### PR DESCRIPTION
Still dropping unused keys, reorganize translations.
This time the PR is about the `EnrichBundle` translations. We tried to adopt a common structure for all the entities, visible here.
https://github.com/akeneo/pim-community-dev/pull/8192/files#diff-c9fe73a19abe3e7b98ab85e504b3f76fR1

For now, only a few entities were structured, but the PR begins to be huge, so we stopped it now, and another PR is coming.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
