### PR TITLE
[PIM-7367] Fix associations of product and product model with same ids

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7358: Cascade remove variant attribute sets when removing a family variant
+- PIM-7367: Fix association of a product and product model with the same identifier
 
 ## BC breaks
 

--- a/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
@@ -176,6 +176,22 @@ class AssociatedProductDatasource extends ProductDatasource
     }
 
     /**
+     * Generates a unique identifier for a product or a product model.
+     *
+     * @param $productOrProductModel ProductInterface
+     *
+     * @return string
+     */
+    protected function getProductOrProductModelIdentifier(ProductInterface $productOrProductModel): string
+    {
+        return sprintf(
+            '%s-%s',
+            $productOrProductModel instanceof ProductModelInterface ? 'product-model' : 'product',
+            $productOrProductModel->getId()
+        );
+    }
+
+    /**
      * @param CursorInterface $products
      * @param string          $locale
      * @param string          $scope
@@ -201,7 +217,7 @@ class AssociatedProductDatasource extends ProductDatasource
             $normalized = array_merge(
                 $this->normalizer->normalize($product, 'datagrid', $context),
                 [
-                    'id'         => $product->getId(),
+                    'id'         => $this->getProductOrProductModelIdentifier($product),
                     'dataLocale' => $dataLocale,
                     'is_associated' => true,
                 ]

--- a/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
@@ -176,22 +176,6 @@ class AssociatedProductDatasource extends ProductDatasource
     }
 
     /**
-     * Generates a unique identifier for a product or a product model.
-     *
-     * @param $productOrProductModel ProductInterface
-     *
-     * @return string
-     */
-    protected function getProductOrProductModelIdentifier(ProductInterface $productOrProductModel): string
-    {
-        return sprintf(
-            '%s-%s',
-            $productOrProductModel instanceof ProductModelInterface ? 'product-model' : 'product',
-            $productOrProductModel->getId()
-        );
-    }
-
-    /**
      * @param CursorInterface $products
      * @param string          $locale
      * @param string          $scope
@@ -217,7 +201,11 @@ class AssociatedProductDatasource extends ProductDatasource
             $normalized = array_merge(
                 $this->normalizer->normalize($product, 'datagrid', $context),
                 [
-                    'id'         => $this->getProductOrProductModelIdentifier($product),
+                    'id'         => sprintf(
+                        '%s-%s',
+                        $product instanceof ProductModelInterface ? 'product-model' : 'product',
+                        $product->getId()
+                    ),
                     'dataLocale' => $dataLocale,
                     'is_associated' => true,
                 ]

--- a/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
@@ -263,6 +263,9 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
         $results['data']->shouldBeArray();
         $results['data']->shouldHaveCount(3);
         $results['data']->shouldBeAnArrayOfInstanceOf(ResultRecord::class);
+        $results['data'][0]->getValue('id')->shouldReturn('product-2');
+        $results['data'][1]->getValue('id')->shouldReturn('product-3');
+        $results['data'][2]->getValue('id')->shouldReturn('product-model-2');
     }
 
     public function getMatchers()


### PR DESCRIPTION
There is an issue when you associate a product and a product model with the same id.
The Datagrid do not display duplicates with the same "id" field (not used in the association grid).
We just added a specific label for splitting product and product models.




| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -