### PR TITLE
Fix UserContext::toArray() method

### DIFF
--- a/src/Pim/Bundle/UserBundle/Context/UserContext.php
+++ b/src/Pim/Bundle/UserBundle/Context/UserContext.php
@@ -281,7 +281,7 @@ class UserContext
      */
     public function toArray()
     {
-        $channels = array_keys($this->getChannelChoicesWithUserChannel());
+        $channels = array_values($this->getChannelChoicesWithUserChannel());
         $locales = $this->getUserLocaleCodes();
 
         return [

--- a/src/Pim/Bundle/UserBundle/spec/Context/UserContextSpec.php
+++ b/src/Pim/Bundle/UserBundle/spec/Context/UserContextSpec.php
@@ -205,8 +205,8 @@ class UserContextSpec extends ObjectBehavior
 
         $channelRepository->findAll()->willReturn([$ecommerce]);
         $choicesBuilder->buildChoices([$ecommerce])->willReturn([
-            'mobile' => $userChannel,
-            'ecommerce' => $ecommerce
+            'Mobile' =>  'mobile',
+            'Default' => 'ecommerce',
         ]);
 
         $fr->getCode()->willReturn('fr_FR');


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes `Pim\Bundle\UserBundle\Context\UserContext::toArray()` method, which wrongly provides channels' labels instead of codes since #6374 (in [here](https://github.com/akeneo/pim-community-dev/pull/6374/commits/b8df6efac6d3fd2ed4a8476cd4ad6256894753fd#diff-02a42b2a6d7255a5300ae9d4b57f6a49R31))

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
