### PR TITLE
PIM-7382: Fix scopable attributes disappearing from edit form after editing a product model

### DIFF
--- a/features/product-model/edit_product_model.feature
+++ b/features/product-model/edit_product_model.feature
@@ -91,3 +91,13 @@ Feature: Edit a product model
     And I press the "Save" button
     And I visit the "All" group
     Then the Care instructions, Collection, Model picture fields should be highlighted
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7382
+  Scenario: Successfully display a product model's scopable value after editing it 
+    Given I am logged in as "Mary"
+    And I am on the "bacchus" product model page
+    And I fill in the following information:
+      | Model description | Another great description |
+    And I press the "Save" button
+    Then I should not see the text "There are unsaved changes."
+    And the field Model description should contain "Another great description"

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
@@ -373,10 +373,7 @@ class ProductModelController
      */
     private function normalizeProductModel(ProductModelInterface $productModel): array
     {
-        $normalizationContext = $this->userContext->toArray() + [
-                'filter_types'               => ['pim.internal_api.product_value.view'],
-                'disable_grouping_separator' => true
-            ];
+        $normalizationContext = $this->userContext->toArray() + ['filter_types' => []];
 
         return $this->normalizer->normalize(
             $productModel,

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
@@ -92,6 +92,7 @@ class ProductModelController
      * @param EntityWithValuesFilter            $emptyValuesFilter
      * @param ConverterInterface                $productValueConverter
      * @param ObjectUpdaterInterface            $productModelUpdater
+     * @param RemoverInterface                  $productModelRemover
      * @param ValidatorInterface                $validator
      * @param SaverInterface                    $productModelSaver
      * @param NormalizerInterface               $constraintViolationNormalizer

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
@@ -145,15 +145,7 @@ class ProductModelController
      */
     public function getAction(int $id): JsonResponse
     {
-        $productModel = $this->productModelRepository->find($id);
-        $cantView = $this->objectFilter->filterObject($productModel, 'pim.internal_api.product.view');
-
-        if (null === $productModel || true === $cantView) {
-            throw new NotFoundHttpException(
-                sprintf('Product model with id %s could not be found.', $id)
-            );
-        }
-
+        $productModel = $this->findProductModelOr404($id);
         $normalizedProductModel = $this->normalizeProductModel($productModel);
 
         return new JsonResponse($normalizedProductModel);
@@ -235,15 +227,9 @@ class ProductModelController
         }
 
         $this->productModelSaver->save($productModel);
+        $normalizedProductModel = $this->normalizeProductModel($productModel);
 
-        $normalizationContext = $this->userContext->toArray() + ['disable_grouping_separator' => true];
-        $normalizedProduct = $this->normalizer->normalize(
-            $productModel,
-            'internal_api',
-            $normalizationContext
-        );
-
-        return new JsonResponse($normalizedProduct);
+        return new JsonResponse($normalizedProductModel);
     }
 
     /**
@@ -260,7 +246,7 @@ class ProductModelController
             return new RedirectResponse('/');
         }
 
-        $productModel = $this->productModelRepository->find($id);
+        $productModel = $this->findProductModelOr404($id);
         $data = json_decode($request->getContent(), true);
 
         $this->updateProductModel($productModel, $data);
@@ -270,15 +256,9 @@ class ProductModelController
 
         if (0 === $violations->count()) {
             $this->productModelSaver->save($productModel);
+            $normalizedProductModel = $this->normalizeProductModel($productModel);
 
-            $normalizationContext = $this->userContext->toArray() + ['disable_grouping_separator' => true];
-            $normalizedProduct = $this->normalizer->normalize(
-                $productModel,
-                'internal_api',
-                $normalizationContext
-            );
-
-            return new JsonResponse($normalizedProduct);
+            return new JsonResponse($normalizedProductModel);
         }
 
         $normalizedViolations = [];
@@ -302,12 +282,7 @@ class ProductModelController
      */
     public function childrenAction(Request $request): JsonResponse
     {
-        $parentId = $request->query->get('id');
-        $parent = $this->productModelRepository->find($parentId);
-        if (null === $parent) {
-            throw new NotFoundHttpException(sprintf('ProductModel with id "%s" not found', $parentId));
-        }
-
+        $parent = $this->findProductModelOr404($request->get('id'));
         $children = $this->productModelRepository->findChildrenProductModels($parent);
         if (empty($children)) {
             $children = $this->productModelRepository->findChildrenProducts($parent);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

In `Pim\Bundle\EnrichBundle\Controller\Rest\ProductModelController::postAction()`, the normalization context was different from the other actions (no `filter_types` key provided, which resulted in applying the default filters: https://github.com/akeneo/pim-community-dev/blob/2f4f43f99f864d725b3515d59b6c0243fe9ddf5e/src/Pim/Component/Catalog/Normalizer/Standard/ProductModelNormalizer.php#L49

One of these filters is `pim_enrich.filter.product_value.channel`, which filters values for scopable attributes when the value's channel is not in the user context. 

Problem is: the context's channels are provided by the `Pim\Bundle\UserBundle\Context::toArray()` method which is wrong (it returns chanlles' labels instead of codes, see #8207)
This results in every scopable value being filtered unless channel code and label are exactly the same, and the corresponding fields disappearing from the edit form after saving.

This PR fixes several small issues in `Pim\Bundle\EnrichBundle\Controller\Rest\ProductModelController`:
- use the same normalization context (by using `normalizeProductModel()` method) for each action
- remove useless filters from the normalization context (the correct filters are applied in the EE's ProductModelRepository)
- reuse `findProductModelOr404()` protected method to avoid code duplication

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | Yes
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
