### PR TITLE
[NEED-FEEDBACK] Parametrize the URL in behat.env.dist 

### DIFF
--- a/app/config/config_behat.yml
+++ b/app/config/config_behat.yml
@@ -1,3 +1,7 @@
+parameters:
+    env(BEHAT_URL): 'http://127.0.0.1/'
+    behat_url: '%env(BEHAT_URL)%'
+
 imports:
     - { resource: config.yml }
     - { resource: parameters_test.yml }

--- a/app/config/config_behat.yml
+++ b/app/config/config_behat.yml
@@ -1,7 +1,3 @@
-parameters:
-    env(BEHAT_URL): 'http://127.0.0.1/'
-    behat_url: '%env(BEHAT_URL)%'
-
 imports:
     - { resource: config.yml }
     - { resource: parameters_test.yml }
@@ -48,3 +44,9 @@ parameters:
     catalog_storage_dir:  '%kernel.root_dir%/../var/cache/file_storage/catalog'
     tmp_storage_dir:      '%kernel.root_dir%/../var/cache/tmp/pim/file_storage'
     upload_tmp_dir:       '%kernel.root_dir%/../var/cache/tmp/pim/upload_tmp_dir'
+    env(BEHAT_URL): 'http://127.0.0.1/'
+    behat_url: '%env(BEHAT_URL)%'
+    env(BEHAT_TIMEOUT): 50000
+    behat_timeout: '%env(BEHAT_TIMEOUT)%'
+    env(BEHAT_SELENIUM_URL): 'http://127.0.0.1:4444/wd/hub'
+    behat_selenium_url: '%env(BEHAT_SELENIUM_URL)%'

--- a/app/config/parameters_test.yml.dist
+++ b/app/config/parameters_test.yml.dist
@@ -12,3 +12,4 @@ parameters:
     product_model_index_name:              akeneo_pim_product_model
     product_and_product_model_index_name:  akeneo_pim_product_and_product_model
     index_hosts:                          'localhost: 9200'
+    behat_url:                            'http://127.0.0.1/'

--- a/app/config/parameters_test.yml.dist
+++ b/app/config/parameters_test.yml.dist
@@ -13,3 +13,5 @@ parameters:
     product_and_product_model_index_name:  akeneo_pim_product_and_product_model
     index_hosts:                          'localhost: 9200'
     behat_url:                            'http://127.0.0.1/'
+    behat_selenium_url:                   'http://127.0.0.1:4444/wd/hub'
+    behat_timeout:                        '50000'

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -8,7 +8,7 @@ legacy:
             contexts:
                 - Context\FeatureContext:
                     -
-                        base_url: 'http://127.0.0.1/'
+                        base_url: '%%behat_url%%'
                         timeout: 50000
                         window_width: 1280
                         window_height: 1024

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -9,7 +9,7 @@ legacy:
                 - Context\FeatureContext:
                     -
                         base_url: '%%behat_url%%'
-                        timeout: 50000
+                        timeout: '%%behat_timeout%%'
                         window_width: 1280
                         window_height: 1024
                 - Context\FixturesContext:
@@ -24,7 +24,7 @@ legacy:
                     - 'Context\FeatureContext'
                 - Context\NavigationContext:
                     - 'Context\FeatureContext'
-                    - 'http://127.0.0.1/'
+                    - '%%behat_url%%'
                 - Context\TransformationContext:
                     - 'Context\FeatureContext'
                 - Context\AssertionContext:
@@ -120,8 +120,8 @@ legacy:
                     symfony2: ~
                 selenium2:
                     selenium2:
-                        wd_host: 'http://127.0.0.1:4444/wd/hub'
-            base_url: 'http://127.0.0.1/'
+                        wd_host: '%%behat_selenium_url%%'
+            base_url: '%%behat_url%%'
             files_path: 'tests/legacy/features/Context/fixtures/'
         Behat\Symfony2Extension:
             kernel:
@@ -132,7 +132,7 @@ legacy:
                 page: [Context\Page]
             factory:
                 page_parameters:
-                    base_url: 'http://127.0.0.1/'
+                    base_url: '%%behat_url%%'
         Pim\Behat\Extension\PimFormatter\PimFormatterExtension: ~
         Liuggio\Fastest\Behat\ListFeaturesExtension\Extension: ~
 

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -11,6 +11,9 @@ services:
       PHP_IDE_CONFIG: 'serverName=pim-ce-cli'
       PHP_XDEBUG_ENABLED: 0
       XDEBUG_CONFIG: 'remote_host=172.17.0.1'
+      BEHAT_SELENIUM_URL: 'http://selenium:4444/wd/hub'
+      BEHAT_URL: 'http://httpd-behat/'
+      BEHAT_TIMEOUT: 50000
     volumes:
       - '~/.composer:/home/docker/.composer'
       - '/tmp/behat/screenshots:/tmp/behat/screenshots'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Allow to put behat variable in parameters, to avoid to copy past the `behat.yml.dist` everytime.

As it does not support environment variables directly in it, I use a Symfony variable.
There is two ways of doing it:
- just a parameter
- env variable passed into the parameter

I did both of them here, what do you prefer? Or is it useless? Any feedback welcome.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
