### PR TITLE
PIM-7388: [SLA] Completeness filter on product grid for models does not work as expected

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -4,6 +4,7 @@
 
 - PIM-7358: Cascade remove variant attribute sets when removing a family variant
 - PIM-7367: Fix association of a product and product model with the same identifier
+- PIM-7388: Completeness filter on product grid for models does not work as expected
 - PIM-7315: Fix 500 on "IS EMPTY" operator for the SKU filter
 
 ## BC breaks

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductModelDescendantsSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductModelDescendantsSaver.php
@@ -66,7 +66,7 @@ class ProductModelDescendantsSaver implements SaverInterface
         CompletenessManager $completenessManager,
         BulkIndexerInterface $productIndexer,
         BulkIndexerInterface $bulkProductModelIndexer,
-        IndexerInterface $productModelIndexer
+        IndexerInterface $productModelIndexer = null
     ) {
         $this->objectManager = $entityManager;
         $this->productModelRepository = $productModelRepository;
@@ -105,8 +105,12 @@ class ProductModelDescendantsSaver implements SaverInterface
          * it may break the complete filter on the grid because wrong data was indexed in ES.
          *
          * You should have a look to https://akeneo.atlassian.net/browse/PIM-7388
+         *
+         * @TODO We need to remove the if condition during the pull day
          */
-        $this->productModelIndexer->index($productModel);
+        if (null !== $this->productModelIndexer) {
+            $this->productModelIndexer->index($productModel);
+        }
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/savers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/savers.yml
@@ -129,3 +129,4 @@ services:
             - '@pim_catalog.manager.completeness'
             - '@pim_catalog.elasticsearch.indexer.product'
             - '@pim_catalog.elasticsearch.indexer.product_model'
+            - '@pim_catalog.elasticsearch.indexer.product_model'

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Bundle\CatalogBundle\Doctrine\Common\Saver;
 
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
+use Akeneo\Component\StorageUtils\Indexer\IndexerInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductModelDescendantsSaver;
@@ -24,7 +25,8 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         ProductQueryBuilderFactoryInterface $pqbFactory,
         CompletenessManager $completenessManager,
         BulkIndexerInterface $productIndexer,
-        BulkIndexerInterface $productModelIndexer
+        BulkIndexerInterface $bulkProductModelIndexer,
+        IndexerInterface $productModelIndexer
     ) {
         $this->beConstructedWith(
             $objectManager,
@@ -32,6 +34,7 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
             $pqbFactory,
             $completenessManager,
             $productIndexer,
+            $bulkProductModelIndexer,
             $productModelIndexer
         );
     }
@@ -47,9 +50,11 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $completenessManager,
         $objectManager,
         $productIndexer,
+        $bulkProductModelIndexer,
         $productModelIndexer,
         ProductQueryBuilderInterface $pqb,
         ProductModelInterface $productModel,
+        ProductModelInterface $productModelsChildren,
         ProductInterface $variantProduct1,
         ProductInterface $variantProduct2,
         CursorInterface $cursor
@@ -80,8 +85,10 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
 
         $productIndexer->indexAll([$variantProduct1, $variantProduct2])->shouldBeCalled();
 
-        $productModelRepository->findChildrenProductModels($productModel)->willReturn([$productModel]);
-        $productModelIndexer->indexAll([$productModel]);
+        $productModelRepository->findChildrenProductModels($productModel)->willReturn([$productModelsChildren]);
+        $bulkProductModelIndexer->indexAll([$productModelsChildren]);
+
+        $productModelIndexer->index($productModel);
 
         $this->save($productModel);
     }
@@ -92,6 +99,7 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $completenessManager,
         $objectManager,
         $productIndexer,
+        $bulkProductModelIndexer,
         $productModelIndexer,
         ProductQueryBuilderInterface $pqb,
         ProductModelInterface $productModel,
@@ -116,7 +124,9 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $productIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();
 
         $productModelRepository->findChildrenProductModels($productModel)->willReturn([]);
-        $productModelIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();
+        $bulkProductModelIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();
+
+        $productModelIndexer->index($productModel);
 
         $this->save($productModel);
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When you save a product model:

- The product model is saved in database
- The product model is indexed in ES (post save event)
- The completeness is computed for all product model children (post save event)
- The product model indexation is done
- The job which computes product completeness is finished

Problem is that when the indexation is done, the product completeness computation job is not finished. That means the ratio of complete product models may change during this task so we need to index again the product model. If we don't do that it may break the complete filter on the grid because wrong data was indexed in ES.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
