### PR TITLE
[PIM-7040] Fix bad history display on large strings

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,6 +2,7 @@
 
 - PIM-7362: Fix Completeness computing from family keeping in account batch size to free the memory
 - PIM-7349: Fix empty family when using quick export of products
+- PIM-7040: Fix bad display of history grids on large strings
 
 # 2.0.25 (2018-05-21)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/templates/datagrid/cell/history-diff-cell.html
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/templates/datagrid/cell/history-diff-cell.html
@@ -4,7 +4,7 @@
             <tr class="AknGrid-bodyRow">
                 <td class="AknGrid-bodyCell AknGrid-bodyCell--highlightAlternative AknGrid-bodyCell--withoutBottomBorder property" colspan="2"><%= label %></td>
             </tr>
-            <tr class="AknGrid-bodyRow">
+            <tr class="AknGrid-bodyRow AknGrid-bodyRow--wordBreakable">
                 <td class="AknGrid-bodyCell AknGrid-bodyCell--withoutTopBorder"><span class="AknDiff--remove"><%- __('pim_enrich.entity.product.history.old_value') %>:</span> <span class="old-values"><%- value.old %></span></td>
                 <td class="AknGrid-bodyCell AknGrid-bodyCell--withoutTopBorder"><span class="AknDiff--add"><%- __('pim_enrich.entity.product.history.new_value') %>:</span> <span class="new-values"><%- value.new %></span></td>
             </tr>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/history.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/history.html
@@ -32,7 +32,7 @@
                                     <tr class="AknGrid-bodyRow">
                                         <td class="AknGrid-bodyCell AknGrid-bodyCell--highlightAlternative AknGrid-bodyCell--withoutBottomBorder property" colspan="2"><%= value.label %></td>
                                     </tr>
-                                    <tr class="AknGrid-bodyRow">
+                                    <tr class="AknGrid-bodyRow AknGrid-bodyRow--wordBreakable">
                                         <td class="AknGrid-bodyCell AknGrid-bodyCell--withoutTopBorder"><span class="AknDiff--remove"><%- _.__('pim_enrich.entity.product.history.old_value') %>:</span> <span class="old-values"><%- value.old %></span></td>
                                         <td class="AknGrid-bodyCell AknGrid-bodyCell--withoutTopBorder"><span class="AknDiff--add"><%- _.__('pim_enrich.entity.product.history.new_value') %>:</span> <span class="new-values"><%- value.new %></span></td>
                                     </tr>

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -9,6 +9,10 @@
 
   &-bodyRow {
     transition: background 0.2s ease-in;
+
+    &--wordBreakable {
+      word-wrap: break-word;
+    }
   }
 
   &-bodyRow + &-bodyRow:not(&-bodyRow--withoutTopBorder) &-bodyCell {


### PR DESCRIPTION
Before:

![selection_053](https://user-images.githubusercontent.com/1590933/40711436-73a518ee-63fb-11e8-8e48-ce920f3f8579.png)

After:

![selection_052](https://user-images.githubusercontent.com/1590933/40711443-7755c2c2-63fb-11e8-8ecc-5de96a36d567.png)


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | TODO
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -