### PR TITLE
PIM-7391: Fix offset pagination when listing product models with the API

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -10,6 +10,7 @@
 - PIM-6846: Fix bug on click in Display Attributes button on Product edit form
 - PIM-7389: Refactor the 'add to group' mass edit screen to allow big set of groups
 - PIM-7311: Fix the product grid filters list when a sort order is a huge number
+- PIM-7391: Fix offset pagination when listing product models with the API
 
 # 2.0.25 (2018-05-21)
 

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
@@ -169,7 +169,7 @@ class ProductModelController
             throw new NotFoundHttpException(sprintf('Product model "%s" does not exist.', $code));
         }
 
-        $productModelApi = $this->normalizer->normalize($productModels->current(), 'standard');
+        $productModelApi = $this->normalizer->normalize($productModels->current(), 'external_api');
 
         return new JsonResponse($productModelApi);
     }
@@ -301,7 +301,7 @@ class ProductModelController
         try {
             $count = 'true' === $queryParameters['with_count'] ? $productModels->count() : null;
             $paginatedProductModels = $this->offsetPaginator->paginate(
-                $this->normalizer->normalize($productModels, 'standard'),
+                $this->normalizer->normalize($productModels, 'external_api'),
                 $paginationParameters,
                 $count
             );

--- a/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/normalizers.yml
@@ -3,6 +3,7 @@ parameters:
     pim_api.normalizer.exception.violation.class: Pim\Component\Api\Normalizer\Exception\ViolationNormalizer
     pim_api.normalizer.collection.class: Pim\Component\Api\Normalizer\CollectionNormalizer
     pim_api.normalizer.product.class: Pim\Component\Api\Normalizer\ProductNormalizer
+    pim_api.normalizer.product_model.class: Pim\Component\Api\Normalizer\ProductModelNormalizer
     pim_api.normalizer.family.class: Pim\Component\Api\Normalizer\FamilyNormalizer
     pim_api.normalizer.family_variant.class: Pim\Component\Api\Normalizer\FamilyVariantNormalizer
     pim_api.normalizer.category.class: Pim\Component\Api\Normalizer\CategoryNormalizer
@@ -48,6 +49,15 @@ services:
         class: '%pim_api.normalizer.product.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product'
+            - '@pim_api.repository.attribute'
+            - '@router'
+        tags:
+            - { name: pim_serializer.normalizer, priority: 90 }
+
+    pim_api.normalizer.product_model:
+        class: '%pim_api.normalizer.product_model.class%'
+        arguments:
+            - '@pim_catalog.normalizer.standard.product_model'
             - '@pim_api.repository.attribute'
             - '@router'
         tags:

--- a/src/Pim/Component/Api/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Component/Api/Normalizer/ProductModelNormalizer.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Api\Normalizer;
+
+use Pim\Component\Api\Hal\Link;
+use Pim\Component\Api\Repository\AttributeRepositoryInterface;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelNormalizer implements NormalizerInterface
+{
+    /** @var NormalizerInterface */
+    protected $productModelNormalizer;
+
+    /** @var AttributeRepositoryInterface */
+    protected $attributeRepository;
+
+    /** @var RouterInterface */
+    protected $router;
+
+    /**
+     * @param NormalizerInterface          $productModelNormalizer
+     * @param AttributeRepositoryInterface $attributeRepository
+     * @param RouterInterface              $router
+     */
+    public function __construct(
+        NormalizerInterface $productModelNormalizer,
+        AttributeRepositoryInterface $attributeRepository,
+        RouterInterface $router
+    ) {
+        $this->productModelNormalizer = $productModelNormalizer;
+        $this->attributeRepository = $attributeRepository;
+        $this->router = $router;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($product, $format = null, array $context = []): array
+    {
+        $productModelStandard = $this->productModelNormalizer->normalize($product, 'standard', $context);
+
+        $mediaAttributeCodes = $this->attributeRepository->getMediaAttributeCodes();
+        foreach ($productModelStandard['values'] as $attributeCode => $values) {
+            if (in_array($attributeCode, $mediaAttributeCodes)) {
+                $productModelStandard['values'][$attributeCode] = $this->addDownloadLink($values);
+            }
+        }
+
+        if (empty($productModelStandard['values'])) {
+            $productModelStandard['values'] = (object)$productModelStandard['values'];
+        }
+
+        return $productModelStandard;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $data instanceof ProductModelInterface && 'external_api' === $format;
+    }
+
+    /**
+     * @param array $values
+     *
+     * @return array
+     */
+    protected function addDownloadLink(array $values): array
+    {
+        foreach ($values as $index => $value) {
+            if (null !== $value['data']) {
+                $route = $this->router->generate(
+                    'pim_api_media_file_download',
+                    ['code' => $value['data']],
+                    UrlGeneratorInterface::ABSOLUTE_URL
+                );
+                $download = new Link('download', $route);
+                $values[$index]['_links'] = $download->toArray();
+            }
+        }
+
+        return $values;
+    }
+}

--- a/src/Pim/Component/Api/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Component/Api/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace spec\Pim\Component\Api\Normalizer;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Api\Normalizer\ProductModelNormalizer;
+use Pim\Component\Api\Repository\AttributeRepositoryInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Prophecy\Argument;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ProductModelNormalizerSpec extends ObjectBehavior
+{
+    function let(
+        NormalizerInterface $stdNormalizer,
+        AttributeRepositoryInterface $attributeRepository,
+        RouterInterface $router
+    ) {
+        $this->beConstructedWith($stdNormalizer, $attributeRepository, $router);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProductModelNormalizer::class);
+    }
+
+    function it_supports_a_product(ProductModelInterface $productModel)
+    {
+        $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
+        $this->supportsNormalization(new \stdClass(), 'external_api')->shouldReturn(false);
+        $this->supportsNormalization($productModel, 'whatever')->shouldReturn(false);
+        $this->supportsNormalization($productModel, 'external_api')->shouldReturn(true);
+    }
+
+    function it_normalizes_a_product_model_to_the_api_format(
+        $stdNormalizer,
+        $attributeRepository,
+        $router,
+        ProductModelInterface $productModel
+    ) {
+        $productModelStandard = [
+            'identifier' => 'foo',
+            'values'     => [
+                'text' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'text'
+                    ]
+                ],
+                'file' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'a/b/c/artyui_file.txt'
+                    ]
+                ]
+            ]
+        ];
+
+        $productModelApiFormat = [
+            'identifier' => 'foo',
+            'values'     => [
+                'text' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'text'
+                    ]
+                ],
+                'file' => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'a/b/c/artyui_file.txt',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/a/b/c/artyui_file.txt/download'
+                            ]
+                        ],
+                    ]
+                ]
+            ]
+        ];
+
+        $stdNormalizer->normalize($productModel, 'standard', [])->willReturn($productModelStandard);
+
+        $attributeRepository->getMediaAttributeCodes()->willReturn(['file']);
+        $router->generate('pim_api_media_file_download', ['code' => 'a/b/c/artyui_file.txt'], Argument::any())
+            ->willReturn('http://localhost/api/rest/v1/a/b/c/artyui_file.txt/download');
+
+        $this->normalize($productModel, 'external_api', [])->shouldReturn($productModelApiFormat);
+    }
+
+    function it_normalizes_empty_values_as_an_object_for_json_serialization(
+        $stdNormalizer,
+        $attributeRepository,
+        ProductModelInterface $productModel
+    ) {
+        $productStandard = [
+            'identifier'   => 'foo',
+            'values'       => [],
+            'associations' => []
+        ];
+
+        $stdNormalizer->normalize($productModel, 'standard', [])->willReturn($productStandard);
+
+        $attributeRepository->getMediaAttributeCodes()->willReturn(['file']);
+        $attributeRepository->getIdentifierCode()->willReturn('sku');
+
+        $normalizedProduct = $this->normalize($productModel, 'external_api', []);
+        $normalizedProduct->shouldHaveValues($productStandard);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'haveValues' => function ($subject) {
+                return is_object($subject['values']);
+            }
+        ];
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When listing product models with the API, only the ten last where returned.

As the default limit is ten, we didn't see that. But if you increase the limit to 20, it returns only the ten last elements.

The issue is that that the Collecton normalizer was never used: so, it uses wrong the default normalizer of Symfony, that is not working properly with our cursors (problem of key).

The origin of this error is that we have to use the API normalizer instead of "standard" normalizer.
It fixes another error as well:

- links were not generated for media product values (spec is explicit)



<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
