### PR TITLE
[PIM-7014] Fix attribute creation page with large strings

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,7 +3,8 @@
 - PIM-7362: Fix Completeness computing from family keeping in account batch size to free the memory
 - PIM-7349: Fix empty family when using quick export of products
 - PIM-7040: Fix bad display of history grids on large strings
-
+- PIM-7014: Fix attribute creation page with large strings
+ 
 # 2.0.25 (2018-05-21)
 
 ## Bug fixes

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/SquareList.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/SquareList.less
@@ -10,7 +10,7 @@
   line-height: 12px;
 
   &-item {
-    height: 128px;
+    min-height: 128px;
     flex-basis: 128px;
     border: 1px solid @AknMediumGrey;
     margin: 10px;


### PR DESCRIPTION
Before
![selection_055](https://user-images.githubusercontent.com/1590933/40772624-c4724de4-64c0-11e8-9449-da9d5d1451c8.png)

After
![selection_054](https://user-images.githubusercontent.com/1590933/40772620-c26f50fa-64c0-11e8-8506-b7945f1be4d0.png)


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
