### PR TITLE
PIM-7319: Fix association display on product edit form when managing the association type permissions

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,6 +1,7 @@
 # 2.2.x
 
 - PIM-7316: Fix overlap of boolean fields on product edit form
+- PIM-7319: Fix association display on product edit form when managing the association type permissions
 
 # 2.2.7 (2018-05-31)
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AssociationTypeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AssociationTypeController.php
@@ -99,7 +99,7 @@ class AssociationTypeController
      *
      * @return JsonResponse
      *
-     * @AclAncestor("pim_enrich_associationtype_edit")
+     * @AclAncestor("pim_enrich_associationtype_index")
      */
     public function getAction($identifier)
     {


### PR DESCRIPTION
It was a typo on association type rest controller, it raises a Forbidden to get an association type event if you have the permissions.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
