### PR TITLE
PIM-7386: Fix 'NOT IN' operator not taking empty values into account for select fields

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,7 +1,11 @@
 # 2.2.x
 
+## Bug fixes
+
 - PIM-7316: Fix overlap of boolean fields on product edit form
 - PIM-7319: Fix association display on product edit form when managing the association type permissions
+- PIM-7382: Fix scopable attributes disappearing from edit form after editing a product model 
+- PIM-7386: Fix 'NOT IN' operator not taking empty values into account for select fields
 
 # 2.2.7 (2018-05-31)
 

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/OptionFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/OptionFilter.php
@@ -98,13 +98,7 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
                         $attributePath => $values,
                     ],
                 ];
-                $filterClause = [
-                    'exists' => [
-                        'field' => $attributePath,
-                    ],
-                ];
                 $this->searchQueryBuilder->addMustNot($mustNotClause);
-                $this->searchQueryBuilder->addFilter($filterClause);
                 break;
 
             default:

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/OptionFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/OptionFilterSpec.php
@@ -163,14 +163,6 @@ class OptionFilterSpec extends ObjectBehavior
             ]
         )->shouldBeCalled();
 
-        $sqb->addFilter(
-            [
-                'exists' => [
-                    'field' => 'values.color-option.ecommerce.en_US',
-                ],
-            ]
-        )->shouldBeCalled();
-
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($color, Operators::NOT_IN_LIST, ['black'], 'en_US', 'ecommerce', []);
     }

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionIntegration.php
@@ -47,7 +47,7 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
 
         $productsFound = $this->getSearchQueryResults($query);
 
-        $this->assertDocument($productsFound, ['product_7']);
+        $this->assertDocument($productsFound, ['product_7', 'product_8']);
     }
 
     public function testIsNotEmptyOperatorWithOptionValue()
@@ -79,18 +79,13 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
                             'values.color-option.<all_channels>.<all_locales>' => ['black', 'blue'],
                         ],
                     ],
-                    'filter' => [
-                        'exists' => [
-                            'field' => 'values.color-option.<all_channels>.<all_locales>',
-                        ],
-                    ]
                 ],
             ],
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
-        $this->assertDocument($productsFound, ['product_2', 'product_6']);
+        $this->assertDocument($productsFound, ['product_2', 'product_6', 'product_7', 'product_8']);
     }
 
     public function testSortAscending()
@@ -113,7 +108,7 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
 
         $this->assertSame(
             $productsFound,
-            ['product_3', 'product_1', 'product_4', 'product_5', 'product_2', 'product_6', 'product_7']
+            ['product_3', 'product_1', 'product_4', 'product_5', 'product_2', 'product_6', 'product_7', 'product_8']
         );
     }
 
@@ -137,7 +132,7 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
 
         $this->assertSame(
             $productsFound,
-            ['product_2', 'product_6', 'product_4', 'product_5', 'product_3', 'product_1', 'product_7']
+            ['product_2', 'product_6', 'product_4', 'product_5', 'product_3', 'product_1', 'product_7', 'product_8']
         );
     }
 
@@ -210,6 +205,16 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
             [
                 'identifier' => 'product_7',
                 'values'     => [],
+            ],
+            [
+                'identifier' => 'product_8',
+                'values'     => [
+                    'color-option' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => null,
+                        ],
+                    ],
+                ],
             ],
         ];
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionsIntegration.php
@@ -57,7 +57,7 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
 
         $productsFound = $this->getSearchQueryResults($query);
 
-        $this->assertDocument($productsFound, ['product_7']);
+        $this->assertDocument($productsFound, ['product_7', 'product_8']);
     }
 
     public function testIsNotEmptyOperatorWithOptionValue()
@@ -89,18 +89,13 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
                             'values.colors-options.<all_channels>.<all_locales>' => ['black', 'blue'],
                         ],
                     ],
-                    'filter' => [
-                        'exists' => [
-                            'field' => 'values.colors-options.<all_channels>.<all_locales>',
-                        ],
-                    ]
                 ],
             ],
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
-        $this->assertDocument($productsFound, ['product_6']);
+        $this->assertDocument($productsFound, ['product_6', 'product_7', 'product_8']);
     }
 
     public function testSortAscending()
@@ -123,7 +118,7 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
 
         $this->assertSame(
             $productsFound,
-            ['product_3', 'product_1', 'product_5', 'product_2', 'product_4', 'product_6', 'product_7']
+            ['product_3', 'product_1', 'product_5', 'product_2', 'product_4', 'product_6', 'product_7', 'product_8']
         );
     }
 
@@ -147,7 +142,7 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
 
         $this->assertSame(
             $productsFound,
-            ['product_2', 'product_4', 'product_6', 'product_5', 'product_3', 'product_1', 'product_7']
+            ['product_2', 'product_4', 'product_6', 'product_5', 'product_3', 'product_1', 'product_7', 'product_8']
         );
     }
 
@@ -220,6 +215,16 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
             [
                 'identifier' => 'product_7',
                 'values'     => [],
+            ],
+            [
+                'identifier' => 'product_8',
+                'values'     => [
+                    'colors-options' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => [],
+                        ],
+                    ],
+                ],
             ],
         ];
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

When using 'NOT IN' operator with `Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Attribute\OptionFilter`, an 'exists' filter clause for the field is appended to the query. This results in products with an empty value for the attribute (either with a null/empty array value, or not indexed yet in ES) not being returned by the query.
This PR removes this filter clause.

Downside: Now the query returns: 
- products with this attribute but with a different value as the one(s) provided
- products with an empty value for this attribute
- BUT also products **without this attribute** (that's also the current behaviour of other filter/operator couples - e.g EMPTY operator with most of the attribute filters)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
