### PR TITLE
PIM-6846: Fix bug on click in Display Attributes button on Product edit form

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -7,6 +7,7 @@
 - PIM-7040: Fix bad display of history grids on large strings
 - PIM-7014: Fix attribute creation page with large strings
 - PIM-7364: category tree must use the catalog locale for mass edit, not the UI locale
+- PIM-6846: Fix bug on click in Display Attributes button on Product edit form
 
 # 2.0.25 (2018-05-21)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
@@ -24,7 +24,7 @@ define(
             currentFilterCode: null,
 
             events: {
-                'click li': 'onChange'
+                'click .AknDropdown-menuLink': 'onChange'
             },
 
             /**


### PR DESCRIPTION
The event selector for displaying attributes was too generic, and clicking on "Display" title of the Dropdown implies everything removed from the page.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
