### PR TITLE
PIM-7311: Fix the product grid filters list with a sort order is a huge number

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -9,6 +9,7 @@
 - PIM-7364: category tree must use the catalog locale for mass edit, not the UI locale
 - PIM-6846: Fix bug on click in Display Attributes button on Product edit form
 - PIM-7389: Refactor the 'add to group' mass edit screen to allow big set of groups
+- PIM-7311: Fix the product grid filters list when a sort order is a huge number
 
 # 2.0.25 (2018-05-21)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/templates/datagrid/add-filter-select.html
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/templates/datagrid/add-filter-select.html
@@ -1,24 +1,10 @@
 <select id="add-filter-select" multiple>
-    <%  var groups = [systemFilterGroup];
-        _.each(filters, function(filter) {
-            if (filter.group) {
-                var key = filter.groupOrder !== null ? filter.groupOrder : 'last';
-                if (_.isUndefined(groups[key])) {
-                    groups[key] = filter.group;
-                } else if (!_.contains(groups, filter.group)) {
-                    groups.push(filter.group);
-                }
-            } else {
-                filter.group = systemFilterGroup;
-            }
-       });
-    %>
-    <% _.each(groups, function (group) { %>
+    <% groups.forEach((group) => { %>
         <optgroup label="<%= group %>">
-            <% _.each(filters, function (filter, name) { %>
-                <% if (filter.group == group) { %>
-                    <option value="<%= name %>" <% if (filter.enabled) { %>selected<% } %>>
-                        <%= filter.label %>
+            <% Object.keys(filters).forEach((filterKey) => { %>
+                <% if (filters[filterKey].group === group) { %>
+                    <option value="<%= filterKey %>" <% if (filters[filterKey].enabled) { %>selected<% } %>>
+                        <%= filters[filterKey].label %>
                     </option>
                     <% } %>
             <% }); %>


### PR DESCRIPTION
Previously, when you set a sort order like 100000000 on an attribute group, the grid was unable to load.
Why ? Because on the function sorting the attribute groups, it generated an array of 1000000000 elements... And it crashed.
Second thing is that if 2 attribute groups had the same sort order, it puts the second encountered one at the end of the list.

Now, the sort is a little bit complex, but it works as designed and does not fail.
IMHO, this is not "easily" testable (and have no interest)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
