### PR TITLE
PIM-7381: add more option to the database command for a lighter install

### DIFF
--- a/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -49,6 +49,20 @@ class DatabaseCommand extends ContainerAwareCommand
                 InputOption::VALUE_REQUIRED,
                 'Determines fixtures to load (can be just OroPlatform or all)',
                 self::LOAD_ALL
+            )
+            ->addOption(
+                'withoutIndexes',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Should the command setup the elastic search indexes',
+                false
+            )
+            ->addOption(
+                'withoutFixtures',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Should the command install any fixtures',
+                false
             );
     }
 
@@ -96,7 +110,9 @@ class DatabaseCommand extends ContainerAwareCommand
                 ['--force' => true, '--no-interaction' => true]
             );
 
-        $this->resetElasticsearchIndex($output);
+        if (false === $input->getOption('withoutIndexes')) {
+            $this->resetElasticsearchIndex($output);
+        }
 
         $entityManager = $this->getContainer()->get('doctrine.orm.default_entity_manager');
         $entityManager->clear();
@@ -107,7 +123,10 @@ class DatabaseCommand extends ContainerAwareCommand
         $this->createNotMappedTables($output);
 
         $this->getEventDispatcher()->dispatch(InstallerEvents::PRE_LOAD_FIXTURES);
-        $this->loadFixturesStep($input, $output);
+
+        if (false === $input->getOption('withoutFixtures')) {
+            $this->loadFixturesStep($input, $output);
+        }
         $this->getEventDispatcher()->dispatch(InstallerEvents::POST_LOAD_FIXTURES);
 
         // TODO: Should be in an event subscriber

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/LoadingMask.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/LoadingMask.less
@@ -1,5 +1,30 @@
 @import '../base/variables';
 
+@keyframes loading-breath {
+    0%{background-position:0% 50%}
+    50%{background-position:100% 50%}
+    100%{background-position:0% 50%}
+}
+
+.AknLoadingPlaceHolder {
+  position: relative;
+  border: none;
+
+  &:after {
+    animation: loading-breath 2s infinite;
+    content: "";
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    height: 100%;
+
+    background: linear-gradient(270deg, #fdfdfd, #eee);
+    background-size: 400% 400%;
+    border-radius: 5px;
+  }
+}
+
 .AknLoadingMask {
   background: rgba(255,255,255,0.8) url("../../images/loader-V2.svg") no-repeat center;
   position: absolute;

--- a/tests/front/acceptance/cucumber/world.js
+++ b/tests/front/acceptance/cucumber/world.js
@@ -6,7 +6,6 @@ const path = require('path');
 const htmlTemplate =  fs.readFileSync(process.cwd() + '/web/test_dist/index.html', 'utf-8');
 const translations = fs.readFileSync(path.join(process.cwd(), './web/js/translation/en_US.js'), 'utf-8');
 const userBuilder = new UserBuilder();
-
 module.exports = function(cucumber) {
   const {Before, After, Status } = cucumber;
 

--- a/tests/front/unit/jest/unit.jest.js
+++ b/tests/front/unit/jest/unit.jest.js
@@ -3,15 +3,12 @@ const baseConfig = require(`${__dirname}/../../common/base.jest.json`);
 
 const unitConfig = {
   rootDir: process.cwd(),
-  globals: {
-    '__moduleConfig': {}
-  },
   transform: {
     '^.+\\.tsx?$': 'ts-jest'
   },
   moduleNameMapper: {
-    '^require-context$': '<rootDir>/webpack/require-context.js',
-    '^module-registry$': '<rootDir>/web/js/module-registry.js'
+    '^require-context$': `${__dirname}/../../../../webpack/require-context.js`,
+    '^module-registry$': `${__dirname}/../../../../web/js/module-registry.js`
   },
   testRegex: '(tests/front/unit)(.*)(unit)\.(jsx?|tsx?)$',
   'moduleFileExtensions': [
@@ -24,6 +21,7 @@ const unitConfig = {
   ],
   moduleDirectories: ['<rootDir>/node_modules', `<rootDir>/web/bundles/`],
   globals: {
+    '__moduleConfig': {},
     'ts-jest': {
       tsConfigFile: `${__dirname}/../../../../tsconfig.json`
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR adds options to install the db without indexation and without fixtures. Those options are useful for testing purpose. It also fixes front unit tests and adds a placeholder loading less componnent

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
