### PR TITLE
PIM-7393: Improve error message when importing fields without locale or scope specification

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -2,6 +2,7 @@
 
 - PIM-7316: Fix overlap of boolean fields on product edit form
 - PIM-7319: Fix association display on product edit form when managing the association type permissions
+- PIM-7393: Improve error message when importing fields without locale or scope specification
 
 # 2.2.7 (2018-05-31)
 

--- a/features/import/product/import_products_with_invalid_headers.feature
+++ b/features/import/product/import_products_with_invalid_headers.feature
@@ -167,7 +167,7 @@ Feature: Execute a job
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
     Then I should see the text "Status: FAILED"
-    And I should see the text " The field \"description-fr_FR-print\" does not exist"
+    And I should see the text "The field \"description-fr_FR-print\" does not exist"
 
   Scenario: Skip import with many not existing fields
     Given the following CSV file to import:
@@ -181,4 +181,20 @@ Feature: Execute a job
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
     Then I should see the text "Status: FAILED"
-    And I should see the text " The fields \"unknownfield1, unknownfield2\" do not exist"
+    And I should see the text "The fields \"unknownfield1, unknownfield2\" do not exist"
+
+
+  @jira https://akeneo.atlassian.net/browse/PIM-3369
+  Scenario: Skip import with an unset locale on a localizable attribute
+    Given the following CSV file to import:
+      """
+      sku;description
+      SKU-001;"my name"
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    Then I should see the text "Status: FAILED"
+    And I should see the text "The field \"description\" needs an additional locale and/or a channel information"

--- a/features/import/product/import_products_with_invalid_headers.feature
+++ b/features/import/product/import_products_with_invalid_headers.feature
@@ -183,7 +183,6 @@ Feature: Execute a job
     Then I should see the text "Status: FAILED"
     And I should see the text "The fields \"unknownfield1, unknownfield2\" do not exist"
 
-
   @jira https://akeneo.atlassian.net/browse/PIM-3369
   Scenario: Skip import with an unset locale on a localizable attribute
     Given the following CSV file to import:


### PR DESCRIPTION
The previous error message was really confusing.
Now, it is more explicit, explaining why the field is "unknown".


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | y
| Added legacy Behats               | y
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | y
| Migration script                  | -
| Tech Doc                          | -
