### PR TITLE
Fix-8234 Prevent attributes with code identifier to be created

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -75,7 +75,7 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
             - Length:
                 max: 255
             - Regex:
-                pattern: /^(?!(id|associationTypes|categories|categoryId|completeness|enabled|family|groups|associations|products|scope|treeId|values|category|parent|(.)*_(products|groups)|entity_type)$)/
+                pattern: /^(?!(id|idenfifier|associationTypes|categories|categoryId|completeness|enabled|family|groups|associations|products|scope|treeId|values|category|parent|(.)*_(products|groups)|entity_type)$)/
                 message: This code is not available
         localizable:
             - Type: bool

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/GlobalConstraintsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/GlobalConstraintsIntegration.php
@@ -265,7 +265,7 @@ class GlobalConstraintsIntegration extends AbstractAttributeTestCase
     public function reservedCodesProvider()
     {
         return [
-            ['id'], ['associations'], ['associationTypes'], ['category'], ['categoryId'], ['categories'],
+            ['id'], ['identifier'], ['associations'], ['associationTypes'], ['category'], ['categoryId'], ['categories'],
             ['completeness'], ['enabled'], ['family'], ['groups'], ['products'], ['scope'], ['treeId'], ['values'],
             ['my_groups'], ['my_products']
         ];


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Creating an attribute whose code is `identifier` will cause errors in the PIM. This PR prevents the creation of such an attribute. 

Basically fixing #8234

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
