### PR TITLE
PIM-7383: Fix in-list product filters

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -12,6 +12,7 @@
 - PIM-7311: Fix the product grid filters list when a sort order is a huge number
 - PIM-7391: Fix offset pagination when listing product models with the API
 - PIM-7009: Fix bug with pagination on associated products page on product edit form
+- PIM-7383: Fix 'in list' product filters with large amount of items
 
 # 2.0.25 (2018-05-21)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/abstract-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/abstract-filter.js
@@ -485,11 +485,12 @@ function($, _, Backbone, app) {
                 }
 
                 let expectedTop = this.$el.offset().top;
-                if ((expectedTop + criteria.outerHeight() > body.height()) &&
-                    expectedTop + this.$el.height() - criteria.outerHeight() > 0) {
+                if (expectedTop + criteria.outerHeight() <= body.height()) {
+                    criteria.css({ top: expectedTop });
+                } else if (expectedTop + this.$el.height() - criteria.outerHeight() > 0) {
                     criteria.css({ top: expectedTop + this.$el.height() - criteria.outerHeight() });
                 } else {
-                    criteria.css({ top: expectedTop });
+                    criteria.css({ top: 0 });
                 }
             }
         },


### PR DESCRIPTION
In the case of criteria with big size, it badly displays it to the bottom of the page.
Now, if a place can not be found up or down, it simply displays it on top of the page.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
