### PR TITLE
PIM-7398: Fix unselect category in the tree with numeric code

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -13,6 +13,7 @@
 - PIM-7391: Fix offset pagination when listing product models with the API
 - PIM-7009: Fix bug with pagination on associated products page on product edit form
 - PIM-7383: Fix 'in list' product filters with large amount of items
+- PIM-7398: Fix the impossibility to unselect categories in the category tree in case of category with numeric code
 
 # 2.0.25 (2018-05-21)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
@@ -98,7 +98,7 @@ define(
              * @param {Object} data
              */
             uncheckNode: function (data) {
-                var code = data.rslt.obj.data('code');
+                var code = data.rslt.obj.data('code').toString();
 
                 if ('' !== code) {
                     this.attributes.categories = _.without(this.attributes.categories, code);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

On 2.X, it is not possible to modify the categories in the product import profile (both XLS and CSV), if the categories have a numeric code, it is not possible to unselect categories. 
For 2.0.X this concerns Product Export in CSV and XLSX
For 2.2.X, this concerns Product Export in CSV and XLSX and Product Model Export in CSV and XLSX

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
