### PR TITLE
PIM-7394: add slash as an allowed character for the identifier of a product in the API

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -6,6 +6,7 @@
 - PIM-7385: Fix memory leak on purge job command
 - PIM-7375: Fix metric unit values on export/import with empty values
 - PIM-7370: disable multisorting on group/user and role/user grid for a better sort experience
+- PIM-7394: add slash as an allowed character for the identifier of a product in the API
 
 # 1.7.21 (2018-04-23)
 

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/product.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/product.yml
@@ -7,6 +7,8 @@ pim_api_product_get:
     path: /products/{code}
     defaults: { _controller: pim_api.controller.product:getAction, _format: json }
     methods: [GET]
+    requirements:
+        code: .+
 
 pim_api_product_create:
     path: /products
@@ -17,6 +19,8 @@ pim_api_product_partial_update:
     path: /products/{code}
     defaults: { _controller: pim_api.controller.product:partialUpdateAction, _format: json }
     methods: [PATCH]
+    requirements:
+        code: .+
 
 pim_api_product_partial_update_list:
     path: /products
@@ -27,3 +31,5 @@ pim_api_product_delete:
     path: /products/{code}
     defaults: { _controller: pim_api.controller.product:deleteAction, _format: json }
     methods: [DELETE]
+    requirements:
+        code: .+


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Not really testable:
- fake request use a fake router
- ideally, it should test it with apache as it is infrastructure stuff


I tested and it works with GET and PATCH:
- /products//my_identifier  ("/my_identifier")
- /products/my_identifier/  ("/my_identifier/")
- /products/my_id/entifier  ("my_id/entifier")

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo?
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
