### PR TITLE
PIM-7308: bulk associate to product models

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -14,6 +14,7 @@
 - PIM-7326: Create a version when the parent of a variant product or a sub product model is changed.
 - PIM-6250: As Julia, I would like to change the parent of a variant product/sub product model from the UI
 - PIM-6784: Improve the product grid search with categories
+- PIM-7308: As Julia, I would like to bulk add product models associations if product models are selected.
 
 ## Technical improvements
 

--- a/src/Akeneo/Component/Versioning/Model/VersionableInterface.php
+++ b/src/Akeneo/Component/Versioning/Model/VersionableInterface.php
@@ -8,8 +8,6 @@ namespace Akeneo\Component\Versioning\Model;
  * @author    Filips Alpe <filips@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
- *
- * TODO: use constructor and remove setters to make it immutable
  */
 interface VersionableInterface
 {

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/readers.yml
@@ -31,16 +31,6 @@ services:
             - '@pim_catalog.manager.completeness'
             - false
 
-    pim_enrich.reader.database.add_association:
-        class: '%pim_enrich.reader.database.filtered_product_and_product_model.class%'
-        arguments:
-            - '@pim_catalog.query.product_and_product_model_query_builder_factory'
-            - '@pim_catalog.repository.channel'
-            - '@pim_catalog.manager.completeness'
-            - '@pim_catalog.converter.metric'
-            - true
-            - true
-
     pim_enrich.reader.database.products_and_variant_products_of_product_models:
         class: '%pim_enrich.reader.database.filtered_product_and_product_model.class%'
         arguments:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/steps.yml
@@ -131,7 +131,7 @@ services:
             - 'perform'
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
-            - '@pim_enrich.reader.database.add_association'
+            - '@pim_enrich.reader.database.grouped_product_and_product_model'
             - '@pim_enrich.connector.processor.mass_edit.product.add_value'
             - '@pim_enrich.writer.database.product_and_product_model_writer'
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/associate.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/associate.js
@@ -1,6 +1,6 @@
 'use strict';
 /**
- * Mass associate product
+ * Mass associate
  *
  * @author    Julien Sanchez <julien@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -1094,7 +1094,7 @@ pim_enrich:
                     label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to an existing product model|] 1, Inf [Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to an existing product model"
                     description: The product model selected will gather the products and allows the enrichment of their common properties.
                 associate_to_product_and_product_model:
-                    label: Associate to products
+                    label: Associate
                     label_count: "{1}Associate <span class=\"AknFullPage-title--highlight\">1 product</span> to products or product models|] 1, Inf [Associate <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to products or product models"
                     description: The products selected in the grid will be associated to the selected products and product models for the chosen association type
                     validate: Please add association before going to the next step
@@ -1201,9 +1201,9 @@ batch_jobs:
         perform:
             label: Remove from category
     add_association:
-        label: Associate to products
+        label: Associate
         perform:
-            label: Associate to products
+            label: Associate
     add_to_existing_product_model:
         label: Add to an existing product model
         perform:

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -938,9 +938,9 @@ batch_jobs:
         perform:
             label: Remove from category
     add_association:
-        label: Associate to products
+        label: Associate
         perform:
-            label: Associate to products
+            label: Associate
     add_to_existing_product_model:
         label: Add to an existing product model
         perform:

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -238,7 +238,7 @@ jobs:
     add_association:
         connector: Akeneo Mass Edit Connector
         alias:     add_association
-        label:     Mass associate products
+        label:     Mass associate
         type:      mass_edit
     edit_common_attributes:
         connector: Akeneo Mass Edit Connector

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/minimal/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/minimal/jobs.yml
@@ -22,7 +22,7 @@ jobs:
     add_association:
         connector: Akeneo Mass Edit Connector
         alias:     add_association
-        label:     Mass associate products
+        label:     Mass associate
         type:      mass_edit
     add_to_category:
         connector: Akeneo Mass Edit Connector

--- a/tests/legacy/features/Context/Page/Batch/Operation.php
+++ b/tests/legacy/features/Context/Page/Batch/Operation.php
@@ -26,7 +26,7 @@ class Operation extends Wizard
         'Move between categories'          => 'Batch Classify',
         'Remove from categories'           => 'Batch Classify',
         'Add to an existing product model' => 'Batch AddToExistingProductModel',
-        'Associate to products'            => 'Batch AssociateToProduct'
+        'Associate'                        => 'Batch AssociateToProduct',
     ];
 
     /**

--- a/tests/legacy/features/mass-action/mass_associate.feature
+++ b/tests/legacy/features/mass-action/mass_associate.feature
@@ -82,12 +82,15 @@ Feature: Associate many products at once
     And I should see the text "Sunglasses"
     And I validate mass edit
     And I wait for the "add_association" job to finish
-    Then the product "1111111113" should have the following associations:
+    And the product "1111111113" should have the following associations:
       | type   | products              |
       | X_SELL | 1111111292,1111111304 |
-    Then the product "1111111112" should have the following associations:
+    And the product "1111111112" should have the following associations:
       | type   | products              |
       | X_SELL | 1111111292,1111111304 |
-    Then the product "1111111111" should have the following associations:
+    And the product "1111111111" should have the following associations:
+      | type   | products              |
+      | X_SELL | 1111111292,1111111304 |
+    Then the product model "amor" should have the following associations:
       | type   | products              |
       | X_SELL | 1111111292,1111111304 |

--- a/tests/legacy/features/mass-action/mass_associate.feature
+++ b/tests/legacy/features/mass-action/mass_associate.feature
@@ -13,9 +13,9 @@ Feature: Associate many products at once
     When I sort by "ID" value ascending
     Given I select rows Bag, Belt and Hat
     And I press the "Bulk actions" button
-    And I choose the "Associate to products" operation
+    And I choose the "Associate" operation
     And I move on to the choose step
-    And I choose the "Associate to products" operation
+    And I choose the "Associate" operation
     Given I press the "Add associations" button and wait for modal
     And I check the row "Scarf"
     And the item picker basket should contain Scarf
@@ -40,9 +40,9 @@ Feature: Associate many products at once
     When I sort by "ID" value ascending
     Given I select rows Bag, Belt and Hat
     And I press the "Bulk actions" button
-    And I choose the "Associate to products" operation
+    And I choose the "Associate" operation
     And I move on to the choose step
-    And I choose the "Associate to products" operation
+    And I choose the "Associate" operation
     Given I press the "Add associations" button and wait for modal
     And I search "juno"
     And I check the row "juno"
@@ -69,9 +69,9 @@ Feature: Associate many products at once
     When I sort by "ID" value ascending
     Given I select rows amor
     And I press the "Bulk actions" button
-    And I choose the "Associate to products" operation
+    And I choose the "Associate" operation
     And I move on to the choose step
-    And I choose the "Associate to products" operation
+    And I choose the "Associate" operation
     Given I press the "Add associations" button and wait for modal
     And I check the row "Scarf"
     And the item picker basket should contain Scarf


### PR DESCRIPTION
Currently, when we try to bulk associate products to product model, it will in fact make associations with all the variant products.
We now can associate directly to product models so we don't need to associate to it's children.
This is done very simply just by using the 'grouped' reader which will apply associations on the selected items without fetching the children.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | Updated
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
