### PR TITLE
PIM-7399: Fix order attributes on Product model export

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -7,6 +7,7 @@
 - PIM-7393: Improve error message when importing fields without locale or scope specification
 - PIM-7382: Fix scopable attributes disappearing from edit form after editing a product model 
 - PIM-7386: Fix 'NOT IN' operator not taking empty values into account for select fields
+- PIM-7399: Fix attributes order on Product model export
 
 # 2.2.7 (2018-05-31)
 

--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/writers.yml
@@ -503,7 +503,9 @@ services:
             - ['categories', 'enabled', 'family', 'parent', 'groups']
 
     pim_connector.writer.file.product_model.column_sorter:
-        class: '%pim_connector.writer.file.default.column_sorter.class%'
+        class: '%pim_connector.writer.file.product.column_sorter.class%'
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.field_splitter'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.repository.association_type'
             - ['code', 'family_variant', 'parent', 'categories']


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The product export builder allows to select attributes to export and reorder them.
It's working fine for the product exports but not for product models exports.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
