### PR TITLE
PIM-7405: Extract ordering in ProductValueNormalizer

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -82,7 +82,7 @@ legacy:
                     - 1024
                 - Pim\Behat\Context\JobContext:
                     - 'Context\FeatureContext'
-                - Pim\Behat\Context\ImportFileContext:
+                - Pim\Behat\Context\ImportExportFileContext:
                     - 'Context\FeatureContext'
                 - Pim\Behat\Context\Storage\FileInfoStorage:
                     - 'Context\FeatureContext'

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -55,8 +55,7 @@ legacy:
                     - '@pim_catalog.saver.product_model'
                     - '@pim_catalog.validator.product'
                     - '@pim_versioning.repository.version'
-                - Pim\Behat\Context\Domain\Enrich\VariantProductContext:
-                    - 'Context\FeatureContext'
+                - Pim\Behat\Context\Domain\Enrich\ProductContext:
                     - '@pim_catalog.repository.product'
                     - '@pim_catalog.updater.product'
                     - '@pim_catalog.saver.product'
@@ -112,7 +111,6 @@ legacy:
                     - 'Context\FeatureContext'
                     - '@pim_catalog.repository.product'
                     - '@pim_catalog.repository.product_model'
-
     extensions:
         Behat\ChainedStepsExtension: ~
         Behat\MinkExtension:

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/field.js
@@ -7,7 +7,8 @@
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-define([
+define(
+    [
         'jquery',
         'backbone',
         'underscore',

--- a/src/Pim/Component/Catalog/Normalizer/Standard/Product/ProductValueNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/Product/ProductValueNormalizer.php
@@ -28,7 +28,7 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
     /**
      * {@inheritdoc}
      */
-    public function setSerializer(SerializerInterface $serializer)
+    public function setSerializer(SerializerInterface $serializer): void
     {
         $this->serializer = $serializer;
     }
@@ -36,7 +36,7 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
     /**
      * {@inheritdoc}
      */
-    public function normalize($entity, $format = null, array $context = [])
+    public function normalize($entity, $format = null, array $context = []): array
     {
         $isCollection = $entity instanceof OptionsValueInterface
             || $entity instanceof PriceCollectionValueInterface
@@ -55,7 +55,7 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ValueInterface && 'standard' === $format;
     }
@@ -67,7 +67,7 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
      *
      * @return array
      */
-    protected function getCollectionValue(ValueInterface $value, $format = null, array $context = [])
+    protected function getCollectionValue(ValueInterface $value, ?string $format = null, array $context = []): array
     {
         $attributeType = $value->getAttribute()->getType();
         $context['is_decimals_allowed'] = $value->getAttribute()->isDecimalsAllowed();
@@ -82,6 +82,19 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
             }
         }
 
+        $data = $this->sortData($data, $attributeType);
+
+        return $data;
+    }
+
+    /**
+     * @param array  $data
+     * @param string $attributeType
+     *
+     * @return array
+     */
+    protected function sortData(array $data, string $attributeType): array
+    {
         if (AttributeTypes::PRICE_COLLECTION === $attributeType) {
             usort($data, function ($a, $b) {
                 return strnatcasecmp($a['currency'], $b['currency']);
@@ -95,12 +108,12 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
 
     /**
      * @param ValueInterface $value
-     * @param null           $format
+     * @param null|string    $format
      * @param array          $context
      *
      * @return mixed
      */
-    protected function getSimpleValue(ValueInterface $value, $format = null, array $context = [])
+    protected function getSimpleValue(ValueInterface $value, ?string $format = null, array $context = [])
     {
         if (null === $value->getData()) {
             return null;

--- a/tests/legacy/features/Context/FeatureContext.php
+++ b/tests/legacy/features/Context/FeatureContext.php
@@ -24,7 +24,7 @@ use Pim\Behat\Context\Domain\Spread\XlsxFileContext;
 use Pim\Behat\Context\Domain\System\PermissionsContext;
 use Pim\Behat\Context\Domain\TreeContext;
 use Pim\Behat\Context\HookContext;
-use Pim\Behat\Context\ImportFileContext;
+use Pim\Behat\Context\ImportExportFileContext;
 use Pim\Behat\Context\JobContext;
 use Pim\Behat\Context\PimContext;
 use Pim\Behat\Context\Storage\AttributeOptionStorage;
@@ -108,7 +108,7 @@ class FeatureContext extends PimContext implements KernelAwareContext
         $this->contexts['domain-group'] = $environment->getContext(ProductGroupContext::class);
         $this->contexts['hook'] = $environment->getContext(HookContext::class);
         $this->contexts['job'] = $environment->getContext(JobContext::class);
-        $this->contexts['importFile'] = $environment->getContext(ImportFileContext::class);
+        $this->contexts['importExportFile'] = $environment->getContext(ImportExportFileContext::class);
         $this->contexts['viewSelector'] = $environment->getContext(ViewSelectorContext::class);
         $this->contexts['storage-product'] = $environment->getContext(ProductStorage::class);
         $this->contexts['storage-file-info'] = $environment->getContext(FileInfoStorage::class);

--- a/tests/legacy/features/Pim/Behat/Context/Domain/Enrich/ProductContext.php
+++ b/tests/legacy/features/Pim/Behat/Context/Domain/Enrich/ProductContext.php
@@ -8,11 +8,10 @@ use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterfa
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
-use Context\Spin\SpinCapableTrait;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
-use Pim\Behat\Context\PimContext;
 use Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -24,10 +23,8 @@ use Webmozart\Assert\Assert;
  * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class VariantProductContext extends PimContext
+class ProductContext implements Context
 {
-    use SpinCapableTrait;
-
     /** @var IdentifiableObjectRepositoryInterface */
     private $productRepository;
 
@@ -47,7 +44,6 @@ class VariantProductContext extends PimContext
     private $versionRepository;
 
     /**
-     * @param string                                $mainContextClass
      * @param IdentifiableObjectRepositoryInterface $productRepository
      * @param ObjectUpdaterInterface                $productUpdater
      * @param SaverInterface                        $productSaver
@@ -56,7 +52,6 @@ class VariantProductContext extends PimContext
      * @param VersionRepositoryInterface            $versionRepository
      */
     public function __construct(
-        string $mainContextClass,
         IdentifiableObjectRepositoryInterface $productRepository,
         ObjectUpdaterInterface $productUpdater,
         SaverInterface $productSaver,
@@ -64,8 +59,6 @@ class VariantProductContext extends PimContext
         EntityManagerInterface $entityManager,
         VersionRepositoryInterface $versionRepository
     ) {
-        parent::__construct($mainContextClass);
-
         $this->productRepository = $productRepository;
         $this->productUpdater = $productUpdater;
         $this->productSaver = $productSaver;
@@ -124,9 +117,10 @@ class VariantProductContext extends PimContext
      * @param string    $identifier
      * @param TableNode $expectedVersion
      *
+     * @Then the last version of the product :identifier should be:
      * @Then the last version of the variant product :identifier should be:
      */
-    public function checkVariantProductLastVersion(string $identifier, TableNode $expectedVersion): void
+    public function checkProductLastVersion(string $identifier, TableNode $expectedVersion): void
     {
         $product = $this->findProduct($identifier);
         $lastVersion = $this->versionRepository->getNewestLogEntry(


### PR DESCRIPTION
## Description 

When normalizing product values, we always sort them, as we usually don't care about the order. However, to be able to sort assets in asset collection, in EE, we need to be able to prevent this sorting.

This PR 
- extracts this sorting in a dedicated, protected method, so it can be overridden in EE, specifically for the asset collection attribute type,
- reworks some behat contexts, so two steps that were dedicated to variant products can also be used on regular products too (it also removes some useless stuff from one of this context)

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
