### PR TITLE
PIM-7411: [SLA] Use json post for selected categories in product export

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7323: Fix unique data synchronizer to handle value removal
+- PIM-7411: Fix Request-URI Too Large issue on category selection for product export builder
 
 # 2.0.23 (2018-04-30)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/category.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/category.yml
@@ -1,7 +1,7 @@
 pim_enrich_category_rest_list_selected_children:
     path: /rest/{identifier}/selected-children
     defaults: { _controller: pim_enrich.controller.rest.category:listSelectedChildrenAction }
-    methods: [GET]
+    methods: [POST]
 
 pim_enrich_category_rest_list:
     path: /rest

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
@@ -169,7 +169,7 @@ define(
                                                     return Routing.generate(
                                                         'pim_enrich_category_rest_list_selected_children',
                                                         {
-                                                            identifier: category.code,
+                                                            identifier: category.code
                                                         }
                                                     );
                                                 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
@@ -156,17 +156,20 @@ define(
                                     )
                                 }));
 
+                                var selectedCategories = this.attributes.categories;
+
                                 this.$('.root').jstree(_.extend(this.config, {
                                     json_data: {
                                         ajax: {
+                                            dataType: 'json',
+                                            method: 'POST',
                                             url: function (node) {
-                                                if (-1 === node && 0 < this.attributes.categories.length) {
+                                                if (-1 === node && 0 < selectedCategories.length) {
                                                     // First load of the tree: get the checked categories
                                                     return Routing.generate(
                                                         'pim_enrich_category_rest_list_selected_children',
                                                         {
                                                             identifier: category.code,
-                                                            selected: this.attributes.categories
                                                         }
                                                     );
                                                 }
@@ -177,7 +180,10 @@ define(
                                             }.bind(this),
                                             data: function (node) {
                                                 if (-1 === node) {
-                                                    return {id: this.get_container().data('tree-id')};
+                                                    return {
+                                                        id: this.get_container().data('tree-id'),
+                                                        selected: selectedCategories
+                                                    };
                                                 }
 
                                                 return {id: node.attr('id').replace('node_', '')};


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a bug in the export product category selection. Previously, selecting many categories caused the request to `/rest/{identifier}/selected-children` to fail with a `414 Request-URI Too Large` error because we were appending every selected category to the url as a query parameter. 

I changed this method to a POST to send the selected categories in the body instead. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
