### PR TITLE
[PIM-7426] Fix search on add to group mass edit

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Bug fixes
+
+- PIM-7426: Fix search on the product 'add to group' mass edit
+
 # 2.0.26 (2018-06-06)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/GroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/GroupController.php
@@ -124,7 +124,7 @@ class GroupController
         $groups = $this->groupRepository->getOptions(
             $dataLocale = $this->userContext->getUiLocaleCode(),
             null,
-            $request->request->get('search'),
+            $request->get('search'),
             $this->parseOptions($request)
         );
 


### PR DESCRIPTION
I went too fast on the PIM-7389 and there was a but about the search.
This PR fixes the fact than the search was not active on the select2.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | y
| Micro Demo to the PO (Story only) | y
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
