### PR TITLE
PIM-7400: ensureIndexes uses a retry loop

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug fixes
+
+- PIM-7400: Fix 'ensure-indexes' timeout command
+
 # 1.7.22 (2018-06-05)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
@@ -8,7 +8,6 @@ use Pim\Bundle\CatalogBundle\ProductQueryUtility;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ChannelInterface;
-use Pim\Component\Catalog\Model\CurrencyInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Psr\Log\LoggerInterface;
 
@@ -106,8 +105,7 @@ class IndexCreator
 
         $scopables = $this->namingUtility->getScopableAttributes();
         foreach ($scopables as $scopable) {
-            $indexType = $this->getIndexTypeFromAttribute($scopable);
-            $this->ensureIndexesFromAttribute($scopable, $indexType);
+            $this->ensureIndexesFromAttribute($scopable);
         }
     }
 
@@ -125,8 +123,7 @@ class IndexCreator
 
         $localizables = $this->namingUtility->getLocalizableAttributes();
         foreach ($localizables as $localizable) {
-            $indexType = $this->getIndexTypeFromAttribute($localizable);
-            $this->ensureIndexesFromAttribute($localizable, $indexType);
+            $this->ensureIndexesFromAttribute($localizable);
         }
     }
 
@@ -135,15 +132,12 @@ class IndexCreator
      *
      * Indexes will be created on the normalizedData part for:
      * - prices (because of potentially added currency)
-     *
-     * @param CurrencyInterface $currency
      */
     public function ensureIndexesFromCurrency()
     {
         $pricesAttributes = $this->namingUtility->getPricesAttributes();
         foreach ($pricesAttributes as $pricesAttribute) {
-            $indexType = $this->getIndexTypeFromAttribute($pricesAttribute);
-            $this->ensureIndexesFromAttribute($pricesAttribute, $indexType);
+            $this->ensureIndexesFromAttribute($pricesAttribute);
         }
     }
 
@@ -162,14 +156,13 @@ class IndexCreator
     public function ensureUniqueAttributesIndexes()
     {
         $attributes = $this->getAttributeRepository()->findBy(
-            ['unique'  => true],
+            ['unique' => true],
             ['created' => 'ASC'],
             self::MONGODB_INDEXES_LIMIT
         );
 
         foreach ($attributes as $attribute) {
-            $indexType = $this->getIndexTypeFromAttribute($attribute);
-            $this->ensureIndexesFromAttribute($attribute, $indexType);
+            $this->ensureIndexesFromAttribute($attribute);
         }
     }
 
@@ -180,13 +173,12 @@ class IndexCreator
     {
         $attributes = $this->getAttributeRepository()->findBy(
             ['useableAsGridFilter' => true],
-            ['created'             => 'ASC'],
+            ['created' => 'ASC'],
             self::MONGODB_INDEXES_LIMIT
         );
 
         foreach ($attributes as $attribute) {
-            $indexType = $this->getIndexTypeFromAttribute($attribute);
-            $this->ensureIndexesFromAttribute($attribute, $indexType);
+            $this->ensureIndexesFromAttribute($attribute);
         }
     }
 
@@ -275,7 +267,15 @@ class IndexCreator
     protected function ensureIndexes(array $fields, $indexType = self::ASCENDANT_INDEX_TYPE)
     {
         $collection = $this->getCollection();
-        $preNbIndexes = count($collection->getIndexInfo());
+        $preNbIndexes = -1;
+        do {
+            try {
+                $preNbIndexes = count($collection->getIndexInfo());
+            } catch (\MongoCursorTimeoutException $e) {
+                $erroMessage = sprintf('%s : getIndexInfo timeout.', self::class);
+                $this->logger->error($erroMessage);
+            }
+        } while ($preNbIndexes === -1);
         $postNbIndexes = $preNbIndexes + count($fields);
         if ($postNbIndexes > self::MONGODB_INDEXES_LIMIT) {
             $msg = sprintf('Too many MongoDB indexes (%d), no way to add %s', $preNbIndexes, print_r($fields, true));
@@ -286,25 +286,20 @@ class IndexCreator
 
         $indexOptions = [
             'background' => true,
-            'w'          => 0
+            'w'          => 0,
         ];
 
         foreach ($fields as $field) {
-            $nbTry = 1;
-            $indexed = false;
-            do {
-                try {
-                    $collection->ensureIndex(
-                        [$field => $indexType],
-                        $indexOptions
-                    );
+            try {
+                $collection->ensureIndex(
+                    [$field => $indexType],
+                    $indexOptions
+                );
+            } catch (\MongoResultException $e) {
+                $this->logger->error($e->getMessage());
 
-                    $indexed = true;
-                } catch (\MongoResultException $e) {
-                    $this->logger->error($e->getMessage());
-                    $nbTry ++;
-                }
-            } while ($nbTry < 4 and $indexed == false);
+                return;
+            }
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/IndexCreator.php
@@ -290,16 +290,21 @@ class IndexCreator
         ];
 
         foreach ($fields as $field) {
-            try {
-                $collection->ensureIndex(
-                    [$field => $indexType],
-                    $indexOptions
-                );
-            } catch (\MongoResultException $e) {
-                $this->logger->error($e->getMessage());
+            $nbTry = 1;
+            $indexed = false;
+            do {
+                try {
+                    $collection->ensureIndex(
+                        [$field => $indexType],
+                        $indexOptions
+                    );
 
-                return;
-            }
+                    $indexed = true;
+                } catch (\MongoResultException $e) {
+                    $this->logger->error($e->getMessage());
+                    $nbTry ++;
+                }
+            } while ($nbTry < 4 and $indexed == false);
         }
     }
 


### PR DESCRIPTION
We had a problem with locks on big mongo db database when trying to reindex data.
After digging into the code, it appears that this timeout comes from trying to get the index info while some indexes where still under processing.

This PR adds a loop over this get index info function to wait for the lock released.

Note: in tests on client environment, the loop is just used one time.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Yes
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
