### PR TITLE
PIM-7001: Don't display remove button on an association if it comes from inheritance

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -14,6 +14,7 @@
 - PIM-7326: Create a version when the parent of a variant product or a sub product model is changed.
 - PIM-6250: As Julia, I would like to change the parent of a variant product/sub product model from the UI
 - PIM-6784: Improve the product grid search with categories
+- PIM-7001: Don't display remove button on an association if it comes from inheritance
 
 ## Technical improvements
 

--- a/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
@@ -7,6 +7,7 @@ use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Oro\Bundle\DataGridBundle\Datasource\ResultRecord;
 use Pim\Bundle\DataGridBundle\Extension\Pager\PagerExtension;
 use Pim\Component\Catalog\Model\AssociationInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -70,6 +71,14 @@ class AssociatedProductDatasource extends ProductDatasource
         $from = null !== $this->getConfiguration('from', false) ?
             (int) $this->getConfiguration('from', false) : 0;
 
+        $associatedProductsIdentifiersFromParent = [];
+        $associatedProductModelsIdentifiersFromParent = [];
+        $parentAssociation = $this->getParentAssociation($sourceProduct, $this->getConfiguration('association_type_id'));
+        if (null !== $parentAssociation) {
+            $associatedProductsIdentifiersFromParent = $this->getAssociatedProductIdentifiers($parentAssociation);
+            $associatedProductModelsIdentifiersFromParent = $this->getAssociatedProductModelIdentifiers($parentAssociation);
+        }
+
         $associatedProducts = $this->getAssociatedProducts(
             $associatedProductsIdentifiers,
             $limit,
@@ -78,10 +87,10 @@ class AssociatedProductDatasource extends ProductDatasource
             $scope
         );
 
-        $productModelLimit = $limit - count($associatedProducts);
+        $productModelLimit = $limit - $associatedProducts->count();
         $associatedProductModels = [];
         if ($productModelLimit > 0) {
-            $productModelFrom = $from - count($associatedProductsIdentifiers) + count($associatedProducts);
+            $productModelFrom = $from - count($associatedProductsIdentifiers) + $associatedProducts->count();
             $associatedProductModels = $this->getAssociatedProductModels(
                 $associatedProductModelsIdentifiers,
                 $productModelLimit,
@@ -91,10 +100,47 @@ class AssociatedProductDatasource extends ProductDatasource
             );
         }
 
+        $normalizedAssociatedProducts = $this->normalizeProductsAndProductModels(
+            $associatedProducts,
+            $associatedProductsIdentifiersFromParent,
+            $locale,
+            $scope
+        );
+
+        $normalizedAssociatedProductModels = $this->normalizeProductsAndProductModels(
+            $associatedProductModels,
+            $associatedProductModelsIdentifiersFromParent,
+            $locale,
+            $scope
+        );
+
         $rows = ['totalRecords' => count($associatedProductsIdentifiers) + count($associatedProductModelsIdentifiers)];
-        $rows['data'] = array_merge($associatedProducts, $associatedProductModels);
+        $rows['data'] = array_merge($normalizedAssociatedProducts, $normalizedAssociatedProductModels);
 
         return $rows;
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $product
+     * @param mixed                            $associationTypeId
+     *
+     * @return AssociationInterface|null
+     */
+    protected function getParentAssociation(EntityWithFamilyVariantInterface $product, $associationTypeId): ?AssociationInterface
+    {
+        $parent = $product->getParent();
+
+        if (null === $parent) {
+            return null;
+        }
+
+        foreach ($parent->getAllAssociations() as $association) {
+            if ($association->getAssociationType()->getId() === (int)$associationTypeId) {
+                return $association;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -134,7 +180,7 @@ class AssociatedProductDatasource extends ProductDatasource
      * @param string $locale
      * @param string $scope
      *
-     * @return array
+     * @return CursorInterface
      */
     protected function getAssociatedProducts(
         array $associatedProductsIdentifiers,
@@ -146,9 +192,8 @@ class AssociatedProductDatasource extends ProductDatasource
         $pqb = $this->createQueryBuilder($limit, $from, $locale, $scope);
         $pqb->addFilter('identifier', Operators::IN_LIST, $associatedProductsIdentifiers);
         $pqb->addFilter('entity_type', Operators::EQUALS, ProductInterface::class);
-        $products = $pqb->execute();
 
-        return $this->normalizeProductsAndProductModels($products, $locale, $scope);
+        return $pqb->execute();
     }
 
     /**
@@ -158,7 +203,7 @@ class AssociatedProductDatasource extends ProductDatasource
      * @param string $locale
      * @param string $scope
      *
-     * @return array
+     * @return CursorInterface
      */
     protected function getAssociatedProductModels(
         array $associatedProductModelsIdentifiers,
@@ -170,13 +215,13 @@ class AssociatedProductDatasource extends ProductDatasource
         $pqb = $this->createQueryBuilder($limit, $from, $locale, $scope);
         $pqb->addFilter('identifier', Operators::IN_LIST, $associatedProductModelsIdentifiers);
         $pqb->addFilter('entity_type', Operators::EQUALS, ProductModelInterface::class);
-        $products = $pqb->execute();
 
-        return $this->normalizeProductsAndProductModels($products, $locale, $scope);
+        return $pqb->execute();
     }
 
     /**
      * @param CursorInterface $products
+     * @param array           $identifiersFromInheritance
      * @param string          $locale
      * @param string          $scope
      *
@@ -184,6 +229,7 @@ class AssociatedProductDatasource extends ProductDatasource
      */
     protected function normalizeProductsAndProductModels(
         CursorInterface $products,
+        array $identifiersFromInheritance,
         $locale,
         $scope
     ) {
@@ -210,6 +256,14 @@ class AssociatedProductDatasource extends ProductDatasource
                     'is_associated' => true,
                 ]
             );
+
+            if ($product instanceof ProductModelInterface) {
+                $identifier = $product->getCode();
+            } else {
+                $identifier = $product->getIdentifier();
+            }
+
+            $normalized['from_inheritance'] = in_array($identifier, $identifiersFromInheritance);
 
             $data[] = new ResultRecord($normalized);
         }

--- a/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductModelDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductModelDatasource.php
@@ -8,6 +8,7 @@ use Oro\Bundle\DataGridBundle\Datasource\ResultRecord;
 use Pim\Bundle\DataGridBundle\Extension\Pager\PagerExtension;
 use Pim\Component\Catalog\Model\AssociationInterface;
 use Pim\Component\Catalog\Model\EntityWithAssociationsInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
@@ -71,6 +72,14 @@ class AssociatedProductModelDatasource extends ProductDatasource
         $from = null !== $this->getConfiguration('from', false) ?
             (int) $this->getConfiguration('from', false) : 0;
 
+        $associatedProductsIdentifiersFromParent = [];
+        $associatedProductModelsIdentifiersFromParent = [];
+        $parentAssociation = $this->getParentAssociation($sourceProduct, $this->getConfiguration('association_type_id'));
+        if (null !== $parentAssociation) {
+            $associatedProductsIdentifiersFromParent = $this->getAssociatedProductIdentifiers($parentAssociation);
+            $associatedProductModelsIdentifiersFromParent = $this->getAssociatedProductModelIdentifiers($parentAssociation);
+        }
+
         $associatedProducts = $this->getAssociatedProducts(
             $associatedProductsIdentifiers,
             $limit,
@@ -79,10 +88,10 @@ class AssociatedProductModelDatasource extends ProductDatasource
             $scope
         );
 
-        $productModelLimit = $limit - count($associatedProducts);
+        $productModelLimit = $limit - $associatedProducts->count();
         $associatedProductModels = [];
         if ($productModelLimit > 0) {
-            $productModelFrom = $from - count($associatedProductsIdentifiers) + count($associatedProducts);
+            $productModelFrom = $from - count($associatedProductsIdentifiers) + $associatedProducts->count();;
             $associatedProductModels = $this->getAssociatedProductModels(
                 $associatedProductModelsIdentifiers,
                 $productModelLimit,
@@ -92,10 +101,47 @@ class AssociatedProductModelDatasource extends ProductDatasource
             );
         }
 
+        $normalizedAssociatedProducts = $this->normalizeProductsAndProductModels(
+            $associatedProducts,
+            $associatedProductsIdentifiersFromParent,
+            $locale,
+            $scope
+        );
+
+        $normalizedAssociatedProductModels = $this->normalizeProductsAndProductModels(
+            $associatedProductModels,
+            $associatedProductModelsIdentifiersFromParent,
+            $locale,
+            $scope
+        );
+
         $rows = ['totalRecords' => count($associatedProductsIdentifiers) + count($associatedProductModelsIdentifiers)];
-        $rows['data'] = array_merge($associatedProducts, $associatedProductModels);
+        $rows['data'] = array_merge($normalizedAssociatedProducts, $normalizedAssociatedProductModels);
 
         return $rows;
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $product
+     * @param mixed                            $associationTypeId
+     *
+     * @return AssociationInterface|null
+     */
+    protected function getParentAssociation(EntityWithFamilyVariantInterface $product, $associationTypeId): ?AssociationInterface
+    {
+        $parent = $product->getParent();
+
+        if (null === $parent) {
+            return null;
+        }
+
+        foreach ($parent->getAllAssociations() as $association) {
+            if ($association->getAssociationType()->getId() === (int)$associationTypeId) {
+                return $association;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -135,7 +181,7 @@ class AssociatedProductModelDatasource extends ProductDatasource
      * @param string $locale
      * @param string $scope
      *
-     * @return array
+     * @return CursorInterface
      */
     protected function getAssociatedProducts(
         array $associatedProductsIdentifiers,
@@ -147,9 +193,8 @@ class AssociatedProductModelDatasource extends ProductDatasource
         $pqb = $this->createQueryBuilder($limit, $from, $locale, $scope);
         $pqb->addFilter('identifier', Operators::IN_LIST, $associatedProductsIdentifiers);
         $pqb->addFilter('entity_type', Operators::EQUALS, ProductInterface::class);
-        $products = $pqb->execute();
 
-        return $this->normalizeProductsAndProductModels($products, $locale, $scope);
+        return $pqb->execute();
     }
 
     /**
@@ -159,7 +204,7 @@ class AssociatedProductModelDatasource extends ProductDatasource
      * @param string $locale
      * @param string $scope
      *
-     * @return array
+     * @return CursorInterface
      */
     protected function getAssociatedProductModels(
         array $associatedProductModelsIdentifiers,
@@ -171,13 +216,13 @@ class AssociatedProductModelDatasource extends ProductDatasource
         $pqb = $this->createQueryBuilder($limit, $from, $locale, $scope);
         $pqb->addFilter('identifier', Operators::IN_LIST, $associatedProductModelsIdentifiers);
         $pqb->addFilter('entity_type', Operators::EQUALS, ProductModelInterface::class);
-        $products = $pqb->execute();
 
-        return $this->normalizeProductsAndProductModels($products, $locale, $scope);
+        return $pqb->execute();
     }
 
     /**
      * @param CursorInterface $products
+     * @param array           $identifiersFromInheritance
      * @param string          $locale
      * @param string          $scope
      *
@@ -185,6 +230,7 @@ class AssociatedProductModelDatasource extends ProductDatasource
      */
     protected function normalizeProductsAndProductModels(
         CursorInterface $products,
+        array $identifiersFromInheritance,
         $locale,
         $scope
     ) {
@@ -202,11 +248,23 @@ class AssociatedProductModelDatasource extends ProductDatasource
             $normalized = array_merge(
                 $this->normalizer->normalize($product, 'datagrid', $context),
                 [
-                    'id'         => $product->getId(),
+                    'id'         => sprintf(
+                        '%s-%s',
+                        $product instanceof ProductModelInterface ? 'product-model' : 'product',
+                        $product->getId()
+                    ),
                     'dataLocale' => $dataLocale,
                     'is_associated' => true,
                 ]
             );
+
+            if ($product instanceof ProductModelInterface) {
+                $identifier = $product->getCode();
+            } else {
+                $identifier = $product->getIdentifier();
+            }
+
+            $normalized['from_inheritance'] = in_array($identifier, $identifiersFromInheritance);
 
             $data[] = new ResultRecord($normalized);
         }

--- a/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductModelDatasourceSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductModelDatasourceSpec.php
@@ -10,6 +10,7 @@ use Oro\Bundle\DataGridBundle\Datagrid\Datagrid;
 use Oro\Bundle\DataGridBundle\Datasource\ResultRecord;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\DataGridBundle\Datasource\AssociatedProductDatasource;
+use Pim\Bundle\DataGridBundle\Datasource\AssociatedProductModelDatasource;
 use Pim\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Pim\Bundle\DataGridBundle\Datasource\ParameterizableInterface;
 use Pim\Bundle\DataGridBundle\EventSubscriber\FilterEntityWithValuesSubscriber;
@@ -24,7 +25,7 @@ use Pim\Component\Catalog\Query\Sorter\Directions;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-class AssociatedProductDatasourceSpec extends ObjectBehavior
+class AssociatedProductModelDatasourceSpec extends ObjectBehavior
 {
     public function let(
         ObjectManager $objectManager,
@@ -40,7 +41,7 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType(AssociatedProductDatasource::class);
+        $this->shouldHaveType(AssociatedProductModelDatasource::class);
     }
 
     function it_is_a_datasource()
@@ -67,19 +68,19 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
         $this->shouldThrow(
             InvalidObjectException::objectExpected(
                 'not a product instance',
-                ProductInterface::class
+                ProductModelInterface::class
             )
         )->during('getResults');
     }
 
-    function it_gets_products_sorted_by_association_status(
+    function it_gets_product_models_sorted_by_association_status(
         $pqbFactory,
         $productNormalizer,
         Datagrid $datagrid,
         ProductQueryBuilderInterface $pqb,
         ProductQueryBuilderInterface $pqbAsso,
         ProductQueryBuilderInterface $pqbAssoProductModel,
-        ProductInterface $currentProduct,
+        ProductModelInterface $currentProduct,
         ProductModelInterface $parent,
         ProductInterface $associatedProduct1,
         ProductInterface $associatedProduct2,
@@ -124,7 +125,6 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
         $associatedProductModel->getCode()->willReturn('associated_product_model_1');
         $associatedProductModel->getId()->willReturn('2');
         $currentProduct->getAllAssociations()->willReturn($associationCollection);
-        $currentProduct->getIdentifier()->willReturn('current_product');
         $currentProduct->getParent()->willReturn($parent);
 
         $parent->getAllAssociations()->willReturn($parentAssociationCollection);

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product.yml
@@ -54,6 +54,8 @@ datagrid:
             updated:
                 label:         Updated At
                 type:          field
+            from_inheritance:
+                frontend_type: boolean
         properties:
             id: ~
             document_type: ~

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_model.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/association_product_model.yml
@@ -54,6 +54,8 @@ datagrid:
             updated:
                 label:         Updated At
                 type:          field
+            from_inheritance:
+                frontend_type: boolean
         properties:
             id: ~
             document_type: ~

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associated-product-row.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/associated-product-row.js
@@ -28,13 +28,18 @@ define(
             thumbnailTemplate: _.template(thumbnailTemplate),
 
             /**
-             * Returns true if the user has the right to remove an association,
-             * hide the remove button in this case.
+             * Return true if the user can remove the association, false otherwise.
+             *
+             * The use can remove an association if he has the permission and if the association
+             * does not come from inheritance.
              *
              * @return {Boolean}
              */
             canRemoveAssociation() {
-                return SecurityContext.isGranted('pim_enrich_associations_remove');
+                const permissionGranted = SecurityContext.isGranted('pim_enrich_associations_remove');
+                const fromInheritance = this.model.get('from_inheritance');
+
+                return permissionGranted && !fromInheritance;
             },
 
             /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR removes the button to delete an association if this one comes from inheritance (from parents).
So if you can delete it, you'll have the cross (as of nowadays):
![screenshot at 2018-06-08 11-16-11](https://user-images.githubusercontent.com/301169/41150178-b66f18e6-6b0d-11e8-8aef-74306fc29677.png)

But if you can't, it's not displayed:
![screenshot at 2018-06-08 11-16-17](https://user-images.githubusercontent.com/301169/41150201-bcf9786e-6b0d-11e8-9833-65e10c7a01b9.png)

---- 

**Note that it also complement the fix made on https://github.com/akeneo/pim-community-dev/pull/8206 (PIM-7367) to handle associations displayed on root and sub product models.**

---- 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added legacy Behats               | N
| Added acceptance tests            | N
| Added integration tests           | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | Y