### PR TITLE
PIM-7390: In the Product Edit Form, we now keep the context of attributes filter (missing, all, level specific...)

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -16,6 +16,7 @@
 - PIM-6784: Improve the product grid search with categories for products with variants
 - PIM-7308: As Julia, I would like to bulk add product models associations if product models are selected.
 - PIM-7001: Don't display remove button on an association if it comes from inheritance
+- PIM-7390: In the Product Edit Form, we now keep the context of attributes filter (missing, all, level specific...)
 
 ## Technical improvements
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/attribute-filter.js
@@ -21,7 +21,6 @@ define(
         return BaseForm.extend({
             className: 'AknDropdown AknButtonList-item nav nav-tabs attribute-filter',
             template: _.template(template),
-            currentFilterCode: null,
 
             events: {
                 'click .AknDropdown-menuLink': 'onChange'
@@ -79,11 +78,14 @@ define(
              * @returns {Object}
              */
             getCurrentFilter() {
-                if (null === this.currentFilterCode) {
+                const currentFilterCode = sessionStorage.getItem('current_attribute_filter');
+                const filter = this.getFilters().find((filter) => currentFilterCode === filter.getCode());
+
+                if (undefined === filter || !filter.isVisible()) {
                     return this.getFilters()[0];
                 }
 
-                return this.getFilters().find((filter) => this.currentFilterCode === filter.getCode());
+                return filter;
             },
 
             /**
@@ -101,12 +103,13 @@ define(
              * @param {string} filterCode
              */
             setCurrent(filterCode) {
-                if (filterCode === this.currentFilterCode) {
+                if (filterCode === sessionStorage.getItem('current_attribute_filter')) {
                     return;
                 }
 
-                this.currentFilterCode = filterCode;
+                sessionStorage.setItem('current_attribute_filter', filterCode);
                 this.trigger('attribute_filter:change');
+                this.$el.removeClass('open');
             }
         });
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Now we keep context filter for attributes:

![screenshot-2018-6-11 product t-shirt unique size red edit](https://user-images.githubusercontent.com/301169/41226063-a09f91de-6d70-11e8-95c7-b89e526afb39.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added legacy Behats               | N
| Added acceptance tests            | N
| Added integration tests           | N
| Changelog updated                 | Y
| Review and 2 GTM                  | Y
| Micro Demo to the PO (Story only) | Y