### PR TITLE
PIM-7345 : Remove the is_empty operator on the SKU filter

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Improve Julia's experience
 
 - PIM-7347: Improve the calculation of the completeness for locale specific attributes.
+- PIM-7345: Remove the "is empty" operator for sku.
 
 # 2.3.0-ALPHA2 (2018-06-07)
 

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/TextFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/TextFilterType.php
@@ -14,7 +14,6 @@ class TextFilterType extends AbstractType
     const TYPE_EQUAL = 3;
     const TYPE_STARTS_WITH = 4;
     const TYPE_ENDS_WITH = 5;
-    const TYPE_EMPTY = 'empty';
     const NAME = 'oro_type_text_filter';
 
     /**
@@ -56,7 +55,6 @@ class TextFilterType extends AbstractType
             self::TYPE_NOT_CONTAINS => $this->translator->trans('oro.filter.form.label_type_not_contains'),
             self::TYPE_EQUAL        => $this->translator->trans('oro.filter.form.label_type_equals'),
             self::TYPE_STARTS_WITH  => $this->translator->trans('oro.filter.form.label_type_start_with'),
-            self::TYPE_EMPTY  => $this->translator->trans('oro.filter.form.label_type_empty'),
         ];
 
         $resolver->setDefaults(

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/IdentifierFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/IdentifierFilter.php
@@ -181,15 +181,6 @@ class IdentifierFilter extends AbstractAttributeFilter implements AttributeFilte
 
                 $this->searchQueryBuilder->addMustNot($clause);
                 break;
-
-            case Operators::IS_EMPTY:
-                $clause = [
-                    'exists' => ['field' => static::IDENTIFIER_KEY],
-                ];
-
-                $this->searchQueryBuilder->addMustNot($clause);
-                break;
-
             default:
                 throw InvalidOperatorException::notSupported($operator, static::class);
         }

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/IdentifierFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/IdentifierFilter.php
@@ -172,15 +172,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
 
                 $this->searchQueryBuilder->addMustNot($clause);
                 break;
-
-            case Operators::IS_EMPTY:
-                $clause = [
-                    'exists' => ['field' => static::IDENTIFIER_KEY],
-                ];
-
-                $this->searchQueryBuilder->addMustNot($clause);
-                break;
-
+                
             default:
                 throw InvalidOperatorException::notSupported($operator, static::class);
         }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -213,7 +213,7 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.identifier_field.class%'
         arguments:
             - ['identifier']
-            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN', 'EMPTY']
+            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
@@ -411,7 +411,7 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.identifier_attribute.class%'
         arguments:
             - ['pim_catalog_identifier']
-            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN', 'EMPTY']
+            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/IdentifierFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Attribute/IdentifierFilterSpec.php
@@ -29,8 +29,7 @@ class IdentifierFilterSpec extends ObjectBehavior
                 '=',
                 '!=',
                 'IN LIST',
-                'NOT IN LIST',
-                'EMPTY'
+                'NOT IN LIST'
             ]
         );
     }
@@ -55,8 +54,7 @@ class IdentifierFilterSpec extends ObjectBehavior
             '=',
             '!=',
             'IN LIST',
-            'NOT IN LIST',
-            'EMPTY'
+            'NOT IN LIST'
         ]);
         $this->supportsOperator('=')->shouldReturn(true);
         $this->supportsOperator('FAKE')->shouldReturn(false);
@@ -241,19 +239,5 @@ class IdentifierFilterSpec extends ObjectBehavior
                 'sku-001'
             )
         )->during('addAttributeFilter', [$sku, Operators::IN_LIST, 'sku-001', null, null, []]);
-    }
-
-    function it_adds_an_attribute_filter_with_operator_empty(SearchQueryBuilder $sqb, AttributeInterface $sku)
-    {
-        $sku->getCode()->willReturn('sku');
-        $sku->getBackendType()->willReturn('identifier');
-        $sqb->addMustNot(
-            [
-                'exists' => ['field' => 'identifier'],
-            ]
-        )->shouldBeCalled();
-
-        $this->setQueryBuilder($sqb);
-        $this->addAttributeFilter($sku, Operators::IS_EMPTY, 'sku-001', null, null, []);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/IdentifierFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/IdentifierFilterSpec.php
@@ -25,8 +25,7 @@ class IdentifierFilterSpec extends ObjectBehavior
                 '=',
                 '!=',
                 'IN LIST',
-                'NOT IN LIST',
-                'EMPTY'
+                'NOT IN LIST'
             ]
         );
     }
@@ -51,8 +50,7 @@ class IdentifierFilterSpec extends ObjectBehavior
                 '=',
                 '!=',
                 'IN LIST',
-                'NOT IN LIST',
-                'EMPTY'
+                'NOT IN LIST'
             ]
 
         );

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/IdentifierFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/IdentifierFilterIntegration.php
@@ -140,12 +140,6 @@ class IdentifierFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
     }
 
-    public function testOperatorIsEmpty()
-    {
-        $result = $this->executeFilter([['identifier', Operators::IS_EMPTY, 'baz']]);
-        $this->assert($result, []);
-    }
-
     /**
      * @expectedException \Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException
      * @expectedExceptionMessage Property "identifier" expects a string as data, "array" given.


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since we added a parent filter in the 2.1 version, we got the "IS EMPTY" operator on the SKU filter lin to this PR https://github.com/akeneo/pim-community-dev/pull/7312. 

This behavior was because we added the is_empty choice on the TextTypeFilter to have it on the parent filter (https://github.com/akeneo/pim-community-dev/blob/2.3/src/Oro/Bundle/FilterBundle/Form/Type/Filter/TextFilterType.php#L59). 
However, the operator choices for the parent filter are hardcoded on the frontend (https://github.com/akeneo/pim-community-dev/blob/2.3/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/parent-filter.js#L13).  
So, we could remove this is_empty on the TextTypeFilter as it's not used by the parent filter on the frontend side.

By the way, I removed also all the code to admit the is_empty operator on the ES filter as we can't select is_empty anymore.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
