### PR TITLE
Add the composer command arg when running a EE build through the CE

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -71,7 +71,7 @@ stage("Build") {
                             checkout scm
                         }
 
-                        sh "gcloud container builds submit --config .ci/builder.yaml --substitutions _IMAGE_TAG=${tag}-ee ."
+                        sh "gcloud container builds submit --config .ci/builder.yaml --substitutions _IMAGE_TAG=${tag}-ee,_COMPOSER_COMMAND=${composer_command} ."
                     }}
                 } else {
                     echo "Skipping Enterprise Edition matrix"


### PR DESCRIPTION
I missed to give the argument when we launch a EE build through the CE.