### PR TITLE
PIM-7415: Force the minus symbol for number on localization

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - PIM-7327: Fix memory leak on completeness calculation
 - PIM-7426: Fix search on the product 'add to group' mass edit
+- PIM-7415: Force the minus symbol for number on localization, whatever the locale of the user
 
 # 2.0.26 (2018-06-06)
 

--- a/src/Akeneo/Component/Localization/Localizer/NumberLocalizer.php
+++ b/src/Akeneo/Component/Localization/Localizer/NumberLocalizer.php
@@ -54,6 +54,7 @@ class NumberLocalizer implements LocalizerInterface
             $numberFormatter = $this->numberFactory->create($options);
 
             $numberFormatter->setSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL, '');
+            $numberFormatter->setSymbol(\NumberFormatter::MINUS_SIGN_SYMBOL, '-');
 
             if (floor($number) != $number) {
                 $numberFormatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, 2);

--- a/src/Akeneo/Component/Localization/spec/Localizer/NumberLocalizerSpec.php
+++ b/src/Akeneo/Component/Localization/spec/Localizer/NumberLocalizerSpec.php
@@ -69,4 +69,15 @@ class NumberLocalizerSpec extends ObjectBehavior
         $this->delocalize('10,00', ['decimal_separator' => ''])->shouldReturn('10.00');
         $this->delocalize('gruik', ['decimal_separator' => ''])->shouldReturn('gruik');
     }
+
+    function it_returns_always_a_negative_symbol_for_negative_number(
+        $numberFactory
+    ) {
+        $options = ['locale' => 'sv_SE'];
+        $numberFormatter = new \NumberFormatter('sv_SE', \NumberFormatter::DECIMAL);
+
+        $numberFactory->create($options)->willReturn($numberFormatter);
+
+        $this->localize('-10.4', $options)->shouldReturn('-10,40');
+    }
 }


### PR DESCRIPTION
For some locales (Swedish for instance), the minus symbol is not a `-` symbol but a `−` (yes, it's not the same character ;) ). To avoid that, we force the sign to always have the common sign `-`


<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
