### PR TITLE
PIM-7438: fix usage of identifier attribute on association grid

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,9 +1,10 @@
 #2.2.x
 
-##Bug fixes
+## Bug fixes
 
 - PIM-7399: Fix attributes order on Product model export
 - PIM-7384: Fix Memory leak on Quick export
+- PIM-7438: Fix usage of identifier attribute on association grid
 
 # 2.2.8 (2018-06-07)
 
@@ -12,7 +13,7 @@
 - PIM-7316: Fix overlap of boolean fields on product edit form
 - PIM-7319: Fix association display on product edit form when managing the association type permissions
 - PIM-7393: Improve error message when importing fields without locale or scope specification
-- PIM-7382: Fix scopable attributes disappearing from edit form after editing a product model 
+- PIM-7382: Fix scopable attributes disappearing from edit form after editing a product model
 - PIM-7386: Fix 'NOT IN' operator not taking empty values into account for select fields
 
 # 2.2.7 (2018-05-31)

--- a/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
+++ b/src/Pim/Bundle/DataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
@@ -111,12 +111,9 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
             'association_type_id' => '1'
         ]);
 
-        $associatedProduct1->getIdentifier()->willReturn('associated_product_1');
-        $associatedProduct1->getId()->willReturn('2');
-        $associatedProduct2->getIdentifier()->willReturn('associated_product_2');
-        $associatedProduct2->getId()->willReturn('3');
-        $associatedProductModel->getCode()->willReturn('associated_product_model_1');
-        $associatedProductModel->getId()->willReturn('2');
+        $associatedProduct1->getId()->willReturn('1');
+        $associatedProduct2->getId()->willReturn('2');
+        $associatedProductModel->getId()->willReturn('1');
         $currentProduct->getAssociations()->willReturn($associationCollection);
         $currentProduct->getIdentifier()->willReturn('current_product');
 
@@ -153,9 +150,9 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
 
         $pqbAsso
             ->addFilter(
-                'identifier',
+                'id',
                 Operators::IN_LIST,
-                ['associated_product_1', 'associated_product_2']
+                ['product_1', 'product_2']
             )->shouldBeCalled();
         $pqbAsso
             ->addFilter(
@@ -182,9 +179,9 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
 
         $pqbAssoProductModel
             ->addFilter(
-                'identifier',
+                'id',
                 Operators::IN_LIST,
-                ['associated_product_model_1']
+                ['product_model_1']
             )->shouldBeCalled();
         $pqbAssoProductModel
             ->addFilter(
@@ -263,9 +260,9 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
         $results['data']->shouldBeArray();
         $results['data']->shouldHaveCount(3);
         $results['data']->shouldBeAnArrayOfInstanceOf(ResultRecord::class);
-        $results['data'][0]->getValue('id')->shouldReturn('product-2');
-        $results['data'][1]->getValue('id')->shouldReturn('product-3');
-        $results['data'][2]->getValue('id')->shouldReturn('product-model-2');
+        $results['data'][0]->getValue('id')->shouldReturn('product-1');
+        $results['data'][1]->getValue('id')->shouldReturn('product-2');
+        $results['data'][2]->getValue('id')->shouldReturn('product-model-1');
     }
 
     public function getMatchers()


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

We were using the identifier filter to find associated products. If an attribute is called "identifier" the pqb was not able to know what to do. I fixed it by using Ids instead.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Yes
| Added legacy Behats               | No
| Added acceptance tests            | No
| Added integration tests           | No
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
