### PR TITLE
Delete ADP Currency

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/PartialUpdateChannelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Channel/PartialUpdateChannelIntegration.php
@@ -285,7 +285,7 @@ JSON;
     {
         $client = $this->createAuthenticatedClient();
 
-        $data = '{ "currencies": ["ADP"] }';
+        $data = '{ "currencies": ["AED"] }';
 
         $expectedContent =
 <<<JSON
@@ -295,7 +295,7 @@ JSON;
     "errors": [
         {
             "property": "currencies",
-            "message": "The currency \"ADP\" has to be activated."
+            "message": "The currency \"AED\" has to be activated."
         }
     ]
 }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Currency/ListCurrencyIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Currency/ListCurrencyIntegration.php
@@ -32,7 +32,6 @@ class ListCurrencyIntegration extends ApiTestCase
     "current_page": 1,
     "_embedded" : {
         "items" : [
-            {$standardizedCurrencies['ADP']},
             {$standardizedCurrencies['AED']},
             {$standardizedCurrencies['AFA']},
             {$standardizedCurrencies['ALK']},
@@ -212,17 +211,6 @@ JSON;
      */
     protected function getStandardizedCurrencies()
     {
-        $standarizedCurrencies['ADP'] = <<<JSON
-{
-    "_links": {
-        "self": {
-            "href": "http://localhost/api/rest/v1/currencies/ADP"
-        }
-    },
-    "code": "ADP",
-    "enabled": false
-}
-JSON;
 
         $standarizedCurrencies['AED'] = <<<JSON
 {

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/currencies.csv
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/currencies.csv
@@ -1,7 +1,6 @@
 code;activated
 USD;1
 EUR;1
-ADP;0
 AED;0
 AFA;0
 AFN;0

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/minimal/currencies.csv
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/minimal/currencies.csv
@@ -1,7 +1,6 @@
 code;activated
 USD;1
 EUR;1
-ADP;0
 AED;0
 AFA;0
 AFN;0

--- a/tests/back/Integration/catalog/technical/currencies.csv
+++ b/tests/back/Integration/catalog/technical/currencies.csv
@@ -1,7 +1,6 @@
 code;activated
 USD;1
 EUR;1
-ADP;0
 AED;0
 AFA;0
 ALK;0

--- a/tests/legacy/features/Context/catalog/apparel/currencies.csv
+++ b/tests/legacy/features/Context/catalog/apparel/currencies.csv
@@ -2,7 +2,6 @@ code;activated
 USD;1
 EUR;1
 GBP;1
-ADP;0
 AED;0
 AFA;0
 AFN;0

--- a/tests/legacy/features/Context/catalog/catalog_modeling/currencies.csv
+++ b/tests/legacy/features/Context/catalog/catalog_modeling/currencies.csv
@@ -1,7 +1,6 @@
 code;activated
 USD;1
 EUR;1
-ADP;0
 AED;0
 AFA;0
 AFN;0

--- a/tests/legacy/features/Context/catalog/default/currencies.csv
+++ b/tests/legacy/features/Context/catalog/default/currencies.csv
@@ -1,7 +1,6 @@
 code;activated
 USD;1
 EUR;1
-ADP;0
 AED;0
 AFA;0
 AFN;0

--- a/tests/legacy/features/Context/catalog/footwear/currencies.csv
+++ b/tests/legacy/features/Context/catalog/footwear/currencies.csv
@@ -1,7 +1,6 @@
 code;activated
 USD;1
 EUR;1
-ADP;0
 AED;0
 AFA;0
 AFN;0

--- a/tests/legacy/features/export/export_currencies.feature
+++ b/tests/legacy/features/export/export_currencies.feature
@@ -19,7 +19,6 @@ Feature: Export currencies
     code;activated
     USD;1
     EUR;1
-    ADP;0
     AED;0
     AFA;0
     AFN;0


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

Delete ADP Currency, Andorran Peseta is not a valid currency since Euro was added in country.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
