### PR TITLE
PIM-7430: association versioning

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -18,6 +18,7 @@
 - PIM-7308: As Julia, I would like to bulk add product models associations if product models are selected.
 - PIM-7001: Don't display remove button on an association if it comes from inheritance
 - PIM-7390: In the Product Edit Form, we now keep the context of attributes filter (missing, all, level specific...)
+- PIM-7430: mass associate generate new product version
 
 ## Technical improvements
 

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/guessers.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/guessers.yml
@@ -5,6 +5,7 @@ parameters:
     pim_versioning.update_guesser.contains_products.class: Pim\Bundle\VersioningBundle\UpdateGuesser\ContainsProductsUpdateGuesser
     pim_versioning.update_guesser.translations.class:      Pim\Bundle\VersioningBundle\UpdateGuesser\TranslationsUpdateGuesser
     pim_versioning.update_guesser.versionable.class:       Pim\Bundle\VersioningBundle\UpdateGuesser\VersionableUpdateGuesser
+    pim_versioning.update_guesser.associations.class:      Pim\Bundle\VersioningBundle\UpdateGuesser\AssociationsUpdateGuesser
 
 services:
     pim_versioning.update_guesser.attribute_group:
@@ -31,6 +32,13 @@ services:
 
     pim_versioning.update_guesser.versionable:
         class: '%pim_versioning.update_guesser.versionable.class%'
+        arguments:
+            - '%pim_versioning.versionable_entities%'
+        tags:
+            - { name: pim_versioning.update_guesser }
+
+    pim_versioning.update_guesser.associations:
+        class: '%pim_versioning.update_guesser.associations.class%'
         arguments:
             - '%pim_versioning.versionable_entities%'
         tags:

--- a/src/Pim/Bundle/VersioningBundle/UpdateGuesser/AssociationsUpdateGuesser.php
+++ b/src/Pim/Bundle/VersioningBundle/UpdateGuesser/AssociationsUpdateGuesser.php
@@ -2,18 +2,17 @@
 
 namespace Pim\Bundle\VersioningBundle\UpdateGuesser;
 
-use Akeneo\Component\Versioning\Model\VersionableInterface;
-use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManager;
+use Pim\Component\Catalog\Model\AssociationInterface;
 
 /**
- * Fields update guesser
+ * Guess for associations updates and add the owner product entity to pendings versionnning if needed
  *
- * @author    Nicolas Dupont <nicolas@akeneo.com>
- * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
+ * @author    jm leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class VersionableUpdateGuesser implements UpdateGuesserInterface
+class AssociationsUpdateGuesser implements UpdateGuesserInterface
 {
     /**
      * Entities configured as versionable without implementing interface because coming
@@ -47,10 +46,8 @@ class VersionableUpdateGuesser implements UpdateGuesserInterface
     public function guessUpdates(EntityManager $em, $entity, $action)
     {
         $pendings = [];
-        if ($entity instanceof VersionableInterface ||
-            in_array(ClassUtils::getClass($entity), $this->versionableEntities)
-        ) {
-            $pendings[] = $entity;
+        if ($entity instanceof AssociationInterface) {
+            $pendings[] = $entity->getOwner();
         }
 
         return $pendings;

--- a/src/Pim/Bundle/VersioningBundle/UpdateGuesser/VersionableUpdateGuesser.php
+++ b/src/Pim/Bundle/VersioningBundle/UpdateGuesser/VersionableUpdateGuesser.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\VersioningBundle\UpdateGuesser;
 use Akeneo\Component\Versioning\Model\VersionableInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManager;
+use Pim\Component\Catalog\Model\AssociationInterface;
 
 /**
  * Fields update guesser
@@ -51,6 +52,8 @@ class VersionableUpdateGuesser implements UpdateGuesserInterface
             in_array(ClassUtils::getClass($entity), $this->versionableEntities)
         ) {
             $pendings[] = $entity;
+        } elseif ($entity instanceof AssociationInterface) {
+            $pendings[] = $entity->getOwner();
         }
 
         return $pendings;

--- a/src/Pim/Bundle/VersioningBundle/spec/UpdateGuesser/AssociationsUpdateGuesserSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/UpdateGuesser/AssociationsUpdateGuesserSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace spec\Pim\Bundle\VersioningBundle\UpdateGuesser;
+
+use Doctrine\ORM\EntityManager;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\VersioningBundle\UpdateGuesser\AssociationsUpdateGuesser;
+use Pim\Bundle\VersioningBundle\UpdateGuesser\UpdateGuesserInterface;
+use Pim\Component\Catalog\Model\AssociationInterface;
+use Pim\Component\Catalog\Model\EntityWithAssociationsInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+
+class AssociationsUpdateGuesserSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(['stdClass']);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AssociationsUpdateGuesser::class);
+    }
+
+    function it_is_an_update_guesser()
+    {
+        $this->shouldImplement(UpdateGuesserInterface::class);
+    }
+
+    function it_supports_update_action()
+    {
+        $this->supportAction(UpdateGuesserInterface::ACTION_UPDATE_ENTITY)->shouldReturn(true);
+        $this->supportAction('foo')->shouldReturn(false);
+    }
+
+    function it_guesses_associations_updates(
+        AssociationInterface $association,
+        EntityWithAssociationsInterface $owner,
+        EntityManager $em
+    ) {
+        $association->getOwner()->willReturn($owner);
+        $this->guessUpdates($em, $association, UpdateGuesserInterface::ACTION_UPDATE_ENTITY)
+            ->shouldReturn([$owner]);
+    }
+
+    function it_returns_no_pending_updates_if_not_given_association_interface(
+        EntityManager $em,
+        LocaleInterface $locale
+    ) {
+        $this->guessUpdates($em, $locale, UpdateGuesserInterface::ACTION_UPDATE_ENTITY)
+            ->shouldReturn([]);
+    }
+}

--- a/tests/legacy/features/mass-action/mass_associate.feature
+++ b/tests/legacy/features/mass-action/mass_associate.feature
@@ -35,6 +35,12 @@ Feature: Associate many products at once
     Then the product "1111111240" should have the following associations:
       | type   | products              |
       | X_SELL | 1111111292,1111111304 |
+    When I am on the "1111111171" product page
+    And I visit the "History" column tab
+    Then there should be 2 update
+    And I should see history:
+      | version | property        | before | value                 | date |
+      | 2       | X_SELL-products |        | 1111111292,1111111304 | now  |
 
   Scenario: Mass associate products to product models
     When I sort by "ID" value ascending


### PR DESCRIPTION
Mass associating products does not generate versioning because the product itself is not modified. It is then not detected as changing , hence the absence of version.

With this PR, we trigger a product versionning when a ProductAssociation is updated.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | Todo
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
