### PR TITLE
[SLA] PIM-7413: Newly created attribute group is correctly sorted after existing ones

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7442: Bulk actions ALL - count not taking variant products into account
+- PIM-7413: Newly created attribute group is correctly sorted after existing ones
 
 # 2.2.9 (2018-06-14)
 

--- a/features/attribute-group/create_attribute_group.feature
+++ b/features/attribute-group/create_attribute_group.feature
@@ -1,3 +1,4 @@
+@javascript
 Feature: Attribute group creation
   In order to organize attributes into group
   As a product manager
@@ -12,3 +13,14 @@ Feature: Attribute group creation
     And I save the attribute group
     Then I should see the text "Attribute group successfully created"
     And I should be on the "seo" attribute group page
+
+  Scenario: Newly created attribute group is sorted after existing ones
+    Given the "default" catalog configuration
+    And I am logged in as "Julia"
+    When I am on the attribute group creation page
+    And I change the Code to "seo"
+    And I save the attribute group
+    When I visit the "History" tab
+    And I should see history:
+      | version | property   | value | date |
+      | 1       | sort_order | 101   | now  |

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeGroupController.php
@@ -216,7 +216,9 @@ class AttributeGroupController
             return new RedirectResponse('/');
         }
 
+        $maxSortOrder = $this->attributeGroupRepo->getMaxSortOrder();
         $attributeGroup = $this->attributeGroupFactory->create();
+        $attributeGroup->setSortOrder($maxSortOrder + 1);
 
         $data = json_decode($request->getContent(), true);
         $this->updater->update($attributeGroup, $data);

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/attribute_groups.csv
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/attribute_groups.csv
@@ -6,7 +6,7 @@ manufacturing;4;Manufacturing;Fabrication;Herstellung
 color;5;Color;Couleur;Farbe
 size;6;Size;Taille;Größe
 medias;7;Media;Media;Media
-erp;1;ERP;ERP;ERP
-ecommerce;4;Ecommerce;Ecommerce;Ecommerce
-product;3;Product;Produit;Product
+erp;8;ERP;ERP;ERP
+ecommerce;9;Ecommerce;Ecommerce;Ecommerce
+product;10;Product;Produit;Product
 other;100;Other;Autre;Ander


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When creating a new attribute group, the sort order was null (so ended by 0 in database).
Now we correctly increment the sort order on creation.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | Y
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Y
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | Todo