### PR TITLE
PIM-7396: Improve performances on Compute Model Descendants

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,11 +3,8 @@
 ## Bug fixes
 
 - PIM-7425: Prevent job 'compute_completeness_of_products_family' to run in some cases.
-<<<<<<< HEAD
-- PIM-7447: do not trigger caclulation of the completeness before exporting products
-=======
 - PIM-7396: Fix memory leak on product model descendants computation
->>>>>>> a8f269e... PIM-7396: Fix memory leaks on compute descendant calculation
+- PIM-7447: do not trigger caclulation of the completeness before exporting products
 
 # 2.0.27 (2018-06-13)
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,7 +3,11 @@
 ## Bug fixes
 
 - PIM-7425: Prevent job 'compute_completeness_of_products_family' to run in some cases.
+<<<<<<< HEAD
 - PIM-7447: do not trigger caclulation of the completeness before exporting products
+=======
+- PIM-7396: Fix memory leak on product model descendants computation
+>>>>>>> a8f269e... PIM-7396: Fix memory leaks on compute descendant calculation
 
 # 2.0.27 (2018-06-13)
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
@@ -24,6 +24,7 @@ services:
         arguments:
             - '@pim_catalog.repository.product_model'
             - '@pim_catalog.saver.product_model_descendants'
+            - '@pim_connector.doctrine.cache_clearer'
         public: false
 
     pim_catalog.tasklet.compute_completeness_of_products_family:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/savers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/savers.yml
@@ -129,3 +129,5 @@ services:
             - '@pim_catalog.manager.completeness'
             - '@pim_catalog.elasticsearch.indexer.product'
             - '@pim_catalog.elasticsearch.indexer.product_model'
+            - '@akeneo_storage_utils.doctrine.object_detacher'
+            - '%pim_job_product_batch_size%'

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\Common\Saver;
 
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
@@ -24,7 +25,8 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         ProductQueryBuilderFactoryInterface $pqbFactory,
         CompletenessManager $completenessManager,
         BulkIndexerInterface $productIndexer,
-        BulkIndexerInterface $productModelIndexer
+        BulkIndexerInterface $productModelIndexer,
+        BulkObjectDetacherInterface $bulkObjectDetacher
     ) {
         $this->beConstructedWith(
             $objectManager,
@@ -32,7 +34,8 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
             $pqbFactory,
             $completenessManager,
             $productIndexer,
-            $productModelIndexer
+            $productModelIndexer,
+            $bulkObjectDetacher
         );
     }
 
@@ -104,8 +107,6 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $pqbFactory->create()->willReturn($pqb);
         $pqb->addFilter('identifier', Operators::IN_LIST, [])->shouldBeCalled();
         $pqb->execute()->willReturn($cursor);
-
-        $cursor->count()->willReturn(0);
 
         $completenessManager->schedule(Argument::cetera())->shouldNotBeCalled();
         $completenessManager->generateMissingForProduct(Argument::cetera())->shouldNotBeCalled();

--- a/src/Pim/Component/Catalog/spec/Job/ComputeProductModelsDescendantsTaskletSpec.php
+++ b/src/Pim/Component/Catalog/spec/Job/ComputeProductModelsDescendantsTaskletSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Catalog\Job;
 
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
 use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\ProductModelInterface;
@@ -13,15 +14,19 @@ class ComputeProductModelsDescendantsTaskletSpec extends ObjectBehavior
 {
     function let(
         ProductModelRepositoryInterface $productModelRepository,
-        SaverInterface $productModelDescendantsSaver
+        SaverInterface $productModelDescendantsSaver,
+        CacheClearerInterface $cacheClearer,
+        StepExecution $stepExecution
     ) {
-        $this->beConstructedWith($productModelRepository, $productModelDescendantsSaver);
+        $this->beConstructedWith($productModelRepository, $productModelDescendantsSaver, $cacheClearer);
+        $this->setStepExecution($stepExecution);
     }
 
     function it_saves_the_product_model_descendants_on_execute(
         $productModelRepository,
         $productModelDescendantsSaver,
-        StepExecution $stepExecution,
+        $cacheClearer,
+        $stepExecution,
         JobParameters $jobParameters,
         ProductModelInterface $productModel1,
         ProductModelInterface $productModel2
@@ -30,9 +35,13 @@ class ComputeProductModelsDescendantsTaskletSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('product_model_codes')->willReturn(['tshirt_root', 'another_model']);
 
-        $productModelRepository->findByIdentifiers(['tshirt_root', 'another_model'])->willReturn([$productModel1, $productModel2]);
+        $productModelRepository->findOneByIdentifier('tshirt_root')->willReturn($productModel1);
         $productModelDescendantsSaver->save($productModel1)->shouldBeCalled();
+
+        $productModelRepository->findOneByIdentifier('another_model')->willReturn($productModel2);
         $productModelDescendantsSaver->save($productModel2)->shouldBeCalled();
+
+        $cacheClearer->clear()->shouldBeCalled();
 
         $this->execute();
     }


### PR DESCRIPTION
This PR fixes memory leak on product model descendants computation. Nothing is detached so every product and linked entities are kept in Doctrine UOW.

Tasklet does need to detach as product model descendants saver clears UOW + cached repositories.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
