### PR TITLE
PIM-7345 : Remove "is_empty" operator on the sku filter.

### DIFF
--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/TextFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/TextFilterType.php
@@ -14,6 +14,7 @@ class TextFilterType extends AbstractType
     const TYPE_EQUAL = 3;
     const TYPE_STARTS_WITH = 4;
     const TYPE_ENDS_WITH = 5;
+    const TYPE_EMPTY = 'empty';
     const NAME = 'oro_type_text_filter';
 
     /**
@@ -55,6 +56,7 @@ class TextFilterType extends AbstractType
             self::TYPE_NOT_CONTAINS => $this->translator->trans('oro.filter.form.label_type_not_contains'),
             self::TYPE_EQUAL        => $this->translator->trans('oro.filter.form.label_type_equals'),
             self::TYPE_STARTS_WITH  => $this->translator->trans('oro.filter.form.label_type_start_with'),
+            self::TYPE_EMPTY        => $this->translator->trans('oro.filter.form.label_type_empty'),
         ];
 
         $resolver->setDefaults(

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/attribute_types.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/attribute_types.yml
@@ -4,7 +4,7 @@ parameters:
             type:        product_value_field
         filter:
             type:        product_value_string
-            ftype:       string
+            ftype:       identifier
             options:
                 field_options:
                     attr:

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/requirejs.yml
@@ -134,6 +134,7 @@ config:
         oro/datafilter/select-row-filter:           pimdatagrid/js/datafilter/filter/select-row-filter
         oro/datafilter/text-filter:                 pimdatagrid/js/datafilter/filter/text-filter
         oro/datafilter/parent-filter:               pimdatagrid/js/datafilter/filter/parent-filter
+        oro/datafilter/identifier-filter:           pimdatagrid/js/datafilter/filter/identifier-filter
         pim/filter/text:                            pimdatagrid/js/datafilter/filter/text-filter
         oro/datafilter/abstract-formatter:          pimdatagrid/js/datafilter/formatter/abstract-formatter
         oro/datafilter/filters-manager:             pimdatagrid/js/datafilter/filters-manager

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter-builder.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter-builder.js
@@ -20,6 +20,7 @@ define(
             config: {
                 filterModuleName: 'oro/datafilter/{{type}}-filter',
                 filterTypes: {
+                    identifier: 'identifier',
                     string: 'choice',
                     choice: 'select',
                     selectrow: 'select-row',

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/identifier-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/identifier-filter.js
@@ -1,0 +1,38 @@
+/* global define */
+define(['underscore', 'oro/translator', 'oro/datafilter/choice-filter'],
+  function (_, __, ChoiceFilter) {
+    'use strict';
+
+    /**
+     * @export  oro/datafilter/identifierFilter
+     * @class   oro.datafilter.identifierFilter
+     * @extends oro.datafilter.ChoiceFilter
+     */
+    return ChoiceFilter.extend({
+      initialize: function() {
+        this.choices = [
+          {'label': __('pim.grid.choice_filter.label_contains'), 'value': '1'},
+          {'label': __('pim.grid.choice_filter.label_does_not_contain'), 'value': '2'},
+          {'label': __('pim.grid.choice_filter.label_equal'), 'value': '3'},
+          {'label': __('pim.grid.choice_filter.label_start_with'), 'value': '4'},
+          {'label': __('pim.grid.choice_filter.label_in_list'), 'value': 'in'},
+        ];
+        this.emptyValue = { 'type': 'in', 'value': ''};
+
+        ChoiceFilter.prototype.initialize.apply(this, arguments);
+      },
+
+      /**
+       * {@inheritdoc}
+       */
+      _getOperatorChoices() {
+        return {
+          '1': __('pim.grid.choice_filter.label_contains'),
+          '2': __('pim.grid.choice_filter.label_does_not_contain'),
+          '3': __('pim.grid.choice_filter.label_equal'),
+          '4': __('pim.grid.choice_filter.label_start_with'),
+          'in': __('pim.grid.choice_filter.label_in_list'),
+        };
+      },
+    });
+  });

--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
@@ -51,6 +51,11 @@ pim.grid.ajax_choice_filter.label_not_empty: is not empty
 pim:
   grid:
     choice_filter:
+      label_contains: contains
+      label_does_not_contain: does not contains
+      label_equal: is equal to
+      label_contains: contains
+      label_start_with: starts with
       label_empty: is empty
       label_not_empty: is not empty
       label_in_list: in list

--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en.yml
@@ -52,7 +52,7 @@ pim:
   grid:
     choice_filter:
       label_contains: contains
-      label_does_not_contain: does not contains
+      label_does_not_contain: does not contain
       label_equal: is equal to
       label_contains: contains
       label_start_with: starts with

--- a/tests/legacy/features/Context/Page/Base/Grid.php
+++ b/tests/legacy/features/Context/Page/Base/Grid.php
@@ -140,6 +140,10 @@ class Grid extends Index
         'parent' => [
             'Pim\Behat\Decorator\Grid\Filter\BaseDecorator',
             'Pim\Behat\Decorator\Grid\Filter\StringDecorator',
+        ],
+        'identifier' => [
+            'Pim\Behat\Decorator\Grid\Filter\BaseDecorator',
+            'Pim\Behat\Decorator\Grid\Filter\StringDecorator',
         ]
     ];
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Following the behavior error we have on the parent filter, we can't remove the 'is_empty' from the operator choice in the TextFilterType. So, we had to add a specific js filter for the identifier.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
