### PR TITLE
PIM 7447: do not trigger calculation of completeness before exporting products

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7425: Prevent job 'compute_completeness_of_products_family' to run in some cases.
+- PIM-7447: do not trigger caclulation of the completeness before exporting products
 
 # 2.0.27 (2018-06-13)
 

--- a/src/Pim/Component/Catalog/Completeness/CompletenessGenerator.php
+++ b/src/Pim/Component/Catalog/Completeness/CompletenessGenerator.php
@@ -51,7 +51,7 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
     /**
      * {@inheritdoc}
      *
-     * @TODO @merge PIM-7348 - Add to interface
+     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
      */
     public function generateMissingForProducts(ChannelInterface $channel, array $filters)
     {
@@ -63,6 +63,8 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
      */
     public function generateMissingForChannel(ChannelInterface $channel)
     {
@@ -74,6 +76,8 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated to remove as it is not used
      */
     public function generateMissing()
     {

--- a/src/Pim/Component/Catalog/Completeness/CompletenessGeneratorInterface.php
+++ b/src/Pim/Component/Catalog/Completeness/CompletenessGeneratorInterface.php
@@ -25,11 +25,15 @@ interface CompletenessGeneratorInterface
      * Generate completeness for a channel
      *
      * @param ChannelInterface $channel
+     *
+     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
      */
     public function generateMissingForChannel(ChannelInterface $channel);
 
     /**
      * Generate missing completenesses
+     *
+     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
      */
     public function generateMissing();
 }

--- a/src/Pim/Component/Catalog/Manager/CompletenessManager.php
+++ b/src/Pim/Component/Catalog/Manager/CompletenessManager.php
@@ -75,28 +75,24 @@ class CompletenessManager
     }
 
     /**
-     * Insert missing completenesses for filtered products
+     * @param ChannelInterface $channel
+     * @param array            $filters
      *
-     * @param $products
+     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
      */
     public function generateMissingForProducts(ChannelInterface $channel, array $filters)
     {
-        // @TODO @merge PIM-7348 - Remove this BC workaround when merged
-        if (method_exists($this->generator, 'generateMissingForProducts')) {
-            $this->generator->generateMissingForProducts($channel, $filters);
-        } else {
-            $this->generator->generateMissingForChannel($channel);
-        }
     }
 
     /**
      * Insert missing completenesses for a given channel
      *
      * @param ChannelInterface $channel
+     *
+     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
      */
     public function generateMissingForChannel(ChannelInterface $channel)
     {
-        $this->generator->generateMissingForChannel($channel);
     }
 
     /**

--- a/src/Pim/Component/Catalog/spec/Manager/CompletenessManagerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Manager/CompletenessManagerSpec.php
@@ -31,22 +31,4 @@ class CompletenessManagerSpec extends ObjectBehavior
             $valueCompleteChecker
         );
     }
-
-    function it_generates_missing_completenesses_for_products(
-        ChannelInterface $channel,
-        $generator
-    )
-    {
-        $generator->generateMissingForProducts($channel, [])->shouldBeCalled();
-
-        $this->generateMissingForProducts($channel, []);
-    }
-}
-
-// @TODO @merge PIM-7348 - Remove when merged
-class CompletenessGenerator implements CompletenessGeneratorInterface {
-    public function generateMissingForProduct(ProductInterface $product) {}
-    public function generateMissingForChannel(ChannelInterface $channel) {}
-    public function generateMissing() {}
-    public function generateMissingForProducts(ChannelInterface $channel, array $filters) {}
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Original issue was a memory leak when exporting products.

**Before the fix PIM-7348 (https://github.com/akeneo/pim-community-dev/pull/8109):**

- we want to export products
- we trigger calculation for all products with missing completeness
- and this calculation was never saved... so it was totally useless
- this calculation load every products in memory with missing completeness (which means a potential memory leak)

The piece of responsible of it is here:
https://github.com/akeneo/pim-community-dev/blob/2.3/src/Pim/Component/Catalog/Completeness/CompletenessGenerator.php#L56

What does it mean?

It means that we never have a lot of missing completeness, or all our customers would complain about memory leak...
It means also that this calculation is useless as it saves nothing (but not a bug, see next paragraph).

This ticket was raised by Leo that is using the data generator (which don't use saver and so, don't generate the completeness).

**After the fix PIM-7348 (https://github.com/akeneo/pim-community-dev/pull/8109):**

This fix had a wrong condition for default values: https://github.com/akeneo/pim-community-dev/pull/8109/files#diff-7619b6e48009460276ac4ee022a74ae2R104

The filters used for the export was used for the selection of the products to calculate the completeness. If you export all products, it selects all products for the completeness.

As it loads everything in memory.... BOUM. Leak. Game over.
Without this PR, the memory leak does not exist. 

It's a big regression (and it's my responsibility because I did it in pair with Tam).

**Fix**

As discussed with @jjanvier (with help of @SamirBoulil + @juliensnz), this piece of code should be removed in 2.3.
As completeness is calculated on the fly when saving a product, no need to recalculate it.
A missing completeness should not exist anymore in 2.x.

And the fact it never worked (as product completeness is never saved) is good example that it's totally useless. 

So, to avoid BC, I just deleted the code.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
