### PR TITLE
PIM-7442: Bulk actions ALL - count not taking into account variants

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,3 +1,9 @@
+# 2.2.x
+
+## Bug fixes
+
+- PIM-7442: Bulk actions ALL - count not taking variant products into account
+
 # 2.2.9 (2018-06-14)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/CountImpactedProducts.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/CountImpactedProducts.php
@@ -135,7 +135,7 @@ class CountImpactedProducts
     }
 
     /**
-     * Count all products matching the given filters
+     * Count all products (only variants) matching the given filters
      * (except we remove the ID filter and adapt the completeness filter).
      *
      * @param array $filters
@@ -147,7 +147,9 @@ class CountImpactedProducts
         $filters = $this->adaptGridCompletenessFilter($filters);
         $filters = $this->removeIdFilter($filters);
 
-        $pqb = $this->productQueryBuilderFactory->create(['filters' => $filters]);
+        $filters[] = ['field' => 'entity_type', 'operator' => '=', 'value' => ProductInterface::class];
+
+        $pqb = $this->productAndProductModelQueryBuilderFactory->create(['filters' => $filters]);
 
         return $pqb->execute()->count();
     }

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Query/CountImpactedProductsSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Query/CountImpactedProductsSpec.php
@@ -33,11 +33,13 @@ class CountImpactedProductsSpec extends ObjectBehavior
     ) {
         $pqbFilters = [];
 
-        $productQueryBuilderFactory->create(['filters' => []])->willReturn($pqb);
+        $productAndProductModelQueryBuilderFactory->create(['filters' => [
+            ['field' => 'entity_type', 'operator' => "=", 'value' => ProductInterface::class]
+        ]])->willReturn($pqb);
         $pqb->execute()->willReturn($countable);
         $countable->count()->willReturn(2500);
 
-        $productAndProductModelQueryBuilderFactory->create()->shouldNotBeCalled();
+        $productQueryBuilderFactory->create()->shouldNotBeCalled();
 
         $this->count($pqbFilters)->shouldReturn(2500);
     }
@@ -137,7 +139,6 @@ class CountImpactedProductsSpec extends ObjectBehavior
 
     public function it_substracts_the_product_catalog_count_to_the_selected_entities_when_a_user_selects_all_and_unchecks_products(
         $productAndProductModelQueryBuilderFactory,
-        $productQueryBuilderFactory,
         ProductQueryBuilderInterface $pqbForAllProducts,
         ProductQueryBuilderInterface $pqbForProducts,
         ProductQueryBuilderInterface $pqbForProductsInsideProductModels,
@@ -154,7 +155,9 @@ class CountImpactedProductsSpec extends ObjectBehavior
             ]
         ];
 
-        $productQueryBuilderFactory->create(['filters' => []])->willReturn($pqbForAllProducts);
+        $productAndProductModelQueryBuilderFactory->create(['filters' => [
+            ['field' => 'entity_type', 'operator' => "=", 'value' => "Pim\Component\Catalog\Model\ProductInterface"]
+        ]])->willReturn($pqbForAllProducts);
         $pqbForAllProducts->execute()->willReturn($cursorForAllProducts);
 
         $productAndProductModelQueryBuilderFactory->create(['filters' => [
@@ -182,7 +185,6 @@ class CountImpactedProductsSpec extends ObjectBehavior
 
     public function it_substracts_the_product_catalog_count_to_the_selected_entities_when_a_user_selects_all_and_unchecks_products_and_product_models(
         $productAndProductModelQueryBuilderFactory,
-        $productQueryBuilderFactory,
         ProductQueryBuilderInterface $pqbForAllProducts,
         ProductQueryBuilderInterface $pqbForProducts,
         ProductQueryBuilderInterface $pqbForProductsInsideProductModels,
@@ -199,7 +201,9 @@ class CountImpactedProductsSpec extends ObjectBehavior
             ]
         ];
 
-        $productQueryBuilderFactory->create(['filters' => []])->willReturn($pqbForAllProducts);
+        $productAndProductModelQueryBuilderFactory->create(['filters' => [
+            ['field' => 'entity_type', 'operator' => "=", 'value' => "Pim\Component\Catalog\Model\ProductInterface"]
+        ]])->willReturn($pqbForAllProducts);
         $pqbForAllProducts->execute()->willReturn($cursorForAllProducts);
 
         $productAndProductModelQueryBuilderFactory->create(['filters' => [
@@ -227,7 +231,6 @@ class CountImpactedProductsSpec extends ObjectBehavior
 
     public function it_substracts_the_product_catalog_count_to_the_selected_entities_when_a_user_selects_all_and_unchecks_products_and_product_models_with_a_completeness_filter(
         $productAndProductModelQueryBuilderFactory,
-        $productQueryBuilderFactory,
         ProductQueryBuilderInterface $pqbForAllProducts,
         ProductQueryBuilderInterface $pqbForProducts,
         ProductQueryBuilderInterface $pqbForProductsInsideProductModels,
@@ -265,11 +268,16 @@ class CountImpactedProductsSpec extends ObjectBehavior
                 'operator' => '=',
                 'value'    => 100,
                 'context'  => []
-            ]
+            ],
+            [
+                'field'    => 'entity_type',
+                'operator' => '=',
+                'value'    => ProductInterface::class
+            ],
         ];
         unset($pqbFiltersForAllProducts[0]);
 
-        $productQueryBuilderFactory->create(['filters' => $pqbFiltersForAllProducts])->willReturn($pqbForAllProducts);
+        $productAndProductModelQueryBuilderFactory->create(['filters' => $pqbFiltersForAllProducts])->willReturn($pqbForAllProducts);
         $pqbForAllProducts->execute()->willReturn($cursorForAllProducts);
 
         $productAndProductModelQueryBuilderFactory->create(['filters' => [
@@ -303,7 +311,6 @@ class CountImpactedProductsSpec extends ObjectBehavior
 
     public function it_computes_when_a_user_selects_all_entities_with_other_filters(
         $productAndProductModelQueryBuilderFactory,
-        $productQueryBuilderFactory,
         ProductQueryBuilderInterface $pqb,
         \Countable $countable
     ) {
@@ -319,10 +326,10 @@ class CountImpactedProductsSpec extends ObjectBehavior
                 'operator' => 'IN LIST',
                 'value' => ['l', 'm'],
                 'context' => []
-            ]
+            ],
         ];
 
-        $productQueryBuilderFactory->create(
+        $productAndProductModelQueryBuilderFactory->create(
             [
                 'filters' => [
                     [
@@ -336,14 +343,18 @@ class CountImpactedProductsSpec extends ObjectBehavior
                         'operator' => 'IN LIST',
                         'value' => ['l', 'm'],
                         'context' => []
-                    ]
+                    ],
+                    [
+                        'field'    => 'entity_type',
+                        'operator' => '=',
+                        'value'    => ProductInterface::class
+                    ],
                 ]
             ]
         )->willReturn($pqb);
+
         $pqb->execute()->willReturn($countable);
         $countable->count()->willReturn(12);
-
-        $productAndProductModelQueryBuilderFactory->create()->shouldNotBeCalled();
 
         $this->count($pqbFilters)->shouldReturn(12);
     }

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/Doctrine/ORM/Query/CountImpactedProductsIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/Doctrine/ORM/Query/CountImpactedProductsIntegration.php
@@ -174,6 +174,29 @@ class CountImpactedProductsIntegration extends TestCase
     }
 
     /**
+     * @link jira https://akeneo.atlassian.net/browse/PIM-7442
+     */
+    public function testUserSelectedAllEntitiesWithAdditionnalFilterOnParent()
+    {
+        $pqbFilters = [
+            [
+                'field' => 'parent',
+                'operator' => 'IN',
+                'value' => ['venus'],
+                'context' => [
+                    'locale' => 'en_US',
+                    'scope'  => 'ecommerce',
+                    'limit'  => 25,
+                    'from'   => 0,
+                    'field'  => 'color',
+                ],
+                'type' => 'field',
+            ],
+        ];
+        $this->assertProductsCountInSelection($pqbFilters, 12);
+    }
+
+    /**
      * @return Configuration
      */
     protected function getConfiguration()

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/Doctrine/ORM/Query/CountImpactedProductsIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/Doctrine/ORM/Query/CountImpactedProductsIntegration.php
@@ -180,20 +180,14 @@ class CountImpactedProductsIntegration extends TestCase
     {
         $pqbFilters = [
             [
-                'field' => 'parent',
+                'field'    => 'parent',
                 'operator' => 'IN',
-                'value' => ['venus'],
-                'context' => [
-                    'locale' => 'en_US',
-                    'scope'  => 'ecommerce',
-                    'limit'  => 25,
-                    'from'   => 0,
-                    'field'  => 'color',
-                ],
-                'type' => 'field',
+                'value'    => ['venus'],
+                'context'  => ['locale' => 'en_US', 'scope' => 'ecommerce', 'limit' => 25, 'from' => 0],
+                'type'     => 'field',
             ],
         ];
-        $this->assertProductsCountInSelection($pqbFilters, 12);
+        $this->assertProductsCountInSelection($pqbFilters, 3);
     }
 
     /**


### PR DESCRIPTION
When selecting "all" for bulk actions AND a filter on a parent identifier to have only the variants of a certain product model, the product count displayed in the bulk action confirmation equals 0.
This is because we don't have the `parent` field indexed in the products index and we must use the product and product model index where the field `parent` exists.

Note: we could also fix the product index, but it's less doable in a patch.

This PR uses the product and product model index and filter on product entity types to achieve the same filter result.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Fixed
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
