### PR TITLE
Add constraint on products to check expected attributes

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
@@ -1127,6 +1127,10 @@ JSON;
                     'property' => 'parent',
                     'message'  => 'The variant product "new_product_variant" cannot have product model "test" as parent, (this product model can only have other product models as children)',
                 ],
+                [
+                    'property' => 'attribute',
+                    'message' => 'Cannot set the property "sku" to this entity as it is not in the attribute set'
+                ]
             ],
         ];
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductToVariantIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductToVariantIntegration.php
@@ -110,6 +110,10 @@ JSON;
                         'message' => 'The variant product "product_family_variant" cannot have product model ' .
                             '"test" as parent, (this product model can only have other product models as children)'
                     ],
+                    [
+                        'property' => 'attribute',
+                        'message' => 'Cannot set the property "sku" to this entity as it is not in the attribute set'
+                    ]
                 ]
             ],
             json_decode($response->getContent(), true)

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/product.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/product.yml
@@ -16,6 +16,7 @@ Pim\Component\Catalog\Model\Product:
         - Pim\Component\Catalog\Validator\Constraints\UniqueVariantAxis:
             groups: [UniqueAxis]
         - Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxesValues: ~
+        - Pim\Component\Catalog\Validator\Constraints\OnlyExpectedAttributes: ~
 
     properties:
         identifier:

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateVariantProductIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/CreateVariantProductIntegration.php
@@ -31,7 +31,7 @@ class CreateVariantProductIntegration extends TestCase
         ]);
 
         $errors = $this->get('pim_catalog.validator.product')->validate($variantProduct);
-        $this->assertEquals(2, $errors->count());
+        $this->assertEquals(4, $errors->count());
         $this->assertEquals(
             'The variant product "minerva_blue_m" cannot have product model "minerva" as parent, (this product model can only have other product models as children)',
             $errors->get(1)->getMessage()

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/OnlyExpectedAttributesValidationIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/OnlyExpectedAttributesValidationIntegration.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Validation;
+
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2018 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class OnlyExpectedAttributesValidationIntegration extends TestCase
+{
+    public function testAttributeBelongsToFamilyValidation()
+    {
+        $variantProduct = $this->get('pim_catalog.repository.product')->findOneByIdentifier('running-shoes-m-crimson-red');
+
+        $data = [
+            'values' => [
+                'care_instructions' => [['locale' => null, 'scope' => null, 'data' => 'invalid']]
+            ]
+        ];
+
+        $this->get('pim_catalog.updater.product')->update($variantProduct, $data);
+        $violations = $this->get('pim_catalog.validator.product')->validate($variantProduct);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('Attribute "care_instructions" does not belong to the family "shoes"', $violations->get(0)->getMessage());
+        $this->assertSame('attribute', $violations->get(0)->getPropertyPath());
+    }
+
+    public function testAttributeBelongsToAttributeSetValidation()
+    {
+        $variantProduct = $this->get('pim_catalog.repository.product')->findOneByIdentifier('running-shoes-m-crimson-red');
+
+        $data = [
+            'values' => [
+                'variation_name' => [['locale' => 'en_US', 'scope' => null, 'data' => 'invalid']]
+            ]
+        ];
+
+        $this->get('pim_catalog.updater.product')->update($variantProduct, $data);
+        $violations = $this->get('pim_catalog.validator.product')->validate($variantProduct);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('Cannot set the property "variation_name" to this entity as it is not in the attribute set', $violations->get(0)->getMessage());
+        $this->assertSame('attribute', $violations->get(0)->getPropertyPath());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+}

--- a/src/Pim/Component/Catalog/Validator/Constraints/OnlyExpectedAttributes.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/OnlyExpectedAttributes.php
@@ -14,6 +14,9 @@ class OnlyExpectedAttributes extends Constraint
     public const ATTRIBUTE_UNEXPECTED = 'pim_catalog.constraint.can_have_family_variant_unexpected_attribute';
     public const ATTRIBUTE_DOES_NOT_BELONG_TO_FAMILY = 'pim_catalog.constraint.attribute_does_not_belong_to_family';
 
+    /** @var string */
+    public $propertyPath = 'attribute';
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

There was a missing constraint on products to prevent:
- To set attributes on a product if the attribute is not in the family
- To set attributes on a variant product if the attribute is not in the attribute set (on the level)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | N
| Added legacy Behats               | N
| Added acceptance tests            | N
| Added integration tests           | Y
| Changelog updated                 | N
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo