### PR TITLE
Avoid error when no label is set

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/simple-select-async.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/simple-select-async.js
@@ -186,6 +186,13 @@ define(
              * @returns {Object}
              */
             convertBackendItem(item) {
+                if (undefined !== item.label) {
+                    return {
+                        id: item.code,
+                        text: item.label
+                    }
+                }
+
                 return {
                     id: item.code,
                     text: i18n.getLabel(item.labels, UserContext.get('catalogLocale'), item.code)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/label.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/label.js
@@ -44,6 +44,10 @@ define(
             getLabel: function () {
                 var data = this.getFormData();
 
+                if (undefined === data.labels) {
+                    return '';
+                }
+
                 return i18n.getLabel(
                     data.labels,
                     UserContext.get('catalogLocale'),


### PR DESCRIPTION
Fixes an annoying case that happen often in creation mode : your model is empty so the `labels` index doesn't even exist and you get an error in `i18n.getLabel()` method.