### PR TITLE
Fix mixed missing fields and non localized fields

### DIFF
--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product.php
@@ -315,7 +315,7 @@ class Product implements ArrayConverterInterface
         }
 
         $nonLocalizableOrScopableFields = $this->filterNonLocalizableOrScopableFields($unknownFields);
-        $unknownFields = array_diff($unknownFields, $nonLocalizableOrScopableFields);
+        $unknownFields = array_values(array_diff($unknownFields, $nonLocalizableOrScopableFields));
 
         $messages = [];
         if (0 < count($unknownFields)) {


### PR DESCRIPTION
For example: if $unknownFields is:

```
array(3) {
  [0]=>
  string(16) "meta_description"
  [1]=>
  string(10) "meta_title"
  [2]=>
  string(10) "model_name"
}
```

After filtering it with `array_diff` it contains:

``` 
array(1) {
  [2]=>
  string(10) "model_name"
}
```

And then this line: `sprintf('The field "%s" does not exist.', $unknownFields[0])` would throw a notice: `Notice: Undefined offset: 0`

array_values recreates the index so `[0]` always exists.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
