### PR TITLE
PIM-7465: Set front-end entity into field context

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,3 +1,9 @@
+# 2.3.x
+
+## Enhancements
+
+- PIM-7465: Set form data entity into field context.
+
 # 2.3.0 (2018-06-25)
 
 # 2.3.0-BETA1 (2018-06-21)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -263,10 +263,11 @@ define(
                         AttributeManager.isOptional(field.attribute, object)
                     );
                 }).then(function (field, channels, isOptional) {
-                    var scope = _.findWhere(channels, { code: UserContext.get('catalogScope') });
-                    var locale = UserContext.get('catalogLocale');
+                    const scope = _.findWhere(channels, { code: UserContext.get('catalogScope') });
+                    const locale = UserContext.get('catalogLocale');
 
                     field.setContext({
+                        entity: this.getFormData(),
                         locale,
                         scope: scope.code,
                         scopeLabel: i18n.getLabel(scope.labels, locale, scope.code),


### PR DESCRIPTION
## Description

Until now, product and product model fields were not aware of the entity they belonged too.

With this PR, we send to the form data (meaning, the edited entity) into the field context..

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
