### PR TITLE
PIM-7461 Allow to avoid type check on category filter

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,14 +1,15 @@
 # 1.7.x
 
 ## Bug fixes
- - PIM-7373: Fix deletion and reinsertion of all attributes relations at family save time
+- PIM-7461: Allow to avoid type check on category filter
+- PIM-7366: Fix performance issue related to reloading of selected category children ids on the grid
+- PIM-7373: Fix deletion and reinsertion of all attributes relations at family save time
 
 # 1.7.23 (2018-06-25)
 
 ## Bug fixes
 
 - PIM-7400: Fix 'ensure-indexes' timeout command
-- PIM-7366: Fix performance issue related to reloading of selected category children ids on the grid
 
 # 1.7.22 (2018-06-05)
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/CategoryFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Filter/CategoryFilter.php
@@ -64,7 +64,9 @@ class CategoryFilter implements FieldFilterInterface
     {
         $categoryIds = $value;
         if ($operator !== Operators::UNCLASSIFIED) {
-            $this->checkValue($field, $value);
+            if (!isset($options['type_checking']) || $options['type_checking']) {
+                $this->checkValue($field, $value);
+            }
 
             if (FieldFilterHelper::getProperty($field) === FieldFilterHelper::CODE_PROPERTY) {
                 $categoryIds = $this->objectIdResolver->getIdsFromCodes('category', $value);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The category filter checks that every single parameter provided is in the correct format. When we need to apply a filter to thousands of categories, this check is very costly especially as it's useless because we just got the category ids from the database.

A new option has been added to avoid checking type of parameters.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | WIP
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
