### PR TITLE
Improve usage of docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ npm-debug.log
 !/docker/akeneo.conf
 !/docker/akeneo-behat.conf
 !/docker/httpd.conf
+.env
 docker-compose.override.yml
 .web-server-pid
 

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,0 +1,49 @@
+version: '2'
+
+# Copy this file as "docker-compose.override.yml", and use it to override/add configuration on your containers.
+# You can find a detailed documentation here: https://docs.akeneo.com/master/install_pim/docker/installation_docker.html
+
+services:
+  fpm:
+    environment:
+      COMPOSER_HOME: '/home/docker/.composer'
+      BEHAT_TMPDIR: '/srv/pim/var/cache/tmp'
+      PHP_IDE_CONFIG: 'serverName=pim-ce-cli'
+      PHP_XDEBUG_ENABLED: 0
+      XDEBUG_CONFIG: 'remote_host=172.10.0.1'
+    volumes:
+      - '~/.composer:/home/docker/.composer'
+      - '/tmp/behat/screenshots:/tmp/behat/screenshots'
+
+  node:
+    environment:
+      YARN_CACHE_FOLDER: '/home/node/.yarn-cache'
+    volumes:
+      - ~/.cache/yarn:/home/node/.yarn-cache
+
+  selenium:
+    ports:
+      - '5910:5900'
+
+  httpd:
+    environment:
+      PHP_IDE_CONFIG: 'serverName=pim-ce'
+
+  httpd-behat:
+    environment:
+      PHP_IDE_CONFIG: 'serverName=pim-ce-behat'
+
+  mysql:
+    ports:
+      - '33006:3306'
+
+  mysql-behat:
+    ports:
+      - '33007:3306'
+    tmpfs:
+      - '/tmp'
+      - '/var/lib/mysql'
+
+  elasticsearch:
+    ports:
+      - '9210:9200'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,96 +2,86 @@ version: '2'
 
 services:
   fpm:
-    image: akeneo/fpm:php-7.1
-    environment:
-      COMPOSER_HOME: '/home/docker/.composer'
-      BEHAT_TMPDIR: '/srv/pim/var/cache/tmp'
-    user: docker
+    image: 'akeneo/fpm:php-7.1'
+    user: 'docker'
     volumes:
-      - ./:/srv/pim
-      - ~/.composer:/home/docker/.composer
-      - /tmp/behat/screenshots:/tmp/behat/screenshots
-    working_dir: /srv/pim
+      - './:/srv/pim'
+    working_dir: '/srv/pim'
     networks:
-      - akeneo
-      - behat
+      - 'akeneo'
+      - 'behat'
 
   node:
-    image: juliensnz/node
-    environment:
-      YARN_CACHE_FOLDER: '/home/node/.yarn-cache'
-    user: node
+    image: 'juliensnz/node'
+    user: 'node'
     volumes:
-      - ./:/srv/pim
-      - ~/.cache/yarn:/home/node/.yarn-cache
-    working_dir: /srv/pim
+      - .'/:/srv/pim'
+    working_dir: '/srv/pim'
     networks:
-      - akeneo
-      - behat
+      - 'akeneo'
+      - 'behat'
 
   selenium:
-    image: selenium/standalone-firefox-debug:2.53.1-beryllium
+    image: 'selenium/standalone-firefox-debug:2.53.1-beryllium'
     volumes:
-      - ./:/srv/pim:ro
+      - './:/srv/pim:ro'
     networks:
-      - behat
+      - 'behat'
 
   httpd:
-    image: httpd:2.4
+    image: 'httpd:2.4'
     depends_on:
-      - fpm
-    environment:
-      PHP_IDE_CONFIG: 'serverName=pim-ce'
+      - 'fpm'
     ports:
       - '${DOCKER_PORT_HTTP}:80'
     volumes:
-      - ./:/srv/pim:ro
-      - ./docker/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro
-      - ./docker/akeneo.conf:/usr/local/apache2/conf/vhost.conf:ro
+      - './:/srv/pim:ro'
+      - './docker/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro'
+      - './docker/akeneo.conf:/usr/local/apache2/conf/vhost.conf:ro'
     networks:
-      - akeneo
+      - 'akeneo'
 
   httpd-behat:
-    image: httpd:2.4
+    image: 'httpd:2.4'
     depends_on:
-      - fpm
+      - 'fpm'
     ports:
       - '${DOCKER_PORT_HTTP_BEHAT}:80'
     volumes:
-      - ./:/srv/pim:ro
-      - ./docker/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro
-      - ./docker/akeneo-behat.conf:/usr/local/apache2/conf/vhost.conf:ro
+      - './:/srv/pim:ro'
+      - './docker/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro'
+      - './docker/akeneo-behat.conf:/usr/local/apache2/conf/vhost.conf:ro'
     networks:
-      - behat
+      - 'behat'
 
   mysql:
-    image: mysql:5.7
+    image: 'mysql:5.7'
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_USER: akeneo_pim
-      MYSQL_PASSWORD: akeneo_pim
-      MYSQL_DATABASE: akeneo_pim
+      MYSQL_ROOT_PASSWORD: 'root'
+      MYSQL_USER: 'akeneo_pim'
+      MYSQL_PASSWORD: 'akeneo_pim'
+      MYSQL_DATABASE: 'akeneo_pim'
     networks:
-      - akeneo
+      - 'akeneo'
 
   mysql-behat:
-    image: mysql:5.7
+    image: 'mysql:5.7'
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_USER: akeneo_pim
-      MYSQL_PASSWORD: akeneo_pim
-      MYSQL_DATABASE: akeneo_pim
+      MYSQL_ROOT_PASSWORD: 'root'
+      MYSQL_USER: 'akeneo_pim'
+      MYSQL_PASSWORD: 'akeneo_pim'
+      MYSQL_DATABASE: 'akeneo_pim'
     networks:
-      - behat
+      - 'behat'
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.3
+    image: 'docker.elastic.co/elasticsearch/elasticsearch:5.5.3'
     environment:
       ES_JAVA_OPTS: '-Xms512m -Xmx512m'
       discovery.type: 'single-node'
     networks:
-      - akeneo
-      - behat
+      - 'akeneo'
+      - 'behat'
 
 networks:
   akeneo:


### PR DESCRIPTION
## Description

This PR aims to finish the clean up the `docker-compose.yml` file on `master` branch, and keep in it only what is mandatory to have a working PIM. As the port mapping of the Apache container is mandatory, it was placed in a previous PR in a `.env.yml.dist` file that the developer needs to copy and configure first (this way, the Apache output ports can still be configured).

Every other configuration is to be placed in `docker-compose.override.yml`, at the developer's convenience. A `.dist` example is added.

If this PR is accepted, it will be ported to EE and standard editions, and documentation will be updated.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
