### PR TITLE
Fix memory attribute repository to support array values as filter

### DIFF
--- a/tests/back/Acceptance/Attribute/InMemoryAttributeRepository.php
+++ b/tests/back/Acceptance/Attribute/InMemoryAttributeRepository.php
@@ -69,16 +69,16 @@ class InMemoryAttributeRepository implements AttributeRepositoryInterface, Saver
         foreach ($this->attributes as $attribute) {
             foreach ($criteria as $key => $value) {
                 $getter = sprintf('get%s', ucfirst($key));
-                if(is_array($value))
+
+                if(! is_array($value))
                 {
-                    foreach ($value as $criteriaValue) {
-                        if($attribute->$getter() === $criteriaValue) {
-                            $attributes[] = $attribute;
-                        }
-                    }
+                    $value = [$value];
                 }
-                elseif ($attribute->$getter() === $value) {
-                    $attributes[] = $attribute;
+
+                foreach ($value as $criteriaValue) {
+                    if($attribute->$getter() === $criteriaValue) {
+                        $attributes[] = $attribute;
+                    }
                 }
             }
         }

--- a/tests/back/Acceptance/Attribute/InMemoryAttributeRepository.php
+++ b/tests/back/Acceptance/Attribute/InMemoryAttributeRepository.php
@@ -67,16 +67,19 @@ class InMemoryAttributeRepository implements AttributeRepositoryInterface, Saver
     {
         $attributes = [];
         foreach ($this->attributes as $attribute) {
-            $keepThisAttribute = true;
             foreach ($criteria as $key => $value) {
                 $getter = sprintf('get%s', ucfirst($key));
-                if ($attribute->$getter() !== $value) {
-                    $keepThisAttribute = false;
+                if(is_array($value))
+                {
+                    foreach ($value as $criteriaValue) {
+                        if($attribute->$getter() === $criteriaValue) {
+                            $attributes[] = $attribute;
+                        }
+                    }
                 }
-            }
-
-            if ($keepThisAttribute) {
-                $attributes[] = $attribute;
+                elseif ($attribute->$getter() === $value) {
+                    $attributes[] = $attribute;
+                }
             }
         }
 

--- a/tests/back/Acceptance/spec/Attribute/InMemoryAttributeRepositorySpec.php
+++ b/tests/back/Acceptance/spec/Attribute/InMemoryAttributeRepositorySpec.php
@@ -67,6 +67,21 @@ class InMemoryAttributeRepositorySpec extends ObjectBehavior
         $this->findBy(['code' => 'attribute_2'])->shouldReturn([]);
     }
 
+    function it_finds_attributes_by_array_criteria()
+    {
+        $attribute1 = $this->createAttribute('attribute_1');
+        $attribute2 = $this->createAttribute('attribute_2');
+        $attribute3 = $this->createAttribute('attribute_3');
+
+        $this->beConstructedWith([
+            $attribute1->getCode() => $attribute1,
+            $attribute2->getCode() => $attribute2,
+            $attribute3->getCode() => $attribute3,
+        ]);
+
+        $this->findBy(['code' => ['attribute_1', 'attribute_2']])->shouldReturn([$attribute1, $attribute2]);
+    }
+
     function it_throws_an_exception_if_saved_object_is_not_an_attribute(\StdClass $object)
     {
         $this


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
the findBy method in attribute repository didn't accept array for criteria filter values.
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
