### PR TITLE
[Translations] Fix wrong translation link (not translatable)

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/catalog_volume/index.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/catalog_volume/index.yml
@@ -43,6 +43,7 @@ extensions:
         config:
             title: catalog_volume.product_values
             description: catalog_volume.product_values_description
+            link: https://medium.com/akeneo-labs/because-your-product-catalog-typology-matters-e1a9af4c33e0
 
     pim-catalog-volume-product-values-section:
         module: pim/catalog-volume/section
@@ -56,6 +57,7 @@ extensions:
             hint:
                 code: hint-product-values
                 title: catalog_volume.section.product_values.hint
+                link: https://medium.com/akeneo-labs/because-your-product-catalog-typology-matters-e1a9af4c33e0
             axes: [count_products, count_channels, count_scopable_attributes, average_max_attributes_per_family, count_locales, count_localizable_and_scopable_attributes, count_localizable_attributes]
 
     pim-catalog-volume-catalog-structure-section:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -1256,4 +1256,4 @@ config:
         pim/template/catalog-volume/header:       pimenrich/templates/catalog-volume/header.html
         pim/template/catalog-volume/section:      pimenrich/templates/catalog-volume/section.html
         pim/template/catalog-volume/number:       pimenrich/templates/catalog-volume/number.html
-        pim/template/catalog-volume/average-max:     pimenrich/templates/catalog-volume/average-max.html
+        pim/template/catalog-volume/average-max:  pimenrich/templates/catalog-volume/average-max.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/catalog-volume/header.ts
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/catalog-volume/header.ts
@@ -3,6 +3,7 @@ import * as _ from 'underscore';
 
 const __ = require('oro/translator');
 const template = require('pim/template/catalog-volume/header');
+const userContext = require('pim/user-context');
 
 interface HeaderConfig {
   title: string;
@@ -44,7 +45,10 @@ class HeaderView extends BaseView {
     if (undefined !== productValues && productValues.value > 0) {
       const headerContents: string = this.headerTemplate({
         title: __(this.config.title)
-          .replace('{{values}}', productValues.value.toLocaleString('en', {useGrouping: true}))
+          .replace('{{values}}', productValues.value.toLocaleString(
+            userContext.get('uiLocale').split('_')[0],
+            {useGrouping: true})
+          )
           .replace('{{average}}', productValuesAverage.value.average),
         description: __(this.config.description).replace('{{link}}', this.config.link),
       });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/catalog-volume/header.ts
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/catalog-volume/header.ts
@@ -7,6 +7,7 @@ const template = require('pim/template/catalog-volume/header');
 interface HeaderConfig {
   title: string;
   description: string;
+  link: string,
 }
 
 /**
@@ -45,7 +46,7 @@ class HeaderView extends BaseView {
         title: __(this.config.title)
           .replace('{{values}}', productValues.value.toLocaleString('en', {useGrouping: true}))
           .replace('{{average}}', productValuesAverage.value.average),
-        description: __(this.config.description).replace('{{link}}', __('catalog_volume.link')),
+        description: __(this.config.description).replace('{{link}}', this.config.link),
       });
 
       this.$el.html(headerContents);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/catalog-volume/section.ts
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/catalog-volume/section.ts
@@ -26,6 +26,7 @@ interface SectionConfig {
   hint: {
     code: string;
     title: string;
+    link: string;
   };
   title: string;
 }
@@ -58,6 +59,7 @@ class SectionView extends BaseView {
     hint: {
       code: '',
       title: '',
+      link: '',
     },
     title: ''
   };
@@ -117,7 +119,7 @@ class SectionView extends BaseView {
     this.$el.empty().html(
       this.template({
         title: __(this.config.title),
-        hintTitle: __(this.config.hint.title).replace('{{link}}', __('catalog_volume.link')),
+        hintTitle: __(this.config.hint.title).replace('{{link}}', this.config.hint.link),
         hintIsHidden: this.hintIsHidden(),
         align: this.config.align,
       })

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/catalog-volume/section.ts
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/catalog-volume/section.ts
@@ -5,6 +5,7 @@ import BaseView = require('pimenrich/js/view/base');
 const __ = require('oro/translator');
 const template = require('pim/template/catalog-volume/section');
 const requireContext = require('require-context');
+const userContext = require('pim/user-context');
 
 class NoTemplateForAxisError extends Error {}
 
@@ -183,9 +184,12 @@ class SectionView extends BaseView {
         name,
         icon: this.getIconName(name),
         value: axis.value,
-        has_warning: axis.hasWarning,
+        hasWarning: axis.hasWarning,
         title: __(`catalog_volume.axis.${name}`),
         warningText: this.config.warningText,
+        meanLabel: __('catalog_volume.mean'),
+        maxLabel: __('catalog_volume.max'),
+        userLocale: userContext.get('uiLocale').split('_')[0],
       });
 
       this.$('.AknCatalogVolume-axisContainer').append(el);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/catalog-volume/average-max.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/catalog-volume/average-max.html
@@ -1,13 +1,13 @@
 <div class="AknCatalogVolume-axis">
-    <div class="AknCatalogVolume-icon AknCatalogVolume-icon--<%- icon %> <%- (true === has_warning) ? 'AknCatalogVolume-icon--warning': '' %>"></div>
+    <div class="AknCatalogVolume-icon AknCatalogVolume-icon--<%- icon %> <%- (true === hasWarning) ? 'AknCatalogVolume-icon--warning': '' %>"></div>
     <div class="AknCatalogVolume-title">
         <%- title %>
         <div class="AknCatalogVolume-value" data-field="<%- name %>">
-            <span>Mean: <div><%- value.average %></div></span>
-            <span>Max: <div><%- value.max %></div></span>
+            <span><%- meanLabel %> <div><%- value.average.toLocaleString(userLocale, { useGrouping: true }) %></div></span>
+            <span><%- maxLabel %> <div><%- value.max.toLocaleString(userLocale, { useGrouping: true }) %></div></span>
         </div>
 
-        <% if (true === has_warning) { %>
+        <% if (true === hasWarning) { %>
             <div class="AknCatalogVolume-warning">
                 <%- warningText %>
             </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/catalog-volume/number.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/catalog-volume/number.html
@@ -1,11 +1,11 @@
 <div class="AknCatalogVolume-axis">
-    <div class="AknCatalogVolume-icon AknCatalogVolume-icon--<%- icon %> <%- (true === has_warning) ? 'AknCatalogVolume-icon--warning': '' %>"></div>
+    <div class="AknCatalogVolume-icon AknCatalogVolume-icon--<%- icon %> <%- (true === hasWarning) ? 'AknCatalogVolume-icon--warning': '' %>"></div>
     <div class="AknCatalogVolume-title">
         <%- title %>
         <div class="AknCatalogVolume-value" data-field="<%- name %>">
-            <%- value.toLocaleString('en', { useGrouping: true }) %>
+            <%- value.toLocaleString(userLocale, { useGrouping: true }) %>
         </div>
-        <% if (true === has_warning) { %>
+        <% if (true === hasWarning) { %>
             <div class="AknCatalogVolume-warning">
                 <%- warningText %>
             </div>

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -1527,3 +1527,5 @@ catalog_volume:
         count_variant_products: Variant products
         count_product_models: Product models
         warning: Wow! You hit a record with this axis! Don't hesitate to contact us if you need any help with this kind of volume.
+    mean: 'Mean:'
+    max: 'Max:'

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -1499,7 +1499,6 @@ pim_notification:
     loading: Loading...
 
 catalog_volume:
-    link: https://medium.com/akeneo-labs/because-your-product-catalog-typology-matters-e1a9af4c33e0
     product_values: "You have <span>{{values}}</span> product values in your PIM! On average, it's <span>{{average}}</span> product values per product!&nbsp;💪"
     product_values_description: 'The more product values you have, the more valuable your PIM is, the higher your ROI is! More details <a href="{{link}}" target="_blank">here</a>'
     section:

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/CatalogVolume.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/CatalogVolume.less
@@ -168,7 +168,7 @@
 
     &-axis {
         display: flex;
-        width: calc(100% / 3);
+        width: 100% / 3;
         height: auto;
         margin-bottom: 20px;
         padding-right: 20px;

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/CatalogVolume.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/CatalogVolume.less
@@ -168,7 +168,7 @@
 
     &-axis {
         display: flex;
-        width: 33%;
+        width: calc(100% / 3);
         height: auto;
         margin-bottom: 20px;
         padding-right: 20px;


### PR DESCRIPTION
There was a string on translations keys which should not be here.
I replaced it in the conf to not translate it.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

