### PR TITLE
PIM-7455: Fix product model indexation issue when computing descendants completeness

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductModelDescendantsSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductModelDescendantsSaver.php
@@ -109,7 +109,8 @@ class ProductModelDescendantsSaver implements SaverInterface
          * @TODO We need to remove the if condition during the pull day
          */
         if (null !== $this->productModelIndexer) {
-            $this->productModelIndexer->index($productModel);
+            $fullProductModel = $this->productModelRepository->findOneByIdentifier($productModel->getIdentifier());
+            $this->productModelIndexer->index($fullProductModel);
         }
     }
 

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
@@ -55,6 +55,7 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         ProductQueryBuilderInterface $pqb,
         ProductModelInterface $productModel,
         ProductModelInterface $productModelsChildren,
+        ProductModelInterface $fullProductModel,
         ProductInterface $variantProduct1,
         ProductInterface $variantProduct2,
         CursorInterface $cursor
@@ -88,7 +89,8 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $productModelRepository->findChildrenProductModels($productModel)->willReturn([$productModelsChildren]);
         $bulkProductModelIndexer->indexAll([$productModelsChildren]);
 
-        $productModelIndexer->index($productModel);
+        $productModelRepository->findOneByIdentifier('product_model_code')->willReturn($fullProductModel);
+        $productModelIndexer->index($fullProductModel)->shouldBeCalled();
 
         $this->save($productModel);
     }
@@ -103,6 +105,7 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $productModelIndexer,
         ProductQueryBuilderInterface $pqb,
         ProductModelInterface $productModel,
+        ProductModelInterface $fullProductModel,
         CursorInterface $cursor
     ) {
         $productModel->getCode()->willReturn('product_model_code');
@@ -126,7 +129,8 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $productModelRepository->findChildrenProductModels($productModel)->willReturn([]);
         $bulkProductModelIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();
 
-        $productModelIndexer->index($productModel);
+        $productModelRepository->findOneByIdentifier('product_model_code')->willReturn($fullProductModel);
+        $productModelIndexer->index($fullProductModel)->shouldBeCalled();
 
         $this->save($productModel);
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

Ensures that the product model being passed to `Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\ProductModelDescendantsSaver::save()` is rehydrated before being indexed in order to index the full data. See full description in https://github.com/akeneo/pim-enterprise-dev/pull/4149

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
