### PR TITLE
PIM-7462: Fix step execution read count

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7460: Fix locale flag for locales with two underscores like az_cyrl_AZ.
+- PIM-7462: Fix step execution read count
 
 # 2.0.28 (2018-06-26)
 

--- a/features/export/export_products.feature
+++ b/features/export/export_products.feature
@@ -43,6 +43,8 @@ Feature: Export products
     When I am on the "ecommerce_product_export" export job page
     And I launch the export job
     And I wait for the "ecommerce_product_export" job to finish
+    Then I should see the text "Read 2"
+    And I should see the text "Written 2"
     Then exported file of "ecommerce_product_export" should contain:
     """
     sku;additional_colors;categories;color;cost-EUR;cost-GBP;cost-USD;country_of_manufacture;customer_rating-ecommerce;customs_tax-de_DE-EUR;customs_tax-de_DE-GBP;customs_tax-de_DE-USD;datasheet;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;enabled;family;groups;handmade;image;legend-de_DE;legend-en_GB;legend-en_US;legend-fr_FR;manufacturer;material;name-de_DE;name-en_GB;name-en_US;name-fr_FR;number_in_stock-ecommerce;price-EUR;price-GBP;price-USD;release_date-ecommerce;size;thumbnail;washing_temperature;washing_temperature-unit;weight;weight-unit

--- a/features/export/xlsx/export_products.feature
+++ b/features/export/xlsx/export_products.feature
@@ -43,6 +43,8 @@ Feature: Export products in XLSX
     And I am on the "xlsx_tablet_product_export" export job page
     And I launch the export job
     And I wait for the "xlsx_tablet_product_export" job to finish
+    Then I should see the text "Read 2"
+    And I should see the text "Written 2"
     Then exported xlsx file of "xlsx_tablet_product_export" should contain:
       | sku          | additional_colors | categories                 | color | cost-EUR | cost-GBP | cost-USD | country_of_manufacture | customer_rating-tablet | datasheet | description-en_GB-tablet | description-en_US-tablet | enabled | family  | groups | handmade | image                                 | legend-en_GB | legend-en_US | manufacturer     | material | name-en_GB    | name-en_US    | number_in_stock-tablet | price-EUR | price-GBP | price-USD | release_date-tablet | size   | thumbnail | washing_temperature | washing_temperature-unit | weight | weight-unit |
       | tshirt-white |                   | men_2013,men_2014,men_2015 | white | 10.00    | 30.00    | 20.00    | usa                    | 2                      |           |                          | A stylish white t-shirt  | 1       | tshirts |        | 1        | files/tshirt-white/image/SNKRS-1R.png |              |              | american_apparel | cotton   | White t-shirt | White t-shirt | 10                     | 10.00     | 9.00      | 15.00     | 2016-10-12          | size_M |           |                     |                          | 5      | KILOGRAM    |

--- a/src/Pim/Component/Connector/Reader/Database/ProductReader.php
+++ b/src/Pim/Component/Connector/Reader/Database/ProductReader.php
@@ -95,10 +95,11 @@ class ProductReader implements ItemReaderInterface, InitializableInterface, Step
                 $this->products->next();
             }
             $product = $this->products->current();
-            $this->stepExecution->incrementSummaryInfo('read');
         }
 
         if (null !== $product) {
+            $this->stepExecution->incrementSummaryInfo('read');
+
             $channel = $this->getConfiguredChannel();
             if (null !== $channel) {
                 $this->metricConverter->convert($product, $channel);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a bug in the product export summary where the read count was out of sync with the write count. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
