### PR TITLE
PIM-7473 - Enable cache for validation mapping

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -4,6 +4,7 @@
 
 - PIM-7429: Fix category tab in product edit form
 - PIM-7523: Fix accessibility for boolean switches
+- PIM-7473: Enables cache to avoid reloading validation mapping files
 
 # 1.7.25 (2018-07-06)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/pim.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/pim.yml
@@ -56,3 +56,7 @@ pim_catalog:
             - { value: 'MM/dd/yyyy', label: 'mm/dd/yyyy' }
             - { value: 'dd/MM/yyyy', label: 'dd/mm/yyyy' }
             - { value: 'dd.MM.yyyy', label: 'dd.mm.yyyy' }
+
+framework:
+    validation:
+        cache: apc


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

A lot of screens are using validation (grid, pef, etc...), but every time a HTTP request for those screens is made, the validation configuration is read from disk and the YML is interpreted, leading to slowness.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | WIP
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -