### PR TITLE
PIM-7474: Show job profile label instead of code in the headers

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -4,6 +4,7 @@
 - PIM-7461: Allow to avoid type check on category filter
 - PIM-7366: Fix performance issue related to reloading of selected category children ids on the grid
 - PIM-7373: Fix deletion and reinsertion of all attributes relations at family save time
+- PIM-7474: Show job profile label instead of code in the headers
 
 # 1.7.23 (2018-06-25)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/common/edit/meta.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/common/edit/meta.html
@@ -1,1 +1,1 @@
-<span class="AknTitleContainer-metaItem"><%- __('pim_enrich.form.job_instance.meta.job') %>: <%- jobInstance.code %> | <%- __('pim_enrich.form.job_instance.meta.connector') %>: <%- jobInstance.connector %></span>
+<span class="AknTitleContainer-metaItem"><%- __('pim_enrich.form.job_instance.meta.job') %>: <%- jobInstance.label %> | <%- __('pim_enrich.form.job_instance.meta.connector') %>: <%- jobInstance.connector %></span>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a bug where in the export and import profile headers the job code was shown instead of the label. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
