### PR TITLE
PIM-7460: Fix locale flag for locales with two underscores.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Bug fixes
+
+- PIM-7460: Fix locale flag for locales with two underscores like az_cyrl_AZ.
+
 # 2.0.28 (2018-06-26)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/i18n.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/i18n.js
@@ -8,10 +8,15 @@ define(
             getFlag: function (locale, displayLanguage) {
                 displayLanguage = (undefined === displayLanguage) ? true : displayLanguage;
                 if (locale) {
-                    var info = locale.split('_');
+                    const info = locale.split('_');
+                    let country = info[1];
+
+                    if (3 === info.length) {
+                        country = info[2];
+                    }
 
                     return this.flagTemplate({
-                        'country': info[1].toLowerCase(),
+                        'country': country.toLowerCase(),
                         'language': info[0],
                         'displayLanguage': displayLanguage
                     });


### PR DESCRIPTION
For the locales with multiples underscore like 'az_Cyrl_AZ' the flag don't appear.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
