### PR TITLE
Cast entity id for comparaison with MongoObject

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
@@ -399,7 +399,7 @@ class ProductRepository extends DocumentRepository implements
         $productQueryBuilder->addFilter($value->getAttribute()->getCode(), '=', $value->getData());
         $result = $qb->hydrate(false)->getQuery()->getSingleResult();
 
-        if (null === $result || (null !== $result && $value->getEntity()->getId() === (string) $result['_id'])) {
+        if (null === $result || (null !== $result && (string) $value->getEntity()->getId() === (string) $result['_id'])) {
             return false;
         }
 

--- a/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxisValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxisValidator.php
@@ -192,7 +192,7 @@ class UniqueVariantAxisValidator extends ConstraintValidator
         $matchingProducts = array_filter(
             $matchingProducts,
             function ($product) use ($entity) {
-                return $product['id'] !== $entity->getId();
+                return (string) $product['id'] !== (string) $entity->getId();
             }
         );
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

A proposition of https://akeneo.atlassian.net/browse/SDS-3526 : 
Without the fix, validators compare the product id from query (type string) with the validated product id (type object(MongoId)). Even if the value are the same, the test fail because of type and the product is not save.

This validation is made when during variant group save. When propagation are applied on product, product are validated before save.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
