### PR TITLE
PIM-7472: Fix variable who display the username in meta-title

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7460: Fix locale flag for locales with two underscores like az_cyrl_AZ.
+- PIM-7472: Fix variable who display the username in meta-title
 
 # 2.0.28 (2018-06-26)
 

--- a/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
@@ -155,7 +155,7 @@
 
 {% block content_data %}
     <script type="text/javascript">
-        require('pim/page-title').set({'user': '{{ form.vars.value.name }}'});
+        require('pim/page-title').set({'username': '{{ fullname }}'});
 
         window.flashMessages = JSON.parse('{{ app.session.flashbag.all|json_encode()|raw }}');
     </script>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Problem : The name in meta-title was not displayed (wrong variable)
Example: "User {{ username }} | Edit"

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
