### PR TITLE
PIM-7373 Fixes versioning guesser when deleting family

### DIFF
--- a/src/Pim/Bundle/VersioningBundle/UpdateGuesser/FamilyAttributeRequirementUpdateGuesser.php
+++ b/src/Pim/Bundle/VersioningBundle/UpdateGuesser/FamilyAttributeRequirementUpdateGuesser.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\VersioningBundle\UpdateGuesser;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\UnitOfWork;
 use Pim\Bundle\CatalogBundle\Entity\AttributeRequirement;
 
 /**
@@ -31,7 +32,11 @@ class FamilyAttributeRequirementUpdateGuesser implements UpdateGuesserInterface
         $updatedEntities = [];
 
         if ($entity instanceof AttributeRequirement) {
-            $updatedEntities[] = $entity->getFamily();
+            $family = $entity->getFamily();
+
+            if ($em->getUnitOfWork()->getEntityState($family) === UnitOfWork::STATE_MANAGED) {
+                $updatedEntities[] = $entity->getFamily();
+            }
         }
 
         return $updatedEntities;


### PR DESCRIPTION
Fixes Behat broken from PIM-7373 merge.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
