### PR TITLE
PIM-7480: Fix generation of export file name with a date

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -6,6 +6,7 @@
 - PIM-7472: Fix username display in user form title
 - PIM-7478: Fix memory leak on quick export
 - PIM-7462: Fix step execution read count
+- PIM-7480: Fix generation of export file name with a date
 
 # 2.0.28 (2018-06-26)
 

--- a/src/Pim/Component/Connector/Writer/File/AbstractItemMediaWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/AbstractItemMediaWriter.php
@@ -169,7 +169,8 @@ abstract class AbstractItemMediaWriter implements
         $filePath = $parameters->get($this->jobParamFilePath);
 
         if (false !== strpos($filePath, '%')) {
-            $defaultPlaceholders = ['%datetime%' => date($this->datetimeFormat), '%job_label%' => ''];
+            $datetime = $this->stepExecution->getStartTime()->format($this->datetimeFormat);
+            $defaultPlaceholders = ['%datetime%' => $datetime, '%job_label%' => ''];
             $jobExecution = $this->stepExecution->getJobExecution();
 
             if (isset($placeholders['%job_label%'])) {

--- a/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Csv/ProductWriterSpec.php
@@ -72,6 +72,7 @@ class ProductWriterSpec extends ObjectBehavior
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTime());
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . '%job_label%_product.csv');
         $jobParameters->has('ui_locale')->willReturn(false);
@@ -233,6 +234,7 @@ class ProductWriterSpec extends ObjectBehavior
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTime());
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . '%job_label%_product.csv');
         $jobParameters->has('ui_locale')->willReturn(false);
@@ -313,6 +315,7 @@ class ProductWriterSpec extends ObjectBehavior
         $flusher->setStepExecution($stepExecution)->shouldBeCalled();
 
         $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTime());
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobInstance->getLabel()->willReturn('CSV Product export');
         $jobExecution->getExecutionContext()->willReturn($executionContext);

--- a/src/Pim/Component/Connector/spec/Writer/File/Xlsx/ProductWriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Xlsx/ProductWriterSpec.php
@@ -72,6 +72,7 @@ class ProductWriterSpec extends ObjectBehavior
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTime());
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . '%job_label%_product.xlsx');
         $jobParameters->has('ui_locale')->willReturn(false);
@@ -236,6 +237,7 @@ class ProductWriterSpec extends ObjectBehavior
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTime());
         $jobParameters->get('withHeader')->willReturn(true);
         $jobParameters->get('filePath')->willReturn($this->directory . '%job_label%_product.xlsx');
         $jobParameters->has('ui_locale')->willReturn(false);
@@ -315,6 +317,7 @@ class ProductWriterSpec extends ObjectBehavior
         $flusher->setStepExecution($stepExecution)->shouldBeCalled();
 
         $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTime());
         $jobExecution->getExecutionContext()->willReturn($executionContext);
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobInstance->getLabel()->willReturn('CSV Product export');


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The date used to generate the names of the files of an export (the file itself and the archive) must be exactly the same to the nearest second. It was not necessarily the case because a new date is generated for each file (in a different instance of the same writer class), so the seconds could be different between the export file and the archive.

I arbitrarily chose to use the start time of the job step execution because it's the simplest solution to have the same date in the different instances of the writers. It doesn't really have any functional meanings to choose this date but the exact value itself doesn't matter as long as it indicates the time at which the export was executed. And I don't see a better way to do it without doing any BC-breaks.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
