### PR TITLE
Stabilize behat by overriding method of MinkContext with spin

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -6,9 +6,7 @@ default:
             filters:
                 tags: "~@skip&&~@skip-pef&&~@skip-nav&&~@doc&&~@unstable&&~@unstable-app&&~@deprecated"
             contexts:
-                - Behat\MinkExtension\Context\MinkContext
                 - Context\FeatureContext:
-                    - 'Context\FeatureContext'
                     -
                         base_url: 'http://127.0.0.1/'
                         timeout: 50000

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -3,9 +3,9 @@
 namespace Context;
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\Gherkin\Node\PyStringNode;
 use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Exception\ExpectationException;
+use Behat\MinkExtension\Context\MinkContext;
 use Behat\Symfony2Extension\Context\KernelAwareContext;
 use Behat\Testwork\Counter\Exception\TimerException;
 use Context\Spin\SpinCapableTrait;
@@ -24,7 +24,6 @@ use Pim\Behat\Context\Domain\System\PermissionsContext;
 use Pim\Behat\Context\Domain\TreeContext;
 use Pim\Behat\Context\HookContext;
 use Pim\Behat\Context\JobContext;
-use Pim\Behat\Context\PimContext;
 use Pim\Behat\Context\Storage\AttributeOptionStorage;
 use Pim\Behat\Context\Storage\FileInfoStorage;
 use Pim\Behat\Context\Storage\ProductStorage;
@@ -37,7 +36,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class FeatureContext extends PimContext implements KernelAwareContext
+class FeatureContext extends MinkContext implements KernelAwareContext
 {
     use SpinCapableTrait;
 
@@ -58,12 +57,10 @@ class FeatureContext extends PimContext implements KernelAwareContext
     /**
      * Register contexts
      *
-     * @param string $mainContextClass
      * @param array $parameters
      */
-    public function __construct(string $mainContextClass, array $parameters)
+    public function __construct(array $parameters)
     {
-        parent::__construct($mainContextClass);
         $this->setTimeout($parameters);
     }
 
@@ -268,20 +265,6 @@ class FeatureContext extends PimContext implements KernelAwareContext
     }
 
     /**
-     * @param PyStringNode $error
-     *
-     * @Then /^I should see:$/
-     */
-    public function iShouldSeeText(PyStringNode $error)
-    {
-        $this->spin(function () use ($error) {
-            $this->assertSession()->pageTextContains((string) $error);
-
-            return true;
-        }, sprintf('Unable to find the text "%s" in the page', $error));
-    }
-
-    /**
      * Clicks link with specified id|title|alt|text
      * Example: When I follow the link "Log In"
      * Example: And I follow the link "Log In"
@@ -296,30 +279,6 @@ class FeatureContext extends PimContext implements KernelAwareContext
             $this->getSession()->getPage()->clickLink($link);
             return true;
         }, sprintf('Link %s is not present on the page', $link));
-    }
-
-    /**
-     * @param PyStringNode $error
-     *
-     * @Then /^I should not see:$/
-     */
-    public function iShouldNotSeeText(PyStringNode $error)
-    {
-        $this->assertSession()->pageTextNotContains((string) $error);
-    }
-
-    /**
-     * Fills in form field with specified id|name|label|value.
-     *
-     * @param string $field
-     * @param string $value
-     *
-     * @When /^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)" on the current page$/
-     * @When /^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)" on the current page$/
-     */
-    public function fillFieldOnCurrentPage($field, $value)
-    {
-        $this->getMainContext()->getSubcontext('navigation')->getCurrentPage()->fillField($field, $value);
     }
 
     /**
@@ -341,6 +300,20 @@ class FeatureContext extends PimContext implements KernelAwareContext
     }
 
     /**
+     * Fills in form field with specified id|name|label|value.
+     *
+     * @param string $field
+     * @param string $value
+     *
+     * @When /^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with "(?P<value>(?:[^"]|\\")*)" on the current page$/
+     * @When /^(?:|I )fill in "(?P<value>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)" on the current page$/
+     */
+    public function fillFieldOnCurrentPage($field, $value)
+    {
+        $this->getSubcontext('navigation')->getCurrentPage()->fillField($field, $value);
+    }
+
+    /**
      * Get the mail recorder
      *
      * @return \Pim\Bundle\EnrichBundle\Mailer\MailRecorder
@@ -348,18 +321,6 @@ class FeatureContext extends PimContext implements KernelAwareContext
     public function getMailRecorder()
     {
         return $this->getContainer()->get('pim_enrich.mailer.mail_recorder');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assertNumElements($num, $element)
-    {
-        $this->spin(function () use ($num, $element) {
-            parent::assertNumElements($num, $element);
-
-            return true;
-        }, sprintf('Spinning for asserting "%d" num elements', $num));
     }
 
     /**
@@ -384,18 +345,6 @@ class FeatureContext extends PimContext implements KernelAwareContext
 
             return true;
         }, sprintf('Spinning for asserting checkbox "%d" is not checked', $checkbox));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assertPageContainsText($text)
-    {
-        $this->spin(function () use ($text) {
-            parent::assertPageContainsText($text);
-
-            return true;
-        }, sprintf('Current page does not contains "%s"', $text));
     }
 
     /**

--- a/features/Pim/Behat/Context/PimContext.php
+++ b/features/Pim/Behat/Context/PimContext.php
@@ -139,10 +139,6 @@ class PimContext extends RawMinkContext implements KernelAwareContext
      */
     public function getMainContext(): FeatureContext
     {
-        if (null === $this->mainContext) {
-            return $this;
-        }
-
         return $this->mainContext;
     }
 

--- a/features/user/create_and_delete_user.feature
+++ b/features/user/create_and_delete_user.feature
@@ -11,7 +11,7 @@ Feature: Create a user
   Scenario: Have English language as default language for new users
     Given I am on the user creation page
     And I visit the "Interfaces" tab
-    And I should see "English (United States)"
+    And I should see the text "English (United States)"
 
   Scenario: Successfully create a user
     Given I am on the user creation page


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Use spin + delete dead code.

Should fix random on tests/legacy/features/user/edit_user_group_and_role_assignations.feature:33 on master

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
