### PR TITLE
PIM-7490 Disable persistent filesystem cache for ACL

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,6 +1,7 @@
 # 1.7.x
 
 ## Bug fixes
+- PIM-7490: Disable filesystem based cache for ACL
 - PIM-7461: Allow to avoid type check on category filter
 - PIM-7366: Fix performance issue related to reloading of selected category children ids on the grid
 - PIM-7373: Fix deletion and reinsertion of all attributes relations at family save time

--- a/src/Oro/Bundle/SecurityBundle/Resources/config/services.yml
+++ b/src/Oro/Bundle/SecurityBundle/Resources/config/services.yml
@@ -2,7 +2,7 @@ parameters:
     oro_security.security_facade.class:                        Oro\Bundle\SecurityBundle\SecurityFacade
     oro_security.acl.manager.class:                            Oro\Bundle\SecurityBundle\Acl\Persistence\AclManager
     oro_security.acl.sid_manager.class:                        Oro\Bundle\SecurityBundle\Acl\Persistence\AclSidManager
-    oro_security.acl.cache.class:                              Oro\Bundle\SecurityBundle\Acl\Cache\FilesystemCache
+    oro_security.acl.cache.class:                              Doctrine\Common\Cache\ArrayCache
     oro_security.acl.ace_provider.class:                       Oro\Bundle\SecurityBundle\Acl\Persistence\AceManipulationHelper
     oro_security.acl.privilege_repository.class:               Oro\Bundle\SecurityBundle\Acl\Persistence\AclPrivilegeRepository
     oro_security.acl.extension_selector.class:                 Oro\Bundle\SecurityBundle\Acl\Extension\AclExtensionSelector
@@ -68,8 +68,6 @@ services:
     security.acl.cache.doctrine.cache_impl:
         public: false
         class: '%oro_security.acl.cache.class%'
-        arguments:
-            - '%kernel.cache_dir%/oro_acl'
 
     oro_security.acl.ace_provider:
         public: false


### PR DESCRIPTION
**Description**
This PR disables filesystem based persistent cache for ACL cache.

Persistent cache presents several problems when used in a multi-servers environment. Indeed, in this case, when an ACL is modified through the UI, only the cache of the server where this action occurred is refreshed.
The other servers are now desynchronized with the data in the database.

This PR aims to resolve this problem by using a transient cache based on an in-memory array.

This PR *has* a performance impact.

Some rapid tests show around 10% increase (from 1.45s to 1.6s) on the product grid.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | TODO
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
