### PR TITLE
PIM-7466: do not escape quotes for translation

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -5,6 +5,7 @@
 - PIM-7366: Fix performance issue related to reloading of selected category children ids on the grid
 - PIM-7373: Fix deletion and reinsertion of all attributes relations at family save time
 - PIM-7474: Show job profile label instead of code in the headers
+- PIM-7466: do not escape quotes for translation
 
 # 1.7.23 (2018-06-25)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/AttributeGroup/_js-handler.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/AttributeGroup/_js-handler.html.twig
@@ -37,7 +37,7 @@ require(
                     'class': 'no-hash',
                     'data-toggle': 'tooltip',
                     'data-placement': 'right',
-                    'data-original-title': '{{ "btn.create.attribute group"|trans|capitalize }}'
+                    'data-original-title': '{{ "btn.create.attribute group"|trans|striptags|capitalize|raw }}'
                 }).html(
                     $('<i>', { 'class': 'icon-plus-sign' })
                 ).on('click', function() {


### PR DESCRIPTION
French quotes are escaped when translated.
I used the raw filter to not escape them, and added the `striptags` filter to avoid script injection in translation files.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
