### PR TITLE
prevent Fatal Error: Cannot use Oro\Bundle\DataGridBundle\Common\Object as Object because 'Object' is a special class name

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -269,3 +269,7 @@
 - Move `Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxes` to `Akeneo\Pim\Structure\Component\Validator\Constraints\ImmutableVariantAxes`
 - Move `Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxesValidator` to `Akeneo\Pim\Structure\Component\Validator\Constraints\ImmutableVariantAxesValidator`
 - Remove `Pim\Component\Catalog\Model\AttributeTypeTranslationInterface`
+
+- Rename `Oro\Bundle\DataGridBundle\Common\Object` into `Oro\Bundle\DataGridBundle\Common\IterableObject`
+- Rename `Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject` into `Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject`
+- Rename `Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject` into `Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject`

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Technical improvement
 
 - TIP-236: Merge Oro User bundle/component into Akeneo User bundle/component 
+- GITHUB-8451: Add basic compatibility for PHP 7.2  (Thanks [janmyszkier](https://github.com/janmyszkier)!)
 
 ## Enhancements
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -242,3 +242,6 @@ find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Catalog\\Valida
 find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Catalog\\Validator\\Constraints\\FamilyRequirementsValidator/Akeneo\\Pim\\Structure\\Component\\Validator\\Constraints\\FamilyRequirementsValidator/g'
 find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Catalog\\Validator\\Constraints\\ImmutableVariantAxes/Akeneo\\Pim\\Structure\\Component\\Validator\\Constraints\\ImmutableVariantAxes/g'
 find ./src/ -type f -print0 | xargs -0 sed -i 's/Pim\\Component\\Catalog\\Validator\\Constraints\\ImmutableVariantAxesValidator/Akeneo\\Pim\\Structure\\Component\\Validator\\Constraints\\ImmutableVariantAxesValidator/g'
+find ./src/ -type f -print0 | xargs -0 sed -i 's/Oro\\Bundle\\DataGridBundle\\Common\\Object/Oro\\Bundle\\DataGridBundle\\Common\\IterableObject/g'
+find ./src/ -type f -print0 | xargs -0 sed -i 's/Oro\\Bundle\\DataGridBundle\\Datagrid\\Common\\ResultsObject/Oro\\Bundle\\DataGridBundle\\Datagrid\\Common\\ResultsIterableObject/g'
+find ./src/ -type f -print0 | xargs -0 sed -i 's/Oro\\Bundle\\DataGridBundle\\Datagrid\\Common\\MetadataObject/Oro\\Bundle\\DataGridBundle\\Datagrid\\Common\\MetadataIterableObject/g'

--- a/src/Oro/Bundle/DataGridBundle/Common/IterableObject.php
+++ b/src/Oro/Bundle/DataGridBundle/Common/IterableObject.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
-class Object implements \ArrayAccess, \IteratorAggregate
+class IterableObject implements \ArrayAccess, \IteratorAggregate
 {
     const NAME_KEY = 'name';
 

--- a/src/Oro/Bundle/DataGridBundle/Datagrid/Common/MetadataIterableObject.php
+++ b/src/Oro/Bundle/DataGridBundle/Datagrid/Common/MetadataIterableObject.php
@@ -2,9 +2,9 @@
 
 namespace Oro\Bundle\DataGridBundle\Datagrid\Common;
 
-use Oro\Bundle\DataGridBundle\Common\Object;
+use Oro\Bundle\DataGridBundle\Common\IterableObject;
 
-class MetadataObject extends Object
+class MetadataIterableObject extends IterableObject
 {
     const GRID_NAME_KEY = 'gridName';
     const OPTIONS_KEY = 'options';

--- a/src/Oro/Bundle/DataGridBundle/Datagrid/Common/ResultsIterableObject.php
+++ b/src/Oro/Bundle/DataGridBundle/Datagrid/Common/ResultsIterableObject.php
@@ -4,6 +4,6 @@ namespace Oro\Bundle\DataGridBundle\Datagrid\Common;
 
 use Oro\Bundle\DataGridBundle\Common\IterableObject;
 
-class DatagridConfiguration extends IterableObject
+class ResultsIterableObject extends IterableObject
 {
 }

--- a/src/Oro/Bundle/DataGridBundle/Datagrid/Common/ResultsObject.php
+++ b/src/Oro/Bundle/DataGridBundle/Datagrid/Common/ResultsObject.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Oro\Bundle\DataGridBundle\Datagrid\Common;
-
-use Oro\Bundle\DataGridBundle\Common\Object;
-
-class ResultsObject extends Object
-{
-}

--- a/src/Oro/Bundle/DataGridBundle/Datagrid/Datagrid.php
+++ b/src/Oro/Bundle/DataGridBundle/Datagrid/Datagrid.php
@@ -2,8 +2,8 @@
 
 namespace Oro\Bundle\DataGridBundle\Datagrid;
 
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Oro\Bundle\DataGridBundle\Extension\Acceptor;
 
@@ -40,7 +40,7 @@ class Datagrid implements DatagridInterface
         /** @var array $rows */
         $rows = $this->getAcceptedDatasource()->getResults();
 
-        $result = ResultsObject::create(['data' => $rows]);
+        $result = ResultsIterableObject::create(['data' => $rows]);
         $this->acceptor->acceptResult($result);
 
         return $result;
@@ -51,7 +51,7 @@ class Datagrid implements DatagridInterface
      */
     public function getMetadata()
     {
-        $data = MetadataObject::createNamed($this->getName(), []);
+        $data = MetadataIterableObject::createNamed($this->getName(), []);
         $this->acceptor->acceptMetadata($data);
 
         return $data;

--- a/src/Oro/Bundle/DataGridBundle/Datagrid/DatagridInterface.php
+++ b/src/Oro/Bundle/DataGridBundle/Datagrid/DatagridInterface.php
@@ -2,8 +2,8 @@
 
 namespace Oro\Bundle\DataGridBundle\Datagrid;
 
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Oro\Bundle\DataGridBundle\Extension\Acceptor;
 
@@ -62,7 +62,7 @@ interface DatagridInterface
      *    ....      => some additional info added by extensions
      * )
      *
-     * @return ResultsObject
+     * @return ResultsIterableObject
      */
     public function getData();
 
@@ -70,7 +70,7 @@ interface DatagridInterface
      * Retrieve metadata from all extensions
      * Metadata needed to create view layer
      *
-     * @return MetadataObject
+     * @return MetadataIterableObject
      */
     public function getMetadata();
 }

--- a/src/Oro/Bundle/DataGridBundle/Extension/AbstractExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/AbstractExtension.php
@@ -3,8 +3,8 @@
 namespace Oro\Bundle\DataGridBundle\Extension;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject;
 use Oro\Bundle\DataGridBundle\Datagrid\RequestParameters;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -37,14 +37,14 @@ abstract class AbstractExtension implements ExtensionVisitorInterface
     /**
      * {@inheritDoc}
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
     }
 
     /**
      * {@inheritDoc}
      */
-    public function visitResult(DatagridConfiguration $config, ResultsObject $result)
+    public function visitResult(DatagridConfiguration $config, ResultsIterableObject $result)
     {
     }
 

--- a/src/Oro/Bundle/DataGridBundle/Extension/Acceptor.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Acceptor.php
@@ -3,8 +3,8 @@
 namespace Oro\Bundle\DataGridBundle\Extension;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 
 class Acceptor
@@ -41,9 +41,9 @@ class Acceptor
     }
 
     /**
-     * @param ResultsObject $result
+     * @param ResultsIterableObject $result
      */
-    public function acceptResult(ResultsObject $result)
+    public function acceptResult(ResultsIterableObject $result)
     {
         foreach ($this->getExtensions() as $extension) {
             $extension->visitResult($this->getConfig(), $result);
@@ -51,9 +51,9 @@ class Acceptor
     }
 
     /**
-     * @param MetadataObject $data
+     * @param MetadataIterableObject $data
      */
-    public function acceptMetadata(MetadataObject $data)
+    public function acceptMetadata(MetadataIterableObject $data)
     {
         foreach ($this->getExtensions() as $extension) {
             $extension->visitMetadata($this->getConfig(), $data);

--- a/src/Oro/Bundle/DataGridBundle/Extension/Action/ActionConfiguration.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Action/ActionConfiguration.php
@@ -2,8 +2,8 @@
 
 namespace Oro\Bundle\DataGridBundle\Extension\Action;
 
-use Oro\Bundle\DataGridBundle\Common\Object;
+use Oro\Bundle\DataGridBundle\Common\IterableObject;
 
-class ActionConfiguration extends Object
+class ActionConfiguration extends IterableObject
 {
 }

--- a/src/Oro/Bundle/DataGridBundle/Extension/Action/ActionExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Action/ActionExtension.php
@@ -3,7 +3,7 @@
 namespace Oro\Bundle\DataGridBundle\Extension\Action;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
 use Oro\Bundle\DataGridBundle\Datasource\ResultRecordInterface;
 use Oro\Bundle\DataGridBundle\Extension\AbstractExtension;
 use Oro\Bundle\DataGridBundle\Extension\Action\Actions\ActionInterface;
@@ -96,7 +96,7 @@ class ActionExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
         $actionsMetadata = [];
         $actions = $config->offsetGetOr(static::ACTION_KEY, []);

--- a/src/Oro/Bundle/DataGridBundle/Extension/ExtensionVisitorInterface.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/ExtensionVisitorInterface.php
@@ -3,8 +3,8 @@
 namespace Oro\Bundle\DataGridBundle\Extension;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 
 interface ExtensionVisitorInterface
@@ -42,21 +42,21 @@ interface ExtensionVisitorInterface
      * Apply changes provided by applied extensions on result data
      *
      * @param DatagridConfiguration $config
-     * @param ResultsObject         $result
+     * @param ResultsIterableObject         $result
      *
      * @return mixed
      */
-    public function visitResult(DatagridConfiguration $config, ResultsObject $result);
+    public function visitResult(DatagridConfiguration $config, ResultsIterableObject $result);
 
     /**
      * Apply changes provided by applied extensions on metadata
      *
      * @param DatagridConfiguration $config
-     * @param MetadataObject        $data
+     * @param MetadataIterableObject        $data
      *
      * @return mixed
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data);
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data);
 
     /**
      * Returns priority needed for applying

--- a/src/Oro/Bundle/DataGridBundle/Extension/Formatter/FormatterExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Formatter/FormatterExtension.php
@@ -3,8 +3,8 @@
 namespace Oro\Bundle\DataGridBundle\Extension\Formatter;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject;
 use Oro\Bundle\DataGridBundle\Extension\AbstractExtension;
 use Oro\Bundle\DataGridBundle\Extension\Formatter\Property\PropertyConfiguration;
 use Oro\Bundle\DataGridBundle\Extension\Formatter\Property\PropertyInterface;
@@ -58,7 +58,7 @@ class FormatterExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function visitResult(DatagridConfiguration $config, ResultsObject $result)
+    public function visitResult(DatagridConfiguration $config, ResultsIterableObject $result)
     {
         $rows = (array)$result->offsetGetOr('data', []);
 
@@ -88,7 +88,7 @@ class FormatterExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
         // get only columns here because columns will be represented on frontend
         $columns = $config->offsetGetOr(Configuration::COLUMNS_KEY, []);

--- a/src/Oro/Bundle/DataGridBundle/Extension/Formatter/Property/PropertyConfiguration.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Formatter/Property/PropertyConfiguration.php
@@ -2,8 +2,8 @@
 
 namespace Oro\Bundle\DataGridBundle\Extension\Formatter\Property;
 
-use Oro\Bundle\DataGridBundle\Common\Object;
+use Oro\Bundle\DataGridBundle\Common\IterableObject;
 
-class PropertyConfiguration extends Object
+class PropertyConfiguration extends IterableObject
 {
 }

--- a/src/Oro/Bundle/DataGridBundle/Extension/GridViews/GridViewsExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/GridViews/GridViewsExtension.php
@@ -3,7 +3,7 @@
 namespace Oro\Bundle\DataGridBundle\Extension\GridViews;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
 use Oro\Bundle\DataGridBundle\Datagrid\RequestParameters;
 use Oro\Bundle\DataGridBundle\Extension\AbstractExtension;
 use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
@@ -37,7 +37,7 @@ class GridViewsExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
         $params = $this->getRequestParams()->get(RequestParameters::ADDITIONAL_PARAMETERS);
         $currentView = isset($params[self::VIEWS_PARAM_KEY]) ? $params[self::VIEWS_PARAM_KEY] : null;

--- a/src/Oro/Bundle/DataGridBundle/Extension/MassAction/MassActionExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/MassAction/MassActionExtension.php
@@ -3,7 +3,7 @@
 namespace Oro\Bundle\DataGridBundle\Extension\MassAction;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
 use Oro\Bundle\DataGridBundle\Datagrid\DatagridInterface;
 use Oro\Bundle\DataGridBundle\Extension\Action\ActionExtension;
 use Oro\Bundle\DataGridBundle\Extension\Action\Actions\ActionInterface;
@@ -48,7 +48,7 @@ class MassActionExtension extends ActionExtension
         return $action;
     }
 
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
         parent::visitMetadata($config, $data);
 

--- a/src/Oro/Bundle/DataGridBundle/Extension/Pager/OrmPagerExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Pager/OrmPagerExtension.php
@@ -4,8 +4,8 @@ namespace Oro\Bundle\DataGridBundle\Extension\Pager;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Builder;
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject;
 use Oro\Bundle\DataGridBundle\Datagrid\RequestParameters;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Oro\Bundle\DataGridBundle\Datasource\Orm\OrmDatasource;
@@ -73,7 +73,7 @@ class OrmPagerExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function visitResult(DatagridConfiguration $config, ResultsObject $result)
+    public function visitResult(DatagridConfiguration $config, ResultsIterableObject $result)
     {
         $result->offsetAddToArray('options', [self::TOTAL_PARAM => $this->pager->getNbResults()]);
     }
@@ -81,7 +81,7 @@ class OrmPagerExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
         $defaultPerPage = $config->offsetGetByPath(ToolbarExtension::PAGER_DEFAULT_PER_PAGE_OPTION_PATH, 10);
 

--- a/src/Oro/Bundle/DataGridBundle/Extension/Sorter/OrmSorterExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Sorter/OrmSorterExtension.php
@@ -4,7 +4,7 @@ namespace Oro\Bundle\DataGridBundle\Extension\Sorter;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Builder;
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Oro\Bundle\DataGridBundle\Datasource\Orm\OrmDatasource;
 use Oro\Bundle\DataGridBundle\Extension\AbstractExtension;
@@ -73,7 +73,7 @@ class OrmSorterExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
         $multisort = $config->offsetGetByPath(Configuration::MULTISORT_PATH, false);
         $sorters = $this->getSorters($config);
@@ -93,7 +93,7 @@ class OrmSorterExtension extends AbstractExtension
             );
         }
 
-        $data->offsetAddToArray(MetadataObject::OPTIONS_KEY, ['multipleSorting' => $multisort]);
+        $data->offsetAddToArray(MetadataIterableObject::OPTIONS_KEY, ['multipleSorting' => $multisort]);
 
         $sortersState = $data->offsetGetByPath('[state][sorters]', []);
         $sorters = $this->getSortersToApply($config);

--- a/src/Oro/Bundle/DataGridBundle/Extension/Toolbar/ToolbarExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Toolbar/ToolbarExtension.php
@@ -3,7 +3,7 @@
 namespace Oro\Bundle\DataGridBundle\Extension\Toolbar;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
 use Oro\Bundle\DataGridBundle\Extension\AbstractExtension;
 
 class ToolbarExtension extends AbstractExtension
@@ -40,7 +40,7 @@ class ToolbarExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
         /**
          * Default toolbar options
@@ -82,12 +82,12 @@ class ToolbarExtension extends AbstractExtension
         $options = $config->offsetGetByPath(ToolbarExtension::OPTIONS_PATH, []);
 
         // get user specified require js modules from options
-        if (isset($options[MetadataObject::REQUIRED_MODULES_KEY])) {
+        if (isset($options[MetadataIterableObject::REQUIRED_MODULES_KEY])) {
             $data->offsetAddToArray(
-                MetadataObject::REQUIRED_MODULES_KEY,
-                $options[MetadataObject::REQUIRED_MODULES_KEY]
+                MetadataIterableObject::REQUIRED_MODULES_KEY,
+                $options[MetadataIterableObject::REQUIRED_MODULES_KEY]
             );
-            unset($options[MetadataObject::REQUIRED_MODULES_KEY]);
+            unset($options[MetadataIterableObject::REQUIRED_MODULES_KEY]);
         }
 
         // grid options passed under "options" node

--- a/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datagrid/DatagridTest.php
+++ b/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datagrid/DatagridTest.php
@@ -72,7 +72,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
         $dataSource = $this->getMockForAbstractClass('Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface');
         $this->grid->setDatasource($dataSource);
 
-        $resultFQCN = 'Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject';
+        $resultFQCN = 'Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject';
 
         $this->acceptor->expects($this->once())->method('acceptDatasource')
             ->with($dataSource);
@@ -103,7 +103,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetMetaData()
     {
-        $resultFQCN = 'Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject';
+        $resultFQCN = 'Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject';
 
         $this->acceptor->expects($this->once())->method('acceptMetadata')
             ->with($this->isInstanceOf($resultFQCN));

--- a/src/Oro/Bundle/DataGridBundle/Tests/Unit/Extension/AbstractExtensionTest.php
+++ b/src/Oro/Bundle/DataGridBundle/Tests/Unit/Extension/AbstractExtensionTest.php
@@ -3,8 +3,8 @@
 namespace Oro\Bundle\DataGridBundle\Tests\Unit\Extension;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject;
 use Oro\Bundle\DataGridBundle\Extension\ExtensionVisitorInterface;
 use Oro\Bundle\DataGridBundle\Tests\Unit\DataFixtures\Stub\Extension\Configuration;
 use Oro\Bundle\DataGridBundle\Tests\Unit\DataFixtures\Stub\Extension\SomeExtension;
@@ -64,7 +64,7 @@ class AbstractExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testVisitResult()
     {
-        $result = ResultsObject::create([]);
+        $result = ResultsIterableObject::create([]);
         $config = DatagridConfiguration::create([]);
 
         $this->extension->visitResult($config, $result);
@@ -75,7 +75,7 @@ class AbstractExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testVisitMetadata()
     {
-        $data = MetadataObject::create([]);
+        $data = MetadataIterableObject::create([]);
         $config = DatagridConfiguration::create([]);
 
         $this->extension->visitMetadata($config, $data);

--- a/src/Oro/Bundle/DataGridBundle/Tests/Unit/Extension/AcceptorTest.php
+++ b/src/Oro/Bundle/DataGridBundle/Tests/Unit/Extension/AcceptorTest.php
@@ -3,8 +3,8 @@
 namespace Oro\Bundle\DataGridBundle\Tests\Unit\Extension;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject;
 use Oro\Bundle\DataGridBundle\Extension\Acceptor;
 
 class AcceptorTest extends \PHPUnit_Framework_TestCase
@@ -87,7 +87,7 @@ class AcceptorTest extends \PHPUnit_Framework_TestCase
      */
     public function testAcceptResults()
     {
-        $result = ResultsObject::create([]);
+        $result = ResultsIterableObject::create([]);
 
         $extMock = $this->getMockForAbstractClass('Oro\Bundle\DataGridBundle\Extension\ExtensionVisitorInterface');
         $extMock->expects($this->once())->method('visitResult')->with($this->config, $result);
@@ -101,7 +101,7 @@ class AcceptorTest extends \PHPUnit_Framework_TestCase
      */
     public function testAcceptMetadata()
     {
-        $data = MetadataObject::create([]);
+        $data = MetadataIterableObject::create([]);
 
         $extMock = $this->getMockForAbstractClass('Oro\Bundle\DataGridBundle\Extension\ExtensionVisitorInterface');
         $extMock->expects($this->once())->method('visitMetadata')->with($this->config, $data);

--- a/src/Oro/Bundle/FilterBundle/Grid/Extension/OrmFilterExtension.php
+++ b/src/Oro/Bundle/FilterBundle/Grid/Extension/OrmFilterExtension.php
@@ -4,7 +4,7 @@ namespace Oro\Bundle\FilterBundle\Grid\Extension;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Builder;
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
 use Oro\Bundle\DataGridBundle\Datagrid\RequestParameters;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Oro\Bundle\DataGridBundle\Datasource\Orm\OrmDatasource;
@@ -88,7 +88,7 @@ class OrmFilterExtension extends AbstractExtension
     /**
      * {@inheritDoc}
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
         $filtersState = $data->offsetGetByPath('[state][filters]', []);
         $filtersMetaData = [];

--- a/src/Pim/Bundle/DataGridBundle/Extension/Filter/FilterExtension.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Filter/FilterExtension.php
@@ -4,7 +4,7 @@ namespace Pim\Bundle\DataGridBundle\Extension\Filter;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Builder;
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
 use Oro\Bundle\DataGridBundle\Datagrid\RequestParameters;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Oro\Bundle\DataGridBundle\Extension\AbstractExtension;
@@ -116,7 +116,7 @@ class FilterExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
         $filtersState = $data->offsetGetByPath('[state][filters]', []);
         $filtersConfig = $config->offsetGetByPath(Configuration::COLUMNS_PATH);

--- a/src/Pim/Bundle/DataGridBundle/Extension/Pager/PagerExtension.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Pager/PagerExtension.php
@@ -4,8 +4,8 @@ namespace Pim\Bundle\DataGridBundle\Extension\Pager;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Builder;
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\ResultsIterableObject;
 use Oro\Bundle\DataGridBundle\Datagrid\RequestParameters;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Oro\Bundle\DataGridBundle\Extension\AbstractExtension;
@@ -74,7 +74,7 @@ class PagerExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function visitResult(DatagridConfiguration $config, ResultsObject $result)
+    public function visitResult(DatagridConfiguration $config, ResultsIterableObject $result)
     {
         $result->offsetAddToArray('options', [self::TOTAL_PARAM => $this->getPager($config)->getNbResults()]);
     }
@@ -82,7 +82,7 @@ class PagerExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
         $defaultPerPage = $config->offsetGetByPath(ToolbarExtension::PAGER_DEFAULT_PER_PAGE_OPTION_PATH, 10);
 

--- a/src/Pim/Bundle/DataGridBundle/Extension/Sorter/SorterExtension.php
+++ b/src/Pim/Bundle/DataGridBundle/Extension/Sorter/SorterExtension.php
@@ -3,7 +3,7 @@
 namespace Pim\Bundle\DataGridBundle\Extension\Sorter;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
-use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataObject;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\MetadataIterableObject;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface;
 use Oro\Bundle\DataGridBundle\Extension\AbstractExtension;
 
@@ -82,7 +82,7 @@ class SorterExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function visitMetadata(DatagridConfiguration $config, MetadataObject $data)
+    public function visitMetadata(DatagridConfiguration $config, MetadataIterableObject $data)
     {
         $multisort = $config->offsetGetByPath(Configuration::MULTISORT_PATH, false);
         $sorters = $this->getSorters($config);
@@ -102,7 +102,7 @@ class SorterExtension extends AbstractExtension
             );
         }
 
-        $data->offsetAddToArray(MetadataObject::OPTIONS_KEY, ['multipleSorting' => $multisort]);
+        $data->offsetAddToArray(MetadataIterableObject::OPTIONS_KEY, ['multipleSorting' => $multisort]);
 
         $sortersState = $data->offsetGetByPath('[state][sorters]', []);
         $sorters = $this->getSortersToApply($config);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

tested 2.3 with PHP 7.2, got a fatal error:
PHP Fatal error: Cannot use Oro\Bundle\DataGridBundle\Common\Object as Object because 'Object' is a special class name
this pull request is created with PHPStorm refactor function (required small manual work afterward) to prevent this issue. Was easily reproduced by simply entering product grid in admin.

Note: Feel free to prepare the PR with your own naming conventions, I simply want to show what's necessary to make the issue go away correctly.
Especially I'm not sure if MetadataObject needs to be also renamed (again - not sure about naming convention behind it, but this is what PHPStorm refactor suggested so I'm sure there's a good reason it was also renamed)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
