### PR TITLE
PIM-7488: use catalog locale for attributes list in attribute groups

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,3 +1,7 @@
+# 2.3.x
+
+- PIM-7488: use catalog locale for attributes list in attribute groups
+
 # 2.3.1 (2018-07-04)
 
 ## Enhancements

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,7 @@
 # 2.3.x
 
+## Bug fixes
+
 - PIM-7488: use catalog locale for attributes list in attribute groups
 
 # 2.3.1 (2018-07-04)

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/LocaleNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/LocaleNormalizer.php
@@ -18,6 +18,9 @@ class LocaleNormalizer implements NormalizerInterface
     /** @var string[] */
     protected $supportedFormats = ['internal_api'];
 
+    /** @var UserContext */
+    protected $userContext;
+
     /**
      * @param UserContext $userContext
      */
@@ -57,7 +60,7 @@ class LocaleNormalizer implements NormalizerInterface
      */
     private function getLocaleLabel($code, $translateIn = null)
     {
-        $translateIn = $translateIn ?: $this->userContext->getCurrentLocaleCode();
+        $translateIn = $translateIn ?: $this->userContext->getUiLocaleCode();
 
         return \Locale::getDisplayName($code, $translateIn);
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-group/tab/attribute.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-group/tab/attribute.html
@@ -26,7 +26,7 @@
                                     <i class="icon-reorder"></i>
                                 </span>
                             </td>
-                            <td class="AknGrid-bodyCell"><%- i18n.getLabel(attribute.labels, UserContext.get('uiLocale'), attribute.code) %></td>
+                            <td class="AknGrid-bodyCell"><%- i18n.getLabel(attribute.labels, UserContext.get('catalogLocale'), attribute.code) %></td>
                             <td class="AknGrid-bodyCell"><%- __('pim_enrich.entity.attribute.type.' + attribute.type) %></td>
                             <td class="AknGrid-bodyCell">
                                 <input type="checkbox" disabled="disabled"<%- attribute.scopable ? ' checked="checked"' : '' %>>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/attribute-list.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/export/product/edit/content/structure/attribute-list.html
@@ -1,7 +1,7 @@
 <% _.each(attributes, function (attribute) { %>
 <li class="AknVerticalList-item AknVerticalList-item--movable" data-attribute-code="<%- attribute.code %>">
     <div>
-        <span class="attribute-label"><%- i18n.getLabel(attribute.labels, userContext.get('uiLocale'), attribute.code) %></span>
+        <span class="attribute-label"><%- i18n.getLabel(attribute.labels, userContext.get('catalogLocale'), attribute.code) %></span>
     </div>
     <span class="AknIconButton AknIconButton--grey AknIconButton--small remove"><i class="icon-trash"></i></span>
 </li>

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/LocaleNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/LocaleNormalizerSpec.php
@@ -21,7 +21,7 @@ class LocaleNormalizerSpec extends ObjectBehavior
     function it_normalizes_locales($userContext, LocaleInterface $en)
     {
         $en->getCode()->willReturn('en_US');
-        $userContext->getCurrentLocaleCode()->willReturn('en_US');
+        $userContext->getUiLocaleCode()->willReturn('en_US');
 
         $this->normalize($en, 'internal_api')->shouldReturn([
             'code'     => 'en_US',


### PR DESCRIPTION
In Attribute group Edition, attributs labels translation use ui locale when we should use catlaog locale.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
