### PR TITLE
Create a dedicated InstallerEvent

### DIFF
--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Event/InstallerEvent.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Event/InstallerEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Akeneo\Platform\Bundle\InstallerBundle\Event;
+
+use Akeneo\Platform\Bundle\InstallerBundle\CommandExecutor;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InstallerEvent extends GenericEvent
+{
+    /** @var CommandExecutor */
+    protected $commandExecutor;
+
+    /**
+     * @param CommandExecutor $commandExecutor
+     * @param null|string $subject
+     * @param array $arguments
+     */
+    public function __construct(CommandExecutor $commandExecutor, ?string $subject = null, array $arguments = [])
+    {
+        $this->commandExecutor = $commandExecutor;
+
+        parent::__construct($subject, $arguments);
+    }
+
+    /**
+     * @return CommandExecutor
+     */
+    public function getCommandExecutor(): CommandExecutor
+    {
+        return $this->commandExecutor;
+    }
+}

--- a/src/Akeneo/Platform/spec/Bundle/InstallerBundle/Event/InstallerEventSpec.php
+++ b/src/Akeneo/Platform/spec/Bundle/InstallerBundle/Event/InstallerEventSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace spec\Akeneo\Platform\Bundle\InstallerBundle\Event;
+
+use Akeneo\Platform\Bundle\InstallerBundle\CommandExecutor;
+use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvent;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InstallerEventSpec extends ObjectBehavior
+{
+    function let(CommandExecutor $commandExecutor)
+    {
+        $this->beConstructedWith($commandExecutor);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldBeAnInstanceOf(InstallerEvent::class);
+    }
+
+    function it_is_a_generic_event()
+    {
+        $this->shouldHaveType(GenericEvent::class);
+    }
+
+    function it_provides_a_command_executor($commandExecutor)
+    {
+        $this->getCommandExecutor()->shouldReturn($commandExecutor);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Creates a dedicated `InstallerEvent` dispatched during installation. It extends `GenericEvent` (that were formerly dispatched) in order to avoid BC breaks, and holds a CommandExecutor, so that listeners/subscribers can launch commands using the same output as the original command.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
