### PR TITLE
PIM7466: fix attribute group translation again

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug fixes
+
+- PIM-7466: do not escape quotes for translation
+
 # 1.7.24 (2018-07-05)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/AttributeGroup/_js-handler.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/AttributeGroup/_js-handler.html.twig
@@ -37,7 +37,7 @@ require(
                     'class': 'no-hash',
                     'data-toggle': 'tooltip',
                     'data-placement': 'right',
-                    'data-original-title': '{{ "btn.create.attribute group"|trans|striptags|capitalize|raw }}'
+                    'data-original-title': "{{ "btn.create.attribute group"|trans|striptags|capitalize|raw }}"
                 }).html(
                     $('<i>', { 'class': 'icon-plus-sign' })
                 ).on('click', function() {


### PR DESCRIPTION
When the traduction contains one `'` the javascript is wrecked
Using double-quotes in JS solves the issue

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
