### PR TITLE
[FIX] Changes process tracker title for de

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.de.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.de.yml
@@ -1003,7 +1003,7 @@ pim_enrich:
       title: "] -Inf, 1] {{ count }} Gruppe|] 1, Inf [{{ count }} Gruppen"
       create_btn: Gruppe anlegen
     process_tracker:
-      title: "] -Inf, 1] {{ count }} Benutzer|] 1, Inf [{{ count }} Benutzer"
+      title: "] -Inf, 1] {{ count }} Operation|] 1, Inf [{{ count }} Operationen"
     channel:
       title: "] -Inf, 1] {{ count }} Regel|] 1, Inf [{{ count }} Regeln"
       create_btn: Ausgabekanal anlegen


### PR DESCRIPTION
This PR changes the process tracker title from `Benutzer` (which means users) to `Operation` (singular)/`Operationen` (plural).

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added legacy Behats               | No
| Added acceptance tests            | No
| Added integration tests           | No
| Changelog updated                 | No
| Review and 2 GTM                  | No
| Micro Demo to the PO (Story only) | No
| Migration script                  | No
| Tech Doc                          | No
