### PR TITLE
PIM-7517: fix the product models export filter on identifier

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,11 @@
 ## Bug fixes
 
 - PIM-7488: use catalog locale for attributes list in attribute groups
+- PIM-7517: fix the product models export filter on identifier
+
+## Migration
+
+**IMPORTANT** Please run the doctrine migrations command to fix the product models export profiles : `bin/console doctrine:migrations:migrate --env=prod`
 
 # 2.3.1 (2018-07-04)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
@@ -274,12 +274,9 @@ extensions:
                 -
                     field: completeness
                     view: akeneo-product-model-completeness-filter
-
-    pim-job-instance-csv-product-model-export-edit-content-default-attribute-filters:
-        module: pim/job/product/edit/content/data/default-attribute-filters
-        parent: pim-job-instance-csv-product-model-export-edit-content-data
-        config:
-            types: [pim_catalog_identifier]
+                -
+                    field: identifier
+                    view: akeneo-attribute-identifier-filter
 
     pim-job-instance-csv-product-model-export-edit-content-data-help:
         module: pim/job/common/edit/content/data/help

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
@@ -263,12 +263,9 @@ extensions:
                 -
                     field: completeness
                     view: akeneo-product-model-completeness-filter
-
-    pim-job-instance-xlsx-product-model-export-edit-content-default-attribute-filters:
-        module: pim/job/product/edit/content/data/default-attribute-filters
-        parent: pim-job-instance-xlsx-product-model-export-edit-content-data
-        config:
-            types: [pim_catalog_identifier]
+                -
+                    field: identifier
+                    view: akeneo-attribute-identifier-filter
 
     pim-job-instance-xlsx-product-model-export-edit-content-data-help:
         module: pim/job/common/edit/content/data/help

--- a/tests/legacy/features/export/product_model/csv/export_product_models.feature
+++ b/tests/legacy/features/export/product_model/csv/export_product_models.feature
@@ -20,13 +20,17 @@ Feature: Export variant products through CSV export
     And the following associations for the product model "plain_red":
       | type   | products   |
       | X_SELL | 1111111176 |
-    And I am on the "csv_product_model_export" export job page
+    And I am on the "csv_product_model_export" export job edit page
+    And I visit the "Content" tab
+    And I filter by "identifier" with operator "" and value "amor, plain, plain_red"
+    And I press the "Save" button
+    And I should not see the text "There are unsaved changes"
     And I launch the export job
     And I wait for the "csv_product_model_export" job to finish
     Then exported file of "csv_product_model_export" should contain the lines:
       """
-      code;family_variant;parent;categories;brand;care_instructions;collection;color;composition;description-en_US-ecommerce;erp_name-en_US;eu_shoes_size;image;keywords-en_US;material;meta_description-en_US;meta_title-en_US;name-en_US;notice;PACK-groups;PACK-products;PACK-product_models;price-EUR;price-USD;size;sole_composition;SUBSTITUTION-groups;SUBSTITUTION-products;SUBSTITUTION-product_models;supplier;top_composition;UPSELL-groups;UPSELL-products;UPSELL-product_models;variation_image;variation_name-en_US;wash_temperature;weight;weight-unit;X_SELL-groups;X_SELL-products;X_SELL-product_models
-      amor;clothing_colorsize;;master_men_blazers,supplier_zaro;;;summer_2016;;;"Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR";Amor;;;;;;;"Heritage jacket navy";;;;;999.00;;;;;;;zaro;;;1111111177;;;;800;;;;1111111175,1111111176;
-      plain_red;clothing_color_size;plain;tshirts;;;summer_2017;red;;;Plain;;;;;;;plain;;;;;;;;;;;;;;;;;files/plain_red/variation_image/plain_red.jpg;"Plain red ";;;;;1111111176,1111111175;
-      plain;clothing_color_size;;tshirts;;;summer_2017;;;;Plain;;;;;;;plain;;;;;;;;;;;;;;;;;;;;;;;1111111175;
+      code;family_variant;parent;categories;brand;care_instructions;collection;color;composition;description-en_US-ecommerce;erp_name-en_US;image;keywords-en_US;material;meta_description-en_US;meta_title-en_US;name-en_US;notice;PACK-groups;PACK-products;PACK-product_models;price-EUR;price-USD;SUBSTITUTION-groups;SUBSTITUTION-products;SUBSTITUTION-product_models;supplier;UPSELL-groups;UPSELL-products;UPSELL-product_models;variation_image;variation_name-en_US;wash_temperature;weight;weight-unit;X_SELL-groups;X_SELL-products;X_SELL-product_models
+      amor;clothing_colorsize;;master_men_blazers,supplier_zaro;;;summer_2016;;;"Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR";Amor;;;;;;"Heritage jacket navy";;;;;999.00;;;;;zaro;;1111111177;;;;800;;;;1111111175,1111111176;
+      plain;clothing_color_size;;tshirts;;;summer_2017;;;;Plain;;;;;;plain;;;;;;;;;;;;;;;;;;;;1111111175;
+      plain_red;clothing_color_size;plain;tshirts;;;summer_2017;red;;;Plain;;;;;;plain;;;;;;;;;;;;;;files/plain_red/variation_image/plain_red.jpg;"Plain red ";;;;;1111111176,1111111175;
       """

--- a/upgrades/schema/Version_2_3_20180716135306_update_job_instances.php
+++ b/upgrades/schema/Version_2_3_20180716135306_update_job_instances.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Akeneo\Component\Batch\Model\JobInstance;
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version_2_3_20180716135306_update_job_instances extends AbstractMigration implements ContainerAwareInterface
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Replace "sku" by "identifier" in the filters of all the product model export job instances.
+     * See PIM-7517
+     *
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $jobInstanceRepository = $this->container->get('pim_enrich.repository.job_instance');
+        $entityManager = $this->container->get('doctrine.orm.entity_manager');
+
+        $jobInstances = $jobInstanceRepository->findBy(['jobName' => [
+            'xlsx_product_model_export',
+            'csv_product_model_export'
+        ]]);
+
+        foreach ($jobInstances as $jobInstance) {
+            $this->updateJobInstance($jobInstance);
+            $entityManager->persist($jobInstance);
+        }
+
+        $entityManager->flush();
+        $this->disableMigrationWarning();
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    /**
+     * @param JobInstance $jobInstance
+     */
+    private function updateJobInstance(JobInstance $jobInstance)
+    {
+        $rawParameters = $jobInstance->getRawParameters();
+
+        foreach ($rawParameters['filters']['data'] as $index => $filter) {
+            if (isset($filter['field']) && $filter['field'] === 'sku') {
+                $filter['field'] = 'identifier';
+                $rawParameters['filters']['data'][$index] = $filter;
+            }
+        }
+
+        $jobInstance->setRawParameters($rawParameters);
+    }
+
+    /**
+     * Function that does a non altering operation on the DB using SQL to hide the doctrine warning stating that no
+     * sql query has been made to the db during the migration process.
+     */
+    private function disableMigrationWarning()
+    {
+        $this->addSql('SELECT 1');
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The filter on the identifier for the product models exports is broken. It uses the attribute "sku" instead of the field "identifier".

I fixed the form extension configuration for the CSV and XLSX exports, and I added a migration script to fix the existing export profiles that have a filter on the attribute "sku".

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
