### PR TITLE
PIM-7452: Fix memory leak when reinitializing family completeness

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,7 @@
+# 2.0.x
+
+- PIM-7452: Fix a memory leak when computing the completeness of all the products of a family.
+
 # 2.0.29 (2018-07-04)
 
 ## Bug fixes

--- a/features/locale/detach_locale_from_channel.feature
+++ b/features/locale/detach_locale_from_channel.feature
@@ -7,11 +7,10 @@ Feature: Detach locale from channels
   Scenario: Detach a locale from all channels
     Given the "default" catalog configuration
     And I am logged in as "admin"
-    And I set the "Armenian (Armenia), English (United States), French (France)" locales to the "ecommerce" channel
+    When I set the "Armenian (Armenia), English (United States), French (France)" locales to the "ecommerce" channel
     And I am on the locales page
     And I filter by "activated" with operator "" and value "yes"
     Then the grid should contain 3 elements
-    And I set the "English (United States), French (France)" locales to the "ecommerce" channel
+    When I set the "English (United States), French (France)" locales to the "ecommerce" channel
     And I am on the locales page
-    And I filter by "activated" with operator "" and value "yes"
     Then the grid should contain 2 elements

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
@@ -34,6 +34,7 @@ services:
             - '@pim_catalog.query.product_query_builder_factory'
             - '@pim_catalog.saver.product'
             - '@akeneo_storage_utils.doctrine.object_detacher'
+            - '@pim_connector.doctrine.cache_clearer'
         public: false
 
     pim_catalog.step.compute_product_models_descendants:

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -907,6 +907,8 @@ batch_jobs:
             label: Edit attributes
         clean:
             label: Clean files for attributes
+    compute_completeness_of_products_family:
+        compute_completeness_of_products_family.label: Compute completeness
     set_attribute_requirements:
         label: Set attributes requirements
         perform:

--- a/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamilyTasklet.php
+++ b/src/Pim/Component/Catalog/Job/ComputeCompletenessOfProductsFamilyTasklet.php
@@ -6,6 +6,7 @@ namespace Pim\Component\Catalog\Job;
 
 use Akeneo\Component\Batch\Job\UndefinedJobParameterException;
 use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
@@ -42,22 +43,30 @@ class ComputeCompletenessOfProductsFamilyTasklet implements TaskletInterface
     /** @var BulkSaverInterface */
     private $bulkProductSaver;
 
+    /** @var CacheClearerInterface */
+    private $cacheClearer;
+
     /**
+     * @todo merge: Remove the object detacher on master, and remove nullable from the cache clearer.
+     *
      * @param IdentifiableObjectRepositoryInterface $familyRepository
      * @param ProductQueryBuilderFactoryInterface   $productQueryBuilderFactory
-     * @param BulkObjectDetacherInterface           $bulkObjectDetacher
      * @param BulkSaverInterface                    $bulkProductSaver
+     * @param BulkObjectDetacherInterface           $bulkObjectDetacher
+     * @param null|CacheClearerInterface            $cacheClearer
      */
     public function __construct(
         IdentifiableObjectRepositoryInterface $familyRepository,
         ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
         BulkSaverInterface $bulkProductSaver,
-        BulkObjectDetacherInterface $bulkObjectDetacher
+        BulkObjectDetacherInterface $bulkObjectDetacher,
+        CacheClearerInterface $cacheClearer = null
     ) {
         $this->familyRepository = $familyRepository;
         $this->productQueryBuilderFactory = $productQueryBuilderFactory;
         $this->bulkProductSaver = $bulkProductSaver;
         $this->bulkObjectDetacher = $bulkObjectDetacher;
+        $this->cacheClearer = $cacheClearer;
     }
 
     /**
@@ -106,22 +115,30 @@ class ComputeCompletenessOfProductsFamilyTasklet implements TaskletInterface
      */
     private function computeCompletenesses(FamilyInterface $family): void
     {
-        $productToSave = $this->findProductsForFamily($family);
+        $productsToSave = $this->findProductsForFamily($family);
 
         $productBatch = [];
-        foreach ($productToSave as $product) {
+        foreach ($productsToSave as $product) {
             $productBatch[] = $product;
 
             if (self::BATCH_SIZE === count($productBatch)) {
                 $this->bulkProductSaver->saveAll($productBatch);
-                $this->bulkObjectDetacher->detachAll($productBatch);
+                if (null !== $this->cacheClearer) {
+                    $this->cacheClearer->clear();
+                } else {
+                    $this->bulkObjectDetacher->detachAll($productBatch);
+                }
 
                 $productBatch = [];
             }
         }
 
         $this->bulkProductSaver->saveAll($productBatch);
-        $this->bulkObjectDetacher->detachAll($productBatch);
+        if (null !== $this->cacheClearer) {
+            $this->cacheClearer->clear();
+        } else {
+            $this->bulkObjectDetacher->detachAll($productBatch);
+        }
     }
 
     /**

--- a/src/Pim/Component/Catalog/spec/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
+++ b/src/Pim/Component/Catalog/spec/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Pim\Component\Catalog\Job;
 
 use Akeneo\Component\Batch\Job\JobParameters;
 use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
@@ -23,13 +26,15 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
         IdentifiableObjectRepositoryInterface $familyRepository,
         ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
         BulkSaverInterface $bulkProductSaver,
-        BulkObjectDetacherInterface $bulkObjectDetacher
+        BulkObjectDetacherInterface $bulkObjectDetacher,
+        CacheClearerInterface $cacheClearer
     ) {
         $this->beConstructedWith(
             $familyRepository,
             $productQueryBuilderFactory,
             $bulkProductSaver,
-            $bulkObjectDetacher
+            $bulkObjectDetacher,
+            $cacheClearer
         );
     }
 
@@ -47,7 +52,7 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
         $familyRepository,
         $productQueryBuilderFactory,
         $bulkProductSaver,
-        $bulkObjectDetacher,
+        $cacheClearer,
         StepExecution $stepExecution,
         JobParameters $jobParameters,
         FamilyInterface $family,
@@ -72,7 +77,7 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
         $cursor->rewind()->shouldBeCalled();
 
         $bulkProductSaver->saveAll([$product1, $product2, $product3])->shouldBeCalled();
-        $bulkObjectDetacher->detachAll([$product1, $product2, $product3])->shouldBeCalled();
+        $cacheClearer->clear()->shouldBeCalled();
 
         $this->setStepExecution($stepExecution);
         $this->execute();


### PR DESCRIPTION
## Description

When a family is edited, if changes affect the product completeness (like adding or removing a required attribute), completeness is recalculated for all products of this family. This is done by the batch job `compute_product_models_descendants`.

There is a memory leak in this job: products are detached, but not their associations. As a consequence, the process will eventually end up out of memory and crash.

This PR uses the Doctrine cache clearer instead of the product detacher in `Pim\Component\Catalog\Job\ComputeCompletenessOfProductsFamilyTasklet` to solve this memory leak.

It was succesfully tested on a catalog that was know to have the problem. When editing a family with 200K products (containing associations), the batch job stayed under 80 MB.

### Side note

I also fixed an unstable behat scenario.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
