### PR TITLE
PIM-7433: better thumbnail quality for retina and new image upload

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/liip_imagine.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/liip_imagine.yml
@@ -17,13 +17,13 @@ liip_imagine:
             quality:          95
             format:           png
             filters:
-                thumbnail:    { size: [320, 240], mode: outbound }
+                thumbnail:    { size: [320, 320], mode: outbound }
                 strip:        ~
         thumbnail_small:
             quality:          95
             format:           png
             filters:
-                thumbnail:    { size: [140, 140], mode: outbound }
+                thumbnail:    { size: [280, 280], mode: outbound }
                 strip:        ~
         pdf_thumbnail:
             quality:          95

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/media-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/media-field.js
@@ -77,7 +77,6 @@ define([
                     'scope':  this.context.scope
                 };
 
-
                 $.ajax({
                     url: Routing.generate('pim_enrich_media_rest_post'),
                     type: 'POST',

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
@@ -17,6 +17,7 @@
   }
 
   &-imageContainer:not(:empty) {
+    position: relative;
     width: @imageSize + 2px;
     height: @imageSize + 2px;
     border: 1px solid @AknBorderColor;
@@ -28,9 +29,72 @@
     flex-shrink: 0;
   }
 
+  &-imageContainer--editable {
+    &:after {
+      content: '';
+      opacity: 0;
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      display: block;
+      transition: opacity 0.3s;
+    }
+  }
+
+  &-imageContainer--dropping {
+    &:after {
+      background: RGBa(255, 255, 255, 0.8) url("../../images/icon-upload.svg") no-repeat 50% 50%;
+      background-size: 50%;
+      opacity: 1;
+    }
+
+    & .AknTitleContainer-image {
+      filter: blur(4px);
+    }
+  }
+
+  &-imageContainer--removing {
+    &:after {
+      background: RGBa(255, 255, 255, 0.8) url("../../images/icon-delete-slategrey.svg") no-repeat 50% 50%;
+      background-size: 50%;
+      opacity: 1;
+    }
+
+    & .AknTitleContainer-image {
+      filter: blur(4px);
+    }
+  }
+
+  &-imageLoader {
+    opacity: 0;
+    position: absolute;
+    width: 0%;
+    height: 100%;
+    display: block;
+    transition: opacity 0.3s;
+    background-color: RGBa(255, 255, 255, 0.8);
+  }
+
+  &-imageLoader--loading {
+    opacity: 1;
+  }
+
   &-image {
     margin: auto;
     width: 100%;
+    transition: filter 0.3s;
+  }
+
+  &-imageUpdater {
+    opacity: 0;
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    z-index: 11;
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 
   &-mainContainer {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Less code to add this style to container images:

![upload-final](https://user-images.githubusercontent.com/1117272/42880565-088e9ed4-8a95-11e8-89e2-83003642707a.gif)

I could extract that in a dedicated component but not sure for now. What do you think? This PR improves also the thumbnail quality to comply with retina screens.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added legacy Behats               | NA
| Added acceptance tests            | NA
| Added integration tests           | NA
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
