### PR TITLE
PIM-7528: Do not use User timezone for product/product model versionning normalization

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7528: Fix Product and Product Model date attribute rendering in history panel, no timezone needed.
 - PIM-7488: use catalog locale for attributes list in attribute groups
 - PIM-7518: fix memory leak in channel/locale clean command
 - PIM-7517: fix the product models export filter on identifier

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/VersioningController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/VersioningController.php
@@ -60,8 +60,7 @@ class VersioningController
         return new JsonResponse(
             $this->normalizer->normalize(
                 $this->versionRepository->getLogEntries($this->FQCNResolver->getFQCN($entityType), $entityId),
-                'internal_api',
-                ['timezone' => $this->userContext->getUserTimezone()]
+                'internal_api'
             )
         );
     }

--- a/tests/legacy/features/product/date.feature
+++ b/tests/legacy/features/product/date.feature
@@ -42,5 +42,5 @@ Feature: Check that imported date is properly displayed
       | version | property | before | value       |
       | 2       | SKU      | postit | nice_postit |
       | 1       | SKU      |        | postit      |
-      | 1       | release  |        | 04/30/2014  |
+      | 1       | release  |        | 05/01/2014  |
       | 1       | enabled  |        | 1           |


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
