### PR TITLE
Add AppKernel to the composer autoload (non dev)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
             "Akeneo\\Test\\Acceptance\\": "tests/back/Acceptance/",
             "Akeneo\\Test\\Common\\": "tests/back/Common/"
         },
-        "classmap": [ "app/AppKernel.php", "app/AppCache.php", "tests/back/Integration/AppKernelTest.php" ]
+        "classmap": [ "tests/back/Integration/AppKernelTest.php" ]
     },
     "require": {
         "php": ">=7.1.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         },
         "psr-4": {
             "Pim\\Upgrade\\": "upgrades/"
-        }
+        },
+        "classmap": [ "app/AppKernel.php", "app/AppCache.php" ]
     },
     "autoload-dev": {
         "psr-0": {


### PR DESCRIPTION
It has been accidentally removed here: https://github.com/akeneo/pim-community-dev/commit/72d86c77d733dd493f7ec98f92a582236f089a72#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780