### PR TITLE
Use minimal catalog on the CI

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -63,6 +63,7 @@ RUN composer install --no-ansi --optimize-autoloader --no-interaction --no-progr
     && bin/console pim:installer:dump-require-paths --env=prod \
     && yarn install \
     && yarn run webpack \
+    && printf "    installer_data: PimInstallerBundle:minimal\n" >> app/config/parameters.yml \
     && printf "    pim_job_product_batch_size: 50\n" >> app/config/parameters.yml \
     && cp app/config/parameters.yml app/config/parameters_test.yml \
     && chown -R www-data:www-data var web \


### PR DESCRIPTION
## Description

Currently, when the CI perform a `pim:install`, it uses the `icecat_demo_dev` catalog.
This PR set it to the `minimal` one.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
