### PR TITLE
PIM-7433: Enable dev-tools on puppeteer by default

### DIFF
--- a/tests/front/acceptance/cucumber/world.js
+++ b/tests/front/acceptance/cucumber/world.js
@@ -12,6 +12,7 @@ module.exports = function(cucumber) {
   Before({timeout: 10 * 1000}, async function() {
     this.baseUrl = 'http://pim.com';
     this.browser = await puppeteer.launch({
+      devtools: !this.parameters.debug,
       ignoreHTTPSErrors: true,
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
       headless: !this.parameters.debug,


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Show up dev-tools on chromium startup when the debug parameter is set.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
