### PR TITLE
PIM-7519 : Fix infinite scroll on reference-data-simple-select

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/simple-select-async.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/fields/simple-select-async.js
@@ -128,7 +128,10 @@ define(
              * @returns {Object}
              */
             select2Results(response) {
-                const more = this.resultsPerPage === Object.keys(response).length;
+                const nbResults = (response.results) ?
+                    Object.keys(response.results).length :
+                    Object.keys(response).length;
+                const more = this.resultsPerPage === nbResults;
 
                 // The result is already formatted for select2
                 if (response.results) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When we were creating a product model on an axis of a family variant which it's a reference-data-simple-select, we didn't have the infinite scroll pagination.

![screenshot-infinite-scroll](https://user-images.githubusercontent.com/10549767/43082084-76f47022-8e93-11e8-9599-a4be9e678dac.gif)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
