### PR TITLE
PIM-7540: Fix translations of boolean attributes

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug fixes
+
+- PIM-7540: Fix translations of boolean attributes
+
 # 1.7.27 (2018-07-24)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/boolean.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/boolean.html
@@ -1,3 +1,3 @@
-<div class="switch switch-small" tabindex="0" role="checkbox" aria-checked="<%- value && value.data ? 'true' : 'false' %>" data-on-label="<%- _.__('pim_common.yes') %>" data-off-label="<%- _.__('pim_common.no') %>">
+<div class="switch switch-small" tabindex="0" role="checkbox" aria-checked="<%- value && value.data ? 'true' : 'false' %>" data-on-label="<%- _.__('switch_on') %>" data-off-label="<%- _.__('switch_off') %>">
     <input id="<%- fieldId %>" type="checkbox" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" <%- value.data ? 'checked' : '' %> <%- editMode === 'view' ? 'disabled' : '' %>>
 </div>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

SLA qualified as high priority  ¯\_(ツ)_/¯

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
