### PR TITLE
PIM-7529: Fix method with missing parameter when a tree is removed

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -75,7 +75,7 @@ stage("Build") {
                             }
 
                             sh "cp .ci/Dockerfile Dockerfile"
-                            sh "gcloud container builds submit --config .ci/builder.yaml --substitutions _IMAGE_TAG=${tag}-ee ."
+                            sh "gcloud container builds submit --config .ci/builder.yaml --substitutions _IMAGE_TAG=${tag}-ee,_COMPOSER_COMMAND=${composer_command} ."
                         }
                     }
                 } else {

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,3 +1,9 @@
+# 2.3.x
+
+## Bug fixes
+
+- PIM-7529: Fix error when a tree is removed
+
 # 2.3.2 (2018-07-24)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Controller/CategoryTreeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/CategoryTreeController.php
@@ -372,8 +372,6 @@ class CategoryTreeController extends Controller
         }
 
         $category = $this->findCategory($id);
-        $parent = $category->getParent();
-        $params = (null !== $parent) ? ['node' => $parent->getId()] : [];
 
         $this->categoryRemover->remove($category);
 

--- a/src/Pim/Bundle/UserBundle/EventSubscriber/UserPreferencesSubscriber.php
+++ b/src/Pim/Bundle/UserBundle/EventSubscriber/UserPreferencesSubscriber.php
@@ -102,7 +102,7 @@ class UserPreferencesSubscriber implements EventSubscriber
         }
 
         if ($entity instanceof CategoryInterface && $entity->isRoot()) {
-            $this->onTreeRemoved($uow, $entity);
+            $this->onTreeRemoved($uow, $manager, $entity);
         }
     }
 
@@ -187,7 +187,7 @@ class UserPreferencesSubscriber implements EventSubscriber
      *
      * @param CategoryInterface $category
      */
-    protected function onTreeRemoved(UnitOfWork $uow, CategoryInterface $category)
+    protected function onTreeRemoved(UnitOfWork $uow, EntityManagerInterface $manager, CategoryInterface $category)
     {
         $users = $this->findUsersBy(['defaultTree' => $category]);
         $trees = $this->container->get('pim_catalog.repository.category')->getTrees();
@@ -203,7 +203,7 @@ class UserPreferencesSubscriber implements EventSubscriber
 
         foreach ($users as $user) {
             $user->setDefaultTree($defaultTree);
-            $this->computeChangeset($uow, $user);
+            $this->computeChangeset($uow, $manager, $user);
         }
     }
 

--- a/src/Pim/Bundle/UserBundle/spec/EventSubscriber/UserPreferencesSubscriberSpec.php
+++ b/src/Pim/Bundle/UserBundle/spec/EventSubscriber/UserPreferencesSubscriberSpec.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace spec\Pim\Bundle\UserBundle\EventSubscriber;
+
+use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\UnitOfWork;
+use Oro\Bundle\UserBundle\Entity\UserManager;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\UserBundle\Entity\UserInterface;
+use Pim\Bundle\UserBundle\EventSubscriber\UserPreferencesSubscriber;
+use Pim\Bundle\UserBundle\Repository\UserRepositoryInterface;
+use Pim\Component\Catalog\Model\CategoryInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class UserPreferencesSubscriberSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UserPreferencesSubscriber::class);
+    }
+
+    function it_implements_an_event_subscriber()
+    {
+        $this->shouldImplement(EventSubscriber::class);
+    }
+
+    function it_returns_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn([
+            'onFlush',
+            'postFlush',
+        ]);
+    }
+
+    function it_deactivates_a_locale_before_flush(
+        OnFlushEventArgs $args,
+        EntityManagerInterface $em,
+        UnitOfWork $uow,
+        LocaleInterface $localeFR,
+        LocaleInterface $localeEN
+    ) {
+        $args->getEntityManager()->willReturn($em);
+        $em->getUnitOfWork()->willReturn($uow);
+        $uow->getScheduledEntityUpdates()->willReturn([$localeFR, $localeEN]);
+        $uow->getScheduledEntityDeletions()->willReturn([]);
+
+        $localeFR->isActivated()->willReturn(true);
+        $localeFR->getCode()->shouldNotBeCalled();
+        $uow->getEntityChangeSet($localeFR)->shouldNotBeCalled();
+
+        $localeEN->isActivated()->willReturn(false);
+        $localeEN->getCode()->willReturn('en_US');
+        $uow->getEntityChangeSet($localeEN)->willReturn(['activated' => true]);
+
+
+        $this->onFlush($args)->shouldReturn(null);
+    }
+
+    function it_deletes_a_tree_before_flush(
+        OnFlushEventArgs $args,
+        EntityManagerInterface $em,
+        UnitOfWork $uow,
+        ContainerInterface $container,
+        UserManager $userManager,
+        UserRepositoryInterface $userRepository,
+        CategoryInterface $masterCategory,
+        CategoryInterface $summerCategory,
+        UserInterface $mary,
+        UserInterface $julia,
+        CategoryRepositoryInterface $categoryRepository,
+        ClassMetadata $metadata
+    ) {
+        $this->setContainer($container);
+        $container->get('oro_user.manager')->willReturn($userManager);
+
+        $args->getEntityManager()->willReturn($em);
+        $em->getUnitOfWork()->willReturn($uow);
+        $uow->getScheduledEntityUpdates()->willReturn([]);
+        $uow->getScheduledEntityDeletions()->willReturn([$masterCategory]);
+
+        $masterCategory->isRoot()->willReturn(true);
+
+        $userManager->getRepository()->willReturn($userRepository);
+        $userRepository->findBy(['defaultTree' => $masterCategory])->willReturn([$mary, $julia]);
+
+        $container->get('pim_catalog.repository.category')->willReturn($categoryRepository);
+        $categoryRepository->getTrees()->willReturn([$summerCategory, $masterCategory]);
+
+        $summerCategory->getCode()->willReturn('summer');
+        $masterCategory->getCode()->willReturn('master');
+
+        $julia->setDefaultTree($summerCategory)->shouldBeCalled();
+        $mary->setDefaultTree($summerCategory)->shouldBeCalled();
+
+        $uow->persist($julia)->shouldBeCalled();
+        $em->getClassMetadata(Argument::any())->willReturn($metadata);
+        $uow->computeChangeSet($metadata, $julia)->shouldBeCalled();
+        $uow->persist($mary)->shouldBeCalled();
+        $uow->computeChangeSet($metadata, $mary)->shouldBeCalled();
+
+        $this->onFlush($args)->shouldReturn(null);
+    }
+
+    function it_deletes_a_channe_before_flush(
+        OnFlushEventArgs $args,
+        EntityManagerInterface $em,
+        UnitOfWork $uow,
+        ContainerInterface $container,
+        UserManager $userManager,
+        UserRepositoryInterface $userRepository,
+        ChannelInterface $ecommerceChannel,
+        ChannelInterface $printChannel,
+        UserInterface $mary,
+        ChannelRepositoryInterface $channelRepository,
+        ClassMetadata $metadata
+    ) {
+        $this->setContainer($container);
+        $container->get('oro_user.manager')->willReturn($userManager);
+
+        $args->getEntityManager()->willReturn($em);
+        $em->getUnitOfWork()->willReturn($uow);
+        $uow->getScheduledEntityUpdates()->willReturn([]);
+        $uow->getScheduledEntityDeletions()->willReturn([$ecommerceChannel]);
+
+        $userManager->getRepository()->willReturn($userRepository);
+        $userRepository->findBy(['catalogScope' => $ecommerceChannel])->willReturn([$mary]);
+
+        $container->get('pim_catalog.repository.channel')->willReturn($channelRepository);
+        $channelRepository->findAll()->willReturn([$ecommerceChannel, $printChannel]);
+
+        $ecommerceChannel->getCode()->willReturn('ecommerce');
+        $printChannel->getCode()->willReturn('print');
+
+        $mary->setCatalogScope($printChannel)->shouldBeCalled();
+
+        $em->getClassMetadata(Argument::any())->willReturn($metadata);
+        $uow->persist($mary)->shouldBeCalled();
+        $uow->computeChangeSet($metadata, $mary)->shouldBeCalled();
+
+        $this->onFlush($args)->shouldReturn(null);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

A fatal error is thrown when we want to delete a category tree because of a bad refacto :/

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
