### PR TITLE
PIM-7492: move pre install asset event to be usefull

### DIFF
--- a/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
@@ -54,7 +54,6 @@ class AssetsCommand extends ContainerAwareCommand
     {
         $output->writeln('<info>Akeneo PIM assets</info>');
 
-        $this->getEventDispatcher()->dispatch(InstallerEvents::PRE_ASSETS_DUMP);
 
         $webDir = $this->getWebDir();
 
@@ -68,6 +67,14 @@ class AssetsCommand extends ContainerAwareCommand
                 return $e->getCode();
             }
         }
+
+        $event = new GenericEvent();
+        $event->setArguments([
+            'clean'   => $input->getOption('clean'),
+            'symlink' => $input->getOption('symlink')
+        ]);
+
+        $this->getEventDispatcher()->dispatch(InstallerEvents::PRE_ASSETS_DUMP, $event);
 
         $this->commandExecutor
             ->runCommand('fos:js-routing:dump', ['--target' => $webDir.'js/routes.js'])


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR move the event to have a more useful position. It should not cause any problem as if it was used to clean, it will still work today.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
