### PR TITLE
PIM-7522 : Fix versioning when update the association of a variant product

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Bug fixes
+
+- PIM-7522: Fix association changes not save on the product history.
+
 # 2.0.30 (2018-07-25)
 
 ## Technical improvements

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/guessers.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/guessers.yml
@@ -3,6 +3,7 @@ parameters:
     pim_versioning.update_guesser.attribute_option.class:  Pim\Bundle\VersioningBundle\UpdateGuesser\AttributeOptionUpdateGuesser
     pim_versioning.update_guesser.chained.class:           Pim\Bundle\VersioningBundle\UpdateGuesser\ChainedUpdateGuesser
     pim_versioning.update_guesser.contains_products.class: Pim\Bundle\VersioningBundle\UpdateGuesser\ContainsProductsUpdateGuesser
+    pim_versioning.update_guesser.association.class:       Pim\Bundle\VersioningBundle\UpdateGuesser\AssociationUpdateGuesser
     pim_versioning.update_guesser.translations.class:      Pim\Bundle\VersioningBundle\UpdateGuesser\TranslationsUpdateGuesser
     pim_versioning.update_guesser.versionable.class:       Pim\Bundle\VersioningBundle\UpdateGuesser\VersionableUpdateGuesser
 
@@ -19,6 +20,11 @@ services:
 
     pim_versioning.update_guesser.contains_products:
         class: '%pim_versioning.update_guesser.contains_products.class%'
+        tags:
+            - { name: pim_versioning.update_guesser }
+
+    pim_versioning.update_guesser.association:
+        class: '%pim_versioning.update_guesser.association.class%'
         tags:
             - { name: pim_versioning.update_guesser }
 

--- a/src/Pim/Bundle/VersioningBundle/UpdateGuesser/AssociationUpdateGuesser.php
+++ b/src/Pim/Bundle/VersioningBundle/UpdateGuesser/AssociationUpdateGuesser.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Pim\Bundle\VersioningBundle\UpdateGuesser;
+
+use Doctrine\ORM\EntityManager;
+use Pim\Component\Catalog\Model\AssociationInterface;
+
+/**
+ * Association update guesser
+ *
+ * @author    Christophe Chausseray <christophe.chausseray@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AssociationUpdateGuesser implements UpdateGuesserInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportAction($action)
+    {
+        return in_array(
+            $action,
+            [UpdateGuesserInterface::ACTION_UPDATE_ENTITY, UpdateGuesserInterface::ACTION_DELETE]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessUpdates(EntityManager $em, $entity, $action)
+    {
+        $pendings = [];
+
+        if ($entity instanceof AssociationInterface) {
+            $pendings[] = $entity->getOwner();
+        }
+
+        return $pendings;
+    }
+}

--- a/src/Pim/Bundle/VersioningBundle/spec/UpdateGuesser/AssociationUpdateGuesserSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/UpdateGuesser/AssociationUpdateGuesserSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace spec\Pim\Bundle\VersioningBundle\UpdateGuesser;
+
+use Doctrine\ORM\EntityManager;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\VersioningBundle\UpdateGuesser\UpdateGuesserInterface;
+use Pim\Component\Catalog\Model\AssociationInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+class AssociationUpdateGuesserSpec extends ObjectBehavior
+{
+    function it_is_an_update_guesser()
+    {
+        $this->shouldImplement('Pim\Bundle\VersioningBundle\UpdateGuesser\UpdateGuesserInterface');
+    }
+
+    function it_supports_entity_updates_and_deletion()
+    {
+        $this->supportAction(UpdateGuesserInterface::ACTION_UPDATE_ENTITY)->shouldReturn(true);
+        $this->supportAction(UpdateGuesserInterface::ACTION_DELETE)->shouldReturn(true);
+        $this->supportAction(UpdateGuesserInterface::ACTION_UPDATE_COLLECTION)->shouldReturn(false);
+        $this->supportAction('foo')->shouldReturn(false);
+    }
+
+    function it_marks_products_as_updated_when_an_association_is_updated_or_removed(
+        EntityManager $em,
+        ProductInterface $foo,
+        AssociationInterface $association
+    ) {
+        $association->getOwner()->willReturn($foo);
+        $this->guessUpdates($em, $association, UpdateGuesserInterface::ACTION_UPDATE_ENTITY)->shouldReturn([$foo]);
+        $this->guessUpdates($em, $association, UpdateGuesserInterface::ACTION_DELETE)->shouldReturn([$foo]);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We had an issue for the variant product versioning, we weren't able to version the association added or removed on a variant product. 

To create a version of a product, we get the entities updated from the Doctrine UOW. However, in this case the UOW is not able to detect that the entity is updated. So, to fix this bug we added a guesser to enforce the creation of the version.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
