### PR TITLE
PIM-7546: fix the batch size of the cursor for the datagrid

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
@@ -3,6 +3,7 @@ parameters:
     pim_enrich.query.elasticsearch.sorter.in_group.class: Pim\Bundle\EnrichBundle\Elasticsearch\Sorter\InGroupSorter
     pim_enrich.elasticsearch.from_size_cursor_factory.class: Pim\Bundle\EnrichBundle\Elasticsearch\FromSizeCursorFactory
     pim_enrich.query.product_and_product_model_query_builder.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelQueryBuilder
+    pim_enrich.datagrid.product_batch_size: 25
 
 services:
     # Filters
@@ -50,5 +51,5 @@ services:
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@pim_catalog.repository.product'
             - '@pim_catalog.repository.product_model'
-            - '%pim_job_product_batch_size%'
+            - '%pim_enrich.datagrid.product_batch_size%'
             - 'pim_catalog_product'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Tested on a catalog with 1 000 000 products and 20 000 categories.
This fix allows to have a gain of ~800 ms (from 2.5 seconds to 1.7 seconds to get data from the grid).

The PQB requests Elasticsearch 3 times for the datagrid. It's due to the batch size at 10. 
Each ES request takes more than 400 ms. 
For a total of 1.2 seconds, which is a lot. 

Batch size at 10 was done for memory leak purpose due to problems with the garbage collector and circular references during a long running batch.
It's useless for HTTP requests. 

Note: it's the same thing for the API. It's an HTTP call, so we don't care about the garbage collector.

The batch size slows down the whole API for nothing, as we don't handle memory leaks in the API.
We are currently doing 10 requests to ES, for a total of 4 seconds of ES requests, for 100 products.
I think it could be reduced to 400 ms if we adjust the batch size to 100 for the API.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
