### PR TITLE
PIM-7453: forbid to remove a role if user won't have role after deletion

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7453: Forbid to remove a role if user won't have role after deletion
 - PIM-7532: Improve the standard format for products associated to avoid performance impact
 - PIM-7540: Fix translations of boolean attributes
 

--- a/src/Oro/Bundle/UserBundle/Controller/RoleController.php
+++ b/src/Oro/Bundle/UserBundle/Controller/RoleController.php
@@ -58,14 +58,12 @@ class RoleController extends Controller
             throw $this->createNotFoundException(sprintf('Role with id %d could not be found.', $id));
         }
 
-        $em->remove($role);
+        $this->container->get('pim_user.remover.role')->remove($role);
 
         $aclSidManager = $this->get('oro_security.acl.sid_manager');
         if ($aclSidManager->isAclEnabled()) {
             $aclSidManager->deleteSid($aclSidManager->getSid($role));
         }
-
-        $em->flush();
 
         return new JsonResponse('', 204);
     }

--- a/src/Oro/Bundle/UserBundle/Controller/RoleController.php
+++ b/src/Oro/Bundle/UserBundle/Controller/RoleController.php
@@ -9,6 +9,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class RoleController extends Controller
 {
@@ -58,11 +60,15 @@ class RoleController extends Controller
             throw $this->createNotFoundException(sprintf('Role with id %d could not be found.', $id));
         }
 
-        $this->container->get('pim_user.remover.role')->remove($role);
+        try {
+            $this->container->get('pim_user.remover.role')->remove($role);
 
-        $aclSidManager = $this->get('oro_security.acl.sid_manager');
-        if ($aclSidManager->isAclEnabled()) {
-            $aclSidManager->deleteSid($aclSidManager->getSid($role));
+            $aclSidManager = $this->get('oro_security.acl.sid_manager');
+            if ($aclSidManager->isAclEnabled()) {
+                $aclSidManager->deleteSid($aclSidManager->getSid($role));
+            }
+        } catch (\InvalidArgumentException $e) {
+            return new JsonResponse(['message' => $e->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
         return new JsonResponse('', 204);

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
@@ -56,8 +56,8 @@ define([
                 this.model.destroy({
                     url: this.getLink(),
                     wait: true,
-                    error: function() {
-                        this.getErrorDialog().open();
+                    error: function(model, xhr) {
+                        this.getErrorDialog(xhr.responseText).open();
                     }.bind(this),
                     success: function() {
                         var messageText = __('flash.' + this.getEntityHint() + '.removed');
@@ -88,11 +88,18 @@ define([
              *
              * @return {oro.Modal}
              */
-            getErrorDialog: function() {
+            getErrorDialog: function(response) {
                 if (!this.errorModal) {
+                    try {
+                        var response = JSON.parse(response);
+                        var message = response.message;
+                    } catch(e) {
+                        var message = __('error.removing.' + this.getEntityHint());
+                    }
+
                     this.errorModal = new Modal({
                         title: __('Delete Error'),
-                        content: __('error.removing.' + this.getEntityHint()),
+                        content: message,
                         cancelText: false
                     });
                 }

--- a/src/Pim/Bundle/UserBundle/DependencyInjection/PimUserExtension.php
+++ b/src/Pim/Bundle/UserBundle/DependencyInjection/PimUserExtension.php
@@ -34,6 +34,7 @@ class PimUserExtension extends Extension
         $loader->load('form_types.yml');
         $loader->load('normalizers.yml');
         $loader->load('providers.yml');
+        $loader->load('queries.yml');
         $loader->load('removers.yml');
         $loader->load('repositories.yml');
         $loader->load('savers.yml');

--- a/src/Pim/Bundle/UserBundle/DependencyInjection/PimUserExtension.php
+++ b/src/Pim/Bundle/UserBundle/DependencyInjection/PimUserExtension.php
@@ -34,6 +34,7 @@ class PimUserExtension extends Extension
         $loader->load('form_types.yml');
         $loader->load('normalizers.yml');
         $loader->load('providers.yml');
+        $loader->load('removers.yml');
         $loader->load('repositories.yml');
         $loader->load('savers.yml');
         $loader->load('twig.yml');

--- a/src/Pim/Bundle/UserBundle/Doctrine/ORM/Query/IsThereUserWithoutRole.php
+++ b/src/Pim/Bundle/UserBundle/Doctrine/ORM/Query/IsThereUserWithoutRole.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Pim\Bundle\UserBundle\Doctrine\ORM\Query;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Check if there is user who will be without role if we remove a specific role
+ *
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IsThereUserWithoutRole
+{
+    /** @var EntityManagerInterface */
+    private $em;
+
+    public function __construct(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * @param int $roleIdToExclude
+     *
+     * @return bool
+     */
+    public function __invoke($roleIdToExclude)
+    {
+        $stmt = $this->em->getConnection()->prepare(
+        'SELECT COUNT(username) AS count FROM oro_user u LEFT JOIN oro_user_access_role r ON u.id = r.user_id AND role_id != :roleId WHERE role_id IS NULL'
+        );
+        $stmt->bindValue('roleId', $roleIdToExclude, \PDO::PARAM_INT);
+
+        $stmt->execute();
+        $count = $stmt->fetch();
+
+        return $count['count'] > 0;
+    }
+}

--- a/src/Pim/Bundle/UserBundle/EventSubscriber/RemoveRoleSubscriber.php
+++ b/src/Pim/Bundle/UserBundle/EventSubscriber/RemoveRoleSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Pim\Bundle\UserBundle\EventSubscriber;
+
+use Akeneo\Component\StorageUtils\Event\RemoveEvent;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Pim\Bundle\UserBundle\Doctrine\ORM\Query\IsThereUserWithoutRole;
+use Pim\Component\User\Exception\ForbiddenToRemoveRoleException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Role\RoleInterface;
+
+/**
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RemoveRoleSubscriber implements EventSubscriberInterface
+{
+    /** @var IsThereUserWithoutRole */
+    private $isThereUserWithoutRole;
+
+    public function __construct(IsThereUserWithoutRole $isThereUserWithoutRole)
+    {
+        $this->isThereUserWithoutRole = $isThereUserWithoutRole;
+    }
+
+    public function checkIfThereIsUserWithoutRole(RemoveEvent $event)
+    {
+        $role = $event->getSubject();
+        if (!$role instanceof RoleInterface) {
+            return;
+        }
+
+        $isThereUserWithoutRole = $this->isThereUserWithoutRole;
+        $result = $isThereUserWithoutRole($role->getId());
+        if ($result) {
+            throw new ForbiddenToRemoveRoleException('You can not delete this role, otherwise some users will no longer have a role.');
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            StorageEvents::PRE_REMOVE => [['checkIfThereIsUserWithoutRole']],
+        ];
+    }
+}

--- a/src/Pim/Bundle/UserBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/event_subscribers.yml
@@ -1,6 +1,7 @@
 parameters:
     pim_user.event_subscriber.user_preferences.class: Pim\Bundle\UserBundle\EventSubscriber\UserPreferencesSubscriber
     pim_user.event_subscriber.group.class:            Pim\Bundle\UserBundle\EventSubscriber\GroupSubscriber
+    pim_user.event_subscriber.remove_role.class:      Pim\Bundle\UserBundle\EventSubscriber\RemoveRoleSubscriber
     pim_locale.locale_subscriber.class:               Pim\Bundle\UserBundle\EventSubscriber\LocaleSubscriber
     pim_locale.locale_listener.class:                 Pim\Bundle\UserBundle\EventListener\LocaleListener
 
@@ -14,6 +15,13 @@ services:
 
     pim_user.event_subscriber.group:
         class: '%pim_user.event_subscriber.group.class%'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    pim_user.event_subscriber.remove_role:
+        class: '%pim_user.event_subscriber.remove_role.class%'
+        arguments:
+            - '@pim_user.query.is_there_user_without_role'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/Pim/Bundle/UserBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/queries.yml
@@ -1,0 +1,8 @@
+parameters:
+    pim_user.query.is_there_user_without_role.class: Pim\Bundle\UserBundle\Doctrine\ORM\Query\IsThereUserWithoutRole
+
+services:
+    pim_user.query.is_there_user_without_role:
+        class: '%pim_user.query.is_there_user_without_role.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'

--- a/src/Pim/Bundle/UserBundle/Resources/config/removers.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/removers.yml
@@ -1,0 +1,7 @@
+services:
+    pim_user.remover.role:
+        class: '%pim_catalog.remover.base.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@event_dispatcher'
+            - '%pim_user.entity.role.class%'

--- a/src/Pim/Bundle/UserBundle/tests/integration/RemoveRoleIntegration.php
+++ b/src/Pim/Bundle/UserBundle/tests/integration/RemoveRoleIntegration.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Pim\Bundle\UserBundle\test\integration;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+class RemoveRoleIntegration extends TestCase
+{
+    /**
+     * @expectedException \Pim\Component\User\Exception\ForbiddenToRemoveRoleException
+     * @expectedExceptionMessage You can not delete this role, otherwise some users will no longer have a role.
+     */
+    public function testUnableToRemoveARoleIfUsersWillNoLongerHaveRole()
+    {
+        $adminRole = $this->get('pim_user.repository.role')->findOneByIdentifier('ROLE_ADMINISTRATOR');
+        $this->get('pim_user.remover.role')->remove($adminRole);
+    }
+
+    public function testSuccessfullyToRemoveARole()
+    {
+        $adminRole = $this->get('pim_user.repository.role')->findOneByIdentifier('ROLE_USER');
+        $this->get('pim_user.remover.role')->remove($adminRole);
+        $this->assertNull($this->get('pim_user.repository.role')->findOneByIdentifier('ROLE_USER'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return new Configuration([Configuration::getMinimalCatalogPath()]);
+    }
+}

--- a/src/Pim/Component/User/Exception/ForbiddenToRemoveRoleException.php
+++ b/src/Pim/Component/User/Exception/ForbiddenToRemoveRoleException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Pim\Component\User\Exception;
+
+/**
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ForbiddenToRemoveRoleException extends \InvalidArgumentException
+{
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

Forbid to remove a role if a user won't have role after deletion. 
A user without role has no sense on the PIM. 
Moreover, there is a little thing "funny" on the PIM: if a user without role want to connect to the PIM, the application will try to find the role "ROLE_USER" which is a role defined as a default role (don't ask me why...) and then update the user to associated him to "ROLE_USER" role. That's mean a user without role can have much more access than before to the PIM after an authentification \o/




<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
