### PR TITLE
PIM-7548: split normalizers by format to improve performances

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -12,6 +12,12 @@
 
 ## BC breaks
 
+- Register standard format normalizers into  `pim_standard_format_serializer` serializer and untagged them from `pim_serializer` serializer 
+- Register indexing normalizers into  `pim_indexing_serializer` serializer and untagged them from `pim_serializer` serializer
+- Register datagrid normalizers into  `pim_datagrid_serializer` serializer and untagged them from `pim_serializer` serializer
+- Register storage normalizers into  `pim_storage_serializer` serializer and untagged them from `pim_serializer` serializer
+- Register external API normalizers into  `pim_external_api_serializer` serializer and untagged them from `pim_serializer` serializer
+
 - Change constructor of `Pim\Component\Catalog\Updater\ProductUpdater`, remove `$supportedFields` argument 
 
 - Move `Pim\Bundle\CatalogBundle\DependencyInjection\Compiler\Localization\RegisterLocalizersPass` to `Akeneo\Pim\Enrichment\Bundle\DependencyInjection\Compiler\Localization\RegisterLocalizersPass`

--- a/src/Akeneo/Channel/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/controllers.yml
@@ -47,7 +47,7 @@ services:
         class: 'Akeneo\Channel\Bundle\Controller\ExternalApi\CurrencyController'
         arguments:
             - '@pim_api.repository.currency'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_api.pagination.parameter_validator'
             - '@pim_api.pagination.offset_hal_paginator'
             - '%pim_api.configuration%'

--- a/src/Akeneo/Channel/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/controllers.yml
@@ -11,7 +11,7 @@ services:
         class: 'Akeneo\Channel\Bundle\Controller\ExternalApi\LocaleController'
         arguments:
             - '@pim_api.repository.locale'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_api.pagination.offset_hal_paginator'
             - '@pim_api.pagination.parameter_validator'
             - '@pim_api.checker.query_parameters_locale'
@@ -21,7 +21,7 @@ services:
         class: 'Akeneo\Channel\Bundle\Controller\ExternalApi\ChannelController'
         arguments:
             - '@pim_api.repository.channel'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_api.pagination.offset_hal_paginator'
             - '@pim_api.pagination.parameter_validator'
             - '@pim_catalog.factory.channel'

--- a/src/Akeneo/Channel/Bundle/Resources/config/services.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/services.yml
@@ -25,7 +25,7 @@ services:
     pim_catalog.normalizer.standard.locale:
         class: 'Akeneo\Channel\Component\Normalizer\Standard\LocaleNormalizer'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_versioning.serializer.normalizer.flat.locale:
         class: 'Akeneo\Channel\Component\Normalizer\Versioning\LocaleNormalizer'
@@ -114,7 +114,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.translation'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.updater.channel:
         class: 'Akeneo\Channel\Component\Updater\ChannelUpdater'
@@ -137,7 +137,7 @@ services:
     pim_enrich.normalizer.channel:
         class: 'Akeneo\Channel\Component\Normalizer\InternalApi\ChannelNormalizer'
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - '@pim_enrich.normalizer.locale'
             - '@pim_versioning.repository.version'
             - '@pim_enrich.normalizer.version'
@@ -181,7 +181,7 @@ services:
     pim_catalog.normalizer.standard.currency:
         class: 'Akeneo\Channel\Component\Normalizer\Standard\CurrencyNormalizer'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.event_subscriber.currency_disabling:
         class: 'Akeneo\Channel\Bundle\EventListener\CurrencyDisablingSubscriber'

--- a/src/Akeneo/Channel/Bundle/Resources/config/services.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/services.yml
@@ -46,7 +46,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.locale'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     pim_catalog.repository.locale:
         class: 'Akeneo\Channel\Bundle\Doctrine\Repository\LocaleRepository'
@@ -158,7 +158,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.channel'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     ### Currency
     pim_catalog.repository.currency:
@@ -176,7 +176,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.currency'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.currency:
         class: 'Akeneo\Channel\Component\Normalizer\Standard\CurrencyNormalizer'

--- a/src/Akeneo/Channel/Component/tests/integration/Channel/StandardNormalizationIntegration.php
+++ b/src/Akeneo/Channel/Component/tests/integration/Channel/StandardNormalizationIntegration.php
@@ -26,7 +26,7 @@ class StandardNormalizationIntegration extends AbstractStandardNormalizerTestCas
         ];
 
         $repository = $this->get('pim_catalog.repository.channel');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('tablet'), 'standard');
 

--- a/src/Akeneo/Channel/Component/tests/integration/Normalizer/Standard/CurrencyIntegration.php
+++ b/src/Akeneo/Channel/Component/tests/integration/Normalizer/Standard/CurrencyIntegration.php
@@ -19,7 +19,7 @@ class CurrencyIntegration extends TestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.currency');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('USD'), 'standard');
 

--- a/src/Akeneo/Channel/Component/tests/integration/Normalizer/Standard/LocaleIntegration.php
+++ b/src/Akeneo/Channel/Component/tests/integration/Normalizer/Standard/LocaleIntegration.php
@@ -19,7 +19,7 @@ class LocaleIntegration extends TestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.locale');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('en_US'), 'standard');
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
@@ -54,6 +54,7 @@ class AkeneoPimEnrichmentBundle extends Bundle
             ->addCompilerPass(new RegisterSerializerPass('pim_external_api_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_standard_format_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_indexing_serializer'))
+            ->addCompilerPass(new RegisterSerializerPass('pim_storage_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_datagrid_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_serializer'))
             ->addCompilerPass(new RegisterRendererPass());

--- a/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
@@ -53,6 +53,7 @@ class AkeneoPimEnrichmentBundle extends Bundle
             ->addCompilerPass(new RegisterSerializerPass('pim_internal_api_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_external_api_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_standard_format_serializer'))
+            ->addCompilerPass(new RegisterSerializerPass('pim_indexing_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_serializer'))
             ->addCompilerPass(new RegisterRendererPass());
         ;

--- a/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
@@ -52,6 +52,7 @@ class AkeneoPimEnrichmentBundle extends Bundle
             ->addCompilerPass(new RegisterPresentersPass())
             ->addCompilerPass(new RegisterSerializerPass('pim_internal_api_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_external_api_serializer'))
+            ->addCompilerPass(new RegisterSerializerPass('pim_standard_format_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_serializer'))
             ->addCompilerPass(new RegisterRendererPass());
         ;

--- a/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
@@ -50,6 +50,7 @@ class AkeneoPimEnrichmentBundle extends Bundle
             ->addCompilerPass(new RegisterCompleteCheckerPass())
             ->addCompilerPass(new RegisterLocalizersPass())
             ->addCompilerPass(new RegisterPresentersPass())
+            ->addCompilerPass(new RegisterSerializerPass('pim_internal_api_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_serializer'))
             ->addCompilerPass(new RegisterRendererPass());
         ;

--- a/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
@@ -51,6 +51,7 @@ class AkeneoPimEnrichmentBundle extends Bundle
             ->addCompilerPass(new RegisterLocalizersPass())
             ->addCompilerPass(new RegisterPresentersPass())
             ->addCompilerPass(new RegisterSerializerPass('pim_internal_api_serializer'))
+            ->addCompilerPass(new RegisterSerializerPass('pim_external_api_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_serializer'))
             ->addCompilerPass(new RegisterRendererPass());
         ;

--- a/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
@@ -54,6 +54,7 @@ class AkeneoPimEnrichmentBundle extends Bundle
             ->addCompilerPass(new RegisterSerializerPass('pim_external_api_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_standard_format_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_indexing_serializer'))
+            ->addCompilerPass(new RegisterSerializerPass('pim_datagrid_serializer'))
             ->addCompilerPass(new RegisterSerializerPass('pim_serializer'))
             ->addCompilerPass(new RegisterRendererPass());
         ;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/GetProductCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/GetProductCommand.php
@@ -57,7 +57,7 @@ class GetProductCommand extends ContainerAwareCommand
             return;
         }
 
-        $normalizedProduct = $this->getContainer()->get('pim_serializer')->normalize($product, 'standard', []);
+        $normalizedProduct = $this->getContainer()->get('pim_standard_format_serializer')->normalize($product, 'standard', []);
 
         $output->write(json_encode($normalizedProduct));
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/DependencyInjection/AkeneoPimEnrichmentExtension.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/DependencyInjection/AkeneoPimEnrichmentExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Pim\Enrichment\Bundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
@@ -71,6 +73,7 @@ class AkeneoPimEnrichmentExtension extends Extension
         $loader->load('serializers_indexing.yml');
         $loader->load('serializers_standard.yml');
         $loader->load('serializers_storage.yml');
+        $loader->load('serializers.yml');
         $loader->load('builders.yml');
         $loader->load('controllers.yml');
         $loader->load('renderers.yml');

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -21,7 +21,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi\ProductController'
         arguments:
             - '@pim_catalog.query.product_query_builder_search_after_size_factory'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_api.repository.channel'
             - '@pim_api.checker.query_parameters_product'
             - '@pim_api.repository.attribute'
@@ -50,7 +50,7 @@ services:
             - '@pim_catalog.query.product_model_query_builder_factory'
             - '@pim_catalog.query.product_model_query_builder_from_size_factory'
             - '@pim_catalog.query.product_model_query_builder_search_after_size_factory'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_api.repository.channel'
             - '@pim_api.checker.query_parameters_product_model'
             - '@pim_api.pagination.parameter_validator'
@@ -71,7 +71,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi\CategoryController'
         arguments:
             - '@pim_api.repository.category'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_catalog.factory.category'
             - '@pim_catalog.updater.category'
             - '@validator'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
@@ -7,7 +7,7 @@ services:
     pim_catalog.elasticsearch.indexer.product:
         class: '%pim_catalog.elasticsearch.indexer.product.class%'
         arguments:
-            - '@pim_serializer'
+            - '@pim_indexing_serializer'
             - '@akeneo_elasticsearch.client.product'
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - 'pim_catalog_product'
@@ -15,7 +15,7 @@ services:
     pim_catalog.elasticsearch.indexer.product_model:
         class: '%pim_catalog.elasticsearch.indexer.product_model_indexer.class%'
         arguments:
-            - '@pim_serializer'
+            - '@pim_indexing_serializer'
             - '@akeneo_elasticsearch.client.product'
             - '@akeneo_elasticsearch.client.product_model'
             - '@akeneo_elasticsearch.client.product_and_product_model'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
@@ -69,7 +69,7 @@ services:
     pim_catalog.event_subscriber.compute_product_raw_values:
         class: '%pim_catalog.event_subscriber.compute_product_raw_values.class%'
         arguments:
-            - '@pim_serializer'
+            - '@pim_storage_serializer'
             - '@pim_catalog.repository.attribute'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -2,7 +2,7 @@ services:
     pim_comment.normalizer.standard.comment:
         class: 'Akeneo\Pim\Enrichment\Component\Comment\Normalizer\Standard\CommentNormalizer'
         tags:
-            - { name: pim_external_api_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_api.normalizer.product:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ProductNormalizer'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -2,7 +2,7 @@ services:
     pim_comment.normalizer.standard.comment:
         class: 'Akeneo\Pim\Enrichment\Component\Comment\Normalizer\Standard\CommentNormalizer'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     pim_api.normalizer.product:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ProductNormalizer'
@@ -11,11 +11,11 @@ services:
             - '@pim_api.repository.attribute'
             - '@router'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     pim_api.normalizer.category:
         class: 'Akeneo\Pim\Enrichment\Component\Category\Normalizer\ExternalApi\CategoryNormalizer'
         arguments:
             - '@pim_catalog.normalizer.standard.category'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
@@ -14,15 +14,6 @@ services:
     pim_datagrid_serializer:
         class: 'Symfony\Component\Serializer\Serializer'
 
-    pim_indexing_serializer:
-        class: 'Symfony\Component\Serializer\Serializer'
-
-    pim_storage_serializer:
-        class: 'Symfony\Component\Serializer\Serializer'
-
-    pim_datagrid_serializer:
-        class: 'Symfony\Component\Serializer\Serializer'
-
     pim_serializer:
         class: 'Symfony\Component\Serializer\Serializer'
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
@@ -1,25 +1,37 @@
-parameters:
-    # Serializer
-    pim_serializer.class: Symfony\Component\Serializer\Serializer
-
-    # Encoders
-    pim_serializer.encoder.xml.class:  Symfony\Component\Serializer\Encoder\XmlEncoder
-    pim_serializer.encoder.json.class: Symfony\Component\Serializer\Encoder\JsonEncoder
-
 services:
-    # Serializer, TODO : should be moved somewhere else
+    pim_external_api_serializer:
+        class: 'Symfony\Component\Serializer\Serializer'
+
+    pim_standard_format_serializer:
+        class: 'Symfony\Component\Serializer\Serializer'
+
+    pim_indexing_serializer:
+        class: 'Symfony\Component\Serializer\Serializer'
+
+    pim_storage_serializer:
+        class: 'Symfony\Component\Serializer\Serializer'
+
+    pim_datagrid_serializer:
+        class: 'Symfony\Component\Serializer\Serializer'
+
     pim_serializer:
-        class: '%pim_serializer.class%'
+        class: 'Symfony\Component\Serializer\Serializer'
 
     # Encoders
     pim_serializer.encoder.xml:
         public: false
-        class: '%pim_serializer.encoder.xml.class%'
+        class: 'Symfony\Component\Serializer\Encoder\XmlEncoder'
         tags:
             - { name: pim_serializer.encoder, priority: 90 }
 
     pim_serializer.encoder.json:
         public: false
-        class: '%pim_serializer.encoder.json.class%'
+        class: 'Symfony\Component\Serializer\Encoder\JsonEncoder'
         tags:
             - { name: pim_serializer.encoder, priority: 90 }
+
+    pim_internal_api.encoder.json:
+        public: false
+        class: 'Symfony\Component\Serializer\Encoder\JsonEncoder'
+        tags:
+            - { name: pim_internal_api_serializer.encoder, priority: 90 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
@@ -14,6 +14,9 @@ services:
     pim_datagrid_serializer:
         class: 'Symfony\Component\Serializer\Serializer'
 
+    pim_indexing_serializer:
+        class: 'Symfony\Component\Serializer\Serializer'
+
     pim_serializer:
         class: 'Symfony\Component\Serializer\Serializer'
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
@@ -20,6 +20,9 @@ services:
     pim_storage_serializer:
         class: 'Symfony\Component\Serializer\Serializer'
 
+    pim_datagrid_serializer:
+        class: 'Symfony\Component\Serializer\Serializer'
+
     pim_serializer:
         class: 'Symfony\Component\Serializer\Serializer'
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
@@ -17,6 +17,9 @@ services:
     pim_indexing_serializer:
         class: 'Symfony\Component\Serializer\Serializer'
 
+    pim_storage_serializer:
+        class: 'Symfony\Component\Serializer\Serializer'
+
     pim_serializer:
         class: 'Symfony\Component\Serializer\Serializer'
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers.yml
@@ -14,24 +14,21 @@ services:
     pim_datagrid_serializer:
         class: 'Symfony\Component\Serializer\Serializer'
 
+    pim_internal_api_serializer:
+        class: 'Symfony\Component\Serializer\Serializer'
+
     pim_serializer:
         class: 'Symfony\Component\Serializer\Serializer'
 
     # Encoders
-    pim_serializer.encoder.xml:
-        public: false
-        class: 'Symfony\Component\Serializer\Encoder\XmlEncoder'
-        tags:
-            - { name: pim_serializer.encoder, priority: 90 }
-
-    pim_serializer.encoder.json:
+    serializer.encoder.json:
         public: false
         class: 'Symfony\Component\Serializer\Encoder\JsonEncoder'
         tags:
             - { name: pim_serializer.encoder, priority: 90 }
-
-    pim_internal_api.encoder.json:
-        public: false
-        class: 'Symfony\Component\Serializer\Encoder\JsonEncoder'
-        tags:
+            - { name: pim_external_api_serializer.encoder, priority: 90 }
+            - { name: pim_standard_format_serializer.encoder, priority: 90 }
+            - { name: pim_indexing_serializer.encoder, priority: 90 }
+            - { name: pim_storage_serializer.encoder, priority: 90 }
+            - { name: pim_datagrid_serializer.encoder, priority: 90 }
             - { name: pim_internal_api_serializer.encoder, priority: 90 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_indexing.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_indexing.yml
@@ -30,100 +30,100 @@ services:
         arguments:
             - '@pim_catalog.normalizer.indexing_product.product.properties'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.properties:
         class: '%pim_catalog.normalizer.indexing_product.product.properties.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 40 }
+            - { name: pim_indexing_serializer.normalizer, priority: 40 }
 
     pim_catalog.normalizer.indexing_product.datetime:
         class: '%pim_catalog.normalizer.indexing_product.datetime.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.datetime'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.product_value_collection:
         class: '%pim_catalog.normalizer.indexing_product.product.product_value_collection.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.completeness_collection:
         class: '%pim_catalog.normalizer.indexing_product.product.completeness_collection.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.number:
         class: '%pim_catalog.normalizer.indexing_product.product.number.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.options:
         class: '%pim_catalog.normalizer.indexing_product.product.options.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.dummy:
         class: '%pim_catalog.normalizer.indexing_product.product.dummy.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 80 }
+            - { name: pim_indexing_serializer.normalizer, priority: 80 }
 
     pim_catalog.normalizer.indexing_product.date:
         class: '%pim_catalog.normalizer.indexing_product.date.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 100 }
+            - { name: pim_indexing_serializer.normalizer, priority: 100 }
 
     pim_catalog.normalizer.indexing_product.product.text:
         class: '%pim_catalog.normalizer.indexing_product.product.text.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.text_area:
         class: '%pim_catalog.normalizer.indexing_product.product.text_area.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.option:
         class: '%pim_catalog.normalizer.indexing_product.product.option.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.price_collection:
         class: '%pim_catalog.normalizer.indexing_product.product.price_collection.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product.product_value'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.metric:
         class: '%pim_catalog.normalizer.indexing_product.product.metric.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.media:
         class: '%pim_catalog.normalizer.indexing_product.product.media.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.boolean:
         class: '%pim_catalog.normalizer.indexing_product.product.boolean.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product_model.product_model:
         class: '%pim_catalog.normalizer.indexing_product_model.product_model.class%'
         arguments:
             - '@pim_catalog.normalizer.indexing_product_model.product_model.properties'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product_model.product_model.properties:
         class: '%pim_catalog.normalizer.indexing_product_model.product_model.properties.class%'
         arguments:
             - '@pim_catalog.doctrine.query.complete_filter'
         tags:
-            - { name: pim_serializer.normalizer, priority: 40 }
+            - { name: pim_indexing_serializer.normalizer, priority: 40 }
 
     pim_catalog.normalizer.indexing_product_and_product_model.product_model:
         class: '%pim_catalog.normalizer.indexing_product_and_product_model.product_model.class%'
@@ -131,14 +131,14 @@ services:
             - '@pim_catalog.normalizer.indexing_product_and_product_model.product_model.properties'
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product_and_product_model.product_model.properties:
         class: '%pim_catalog.normalizer.indexing_product_and_product_model.product_model.properties.class%'
         arguments:
             - '@pim_catalog.doctrine.query.complete_filter'
         tags:
-            - { name: pim_serializer.normalizer, priority: 40 }
+            - { name: pim_indexing_serializer.normalizer, priority: 40 }
 
     pim_catalog.normalizer.indexing_product_and_product_model.product:
         class: '%pim_catalog.normalizer.indexing_product_and_product_model.product.class%'
@@ -146,11 +146,11 @@ services:
             - '@pim_catalog.normalizer.indexing_product_and_product_model.product.properties'
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product_and_product_model.product.properties:
         class: '%pim_catalog.normalizer.indexing_product_and_product_model.product.properties.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 40 }
+            - { name: pim_indexing_serializer.normalizer, priority: 40 }
 
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
@@ -28,8 +28,10 @@ services:
         arguments:
             - '@pim_catalog.filter.chained'
             - '@pim_catalog.normalizer.standard.product.associations'
+            - '@pim_standard_format_serializer'
         tags:
             - { name: pim_standard_format_serializer.normalizer, priority: 90 }
+        lazy: true
 
     pim_catalog.normalizer.standard.product.properties:
         class: '%pim_catalog.normalizer.standard.product.properties.class%'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
@@ -57,8 +57,11 @@ services:
 
     pim_catalog.normalizer.standard.product.product_value:
         class: '%pim_catalog.normalizer.standard.product.product_value.class%'
+        arguments:
+            - '@pim_standard_format_serializer'
         tags:
             - { name: pim_standard_format_serializer.normalizer, priority: 90 }
+        lazy: true
 
     pim_catalog.normalizer.standard.product.price:
         class: '%pim_catalog.normalizer.standard.product.price.class%'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
@@ -21,7 +21,7 @@ services:
             - '@pim_catalog.normalizer.standard.product.properties'
             - '@pim_catalog.normalizer.standard.product.associations'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.product_model:
         class: '%pim_catalog.normalizer.standard.product_model.class%'
@@ -29,75 +29,75 @@ services:
             - '@pim_catalog.filter.chained'
             - '@pim_catalog.normalizer.standard.product.associations'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.product.properties:
         class: '%pim_catalog.normalizer.standard.product.properties.class%'
         arguments:
             - '@pim_catalog.filter.chained'
         tags:
-            - { name: pim_serializer.normalizer, priority: 40 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 40 }
 
     pim_catalog.normalizer.standard.product.associations:
         class: '%pim_catalog.normalizer.standard.product.associations.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 40 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 40 }
 
     pim_catalog.normalizer.standard.product.parent_associations:
         class: Pim\Component\Catalog\Normalizer\Standard\Product\ParentsAssociationsNormalizer
         tags:
-            - { name: pim_serializer.normalizer, priority: 40 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 40 }
 
     pim_catalog.normalizer.standard.product.product_values:
         class: '%pim_catalog.normalizer.standard.product.product_values.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.product.product_value:
         class: '%pim_catalog.normalizer.standard.product.product_value.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.product.price:
         class: '%pim_catalog.normalizer.standard.product.price.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.product.metric:
         class: '%pim_catalog.normalizer.standard.product.metric.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.datetime:
         class: '%pim_catalog.normalizer.standard.datetime.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.file:
         class: '%pim_catalog.normalizer.standard.file.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.category:
         class: '%pim_catalog.normalizer.standard.category.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.translation'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.group:
         class: '%pim_catalog.normalizer.standard.group.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.translation'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.translation:
         class: '%pim_catalog.normalizer.standard.translation.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 80 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 80 }
 
     pim_catalog.normalizer.standard.job_instance:
         class: '%pim_catalog.normalizer.standard.job_instance.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
@@ -35,8 +35,10 @@ services:
         class: '%pim_catalog.normalizer.standard.product.properties.class%'
         arguments:
             - '@pim_catalog.filter.chained'
+            - '@pim_standard_format_serializer'
         tags:
             - { name: pim_standard_format_serializer.normalizer, priority: 40 }
+        lazy:  true
 
     pim_catalog.normalizer.standard.product.associations:
         class: '%pim_catalog.normalizer.standard.product.associations.class%'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_storage.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_storage.yml
@@ -37,11 +37,20 @@ services:
             - '@pim_catalog.normalizer.standard.product.product_values'
         tags:
             - { name: pim_storage_serializer.normalizer, priority: 90 }
+        lazy: true
+
+    pim_catalog.normalizer.standard_with_standard_format.product.product_value:
+        class: '%pim_catalog.normalizer.standard.product.product_value.class%'
+        arguments:
+            - '@pim_storage_serializer'
+        tags:
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
+        lazy: true
 
     pim_catalog.normalizer.storage.product.product_value:
         class: '%pim_catalog.normalizer.storage.product.product_value.class%'
         arguments:
-            - '@pim_catalog.normalizer.standard.product.product_value'
+            - '@pim_catalog.normalizer.standard_with_standard_format.product.product_value'
         tags:
             - { name: pim_storage_serializer.normalizer, priority: 90 }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_storage.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_storage.yml
@@ -39,7 +39,7 @@ services:
             - { name: pim_storage_serializer.normalizer, priority: 90 }
         lazy: true
 
-    pim_catalog.normalizer.standard_with_standard_format.product.product_value:
+    pim_catalog.normalizer.storage_with_standard_format.product.product_value:
         class: '%pim_catalog.normalizer.standard.product.product_value.class%'
         arguments:
             - '@pim_storage_serializer'
@@ -50,7 +50,7 @@ services:
     pim_catalog.normalizer.storage.product.product_value:
         class: '%pim_catalog.normalizer.storage.product.product_value.class%'
         arguments:
-            - '@pim_catalog.normalizer.standard_with_standard_format.product.product_value'
+            - '@pim_catalog.normalizer.storage_with_standard_format.product.product_value'
         tags:
             - { name: pim_storage_serializer.normalizer, priority: 90 }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_storage.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_storage.yml
@@ -15,61 +15,61 @@ services:
             - '@pim_catalog.normalizer.storage.product.properties'
             - '@pim_catalog.normalizer.storage.product.associations'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_storage_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.storage.product.properties:
         class: '%pim_catalog.normalizer.storage.product.properties.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product.properties'
         tags:
-            - { name: pim_serializer.normalizer, priority: 40 }
+            - { name: pim_storage_serializer.normalizer, priority: 40 }
 
     pim_catalog.normalizer.storage.product.associations:
         class: '%pim_catalog.normalizer.storage.product.associations.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product.associations'
         tags:
-            - { name: pim_serializer.normalizer, priority: 40 }
+            - { name: pim_storage_serializer.normalizer, priority: 40 }
 
     pim_catalog.normalizer.storage.product.product_values:
         class: '%pim_catalog.normalizer.storage.product.product_values.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product.product_values'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_storage_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.storage.product.product_value:
         class: '%pim_catalog.normalizer.storage.product.product_value.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product.product_value'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_storage_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.storage.product.price:
         class: '%pim_catalog.normalizer.storage.product.price.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product.price'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_storage_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.storage.product.metric:
         class: '%pim_catalog.normalizer.storage.product.metric.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product.metric'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_storage_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.storage.datetime:
         class: '%pim_catalog.normalizer.storage.datetime.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.datetime'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_storage_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.storage.file:
         class: '%pim_catalog.normalizer.storage.file.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.file'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_storage_serializer.normalizer, priority: 90 }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/updaters.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/updaters.yml
@@ -265,7 +265,7 @@ services:
         class: '%pim_catalog.updater.copier.value.class%'
         parent: pim_catalog.updater.copier.abstract
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - ['pim_catalog_text']
             - ['pim_catalog_text']
         tags:
@@ -299,7 +299,7 @@ services:
         class: '%pim_catalog.updater.copier.value.class%'
         parent: pim_catalog.updater.copier.abstract
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - ['pim_catalog_textarea']
             - ['pim_catalog_textarea']
         tags:
@@ -309,7 +309,7 @@ services:
         class: '%pim_catalog.updater.copier.value.class%'
         parent: pim_catalog.updater.copier.abstract
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - ['pim_catalog_boolean']
             - ['pim_catalog_boolean']
         tags:
@@ -319,7 +319,7 @@ services:
         class: '%pim_catalog.updater.copier.value.class%'
         parent: pim_catalog.updater.copier.abstract
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - ['pim_catalog_number']
             - ['pim_catalog_number']
         tags:
@@ -329,7 +329,7 @@ services:
         class: '%pim_catalog.updater.copier.value.class%'
         parent: pim_catalog.updater.copier.abstract
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - ['pim_catalog_date']
             - ['pim_catalog_date']
         tags:
@@ -339,7 +339,7 @@ services:
         class: '%pim_catalog.updater.copier.metric_value.class%'
         parent: pim_catalog.updater.copier.abstract
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - ['pim_catalog_metric']
             - ['pim_catalog_metric']
         tags:
@@ -349,7 +349,7 @@ services:
         class: '%pim_catalog.updater.copier.value.class%'
         parent: pim_catalog.updater.copier.abstract
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - ['pim_catalog_simpleselect']
             - ['pim_catalog_simpleselect']
         tags:
@@ -359,7 +359,7 @@ services:
         class: '%pim_catalog.updater.copier.value.class%'
         parent: pim_catalog.updater.copier.abstract
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - ['pim_catalog_multiselect']
             - ['pim_catalog_multiselect']
         tags:
@@ -369,7 +369,7 @@ services:
         class: '%pim_catalog.updater.copier.value.class%'
         parent: pim_catalog.updater.copier.abstract
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - ['pim_catalog_price_collection']
             - ['pim_catalog_price_collection']
         tags:
@@ -420,7 +420,7 @@ services:
         class: '%pim_catalog.updater.adder.price_collection_value.class%'
         arguments:
             - '@pim_catalog.builder.entity_with_values'
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - ['pim_catalog_price_collection']
         tags:
             - { name: 'pim_catalog.updater.adder' }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
@@ -4,7 +4,7 @@ services:
         class: 'Akeneo\Pim\Structure\Bundle\Controller\ExternalApi\AttributeController'
         arguments:
             - '@pim_api.repository.attribute'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_catalog.factory.attribute'
             - '@pim_catalog.updater.attribute'
             - '@validator'
@@ -19,7 +19,7 @@ services:
         class: 'Akeneo\Pim\Structure\Bundle\Controller\ExternalApi\AttributeGroupController'
         arguments:
             - '@pim_api.repository.attribute_group'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_api.pagination.parameter_validator'
             - '@pim_api.pagination.offset_hal_paginator'
             - '@pim_catalog.factory.attribute_group'
@@ -35,7 +35,7 @@ services:
         arguments:
             - '@pim_api.repository.attribute'
             - '@pim_api.repository.attribute_option'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_catalog.factory.attribute_option'
             - '@pim_catalog.updater.attribute_option'
             - '@validator'
@@ -51,7 +51,7 @@ services:
         class: 'Akeneo\Pim\Structure\Bundle\Controller\ExternalApi\FamilyController'
         arguments:
             - '@pim_api.repository.family'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_catalog.factory.family'
             - '@pim_catalog.updater.family'
             - '@validator'
@@ -67,7 +67,7 @@ services:
         arguments:
             - '@pim_api.repository.family'
             - '@pim_api.repository.family_variant'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_api.pagination.offset_hal_paginator'
             - '@pim_api.pagination.parameter_validator'
             - '@validator'
@@ -82,7 +82,7 @@ services:
         class: 'Akeneo\Pim\Structure\Bundle\Controller\ExternalApi\AssociationTypeController'
         arguments:
             - '@pim_api.repository.association_type'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_api.pagination.parameter_validator'
             - '@pim_api.pagination.offset_hal_paginator'
             - '@pim_catalog.factory.association_type'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/normalizers.yml
@@ -111,7 +111,7 @@ services:
             - '@pim_catalog.normalizer.standard.translation'
             - '@pim_catalog.repository.locale'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     ### Family Variant
     pim_enrich.normalizer.family_variant:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/normalizers.yml
@@ -64,7 +64,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.attribute_option'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_storage_serializer.normalizer, priority: 90 }
 
     ### Family
     pim_enrich.normalizer.family:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/normalizers.yml
@@ -14,7 +14,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.attribute'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     pim_enrich.normalizer.attribute:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\InternalApi\AttributeNormalizer'
@@ -47,7 +47,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.attribute_option'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     pim_versioning.serializer.normalizer.flat.option:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\Versionning\AttributeOptionNormalizer'
@@ -85,7 +85,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.family'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     pim_versioning.serializer.normalizer.flat.family:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\Versionning\FamilyNormalizer'
@@ -127,7 +127,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.family_variant'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.standard.family_variant:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\Standard\FamilyVariantNormalizer'
@@ -165,7 +165,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.attribute_group'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     pim_enrich.normalizer.group_type:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\InternalApi\GroupTypeNormalizer'
@@ -212,4 +212,4 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.association_type'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/normalizers.yml
@@ -7,7 +7,7 @@ services:
             - '@pim_catalog.normalizer.standard.datetime'
             - ['auto_option_sorting']
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_api.normalizer.attribute:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\ExternalApi\AttributeNormalizer'
@@ -19,7 +19,7 @@ services:
     pim_enrich.normalizer.attribute:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\InternalApi\AttributeNormalizer'
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - '@pim_enrich.provider.field.chained'
             - '@pim_enrich.provider.empty_value.chained'
             - '@pim_enrich.provider.filter.chained'
@@ -57,7 +57,7 @@ services:
     pim_catalog.normalizer.standard.attribute_option:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\Standard\AttributeOptionNormalizer'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.storage.attribute_option:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\Storage\AttributeOptionNormalizer'
@@ -103,7 +103,7 @@ services:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.attribute_requirement'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_catalog.normalizer.indexing_product.product.family:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\Indexing\FamilyNormalizer'
@@ -117,7 +117,7 @@ services:
     pim_enrich.normalizer.family_variant:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\InternalApi\FamilyVariantNormalizer'
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - '@pim_enrich.provider.structure_version.family_variant'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
@@ -134,12 +134,12 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.translation'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_enrich.normalizer.attribute_group:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\InternalApi\AttributeGroupNormalizer'
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - '@pim_catalog.repository.attribute'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
@@ -158,7 +158,7 @@ services:
             - '@pim_catalog.normalizer.standard.translation'
             - '@pim_catalog.repository.attribute'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_api.normalizer.attribute_group:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\ExternalApi\AttributeGroupNormalizer'
@@ -170,7 +170,7 @@ services:
     pim_enrich.normalizer.group_type:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\InternalApi\GroupTypeNormalizer'
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - '@pim_enrich.provider.structure_version.group_type'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
@@ -180,13 +180,13 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.translation'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     ### Association type
     pim_enrich.normalizer.association_type:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\InternalApi\AssociationTypeNormalizer'
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - '@pim_versioning.manager.version'
             - '@pim_enrich.normalizer.version'
         tags:
@@ -205,7 +205,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.translation'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
 
     pim_api.normalizer.association_type:
         class: 'Akeneo\Pim\Structure\Component\Normalizer\ExternalApi\AssociationTypeNormalizer'

--- a/src/Akeneo/Pim/Structure/Component/tests/Integration/ExternalApi/AttributeOptionIntegration.php
+++ b/src/Akeneo/Pim/Structure/Component/tests/Integration/ExternalApi/AttributeOptionIntegration.php
@@ -23,7 +23,7 @@ class AttributeOptionIntegration extends TestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.attribute_option');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_external_api_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('a_multi_select.optionA'), 'external_api');
 

--- a/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/AssociationTypeIntegration.php
+++ b/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/AssociationTypeIntegration.php
@@ -22,7 +22,7 @@ class AssociationTypeIntegration extends TestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.association_type');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('SUBSTITUTION'), 'standard');
 

--- a/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/AttributeGroupIntegration.php
+++ b/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/AttributeGroupIntegration.php
@@ -64,7 +64,7 @@ class AttributeGroupIntegration extends AbstractStandardNormalizerTestCase
     private function assert($identifier, array $expected)
     {
         $repository = $this->get('pim_catalog.repository.attribute_group');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier($identifier), 'standard');
 

--- a/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/AttributeIntegration.php
+++ b/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/AttributeIntegration.php
@@ -895,7 +895,7 @@ class AttributeIntegration extends TestCase
     private function assert($identifier, array $expected)
     {
         $repository = $this->get('pim_catalog.repository.attribute');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier($identifier), 'standard');
 

--- a/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/AttributeOptionIntegration.php
+++ b/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/AttributeOptionIntegration.php
@@ -23,7 +23,7 @@ class AttributeOptionIntegration extends TestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.attribute_option');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('a_multi_select.optionA'), 'standard');
 

--- a/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/FamilyIntegration.php
+++ b/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/FamilyIntegration.php
@@ -92,7 +92,7 @@ class FamilyIntegration extends TestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.family');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('familyA'), 'standard');
 

--- a/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/FamilyVariantIntegration.php
+++ b/src/Akeneo/Pim/Structure/Component/tests/Integration/Normalizer/Standard/FamilyVariantIntegration.php
@@ -37,7 +37,7 @@ class FamilyVariantIntegration extends TestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.family_variant');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize(
             $repository->findOneByIdentifier('clothing_color_size'),

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -19,7 +19,7 @@ services:
         class: '%pim_api.controller.media_file.class%'
         arguments:
             - '@pim_api.repository.media_file'
-            - '@pim_serializer'
+            - '@pim_external_api_serializer'
             - '@pim_api.pagination.parameter_validator'
             - '@pim_api.pagination.offset_hal_paginator'
             - '@akeneo_file_storage.file_storage.filesystem_provider'

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Resources/config/normalizers.yml
@@ -33,7 +33,7 @@ services:
     pim_api.normalizer.collection:
         class: '%pim_api.normalizer.collection.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     pim_api.normalizer.product_model:
         class: '%pim_api.normalizer.product_model.class%'
@@ -42,7 +42,7 @@ services:
             - '@pim_api.repository.attribute'
             - '@router'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }
 
     pim_api.normalizer.file:
         class: '%pim_api.normalizer.file.class%'
@@ -50,4 +50,4 @@ services:
             - '@pim_catalog.normalizer.standard.file'
             - '@router'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_external_api_serializer.normalizer, priority: 90 }

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/AbstractProductTestCase.php
@@ -133,7 +133,7 @@ abstract class AbstractProductTestCase extends ApiTestCase
     {
         $product = $this->getFromTestContainer('pim_catalog.repository.product')->findOneByIdentifier($identifier);
 
-        $standardizedProduct = $this->getFromTestContainer('pim_serializer')->normalize($product, 'standard');
+        $standardizedProduct = $this->getFromTestContainer('pim_standard_format_serializer')->normalize($product, 'standard');
 
         NormalizedProductCleaner::clean($expectedProduct);
         NormalizedProductCleaner::clean($standardizedProduct);

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
@@ -643,7 +643,7 @@ JSON;
         $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
 
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('foo');
-        $standardizedProduct = $this->get('pim_serializer')->normalize($product, 'standard');
+        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 
         $this->assertNotSame('2014-06-14T13:12:50+02:00', $standardizedProduct['created']);
         $this->assertNotSame('2014-06-14T13:12:50+02:00', $standardizedProduct['updated']);
@@ -984,7 +984,7 @@ JSON;
     protected function assertSameProducts(array $expectedProduct, $identifier)
     {
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
-        $standardizedProduct = $this->get('pim_serializer')->normalize($product, 'standard');
+        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 
         NormalizedProductCleaner::clean($standardizedProduct);
         NormalizedProductCleaner::clean($expectedProduct);

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
@@ -1028,7 +1028,7 @@ JSON;
         $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
 
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('foo');
-        $standardizedProduct = $this->get('pim_serializer')->normalize($product, 'standard');
+        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 
         $this->assertNotSame('2014-06-14T13:12:50+02:00', $standardizedProduct['created']);
         $this->assertNotSame('2014-06-14T13:12:50+02:00', $standardizedProduct['updated']);

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -1148,7 +1148,7 @@ JSON;
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
 
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('product_categories');
-        $standardizedProduct = $this->get('pim_serializer')->normalize($product, 'standard');
+        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 
         $this->assertNotSame('2014-06-14T13:12:50+02:00', $standardizedProduct['created']);
         $this->assertNotSame('2014-06-14T13:12:50+02:00', $standardizedProduct['updated']);

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductToVariantIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductToVariantIntegration.php
@@ -47,7 +47,7 @@ JSON;
         $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
 
         $product = $this->getFromTestContainer('pim_catalog.repository.product')->findOneByIdentifier('product_family_variant');
-        $standardizedProduct = $this->getFromTestContainer('pim_serializer')->normalize($product, 'standard');
+        $standardizedProduct = $this->getFromTestContainer('pim_standard_format_serializer')->normalize($product, 'standard');
         unset($standardizedProduct['categories']);
         NormalizedProductCleaner::clean($expectedProduct);
         NormalizedProductCleaner::clean($standardizedProduct);

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateVariantProductIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateVariantProductIntegration.php
@@ -1724,7 +1724,7 @@ JSON;
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
 
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_optionb_false');
-        $standardizedProduct = $this->get('pim_serializer')->normalize($product, 'standard');
+        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 
         $this->assertNotSame('2014-06-14T13:12:50+02:00', $standardizedProduct['created']);
         $this->assertNotSame('2014-06-14T13:12:50+02:00', $standardizedProduct['updated']);

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
@@ -909,7 +909,7 @@ JSON;
     protected function assertSameProductModels(array $expectedProductModel, $identifier)
     {
         $productModel = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier($identifier);
-        $standardizedProductModel = $this->get('pim_serializer')->normalize($productModel, 'standard');
+        $standardizedProductModel = $this->get('pim_standard_format_serializer')->normalize($productModel, 'standard');
 
         NormalizedProductCleaner::clean($expectedProductModel);
         NormalizedProductCleaner::clean($standardizedProductModel);

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateListProductModelIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateListProductModelIntegration.php
@@ -311,7 +311,7 @@ JSON;
     protected function assertSameProductModels(array $expectedProductModel, $code)
     {
         $productModel = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier($code);
-        $standardizedProductModel = $this->get('pim_serializer')->normalize($productModel, 'standard');
+        $standardizedProductModel = $this->get('pim_standard_format_serializer')->normalize($productModel, 'standard');
 
         NormalizedProductCleaner::clean($expectedProductModel);
         NormalizedProductCleaner::clean($standardizedProductModel);

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
@@ -81,7 +81,7 @@ JSON;
         $this->assertSame('', $response->getContent());
 
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_optionb_false');
-        $standardizedProduct = $this->get('pim_serializer')->normalize($product, 'standard');
+        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
         $this->assertSame($standardizedProduct['values']['a_text'][0]['data'], 'My awesome text');
     }
 
@@ -153,7 +153,7 @@ JSON;
         $this->assertSame('', $response->getContent());
 
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_optionb_false');
-        $standardizedProduct = $this->get('pim_serializer')->normalize($product, 'standard');
+        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
         $this->assertSame($standardizedProduct['values']['a_text'][0]['data'], 'My awesome text');
     }
 
@@ -387,7 +387,7 @@ JSON;
         $this->assertSame('', $response->getContent());
 
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_optionb_false');
-        $standardizedProduct = $this->get('pim_serializer')->normalize($product, 'standard');
+        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
         $this->assertSame($standardizedProduct['values']['a_number_float'][0]['data'], '15.3000');
 
     }
@@ -1172,7 +1172,7 @@ JSON;
     protected function assertSameProductModels(array $expectedProductModel, $identifier)
     {
         $productModel = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier($identifier);
-        $standardizedProductModel = $this->get('pim_serializer')->normalize($productModel, 'standard');
+        $standardizedProductModel = $this->get('pim_standard_format_serializer')->normalize($productModel, 'standard');
 
         NormalizedProductCleaner::clean($expectedProductModel);
         NormalizedProductCleaner::clean($standardizedProductModel);

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Resources/config/serializer/serializer.yml
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Resources/config/serializer/serializer.yml
@@ -4,7 +4,7 @@ parameters:
 
 services:
     pim_versioning.serializer:
-        class: '%pim_serializer.class%'
+        class: 'Symfony\Component\Serializer\Serializer'
 
     # Encoder
     pim_versioning.serializer.encoder.csv:

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AssociationTypeIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AssociationTypeIntegration.php
@@ -20,7 +20,7 @@ class AssociationTypeIntegration extends AbstractNormalizerTestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.association_type');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_external_api_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('X_SELL'), 'external_api');
 

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AttributeGroupIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AttributeGroupIntegration.php
@@ -37,7 +37,7 @@ class AttributeGroupIntegration extends AbstractNormalizerTestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.attribute_group');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_external_api_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('attributeGroupA'), 'external_api');
 

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AttributeIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AttributeIntegration.php
@@ -893,7 +893,7 @@ class AttributeIntegration extends AbstractNormalizerTestCase
     private function assert($identifier, array $expected)
     {
         $repository = $this->get('pim_catalog.repository.attribute');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_external_api_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier($identifier), 'external_api');
 

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/CategoryIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/CategoryIntegration.php
@@ -37,7 +37,7 @@ class CategoryIntegration extends AbstractNormalizerTestCase
     private function assert($identifier, array $expected)
     {
         $repository = $this->get('pim_catalog.repository.category');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_external_api_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier($identifier), 'external_api');
 

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/ChannelNormalizerIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/ChannelNormalizerIntegration.php
@@ -36,7 +36,7 @@ class ChannelNormalizerIntegration extends AbstractNormalizerTestCase
     private function assert($channelCode, array $expected)
     {
         $repository = $this->get('pim_catalog.repository.channel');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_external_api_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier($channelCode), 'external_api');
 

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/CurrencyIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/CurrencyIntegration.php
@@ -17,7 +17,7 @@ class CurrencyIntegration extends AbstractNormalizerTestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.currency');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_external_api_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('EUR'), 'external_api');
 

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/FamilyIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/FamilyIntegration.php
@@ -90,7 +90,7 @@ class FamilyIntegration extends AbstractNormalizerTestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.family');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_external_api_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('familyA'), 'external_api');
 

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/LocaleNormalizerIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/LocaleNormalizerIntegration.php
@@ -26,7 +26,7 @@ class LocaleNormalizerIntegration extends AbstractNormalizerTestCase
     private function assert($localeCode, array $expected)
     {
         $repository = $this->get('pim_catalog.repository.locale');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_external_api_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier($localeCode), 'external_api');
 

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
@@ -382,7 +382,7 @@ class ProductNormalizerIntegration extends TestCase
      */
     private function normalizeProductToStandardFormat(ProductInterface $product, array $context)
     {
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_external_api_serializer');
 
         return $serializer->normalize($product, 'external_api', $context);
     }

--- a/src/Pim/Bundle/CatalogBundle/PimCatalogBundle.php
+++ b/src/Pim/Bundle/CatalogBundle/PimCatalogBundle.php
@@ -2,8 +2,6 @@
 
 namespace Pim\Bundle\CatalogBundle;
 
-use Akeneo\Pim\Enrichment\Bundle\DependencyInjection\Compiler\RegisterQueryGeneratorsPass;
-use Akeneo\Pim\Enrichment\Bundle\DependencyInjection\Compiler\ResolveDoctrineTargetModelPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/data_sources.yml
@@ -128,7 +128,7 @@ services:
         arguments:
             - '@pim_catalog.object_manager.product'
             - '@pim_enrich.query.product_and_product_model_query_builder_from_size_factory'
-            - '@pim_serializer'
+            - '@pim_datagrid_serializer'
             - '@pim_datagrid.event_subscriber.filter_entity_with_values_subscriber'
         calls:
             - [ setMassActionRepository, ['@pim_catalog.repository.product_mass_action'] ]
@@ -140,7 +140,7 @@ services:
         arguments:
             - '@pim_catalog.object_manager.product'
             - '@pim_enrich.query.product_and_product_model_query_builder_from_size_factory'
-            - '@pim_serializer'
+            - '@pim_datagrid_serializer'
             - '@pim_datagrid.event_subscriber.filter_entity_with_values_subscriber'
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_associated_product }
@@ -150,7 +150,7 @@ services:
             arguments:
                 - '@pim_catalog.object_manager.product'
                 - '@pim_enrich.query.product_and_product_model_query_builder_from_size_factory'
-                - '@pim_serializer'
+                - '@pim_datagrid_serializer'
                 - '@pim_datagrid.event_subscriber.filter_entity_with_values_subscriber'
             tags:
                 - { name: oro_datagrid.datasource, type: pim_datasource_associated_product_model }

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/normalizers.yml
@@ -18,7 +18,7 @@ services:
             - '@pim_catalog.filter.chained'
             - '@pim_enrich.normalizer.image'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_datagrid_serializer.normalizer }
 
     pim_datagrid.normalizer.product_model:
         class: '%pim_datagrid.normalizer.product_model.class%'
@@ -28,24 +28,24 @@ services:
             - '@pim_catalog.product_models.image_as_label'
             - '@pim_enrich.normalizer.image'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_datagrid_serializer.normalizer }
 
     pim_datagrid.normalizer.product_association:
         class: '%pim_datagrid.normalizer.product_association.class%'
         arguments:
             - '@pim_enrich.normalizer.image'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_datagrid_serializer.normalizer }
 
     pim_datagrid.normalizer.product.option:
         class: '%pim_datagrid.normalizer.product.option.class%'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_datagrid_serializer.normalizer }
 
     pim_datagrid.normalizer.product.options:
         class: '%pim_datagrid.normalizer.product.options.class%'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_datagrid_serializer.normalizer }
 
     pim_datagrid.normalizer.product.product_values:
         class: '%pim_datagrid.normalizer.product.product_values.class%'
@@ -53,7 +53,7 @@ services:
             - '@pim_catalog.localization.presenter.registry'
             - '@pim_user.context.user'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_datagrid_serializer.normalizer }
 
     pim_datagrid.normalizer.datetime:
         class: '%pim_datagrid.normalizer.datetime.class%'
@@ -62,19 +62,19 @@ services:
             - '@pim_catalog.localization.presenter.date'
             - '@pim_user.context.user'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_datagrid_serializer.normalizer }
 
     pim_datagrid.normalizer.product.file:
         class: '%pim_datagrid.normalizer.product.file.class%'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_datagrid_serializer.normalizer }
 
     pim_datagrid.normalizer.product.product_value:
         class: '%pim_datagrid.normalizer.product.product_value.class%'
         arguments:
             - '@pim_catalog.normalizer.standard.product.product_value'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_datagrid_serializer.normalizer, priority: 90 }
 
     pim_datagrid.normalizer.group_product:
         class: '%pim_datagrid.normalizer.group_product.class%'
@@ -82,7 +82,7 @@ services:
             - '@pim_catalog.filter.chained'
             - '@pim_enrich.normalizer.image'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_datagrid_serializer.normalizer }
 
     pim_datagrid.normalizer.family_variant:
         class: '%pim_datagrid.normalizer.family_variant.class%'

--- a/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
+++ b/src/Pim/Bundle/EnrichBundle/DependencyInjection/PimEnrichExtension.php
@@ -61,7 +61,6 @@ class PimEnrichExtension extends Extension
         $loader->load('readers.yml');
         $loader->load('repositories.yml');
         $loader->load('resolvers.yml');
-        $loader->load('serializers.yml');
         $loader->load('steps.yml');
         $loader->load('structure_version.yml');
         $loader->load('twig.yml');

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/IncompleteValuesNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/IncompleteValuesNormalizer.php
@@ -22,9 +22,6 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class IncompleteValuesNormalizer implements NormalizerInterface
 {
-    /** @var NormalizerInterface */
-    private $normalizer;
-
     /** @var RequiredValueCollectionFactory */
     private $requiredValueCollectionFactory;
 
@@ -32,16 +29,13 @@ class IncompleteValuesNormalizer implements NormalizerInterface
     private $incompleteValueCollectionFactory;
 
     /**
-     * @param NormalizerInterface              $normalizer
      * @param RequiredValueCollectionFactory   $requiredValueCollectionFactory
      * @param IncompleteValueCollectionFactory $incompleteValueCollectionFactory
      */
     public function __construct(
-        NormalizerInterface $normalizer,
         RequiredValueCollectionFactory $requiredValueCollectionFactory,
         IncompleteValueCollectionFactory $incompleteValueCollectionFactory
     ) {
-        $this->normalizer = $normalizer;
         $this->requiredValueCollectionFactory = $requiredValueCollectionFactory;
         $this->incompleteValueCollectionFactory = $incompleteValueCollectionFactory;
     }

--- a/src/Pim/Bundle/EnrichBundle/PimEnrichBundle.php
+++ b/src/Pim/Bundle/EnrichBundle/PimEnrichBundle.php
@@ -31,7 +31,6 @@ class PimEnrichBundle extends Bundle
             ->addCompilerPass(new Compiler\RegisterGenericProvidersPass(new ReferenceFactory(), 'form'))
             ->addCompilerPass(new Compiler\RegisterGenericProvidersPass(new ReferenceFactory(), 'filter'))
             ->addCompilerPass(new Compiler\RegisterCategoryItemCounterPass())
-            ->addCompilerPass(new RegisterSerializerPass('pim_internal_api_serializer'))
             ->addCompilerPass(new RegisterProductQueryFilterPass('product_and_product_model'))
         ;
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -101,7 +101,7 @@ services:
             - '@event_dispatcher'
             - '@pim_enrich.repository.job_execution'
             - '@pim_connector.event_listener.archivist'
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - '@akeneo_batch_queue.manager.job_execution_manager'
             - '@oro_security.security_facade'
             - {'import': 'pim_importexport_import_profile_show', 'export': 'pim_importexport_export_profile_show'}
@@ -246,7 +246,7 @@ services:
             - '@pim_comment.repository.comment'
             - '@pim_comment.saver.comment'
             - '@pim_comment.builder.comment'
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - '@validator'
             - '@pim_catalog.localization.presenter.datetime'
             - '@pim_enrich.resolver.locale'
@@ -287,7 +287,7 @@ services:
         arguments:
             - '@translator'
             - '@pim_connector.event_listener.archivist'
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - '@akeneo_batch_queue.manager.job_execution_manager'
             - '@pim_enrich.repository.job_execution'
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -36,7 +36,7 @@ services:
     pim_enrich.normalizer.product:
         class: '%pim_enrich.normalizer.product.class%'
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - '@pim_enrich.normalizer.version'
             - '@pim_versioning.manager.version'
             - '@pim_enrich.normalizer.image'
@@ -65,7 +65,7 @@ services:
     pim_enrich.normalizer.product_model:
         class: '%pim_enrich.normalizer.product_model.class%'
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
             - '@pim_enrich.normalizer.version'
             - '@pim_versioning.manager.version'
             - '@pim_enrich.normalizer.image'
@@ -89,7 +89,6 @@ services:
     pim_enrich.normalizer.incomplete_values:
         class: '%pim_enrich.normalizer.incomplete_values.class%'
         arguments:
-            - '@pim_serializer'
             - '@pim_catalog.entity_with_family.required_value_collection_factory'
             - '@pim_catalog.entity_with_family.incomplete_value_collection_factory'
         tags:
@@ -185,7 +184,7 @@ services:
     pim_enrich.normalizer.category:
         class: '%pim_enrich.normalizer.category.class%'
         arguments:
-            - '@pim_serializer'
+            - '@pim_standard_format_serializer'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/serializers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/serializers.yml
@@ -1,9 +1,0 @@
-parameters:
-    pim_enrich.encoder.json.class:     Symfony\Component\Serializer\Encoder\JsonEncoder
-
-services:
-    pim_enrich.encoder.json:
-        public: false
-        class: '%pim_enrich.encoder.json.class%'
-        tags:
-            - { name: pim_internal_api_serializer.encoder, priority: 90 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/serializers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/serializers.yml
@@ -1,12 +1,7 @@
 parameters:
-    pim_internal_api_serializer.class: Symfony\Component\Serializer\Serializer
     pim_enrich.encoder.json.class:     Symfony\Component\Serializer\Encoder\JsonEncoder
 
 services:
-    pim_internal_api_serializer:
-        class: '%pim_internal_api_serializer.class%'
-
-
     pim_enrich.encoder.json:
         public: false
         class: '%pim_enrich.encoder.json.class%'

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/IncompleteValuesNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/IncompleteValuesNormalizerSpec.php
@@ -23,11 +23,10 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class IncompleteValuesNormalizerSpec extends ObjectBehavior
 {
     function let(
-        NormalizerInterface $normalizer,
         RequiredValueCollectionFactory $requiredValueCollectionFactory,
         IncompleteValueCollectionFactory $incompleteValueCollectionFactory
     ) {
-        $this->beConstructedWith($normalizer, $requiredValueCollectionFactory, $incompleteValueCollectionFactory);
+        $this->beConstructedWith($requiredValueCollectionFactory, $incompleteValueCollectionFactory);
     }
 
     function it_is_initializable()

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobExecutionController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobExecutionController.php
@@ -38,9 +38,6 @@ class JobExecutionController
     /** @var string */
     protected $jobType;
 
-    /** @var SerializerInterface */
-    protected $serializer;
-
     /** @var JobExecutionManager */
     protected $jobExecutionManager;
 
@@ -62,7 +59,6 @@ class JobExecutionController
      * @param EventDispatcherInterface $eventDispatcher
      * @param BatchLogHandler          $batchLogHandler
      * @param JobExecutionArchivist    $archivist
-     * @param SerializerInterface      $serializer
      * @param JobExecutionManager      $jobExecutionManager
      * @param JobExecutionRepository   $jobExecutionRepo
      * @param string                   $jobType
@@ -73,7 +69,6 @@ class JobExecutionController
         EventDispatcherInterface $eventDispatcher,
         BatchLogHandler $batchLogHandler,
         JobExecutionArchivist $archivist,
-        SerializerInterface $serializer,
         JobExecutionManager $jobExecutionManager,
         JobExecutionRepository $jobExecutionRepo,
         $jobType
@@ -83,7 +78,6 @@ class JobExecutionController
         $this->eventDispatcher = $eventDispatcher;
         $this->batchLogHandler = $batchLogHandler;
         $this->archivist = $archivist;
-        $this->serializer = $serializer;
         $this->jobExecutionManager = $jobExecutionManager;
         $this->jobExecutionRepo = $jobExecutionRepo;
         $this->jobType = $jobType;

--- a/src/Pim/Bundle/ImportExportBundle/Controller/JobExecutionController.php
+++ b/src/Pim/Bundle/ImportExportBundle/Controller/JobExecutionController.php
@@ -12,12 +12,9 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/controllers.yml
@@ -39,7 +39,6 @@ services:
             - '@event_dispatcher'
             - '@akeneo_batch.logger.batch_log_handler'
             - '@pim_connector.event_listener.archivist'
-            - '@pim_serializer'
             - '@akeneo_batch.manager.job_execution'
             - '@pim_enrich.repository.job_execution'
             - export
@@ -52,7 +51,6 @@ services:
             - '@event_dispatcher'
             - '@akeneo_batch.logger.batch_log_handler'
             - '@pim_connector.event_listener.archivist'
-            - '@pim_serializer'
             - '@akeneo_batch.manager.job_execution'
             - '@pim_enrich.repository.job_execution'
             - import

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/normalizers.yml
@@ -10,6 +10,7 @@ services:
             - '@pim_catalog.normalizer.standard.job_instance'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
             - { name: pim_versioning.serializer.normalizer, priority: 90 }
 
     pim_import_export.normalizer.step_execution:
@@ -19,4 +20,5 @@ services:
             - '@pim_catalog.localization.presenter.datetime'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_standard_format_serializer.normalizer, priority: 90 }
             - { name: pim_versioning.serializer.normalizer, priority: 90 }

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/datagrid/normalizers.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/datagrid/normalizers.yml
@@ -6,9 +6,9 @@ services:
     pim_reference_data.datagrid.normalizer.reference_data:
         class: '%pim_reference_data.datagrid.normalizer.reference_data.class%'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_datagrid_serializer.normalizer }
 
     pim_reference_data.datagrid.normalizer.reference_data_collection:
         class: '%pim_reference_data.datagrid.normalizer.reference_data_collection.class%'
         tags:
-            - { name: pim_serializer.normalizer }
+            - { name: pim_datagrid_serializer.normalizer }

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/serializers_indexing.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/serializers_indexing.yml
@@ -6,9 +6,9 @@ services:
     pim_reference_data.normalizer.indexing.product.reference_data:
         class: '%pim_reference_data.normalizer.indexing.product.reference_data.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }
 
     pim_reference_data_collection.normalizer.indexing.product.reference_data:
         class: '%pim_reference_data_collection.normalizer.indexing.product.reference_data.class%'
         tags:
-            - { name: pim_serializer.normalizer, priority: 90 }
+            - { name: pim_indexing_serializer.normalizer, priority: 90 }

--- a/src/Pim/Component/Catalog/Normalizer/Standard/Product/ProductValueNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/Product/ProductValueNormalizer.php
@@ -5,6 +5,7 @@ namespace Pim\Component\Catalog\Normalizer\Standard\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Value\OptionsValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Value\PriceCollectionValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\ReferenceData\Value\ReferenceDataCollectionValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -97,7 +98,6 @@ class ProductValueNormalizer implements NormalizerInterface
         }
 
         $attributeType = $value->getAttribute()->getType();
-        $context['is_decimals_allowed'] = $value->getAttribute()->isDecimalsAllowed();
 
         // if decimals_allowed is false, we return an integer
         // if true, we return a string to avoid to loose precision (http://floating-point-gui.de)
@@ -107,16 +107,23 @@ class ProductValueNormalizer implements NormalizerInterface
                 : (int) $value->getData();
         }
 
-        if (in_array($attributeType, [
-            AttributeTypes::OPTION_SIMPLE_SELECT,
-            AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT
-        ])) {
+        if ($value instanceof ScalarValue) {
+            return $value->getData();
+        }
+
+        if ($attributeType === AttributeTypes::OPTION_SIMPLE_SELECT ||
+            $attributeType === AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT
+        ) {
             return $value->getData()->getCode();
         }
 
-        if (in_array($attributeType, [AttributeTypes::FILE, AttributeTypes::IMAGE])) {
+        if ($attributeType === AttributeTypes::FILE ||
+            $attributeType === AttributeTypes::IMAGE
+        ) {
             return $value->getData()->getKey();
         }
+
+        $context['is_decimals_allowed'] = $value->getAttribute()->isDecimalsAllowed();
 
         return $this->normalizer->normalize($value->getData(), $format, $context);
     }

--- a/src/Pim/Component/Catalog/Normalizer/Standard/Product/ProductValueNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/Product/ProductValueNormalizer.php
@@ -8,8 +8,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Value\PriceCollectionValueInterface;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\ReferenceData\Value\ReferenceDataCollectionValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Serializer\SerializerAwareInterface;
-use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Normalize a product value into an array
@@ -18,19 +16,19 @@ use Symfony\Component\Serializer\SerializerInterface;
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInterface
+class ProductValueNormalizer implements NormalizerInterface
 {
     const DECIMAL_PRECISION = 4;
 
-    /** @var SerializerInterface */
-    protected $serializer;
+    /** @var NormalizerInterface */
+    private $normalizer;
 
     /**
-     * {@inheritdoc}
+     * @param NormalizerInterface $normalizer
      */
-    public function setSerializer(SerializerInterface $serializer): void
+    public function __construct(NormalizerInterface $normalizer)
     {
-        $this->serializer = $serializer;
+        $this->normalizer = $normalizer;
     }
 
     /**
@@ -78,7 +76,7 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
                 $value->getAttribute()->isBackendTypeReferenceData()) {
                 $data[] = $item->getCode();
             } else {
-                $data[] = $this->serializer->normalize($item, $format, $context);
+                $data[] = $this->normalizer->normalize($item, $format, $context);
             }
         }
 
@@ -120,6 +118,6 @@ class ProductValueNormalizer implements NormalizerInterface, SerializerAwareInte
             return $value->getData()->getKey();
         }
 
-        return $this->serializer->normalize($value->getData(), $format, $context);
+        return $this->normalizer->normalize($value->getData(), $format, $context);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/Product/ProductValueNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/Product/ProductValueNormalizerSpec.php
@@ -8,15 +8,15 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\ProductValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Value\OptionsValueInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 
 class ProductValueNormalizerSpec extends ObjectBehavior
 {
-    function let(SerializerInterface $serializer)
+    function let(NormalizerInterface $normalizer)
     {
-        $serializer->implement('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
-        $this->setSerializer($serializer);
+        $this->beConstructedWith($normalizer);
     }
 
     function it_is_initializable()
@@ -27,7 +27,6 @@ class ProductValueNormalizerSpec extends ObjectBehavior
     function it_is_a_normalizer()
     {
         $this->shouldImplement('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
-        $this->shouldImplement('Symfony\Component\Serializer\SerializerAwareInterface');
     }
 
     function it_supports_standard_format_and_product_value(ValueInterface $value)
@@ -39,14 +38,13 @@ class ProductValueNormalizerSpec extends ObjectBehavior
     }
 
     function it_normalizes_a_product_value_in_standard_format_with_no_locale_and_no_scope(
-        SerializerInterface $serializer,
+        $normalizer,
         ValueInterface $value,
         AttributeInterface $attribute
     ) {
-        $serializer->normalize('product_value_data', null, ['is_decimals_allowed' => false])
+        $normalizer->normalize('product_value_data', null, ['is_decimals_allowed' => false])
             ->shouldBeCalled()
             ->willReturn('product_value_data');
-        $this->setSerializer($serializer);
 
         $value->getData()->willReturn('product_value_data');
         $value->getLocale()->willReturn(null);
@@ -65,14 +63,13 @@ class ProductValueNormalizerSpec extends ObjectBehavior
     }
 
     function it_normalizes_a_product_value_in_standard_format_with_locale_and_no_scope(
-        SerializerInterface $serializer,
+        $normalizer,
         ValueInterface $value,
         AttributeInterface $attribute
     ) {
-        $serializer->normalize('product_value_data', null, ['is_decimals_allowed' => false])
+        $normalizer->normalize('product_value_data', null, ['is_decimals_allowed' => false])
             ->shouldBeCalled()
             ->willReturn('product_value_data');
-        $this->setSerializer($serializer);
 
         $value->getData()->willReturn('product_value_data');
         $value->getLocale()->willReturn('en_US');
@@ -91,14 +88,13 @@ class ProductValueNormalizerSpec extends ObjectBehavior
     }
 
     function it_normalizes_a_product_value_in_standard_format_with_locale_and_scope(
-        SerializerInterface $serializer,
+        $normalizer,
         ValueInterface $value,
         AttributeInterface $attribute
     ) {
-        $serializer->normalize('product_value_data', null, ['is_decimals_allowed' => false])
+        $normalizer->normalize('product_value_data', null, ['is_decimals_allowed' => false])
             ->shouldBeCalled()
             ->willReturn('product_value_data');
-        $this->setSerializer($serializer);
 
         $value->getData()->willReturn('product_value_data');
         $value->getLocale()->willReturn('en_US');
@@ -117,13 +113,12 @@ class ProductValueNormalizerSpec extends ObjectBehavior
     }
 
     function it_normalizes_a_number_product_value_with_decimal(
-        SerializerInterface $serializer,
+        $normalizer,
         ValueInterface $value,
         AttributeInterface $attribute
     ) {
-        $serializer->normalize('15.50', null, ['is_decimals_allowed' => true])
+        $normalizer->normalize('15.50', null, ['is_decimals_allowed' => true])
             ->shouldNotBeCalled();
-        $this->setSerializer($serializer);
 
         $value->getData()->willReturn('15.50');
         $value->getLocale()->willReturn('en_US');
@@ -143,13 +138,12 @@ class ProductValueNormalizerSpec extends ObjectBehavior
     }
 
     function it_normalizes_a_number_product_value_without_decimal(
-        SerializerInterface $serializer,
+        $normalizer,
         ValueInterface $value,
         AttributeInterface $attribute
     ) {
-        $serializer->normalize('15.00', null, [])
+        $normalizer->normalize('15.00', null, [])
             ->shouldNotBeCalled();
-        $this->setSerializer($serializer);
 
         $value->getData()->willReturn('15.00');
         $value->getLocale()->willReturn('en_US');
@@ -169,14 +163,13 @@ class ProductValueNormalizerSpec extends ObjectBehavior
     }
 
     function it_normalizes_a_simple_select(
-        SerializerInterface $serializer,
+        $normalizer,
         ValueInterface $value,
         AttributeInterface $attribute,
         AttributeOptionInterface $simpleSelect
     ) {
         $simpleSelect->getCode()->willReturn('optionA');
-        $serializer->normalize($simpleSelect, null, [])->shouldNotBeCalled();
-        $this->setSerializer($serializer);
+        $normalizer->normalize($simpleSelect, null, [])->shouldNotBeCalled();
 
         $value->getData()->willReturn($simpleSelect);
         $value->getLocale()->willReturn(null);
@@ -195,14 +188,13 @@ class ProductValueNormalizerSpec extends ObjectBehavior
     }
 
     function it_normalizes_a_multi_select(
-        SerializerInterface $serializer,
+        $normalizer,
         OptionsValueInterface $value,
         AttributeInterface $attribute,
         AttributeOptionInterface $multiSelect
     ) {
         $multiSelect->getCode()->willReturn('optionA');
-        $serializer->normalize($multiSelect, null, [])->shouldNotBeCalled();
-        $this->setSerializer($serializer);
+        $normalizer->normalize($multiSelect, null, [])->shouldNotBeCalled();
 
         $values = [$multiSelect];
 

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/Product/ProductValueNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/Product/ProductValueNormalizerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Normalizer\Standard\Product;
 
+use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
@@ -210,6 +211,25 @@ class ProductValueNormalizerSpec extends ObjectBehavior
                 'locale' => null,
                 'scope'  => null,
                 'data'   => ['optionA'],
+            ]
+        );
+    }
+
+    function it_normalizes_a_scalar(
+        ScalarValue $value,
+        AttributeInterface $attribute
+    ) {
+        $value->getData()->willReturn('foo');
+        $value->getLocale()->willReturn('en_US');
+        $value->getScope()->willReturn('ecommerce');
+        $value->getAttribute()->willReturn($attribute);
+        $attribute->getType()->willReturn(AttributeTypes::TEXT);
+
+        $this->normalize($value)->shouldReturn(
+            [
+                'locale' => 'en_US',
+                'scope'  => 'ecommerce',
+                'data'   => 'foo',
             ]
         );
     }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/Product/PropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/Product/PropertiesNormalizerSpec.php
@@ -10,16 +10,14 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
 use Pim\Component\Catalog\Model\ValueCollection;
 use Pim\Component\Catalog\Normalizer\Standard\Product\PropertiesNormalizer;
 use Prophecy\Argument;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class PropertiesNormalizerSpec extends ObjectBehavior
 {
-    function let(CollectionFilterInterface $filter, SerializerInterface $serializer)
+    function let(CollectionFilterInterface $filter, NormalizerInterface $normalizer)
     {
-        $this->beConstructedWith($filter);
-
-        $serializer->implement('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
-        $this->setSerializer($serializer);
+        $this->beConstructedWith($filter, $normalizer);
     }
 
     function it_is_initializable()
@@ -42,7 +40,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
     function it_normalizes_the_properties_of_the_product(
         $filter,
-        $serializer,
+        $normalizer,
         ProductInterface $product,
         FamilyInterface $family,
         ValueCollection $values,
@@ -65,17 +63,17 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $context = ['filter_types' => ['pim.transform.product_value.structured']];
 
-        $serializer
+        $normalizer
             ->normalize($values, 'standard', $context)
             ->willReturn(['name' => [['locale' => null, 'scope' => null, 'value' => 'foo']]]);
 
         $created = new \DateTime('2010-06-23');
         $product->getCreated()->willReturn($created);
-        $serializer->normalize($created, 'standard')->willReturn('2010-06-23T00:00:00+01:00');
+        $normalizer->normalize($created, 'standard')->willReturn('2010-06-23T00:00:00+01:00');
 
         $updated = new \DateTime('2010-06-23 23:00:00');
         $product->getUpdated()->willReturn($updated);
-        $serializer->normalize($updated, 'standard')->willReturn('2010-06-23T23:00:00+01:00');
+        $normalizer->normalize($updated, 'standard')->willReturn('2010-06-23T23:00:00+01:00');
 
         $this->normalize($product, 'standard', $context)->shouldReturn([
             'identifier'    => 'my_code',
@@ -100,7 +98,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
     function it_normalizes_the_properties_of_the_variant_product(
         $filter,
-        $serializer,
+        $normalizer,
         ProductInterface $product,
         ProductModel $productModel,
         FamilyInterface $family,
@@ -126,17 +124,17 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $context = ['filter_types' => ['pim.transform.product_value.structured']];
 
-        $serializer
+        $normalizer
             ->normalize($values, 'standard', $context)
             ->willReturn(['name' => [['locale' => null, 'scope' => null, 'value' => 'foo']]]);
 
         $created = new \DateTime('2010-06-23');
         $product->getCreated()->willReturn($created);
-        $serializer->normalize($created, 'standard')->willReturn('2010-06-23T00:00:00+01:00');
+        $normalizer->normalize($created, 'standard')->willReturn('2010-06-23T00:00:00+01:00');
 
         $updated = new \DateTime('2010-06-23 23:00:00');
         $product->getUpdated()->willReturn($updated);
-        $serializer->normalize($updated, 'standard')->willReturn('2010-06-23T23:00:00+01:00');
+        $normalizer->normalize($updated, 'standard')->willReturn('2010-06-23T23:00:00+01:00');
 
         $this->normalize($product, 'standard', $context)->shouldReturn([
             'identifier'    => 'my_code',

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
@@ -604,7 +604,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
      */
     private function assertIndexingFormat($entity, array $expected)
     {
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_indexing_serializer');
         $actual = $serializer->normalize($entity, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX);
 
         NormalizedProductCleaner::clean($actual);

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -341,7 +341,7 @@ class ProductIndexingIntegration extends TestCase
         $repository = $this->get('pim_catalog.repository.product');
         $product = $repository->findOneByIdentifier($identifier);
 
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_indexing_serializer');
         $actual = $serializer->normalize($product, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX);
 
         NormalizedProductCleaner::clean($actual);

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/CategoryIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/CategoryIntegration.php
@@ -39,7 +39,7 @@ class CategoryIntegration extends AbstractStandardNormalizerTestCase
     private function assert($identifier, array $expected)
     {
         $repository = $this->get('pim_catalog.repository.category');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier($identifier), 'standard');
 

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/DateTimeIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/DateTimeIntegration.php
@@ -17,7 +17,7 @@ class DateTimeIntegration extends AbstractStandardNormalizerTestCase
         $timezone = new \DateTimeZone('Europe/Paris');
         $datetime->setTimezone($timezone);
 
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
         $result = $serializer->normalize($datetime, 'standard');
 
         $this->assertSame('2015-01-01T23:50:00+01:00', $result);
@@ -29,7 +29,7 @@ class DateTimeIntegration extends AbstractStandardNormalizerTestCase
         $timezone = new \DateTimeZone('America/New_York');
         $datetime->setTimezone($timezone);
 
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
         $result = $serializer->normalize($datetime, 'standard');
 
         $this->assertSame('2014-12-31T18:00:00-05:00', $result);

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/FileIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/FileIntegration.php
@@ -34,7 +34,7 @@ class FileIntegration extends AbstractStandardNormalizerTestCase
     private function assert($name, array $expected)
     {
         $repository = $this->get('akeneo_file_storage.repository.file_info');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize($repository->findOneBy(['originalFilename' => $name]), 'standard');
 

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/GroupIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/GroupIntegration.php
@@ -20,7 +20,7 @@ class GroupIntegration extends AbstractStandardNormalizerTestCase
         ];
 
         $repository = $this->get('pim_catalog.repository.group');
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         $result = $serializer->normalize($repository->findOneByIdentifier('groupA'), 'standard');
 

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
@@ -291,7 +291,7 @@ class ProductStandardIntegration extends TestCase
      */
     private function normalizeProductToStandardFormat(ProductInterface $product)
     {
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
 
         return $serializer->normalize($product, 'standard');
     }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardSortedCollectionIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardSortedCollectionIntegration.php
@@ -188,7 +188,7 @@ class ProductStandardSortedCollectionIntegration extends TestCase
 
     private function assertStandardFormat(ProductInterface $product, array $expected): void
     {
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_standard_format_serializer');
         $result = $serializer->normalize($product, 'standard');
 
         $this->assertSame($expected, $result);

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Storage/EntityWithValuesStorageIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Storage/EntityWithValuesStorageIntegration.php
@@ -229,7 +229,7 @@ class EntityWithValuesStorageIntegration extends TestCase
      */
     private function assertStorageFormatForEntityWithValues(EntityWithValuesInterface $entity, array $expected)
     {
-        $serializer = $this->get('pim_serializer');
+        $serializer = $this->get('pim_storage_serializer');
         $result = $serializer->normalize($entity->getValues(), 'storage');
 
         NormalizedProductCleaner::cleanOnlyValues($expected);

--- a/src/Pim/Component/Catalog/tests/integration/Updater/Copier/MediaAttributeCopierIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/Copier/MediaAttributeCopierIntegration.php
@@ -163,7 +163,7 @@ class MediaAttributeCopierIntegration extends AbstractCopierTestCase
 
         $this->get('pim_catalog.saver.product')->save($product);
 
-        $standardProduct = $this->get('pim_serializer')->normalize($product, 'standard');
+        $standardProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 
 
         $result = $this->sanitizeMediaAttributeData($result);

--- a/src/Pim/Component/Catalog/tests/integration/Updater/Setter/MediaAttributeSetterIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Updater/Setter/MediaAttributeSetterIntegration.php
@@ -145,7 +145,7 @@ class MediaAttributeSetterIntegration extends TestCase
 
         $this->get('pim_catalog.saver.product')->save($product);
 
-        $standardProduct = $this->get('pim_serializer')->normalize($product, 'standard');
+        $standardProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 
         $result = $this->sanitizeMediaAttributeData($result);
         $standardValues = $this->sanitizeMediaAttributeData($standardProduct['values'][$attributeName]);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Before:
3.6 seconds in CE to return 100 products with the API, 380 PV/product.

After:
2.7 seconds in CE to return 100 products with the API, 380 PV/product.

It should probably improve:
- indexation
- persistence into the storage
- export with API
- export with jobs

I will benchmark it later more in details, once every improvement are done.


**Lazy service declaration**

If you read the PR, you will see I use sometimes the "lazy" loading of Symfony services instead of the `setSerializer`.
https://symfony.com/doc/current/service_container/lazy_services.html

**Why?**

If you inject directly the normalizer service (without calling the serializer), the function `setSerializer` will not be called. So, the service will not be correctly initialized. And then, it fails.

Actually, we are doing it quite often.
It was working before only because the serializer `pim_serializer` was called before calling directly the normalizer (so, the initialization was done). But it was not done in purpose: we are just kind of lucky.

The solution is to inject the desired normalizer with the DI, instead of relying on `setSerializer`.  
Then you can use directly the normalizer.
Also, the service is immutable, which is a good thing. And you are sure to have the serializer injected.

But then, you have circular dependencies.
That's why I use the "lazy" option.

Note: using `setSerializer` is actually the same trick as declaring a service as "lazy".

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
