### PR TITLE
Fix filtering by completeness in product groups

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/Product/CompletenessFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/Product/CompletenessFilter.php
@@ -65,7 +65,15 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
             return $this;
         }
 
-        $this->checkChannelAndValue($field, $channel, $value);
+        if (!in_array(
+            $operator,
+            [
+                Operators::AT_LEAST_COMPLETE,
+                Operators::AT_LEAST_INCOMPLETE,
+            ]
+        )) {
+            $this->checkChannelAndValue($field, $channel, $value);
+        }
 
         if (in_array(
             $operator,
@@ -129,7 +137,7 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
         $shouldClauses = [];
 
         foreach ($localeCodes as $localeCode) {
-            $field = sprintf('completeness.%s.%s', $channel, $localeCode);
+            $field = $this->getFieldWithChannelAndLocale('completeness', $channel, $localeCode);
 
             switch ($operator) {
                 case Operators::EQUALS:
@@ -230,6 +238,36 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
                     ];
                     $this->searchQueryBuilder->addFilter($clause);
                     break;
+                case Operators::AT_LEAST_COMPLETE:
+                    $allIncompleteField = $this->getFieldWithChannelAndLocale('all_incomplete', $channel, $localeCode);
+
+                    $clause = [
+                        'bool' => [
+                            'should' => [
+                                ['term' => [$field => 100]],
+                                ['term' => [$allIncompleteField => 0]],
+                            ],
+                            'minimum_should_match' => 1,
+                        ],
+                    ];
+
+                    $shouldClauses[] = $clause;
+                    break;
+                case Operators::AT_LEAST_INCOMPLETE:
+                    $allCompleteField = $this->getFieldWithChannelAndLocale('all_complete', $channel, $localeCode);
+
+                    $clause = [
+                        'bool' => [
+                            'should' => [
+                                ['range' => [$field => ['lt' => 100]]],
+                                ['term' => [$allCompleteField => 0]],
+                            ],
+                            'minimum_should_match' => 1,
+                        ],
+                    ];
+
+                    $shouldClauses[] = $clause;
+                    break;
                 default:
                     throw InvalidOperatorException::notSupported($operator, static::class);
             }
@@ -310,5 +348,17 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
         }
 
         return $channel;
+    }
+
+    /**
+     * @param string $field
+     * @param string $channel
+     * @param string $localeCode
+     *
+     * @return string
+     */
+    private function getFieldWithChannelAndLocale($field, $channel, $localeCode): string
+    {
+        return sprintf('%s.%s.%s', $field, $channel, $localeCode);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -348,6 +348,8 @@ services:
                 - '<='
                 - '<'
                 - 'EMPTY'
+                - 'AT LEAST COMPLETE'
+                - 'AT LEAST INCOMPLETE'
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
 


### PR DESCRIPTION
Fix for #8565

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

## Problem

The competeness filter for a product group grid works as a boolean filter and supports only 2 types of competeness: 
1. yes => AT_LEAST_COMPLETE
1. no => AT_LEAST_INCOMPLETE

See `Pim/Bundle/FilterBundle/Filter/CompletenessFilter.php`.

At the same time the elasticsearch product completeness filter doesn't support those two types of filtering.
See: `Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/Product/CompletenessFilter.php`.
Basically, any grid that displays products would fail by filtering by completeness because of this issue.

## Solution

Add support of `AT LEAST COMPLETE/INCOMPLETE` operators for product completeness filter.