### PR TITLE
Data collector to expose Elasticsearch version in system info reports

### DIFF
--- a/src/Pim/Bundle/AnalyticsBundle/DataCollector/SearchEngineDataCollector.php
+++ b/src/Pim/Bundle/AnalyticsBundle/DataCollector/SearchEngineDataCollector.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Pim\Bundle\AnalyticsBundle\DataCollector;
+
+use Akeneo\Tool\Component\Analytics\DataCollectorInterface;
+use Elasticsearch\ClientBuilder;
+
+/**
+ * Collects Elasticsearch version.
+ *
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SearchEngineDataCollector implements DataCollectorInterface
+{
+    /**
+     * @var ClientBuilder
+     */
+    private $clientBuilder;
+
+    /**
+     * @var array
+     */
+    private $hosts;
+
+    /**
+     * @param ClientBuilder $clientBuilder
+     * @param array $hosts
+     */
+    public function __construct(ClientBuilder $clientBuilder, array $hosts)
+    {
+        $this->clientBuilder = $clientBuilder;
+        $this->hosts = $hosts;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function collect()
+    {
+        $client = $this->clientBuilder
+            ->setHosts($this->hosts)
+            ->build();
+
+        $info = $client->info();
+
+        $version = $info['version']['number'] ?? '';
+
+        return ['elasticsearch_version' => $version];
+    }
+}

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
@@ -8,6 +8,7 @@ parameters:
     pim_analytics.data_collector.bundles.class:          Pim\Bundle\AnalyticsBundle\DataCollector\BundlesDataCollector
     pim_analytics.data_collector.storage.class:          Pim\Bundle\AnalyticsBundle\DataCollector\StorageDataCollector
     pim_analytics.data_collector.attribute.class:        Pim\Bundle\AnalyticsBundle\DataCollector\AttributeDataCollector
+    pim_analytics.data_collector.search_engine.class:    Pim\Bundle\AnalyticsBundle\DataCollector\SearchEngineDataCollector
 
 services:
     pim_analytics.data_collector.chained:
@@ -90,4 +91,13 @@ services:
             - '%database_password%'
         tags:
             - { name: pim_analytics.data_collector, type: system_info_report }
+            - { name: pim_analytics.data_collector, type: system_info_report }
+
+    pim_analytics.data_collector.search_engine:
+        class: '%pim_analytics.data_collector.search_engine.class%'
+        arguments:
+            - '@akeneo_elasticsearch.client_builder'
+            -
+                - '%index_hosts%'
+        tags:
             - { name: pim_analytics.data_collector, type: system_info_report }

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.ca_ES.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.ca_ES.yml
@@ -31,6 +31,7 @@ pim_analytics:
     mongodb_version: Versió MongoDB
     server_version: Versió del servidor
     php_extensions: Extensions de PHP
+    elasticsearch_version: Versió Elasticsearch
   acl:
     system_info:
       index: Informació del sistema

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.da_DK.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.da_DK.yml
@@ -34,6 +34,7 @@ pim_analytics:
     mongodb_version: MongoDB version
     server_version: Serverversion
     php_extensions: PHP suffiks
+    elasticsearch_version: Elasticsearch version
   acl:
     system_info:
       index: Systemoplysninger

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.de_DE.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.de_DE.yml
@@ -34,6 +34,7 @@ pim_analytics:
     mongodb_version: MongoDB-Version
     server_version: Server-Version
     php_extensions: PHP-Erweiterungen
+    elasticsearch_version: Elasticsearch-Version
   acl:
     system_info:
       index: Systeminformationen

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en_US.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en_US.yml
@@ -45,6 +45,7 @@ pim_analytics:
         mongodb_version: MongoDB version
         server_version: Server version
         php_extensions: PHP extensions
+        elasticsearch_version: Elasticsearch version
     acl:
         system_info:
             index: System information

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.es_ES.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.es_ES.yml
@@ -34,6 +34,7 @@ pim_analytics:
     mongodb_version: Versión de MongoDB
     server_version: Versión Servidor
     php_extensions: Extensiones de PHP
+    elasticsearch_version: Versión de Elasticsearch
   acl:
     system_info:
       index: Información del sistema

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.fi_FI.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.fi_FI.yml
@@ -37,6 +37,7 @@ pim_analytics:
     mongodb_version: MongoDB-versio
     server_version: Palvelimen versio
     php_extensions: PHP-laajennukset
+    elasticsearch_version: Elasticsearch-versio
   acl:
     system_info:
       index: Järjestelmätiedot

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.fr_FR.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.fr_FR.yml
@@ -38,11 +38,11 @@ pim_analytics:
     pim_storage_version: Version de stockage
     os_version: Version du système d'exploitation
     php_version: Version de PHP
-    mysql_version: Version de MySQL
     mariadb_version: Version de MariaDB
     mongodb_version: Version de MongoDB
     server_version: Version du serveur
     php_extensions: Extensions PHP
+    elasticsearch_version: Version de Elasticsearch
   acl:
     system_info:
       index: Informations système

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.hr_HR.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.hr_HR.yml
@@ -31,6 +31,7 @@ pim_analytics:
     mongodb_version: MongoDB verzija
     server_version: Verzija poslužitelja
     php_extensions: PHP ekstenzije
+    elasticsearch_version: Elasticsearch verzija
   acl:
     system_info:
       index: Informacije o sustavu

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.it_IT.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.it_IT.yml
@@ -40,6 +40,7 @@ pim_analytics:
     mongodb_version: Versione di MongoDB
     server_version: Versione del server
     php_extensions: Estensioni PHP
+    elasticsearch_version: Versione di Elasticsearch
   acl:
     system_info:
       index: Informazioni di sistema

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.ja_JP.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.ja_JP.yml
@@ -34,6 +34,7 @@ pim_analytics:
     mongodb_version: MongoDB バージョン
     server_version: サーバーのバージョン
     php_extensions: PHP の拡張モジュール
+    elasticsearch_version: Elasticsearch バージョン
   acl:
     system_info:
       index: システム情報

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.nl_NL.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.nl_NL.yml
@@ -31,6 +31,7 @@ pim_analytics:
     mongodb_version: MongoDB versie
     server_version: Server versie
     php_extensions: PHP extensies
+    elasticsearch_version: Elasticsearch versie
   acl:
     system_info:
       index: Systeeminformatie

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.pl_PL.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.pl_PL.yml
@@ -31,6 +31,7 @@ pim_analytics:
     mongodb_version: Wersja bazy danych MongoDB
     server_version: Wersja serwera
     php_extensions: Rozszerzenia PHP
+    elasticsearch_version: Wersja Elasticsearch
   acl:
     system_info:
       index: Informacje o systemie

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.pt_BR.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.pt_BR.yml
@@ -31,6 +31,7 @@ pim_analytics:
     mongodb_version: Versão do MongoDB
     server_version: Versão do servidor
     php_extensions: Extensões do PHP
+    elasticsearch_version: Versão do Elasticsearch
   acl:
     system_info:
       index: Informações do Sistema

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.pt_PT.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.pt_PT.yml
@@ -31,6 +31,7 @@ pim_analytics:
     mongodb_version: Versão do MongoDB
     server_version: Versão do servidor
     php_extensions: Extensões do PHP
+    elasticsearch_version: Versão do Elasticsearch
   acl:
     system_info:
       index: Informações do Sistema

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.ru_RU.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.ru_RU.yml
@@ -31,6 +31,7 @@ pim_analytics:
     mongodb_version: Версия MongoDB
     server_version: Версия сервера
     php_extensions: Расширения PHP
+    elasticsearch_version: Версия Elasticsearch
   acl:
     system_info:
       index: Информация о системе

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.sv_SE.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.sv_SE.yml
@@ -36,6 +36,7 @@ pim_analytics:
     mongodb_version: MongoDB version
     server_version: Server version
     php_extensions: PHP-tillägg
+    elasticsearch_version: Elasticsearch-version
   acl:
     system_info:
       index: Systeminformation

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.tl_PH.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.tl_PH.yml
@@ -37,6 +37,7 @@ pim_analytics:
     mongodb_version: Bersyon ng MongoDB
     server_version: Bersyon ng server
     php_extensions: Mga ekstensyon ng PHP
+    elasticsearch_version: Bersyon ng Elasticsearch
   acl:
     system_info:
       index: Impormasyon ng sistema

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.zh_CN.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.zh_CN.yml
@@ -31,6 +31,7 @@ pim_analytics:
     mongodb_version: MariaDB 版本
     server_version: 服务器版本
     php_extensions: PHP 扩展
+    elasticsearch_version: Elasticsearch 版本
   acl:
     system_info:
       index: 系统信息

--- a/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/SearchEngineDataCollectorSpec.php
+++ b/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/SearchEngineDataCollectorSpec.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace spec\Pim\Bundle\AnalyticsBundle\DataCollector;
+
+use Akeneo\Tool\Component\Analytics\DataCollectorInterface;
+use Elasticsearch\Client;
+use Elasticsearch\ClientBuilder;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\AnalyticsBundle\DataCollector\SearchEngineDataCollector;
+use Prophecy\Argument;
+
+class SearchEngineDataCollectorSpec extends ObjectBehavior
+{
+    function let(ClientBuilder $clientBuilder)
+    {
+        $this->beConstructedWith($clientBuilder, []);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(SearchEngineDataCollector::class);
+        $this->shouldHaveType(DataCollectorInterface::class);
+    }
+
+    function it_collects_search_engine_version($clientBuilder, Client $client)
+    {
+        $clientBuilder->setHosts(Argument::type('array'))->willReturn($clientBuilder);
+        $clientBuilder->build()->willReturn($client);
+
+        $client->info()->willReturn(
+            [
+                'version' => [
+                    'number' => '1.2.3',
+                ],
+            ]
+        );
+
+        $this->collect()->shouldReturn(
+            [
+                'elasticsearch_version' => '1.2.3',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

## Motivation
At the moment we can see OS, PHP, MySQL versions on the system information page.
Search engine version is missing although Elasticsearch is one of the crucial components of Akeneo PIM.

Moreover, if you agree that this information should be in system reports, I'd also suggest to expose Elasticsearch cluster name which is also available.
