### PR TITLE
[SLA] PIM-7531: improve indexation time for "compute product models descendants" step

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,3 +1,13 @@
+# 2.2.x
+
+## Performances
+
+- PIM-7531: Improve indexation during the "compute product models descendants" step on product models import
+
+## BC Breaks
+
+- Added the method `removeForProductWithoutIndexing` on the `Pim\Component\Catalog\Completeness\CompletenessRemoverInterface`
+
 # 2.2.12 (2018-07-25)
 
 # 2.2.11 (2018-07-04)

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductModelDescendantsSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductModelDescendantsSaver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pim\Bundle\CatalogBundle\Doctrine\Common\Saver;
 
+use Akeneo\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Akeneo\Component\StorageUtils\Indexer\IndexerInterface;
@@ -149,7 +150,7 @@ class ProductModelDescendantsSaver implements SaverInterface
     {
         $productModelsChildren = $this->productModelRepository->findChildrenProductModels($productModel);
         if (!empty($productModelsChildren)) {
-            $this->bulkProductModelIndexer->indexAll($productModelsChildren);
+            $this->bulkProductModelIndexer->indexAll($productModelsChildren, ['index_refresh' => Refresh::disable()]);
         }
 
         /**
@@ -212,10 +213,10 @@ class ProductModelDescendantsSaver implements SaverInterface
             $productsToIndex[] = $product;
 
             if (0 === count($productsToIndex) % self::INDEX_BULK_SIZE) {
-                $this->bulkProductIndexer->indexAll($productsToIndex);
+                $this->bulkProductIndexer->indexAll($productsToIndex, ['index_refresh' => Refresh::disable()]);
                 $productsToIndex = [];
             }
         }
-        $this->bulkProductIndexer->indexAll($productsToIndex);
+        $this->bulkProductIndexer->indexAll($productsToIndex, ['index_refresh' => Refresh::disable()]);
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductModelDescendantsSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductModelDescendantsSaver.php
@@ -192,8 +192,9 @@ class ProductModelDescendantsSaver implements SaverInterface
      */
     private function computeCompletenesses(array $products): void
     {
+        $this->completenessManager->bulkSchedule($products);
+
         foreach ($products as $product) {
-            $this->completenessManager->schedule($product);
             $this->completenessManager->generateMissingForProduct($product);
             $this->objectManager->persist($product);
         }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessRemover.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessRemover.php
@@ -88,6 +88,22 @@ class CompletenessRemover implements CompletenessRemoverInterface
     /**
      * {@inheritdoc}
      */
+    public function removeForProductWithoutIndexing(ProductInterface $product): void
+    {
+        $statement = $this->entityManager->getConnection()->prepare(sprintf('
+            DELETE c
+            FROM %s c
+            WHERE c.product_id = :productId
+        ', $this->completenessTable));
+        $statement->bindValue('productId', $product->getId());
+        $statement->execute();
+
+        $product->getCompletenesses()->clear();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function removeForFamily(FamilyInterface $family)
     {
         $familyFilter = ['field' => 'family', 'operator' => Operators::IN_LIST, 'value' => [$family->getCode()]];

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\CatalogBundle\Doctrine\Common\Saver;
 
+use Akeneo\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Component\StorageUtils\Indexer\BulkIndexerInterface;
@@ -76,17 +77,17 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $cursor->current()->willReturn($variantProduct1, $variantProduct2, $variantProduct1, $variantProduct2);
         $cursor->next()->shouldBeCalled();
 
-        $completenessManager->schedule($variantProduct1)->shouldBeCalled();
+        $completenessManager->bulkSchedule([$variantProduct1, $variantProduct2])->shouldBeCalled();
+
         $completenessManager->generateMissingForProduct($variantProduct1)->shouldBeCalled();
         $objectManager->persist($variantProduct1)->shouldBeCalled();
 
-        $completenessManager->schedule($variantProduct2)->shouldBeCalled();
         $completenessManager->generateMissingForProduct($variantProduct2)->shouldBeCalled();
         $objectManager->persist($variantProduct2)->shouldBeCalled();
 
         $objectManager->flush()->shouldBeCalled();
 
-        $bulkProductIndexer->indexAll([$variantProduct1, $variantProduct2])->shouldBeCalled();
+        $bulkProductIndexer->indexAll([$variantProduct1, $variantProduct2], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
 
         $productModelRepository->findChildrenProductModels($productModel)->willReturn([$productModelsChildren]);
         $bulkProductModelIndexer->indexAll([$productModelsChildren]);

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/CompletenessRemoverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/ORM/CompletenessRemoverSpec.php
@@ -60,6 +60,26 @@ class CompletenessRemoverSpec extends ObjectBehavior
         $this->removeForProduct($product);
     }
 
+    function it_removes_completeness_of_a_product_without_indexing_it(
+        $indexer,
+        $connection,
+        ProductInterface $product,
+        Collection $completenesses,
+        Statement $statement
+    ) {
+        $product->getId()->willReturn(42);
+        $product->getCompletenesses()->willReturn($completenesses);
+        $completenesses->clear()->shouldBeCalled();
+
+        $connection->prepare(Argument::any())->willReturn($statement);
+        $statement->bindValue('productId', 42)->shouldBeCalled();
+        $statement->execute()->shouldBeCalled();
+
+        $indexer->index($product)->shouldNotBeCalled();
+
+        $this->removeForProductWithoutIndexing($product);
+    }
+
     function it_removes_completeness_of_a_family(
         $indexer,
         $connection,

--- a/src/Pim/Component/Catalog/Completeness/CompletenessRemoverInterface.php
+++ b/src/Pim/Component/Catalog/Completeness/CompletenessRemoverInterface.php
@@ -29,6 +29,13 @@ interface CompletenessRemoverInterface
     public function removeForProduct(ProductInterface $product);
 
     /**
+     * Remove completeness of a product without indexing it.
+     *
+     * @param ProductInterface $product
+     */
+    public function removeForProductWithoutIndexing(ProductInterface $product): void;
+
+    /**
      * Remove completenesses for all product of a family
      *
      * @param FamilyInterface $family

--- a/src/Pim/Component/Catalog/Manager/CompletenessManager.php
+++ b/src/Pim/Component/Catalog/Manager/CompletenessManager.php
@@ -116,6 +116,18 @@ class CompletenessManager
     }
 
     /**
+     * @param ProductInterface[] $products
+     */
+    public function bulkSchedule(array $products): void
+    {
+        foreach ($products as $product) {
+            if ($product->getId()) {
+                $this->remover->removeForProductWithoutIndexing($product);
+            }
+        }
+    }
+
+    /**
      * Schedule recalculation of completenesses for all product
      * of a family
      *

--- a/src/Pim/Component/Catalog/spec/Manager/CompletenessManagerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Manager/CompletenessManagerSpec.php
@@ -3,10 +3,9 @@
 namespace spec\Pim\Component\Catalog\Manager;
 
 use PhpSpec\ObjectBehavior;
-use Pim\Component\Catalog\Completeness\CompletenessGeneratorInterface;
 use Pim\Component\Catalog\Completeness\Checker\ValueCompleteCheckerInterface;
+use Pim\Component\Catalog\Completeness\CompletenessGeneratorInterface;
 use Pim\Component\Catalog\Completeness\CompletenessRemoverInterface;
-use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
 use Pim\Component\Catalog\Repository\FamilyRepositoryInterface;
@@ -18,7 +17,7 @@ class CompletenessManagerSpec extends ObjectBehavior
         FamilyRepositoryInterface $familyRepository,
         ChannelRepositoryInterface $channelRepository,
         LocaleRepositoryInterface $localeRepository,
-        CompletenessGenerator $generator,
+        CompletenessGeneratorInterface $generator,
         CompletenessRemoverInterface $remover,
         ValueCompleteCheckerInterface $valueCompleteChecker
     ) {
@@ -30,5 +29,19 @@ class CompletenessManagerSpec extends ObjectBehavior
             $remover,
             $valueCompleteChecker
         );
+    }
+
+    function it_bulk_schedules_completeness_on_several_products(
+        CompletenessRemoverInterface $remover,
+        ProductInterface $product1,
+        ProductInterface $product2
+    ) {
+        $product1->getId()->willReturn(1);
+        $product2->getId()->willReturn(2);
+
+        $remover->removeForProductWithoutIndexing($product1)->shouldBeCalled();
+        $remover->removeForProductWithoutIndexing($product2)->shouldBeCalled();
+
+        $this->bulkSchedule([$product1, $product2]);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

## 1st commit
The first focus has been to find on which step the "compute product models descendants" was slower.

![screenshot_2018-07-30 reference profile - blackfire 3](https://user-images.githubusercontent.com/301169/43405888-3e490480-941b-11e8-8b88-6ddf27002b17.png)

**73% of the time was about indexing**. 

I took a look at a PR @BitOne did on October 2017: https://github.com/akeneo/pim-community-dev/pull/7074. His PR was taking profit of the `index_refresh` option given to the indexer. 

> The refresh strategy is now at disable, relying on the standard refreshing feature of Elasticsearch without waiting for it to take effect, cf https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html

So I tried to apply the same option when indexing products & product models in the step. The result is immediate:

**Time of the "compute product models descendants" step** _(tested on the staging of a customer)_
Before: 1h54
After: 44m (-61%)

_(Locally with icecat demo dev fixtures, the gain is quite the same. We go from 1m55 to 48s (-58%))_

## 2nd commit
Once this done, I noticed that some indexing stuff was still taking a good part of the overall time (left part):

![screenshot_2018-07-30 index refresh disabled profile - blackfire 1](https://user-images.githubusercontent.com/301169/43406706-1dc77d2a-941d-11e8-959e-e230a33c0d1b.png)

What we do in the `ProductModelDescendantsSaver`:

```php
private function computeCompletenesses(array $products): void
{
    foreach ($products as $product) {
        $this->completenessManager->schedule($product); // this is where the 25% are
        $this->completenessManager->generateMissingForProduct($product);
        $this->objectManager->persist($product);
    }

    $this->objectManager->flush();
}
```
Indeed, each time we `schedule` a product for completeness, **we index it**.
Problem is that we index it later in the "compute product models descendants" step, so we were achieving a double indexing, the "schedule" indexing was useless for our case.

So I decided to implement a "schedule without indexing" method for the remover.

**Time of the "compute product models descendants" step** _(tested on the staging of a customer)_
Before: 44m (with the first commit)
After: 30m (-31%)

## Summup
The 2 commits cumulated, we gain 73% of time on this step (1h54 to 30m).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -