### PR TITLE
[SLA] PIM-7538: Reset datagrid state correctly

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug fixes
+
+- PIM-7538: Fix persistent grid filters
+
 # 1.7.28 (2018-07-26)
 
 ## Bug fixes
@@ -24,13 +30,13 @@
 
 ## BC breaks:
 
-### AppKernel 
+### AppKernel
 
 - Remove `Pim\Bundle\JsFormValidationBundle\PimJsFormValidationBundle` and `APY\JsFormValidationBundle\APYJsFormValidationBundle`
 
 ### Routing
 
-- Remove routing from `APYJsFormValidationBundle` 
+- Remove routing from `APYJsFormValidationBundle`
 
 # 1.7.25 (2018-07-06)
 

--- a/features/product/filtering/filter_products.feature
+++ b/features/product/filtering/filter_products.feature
@@ -69,6 +69,29 @@ Feature: Filter products
     When I reset the grid
     Then the grid should contain 6 elements
 
+  Scenario: Successfully reset the filters after switching pages
+    Given I am on the products page
+    Then I filter by "enabled" with operator "" and value "Enabled"
+    And the grid should contain 5 elements
+    Then I am on the families page
+    Then I am on the products page
+    When I reset the grid
+    Then the grid should contain 6 elements
+
+  Scenario: Successfully reset the filters for a selected view
+    Given I am on the products page
+    And I filter by "family" with operator "in list" and value "furniture"
+    And I create the view:
+      | new-view-label | Furniture only |
+    Then the grid should contain 2 elements
+    When I refresh the grid
+    Then I filter by "enabled" with operator "" and value "Disabled"
+    And the grid should contain 0 elements
+    Then I am on the families page
+    And I am on the products page
+    When I reset the grid
+    Then the grid should contain 2 elements
+
   Scenario: Successfully refresh the grid
     Given I am on the products page
     Then I filter by "enabled" with operator "" and value "Enabled"

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/reset-collection-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/reset-collection-action.js
@@ -1,6 +1,6 @@
 /* global define */
-define(['underscore', 'oro/datagrid/abstract-action'],
-function(_, AbstractAction) {
+define(['underscore', 'oro/datagrid/abstract-action', 'pim/datagrid/state'],
+function(_, AbstractAction, DatagridState) {
     'use strict';
 
     /**
@@ -29,6 +29,7 @@ function(_, AbstractAction) {
                 throw new TypeError("'datagrid' is required");
             }
             this.collection = options.datagrid.collection;
+            this.datagrid = options.datagrid;
 
             AbstractAction.prototype.initialize.apply(this, arguments);
         },
@@ -37,10 +38,16 @@ function(_, AbstractAction) {
          * Execute reset collection
          */
         execute: function() {
-            var initialState = this.collection._initState;
+            var initialState = this.collection.initialState;
+            var view = initialState.parameters.view
 
             if (_.has(initialState, 'filters')) {
                 initialState.filters = _.omit(initialState.filters, 'scope');
+            }
+
+            if (view.id !== '0') {
+                var datagridState = DatagridState.get(this.datagrid.name, ['initialViewState'])
+                initialState = this.collection.decodeStateData(datagridState.initialViewState)
             }
 
             this.collection.updateState(initialState);

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/reset-collection-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/reset-collection-action.js
@@ -39,14 +39,14 @@ function(_, AbstractAction, DatagridState) {
          */
         execute: function() {
             var initialState = this.collection.initialState;
+            var datagridState = DatagridState.get(this.datagrid.name, ['initialViewState'])
             var view = initialState.parameters.view
 
             if (_.has(initialState, 'filters')) {
                 initialState.filters = _.omit(initialState.filters, 'scope');
             }
 
-            if (view.id !== '0') {
-                var datagridState = DatagridState.get(this.datagrid.name, ['initialViewState'])
+            if (view && view.id !== '0' && datagridState.initialViewState.length !== 0) {
                 initialState = this.collection.decodeStateData(datagridState.initialViewState)
             }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
@@ -279,7 +279,7 @@ define(
                         this.currentView.columns = datagridState.columns.split(',');
                     }
 
-                    DatagridState.set(this.gridAlias, { initialViewState: view.filters })
+                    DatagridState.set(this.gridAlias, { initialViewState: this.initialView.filters })
                     this.getRoot().trigger('grid:view-selector:initialized', this.currentView);
 
                     return initView;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
@@ -279,6 +279,7 @@ define(
                         this.currentView.columns = datagridState.columns.split(',');
                     }
 
+                    DatagridState.set(this.gridAlias, { initialViewState: view.filters })
                     this.getRoot().trigger('grid:view-selector:initialized', this.currentView);
 
                     return initView;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
@@ -279,7 +279,7 @@ define(
                         this.currentView.columns = datagridState.columns.split(',');
                     }
 
-                    DatagridState.set(this.gridAlias, { initialViewState: this.initialView.filters })
+                    DatagridState.set(this.gridAlias, { initialViewState: this.initialView.filters });
                     this.getRoot().trigger('grid:view-selector:initialized', this.currentView);
 
                     return initView;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes an issue for the reset collection action in the datagrid. Currently, we store the initial state of the filters, and when we click reset, we revert to those filters. 

If we set the family to e.g. 'Accessories' and then change to another page, if we come back to the grid and click reset, it doesn't remove 'Accessories' because the initial state now includes this filter. This behaviour is a bug and it also happens when the user has a view selected.  

To fix this issue - first for the default view I updated the reset-collection-action to correctly reset the state using `initialState` instead of `_initState`. For a selected view, we now store the initial view filters so that when the user clicks reset we can revert to them. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)** 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
