### PR TITLE
Fix 8578 - Fixed wrong labels displayed in the active/inactive filter of user grid

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-7529: Fix error when a tree is removed
 - PIM-7536: Fix tool-tip error
+- GITHUB-8578 : Fixed wrong labels displayed in the "active/inactive" filter of user grid" 
 
 # 2.3.2 (2018-07-24)
 

--- a/src/Pim/Bundle/UserBundle/Resources/config/datagrid/user.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/datagrid/user.yml
@@ -81,8 +81,8 @@ datagrid:
                     options:
                         field_options:
                             choices:
-                               - Inactive
-                               - Active
+                                Inactive : 0
+                                Active : 1
 
         actions:
             view:


### PR DESCRIPTION
Fixes github issue #8578 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
