### PR TITLE
fix 8580 - Fixed translations for yes/no of boolean field.

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -15,6 +15,7 @@
 - PIM-7517: fix the product models export filter on identifier
 - PIM-7476: fix family select2 to have the right limit
 - PIM-7516: fix metric default value on product edit form
+- GITHUB-8580 : Fixed translations for yes/no of boolean field.
 
 ## Migration
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/boolean.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/boolean.html
@@ -1,3 +1,3 @@
-<div class="switch switch-small" tabindex="0" role="checkbox" aria-checked="<%- value && value.data ? 'true' : 'false' %>" data-on-label="<%- _.__('pim_common.yes') %>" data-off-label="<%- _.__('pim_common.no') %>">
+<div class="switch switch-small" tabindex="0" role="checkbox" aria-checked="<%- value && value.data ? 'true' : 'false' %>" data-on-label="<%- _.__('Yes') %>" data-off-label="<%- _.__('No') %>">
     <input id="<%- fieldId %>" type="checkbox" data-locale="<%- locale %>" data-scope="<%- scope %>" <%- value && value.data ? 'checked' : '' %> <%- editMode === 'view' ? 'disabled' : '' %>>
 </div>


### PR DESCRIPTION
Fixes #8580

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
