### PR TITLE
GITHUB-8578 - Fixed wrong labels displayed in the 'active/inactive' filters in user grid

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-7529: Fix error when a tree is removed
 - PIM-7536: Fix tool-tip error
 - GITHUB-8550: Exclude more folders in typescript to improve build time
+- GITHUB-8578: Fixed wrong labels displayed in the "active/inactive" filter of user grid" (Thanks [oliverde8](https://github.com/oliverde8)!)
 
 # 2.3.2 (2018-07-24)
 

--- a/src/Pim/Bundle/UserBundle/Resources/config/datagrid/user.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/datagrid/user.yml
@@ -81,8 +81,8 @@ datagrid:
                     options:
                         field_options:
                             choices:
-                               - Inactive
-                               - Active
+                                Inactive : 0
+                                Active : 1
 
         actions:
             view:


### PR DESCRIPTION

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR is a rework of https://github.com/akeneo/pim-community-dev/pull/8579 to rebase and update the changelog. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
