### PR TITLE
Pim 7541 - Fix timezone settings for API requests

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,7 +7,7 @@
 - GITHUB-8550: Exclude more folders in typescript to improve build time
 - GITHUB-8578: Fixed wrong labels displayed in the "active/inactive" filter of user grid" (Thanks [oliverde8](https://github.com/oliverde8)!)
 - PIM-7551: Fix issue on product model import when using custom column headers
-- PIM-7541: Force the date string value to be datetime object within the product and product model API controller.
+- PIM-7541: Fix issue on filtered search on created and updated product and product model properties. Date must be instanciated on server timezone.
 
 # 2.3.2 (2018-07-24)
 

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,6 +7,7 @@
 - GITHUB-8550: Exclude more folders in typescript to improve build time
 - GITHUB-8578: Fixed wrong labels displayed in the "active/inactive" filter of user grid" (Thanks [oliverde8](https://github.com/oliverde8)!)
 - PIM-7551: Fix issue on product model import when using custom column headers
+- PIM-7541: Force the date string value to be datetime object within the product and product model API controller.
 
 # 2.3.2 (2018-07-24)
 

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -561,6 +561,7 @@ class ProductController
                 $value = isset($filter['value']) ? $filter['value'] : null;
 
                 if (in_array($propertyCode, ['created', 'updated'])) {
+                    //PIM-7541 Create the date with the server timezone configuration. Do not force it to UTC timezone.
                     $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
                 }
 

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -560,6 +560,10 @@ class ProductController
 
                 $value = isset($filter['value']) ? $filter['value'] : null;
 
+                if (in_array($propertyCode, ['created', 'updated'])) {
+                    $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
+                }
+
                 $this->queryParametersChecker->checkPropertyParameters($propertyCode, $filter['operator']);
 
                 $pqb->addFilter($propertyCode, $filter['operator'], $value, $context);

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
@@ -642,6 +642,10 @@ class ProductModelController
 
                 $value = isset($filter['value']) ? $filter['value'] : null;
 
+                if (in_array($propertyCode, ['created', 'updated'])) {
+                    $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
+                }
+
                 $this->queryParametersChecker->checkPropertyParameters($propertyCode, $filter['operator']);
 
                 $pqb->addFilter($propertyCode, $filter['operator'], $value, $context);

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
@@ -643,6 +643,7 @@ class ProductModelController
                 $value = isset($filter['value']) ? $filter['value'] : null;
 
                 if (in_array($propertyCode, ['created', 'updated'])) {
+                    //PIM-7541 Create the date with the server timezone configuration. Do not force it to UTC timezone.
                     $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
                 }
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -1071,6 +1071,76 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
+    public function testListProductsWithSearchOnDateAttributesWithPositiveTimeZoneOffset()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        date_default_timezone_set('Pacific/Kiritimati');
+
+        $currentDate = (new \DateTime('now'))->modify("- 30 minutes")->format('Y-m-d H:i:s');
+
+        $search = sprintf('{"updated":[{"operator":">","value":"%s"}]}', $currentDate);
+        $client->request('GET', 'api/rest/v1/products?pagination_type=page&limit=10&search=' . $search);
+        $searchEncoded = rawurlencode($search);
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [            
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['product_china']},
+            {$standardizedProducts['product_without_category']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithSearchOnDateAttributesWithNegativeTimeZoneOffset()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        date_default_timezone_set('America/Los_Angeles');
+
+        $currentDate = (new \DateTime('now'))->modify("+ 30 minutes")->format('Y-m-d H:i:s');
+
+        $search = sprintf('{"updated":[{"operator":"<","value":"%s"}]}', $currentDate);
+        $client->request('GET', 'api/rest/v1/products?pagination_type=page&limit=10&search=' . $search);
+        $searchEncoded = rawurlencode($search);
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [            
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['product_china']},
+            {$standardizedProducts['product_without_category']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
     public function testOffsetPaginationListProductsWithMultiplePQBFilters()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductDeltaIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListVariantProductDeltaIntegration.php
@@ -326,7 +326,7 @@ JSON;
     private function getDiscriminantDatetime(): \Datetime
     {
         sleep(1);
-        $datetime = new \DateTime('now', new \DateTimeZone('UTC'));
+        $datetime = new \DateTime('now');
         sleep(1);
 
         return $datetime;

--- a/tests/back/Integration/IntegrationTestsBundle/Sanitizer/DateSanitizer.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Sanitizer/DateSanitizer.php
@@ -18,7 +18,7 @@ namespace Akeneo\Test\IntegrationTestsBundle\Sanitizer;
 class DateSanitizer
 {
     const DATE_FIELD_COMPARISON = 'this is a date formatted to ISO-8601';
-    const DATE_FIELD_PATTERN = '#[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\+[0-9]{2}:[0-9]{2}$#';
+    const DATE_FIELD_PATTERN = '#[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\+|\-)[0-9]{2}:[0-9]{2}$#';
 
     /**
      * Replaces date by self::DATE_FIELD_COMPARISON.


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

For date manipulations, we only deal with UTC timezone.

As the documention of the API says, when filtered search on "created" or "updated" properties are done within the API, the date values are intended to be on the timezone of the server configuration. (see [ON CREATION OR UPDATE DATE](https://api.akeneo.com/documentation/filter.html#on-creation-or-update-date-2) filter api documentation).

As the date provided in the search criteria do not handle the timezone modifier (not a ISO format with the +/- hours) we force the date value to be considered as a DateTime object that will be created with the default date.timezone value of the server.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
