### PR TITLE
PIM-7559: Fix versionning query too slow on the PEF

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,13 @@
+# 2.0.x
+
+## Bug fixes
+
+- PIM-7559: Fix versionning query too slow on the PEF
+
+## BC Breaks
+
+- Method `Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface::getNewestLogEntryForRessources` returns now an array
+
 # 2.0.31 (2018-08-01)
 
 ## Performances

--- a/src/Pim/Bundle/EnrichBundle/Provider/StructureVersion/StructureVersionProvider.php
+++ b/src/Pim/Bundle/EnrichBundle/Provider/StructureVersion/StructureVersionProvider.php
@@ -38,7 +38,7 @@ class StructureVersionProvider implements StructureVersionProviderInterface
             return null;
         }
 
-        return $latest->getLoggedAt()->getTimestamp();
+        return $latest['loggedAt']->getTimestamp();
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/spec/Provider/StructureVersion/StructureVersionProviderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Provider/StructureVersion/StructureVersionProviderSpec.php
@@ -13,24 +13,22 @@ class StructureVersionProviderSpec extends ObjectBehavior
         $this->beConstructedWith($versionRepository);
     }
 
-    function it_provides_a_structure_version($versionRepository, Version $lastVersion, \DateTime $lastUpdate)
+    function it_provides_a_structure_version($versionRepository, \DateTime $lastUpdate)
     {
         $versionRepository->getNewestLogEntryForRessources([])
-            ->willReturn($lastVersion);
+            ->willReturn(['loggedAt' => $lastUpdate]);
 
-        $lastVersion->getLoggedAt()->willReturn($lastUpdate);
         $lastUpdate->getTimestamp()->willReturn(12);
 
         $this->getStructureVersion()->shouldReturn(12);
     }
 
-    function it_provides_a_structure_version_for_given_resources($versionRepository, Version $lastVersion, \DateTime $lastUpdate)
+    function it_provides_a_structure_version_for_given_resources($versionRepository, \DateTime $lastUpdate)
     {
         $this->addResource('Locale');
         $versionRepository->getNewestLogEntryForRessources(['Locale'])
-            ->willReturn($lastVersion);
+            ->willReturn(['loggedAt' => $lastUpdate]);
 
-        $lastVersion->getLoggedAt()->willReturn($lastUpdate);
         $lastUpdate->getTimestamp()->willReturn(12);
 
         $this->getStructureVersion()->shouldReturn(12);

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\VersioningBundle\Doctrine\ORM;
 
 use Akeneo\Bundle\StorageUtilsBundle\Doctrine\ORM\Repository\CursorableRepositoryInterface;
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NoResultException;
@@ -50,7 +51,18 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
      */
     public function getNewestLogEntryForRessources($resourceNames)
     {
-        return $this->findOneBy(['resourceName' => $resourceNames], ['loggedAt' => 'desc'], 1);
+        if (empty($resourceNames)) {
+            return null;
+        }
+
+        $qb = $this->createQueryBuilder('v')
+            ->select('v.loggedAt')
+            ->where('v.resourceName IN (:resourceNames)')
+            ->orderBy('v.loggedAt', Criteria::DESC)
+            ->setMaxResults(1)
+            ->setParameter('resourceNames', $resourceNames);
+
+        return $qb->getQuery()->getSingleResult();
     }
 
     /**

--- a/src/Pim/Bundle/VersioningBundle/Repository/VersionRepositoryInterface.php
+++ b/src/Pim/Bundle/VersioningBundle/Repository/VersionRepositoryInterface.php
@@ -51,7 +51,7 @@ interface VersionRepositoryInterface
      *
      * @param array $resourceNames
      *
-     * @return Version|null
+     * @return array|null
      */
     public function getNewestLogEntryForRessources($resourceNames);
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

With too many versions in `pim_versioning_version` table, the query was too slow and broke the PEF (`getNewestLogEntryForRessources()` is only called in it).

FYI, we could only reproduce the bug with a custo on category (the client overidden the table)

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
