### PR TITLE
PIM-7537: Use pure JS for reset password trigger form change

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,3 +1,9 @@
+# 2.3.x
+
+## Bug fixes
+
+- PIM-7537: Fix console error in password reset form
+
 # 2.3.3 (2018-08-01)
 
 ## Bug fixes

--- a/src/Pim/Bundle/UIBundle/Resources/views/Form/pim-fields.html.twig
+++ b/src/Pim/Bundle/UIBundle/Resources/views/Form/pim-fields.html.twig
@@ -169,7 +169,7 @@
 {% block form_errors %}{% spaceless %}
     {% if errors|length > 0 %}
         <script type="text/javascript">
-            var el = document.getElementById($('{{ _self.getRootId(form) }}');
+            var el = document.getElementById('{{ _self.getRootId(form) }}');
 
             if (el) {
                 el.dispatchEvent(new Event('change'));

--- a/src/Pim/Bundle/UIBundle/Resources/views/Form/pim-fields.html.twig
+++ b/src/Pim/Bundle/UIBundle/Resources/views/Form/pim-fields.html.twig
@@ -169,9 +169,12 @@
 {% block form_errors %}{% spaceless %}
     {% if errors|length > 0 %}
         <script type="text/javascript">
-            $(function() {
-                $('#{{ _self.getRootId(form) }}').trigger('change');
-            });
+            var el = document.getElementById($('{{ _self.getRootId(form) }}');
+
+            if (el) {
+                el.dispatchEvent(new Event('change'));
+            }
+
         </script>
         {% if form.parent %}
             {% set combinedError = '' %}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Since we don't use jQuery on the old login pages anymore when the reset password form was validated it threw an error. This PR updates the old twig to use pure js to trigger the form change instead. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
