### PR TITLE
PIM-7552: Fix sku filter display bug

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7537: Fix console error in password reset form
+- PIM-7552: Fix SKU filter display bug on group grid
 
 # 2.3.3 (2018-08-01)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/text-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/text-filter.js
@@ -35,7 +35,7 @@ define(
                 '<% if (showLabel) { %>' +
                     '<span class="AknFilterBox-filterLabel"><%= label %></span>' +
                 '<% } %>' +
-                '<span class="AknFilterBox-filterCriteria filter-criteria-hint"><%= criteriaHint %></span>' +
+                '<span class="AknFilterBox-filterCriteria AknFilterBox-filterCriteria--limited filter-criteria-hint"><%= criteriaHint %></span>' +
                 '<span class="AknFilterBox-filterCaret"></span>' +
             '</div>' +
             '<div class="filter-criteria dropdown-menu" />' +

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -117,6 +117,13 @@
       line-height: 0;
       height: 0;
     }
+
+    &--limited {
+      max-width: 100%;
+      max-width: 200px;
+      overflow: hidden;
+      white-space: nowrap;
+    }
   }
 
   &--search &-filter {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -119,7 +119,6 @@
     }
 
     &--limited {
-      max-width: 100%;
       max-width: 200px;
       overflow: hidden;
       white-space: nowrap;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a display issue when filtering with many SKUs on the group grid 

Before
![screenshot from 2018-08-02 16-19-09](https://user-images.githubusercontent.com/1336344/43590422-3ff0d4c2-9671-11e8-8246-8ff849a1b149.png)

After
![screenshot from 2018-08-02 16-19-20](https://user-images.githubusercontent.com/1336344/43590423-4018b866-9671-11e8-8d6b-f2220faa9aa1.png)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
