### PR TITLE
PIM-7543: Forbid usage of 'label' code for attributes to prevent UI bugs

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-7537: Fix console error in password reset form
 - PIM-7552: Fix SKU filter display bug on group grid
+- PIM-7543: Forbid usage of 'label' code for attributes to prevent UI bugs
 
 # 2.3.3 (2018-08-01)
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -75,7 +75,7 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
             - Length:
                 max: 255
             - Regex:
-                pattern: /^(?!(id|associationTypes|categories|categoryId|completeness|enabled|family|groups|associations|products|scope|treeId|values|category|parent|(.)*_(products|groups)|entity_type)$)/
+                pattern: /^(?!(id|associationTypes|categories|categoryId|completeness|enabled|family|groups|associations|products|scope|treeId|values|category|parent|label|(.)*_(products|groups)|entity_type)$)/
                 message: This code is not available
         localizable:
             - Type: bool


### PR DESCRIPTION
When you set 'label' as code, it raises some bugs on the datagrid because the 'label' attribute is generated automatically.
You can not, for example, use the filters on the "label" field.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
