### PR TITLE
PIM-7545: Redirect to login page when user is not authenticated anymore

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-7537: Fix console error in password reset form
 - PIM-7552: Fix SKU filter display bug on group grid
 - PIM-7543: Forbid usage of 'label' code for attributes to prevent UI bugs
+- PIM-7545: Redirect to login page when user is not authenticated anymore
 
 # 2.3.3 (2018-08-01)
 

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -61,6 +61,7 @@ security:
                 csrf_token_generator:       security.csrf.token_manager
                 check_path:                 oro_user_security_check
                 login_path:                 oro_user_security_login
+                use_forward:                true
             logout:
                 path:                       oro_user_security_logout
             remember_me:

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/widget/export-widget.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/widget/export-widget.js
@@ -1,6 +1,6 @@
 define(
-    ['jquery', 'underscore', 'backbone', 'oro/messenger'],
-    function ($, _, Backbone, messenger) {
+    ['jquery', 'underscore', 'backbone', 'oro/messenger', 'oro/error'],
+    function ($, _, Backbone, messenger, Error) {
         'use strict';
 
         return Backbone.View.extend({
@@ -20,10 +20,14 @@ define(
                         );
                     })
                     .error(function (jqXHR) {
-                        messenger.notify(
-                            'error',
-                            _.__(jqXHR.responseText)
-                        );
+                        if (jqXHR.status === 401) {
+                            Error.dispatch(null, jqXHR);
+                        } else {
+                            messenger.notify(
+                                'error',
+                                _.__(jqXHR.responseText)
+                            );
+                        }
                     });
             }
         });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/grid.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/grid.js
@@ -14,6 +14,7 @@ define([
         'pim/template/form/grid',
         'oro/pageable-collection',
         'pim/datagrid/state',
+        'oro/error',
         'require-context'
     ],
     function (
@@ -26,6 +27,7 @@ define([
         template,
         PageableCollection,
         DatagridState,
+        Error,
         requireContext
     ) {
         return Backbone.View.extend({
@@ -97,7 +99,6 @@ define([
                 //TODO Manage columns for product form (when refactoring product form index)
                 //TODO Manage category filter (when refactoring category index)
                 $.get(Routing.generate('pim_datagrid_load', this.urlParams)).then(function (response) {
-
                     this.$el.find('.grid-drop').data({
                         metadata: response.metadata,
                         data: JSON.parse(response.data)
@@ -110,7 +111,10 @@ define([
                         resolvedModules.push(requireContext(module))
                     })
                     datagridBuilder(resolvedModules)
-                }.bind(this));
+                }.bind(this))
+                .fail(function(response) {
+                    Error.dispatch(null, response);
+                });
             },
 
             /**


### PR DESCRIPTION
This PR fixes the fact that the user is not redirected to the login page automatically when the session timed out.
There is no tests because the behavior is untestable on the CI, but it works by putting the `gc_maxlifetime` to a little value (like 10s)


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
