### PR TITLE
 PIM-7569: Fix limit of 20 results for view selector

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-7537: Fix console error in password reset form
 - PIM-7552: Fix SKU filter display bug on group grid
 - PIM-7543: Forbid usage of 'label' code for attributes to prevent UI bugs
+- PIM-7569: Fix limit of 20 results for view selector
 
 # 2.3.3 (2018-08-01)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/controllers.yml
@@ -2,7 +2,6 @@ parameters:
     pim_datagrid.controller.datagrid.class:       Pim\Bundle\DataGridBundle\Controller\DatagridController
     pim_datagrid.controller.export.class:         Pim\Bundle\DataGridBundle\Controller\ExportController
     pim_datagrid.controller.product_export.class: Pim\Bundle\DataGridBundle\Controller\ProductExportController
-    pim_datagrid.controller.datagrid_view.class:  Pim\Bundle\DataGridBundle\Controller\DatagridViewController
     pim_datagrid.controller.rest.datagrid_view.class:  Pim\Bundle\DataGridBundle\Controller\Rest\DatagridViewController
     pim_datagrid.controller.mass_action.class:    Pim\Bundle\DataGridBundle\Controller\MassActionController
 
@@ -32,11 +31,6 @@ services:
             - '@akeneo_batch_queue.launcher.queue_job_launcher'
             - '@oro_datagrid.datagrid.manager'
             - '@oro_datagrid.mass_action.parameters_parser'
-
-    pim_datagrid.controller.datagrid_view:
-        class: '%pim_datagrid.controller.datagrid_view.class%'
-        arguments:
-            - '@templating'
 
     pim_datagrid.controller.mass_action:
         class: '%pim_datagrid.controller.mass_action.class%'

--- a/src/Pim/Bundle/DataGridBundle/Resources/config/routing/datagrid_view.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/config/routing/datagrid_view.yml
@@ -32,10 +32,3 @@ pim_datagrid_view_rest_get:
     path: /rest/{identifier}
     defaults: { _controller: pim_datagrid.controller.rest.datagrid_view:getAction }
     methods: [GET]
-
-pim_datagrid_view_index:
-    path: /{alias}/{id}
-    defaults: { _controller: pim_datagrid.controller.datagrid_view:indexAction, id: ~ }
-    methods: [GET, POST]
-    requirements:
-        id: \d+


### PR DESCRIPTION
When the user create more than 20 views, he can not access to the "load more" select2 feature.
Why ? Because there was a test saying "if there is 20 results from the back, please show the "load more"". But there is a function it automatically adds the default view to this list... So the results are 21, and it always fail.
Now, it did the test of 20 === 20 before adding the default view.
I use this PR to better format the file, and to remove a useless route (not used in EE too)
I can not add a test because we don't have any methods to scroll down into a select2. If you want me to add this one, I can try to make something.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
