### PR TITLE
[SLA] PIM-7573: Fix "nesting level too deep" error during family import

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,3 +1,7 @@
+# 2.3.x
+
+- PIM-7573: Fix "nesting level too deep" error during family import
+
 # 2.3.4 (2018-08-08)
 
 ## Bug fixes

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateVariantProductIntegration.php
@@ -1288,6 +1288,10 @@ JSON;
                     'property' => 'attribute',
                     'message'  => 'Attribute "a_yes_no" cannot be empty, as it is defined as an axis for this entity',
                 ],
+                [
+                    'property' => 'attribute',
+                    'message'  => 'Variant axis "a_yes_no" cannot be modified, "" given',
+                ],
             ],
         ];
 

--- a/src/Pim/Component/Catalog/Model/AbstractValue.php
+++ b/src/Pim/Component/Catalog/Model/AbstractValue.php
@@ -57,7 +57,7 @@ abstract class AbstractValue implements ValueInterface
      */
     public function isEqual(ValueInterface $value)
     {
-        return $this->getData() == $value->getData() &&
+        return $this->getData() === $value->getData() &&
             $this->scope === $value->getScope() &&
             $this->locale === $value->getLocale();
     }

--- a/src/Pim/Component/Catalog/spec/EntityWithFamilyVariant/KeepOnlyValuesForVariationSpec.php
+++ b/src/Pim/Component/Catalog/spec/EntityWithFamilyVariant/KeepOnlyValuesForVariationSpec.php
@@ -19,6 +19,7 @@ class KeepOnlyValuesForVariationSpec extends ObjectBehavior
         ProductModelInterface $rootProductModel,
         FamilyVariantInterface $familyVariant,
         CommonAttributeCollection $commonAttributeCollection,
+        \Iterator $commonAttributesIterator,
         AbstractAttribute $description,
         AbstractAttribute $price,
         AbstractAttribute $width,
@@ -35,19 +36,22 @@ class KeepOnlyValuesForVariationSpec extends ObjectBehavior
         $rootProductModel->getVariationLevel()->willReturn(0);
         $rootProductModel->getFamilyVariant()->willReturn($familyVariant);
 
-        $familyVariant->getCommonAttributes()->willReturn($commonAttributeCollection);
-        $commonAttributeCollection->toArray()->willReturn([
-            $description, $price, $width
-        ]);
+        $description->getCode()->willReturn('description');
+        $price->getCode()->willReturn('price');
+        $width->getCode()->willReturn('width');
+        $sku->getCode()->willReturn('sku');
+        $image->getCode()->willReturn('image');
 
-        $description->__toString()->willReturn('description');
-        $price->__toString()->willReturn('price');
-        $width->__toString()->willReturn('width');
-        $sku->__toString()->willReturn('sku');
-        $image->__toString()->willReturn('image');
+        $familyVariant->getCommonAttributes()->willReturn($commonAttributeCollection);
+        $commonAttributeCollection->getIterator()->willReturn($commonAttributesIterator);
+        $commonAttributesIterator->rewind()->shouldBeCalled();
+        $commonAttributesIterator->valid()->willReturn(true, true, true, false);
+        $commonAttributesIterator->current()->willReturn(
+            $description, $price, $width
+        );
+        $commonAttributesIterator->next()->shouldBeCalled();
 
         $rootProductModel->getValues()->willReturn($valueCollection);
-
         $valueCollection->getIterator()->willReturn($valuesIterator);
         $valuesIterator->rewind()->shouldBeCalled();
         $valuesIterator->valid()->willReturn(true, true, true, true, true, false);
@@ -106,12 +110,12 @@ class KeepOnlyValuesForVariationSpec extends ObjectBehavior
         $attributes->toArray()->willReturn([$description, $price, $width]);
         $axes->toArray()->willReturn([$color]);
 
-        $description->__toString()->willReturn('description');
-        $price->__toString()->willReturn('price');
-        $width->__toString()->willReturn('width');
-        $sku->__toString()->willReturn('sku');
-        $image->__toString()->willReturn('image');
-        $color->__toString()->willReturn('color');
+        $description->getCode()->willReturn('description');
+        $price->getCode()->willReturn('price');
+        $width->getCode()->willReturn('width');
+        $sku->getCode()->willReturn('sku');
+        $image->getCode()->willReturn('image');
+        $color->getCode()->willReturn('color');
 
         $subProductModel->getValues()->willReturn($valueCollection);
 
@@ -175,12 +179,12 @@ class KeepOnlyValuesForVariationSpec extends ObjectBehavior
         $attributes->toArray()->willReturn([$sku, $image]);
         $axes->toArray()->willReturn([$size]);
 
-        $description->__toString()->willReturn('description');
-        $price->__toString()->willReturn('price');
-        $width->__toString()->willReturn('width');
-        $sku->__toString()->willReturn('sku');
-        $image->__toString()->willReturn('image');
-        $size->__toString()->willReturn('size');
+        $description->getCode()->willReturn('description');
+        $price->getCode()->willReturn('price');
+        $width->getCode()->willReturn('width');
+        $sku->getCode()->willReturn('sku');
+        $image->getCode()->willReturn('image');
+        $size->getCode()->willReturn('size');
 
         $variantProduct->getValues()->willReturn($valueCollection);
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In some cases, using loose comparison (`==`) can result in a `nesting level too deep - recursive dependency ?` fatal error when working on large collections, especially if you're comparing objects.
It can also happen with `in_array()` without the strict flag.

This error occurred at two places :

- In `Pim\Component\Catalog\EntityWithFamilyVariant\KeepOnlyValuesForVariation::updateEntitiesWithFamilyVariant()`
Solution : stop comparing objects and compare codes instead (it's lighter). We don't need to compare full objects in this case.

- In `Pim\Component\Catalog\Model\AbstractValue::isEqual()`
This one is trickier. I rolled back a change made in [this PR](https://github.com/akeneo/pim-community-dev/pull/6430/files#diff-a11e715648fb0a71e3f57b9823a42bf0R60). Apparently this has been done to make the CI pass.
When I put the `===` back, only one test broke. I fixed it since it looked like a false positive before : we are trying to change a boolean axis from `false` to `null`, so we are supposed to get the "not null" error AND the "immutable" error, but the loose `==` comparison made it pass even though it shouldn't.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

PS : this PR has been merged without the CI tick because the previous build was ok and only the changelog has been updated after.