### PR TITLE
PIM-7509: Fix search on categories with product models

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,3 +1,9 @@
+# 2.3.x
+
+## Bug fixes
+
+- PIM-7580: Fixes the search on categories with product models
+
 # 2.3.4 (2018-08-08)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -159,14 +159,16 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
      */
     private function hasFilterOnCategoryWhichImplyAggregation(): bool
     {
-        return !empty(array_filter(
+        $hasFilter = !empty(array_filter(
             $this->getRawFilters(),
             function (array $filter) {
                 return 'field' === $filter['type'] &&
                     'categories' === $filter['field'] &&
-                    $filter['operator'] === Operators::IN_LIST;
+                    (Operators::IN_LIST === $filter['operator'] || Operators::IN_CHILDREN_LIST === $filter['operator']);
             }
         ));
+
+        return $hasFilter;
     }
 
     /**
@@ -240,7 +242,7 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
             function ($filter) {
                 return 'field' === $filter['type'] &&
                     'categories' === $filter['field'] &&
-                    $filter['operator'] === Operators::IN_LIST;
+                    (Operators::IN_LIST === $filter['operator'] || Operators::IN_CHILDREN_LIST === $filter['operator']);
             }
         );
 

--- a/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
@@ -447,7 +447,7 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_filter_on_category_with_operator_IN(
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_filter_on_category_with_operator_IN_LIST(
         $pqb,
         CursorInterface $cursor,
         SearchQueryBuilder $sqb
@@ -470,6 +470,31 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
         $this->execute()->shouldReturn($cursor);
     }
+
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_filter_on_category_with_operator_IN_CHILDREN(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb
+    ) {
+        $pqb->getRawFilters()->willReturn(
+            [
+                [
+                    'field'    => 'categories',
+                    'operator' => 'IN CHILDREN',
+                    'value'    => ['category_A', 'category_B'],
+                    'context'  => [],
+                    'type'     => 'field'
+                ],
+            ]
+        );
+
+        $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
+        $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+
+        $this->execute()->shouldReturn($cursor);
+    }
+
     function it_does_not_aggregate_when_there_is_a_filter_on_parent($pqb, CursorInterface $cursor,  SearchQueryBuilder $sqb)
     {
         $pqb->getRawFilters()->willReturn(

--- a/tests/legacy/features/Context/Page/Base/Grid.php
+++ b/tests/legacy/features/Context/Page/Base/Grid.php
@@ -190,16 +190,19 @@ class Grid extends Index
      */
     public function getGrid()
     {
-        return $this->spin(function () {
+        $grids = $this->spin(function () {
             $container = $this->getContainer();
-            $grids = $container->findAll('css', $this->elements['Grid']['css']);
 
+            return $container->findAll('css', $this->elements['Grid']['css']);
+        }, 'No grid found');
+
+        return $this->spin(function () use ($grids) {
             foreach ($grids as $grid) {
                 if ($grid->isVisible()) {
                     return $grid;
                 }
             }
-        }, 'No visible grid found');
+        }, 'The grid was found but it was not visible');
     }
 
     /**


### PR DESCRIPTION
**Context:**

Following the wonderful work made by @ahocquard https://github.com/akeneo/pim-community-dev/pull/8312 on improving the
scalability of the search on categories, the "aggregated" search of
product models with categories was not working properly.

**Problem:**

In his refactoring, he introduces a new way to filter on categories on
the product grid. Before his changes when a user would select a category
in the category tree with the "include children" flag set to "yes". The
whole list of categories would be passed on to the back-end (category
selected + children) instead of using the IN_CHILDREN operator available
with the category filter.

@ahocquard fixes does just that, it uses the IN_CHILDREN operator
instead of the IN_LIST with a big list of category codes.

**Solution:**

Make sure the PQB of products and product models in enrich takes this new
case into account and aggregates the result when a filter with
"IN_CHILDREN" is used.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
