### PR TITLE
PIM-7563: remove unused generic checker service

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Resources/config/checkers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/checkers.yml
@@ -2,13 +2,6 @@ parameters:
     pim_api.checker.query_parameters.class: Pim\Bundle\ApiBundle\Checker\QueryParametersChecker
 
 services:
-    pim_api.checker.query_parameters:
-        class: '%pim_api.checker.query_parameters.class%'
-        arguments:
-            - '@pim_catalog.repository.cached_locale'
-            - '@pim_catalog.repository.cached_attribute'
-            - '@pim_catalog.repository.cached_category'
-            - ['family', 'enabled', 'groups', 'categories', 'completeness', 'identifier', 'created', 'updated']
     pim_api.checker.query_parameters_locale:
         class: '%pim_api.checker.query_parameters.class%'
         arguments:


### PR DESCRIPTION
With the fix done on  EE : https://github.com/akeneo/pim-enterprise-dev/pull/4402 The service `pim_api.checker.query_parameters` has become useless.

I existed only for the EE (see #8347 )