### PR TITLE
PIM-7574: Use step start time to name exported files instead of current time

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Bug fixes
+
+- PIM-7574: Use step start time to name exported files instead of current time
+
 # 2.0.32 (2018-08-06)
 
 ## Bug fixes

--- a/src/Pim/Component/Connector/Writer/File/AbstractFileWriter.php
+++ b/src/Pim/Component/Connector/Writer/File/AbstractFileWriter.php
@@ -44,7 +44,8 @@ abstract class AbstractFileWriter implements ItemWriterInterface, StepExecutionA
         $filePath = $parameters->get('filePath');
 
         if (false !== strpos($filePath, '%')) {
-            $defaultPlaceholders = ['%datetime%' => date($this->datetimeFormat), '%job_label%' => ''];
+            $datetime = $this->stepExecution->getStartTime()->format($this->datetimeFormat);
+            $defaultPlaceholders = ['%datetime%' => $datetime, '%job_label%' => ''];
             $jobExecution = $this->stepExecution->getJobExecution();
 
             if (isset($placeholders['%job_label%'])) {

--- a/src/Pim/Component/Connector/spec/Writer/File/Csv/WriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Csv/WriterSpec.php
@@ -11,7 +11,6 @@ use PhpSpec\ObjectBehavior;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Writer\File\FlatItemBuffer;
 use Pim\Component\Connector\Writer\File\FlatItemBufferFlusher;
-use Prophecy\Argument;
 
 class WriterSpec extends ObjectBehavior
 {
@@ -45,9 +44,10 @@ class WriterSpec extends ObjectBehavior
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTimeImmutable('1967-08-05 15:15:00'));
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobInstance->getLabel()->willReturn('job_label');
-        $jobParameters->get('filePath')->willReturn(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'my/file/path/%job_label%_%datetime%.csv');
+        $jobParameters->get('filePath')->willReturn(sys_get_temp_dir() . '/my/file/path/%job_label%_%datetime%.csv');
         $jobParameters->has('ui_locale')->willReturn(false);
         $jobParameters->get('withHeader')->willReturn(true);
 
@@ -127,9 +127,10 @@ class WriterSpec extends ObjectBehavior
         $jobParameters->has('linesPerFile')->willReturn(false);
         $jobParameters->get('delimiter')->willReturn(';');
         $jobParameters->get('enclosure')->willReturn('"');
-        $jobParameters->get('filePath')->willReturn(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'my/file/path/%job_label%_%datetime%.csv');
+        $jobParameters->get('filePath')->willReturn(sys_get_temp_dir() . '/my/file/path/%job_label%_%datetime%.csv');
         $jobParameters->has('ui_locale')->willReturn(false);
         $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTimeImmutable('1967-08-05 15:15:00'));
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobInstance->getLabel()->willReturn('job_label');
 
@@ -146,14 +147,26 @@ class WriterSpec extends ObjectBehavior
         $this->initialize();
         $flusher->flush(
             $flatRowBuffer,
-            Argument::type('array'),
-            Argument::type('string'),
+            [
+                'type'           => 'csv',
+                'fieldDelimiter' => ';',
+                'fieldEnclosure' => '"',
+                'shouldAddBOM'   => false,
+            ],
+            sys_get_temp_dir() . '/my/file/path/job_label_1967-08-05_15-15-00.csv',
             -1
-        )->willReturn([
-            sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'my/file/path/foo1',
-            sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'my/file/path/foo2',
-        ]);
+        )->willReturn(
+            [
+                sys_get_temp_dir() . '/my/file/path/job_label_1967-08-05_15-15-00.csv'
+            ]
+        );
 
         $this->flush();
+
+        $this->getWrittenFiles()->shouldReturn(
+            [
+                sys_get_temp_dir() . '/my/file/path/job_label_1967-08-05_15-15-00.csv' => 'job_label_1967-08-05_15-15-00.csv',
+            ]
+        );
     }
 }

--- a/src/Pim/Component/Connector/spec/Writer/File/Xlsx/WriterSpec.php
+++ b/src/Pim/Component/Connector/spec/Writer/File/Xlsx/WriterSpec.php
@@ -11,7 +11,6 @@ use PhpSpec\ObjectBehavior;
 use Pim\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Pim\Component\Connector\Writer\File\FlatItemBuffer;
 use Pim\Component\Connector\Writer\File\FlatItemBufferFlusher;
-use Prophecy\Argument;
 
 class WriterSpec extends ObjectBehavior
 {
@@ -50,10 +49,11 @@ class WriterSpec extends ObjectBehavior
         $this->setStepExecution($stepExecution);
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTimeImmutable('1967-08-05 15:15:00'));
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobInstance->getLabel()->willReturn('XLSX Group export');
         $jobParameters->get('withHeader')->willReturn(true);
-        $jobParameters->get('filePath')->willReturn('%job_label%_group.xlsx');
+        $jobParameters->get('filePath')->willReturn(sys_get_temp_dir() . '/my/file/path/%job_label%_%datetime%.xlsx');
         $jobParameters->has('ui_locale')->willReturn(false);
 
         $groups = [
@@ -129,22 +129,35 @@ class WriterSpec extends ObjectBehavior
 
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTimeImmutable('1967-08-05 15:15:00'));
         $jobExecution->getJobInstance()->willReturn($jobInstance);
         $jobInstance->getLabel()->willReturn('XLSX Group export');
-        $jobParameters->get('linesPerFile')->willReturn(2);
-        $jobParameters->get('filePath')->willReturn('my/file/path/foo/%job_label%_group.xlsx');
+        $jobParameters->get('linesPerFile')->willReturn(1);
+        $jobParameters->get('filePath')->willReturn(sys_get_temp_dir() . '/my/file/path/%job_label%_%datetime%.xlsx');
         $jobParameters->has('ui_locale')->willReturn(false);
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
 
+        $this->initialize();
         $flusher->flush(
             $flatRowBuffer,
-            Argument::type('array'),
-            Argument::type('string'),
-            2
-        )->willReturn(['my/file/path/foo1', 'my/file/path/foo2']);
+            ['type' => 'xlsx'],
+            sys_get_temp_dir() . '/my/file/path/XLSX_Group_export_1967-08-05_15-15-00.xlsx',
+            1
+        )->willReturn(
+            [
+                sys_get_temp_dir() . '/my/file/path/XLSX_Group_export_1967-08-05_15-15-00_1.xlsx',
+                sys_get_temp_dir() . '/my/file/path/XLSX_Group_export_1967-08-05_15-15-00_2.xlsx',
+            ]
+        );
 
-        $this->initialize();
         $this->flush();
+
+        $this->getWrittenFiles()->shouldReturn(
+            [
+                sys_get_temp_dir() . '/my/file/path/XLSX_Group_export_1967-08-05_15-15-00_1.xlsx' => 'XLSX_Group_export_1967-08-05_15-15-00_1.xlsx',
+                sys_get_temp_dir() . '/my/file/path/XLSX_Group_export_1967-08-05_15-15-00_2.xlsx' => 'XLSX_Group_export_1967-08-05_15-15-00_2.xlsx',
+            ]
+        );
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Same fix than https://github.com/akeneo/pim-community-dev/pull/8432.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
