### PR TITLE
PIM-7557: Don't display attribute group filter if there is no choices

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,3 +1,9 @@
+# 2.0.x
+
+## Bug fixes
+
+- PIM-7557: Don't display attribute group filter if no attribute is chosen in "edit common attributes" action
+
 # 2.0.34 (2018-08-17)
 
 # 2.0.33 (2018-08-16)

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -1108,6 +1108,7 @@ config:
         pim/template/product/form/variant-navigation/product-item: pimenrich/templates/product/form/variant-navigation/product-item.html
         pim/template/product/form/variant-navigation/product-model-item: pimenrich/templates/product/form/variant-navigation/product-model-item.html
         pim/template/product/form/variant-navigation/add-child-button: pimenrich/templates/product/form/variant-navigation/add-child-button.html
+        pim/template/product/form/mass-edit/attributes:      pimenrich/templates/product/form/mass-edit/attributes.html
         pim/template/attribute-option/form:                  pimenrich/templates/attribute-option/form.html
         pim/template/attribute-option/validation-error:      pimenrich/templates/attribute-option/validation-error.html
         pim/template/attribute-option/index:                 pimenrich/templates/attribute-option/index.html

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/attribute-group-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes/attribute-group-selector.js
@@ -113,7 +113,7 @@ define(
                     }));
 
                     this.$el.empty();
-                    if (!_.isEmpty(this.getElements())) {
+                    if (this.shouldBeDisplayed(this.getElements())) {
                         this.$el.html(this.template({
                             current: this.getCurrent(),
                             elements: _.sortBy(this.getElements(), 'sort_order'),
@@ -131,6 +131,19 @@ define(
                 }.bind(this));
 
                 return this;
+            },
+
+            /**
+             * Don't display the dropdown if there is no elements or if the only element is the "All" group.
+             *
+             * @param {Object} elements
+             *
+             * @returns {Boolean}
+             */
+            shouldBeDisplayed: function (elements) {
+                const length = Object.keys(elements).length;
+
+                return length > 1 || (1 === length && this.all.code !== Object.values(elements)[0].code);
             },
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/edit-common-attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/edit-common-attributes.js
@@ -91,7 +91,11 @@ define(
                     // This method renders a complete PEF page, we need to remove useless elements manually.
                     this.$el.find('.navigation').remove();
                     this.$el.find('.AknDefault-thirdColumnContainer').remove();
-                    this.$el.find('.AknDefault-mainContent').addClass('AknDefault-mainContent--withoutPadding');
+
+                    this.$el.find('.AknDefault-mainContent')
+                        .addClass('AknDefault-mainContent--withoutPadding')
+                        .css({'overflow-x': 'hidden'})
+                    ;
 
                     if (this.errors) {
                         const event = {

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
@@ -20,7 +20,8 @@ define(
         'pim/fetcher-registry',
         'pim/attribute-manager',
         'pim/user-context',
-        'oro/mediator'
+        'oro/mediator',
+        'pim/template/product/form/mass-edit/attributes'
     ],
     function (
         $,
@@ -31,9 +32,11 @@ define(
         FetcherRegistry,
         AttributeManager,
         UserContext,
-        mediator
+        mediator,
+        template
     ) {
         return BaseAttributes.extend({
+            template: _.template(template),
             locked: false,
 
             /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/mass-edit/attributes.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/mass-edit/attributes.html
@@ -1,0 +1,9 @@
+<div class="tab-content">
+    <header data-drop-zone="header" class="AknAttributeActions tab-header attribute-actions">
+        <div data-drop-zone="edit-actions" class="AknAttributeActions-editActions attribute-edit-actions">
+            <div data-drop-zone="context-selectors" class="AknButtonList AknAttributeActions-contextSelectors context-selectors"></div>
+            <div data-drop-zone="other-actions" class="AknAttributeActions-otherActions AknButtonList AknButtonList--vertical other-actions"></div>
+        </div>
+    </header>
+    <div class="tab-pane active object-values"></div>
+</div>

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/ButtonList.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/button/ButtonList.less
@@ -58,4 +58,13 @@
   &--single {
     margin-top: @marginSpace;
   }
+
+  &--vertical {
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
+  &--vertical &-item:not(:first-child) {
+    margin-top: 10px;
+  }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In the mass edit, when no attribute is chosen yet the filter is useless, so it shouldn't be displayed.

Also transform this :
![screenshot 4](https://user-images.githubusercontent.com/659491/44095864-22cb157a-9fda-11e8-8648-9722995f7e21.png)
into this :
![screenshot 5](https://user-images.githubusercontent.com/659491/44095880-2e662e56-9fda-11e8-8c2b-98193fca3e97.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
