### PR TITLE
Do not try to validate a locale if value is null

### DIFF
--- a/src/Pim/Component/Catalog/Validator/Constraints/LocaleValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/LocaleValidator.php
@@ -31,6 +31,10 @@ class LocaleValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if (null === $value) {
+            return;
+        }
+
         $locale = $this->localeRepository->findOneByIdentifier($value);
         if (null === $locale) {
             if (null !== $constraint->propertyPath) {

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/LocaleValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/LocaleValidatorSpec.php
@@ -46,4 +46,14 @@ class LocaleValidatorSpec extends ObjectBehavior
 
         $this->validate($localeCode, $constraint);
     }
+
+    function it_does_not_validate_if_value_is_null($localeRepository, $context, Locale $constraint)
+    {
+        $localeCode = null;
+
+        $localeRepository->findOneByIdentifier(Argument::any())->shouldNotBeCalled();
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($localeCode, $constraint);
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

On the onboarder, we have acceptance tests failing if value is null.

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
