### PR TITLE
PIM-7586: do not show category switcher when there is no label

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/grid/category-switcher.js
@@ -47,6 +47,10 @@ define(
              * {@inheritdoc}
              */
             render() {
+                if (null === this.treeLabel || '' === this.treeLabel.trim()) {
+                    return;
+                }
+
                 this.$el.html(this.template({
                     label: __('pim_enrich.entity.product.category'),
                     isOpen: this.isOpen,


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

Needs for the EE. When a user has no permission on any categories, we want to hide the category filter.

If you have permission on at least one category, the label will always be filled (even if there is no translation, the code will be the label).
The only way to have an empty label is when you don't have permission or if there is no category.

I don't find a better way to do that, if it's not GTM, I will need a frontend dev.

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
