### PR TITLE
PIM-7568: remove scenario from ee build

### DIFF
--- a/tests/legacy/features/attribute-group/display_attribute_group_history.feature
+++ b/tests/legacy/features/attribute-group/display_attribute_group_history.feature
@@ -11,6 +11,7 @@ Feature: Display the attribute group history
       | label-en_US | group | type             | code        |
       | Description | other | pim_catalog_text | description |
 
+  @ce
   Scenario: Successfully edit a group and see the history
     Given I am on the attribute group creation page
     And I change the Code to "Technical"

--- a/tests/legacy/features/versioning/ensure_versioning_on_attribute_group.feature
+++ b/tests/legacy/features/versioning/ensure_versioning_on_attribute_group.feature
@@ -8,6 +8,7 @@ Feature: Ensure versioning on attribute group
     Given a "footwear" catalog configuration
     And I am logged in as "Julia"
 
+  @ce
   Scenario: Successfully version an attribute group
     Given I am on the "sizes" attribute group page
     And I visit the "History" tab


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

On this EE PR (https://github.com/akeneo/pim-enterprise-dev/pull/4406) we add the versioning on the rights property (EE only feature). Problem is that it will change the result of those scenario if they are run on a EE build (more versions, different properties, etc).

I don't think we should duplicate those scenarios in EE just to check that the rights are well versioned (it's not a critical use case).

No ci will run on this PR of course

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added legacy Behats               | NA
| Added acceptance tests            | NA
| Added integration tests           | NA
| Changelog updated                 | NA
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | NA
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
