### PR TITLE
PIM-7568: remove scenario from ee build

### DIFF
--- a/tests/legacy/features/attribute-group/display_attribute_group_history.feature
+++ b/tests/legacy/features/attribute-group/display_attribute_group_history.feature
@@ -60,7 +60,7 @@ Feature: Display the attribute group history
       | 3       | attributes  | sku,description    | now  |
       | 4       | attributes  | sku                | now  |
 
-  @javascript @jira https://akeneo.atlassian.net/browse/PIM-7279
+  @ce @jira https://akeneo.atlassian.net/browse/PIM-7279
   Scenario: Prevent javascript execution from history tab while updating attribute group label translations
     Given I am on the "other" attribute group page
     And I fill in the following information:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

On this EE PR (akeneo/pim-enterprise-dev#4406) we add the versioning on the rights property (EE only feature). Problem is that it will change the result of those scenario if they are run on a EE build (more versions, different properties, etc).

I don't think we should duplicate those scenarios in EE just to check that the rights are well versioned (it's not a critical use case).

No ci will run on this PR of course

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | NA
| Added legacy Behats               | NA
| Added acceptance tests            | NA
| Added integration tests           | NA
| Changelog updated                 | NA
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
