### PR TITLE
GITHUB-8627: Security vulnerabilities in dependencies

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,3 +1,9 @@
+# 1.7.x
+
+## Bug fixes
+
+- GITHUB-8627: Security vulnerabilities in dependencies
+
 # 1.7.30 (2018-08-14)
 
 - PIM-7570: Adds 'Locale specific' fields in attribute versioning

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "symfony/assetic-bundle": "2.8.1",
         "symfony/monolog-bundle": "2.12.1",
         "symfony/swiftmailer-bundle": "2.4.2",
-        "symfony/symfony": "2.7.48",
+        "symfony/symfony": "2.7.49",
         "twig/extensions": "1.2.0",
         "box/spout": "2.5.0"
     },


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Fix #8627: Update from symfony 2.7.48 to 2.7.49

Vulnerabilities of paragonie/random_compat is still here because it's in the composer.json of symfony 2.7 (https://github.com/symfony/symfony/blob/80980330dbed08518ac685147036a03bc46d1924/composer.json#L22)
To fix it, we need to use at least the 2.0.x version : 
https://github.com/paragonie/random_compat/issues/96
 
**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
