### PR TITLE
PIM-7572: Cross to remove associations displayed at PV level whereas …

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7600: Change the default return value of ResetIndexesCommand to true to allow the --no-interaction parameter.
+- PIM-7572: Cross to remove associations displayed at PV level whereas association is done at PM level
 
 # 2.3.5 (2018-08-22)
 

--- a/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
@@ -230,7 +230,7 @@ class AssociatedProductDatasource extends ProductDatasource
      */
     protected function normalizeProductsAndProductModels(
         CursorInterface $products,
-        array $idsFromInheritance,
+        array $identifiersFromInheritance,
         $locale,
         $scope
     ) {
@@ -258,7 +258,13 @@ class AssociatedProductDatasource extends ProductDatasource
                 ]
             );
 
-            $normalized['from_inheritance'] = in_array($product->getId(), $idsFromInheritance);
+            if ($product instanceof ProductModelInterface) {
+                $identifier = IdEncoder::encode(IdEncoder::PRODUCT_MODEL_TYPE, $product->getId());
+            } else {
+                $identifier = IdEncoder::encode(IdEncoder::PRODUCT_TYPE, $product->getId());
+            }
+
+            $normalized['from_inheritance'] = in_array($identifier, $identifiersFromInheritance);
 
             $data[] = new ResultRecord($normalized);
         }


### PR DESCRIPTION
…association is done at PM level


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

