### PR TITLE
PIM-7414 : Use catalog locale to normalize the image when we save the product

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -9,6 +9,11 @@
 - PIM-7542: Fix completeness filter on edit product group page
 - PIM-7589: Fix job `compute_product_models_descendants` launched too many times
 - PIM-7587: Fix the preview generation configuration with imagine
+- PIM-7414: Fix localisable assets used as main image for family and added to product, break the product form
+
+## BC breaks
+
+- PIM-7414: Change the constructor of `Pim\Bundle\EnrichBundle\Normalizer\ProductNormalizer` to add `Pim\Bundle\CatalogBundle\Context\CatalogContext` as a new argument.
 
 # 2.3.4 (2018-08-08)
 

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -3,6 +3,7 @@
 namespace Pim\Bundle\EnrichBundle\Normalizer;
 
 use Doctrine\Common\Persistence\ObjectManager;
+use Pim\Bundle\CatalogBundle\Context\CatalogContext;
 use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
 use Pim\Bundle\EnrichBundle\Provider\Form\FormProviderInterface;
 use Pim\Bundle\EnrichBundle\Provider\StructureVersion\StructureVersionProviderInterface;
@@ -79,6 +80,9 @@ class ProductNormalizer implements NormalizerInterface
     /** @var UserContext */
     protected $userContext;
 
+    /** @var CatalogContext */
+    protected $catalogContext;
+
     /** @var CompletenessCalculatorInterface */
     private $completenessCalculator;
 
@@ -120,6 +124,7 @@ class ProductNormalizer implements NormalizerInterface
      * @param CollectionFilterInterface                 $collectionFilter
      * @param NormalizerInterface                       $completenessCollectionNormalizer
      * @param UserContext                               $userContext
+     * @param CatalogContext                            $catalogContext
      * @param CompletenessCalculatorInterface           $completenessCalculator
      * @param EntityWithFamilyValuesFillerInterface     $productValuesFiller
      * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
@@ -145,6 +150,7 @@ class ProductNormalizer implements NormalizerInterface
         CollectionFilterInterface $collectionFilter,
         NormalizerInterface $completenessCollectionNormalizer,
         UserContext $userContext,
+        CatalogContext $catalogContext,
         CompletenessCalculatorInterface $completenessCalculator,
         EntityWithFamilyValuesFillerInterface $productValuesFiller,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
@@ -169,6 +175,7 @@ class ProductNormalizer implements NormalizerInterface
         $this->collectionFilter                 = $collectionFilter;
         $this->completenessCollectionNormalizer = $completenessCollectionNormalizer;
         $this->userContext                      = $userContext;
+        $this->catalogContext                   = $catalogContext;
         $this->completenessCalculator           = $completenessCalculator;
         $this->productValuesFiller              = $productValuesFiller;
         $this->attributesProvider               = $attributesProvider;
@@ -227,7 +234,7 @@ class ProductNormalizer implements NormalizerInterface
             'structure_version' => $this->structureVersionProvider->getStructureVersion(),
             'completenesses'    => $this->getNormalizedCompletenesses($product),
             'required_missing_attributes' => $incompleteValues,
-            'image'             => $this->normalizeImage($product->getImage(), $context),
+            'image'             => $this->normalizeImage($product->getImage(), $this->catalogContext->getLocaleCode()),
         ] + $this->getLabels($product, $scopeCode) + $this->getAssociationMeta($product);
 
         $normalizedProduct['meta']['ascendant_category_ids'] = $product->isVariant() ?
@@ -307,13 +314,13 @@ class ProductNormalizer implements NormalizerInterface
 
     /**
      * @param ValueInterface $value
-     * @param array          $context
+     * @param string         $localeCode
      *
      * @return array|null
      */
-    protected function normalizeImage(?ValueInterface $value, array $context = []): ?array
+    protected function normalizeImage(?ValueInterface $value, ?string $localeCode = null): ?array
     {
-        return $this->imageNormalizer->normalize($value, $context['locale']);
+        return $this->imageNormalizer->normalize($value, $localeCode);
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -80,9 +80,6 @@ class ProductNormalizer implements NormalizerInterface
     /** @var UserContext */
     protected $userContext;
 
-    /** @var CatalogContext */
-    protected $catalogContext;
-
     /** @var CompletenessCalculatorInterface */
     private $completenessCalculator;
 
@@ -108,6 +105,9 @@ class ProductNormalizer implements NormalizerInterface
      */
     private $missingAssociationAdder;
 
+    /** @var CatalogContext */
+    protected $catalogContext;
+
     /**
      * @param NormalizerInterface                       $normalizer
      * @param NormalizerInterface                       $versionNormalizer
@@ -124,7 +124,6 @@ class ProductNormalizer implements NormalizerInterface
      * @param CollectionFilterInterface                 $collectionFilter
      * @param NormalizerInterface                       $completenessCollectionNormalizer
      * @param UserContext                               $userContext
-     * @param CatalogContext                            $catalogContext
      * @param CompletenessCalculatorInterface           $completenessCalculator
      * @param EntityWithFamilyValuesFillerInterface     $productValuesFiller
      * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
@@ -133,6 +132,7 @@ class ProductNormalizer implements NormalizerInterface
      * @param NormalizerInterface                       $incompleteValuesNormalizer
      * @param MissingAssociationAdder                   $missingAssociationAdder
      * @param NormalizerInterface                       $parentAssociationsNormalizer
+     * @param CatalogContext                            $catalogContext
      */
     public function __construct(
         NormalizerInterface $normalizer,
@@ -150,7 +150,6 @@ class ProductNormalizer implements NormalizerInterface
         CollectionFilterInterface $collectionFilter,
         NormalizerInterface $completenessCollectionNormalizer,
         UserContext $userContext,
-        CatalogContext $catalogContext,
         CompletenessCalculatorInterface $completenessCalculator,
         EntityWithFamilyValuesFillerInterface $productValuesFiller,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
@@ -158,7 +157,8 @@ class ProductNormalizer implements NormalizerInterface
         AscendantCategoriesInterface $ascendantCategoriesQuery,
         NormalizerInterface $incompleteValuesNormalizer,
         MissingAssociationAdder $missingAssociationAdder,
-        NormalizerInterface $parentAssociationsNormalizer
+        NormalizerInterface $parentAssociationsNormalizer,
+        CatalogContext $catalogContext = null
     ) {
         $this->normalizer                       = $normalizer;
         $this->versionNormalizer                = $versionNormalizer;
@@ -175,7 +175,6 @@ class ProductNormalizer implements NormalizerInterface
         $this->collectionFilter                 = $collectionFilter;
         $this->completenessCollectionNormalizer = $completenessCollectionNormalizer;
         $this->userContext                      = $userContext;
-        $this->catalogContext                   = $catalogContext;
         $this->completenessCalculator           = $completenessCalculator;
         $this->productValuesFiller              = $productValuesFiller;
         $this->attributesProvider               = $attributesProvider;
@@ -184,6 +183,7 @@ class ProductNormalizer implements NormalizerInterface
         $this->incompleteValuesNormalizer       = $incompleteValuesNormalizer;
         $this->parentAssociationsNormalizer     = $parentAssociationsNormalizer;
         $this->missingAssociationAdder          = $missingAssociationAdder;
+        $this->catalogContext                   = $catalogContext;
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -67,6 +67,7 @@ services:
             - '@pim_catalog.filter.chained'
             - '@pim_enrich.normalizer.completeness_collection'
             - '@pim_user.context.user'
+            - '@pim_catalog.context.catalog'
             - '@pim_catalog.completeness.calculator'
             - '@pim_catalog.values_filler.product'
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -67,7 +67,6 @@ services:
             - '@pim_catalog.filter.chained'
             - '@pim_enrich.normalizer.completeness_collection'
             - '@pim_user.context.user'
-            - '@pim_catalog.context.catalog'
             - '@pim_catalog.completeness.calculator'
             - '@pim_catalog.values_filler.product'
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
@@ -76,6 +75,7 @@ services:
             - '@pim_enrich.normalizer.incomplete_values'
             - '@pim_catalog.association.missing_association_adder'
             - '@pim_catalog.normalizer.standard.product.parent_associations'
+            - '@pim_catalog.context.catalog'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -5,6 +5,7 @@ namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Context\CatalogContext;
 use Pim\Bundle\CatalogBundle\Filter\CollectionFilterInterface;
 use Pim\Bundle\EnrichBundle\Normalizer\ImageNormalizer;
 use Pim\Bundle\EnrichBundle\Normalizer\VariantNavigationNormalizer;
@@ -51,6 +52,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         CollectionFilterInterface $collectionFilter,
         NormalizerInterface $completenessCollectionNormalizer,
         UserContext $userContext,
+        CatalogContext $catalogContext,
         CompletenessCalculatorInterface $completenessCalculator,
         EntityWithFamilyValuesFillerInterface $productValuesFiller,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
@@ -76,6 +78,7 @@ class ProductNormalizerSpec extends ObjectBehavior
             $collectionFilter,
             $completenessCollectionNormalizer,
             $userContext,
+            $catalogContext,
             $completenessCalculator,
             $productValuesFiller,
             $attributesProvider,

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductNormalizerSpec.php
@@ -52,7 +52,6 @@ class ProductNormalizerSpec extends ObjectBehavior
         CollectionFilterInterface $collectionFilter,
         NormalizerInterface $completenessCollectionNormalizer,
         UserContext $userContext,
-        CatalogContext $catalogContext,
         CompletenessCalculatorInterface $completenessCalculator,
         EntityWithFamilyValuesFillerInterface $productValuesFiller,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
@@ -60,7 +59,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         AscendantCategoriesInterface $ascendantCategories,
         NormalizerInterface $incompleteValuesNormalizer,
         MissingAssociationAdder $missingAssociationAdder,
-        NormalizerInterface $parentAssociationsNormalizer
+        NormalizerInterface $parentAssociationsNormalizer,
+        CatalogContext $catalogContext
     ) {
         $this->beConstructedWith(
             $normalizer,
@@ -78,7 +78,6 @@ class ProductNormalizerSpec extends ObjectBehavior
             $collectionFilter,
             $completenessCollectionNormalizer,
             $userContext,
-            $catalogContext,
             $completenessCalculator,
             $productValuesFiller,
             $attributesProvider,
@@ -86,7 +85,8 @@ class ProductNormalizerSpec extends ObjectBehavior
             $ascendantCategories,
             $incompleteValuesNormalizer,
             $missingAssociationAdder,
-            $parentAssociationsNormalizer
+            $parentAssociationsNormalizer,
+            $catalogContext
         );
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We got an SLA because the UI locale was used instead of the Catalog locale to normalize the image from a localizable asset when we save the product.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
