### PR TITLE
PIM-7594: Put cursor back instead of doctrine Paginator who load all data and memory leak occurs

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,11 @@
 ## Bug fixes
 
 - PIM-7628: Fix the initialization of the product datagrid identifier filter.
+- PIM-7594: Fix memory leak in `pim:versioning:purge` command
+
+## BC breaks
+
+- PIM-7594: Method `Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface::findPotentiallyPurgeableBy` returns now an CursorInterface
 
 # 2.3.6 (2018-09-06)
 

--- a/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
+++ b/src/Pim/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
@@ -3,11 +3,11 @@
 namespace Pim\Bundle\VersioningBundle\Doctrine\ORM;
 
 use Akeneo\Bundle\StorageUtilsBundle\Doctrine\ORM\Repository\CursorableRepositoryInterface;
+use Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NoResultException;
-use Doctrine\ORM\Tools\Pagination\Paginator;
 use Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface;
 
 /**
@@ -19,6 +19,9 @@ use Pim\Bundle\VersioningBundle\Repository\VersionRepositoryInterface;
  */
 class VersionRepository extends EntityRepository implements VersionRepositoryInterface, CursorableRepositoryInterface
 {
+    /** @var CursorFactoryInterface */
+    protected $cursorFactory;
+
     /**
      * {@inheritdoc}
      */
@@ -143,7 +146,7 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
             $qb->setParameter('limit_date', $options['limit_date'], Type::DATETIME);
         }
 
-        return new Paginator($qb);
+        return $this->cursorFactory->createCursor($qb);
     }
 
     /**
@@ -186,6 +189,14 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
         }
 
         return $versionId;
+    }
+
+    /**
+     * @param CursorFactoryInterface $cursorFactory
+     */
+    public function setCursorFactory(CursorFactoryInterface $cursorFactory)
+    {
+        $this->cursorFactory = $cursorFactory;
     }
 
     /**

--- a/src/Pim/Bundle/VersioningBundle/Purger/VersionPurger.php
+++ b/src/Pim/Bundle/VersioningBundle/Purger/VersionPurger.php
@@ -69,9 +69,9 @@ class VersionPurger implements VersionPurgerInterface
         $this->configureOptions($optionResolver);
         $options = $optionResolver->resolve($options);
 
-        $versionsPaginator = $this->versionRepository->findPotentiallyPurgeableBy($options);
+        $versionsCursor = $this->versionRepository->findPotentiallyPurgeableBy($options);
 
-        foreach ($versionsPaginator as $version) {
+        foreach ($versionsCursor as $version) {
             $this->eventDispatcher->dispatch(
                 PurgeVersionEvents::PRE_ADVISEMENT,
                 new PreAdvisementVersionEvent($version)
@@ -89,7 +89,6 @@ class VersionPurger implements VersionPurgerInterface
                     $this->versionRemover->removeAll($versionsToPurge);
                     $this->objectDetacher->detachAll($versionsToPurge);
                     $versionsToPurge = [];
-                    $this->versionRepository->clear();
                 }
             } else {
                 $this->objectDetacher->detach($version);
@@ -111,9 +110,9 @@ class VersionPurger implements VersionPurgerInterface
         $this->configureOptions($optionResolver);
         $options = $optionResolver->resolve($options);
 
-        $versionsPaginator = $this->versionRepository->findPotentiallyPurgeableBy($options);
+        $versionsCursor = $this->versionRepository->findPotentiallyPurgeableBy($options);
 
-        return $versionsPaginator->count();
+        return $versionsCursor->count();
     }
 
     /**

--- a/src/Pim/Bundle/VersioningBundle/Repository/VersionRepositoryInterface.php
+++ b/src/Pim/Bundle/VersioningBundle/Repository/VersionRepositoryInterface.php
@@ -2,8 +2,8 @@
 
 namespace Pim\Bundle\VersioningBundle\Repository;
 
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\Versioning\Model\Version;
-use Doctrine\ORM\Tools\Pagination\Paginator;
 
 /**
  * Version repository interface
@@ -88,7 +88,7 @@ interface VersionRepositoryInterface
      *
      * @param array $options
      *
-     * @return Paginator
+     * @return CursorInterface
      */
     public function findPotentiallyPurgeableBy(array $options = []);
 

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/repositories.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/repositories.yml
@@ -11,6 +11,10 @@ services:
         arguments: ['%pim_versioning.entity.version.class%']
         tags:
             - { name: 'pim_repository' }
+        calls:
+            - method: setCursorFactory
+              arguments:
+                - '@pim_versioning.factory.version_cursor'
 
     pim_versioning.object_manager.version:
         alias: doctrine.orm.entity_manager


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
In 1.7 we remove Akeneo cursor from purge command to put doctrine Paginator (by the way it is not an iterrator)
So put cursor back instead of doctrine Paginator who load all data and memory leak occurs

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
