### PR TITLE
PIM-7595: Add missing acl on family variant managment

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7595: Add missing acl on family variant managment 
 - PIM-7557: Don't display attribute group filter if no attribute is chosen in "edit common attributes" action
 
 # 2.0.34 (2018-08-17)

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
@@ -158,6 +158,10 @@ pim_enrich_family_edit_attributes:
     type: action
     label: pim_enrich.acl.family.edit_attributes
     group_name: pim_enrich.acl_group.family
+pim_enrich_family_edit_variants:
+    type: action
+    label: pim_enrich.acl.family.edit_variants
+    group_name: pim_enrich.acl_group.family
 pim_enrich_family_remove:
     type: action
     label: pim_enrich.acl.family.remove

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/family_variant.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/family_variant.yml
@@ -33,6 +33,7 @@ datagrid:
                 fetcher:      family-variant
                 form:         pim-family-variant-edit-form
                 rowAction:    true
+                acl_resource: pim_enrich_family_edit_variants
         filters:
             columns:
                 label:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/family/edit.yml
@@ -236,6 +236,7 @@ extensions:
         parent: pim-family-edit-form-variant
         targetZone: variant-toolbar
         position: 100
+        aclResourceId: pim_enrich_family_edit_variants
 
     pim-family-edit-form-history:
         module: pim/common/tab/history

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -210,6 +210,7 @@ pim_enrich:
             create: Create a family
             edit_properties: Edit properties of a family
             edit_attributes: Edit attributes of a family
+            edit_variants: Edit a family variant
             remove: Remove a family
             history: View family history
         attribute_group:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

An Acl was missing for manage family variant (add/edit), so with only List families permissions you could edit a family variant

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
