### PR TITLE
PIM-7600: change the default return value to true of ResetIndexesCommand

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,3 +1,9 @@
+# 2.3.x
+
+## Bug fixes
+
+- PIM-7600: Change the default return value of ResetIndexesCommand to true to allow the --no-interaction parameter.
+
 # 2.3.5 (2018-08-22)
 
 ## Bug fixes

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Command/ResetIndexesCommand.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Command/ResetIndexesCommand.php
@@ -66,8 +66,8 @@ class ResetIndexesCommand extends ContainerAwareCommand
     {
         $output->writeln('<info>This action will entirely reset all indexes registered in the PIM.</info>');
         $question = new ConfirmationQuestion(
-            '<question>Are you sure you want to proceed ?</question> (y/N)',
-            false
+            '<question>Are you sure you want to proceed ?</question> (Y/n)',
+            true
         );
         $question->setMaxAttempts(2);
         $helper = $this->getHelper('question');


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Allows to use the command with the --no-interaction parameter
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
