### PR TITLE
Use a dedicated system user token instead of UsernamePasswordToken for commands

### DIFF
--- a/src/Pim/Bundle/UserBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/event_subscribers.yml
@@ -4,7 +4,7 @@ parameters:
     pim_user.event_subscriber.remove_role.class:      Pim\Bundle\UserBundle\EventSubscriber\RemoveRoleSubscriber
     pim_locale.locale_subscriber.class:               Pim\Bundle\UserBundle\EventSubscriber\LocaleSubscriber
     pim_locale.locale_listener.class:                 Pim\Bundle\UserBundle\EventListener\LocaleListener
-    pim_user.event_listener.create_user_system.class: Pim\Bundle\UserBundle\EventSubscriber\CreateUserSystemListener
+    pim_user.create_system_user_for_commands.class:   Pim\Bundle\UserBundle\EventListener\CreateSystemUserForCommandsListener
 
 services:
     pim_user.event_subscriber.user_preferences:
@@ -40,12 +40,12 @@ services:
         tags:
             - { name: kernel.event_listener, event: security.interactive_login, method: onSecurityInteractiveLogin }
 
-    pim_user.event_listener.create_user_system:
-        class: '%pim_user.event_listener.create_user_system.class%'
+    pim_user.create_system_user_for_commands:
+        class: '%pim_user.create_system_user_for_commands.class%'
         arguments:
             - '@security.token_storage'
             - '@pim_user.repository.group'
             - '@pim_user.repository.role'
             - '@pim_user.factory.user'
         tags:
-            - { name: kernel.event_listener, event: console.command, method: createUserSystem }
+            - { name: kernel.event_listener, event: console.command, method: createSystemUser }

--- a/src/Pim/Bundle/UserBundle/Security/SystemUserToken.php
+++ b/src/Pim/Bundle/UserBundle/Security/SystemUserToken.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\UserBundle\Security;
+
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Token holding system user info.
+ * A system user has no password, no credentials and is authenticated by default.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class SystemUserToken extends AbstractToken
+{
+    public function __construct(UserInterface $user)
+    {
+        $this->setUser($user);
+        $this->setAuthenticated(true);
+
+        parent::__construct($user->getRoles());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCredentials()
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**Why ?**
To run system commands (especially installer commands) and still be able to use permissions, we create a system user on-the-fly and set it in a `UsernamePasswordToken`.
The problem is that the `UsernamePasswordToken` is only supported by the `DaoAuthenticationProvider`. This provider is loaded only when a `login_form` is declared in a security firewall, so we coupled two things completely unrelated. And when we want to use a different firewall configuration, the installer is broken.

**Solution**
Use a dedicated token for the system user, and since it's authenticated by default there is no need for an authentication provider (nor a firewall listener).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
