### PR TITLE
TIP-879 Uses utf8mb4 instead of MySQL flawed utf8

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -7,6 +7,7 @@
 - GITHUB-8451: Add basic compatibility for PHP 7.2  (Thanks [janmyszkier](https://github.com/janmyszkier)!)
 - PIM-7371: Improve the performance to display the category tree in the product grid
 - PIM-7506: Cache default views and columns on the product grid
+- TIP-879: Uses utf8mb4 as encoding for MySQL instead of the less efficient utf8
 - Centralizes technical requirements checks to reuse them on standard edition
 
 ## Enhancements
@@ -15,6 +16,7 @@
 
 ## BC breaks
 
+- MySQL charset for Akeneo is now utf8mb4, instead of the flawed utf8. If you have custom table, you can convert them with `ALTER TABLE my_custom_table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`. For Akeneo native tables, the migration scripts apply the conversion.
 - Move `Pim\Bundle\ReferenceDataBundle\DataGrid\Extension\Sorter\ReferenceDataSorter` to `Oro\Bundle\PimDataGridBundle\Extension\Sorter\Produc\ReferenceDataSorter`
 - Move `Pim\Bundle\ReferenceDataBundle\DataGrid\Normalizer\ReferenceDataCollectionNormalizer` to `Oro\Bundle\PimDataGridBundle\Normalizer\Product\ReferenceDataCollectionNormalizer`
 - Move `Pim\Bundle\ReferenceDataBundle\DataGrid\Normalizer\ReferenceDataNormalizer` to `Oro\Bundle\PimDataGridBundle\Normalizer\Product\ReferenceDataNormalizer`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,6 +45,10 @@
     * For Enterprise Edition, you also need to add the following bundle:
         - TODO
 
+## Database charset migration
+
+MySQL charset for Akeneo is now utf8mb4, instead of the flawed utf8. If you have custom table, you can convert them with `ALTER TABLE my_custom_table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`. For Akeneo native tables, the migration scripts apply the conversion.
+
 ## Migrate your custom code
 
 Several classes and services have been moved or renamed. The following commands help to migrate references to them:

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/EventListener/InstallDatabase.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/EventListener/InstallDatabase.php
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS pim_aggregated_volume (
   volume json NOT NULL COMMENT '(DC2Type:native_json)',
   aggregated_at DATETIME NOT NULL COMMENT '(DC2Type:datetime)',
   PRIMARY KEY(volume_name)
-) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB
 SQL;
 
         $this->connection->exec($sql);

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -179,7 +179,7 @@ class DatabaseCommand extends ContainerAwareCommand
                 `sess_data` BLOB NOT NULL,
                 `sess_time` INTEGER UNSIGNED NOT NULL,
                 `sess_lifetime` MEDIUMINT NOT NULL DEFAULT  '0'
-            ) COLLATE utf8_bin, ENGINE = InnoDB";
+            ) COLLATE utf8mb4_bin, ENGINE = InnoDB";
 
         $db = $this->getContainer()->get('doctrine');
 

--- a/src/Akeneo/Platform/Requirement.php
+++ b/src/Akeneo/Platform/Requirement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Platform;
 
 /**

--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/tests/integration/Utf8mb4SupportIntegrationTest.php
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/tests/integration/Utf8mb4SupportIntegrationTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\StorageUtilsBundle\tests\integration;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Table;
+
+/**
+ * Checks that Utf8mb4Support is properly taken into account by Doctrine ORM
+ * and supported by the MySQL DB.
+ */
+class Utf8mb4SupportIntegrationTest extends TestCase
+{
+    const TEST_TABLE_NAME = "test_integration_storageutils_utf8mb4";
+
+    /** @var AbstractSchemaManager */
+    protected $schemaManager;
+
+    /** @var Connection */
+    protected $connection;
+
+    public function setUp() : void
+    {
+        parent::setup();
+        $this->connection = $this->get('doctrine.orm.entity_manager')->getConnection();
+        $this->schemaManager = $this->connection->getSchemaManager();
+    }
+
+    public function testUtf8mb4Support() : void
+    {
+        if ($this->schemaManager->tablesExist([self::TEST_TABLE_NAME])) {
+            $this->schemaManager->dropTable(self::TEST_TABLE_NAME);
+        }
+
+        $schema = $this->schemaManager->createSchema();
+
+        $myTestTable = $schema->createTable(self::TEST_TABLE_NAME);
+        $myTestTable->addColumn('id', 'integer');
+        $myTestTable->addColumn('name', 'string');
+        $myTestTable->setPrimaryKey(['id']);
+
+        $myTestTableSql = array_filter(
+            $schema->toSql($this->connection->getDatabasePlatform()),
+            function ($sql) {
+                return (strpos($sql, 'CREATE TABLE '.self::TEST_TABLE_NAME) === 0);
+            }
+        );
+        $myTestTableSql = reset($myTestTableSql);
+
+        $this->connection->exec($myTestTableSql);
+
+        $insertCount = $this->connection->insert(
+            self::TEST_TABLE_NAME,
+            [
+                'id' =>1,
+                'name' => '𝌆'
+            ]
+        );
+
+        $this->assertEquals(1, $insertCount);
+
+        $resultFromDb = $this->connection->fetchColumn(
+            "SELECT name FROM ".self::TEST_TABLE_NAME." WHERE name = ?",
+            ["𝌆"]
+        );
+
+        $this->assertEquals("𝌆", $resultFromDb);
+    }
+
+    public function tearDown() : void
+    {
+        if ($this->schemaManager->tablesExist([self::TEST_TABLE_NAME])) {
+            $this->schemaManager->dropTable(self::TEST_TABLE_NAME);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return null;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/doctrine.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/bundles/doctrine.yml
@@ -11,7 +11,11 @@ doctrine:
                 dbname:       "%database_name%"
                 user:         "%database_user%"
                 password:     "%database_password%"
-                charset:      UTF8
+                charset:      utf8mb4
+                default_table_options:
+                        charset: utf8mb4
+                        collate: utf8mb4_unicode_ci
+                        row_format: DYNAMIC
                 server_version: 5.7
                 mapping_types:
                     json: string
@@ -23,7 +27,11 @@ doctrine:
                 dbname:       "%database_name%"
                 user:         "%database_user%"
                 password:     "%database_password%"
-                charset:      UTF8
+                charset:      utf8mb4
+                default_table_options:
+                        charset: utf8mb4
+                        collate: utf8mb4_unicode_ci
+                        row_format: DYNAMIC
         types:
             datetime: Akeneo\Tool\Bundle\StorageUtilsBundle\Doctrine\DBAL\Types\UTCDateTimeType
             native_json:

--- a/src/Pim/Bundle/EnrichBundle/StructureVersion/EventListener/TableCreator.php
+++ b/src/Pim/Bundle/EnrichBundle/StructureVersion/EventListener/TableCreator.php
@@ -42,12 +42,12 @@ class TableCreator implements EventSubscriberInterface
     public function onPostDBCreate()
     {
         $sql = <<<'SQL'
-DROP TABLE IF EXISTS `akeneo_structure_version_last_update`;
-CREATE TABLE `akeneo_structure_version_last_update` (
-    `resource_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-    `last_update` datetime NOT NULL COMMENT '(DC2Type:datetime)',
-    PRIMARY KEY(`resource_name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+DROP TABLE IF EXISTS akeneo_structure_version_last_update;
+CREATE TABLE akeneo_structure_version_last_update (
+    resource_name varchar(255) NOT NULL,
+    last_update datetime NOT NULL COMMENT '(DC2Type:datetime)',
+    PRIMARY KEY(resource_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 SQL;
         $this->doctrine->getConnection()->exec($sql);
     }

--- a/upgrades/schema/Version_3_0_20180823184342_switch_to_utf8mb4.php
+++ b/upgrades/schema/Version_3_0_20180823184342_switch_to_utf8mb4.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Switch to full UTF8 support by using MySQL utf8mb4 instead of the incomplete MySQL utf8
+ */
+class Version_3_0_20180823184342_switch_to_utf8mb4 extends AbstractMigration
+{
+    private $tablesList = [
+        "acl_classes",
+        "acl_entries",
+        "acl_object_identities",
+        "acl_object_identity_ancestors",
+        "acl_security_identities",
+        "acme_reference_data_color",
+        "acme_reference_data_fabric",
+        "akeneo_batch_job_execution",
+        "akeneo_batch_job_execution_queue",
+        "akeneo_batch_job_instance",
+        "akeneo_batch_step_execution",
+        "akeneo_batch_warning",
+        "akeneo_file_storage_file_info",
+        "akeneo_structure_version_last_update",
+        "oro_access_group",
+        "oro_access_role",
+        "oro_config",
+        "oro_config_value",
+        "oro_user",
+        "oro_user_access_group",
+        "oro_user_access_group_role",
+        "oro_user_access_role",
+        "pim_aggregated_volume",
+        "pim_api_access_token",
+        "pim_api_auth_code",
+        "pim_api_client",
+        "pim_api_refresh_token",
+        "pim_catalog_association",
+        "pim_catalog_association_group",
+        "pim_catalog_association_product",
+        "pim_catalog_association_product_model",
+        "pim_catalog_association_product_model_to_group",
+        "pim_catalog_association_product_model_to_product",
+        "pim_catalog_association_product_model_to_product_model",
+        "pim_catalog_association_type",
+        "pim_catalog_association_type_translation",
+        "pim_catalog_attribute",
+        "pim_catalog_attribute_group",
+        "pim_catalog_attribute_group_translation",
+        "pim_catalog_attribute_locale",
+        "pim_catalog_attribute_option",
+        "pim_catalog_attribute_option_value",
+        "pim_catalog_attribute_requirement",
+        "pim_catalog_attribute_translation",
+        "pim_catalog_category",
+        "pim_catalog_category_product",
+        "pim_catalog_category_product_model",
+        "pim_catalog_category_translation",
+        "pim_catalog_channel",
+        "pim_catalog_channel_currency",
+        "pim_catalog_channel_locale",
+        "pim_catalog_channel_translation",
+        "pim_catalog_completeness",
+        "pim_catalog_completeness_missing_attribute",
+        "pim_catalog_currency",
+        "pim_catalog_family",
+        "pim_catalog_family_attribute",
+        "pim_catalog_family_translation",
+        "pim_catalog_family_variant",
+        "pim_catalog_family_variant_attribute_set",
+        "pim_catalog_family_variant_has_variant_attribute_sets",
+        "pim_catalog_family_variant_translation",
+        "pim_catalog_group",
+        "pim_catalog_group_product",
+        "pim_catalog_group_translation",
+        "pim_catalog_group_type",
+        "pim_catalog_group_type_translation",
+        "pim_catalog_locale",
+        "pim_catalog_product",
+        "pim_catalog_product_model",
+        "pim_catalog_product_model_association",
+        "pim_catalog_product_unique_data",
+        "pim_catalog_variant_attribute_set_has_attributes",
+        "pim_catalog_variant_attribute_set_has_axes",
+        "pim_comment_comment",
+        "pim_datagrid_view",
+        "pim_notification_notification",
+        "pim_notification_user_notification",
+        "pim_user_default_datagrid_view",
+        "pim_versioning_version"
+    ];
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $dbName = $this->connection->getDatabase();
+
+        $this->addSql(
+            sprintf('ALTER DATABASE %s CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci', $dbName)
+        );
+
+        foreach($this->tablesList as $tableName) {
+            $this->addSql(
+                sprintf('ALTER TABLE %s CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci', $tableName)
+            );
+        }
+
+        $this->addSql(
+            sprintf('ALTER TABLE pim_session CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin', $tableName)
+        );
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This PR changes the default charset from utf8 to utf8mb4, allowing support for more UTF8 characters. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | Done
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
