### PR TITLE
PIM-7621 - add new axes on System Information

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -45,6 +45,11 @@
 - PIM-7613: Fix translations of boolean attributes
 - PIM-7609: Handle 'empty' and 'not empty' filter types in string filter
 
+## BC breaks
+
+- Change the constructor of `Pim\Bundle\AnalyticsBundle\DataCollector\DBDataCollector.php` to add `Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxProductValuesPerFamily` as a new argument
+- Change the constructor of `Pim\Bundle\AnalyticsBundle\DataCollector\AttributeDataCollector.php` to add `Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountUseableAsGridFilterAttributes`, `Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAttributesPerFamily`, `Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxScopableAttributesPerFamily` and `Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAndScopableAttributesPerFamily` as new arguments
+
 # 2.3.5 (2018-08-22)
 
 ## Bug fixes

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -45,11 +45,6 @@
 - PIM-7613: Fix translations of boolean attributes
 - PIM-7609: Handle 'empty' and 'not empty' filter types in string filter
 
-## BC breaks
-
-- Change the constructor of `Pim\Bundle\AnalyticsBundle\DataCollector\DBDataCollector.php` to add `Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxProductValuesPerFamily` as a new argument
-- Change the constructor of `Pim\Bundle\AnalyticsBundle\DataCollector\AttributeDataCollector.php` to add `Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountUseableAsGridFilterAttributes`, `Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAttributesPerFamily`, `Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxScopableAttributesPerFamily` and `Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAndScopableAttributesPerFamily` as new arguments
-
 # 2.3.5 (2018-08-22)
 
 ## Bug fixes

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -59,12 +59,17 @@ parameters:
     # these parameters indicate the advisable limitations of the PIM in term of volume
     # if your volume of data exceeds these limits, it can impact the performance
     average_max_attributes_per_family_limit: 100
+    average_max_localizable_attributes_per_family_limit: -1
+    average_max_scopable_attributes_per_family_limit: -1
+    average_max_localizable_and_scopable_attributes_per_family_limit: -1
+    average_max_product_values_per_family_limit: -1
     average_max_options_per_attribute_limit: -1
     average_max_product_values_limit: -1
     average_max_product_model_values_limit: -1
     average_max_categories_in_one_category_limit: -1
     average_max_category_levels_limit: -1
     count_attributes_limit: 500
+    count_useable_as_grid_filter_attributes_limit: -1
     count_categories_limit: 5000
     count_category_trees_limit: -1
     count_channels_limit: 3

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -157,10 +157,16 @@ acceptance:
             contexts_services:
                 - test.catalog_volume_limits.report_context
                 - test.catalog_volume_limits.system_info_context
+                - test.catalog_volume_limits.system_info_attribute_context
                 - test.catalog_volume_limits.attribute_per_family_context
                 - test.catalog_volume_limits.product_context
                 - test.catalog_volume_limits.channel_context
                 - test.catalog_volume_limits.locale_context
+                - test.catalog_volume_limits.useable_as_grid_filter_attribute_context
+                - test.catalog_volume_limits.product_value_per_family_context
+                - test.catalog_volume_limits.localizable_attribute_per_family_context
+                - test.catalog_volume_limits.scopable_attribute_per_family_context
+                - test.catalog_volume_limits.localizable_and_scopable_attribute_per_family_context
                 - test.catalog_volume_limits.scopable_attribute_context
                 - test.catalog_volume_limits.localizable_attribute_context
                 - test.catalog_volume_limits.localizable_and_scopable_attribute_context

--- a/src/Pim/Bundle/AnalyticsBundle/DataCollector/AttributeDataCollector.php
+++ b/src/Pim/Bundle/AnalyticsBundle/DataCollector/AttributeDataCollector.php
@@ -6,6 +6,7 @@ namespace Pim\Bundle\AnalyticsBundle\DataCollector;
 use Akeneo\Component\Analytics\DataCollectorInterface;
 use Akeneo\Component\StorageUtils\Repository\CountableRepositoryInterface;
 use Pim\Bundle\AnalyticsBundle\Doctrine\Query;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
 use Pim\Component\CatalogVolumeMonitoring\Volume\Query\CountQuery;
 
 /**
@@ -32,34 +33,85 @@ class AttributeDataCollector implements DataCollectorInterface
     /** @var CountQuery */
     private $localizableAndScopableAttributeCountQuery;
 
+    /** @var CountQuery */
+    private $useableAsGridFilterAttributeCountQuery;
+
+    /** @var AverageMaxQuery */
+    private $localizableAttributePerFamilyAverageMaxQuery;
+
+    /** @var AverageMaxQuery */
+    private $scopableAttributePerFamilyAverageMaxQuery;
+
+    /** @var AverageMaxQuery */
+    private $localizableAndScopableAttributePerFamilyAverageMaxQuery;
+
     /**
+     * TODO - on master - remove '= null'
      * @param CountQuery        $attributeCountQuery
      * @param CountQuery        $localizableAttributeCountQuery
      * @param CountQuery        $scopableAttributeCountQuery
      * @param CountQuery        $localizableAndScopableAttributeCountQuery
+     * @param CountQuery        $useableAsGridFilterAttributeCountQuery
+     * @param AverageMaxQuery   $localizableAttributePerFamilyAverageMaxQuery
+     * @param AverageMaxQuery   $scopableAttributePerFamilyAverageMaxQuery
+     * @param AverageMaxQuery   $localizableAndScopableAttributePerFamilyAverageMaxQuery
      */
     public function __construct(
         CountQuery $attributeCountQuery,
         CountQuery $localizableAttributeCountQuery,
         CountQuery $scopableAttributeCountQuery,
-        CountQuery $localizableAndScopableAttributeCountQuery
+        CountQuery $localizableAndScopableAttributeCountQuery,
+        CountQuery $useableAsGridFilterAttributeCountQuery = null,
+        AverageMaxQuery $localizableAttributePerFamilyAverageMaxQuery = null,
+        AverageMaxQuery $scopableAttributePerFamilyAverageMaxQuery = null,
+        AverageMaxQuery $localizableAndScopableAttributePerFamilyAverageMaxQuery = null
     ) {
         $this->attributeCountQuery = $attributeCountQuery;
         $this->localizableAttributeCountQuery = $localizableAttributeCountQuery;
         $this->scopableAttributeCountQuery = $scopableAttributeCountQuery;
         $this->localizableAndScopableAttributeCountQuery = $localizableAndScopableAttributeCountQuery;
+        $this->useableAsGridFilterAttributeCountQuery = $useableAsGridFilterAttributeCountQuery;
+
+        $this->localizableAttributePerFamilyAverageMaxQuery = $localizableAttributePerFamilyAverageMaxQuery;
+        $this->scopableAttributePerFamilyAverageMaxQuery = $scopableAttributePerFamilyAverageMaxQuery;
+        $this->localizableAndScopableAttributePerFamilyAverageMaxQuery = $localizableAndScopableAttributePerFamilyAverageMaxQuery;
     }
 
     /**
+     * TODO - on master - remove the if statements & move all inside the "if session" inside $data
      * {@inheritdoc}
      */
     public function collect(): array
     {
+        $numberOfUseableAsGridFilterAttribute = 0;
+        if (!is_null($this->useableAsGridFilterAttributeCountQuery)) {
+            $numberOfUseableAsGridFilterAttribute = $this->useableAsGridFilterAttributeCountQuery->fetch()->getVolume();
+        }
+
+        $numberOfScopableAttributePerFamilyAverageMaxQuery = 0;
+        if (!is_null($this->scopableAttributePerFamilyAverageMaxQuery)) {
+            $numberOfScopableAttributePerFamilyAverageMaxQuery = $this->scopableAttributePerFamilyAverageMaxQuery->fetch()->getAverageVolume();
+        }
+
+        $numberOfLocalizableAttributePerFamilyAverageMaxQuery = 0;
+        if (!is_null($this->localizableAttributePerFamilyAverageMaxQuery)) {
+            $numberOfLocalizableAttributePerFamilyAverageMaxQuery = $this->localizableAttributePerFamilyAverageMaxQuery->fetch()->getAverageVolume();
+        }
+
+        $numberOfLocalizableAndScopableAttributePerFamilyAverageMaxQuery = 0;
+        if (!is_null($this->localizableAndScopableAttributePerFamilyAverageMaxQuery)) {
+            $numberOfLocalizableAndScopableAttributePerFamilyAverageMaxQuery = $this->localizableAndScopableAttributePerFamilyAverageMaxQuery->fetch()->getAverageVolume();
+        }
+
         $data = [
             'nb_attributes' => $this->attributeCountQuery->fetch()->getVolume(),
             'nb_scopable_attributes' => $this->scopableAttributeCountQuery->fetch()->getVolume(),
             'nb_localizable_attributes' => $this->localizableAttributeCountQuery->fetch()->getVolume(),
             'nb_scopable_localizable_attributes' => $this->localizableAndScopableAttributeCountQuery->fetch()->getVolume(),
+            'nb_useable_as_grid_filter_attributes' => $numberOfUseableAsGridFilterAttribute,
+            'avg_scopable_attributes_per_family' => $numberOfScopableAttributePerFamilyAverageMaxQuery,
+            'avg_localizable_attributes_per_family' => $numberOfLocalizableAttributePerFamilyAverageMaxQuery,
+            'avg_scopable_localizable_attributes_per_family' => $numberOfLocalizableAndScopableAttributePerFamilyAverageMaxQuery,
         ];
 
         return $data;

--- a/src/Pim/Bundle/AnalyticsBundle/DataCollector/AttributeDataCollector.php
+++ b/src/Pim/Bundle/AnalyticsBundle/DataCollector/AttributeDataCollector.php
@@ -46,7 +46,7 @@ class AttributeDataCollector implements DataCollectorInterface
     private $localizableAndScopableAttributePerFamilyAverageMaxQuery;
 
     /**
-     * TODO - on master - remove '= null'
+     * @merge TODO - on master - remove '= null'
      * @param CountQuery        $attributeCountQuery
      * @param CountQuery        $localizableAttributeCountQuery
      * @param CountQuery        $scopableAttributeCountQuery
@@ -78,28 +78,28 @@ class AttributeDataCollector implements DataCollectorInterface
     }
 
     /**
-     * TODO - on master - remove the if statements & move all inside the "if session" inside $data
+     * @merge TODO - on master - remove the if statements & move all inside the "if session" inside $data
      * {@inheritdoc}
      */
     public function collect(): array
     {
         $numberOfUseableAsGridFilterAttribute = 0;
-        if (!is_null($this->useableAsGridFilterAttributeCountQuery)) {
+        if (null !== $this->useableAsGridFilterAttributeCountQuery) {
             $numberOfUseableAsGridFilterAttribute = $this->useableAsGridFilterAttributeCountQuery->fetch()->getVolume();
         }
 
         $numberOfScopableAttributePerFamilyAverageMaxQuery = 0;
-        if (!is_null($this->scopableAttributePerFamilyAverageMaxQuery)) {
+        if (null !== $this->scopableAttributePerFamilyAverageMaxQuery) {
             $numberOfScopableAttributePerFamilyAverageMaxQuery = $this->scopableAttributePerFamilyAverageMaxQuery->fetch()->getAverageVolume();
         }
 
         $numberOfLocalizableAttributePerFamilyAverageMaxQuery = 0;
-        if (!is_null($this->localizableAttributePerFamilyAverageMaxQuery)) {
+        if (null !== $this->localizableAttributePerFamilyAverageMaxQuery) {
             $numberOfLocalizableAttributePerFamilyAverageMaxQuery = $this->localizableAttributePerFamilyAverageMaxQuery->fetch()->getAverageVolume();
         }
 
         $numberOfLocalizableAndScopableAttributePerFamilyAverageMaxQuery = 0;
-        if (!is_null($this->localizableAndScopableAttributePerFamilyAverageMaxQuery)) {
+        if (null !== $this->localizableAndScopableAttributePerFamilyAverageMaxQuery) {
             $numberOfLocalizableAndScopableAttributePerFamilyAverageMaxQuery = $this->localizableAndScopableAttributePerFamilyAverageMaxQuery->fetch()->getAverageVolume();
         }
 
@@ -109,9 +109,9 @@ class AttributeDataCollector implements DataCollectorInterface
             'nb_localizable_attributes' => $this->localizableAttributeCountQuery->fetch()->getVolume(),
             'nb_scopable_localizable_attributes' => $this->localizableAndScopableAttributeCountQuery->fetch()->getVolume(),
             'nb_useable_as_grid_filter_attributes' => $numberOfUseableAsGridFilterAttribute,
-            'avg_scopable_attributes_per_family' => $numberOfScopableAttributePerFamilyAverageMaxQuery,
-            'avg_localizable_attributes_per_family' => $numberOfLocalizableAttributePerFamilyAverageMaxQuery,
-            'avg_scopable_localizable_attributes_per_family' => $numberOfLocalizableAndScopableAttributePerFamilyAverageMaxQuery,
+            'avg_percentage_scopable_attributes_per_family' => $numberOfScopableAttributePerFamilyAverageMaxQuery,
+            'avg_percentage_localizable_attributes_per_family' => $numberOfLocalizableAttributePerFamilyAverageMaxQuery,
+            'avg_percentage_scopable_localizable_attributes_per_family' => $numberOfLocalizableAndScopableAttributePerFamilyAverageMaxQuery,
         ];
 
         return $data;

--- a/src/Pim/Bundle/AnalyticsBundle/DataCollector/DBDataCollector.php
+++ b/src/Pim/Bundle/AnalyticsBundle/DataCollector/DBDataCollector.php
@@ -70,7 +70,7 @@ class DBDataCollector implements DataCollectorInterface
     protected $productValuePerFamilyAverageMaxQuery;
 
     /**
-     * TODO - on master - remove '= null'
+     * @merge TODO - on master - remove '= null'
      * @param CountQuery      $channelCountQuery
      * @param CountQuery      $productCountQuery
      * @param CountQuery      $localeCountQuery
@@ -119,14 +119,14 @@ class DBDataCollector implements DataCollectorInterface
     }
 
     /**
-     * TODO - on master - remove the if statement & move all inside the "if session" inside $data
+     * @merge TODO - on master - remove the if statement & move all inside the "if session" inside $data
      * {@inheritdoc}
      */
     public function collect()
     {
         $averageOfProductValuePerFamily = 0;
         $maxOfProductValuePerFamily = 0;
-        if (!is_null($this->productValuePerFamilyAverageMaxQuery)) {
+        if (null !== $this->productValuePerFamilyAverageMaxQuery) {
             $averageOfProductValuePerFamily = $this->productValuePerFamilyAverageMaxQuery->fetch()->getAverageVolume();
             $maxOfProductValuePerFamily = $this->productValuePerFamilyAverageMaxQuery->fetch()->getMaxVolume();
         }
@@ -144,8 +144,8 @@ class DBDataCollector implements DataCollectorInterface
             'max_category_levels'            => $this->categoryLevelsAverageMax->fetch()->getMaxVolume(),
             'nb_product_values'              => $this->productValueCountQuery->fetch()->getVolume(),
             'avg_product_values_by_product'  => $this->productValueAverageMaxQuery->fetch()->getAverageVolume(),
-            'avg_product_values_per_family'  => $averageOfProductValuePerFamily,
-            'max_product_values_per_family'  => $maxOfProductValuePerFamily,
+            'avg_product_values_by_family'  => $averageOfProductValuePerFamily,
+            'max_product_values_by_family'  => $maxOfProductValuePerFamily,
         ];
     }
 }

--- a/src/Pim/Bundle/AnalyticsBundle/DataCollector/DBDataCollector.php
+++ b/src/Pim/Bundle/AnalyticsBundle/DataCollector/DBDataCollector.php
@@ -66,7 +66,11 @@ class DBDataCollector implements DataCollectorInterface
     /** @var AverageMaxQuery */
     protected $categoriesInOneCategoryAverageMax;
 
+    /** @var AverageMaxQuery */
+    protected $productValuePerFamilyAverageMaxQuery;
+
     /**
+     * TODO - on master - remove '= null'
      * @param CountQuery      $channelCountQuery
      * @param CountQuery      $productCountQuery
      * @param CountQuery      $localeCountQuery
@@ -80,6 +84,7 @@ class DBDataCollector implements DataCollectorInterface
      * @param AverageMaxQuery $categoryLevelsAverageMax
      * @param CountQuery      $productValueCountQuery
      * @param AverageMaxQuery $productValueAverageMaxQuery
+     * @param AverageMaxQuery $productValuePerFamilyAverageMaxQuery
      */
     public function __construct(
         CountQuery        $channelCountQuery,
@@ -94,7 +99,8 @@ class DBDataCollector implements DataCollectorInterface
         AverageMaxQuery   $categoriesInOneCategoryAverageMax,
         AverageMaxQuery   $categoryLevelsAverageMax,
         CountQuery        $productValueCountQuery,
-        AverageMaxQuery   $productValueAverageMaxQuery
+        AverageMaxQuery   $productValueAverageMaxQuery,
+        AverageMaxQuery   $productValuePerFamilyAverageMaxQuery = null
     ) {
         $this->channelCountQuery = $channelCountQuery;
         $this->productCountQuery = $productCountQuery;
@@ -109,13 +115,21 @@ class DBDataCollector implements DataCollectorInterface
         $this->categoryTreeCountQuery = $categoryTreeCountQuery;
         $this->productValueCountQuery = $productValueCountQuery;
         $this->productValueAverageMaxQuery = $productValueAverageMaxQuery;
+        $this->productValuePerFamilyAverageMaxQuery = $productValuePerFamilyAverageMaxQuery;
     }
 
     /**
+     * TODO - on master - remove the if statement & move all inside the "if session" inside $data
      * {@inheritdoc}
      */
     public function collect()
     {
+        $averageOfProductValuePerFamily = 0;
+        $maxOfProductValuePerFamily = 0;
+        if (!is_null($this->productValuePerFamilyAverageMaxQuery)) {
+            $averageOfProductValuePerFamily = $this->productValuePerFamilyAverageMaxQuery->fetch()->getAverageVolume();
+            $maxOfProductValuePerFamily = $this->productValuePerFamilyAverageMaxQuery->fetch()->getMaxVolume();
+        }
         return [
             'nb_channels'                    => $this->channelCountQuery->fetch()->getVolume(),
             'nb_locales'                     => $this->localeCountQuery->fetch()->getVolume(),
@@ -130,6 +144,8 @@ class DBDataCollector implements DataCollectorInterface
             'max_category_levels'            => $this->categoryLevelsAverageMax->fetch()->getMaxVolume(),
             'nb_product_values'              => $this->productValueCountQuery->fetch()->getVolume(),
             'avg_product_values_by_product'  => $this->productValueAverageMaxQuery->fetch()->getAverageVolume(),
+            'avg_product_values_per_family'  => $averageOfProductValuePerFamily,
+            'max_product_values_per_family'  => $maxOfProductValuePerFamily,
         ];
     }
 }

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
@@ -54,6 +54,7 @@ services:
             - '@pim_volume_monitoring.persistence.query.average_max_category_levels'
             - '@pim_volume_monitoring.persistence.query.aggregated_count_product_and_product_model_values'
             - '@pim_volume_monitoring.persistence.query.aggregated_average_max_product_and_product_model_values'
+            - '@pim_volume_monitoring.persistence.query.average_max_product_values_per_family'
         tags:
             - { name: pim_analytics.data_collector, type: update_checker }
             - { name: pim_analytics.data_collector, type: system_info_report }
@@ -65,6 +66,10 @@ services:
             - '@pim_volume_monitoring.persistence.query.count_localizable_attributes'
             - '@pim_volume_monitoring.persistence.query.count_scopable_attributes'
             - '@pim_volume_monitoring.persistence.query.count_localizable_and_scopable_attributes'
+            - '@pim_volume_monitoring.persistence.query.count_useable_as_grid_filter_attributes'
+            - '@pim_volume_monitoring.persistence.query.average_max_localizable_attributes_per_family'
+            - '@pim_volume_monitoring.persistence.query.average_max_scopable_attributes_per_family'
+            - '@pim_volume_monitoring.persistence.query.average_max_localizable_and_scopable_attributes_per_family'
         tags:
             - { name: pim_analytics.data_collector, type: system_info_report }
 

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en.yml
@@ -29,9 +29,9 @@ pim_analytics:
         nb_localizable_attributes: Number of localizable attributes
         nb_scopable_localizable_attributes: Number of localizable and scopable attributes
         nb_useable_as_grid_filter_attributes: Number of attributes useable as grid filter
-        avg_scopable_attributes_per_family: Average of scopable attributes per family
-        avg_localizable_attributes_per_family: Average of localizable attributes per family
-        avg_scopable_localizable_attributes_per_family: Average of localizable and scopable attributes per family
+        avg_percentage_scopable_attributes_per_family: Average percentage of scopable attributes per family (%)
+        avg_percentage_localizable_attributes_per_family: Average percentage of localizable attributes per family (%)
+        avg_percentage_scopable_localizable_attributes_per_family: Average percentage of localizable and scopable attributes per family (%)
         nb_locales: Number of locales
         nb_families: Number of families
         nb_users: Number of users
@@ -41,8 +41,8 @@ pim_analytics:
         max_category_levels: Max number of category levels
         nb_product_values: Number of product values
         avg_product_values_by_product: Average number of product values by product
-        avg_product_values_per_family: Average number of product values by family
-        max_product_values_per_family: Max number of product values by family
+        avg_product_values_by_family: Average number of potential product values by family
+        max_product_values_by_family: Max number of potential product values by family
         pim_storage_version: Storage version
         os_version: OS version
         php_version: PHP version

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en.yml
@@ -28,6 +28,10 @@ pim_analytics:
         nb_scopable_attributes: Number of scopable attributes
         nb_localizable_attributes: Number of localizable attributes
         nb_scopable_localizable_attributes: Number of localizable and scopable attributes
+        nb_useable_as_grid_filter_attributes: Number of attributes useable as grid filter
+        avg_scopable_attributes_per_family: Average of scopable attributes per family
+        avg_localizable_attributes_per_family: Average of localizable attributes per family
+        avg_scopable_localizable_attributes_per_family: Average of localizable and scopable attributes per family
         nb_locales: Number of locales
         nb_families: Number of families
         nb_users: Number of users
@@ -37,6 +41,8 @@ pim_analytics:
         max_category_levels: Max number of category levels
         nb_product_values: Number of product values
         avg_product_values_by_product: Average number of product values by product
+        avg_product_values_per_family: Average number of product values by family
+        max_product_values_per_family: Max number of product values by family
         pim_storage_version: Storage version
         os_version: OS version
         php_version: PHP version

--- a/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/AttributeDataCollectorSpec.php
+++ b/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/AttributeDataCollectorSpec.php
@@ -9,7 +9,9 @@ use PhpSpec\ObjectBehavior;
 use Pim\Bundle\AnalyticsBundle\Doctrine\Query\CountLocalizableAttribute;
 use Pim\Bundle\AnalyticsBundle\Doctrine\Query\CountScopableAndLocalizableAttribute;
 use Pim\Bundle\AnalyticsBundle\Doctrine\Query\CountScopableAttribute;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
 use Pim\Component\CatalogVolumeMonitoring\Volume\Query\CountQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
 use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\CountVolume;
 
 class AttributeDataCollectorSpec extends ObjectBehavior
@@ -18,13 +20,21 @@ class AttributeDataCollectorSpec extends ObjectBehavior
         CountQuery $attributeCountQuery,
         CountQuery $localizableAttributeCountQuery,
         CountQuery $scopableAttributeCountQuery,
-        CountQuery $localizableAndScopableAttributeCountQuery
+        CountQuery $localizableAndScopableAttributeCountQuery,
+        CountQuery $useableAsGridFilterAttributeCountQuery,
+        AverageMaxQuery $localizableAttributePerFamilyAverageMaxQuery,
+        AverageMaxQuery $scopableAttributePerFamilyAverageMaxQuery,
+        AverageMaxQuery $localizableAndScopableAttributePerFamilyAverageMaxQuery
     ) {
         $this->beConstructedWith(
             $attributeCountQuery,
             $localizableAttributeCountQuery,
             $scopableAttributeCountQuery,
-            $localizableAndScopableAttributeCountQuery
+            $localizableAndScopableAttributeCountQuery,
+            $useableAsGridFilterAttributeCountQuery,
+            $localizableAttributePerFamilyAverageMaxQuery,
+            $scopableAttributePerFamilyAverageMaxQuery,
+            $localizableAndScopableAttributePerFamilyAverageMaxQuery
         );
     }
 
@@ -42,18 +52,31 @@ class AttributeDataCollectorSpec extends ObjectBehavior
         $attributeCountQuery,
         $localizableAttributeCountQuery,
         $scopableAttributeCountQuery,
-        $localizableAndScopableAttributeCountQuery
+        $localizableAndScopableAttributeCountQuery,
+        $useableAsGridFilterAttributeCountQuery,
+        $localizableAttributePerFamilyAverageMaxQuery,
+        $scopableAttributePerFamilyAverageMaxQuery,
+        $localizableAndScopableAttributePerFamilyAverageMaxQuery
     ) {
         $attributeCountQuery->fetch()->willReturn(new CountVolume(1000, -1, 'count_attributes'));
         $localizableAttributeCountQuery->fetch()->willReturn(new CountVolume(33, -1, 'count_localizable_attributes'));
         $scopableAttributeCountQuery->fetch()->willReturn(new CountVolume(40, -1, 'count_scopable_attributes'));
         $localizableAndScopableAttributeCountQuery->fetch()->willReturn(new CountVolume(64, -1, 'count_localizable_and_scopable_attributes'));
+        $useableAsGridFilterAttributeCountQuery->fetch()->willReturn(new CountVolume(12, -1, 'count_useable_as_grid_filter_attributes'));
+
+        $localizableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(12, 7, -1, 'average_max_localizable_attributes_per_family'));
+        $scopableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(13, 9, -1, 'average_max_scopable_attributes_per_family'));
+        $localizableAndScopableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(10, 7, -1, 'average_max_localizable_and_scopable_attributes_per_family'));
 
         $this->collect()->shouldReturn([
             'nb_attributes' => 1000,
             'nb_scopable_attributes' => 40,
             'nb_localizable_attributes' => 33,
             'nb_scopable_localizable_attributes' => 64,
+            'nb_useable_as_grid_filter_attributes' => 12,
+            'avg_scopable_attributes_per_family' => 9,
+            'avg_localizable_attributes_per_family' => 7,
+            'avg_scopable_localizable_attributes_per_family' => 7
         ]);
     }
 }

--- a/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/AttributeDataCollectorSpec.php
+++ b/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/AttributeDataCollectorSpec.php
@@ -74,9 +74,9 @@ class AttributeDataCollectorSpec extends ObjectBehavior
             'nb_localizable_attributes' => 33,
             'nb_scopable_localizable_attributes' => 64,
             'nb_useable_as_grid_filter_attributes' => 12,
-            'avg_scopable_attributes_per_family' => 9,
-            'avg_localizable_attributes_per_family' => 7,
-            'avg_scopable_localizable_attributes_per_family' => 7
+            'avg_percentage_scopable_attributes_per_family' => 9,
+            'avg_percentage_localizable_attributes_per_family' => 7,
+            'avg_percentage_scopable_localizable_attributes_per_family' => 7
         ]);
     }
 }

--- a/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/DBDataCollectorSpec.php
+++ b/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/DBDataCollectorSpec.php
@@ -96,8 +96,8 @@ class DBDataCollectorSpec extends ObjectBehavior
                 'max_category_levels'   => 6,
                 'nb_product_values'     => 254897,
                 'avg_product_values_by_product' => 7,
-                'avg_product_values_per_family' => 10,
-                'max_product_values_per_family' => 12
+                'avg_product_values_by_family' => 10,
+                'max_product_values_by_family' => 12
             ]
         );
     }

--- a/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/DBDataCollectorSpec.php
+++ b/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/DBDataCollectorSpec.php
@@ -23,7 +23,8 @@ class DBDataCollectorSpec extends ObjectBehavior
         AverageMaxQuery   $categoriesInOneCategoryAverageMax,
         AverageMaxQuery   $categoryLevelsAverageMax,
         CountQuery        $productValueCountQuery,
-        AverageMaxQuery   $productValueAverageMaxQuery
+        AverageMaxQuery   $productValueAverageMaxQuery,
+        AverageMaxQuery   $productValuePerFamilyAverageMaxQuery
     ) {
         $this->beConstructedWith(
             $channelCountQuery,
@@ -38,7 +39,8 @@ class DBDataCollectorSpec extends ObjectBehavior
             $categoriesInOneCategoryAverageMax,
             $categoryLevelsAverageMax,
             $productValueCountQuery,
-            $productValueAverageMaxQuery
+            $productValueAverageMaxQuery,
+            $productValuePerFamilyAverageMaxQuery
         );
     }
 
@@ -61,7 +63,8 @@ class DBDataCollectorSpec extends ObjectBehavior
         $categoriesInOneCategoryAverageMax,
         $categoryLevelsAverageMax,
         $productValueCountQuery,
-        $productValueAverageMaxQuery
+        $productValueAverageMaxQuery,
+        $productValuePerFamilyAverageMaxQuery
     ) {
         $channelCountQuery->fetch()->willReturn(new CountVolume(3, -1, 'count_channels'));
         $productCountQuery->fetch()->willReturn(new CountVolume(1121, -1, 'count_products'));
@@ -76,6 +79,7 @@ class DBDataCollectorSpec extends ObjectBehavior
         $categoryLevelsAverageMax->fetch()->willReturn(new AverageMaxVolumes(6, 4, -1, 'average_max_category_levels'));
         $productValueCountQuery->fetch()->willReturn(new CountVolume(254897, -1, 'count_product_values'));
         $productValueAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(8,7, -1, 'average_max_product_values'));
+        $productValuePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(12,10, -1, 'average_max_product_values_per_family'));
 
         $this->collect()->shouldReturn(
             [
@@ -91,7 +95,9 @@ class DBDataCollectorSpec extends ObjectBehavior
                 'max_category_in_one_category'   => 25,
                 'max_category_levels'   => 6,
                 'nb_product_values'     => 254897,
-                'avg_product_values_by_product' => 7
+                'avg_product_values_by_product' => 7,
+                'avg_product_values_per_family' => 10,
+                'max_product_values_per_family' => 12
             ]
         );
     }

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAndScopableAttributesPerFamily.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAndScopableAttributesPerFamily.php
@@ -39,16 +39,15 @@ class AverageMaxLocalizableAndScopableAttributesPerFamily implements AverageMaxQ
     public function fetch(): AverageMaxVolumes
     {
         $sql = <<<SQL
-            SELECT 
-                CEIL(AVG(a.count_attributes_per_family)) average,
-                MAX(a.count_attributes_per_family) max
+            SELECT
+                CEIL(AVG(count_localizable_and_scopable_attributes * 100 / count_attributes)) average,
+                CEIL(MAX(count_localizable_and_scopable_attributes * 100 / count_attributes)) max
             FROM (
-                SELECT count(fa.attribute_id) count_attributes_per_family 
+                SELECT fa.family_id as family_id, SUM(a.is_localizable = 1 AND a.is_scopable = 1) as count_localizable_and_scopable_attributes, COUNT(a.code) as count_attributes
                 FROM pim_catalog_family_attribute as fa
                 INNER JOIN pim_catalog_attribute as a ON fa.attribute_id = a.id
-                WHERE a.is_localizable = 1 AND a.is_scopable = 1
                 GROUP BY fa.family_id
-            ) a
+            ) as attr;
 SQL;
         $result = $this->connection->query($sql)->fetch();
         $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAndScopableAttributesPerFamily.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAndScopableAttributesPerFamily.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+
+/**
+ * @author    Elodie Rapos <elodie.raposo@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AverageMaxLocalizableAndScopableAttributesPerFamily implements AverageMaxQuery
+{
+    private const VOLUME_NAME = 'average_max_localizable_and_scopable_attributes_per_family';
+
+    /** @var Connection */
+    private $connection;
+
+    /** @var int */
+    private $limit;
+
+    /**
+     * @param Connection $connection
+     * @param int $limit
+     */
+    public function __construct(Connection $connection, int $limit)
+    {
+        $this->connection = $connection;
+        $this->limit = $limit;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch(): AverageMaxVolumes
+    {
+        $sql = <<<SQL
+            SELECT 
+                CEIL(AVG(a.count_attributes_per_family)) average,
+                MAX(a.count_attributes_per_family) max
+            FROM (
+                SELECT count(fa.attribute_id) count_attributes_per_family 
+                FROM pim_catalog_family_attribute as fa
+                INNER JOIN pim_catalog_attribute as a ON fa.attribute_id = a.id
+                WHERE a.is_localizable = 1 AND a.is_scopable = 1
+                GROUP BY fa.family_id
+            ) a
+SQL;
+        $result = $this->connection->query($sql)->fetch();
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+
+        return $volume;
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAttributesPerFamily.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAttributesPerFamily.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+
+/**
+ * @author    Elodie Rapos <elodie.raposo@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AverageMaxLocalizableAttributesPerFamily implements AverageMaxQuery
+{
+    private const VOLUME_NAME = 'average_max_localizable_attributes_per_family';
+
+    /** @var Connection */
+    private $connection;
+
+    /** @var int */
+    private $limit;
+
+    /**
+     * @param Connection $connection
+     * @param int $limit
+     */
+    public function __construct(Connection $connection, int $limit)
+    {
+        $this->connection = $connection;
+        $this->limit = $limit;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch(): AverageMaxVolumes
+    {
+        $sql = <<<SQL
+            SELECT 
+                CEIL(AVG(a.count_attributes_per_family)) average,
+                MAX(a.count_attributes_per_family) max
+            FROM (
+                SELECT count(fa.attribute_id) count_attributes_per_family 
+                FROM pim_catalog_family_attribute as fa
+                INNER JOIN pim_catalog_attribute as a ON fa.attribute_id = a.id
+                WHERE a.is_localizable = 1 AND a.is_scopable = 0
+                GROUP BY fa.family_id
+            ) a
+SQL;
+        $result = $this->connection->query($sql)->fetch();
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+
+        return $volume;
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAttributesPerFamily.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAttributesPerFamily.php
@@ -39,16 +39,15 @@ class AverageMaxLocalizableAttributesPerFamily implements AverageMaxQuery
     public function fetch(): AverageMaxVolumes
     {
         $sql = <<<SQL
-            SELECT 
-                CEIL(AVG(a.count_attributes_per_family)) average,
-                MAX(a.count_attributes_per_family) max
+            SELECT
+                CEIL(AVG(count_only_localizable_attributes * 100 / count_attributes)) average,
+                CEIL(MAX(count_only_localizable_attributes * 100 / count_attributes)) max
             FROM (
-                SELECT count(fa.attribute_id) count_attributes_per_family 
+                SELECT fa.family_id as family_id, SUM(a.is_localizable = 1 AND a.is_scopable = 0) as count_only_localizable_attributes, COUNT(a.code) as count_attributes
                 FROM pim_catalog_family_attribute as fa
                 INNER JOIN pim_catalog_attribute as a ON fa.attribute_id = a.id
-                WHERE a.is_localizable = 1 AND a.is_scopable = 0
                 GROUP BY fa.family_id
-            ) a
+            ) as attr;
 SQL;
         $result = $this->connection->query($sql)->fetch();
         $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValuesPerFamily.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValuesPerFamily.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+
+/**
+ * @author    Elodie Rapos <elodie.raposo@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AverageMaxProductValuesPerFamily implements AverageMaxQuery
+{
+    private const VOLUME_NAME = 'average_max_product_values_per_family';
+
+    /** @var Connection */
+    private $connection;
+
+    /** @var int */
+    private $limit;
+
+    /**
+     * @param Connection $connection
+     * @param int $limit
+     */
+    public function __construct(Connection $connection, int $limit)
+    {
+        $this->connection = $connection;
+        $this->limit = $limit;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch(): AverageMaxVolumes
+    {
+        $sql = <<<SQL
+            SELECT
+                CEIL(AVG(a.count_product_values_per_families)) average,
+                MAX(a.count_product_values_per_families) max
+            FROM (
+              SELECT
+                  f_stats.not_localizable_and_scopable
+                    + f_stats.is_only_localizable * f_stats.nb_locales
+                    + f_stats.is_only_scopable * f_stats.nb_channels + f_stats.is_localizable_and_scopable * f_stats.nb_channel_locales
+                    count_product_values_per_families
+              FROM (SELECT
+                  COUNT(not_localizable_and_scopable) as not_localizable_and_scopable,
+                  COUNT(f.is_only_localizable) as is_only_localizable,
+                  COUNT(f.is_only_scopable) as is_only_scopable,
+                  COUNT(f.is_localizable_and_scopable) as is_localizable_and_scopable,
+                  (SELECT COUNT(*) as nb_locales FROM pim_catalog_locale WHERE is_activated = 1) as nb_locales,
+                  (SELECT COUNT(*) as nb_channels FROM pim_catalog_channel) as nb_channels,
+                  (SELECT COUNT(*) as nb_channel_locales FROM pim_catalog_channel_locale) as nb_channel_locales
+              FROM (
+                  SELECT
+                      f.code,
+                      CASE WHEN a.is_localizable = 0 AND a.is_scopable = 0 THEN true END as not_localizable_and_scopable,
+                      CASE WHEN a.is_scopable = 0 AND a.is_localizable = 1 THEN true END as is_only_localizable,
+                      CASE WHEN a.is_scopable = 1 AND a.is_localizable = 0 THEN true END as is_only_scopable,
+                      CASE WHEN a.is_localizable = 1 AND a.is_scopable = 1 THEN true END as is_localizable_and_scopable
+                  FROM pim_catalog_family f
+                  JOIN pim_catalog_family_attribute fa on fa.family_id = f.id
+                  JOIN pim_catalog_attribute a on a.id = fa.attribute_id
+                  ORDER BY f.code
+              ) as f
+              GROUP BY f.code) as f_stats
+              JOIN (SELECT count(*) as nb_channels FROM pim_catalog_channel) as f_channels
+            ) as a
+SQL;
+        $result = $this->connection->query($sql)->fetch();
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+
+        return $volume;
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValuesPerFamily.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValuesPerFamily.php
@@ -43,33 +43,34 @@ class AverageMaxProductValuesPerFamily implements AverageMaxQuery
                 CEIL(AVG(a.count_product_values_per_families)) average,
                 MAX(a.count_product_values_per_families) max
             FROM (
-              SELECT
+                SELECT
                   f_stats.not_localizable_and_scopable
                     + f_stats.is_only_localizable * f_stats.nb_locales
-                    + f_stats.is_only_scopable * f_stats.nb_channels + f_stats.is_localizable_and_scopable * f_stats.nb_channel_locales
-                    count_product_values_per_families
-              FROM (SELECT
-                  COUNT(not_localizable_and_scopable) as not_localizable_and_scopable,
-                  COUNT(f.is_only_localizable) as is_only_localizable,
-                  COUNT(f.is_only_scopable) as is_only_scopable,
-                  COUNT(f.is_localizable_and_scopable) as is_localizable_and_scopable,
-                  (SELECT COUNT(*) as nb_locales FROM pim_catalog_locale WHERE is_activated = 1) as nb_locales,
-                  (SELECT COUNT(*) as nb_channels FROM pim_catalog_channel) as nb_channels,
-                  (SELECT COUNT(*) as nb_channel_locales FROM pim_catalog_channel_locale) as nb_channel_locales
-              FROM (
-                  SELECT
-                      f.code,
-                      CASE WHEN a.is_localizable = 0 AND a.is_scopable = 0 THEN true END as not_localizable_and_scopable,
-                      CASE WHEN a.is_scopable = 0 AND a.is_localizable = 1 THEN true END as is_only_localizable,
-                      CASE WHEN a.is_scopable = 1 AND a.is_localizable = 0 THEN true END as is_only_scopable,
-                      CASE WHEN a.is_localizable = 1 AND a.is_scopable = 1 THEN true END as is_localizable_and_scopable
-                  FROM pim_catalog_family f
-                  JOIN pim_catalog_family_attribute fa on fa.family_id = f.id
-                  JOIN pim_catalog_attribute a on a.id = fa.attribute_id
-                  ORDER BY f.code
-              ) as f
-              GROUP BY f.code) as f_stats
-              JOIN (SELECT count(*) as nb_channels FROM pim_catalog_channel) as f_channels
+                    + f_stats.is_only_scopable * f_stats.nb_channels 
+                    + f_stats.is_localizable_and_scopable * f_stats.nb_channel_locales as count_product_values_per_families
+                FROM (
+                    SELECT
+                      SUM(not_localizable_and_scopable) as not_localizable_and_scopable,
+                      SUM(f.is_only_localizable) as is_only_localizable,
+                      SUM(f.is_only_scopable) as is_only_scopable,
+                      SUM(f.is_localizable_and_scopable) as is_localizable_and_scopable,
+                      (SELECT COUNT(*) as nb_locales FROM pim_catalog_locale WHERE is_activated = 1) as nb_locales,
+                      (SELECT COUNT(*) as nb_channels FROM pim_catalog_channel) as nb_channels,
+                      (SELECT COUNT(*) as nb_channel_locales FROM pim_catalog_channel_locale) as nb_channel_locales
+                    FROM (
+                        SELECT
+                          f.code,
+                          (a.is_localizable = 0 AND a.is_scopable = 0) as not_localizable_and_scopable,
+                          (a.is_scopable = 0 AND a.is_localizable = 1) as is_only_localizable,
+                          (a.is_scopable = 1 AND a.is_localizable = 0) as is_only_scopable,
+                          (a.is_localizable = 1 AND a.is_scopable = 1) as is_localizable_and_scopable
+                        FROM pim_catalog_family f
+                        JOIN pim_catalog_family_attribute fa on fa.family_id = f.id
+                        JOIN pim_catalog_attribute a on a.id = fa.attribute_id
+                        ORDER BY f.code
+                    ) as f
+                    GROUP BY f.code
+                ) as f_stats
             ) as a
 SQL;
         $result = $this->connection->query($sql)->fetch();

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxScopableAttributesPerFamily.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxScopableAttributesPerFamily.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+
+/**
+ * @author    Elodie Rapos <elodie.raposo@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AverageMaxScopableAttributesPerFamily implements AverageMaxQuery
+{
+    private const VOLUME_NAME = 'average_max_scopable_attributes_per_family';
+
+    /** @var Connection */
+    private $connection;
+
+    /** @var int */
+    private $limit;
+
+    /**
+     * @param Connection $connection
+     * @param int $limit
+     */
+    public function __construct(Connection $connection, int $limit)
+    {
+        $this->connection = $connection;
+        $this->limit = $limit;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch(): AverageMaxVolumes
+    {
+        $sql = <<<SQL
+            SELECT 
+                CEIL(AVG(a.count_attributes_per_family)) average,
+                MAX(a.count_attributes_per_family) max
+            FROM (
+                SELECT count(fa.attribute_id) count_attributes_per_family 
+                FROM pim_catalog_family_attribute as fa
+                INNER JOIN pim_catalog_attribute as a ON fa.attribute_id = a.id
+                WHERE a.is_localizable = 0 AND a.is_scopable = 1
+                GROUP BY fa.family_id
+            ) a
+SQL;
+        $result = $this->connection->query($sql)->fetch();
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+
+        return $volume;
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxScopableAttributesPerFamily.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxScopableAttributesPerFamily.php
@@ -39,16 +39,15 @@ class AverageMaxScopableAttributesPerFamily implements AverageMaxQuery
     public function fetch(): AverageMaxVolumes
     {
         $sql = <<<SQL
-            SELECT 
-                CEIL(AVG(a.count_attributes_per_family)) average,
-                MAX(a.count_attributes_per_family) max
+            SELECT
+                CEIL(AVG(count_only_scopable_attributes * 100 / count_attributes)) average,
+                CEIL(MAX(count_only_scopable_attributes * 100 / count_attributes)) max
             FROM (
-                SELECT count(fa.attribute_id) count_attributes_per_family 
+                SELECT fa.family_id as family_id, SUM(a.is_localizable = 0 AND a.is_scopable = 1) as count_only_scopable_attributes, COUNT(a.code) as count_attributes
                 FROM pim_catalog_family_attribute as fa
                 INNER JOIN pim_catalog_attribute as a ON fa.attribute_id = a.id
-                WHERE a.is_localizable = 0 AND a.is_scopable = 1
                 GROUP BY fa.family_id
-            ) a
+            ) as attr;
 SQL;
         $result = $this->connection->query($sql)->fetch();
         $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountUseableAsGridFilterAttributes.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountUseableAsGridFilterAttributes.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\CountQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\CountVolume;
+
+/**
+ * @author    Elodie Raposo <elodie.raposo@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CountUseableAsGridFilterAttributes implements CountQuery
+{
+    private const VOLUME_NAME = 'count_useable_as_grid_filter_attributes';
+
+    /** @var Connection */
+    private $connection;
+
+    /** @var int */
+    private $limit;
+
+    /**
+     * @param Connection $connection
+     * @param int $limit
+     */
+    public function __construct(Connection $connection, int $limit)
+    {
+        $this->connection = $connection;
+        $this->limit = $limit;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch(): CountVolume
+    {
+        $sql = <<<SQL
+            SELECT COUNT(*) as count
+            FROM pim_catalog_attribute 
+            WHERE useable_as_grid_filter = 1;
+SQL;
+        $result = $this->connection->query($sql)->fetch();
+        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+
+        return $volume;
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/queries.yml
@@ -7,6 +7,24 @@ services:
         tags:
             - { name: pim_volume_monitoring.persistence.average_max_query }
 
+    pim_volume_monitoring.persistence.query.average_max_scopable_attributes_per_family:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxScopableAttributesPerFamily'
+        arguments:
+            - '@database_connection'
+            - '%average_max_scopable_attributes_per_family_limit%'
+
+    pim_volume_monitoring.persistence.query.average_max_localizable_attributes_per_family:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAttributesPerFamily'
+        arguments:
+            - '@database_connection'
+            - '%average_max_localizable_attributes_per_family_limit%'
+
+    pim_volume_monitoring.persistence.query.average_max_localizable_and_scopable_attributes_per_family:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAndScopableAttributesPerFamily'
+        arguments:
+            - '@database_connection'
+            - '%average_max_localizable_and_scopable_attributes_per_family_limit%'
+
     pim_volume_monitoring.persistence.query.average_max_options_per_attribute:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxOptionsPerAttribute'
         arguments:
@@ -47,6 +65,12 @@ services:
         tags:
             - { name: pim_volume_monitoring.persistence.average_max_query }
 
+    pim_volume_monitoring.persistence.query.average_max_product_values_per_family:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxProductValuesPerFamily'
+        arguments:
+            - '@database_connection'
+            - '%average_max_product_values_per_family_limit%'
+
     pim_volume_monitoring.persistence.query.average_max_categories_in_one_category:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxCategoriesInOneCategory'
         arguments:
@@ -66,6 +90,12 @@ services:
             - '%count_attributes_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
+
+    pim_volume_monitoring.persistence.query.count_useable_as_grid_filter_attributes:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountUseableAsGridFilterAttributes'
+        arguments:
+            - '@database_connection'
+            - '%count_useable_as_grid_filter_attributes_limit%'
 
     pim_volume_monitoring.persistence.query.count_categories:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountCategories'

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/Resources/config/queries.yml
@@ -11,19 +11,25 @@ services:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxScopableAttributesPerFamily'
         arguments:
             - '@database_connection'
-            - '%average_max_scopable_attributes_per_family_limit%'
+            # TODO @merge change this line by just passing the parameter %average_max_scopable_attributes_per_family_limit%
+            # WARNING - don't forget to add this new parameter in dev & standard EE & CE
+            - "@=container.hasParameter('average_max_scopable_attributes_per_family_limit') ? parameter('average_max_scopable_attributes_per_family_limit') : -1"
 
     pim_volume_monitoring.persistence.query.average_max_localizable_attributes_per_family:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAttributesPerFamily'
         arguments:
             - '@database_connection'
-            - '%average_max_localizable_attributes_per_family_limit%'
+            # TODO @merge change this line by just passing the parameter %average_max_localizable_attributes_per_family_limit%
+            # WARNING - don't forget to add this new parameter in dev & standard EE & CE
+            - "@=container.hasParameter('average_max_localizable_attributes_per_family_limit') ? parameter('average_max_localizable_attributes_per_family_limit') : -1"
 
     pim_volume_monitoring.persistence.query.average_max_localizable_and_scopable_attributes_per_family:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAndScopableAttributesPerFamily'
         arguments:
             - '@database_connection'
-            - '%average_max_localizable_and_scopable_attributes_per_family_limit%'
+            # TODO @merge change this line by just passing the parameter %average_max_localizable_and_scopable_attributes_per_family_limit%
+            # WARNING - don't forget to add this new parameter in dev & standard EE & CE
+            - "@=container.hasParameter('average_max_localizable_and_scopable_attributes_per_family_limit') ? parameter('average_max_localizable_and_scopable_attributes_per_family_limit') : -1"
 
     pim_volume_monitoring.persistence.query.average_max_options_per_attribute:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxOptionsPerAttribute'
@@ -69,7 +75,9 @@ services:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxProductValuesPerFamily'
         arguments:
             - '@database_connection'
-            - '%average_max_product_values_per_family_limit%'
+            # TODO @merge change this line by just passing the parameter %average_max_product_values_per_family_limit%
+            # WARNING - don't forget to add this new parameter in dev & standard EE & CE
+            - "@=container.hasParameter('average_max_product_values_per_family_limit') ? parameter('average_max_product_values_per_family_limit') : -1"
 
     pim_volume_monitoring.persistence.query.average_max_categories_in_one_category:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxCategoriesInOneCategory'
@@ -95,7 +103,9 @@ services:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountUseableAsGridFilterAttributes'
         arguments:
             - '@database_connection'
-            - '%count_useable_as_grid_filter_attributes_limit%'
+            # TODO @merge change this line by just passing the parameter %count_useable_as_grid_filter_attributes_limit%
+            # WARNING - don't forget to add this new parameter in dev & standard EE & CE
+            - "@=container.hasParameter('count_useable_as_grid_filter_attributes_limit') ? parameter('count_useable_as_grid_filter_attributes_limit') : -1"
 
     pim_volume_monitoring.persistence.query.count_categories:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountCategories'

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/AverageMaxLocalizableAndScopableAttributesPerFamilySpec.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/AverageMaxLocalizableAndScopableAttributesPerFamilySpec.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAndScopableAttributesPerFamily;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+use Prophecy\Argument;
+
+class AverageMaxLocalizableAndScopableAttributesPerFamilySpec extends ObjectBehavior
+{
+    function let(Connection $connection)
+    {
+        $this->beConstructedWith($connection, 15);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AverageMaxLocalizableAndScopableAttributesPerFamily::class);
+    }
+
+    function it_is_an_average_and_max_query()
+    {
+        $this->shouldImplement(AverageMaxQuery::class);
+    }
+
+    function it_gets_average_and_max_volume($connection, Statement $statement)
+    {
+        $connection->query(Argument::type('string'))->willReturn($statement);
+        $statement->fetch()->willReturn(['average' => '5', 'max' => '10']);
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 5, 15, 'average_max_localizable_and_scopable_attributes_per_family'));
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/AverageMaxLocalizableAttributesPerFamilySpec.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/AverageMaxLocalizableAttributesPerFamilySpec.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAttributesPerFamily;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+use Prophecy\Argument;
+
+class AverageMaxLocalizableAttributesPerFamilySpec extends ObjectBehavior
+{
+    function let(Connection $connection)
+    {
+        $this->beConstructedWith($connection, 14);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AverageMaxLocalizableAttributesPerFamily::class);
+    }
+
+    function it_is_an_average_and_max_query()
+    {
+        $this->shouldImplement(AverageMaxQuery::class);
+    }
+
+    function it_gets_average_and_max_volume($connection, Statement $statement)
+    {
+        $connection->query(Argument::type('string'))->willReturn($statement);
+        $statement->fetch()->willReturn(['average' => '5', 'max' => '13']);
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(13, 5, 14, 'average_max_localizable_attributes_per_family'));
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/AverageMaxProductValuesPerFamilySpec.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/AverageMaxProductValuesPerFamilySpec.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxProductValuesPerFamily;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+use Prophecy\Argument;
+
+class AverageMaxProductValuesPerFamilySpec extends ObjectBehavior
+{
+    function let(Connection $connection)
+    {
+        $this->beConstructedWith($connection, 100);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AverageMaxProductValuesPerFamily::class);
+    }
+
+    function it_is_an_average_and_max_query()
+    {
+        $this->shouldImplement(AverageMaxQuery::class);
+    }
+
+    function it_gets_average_and_max_volume($connection, Statement $statement)
+    {
+        $connection->query(Argument::type('string'))->willReturn($statement);
+        $statement->fetch()->willReturn(['average' => '5', 'max' => '10']);
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 5, 100, 'average_max_product_values_per_family'));
+    }
+
+    function it_gets_average_and_max_volume_of_an_empty_catalog($connection, Statement $statement)
+    {
+        $connection->query(Argument::type('string'))->willReturn($statement);
+        $statement->fetch()->willReturn(['average' => null, 'max' => null]);
+
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(0, 0, 100, 'average_max_product_values_per_family'));
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/AverageMaxScopableAttributesPerFamilySpec.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/AverageMaxScopableAttributesPerFamilySpec.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxScopableAttributesPerFamily;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMaxVolumes;
+use Prophecy\Argument;
+
+class AverageMaxScopableAttributesPerFamilySpec extends ObjectBehavior
+{
+    function let(Connection $connection)
+    {
+        $this->beConstructedWith($connection, 14);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AverageMaxScopableAttributesPerFamily::class);
+    }
+
+    function it_is_an_average_and_max_query()
+    {
+        $this->shouldImplement(AverageMaxQuery::class);
+    }
+
+    function it_gets_average_and_max_volume($connection, Statement $statement)
+    {
+        $connection->query(Argument::type('string'))->willReturn($statement);
+        $statement->fetch()->willReturn(['average' => '5', 'max' => '11']);
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(11, 5, 14, 'average_max_scopable_attributes_per_family'));
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/CountUseableAsGridFilterAttributesSpec.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/spec/Persistence/Query/Sql/CountUseableAsGridFilterAttributesSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountScopableAttributes;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountUseableAsGridFilterAttributes;
+use Pim\Component\CatalogVolumeMonitoring\Volume\Query\CountQuery;
+use Pim\Component\CatalogVolumeMonitoring\Volume\ReadModel\CountVolume;
+use Prophecy\Argument;
+
+class CountUseableAsGridFilterAttributesSpec extends ObjectBehavior
+{
+    function let(Connection $connection)
+    {
+        $this->beConstructedWith($connection, 14);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CountUseableAsGridFilterAttributes::class);
+    }
+
+    function it_is_a_count_query()
+    {
+        $this->shouldImplement(CountQuery::class);
+    }
+
+    function it_gets_count_volume($connection, Statement $statement)
+    {
+        $connection->query(Argument::type('string'))->willReturn($statement);
+        $statement->fetch()->willReturn(['count' => '7']);
+        $this->fetch()->shouldBeLike(new CountVolume(7, 14, 'count_useable_as_grid_filter_attributes'));
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/LocalizableAndScopableAttributePerFamilyContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/LocalizableAndScopableAttributePerFamilyContext.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context;
+
+use Behat\Behat\Context\Context;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryAverageMaxQuery;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryCountQuery;
+use Webmozart\Assert\Assert;
+
+final class LocalizableAndScopableAttributePerFamilyContext implements Context
+{
+    /** @var ReportContext */
+    private $reportContext;
+
+    /** @var InMemoryAverageMaxQuery */
+    private $averageMaxQuery;
+
+    /**
+     * @param ReportContext           $reportContext
+     * @param InMemoryAverageMaxQuery $averageMaxQuery
+     */
+    public function __construct(ReportContext $reportContext, InMemoryAverageMaxQuery $averageMaxQuery)
+    {
+        $this->reportContext = $reportContext;
+        $this->averageMaxQuery = $averageMaxQuery;
+    }
+
+    /**
+     * @Given a family with :numberOfAttributes localizable and scopable attributes
+     *
+     * @param int $numberOfAttributes
+     */
+    public function aFamilyWithLocalizableAndScopableAttributes(int $numberOfAttributes): void
+    {
+        $this->averageMaxQuery->addValue($numberOfAttributes);
+    }
+
+    /**
+     * @Then the report returns that the average of localizable and scopable attributes per family is :numberOfAttributes
+     *
+     * @param int $numberOfAttributes
+     */
+    public function theReportReturnsThatTheAverageOfLocalizableAndScopableAttributesPerFamilyIs(int $numberOfAttributes): void
+    {
+        $volumes = $this->reportContext->getVolumes();
+
+        Assert::eq($numberOfAttributes, $volumes['avg_localizable_and_scopable_attributes_per_family']['value']['average']);
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/LocalizableAndScopableAttributePerFamilyContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/LocalizableAndScopableAttributePerFamilyContext.php
@@ -28,24 +28,33 @@ final class LocalizableAndScopableAttributePerFamilyContext implements Context
     }
 
     /**
-     * @Given a family with :numberOfAttributes localizable and scopable attributes
+     * @Given a family with :numberOfLocScopAttributes localizable and scopable attributes, :numberOfLocAttributes localizable attributes, :numberOfScopAttributes scopable attributes and :numberOfAttributes attributes
      *
      * @param int $numberOfAttributes
+     * @param int $numberOfLocAttributes
+     * @param int $numberOfScopAttributes
+     * @param int $numberOfLocScopAttributes
      */
-    public function aFamilyWithLocalizableAndScopableAttributes(int $numberOfAttributes): void
-    {
-        $this->averageMaxQuery->addValue($numberOfAttributes);
+    public function aFamilyWithAttributes(
+        int $numberOfLocScopAttributes,
+        int $numberOfLocAttributes,
+        int $numberOfScopAttributes,
+        int $numberOfAttributes
+    ): void {
+        $totalAttributes = ($numberOfAttributes+$numberOfLocAttributes+$numberOfScopAttributes+$numberOfLocScopAttributes);
+
+        $this->averageMaxQuery->addValue(intval(($numberOfLocScopAttributes*100)/$totalAttributes));
     }
 
     /**
-     * @Then the report returns that the average of localizable and scopable attributes per family is :numberOfAttributes
+     * @Then the report returns that the average percentage of localizable and scopable attributes per family is :numberOfAttributes
      *
      * @param int $numberOfAttributes
      */
-    public function theReportReturnsThatTheAverageOfLocalizableAndScopableAttributesPerFamilyIs(int $numberOfAttributes): void
+    public function theReportReturnsThatTheAveragePercentageOfLocalizableAndScopableAttributesPerFamilyIs(int $numberOfAttributes): void
     {
         $volumes = $this->reportContext->getVolumes();
 
-        Assert::eq($numberOfAttributes, $volumes['avg_localizable_and_scopable_attributes_per_family']['value']['average']);
+        Assert::eq($numberOfAttributes, $volumes['avg_percentage_localizable_and_scopable_attributes_per_family']['value']['average']);
     }
 }

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/LocalizableAttributePerFamilyContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/LocalizableAttributePerFamilyContext.php
@@ -28,24 +28,33 @@ final class LocalizableAttributePerFamilyContext implements Context
     }
 
     /**
-     * @Given a family with :numberOfLocalizableAttributes localizable attributes
+     * @Given a family with :numberOfLocAttributes localizable attributes, :numberOfScopAttributes scopable attributes, :numberOfLocScopAttributes localizable and scopable attributes and :numberOfAttributes attributes
      *
-     * @param int $numberOfLocalizableAttributes
+     * @param int $numberOfLocAttributes
+     * @param int $numberOfScopAttributes
+     * @param int $numberOfLocScopAttributes
+     * @param int $numberOfAttributes
      */
-    public function aFamilyWithLocalizableAttributes(int $numberOfLocalizableAttributes): void
-    {
-        $this->averageMaxQuery->addValue($numberOfLocalizableAttributes);
+    public function aFamilyWithAttributes(
+        int $numberOfLocAttributes,
+        int $numberOfScopAttributes,
+        int $numberOfLocScopAttributes,
+        int $numberOfAttributes
+    ): void {
+        $totalAttributes = ($numberOfAttributes+$numberOfLocAttributes+$numberOfScopAttributes+$numberOfLocScopAttributes);
+
+        $this->averageMaxQuery->addValue(intval(($numberOfLocAttributes*100)/$totalAttributes));
     }
 
     /**
-     * @Then the report returns that the average of localizable attributes per family is :numberOfLocalizableAttributes
+     * @Then the report returns that the average percentage of localizable attributes per family is :numberOfLocalizableAttributes
      *
      * @param int $numberOfLocalizableAttributes
      */
-    public function theReportReturnsThatTheAverageOfLocalizableAttributesPerFamilyIs(int $numberOfLocalizableAttributes): void
+    public function theReportReturnsThatTheAverageOfPercentageLocalizableAttributesPerFamilyIs(int $numberOfLocalizableAttributes): void
     {
         $volumes = $this->reportContext->getVolumes();
 
-        Assert::eq($numberOfLocalizableAttributes, $volumes['avg_localizable_attributes_per_family']['value']['average']);
+        Assert::eq($numberOfLocalizableAttributes, $volumes['avg_percentage_localizable_attributes_per_family']['value']['average']);
     }
 }

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/LocalizableAttributePerFamilyContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/LocalizableAttributePerFamilyContext.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context;
+
+use Behat\Behat\Context\Context;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryAverageMaxQuery;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryCountQuery;
+use Webmozart\Assert\Assert;
+
+final class LocalizableAttributePerFamilyContext implements Context
+{
+    /** @var ReportContext */
+    private $reportContext;
+
+    /** @var InMemoryAverageMaxQuery */
+    private $averageMaxQuery;
+
+    /**
+     * @param ReportContext           $reportContext
+     * @param InMemoryAverageMaxQuery $averageMaxQuery
+     */
+    public function __construct(ReportContext $reportContext, InMemoryAverageMaxQuery $averageMaxQuery)
+    {
+        $this->reportContext = $reportContext;
+        $this->averageMaxQuery = $averageMaxQuery;
+    }
+
+    /**
+     * @Given a family with :numberOfLocalizableAttributes localizable attributes
+     *
+     * @param int $numberOfLocalizableAttributes
+     */
+    public function aFamilyWithLocalizableAttributes(int $numberOfLocalizableAttributes): void
+    {
+        $this->averageMaxQuery->addValue($numberOfLocalizableAttributes);
+    }
+
+    /**
+     * @Then the report returns that the average of localizable attributes per family is :numberOfLocalizableAttributes
+     *
+     * @param int $numberOfLocalizableAttributes
+     */
+    public function theReportReturnsThatTheAverageOfLocalizableAttributesPerFamilyIs(int $numberOfLocalizableAttributes): void
+    {
+        $volumes = $this->reportContext->getVolumes();
+
+        Assert::eq($numberOfLocalizableAttributes, $volumes['avg_localizable_attributes_per_family']['value']['average']);
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/ProductValuePerFamilyContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/ProductValuePerFamilyContext.php
@@ -17,6 +17,12 @@ final class ProductValuePerFamilyContext implements Context
     /** @var InMemoryAverageMaxQuery */
     private $averageMaxQuery;
 
+    /** @var int */
+    private $nbChannels = 0;
+
+    /** @var int */
+    private $nbLocales = 0;
+
     /**
      * @param ReportContext           $reportContext
      * @param InMemoryAverageMaxQuery $averageMaxQuery
@@ -28,13 +34,36 @@ final class ProductValuePerFamilyContext implements Context
     }
 
     /**
-     * @Given a family with :numberOfProductValues product values
+     * @Given a channel defined with :numberOfLocales activated locales
      *
-     * @param int $numberOfProductValues
+     * @param int $numberOfLocales
      */
-    public function aFamilyWithProductValues(int $numberOfProductValues): void
+    public function aChannelDefinedWithActivatedLocales(int $numberOfLocales): void
     {
-        $this->averageMaxQuery->addValue($numberOfProductValues);
+        $this->nbChannels++;
+        $this->nbLocales = $this->nbLocales + $numberOfLocales;
+    }
+
+    /**
+     * @Given a family with :numberOfAttributes attributes, :numberOfLocAttributes localizable attributes, :numberOfScopAttributes scopable attributes and :numberOfLocScopAttributes scopable and localizable attributes
+     *
+     * @param int $numberOfAttributes
+     * @param int $numberOfLocAttributes
+     * @param int $numberOfScopAttributes
+     * @param int $numberOfLocScopAttributes
+     */
+    public function aFamilyWithAttributes(
+        int $numberOfAttributes,
+        int $numberOfLocAttributes,
+        int $numberOfScopAttributes,
+        int $numberOfLocScopAttributes
+    ): void {
+        $nbPotentialProductValues = $numberOfAttributes
+            + $numberOfLocAttributes * $this->nbLocales
+            + $numberOfScopAttributes * $this->nbChannels
+            + $numberOfLocScopAttributes * $this->nbLocales * $this->nbChannels;
+
+        $this->averageMaxQuery->addValue($nbPotentialProductValues);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/ProductValuePerFamilyContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/ProductValuePerFamilyContext.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context;
+
+use Behat\Behat\Context\Context;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryAverageMaxQuery;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryCountQuery;
+use Webmozart\Assert\Assert;
+
+final class ProductValuePerFamilyContext implements Context
+{
+    /** @var ReportContext */
+    private $reportContext;
+
+    /** @var InMemoryAverageMaxQuery */
+    private $averageMaxQuery;
+
+    /**
+     * @param ReportContext           $reportContext
+     * @param InMemoryAverageMaxQuery $averageMaxQuery
+     */
+    public function __construct(ReportContext $reportContext, InMemoryAverageMaxQuery $averageMaxQuery)
+    {
+        $this->reportContext = $reportContext;
+        $this->averageMaxQuery = $averageMaxQuery;
+    }
+
+    /**
+     * @Given a family with :numberOfProductValues product values
+     *
+     * @param int $numberOfProductValues
+     */
+    public function aFamilyWithProductValues(int $numberOfProductValues): void
+    {
+        $this->averageMaxQuery->addValue($numberOfProductValues);
+    }
+
+    /**
+     * @Then the report returns that the average of product values per family is :numberOfProductValues
+     *
+     * @param int $numberOfProductValues
+     */
+    public function theReportReturnsThatTheAverageOfProductValuesPerFamilyIs(int $numberOfProductValues): void
+    {
+        $volumes = $this->reportContext->getVolumes();
+
+        Assert::eq($numberOfProductValues, $volumes['count_product_and_product_model_values']['value']['average']);
+    }
+
+    /**
+     * @Then the report returns that the maximum of product values per family is :numberOfProductValues
+     *
+     * @param int $numberOfProductValues
+     */
+    public function theReportReturnsThatTheMaximumOfProductValuesPerFamilyIs(int $numberOfProductValues): void
+    {
+        $volumes = $this->reportContext->getVolumes();
+
+        Assert::eq($numberOfProductValues, $volumes['count_product_and_product_model_values']['value']['max']);
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/ScopableAttributePerFamilyContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/ScopableAttributePerFamilyContext.php
@@ -28,24 +28,33 @@ final class ScopableAttributePerFamilyContext implements Context
     }
 
     /**
-     * @Given a family with :numberOfAttributes scopable attributes
+     * @Given a family with :numberOfScopAttributes scopable attributes, :numberOfLocAttributes localizable attributes, :numberOfLocScopAttributes localizable and scopable attributes and :numberOfAttributes attributes
      *
+     * @param int $numberOfScopAttributes
+     * @param int $numberOfLocAttributes
+     * @param int $numberOfLocScopAttributes
      * @param int $numberOfAttributes
      */
-    public function aFamilyWithScopableAttributes(int $numberOfAttributes): void
-    {
-        $this->averageMaxQuery->addValue($numberOfAttributes);
+    public function aFamilyWithAttributes(
+        int $numberOfScopAttributes,
+        int $numberOfLocAttributes,
+        int $numberOfLocScopAttributes,
+        int $numberOfAttributes
+    ): void {
+        $totalAttributes = ($numberOfAttributes+$numberOfLocAttributes+$numberOfScopAttributes+$numberOfLocScopAttributes);
+
+        $this->averageMaxQuery->addValue(intval(($numberOfScopAttributes*100)/$totalAttributes));
     }
 
     /**
-     * @Then the report returns that the average of scopable attributes per family is :numberOfAttributes
+     * @Then the report returns that the average percentage of scopable attributes per family is :numberOfAttributes
      *
      * @param int $numberOfAttributes
      */
-    public function theReportReturnsThatTheAverageOfScopableAttributesPerFamilyIs(int $numberOfAttributes): void
+    public function theReportReturnsThatTheAveragePercentageOfScopableAttributesPerFamilyIs(int $numberOfAttributes): void
     {
         $volumes = $this->reportContext->getVolumes();
 
-        Assert::eq($numberOfAttributes, $volumes['avg_scopable_attributes_per_family']['value']['average']);
+        Assert::eq($numberOfAttributes, $volumes['avg_percentage_scopable_attributes_per_family']['value']['average']);
     }
 }

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/ScopableAttributePerFamilyContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/ScopableAttributePerFamilyContext.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context;
+
+use Behat\Behat\Context\Context;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryAverageMaxQuery;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryCountQuery;
+use Webmozart\Assert\Assert;
+
+final class ScopableAttributePerFamilyContext implements Context
+{
+    /** @var ReportContext */
+    private $reportContext;
+
+    /** @var InMemoryAverageMaxQuery */
+    private $averageMaxQuery;
+
+    /**
+     * @param ReportContext           $reportContext
+     * @param InMemoryAverageMaxQuery $averageMaxQuery
+     */
+    public function __construct(ReportContext $reportContext, InMemoryAverageMaxQuery $averageMaxQuery)
+    {
+        $this->reportContext = $reportContext;
+        $this->averageMaxQuery = $averageMaxQuery;
+    }
+
+    /**
+     * @Given a family with :numberOfAttributes scopable attributes
+     *
+     * @param int $numberOfAttributes
+     */
+    public function aFamilyWithScopableAttributes(int $numberOfAttributes): void
+    {
+        $this->averageMaxQuery->addValue($numberOfAttributes);
+    }
+
+    /**
+     * @Then the report returns that the average of scopable attributes per family is :numberOfAttributes
+     *
+     * @param int $numberOfAttributes
+     */
+    public function theReportReturnsThatTheAverageOfScopableAttributesPerFamilyIs(int $numberOfAttributes): void
+    {
+        $volumes = $this->reportContext->getVolumes();
+
+        Assert::eq($numberOfAttributes, $volumes['avg_scopable_attributes_per_family']['value']['average']);
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/SystemInfoAttributeContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/SystemInfoAttributeContext.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context;
+
+use Behat\Behat\Context\Context;
+use Pim\Bundle\AnalyticsBundle\DataCollector\AttributeDataCollector;
+use Webmozart\Assert\Assert;
+
+final class SystemInfoAttributeContext implements Context
+{
+    /** @var array */
+    private $collector = [];
+
+    /** @var AttributeDataCollector */
+    private $attributeDataCollector;
+
+    /**
+     * @param AttributeDataCollector $attributeDataCollector
+     */
+    public function __construct(AttributeDataCollector $attributeDataCollector)
+    {
+        $this->attributeDataCollector = $attributeDataCollector;
+    }
+
+    /**
+     * @When attribute statistics of the customer's catalog are collected
+     */
+    public function theStatisticsAreCollectedFromThisCustomerCatalog(): void
+    {
+        $this->collector = $this->attributeDataCollector->collect();
+    }
+
+    /**
+     * @Then Akeneo statistics engine stores a number of :numberOfAttribute useable as grid filter attribute for this customer
+     *
+     * @param int $numberOfAttribute
+     */
+    public function theSystemInformationReturnsThatTheNumberOfUseableAsGridFilterAttributeIs(int $numberOfAttribute): void
+    {
+        $collectedInfo = $this->getCollectedInformation();
+        Assert::eq($numberOfAttribute, $collectedInfo['nb_useable_as_grid_filter_attributes']);
+    }
+
+    /**
+     * @Then Akeneo statistics engine stores an average of :averageOfAttributes scopable attributes per family for this customer
+     *
+     * @param int $averageOfAttributes
+     */
+    public function theSystemInformationReturnsThatTheAverageOfScopableAttributesPerFamilyIs(int $averageOfAttributes): void
+    {
+        $collectedInfo = $this->getCollectedInformation();
+        Assert::eq($averageOfAttributes, $collectedInfo['avg_scopable_attributes_per_family']);
+    }
+
+    /**
+     * @Then Akeneo statistics engine stores an average of :averageOfAttributes localizable attributes per family for this customer
+     *
+     * @param int $averageOfAttributes
+     */
+    public function theSystemInformationReturnsThatTheAverageOfLocalizableAttributesPerFamilyIs(int $averageOfAttributes): void
+    {
+        $collectedInfo = $this->getCollectedInformation();
+        Assert::eq($averageOfAttributes, $collectedInfo['avg_localizable_attributes_per_family']);
+    }
+
+    /**
+     * @Then Akeneo statistics engine stores an average of :averageOfAttributes localizable and scopable attributes per family for this customer
+     *
+     * @param int $averageOfAttributes
+     */
+    public function theSystemInformationReturnsThatTheAverageOfLocalizableAndScopableAttributesPerFamilyIs(int $averageOfAttributes): void
+    {
+        $collectedInfo = $this->getCollectedInformation();
+        Assert::eq($averageOfAttributes, $collectedInfo['avg_scopable_localizable_attributes_per_family']);
+    }
+
+    /**
+     * @return array
+     */
+    public function getCollectedInformation(): array
+    {
+        return $this->collector;
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/SystemInfoAttributeContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/SystemInfoAttributeContext.php
@@ -33,7 +33,7 @@ final class SystemInfoAttributeContext implements Context
     }
 
     /**
-     * @Then Akeneo statistics engine stores a number of :numberOfAttribute useable as grid filter attribute for this customer
+     * @Then Akeneo statistics engine stores a number of :numberOfAttribute useable as grid filter for this customer
      *
      * @param int $numberOfAttribute
      */
@@ -44,36 +44,36 @@ final class SystemInfoAttributeContext implements Context
     }
 
     /**
-     * @Then Akeneo statistics engine stores an average of :averageOfAttributes scopable attributes per family for this customer
+     * @Then Akeneo statistics engine stores an average percentage of :averageOfAttributes scopable attributes per family for this customer
      *
      * @param int $averageOfAttributes
      */
     public function theSystemInformationReturnsThatTheAverageOfScopableAttributesPerFamilyIs(int $averageOfAttributes): void
     {
         $collectedInfo = $this->getCollectedInformation();
-        Assert::eq($averageOfAttributes, $collectedInfo['avg_scopable_attributes_per_family']);
+        Assert::eq($averageOfAttributes, $collectedInfo['avg_percentage_scopable_attributes_per_family']);
     }
 
     /**
-     * @Then Akeneo statistics engine stores an average of :averageOfAttributes localizable attributes per family for this customer
+     * @Then Akeneo statistics engine stores an average percentage of :averageOfAttributes localizable attributes per family for this customer
      *
      * @param int $averageOfAttributes
      */
     public function theSystemInformationReturnsThatTheAverageOfLocalizableAttributesPerFamilyIs(int $averageOfAttributes): void
     {
         $collectedInfo = $this->getCollectedInformation();
-        Assert::eq($averageOfAttributes, $collectedInfo['avg_localizable_attributes_per_family']);
+        Assert::eq($averageOfAttributes, $collectedInfo['avg_percentage_localizable_attributes_per_family']);
     }
 
     /**
-     * @Then Akeneo statistics engine stores an average of :averageOfAttributes localizable and scopable attributes per family for this customer
+     * @Then Akeneo statistics engine stores an average percentage of :averageOfAttributes localizable and scopable attributes per family for this customer
      *
      * @param int $averageOfAttributes
      */
     public function theSystemInformationReturnsThatTheAverageOfLocalizableAndScopableAttributesPerFamilyIs(int $averageOfAttributes): void
     {
         $collectedInfo = $this->getCollectedInformation();
-        Assert::eq($averageOfAttributes, $collectedInfo['avg_scopable_localizable_attributes_per_family']);
+        Assert::eq($averageOfAttributes, $collectedInfo['avg_percentage_scopable_localizable_attributes_per_family']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/SystemInfoContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/SystemInfoContext.php
@@ -189,6 +189,30 @@ final class SystemInfoContext implements Context
     }
 
     /**
+     * @Then Akeneo statistics engine stores an average of :avgOfProductValuesByProduct product values per family for this customer
+     *
+     * @param int $avgOfProductValuesByProduct
+     */
+    public function theSystemInformationReturnsThatTheAverageOfProductValuesPerFamilyIs(int $avgOfProductValuesByProduct): void
+    {
+        $collectedInfo = $this->getCollectedInformation();
+
+        Assert::eq($avgOfProductValuesByProduct, $collectedInfo['avg_product_values_per_family']);
+    }
+
+    /**
+     * @Then Akeneo statistics engine stores a maximum of :avgOfProductValuesByProduct product values per family for this customer
+     *
+     * @param int $avgOfProductValuesByProduct
+     */
+    public function theSystemInformationReturnsThatTheMaximumOfProductValuesPerFamilyIs(int $avgOfProductValuesByProduct): void
+    {
+        $collectedInfo = $this->getCollectedInformation();
+
+        Assert::eq($avgOfProductValuesByProduct, $collectedInfo['max_product_values_per_family']);
+    }
+
+    /**
      * @return array
      */
     public function getCollectedInformation(): array

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/SystemInfoContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/SystemInfoContext.php
@@ -141,7 +141,7 @@ final class SystemInfoContext implements Context
     }
 
     /**
-     * @Then Akeneo statistics engine stores a maximum of :maxCategoryInOneCategory categories in one category for this customer
+     * @Then Akeneo statistics engine stores a maximum number of :maxCategoryInOneCategory categories in one category for this customer
      *
      * @param int $maxCategoryInOneCategory
      */
@@ -153,7 +153,7 @@ final class SystemInfoContext implements Context
     }
 
     /**
-     * @Then Akeneo statistics engine stores a maximum of :maxCategoryLevels category levels for this customer
+     * @Then Akeneo statistics engine stores a maximum number of :maxCategoryLevels category levels for this customer
      *
      * @param int $maxCategoryLevels
      */
@@ -177,7 +177,7 @@ final class SystemInfoContext implements Context
     }
 
     /**
-     * @Then Akeneo statistics engine stores an average of :avgOfProductValuesByProduct product values for this customer
+     * @Then Akeneo statistics engine stores an average number of :avgOfProductValuesByProduct product values for this customer
      *
      * @param int $avgOfProductValuesByProduct
      */
@@ -189,7 +189,7 @@ final class SystemInfoContext implements Context
     }
 
     /**
-     * @Then Akeneo statistics engine stores an average of :avgOfProductValuesByProduct product values per family for this customer
+     * @Then Akeneo statistics engine stores an average number of :avgOfProductValuesByProduct product values per family for this customer
      *
      * @param int $avgOfProductValuesByProduct
      */
@@ -197,11 +197,11 @@ final class SystemInfoContext implements Context
     {
         $collectedInfo = $this->getCollectedInformation();
 
-        Assert::eq($avgOfProductValuesByProduct, $collectedInfo['avg_product_values_per_family']);
+        Assert::eq($avgOfProductValuesByProduct, $collectedInfo['avg_product_values_by_family']);
     }
 
     /**
-     * @Then Akeneo statistics engine stores a maximum of :avgOfProductValuesByProduct product values per family for this customer
+     * @Then Akeneo statistics engine stores a maximum number of :avgOfProductValuesByProduct product values per family for this customer
      *
      * @param int $avgOfProductValuesByProduct
      */
@@ -209,7 +209,7 @@ final class SystemInfoContext implements Context
     {
         $collectedInfo = $this->getCollectedInformation();
 
-        Assert::eq($avgOfProductValuesByProduct, $collectedInfo['max_product_values_per_family']);
+        Assert::eq($avgOfProductValuesByProduct, $collectedInfo['max_product_values_by_family']);
     }
 
     /**

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/UseableAsGridFilterAttributeContext.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Context/UseableAsGridFilterAttributeContext.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context;
+
+use Behat\Behat\Context\Context;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryCountQuery;
+use Webmozart\Assert\Assert;
+
+final class UseableAsGridFilterAttributeContext implements Context
+{
+    /** @var ReportContext */
+    private $reportContext;
+
+    /** @var InMemoryCountQuery */
+    private $inMemoryQuery;
+
+    /**
+     * @param ReportContext      $reportContext
+     * @param InMemoryCountQuery $inMemoryQuery
+     */
+    public function __construct(ReportContext $reportContext, InMemoryCountQuery $inMemoryQuery)
+    {
+        $this->reportContext = $reportContext;
+        $this->inMemoryQuery = $inMemoryQuery;
+    }
+
+    /**
+     * @Given a catalog with :numberOfAttributes useable as grid filter attributes
+     *
+     * @param int $numberOfAttributes
+     */
+    public function aCatalogWithAttributes(int $numberOfAttributes): void
+    {
+        $this->inMemoryQuery->setVolume($numberOfAttributes);
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Persistence/Query/InMemory/InMemoryAverageMaxQuery.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Persistence/Query/InMemory/InMemoryAverageMaxQuery.php
@@ -37,7 +37,7 @@ class InMemoryAverageMaxQuery implements AverageMaxQuery
      */
     public function fetch(): AverageMaxVolumes
     {
-        $averageVolume = empty($this->values) ? 0 : array_sum($this->values) / count($this->values);
+        $averageVolume = empty($this->values) ? 0 : intval(array_sum($this->values) / count($this->values));
         $maxVolume =  empty($this->values) ? 0 : max($this->values);
 
         return new AverageMaxVolumes($maxVolume, $averageVolume, $this->limit, $this->volumeName);

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Resources/config/behat/services.yml
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Resources/config/behat/services.yml
@@ -6,6 +6,13 @@ services:
         tags:
             - { name: fob.context_service }
 
+    test.catalog_volume_limits.system_info_attribute_context:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context\SystemInfoAttributeContext'
+        arguments:
+            - '@__symfony__.pim_analytics.data_collector.attribute'
+        tags:
+            - { name: fob.context_service }
+
     test.catalog_volume_limits.report_context:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context\ReportContext'
         arguments:
@@ -18,6 +25,30 @@ services:
         arguments:
             - '@test.catalog_volume_limits.report_context'
             - '@__symfony__.pim_volume_monitoring.persistence.query.average_max_attributes_per_family'
+        tags:
+            - { name: fob.context_service }
+
+    test.catalog_volume_limits.localizable_attribute_per_family_context:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context\LocalizableAttributePerFamilyContext'
+        arguments:
+            - '@test.catalog_volume_limits.report_context'
+            - '@__symfony__.pim_volume_monitoring.persistence.query.average_max_localizable_attributes_per_family'
+        tags:
+            - { name: fob.context_service }
+
+    test.catalog_volume_limits.scopable_attribute_per_family_context:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context\ScopableAttributePerFamilyContext'
+        arguments:
+            - '@test.catalog_volume_limits.report_context'
+            - '@__symfony__.pim_volume_monitoring.persistence.query.average_max_scopable_attributes_per_family'
+        tags:
+            - { name: fob.context_service }
+
+    test.catalog_volume_limits.localizable_and_scopable_attribute_per_family_context:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context\LocalizableAndScopableAttributePerFamilyContext'
+        arguments:
+            - '@test.catalog_volume_limits.report_context'
+            - '@__symfony__.pim_volume_monitoring.persistence.query.average_max_localizable_and_scopable_attributes_per_family'
         tags:
             - { name: fob.context_service }
 
@@ -77,11 +108,27 @@ services:
         tags:
             - { name: fob.context_service }
 
+    test.catalog_volume_limits.product_value_per_family_context:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context\ProductValuePerFamilyContext'
+        arguments:
+            - '@test.catalog_volume_limits.report_context'
+            - '@__symfony__.pim_volume_monitoring.persistence.query.average_max_product_values_per_family'
+        tags:
+            - { name: fob.context_service }
+
     test.catalog_volume_limits.attribute_context:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context\AttributeContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
             - '@__symfony__.pim_volume_monitoring.persistence.query.count_attributes'
+        tags:
+            - { name: fob.context_service }
+
+    test.catalog_volume_limits.useable_as_grid_filter_attribute_context:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Context\UseableAsGridFilterAttributeContext'
+        arguments:
+            - '@test.catalog_volume_limits.report_context'
+            - '@__symfony__.pim_volume_monitoring.persistence.query.count_useable_as_grid_filter_attributes'
         tags:
             - { name: fob.context_service }
 

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Resources/config/pim/queries.yml
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Acceptance/Resources/config/pim/queries.yml
@@ -27,6 +27,13 @@ services:
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
+    pim_volume_monitoring.persistence.query.count_useable_as_grid_filter_attributes:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryCountQuery'
+        arguments:
+            - 'count_useable_as_grid_filter_attributes'
+        tags:
+            - { name: pim_volume_monitoring.persistence.count_query }
+
     pim_volume_monitoring.persistence.query.count_scopable_attributes:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryCountQuery'
         arguments:
@@ -96,6 +103,34 @@ services:
             - 'count_product_models'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
+
+    pim_volume_monitoring.persistence.query.average_max_product_values_per_family:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryAverageMaxQuery'
+        arguments:
+            - 'average_max_product_values_per_family'
+        tags:
+            - { name: pim_volume_monitoring.persistence.average_max_query }
+
+    pim_volume_monitoring.persistence.query.average_max_localizable_attributes_per_family:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryAverageMaxQuery'
+        arguments:
+            - 'average_max_localizable_attribute_per_family'
+        tags:
+            - { name: pim_volume_monitoring.persistence.average_max_query }
+
+    pim_volume_monitoring.persistence.query.average_max_scopable_attributes_per_family:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryAverageMaxQuery'
+        arguments:
+            - 'average_max_scopable_attribute_per_family'
+        tags:
+            - { name: pim_volume_monitoring.persistence.average_max_query }
+
+    pim_volume_monitoring.persistence.query.average_max_localizable_and_scopable_attributes_per_family:
+        class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryAverageMaxQuery'
+        arguments:
+            - 'average_max_localizable_and_scopable_attribute_per_family'
+        tags:
+            - { name: pim_volume_monitoring.persistence.average_max_query }
 
     pim_volume_monitoring.persistence.query.aggregated_count_product_and_product_model_values:
         class: 'Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Acceptance\Persistence\Query\InMemory\InMemoryCountQuery'

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxLocalizableAndScopableAttributesPerFamilyIntegration.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxLocalizableAndScopableAttributesPerFamilyIntegration.php
@@ -12,43 +12,56 @@ class AverageMaxLocalizableAndScopableAttributesPerFamilyIntegration extends Que
     public function testGetAverageAndMaximumNumberOfAttributesPerFamily()
     {
         $query = $this->get('pim_volume_monitoring.persistence.query.average_max_localizable_and_scopable_attributes_per_family');
-        $this->createFamilyWithAttributes(4, true, true);
-        $this->createFamilyWithAttributes(8, true, true);
-        $this->createFamilyWithAttributes(5, true, false);
-        $this->createFamilyWithAttributes(2, false, true);
+        $this->createFamilyWithLocalizableAndScopableAttributes(12, 30);
+        $this->createFamilyWithLocalizableAndScopableAttributes(0, 10);
+        $this->createFamilyWithLocalizableAndScopableAttributes(8, 10);
 
         $volume = $query->fetch();
 
-        Assert::assertEquals(8, $volume->getMaxVolume());
-        Assert::assertEquals(6, $volume->getAverageVolume());
+        Assert::assertEquals(80, $volume->getMaxVolume());
+        Assert::assertEquals(40, $volume->getAverageVolume());
         Assert::assertEquals('average_max_localizable_and_scopable_attributes_per_family', $volume->getVolumeName());
         Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**
-     * @param int $numberOfAttributes
-     * @param bool $localizable
-     * @param bool $scopable
+     * @param int $numberOfLocScopAttributes
+     * @param int $numberTotalAttribute
      */
-    private function createFamilyWithAttributes(int $numberOfAttributes, bool $localizable, bool $scopable): void
+    private function createFamilyWithLocalizableAndScopableAttributes(int $numberOfLocScopAttributes, int $numberTotalAttribute): void
     {
         $family = $this->createFamily([
             'code' => 'family_' . rand()
         ]);
 
         $i = 0;
-        while ($i < $numberOfAttributes) {
+        while ($i < $numberOfLocScopAttributes) {
             $attribute = $this->createAttribute([
                 'code'     => 'new_attribute_' . rand(),
                 'type'     => 'pim_catalog_textarea',
                 'group'    => 'other',
-                'localizable' => $localizable,
-                'scopable' => $scopable
+                'localizable' => true,
+                'scopable' => true
             ]);
 
             $family->addAttribute($attribute);
             $i++;
         }
+
+        //attribute sku is automatically added
+        while ($i < $numberTotalAttribute - 1) {
+            $attribute = $this->createAttribute([
+                'code'     => 'new_attribute_' . rand(),
+                'type'     => 'pim_catalog_textarea',
+                'group'    => 'other',
+                'localizable' => false,
+                'scopable' => false
+            ]);
+
+            $family->addAttribute($attribute);
+            $i++;
+        }
+
         $errors = $this->get('validator')->validate($family);
         Assert::assertCount(0, $errors);
 

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxLocalizableAndScopableAttributesPerFamilyIntegration.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxLocalizableAndScopableAttributesPerFamilyIntegration.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Integration\Persistence\Query;
+
+use PHPUnit\Framework\Assert;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Integration\Persistence\QueryTestCase;
+
+class AverageMaxLocalizableAndScopableAttributesPerFamilyIntegration extends QueryTestCase
+{
+    public function testGetAverageAndMaximumNumberOfAttributesPerFamily()
+    {
+        $query = $this->get('pim_volume_monitoring.persistence.query.average_max_localizable_and_scopable_attributes_per_family');
+        $this->createFamilyWithAttributes(4, true, true);
+        $this->createFamilyWithAttributes(8, true, true);
+        $this->createFamilyWithAttributes(5, true, false);
+        $this->createFamilyWithAttributes(2, false, true);
+
+        $volume = $query->fetch();
+
+        Assert::assertEquals(8, $volume->getMaxVolume());
+        Assert::assertEquals(6, $volume->getAverageVolume());
+        Assert::assertEquals('average_max_localizable_and_scopable_attributes_per_family', $volume->getVolumeName());
+        Assert::assertEquals(false, $volume->hasWarning());
+    }
+
+    /**
+     * @param int $numberOfAttributes
+     * @param bool $localizable
+     * @param bool $scopable
+     */
+    private function createFamilyWithAttributes(int $numberOfAttributes, bool $localizable, bool $scopable): void
+    {
+        $family = $this->createFamily([
+            'code' => 'family_' . rand()
+        ]);
+
+        $i = 0;
+        while ($i < $numberOfAttributes) {
+            $attribute = $this->createAttribute([
+                'code'     => 'new_attribute_' . rand(),
+                'type'     => 'pim_catalog_textarea',
+                'group'    => 'other',
+                'localizable' => $localizable,
+                'scopable' => $scopable
+            ]);
+
+            $family->addAttribute($attribute);
+            $i++;
+        }
+        $errors = $this->get('validator')->validate($family);
+        Assert::assertCount(0, $errors);
+
+        $this->get('pim_catalog.saver.family')->save($family);
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxLocalizableAttributesPerFamilyIntegration.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxLocalizableAttributesPerFamilyIntegration.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Integration\Persistence\Query;
+
+use PHPUnit\Framework\Assert;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Integration\Persistence\QueryTestCase;
+
+class AverageMaxLocalizableAttributesPerFamilyIntegration extends QueryTestCase
+{
+    public function testGetAverageAndMaximumNumberOfAttributesPerFamily()
+    {
+        $query = $this->get('pim_volume_monitoring.persistence.query.average_max_localizable_attributes_per_family');
+        $this->createFamilyWithAttributes(4, true);
+        $this->createFamilyWithAttributes(8, true);
+        $this->createFamilyWithAttributes(2, false);
+
+        $volume = $query->fetch();
+
+        Assert::assertEquals(8, $volume->getMaxVolume());
+        Assert::assertEquals(6, $volume->getAverageVolume());
+        Assert::assertEquals('average_max_localizable_attributes_per_family', $volume->getVolumeName());
+        Assert::assertEquals(false, $volume->hasWarning());
+    }
+
+    /**
+     * @param int $numberOfAttributes
+     * @param bool $localizable
+     */
+    private function createFamilyWithAttributes(int $numberOfAttributes, bool $localizable): void
+    {
+        $family = $this->createFamily([
+            'code' => 'family_' . rand()
+        ]);
+
+        $i = 0;
+        while ($i < $numberOfAttributes) {
+            $attribute = $this->createAttribute([
+                'code'     => 'new_attribute_' . rand(),
+                'type'     => 'pim_catalog_textarea',
+                'group'    => 'other',
+                'localizable' => $localizable
+            ]);
+
+            $family->addAttribute($attribute);
+            $i++;
+        }
+        $errors = $this->get('validator')->validate($family);
+        Assert::assertCount(0, $errors);
+
+        $this->get('pim_catalog.saver.family')->save($family);
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxLocalizableAttributesPerFamilyIntegration.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxLocalizableAttributesPerFamilyIntegration.php
@@ -12,40 +12,56 @@ class AverageMaxLocalizableAttributesPerFamilyIntegration extends QueryTestCase
     public function testGetAverageAndMaximumNumberOfAttributesPerFamily()
     {
         $query = $this->get('pim_volume_monitoring.persistence.query.average_max_localizable_attributes_per_family');
-        $this->createFamilyWithAttributes(4, true);
-        $this->createFamilyWithAttributes(8, true);
-        $this->createFamilyWithAttributes(2, false);
+        $this->createFamilyWithLocalizableAttributes(10, 30);
+        $this->createFamilyWithLocalizableAttributes(0, 10);
+        $this->createFamilyWithLocalizableAttributes(3, 10);
 
         $volume = $query->fetch();
 
-        Assert::assertEquals(8, $volume->getMaxVolume());
-        Assert::assertEquals(6, $volume->getAverageVolume());
+        Assert::assertEquals(30, $volume->getMaxVolume());
+        Assert::assertEquals(17, $volume->getAverageVolume());
         Assert::assertEquals('average_max_localizable_attributes_per_family', $volume->getVolumeName());
         Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**
-     * @param int $numberOfAttributes
-     * @param bool $localizable
+     * @param int $numberOfLocAttributes
+     * @param int $numberTotalAttribute
      */
-    private function createFamilyWithAttributes(int $numberOfAttributes, bool $localizable): void
+    private function createFamilyWithLocalizableAttributes(int $numberOfLocAttributes, int $numberTotalAttribute): void
     {
         $family = $this->createFamily([
             'code' => 'family_' . rand()
         ]);
 
         $i = 0;
-        while ($i < $numberOfAttributes) {
+        while ($i < $numberOfLocAttributes-1) {
             $attribute = $this->createAttribute([
                 'code'     => 'new_attribute_' . rand(),
                 'type'     => 'pim_catalog_textarea',
                 'group'    => 'other',
-                'localizable' => $localizable
+                'localizable' => true,
+                'scopable' => false
             ]);
 
             $family->addAttribute($attribute);
             $i++;
         }
+
+        //attribute sku is automatically added
+        while ($i < $numberTotalAttribute - 1) {
+            $attribute = $this->createAttribute([
+                'code'     => 'new_attribute_' . rand(),
+                'type'     => 'pim_catalog_textarea',
+                'group'    => 'other',
+                'localizable' => false,
+                'scopable' => false
+            ]);
+
+            $family->addAttribute($attribute);
+            $i++;
+        }
+
         $errors = $this->get('validator')->validate($family);
         Assert::assertCount(0, $errors);
 

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxScopableAttributesPerFamilyIntegration.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxScopableAttributesPerFamilyIntegration.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Integration\Persistence\Query;
+
+use PHPUnit\Framework\Assert;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Integration\Persistence\QueryTestCase;
+
+class AverageMaxScopableAttributesPerFamilyIntegration extends QueryTestCase
+{
+    public function testGetAverageAndMaximumNumberOfAttributesPerFamily()
+    {
+        $query = $this->get('pim_volume_monitoring.persistence.query.average_max_scopable_attributes_per_family');
+        $this->createFamilyWithAttributes(4, true);
+        $this->createFamilyWithAttributes(8, true);
+        $this->createFamilyWithAttributes(2, false);
+
+        $volume = $query->fetch();
+
+        Assert::assertEquals(8, $volume->getMaxVolume());
+        Assert::assertEquals(6, $volume->getAverageVolume());
+        Assert::assertEquals('average_max_scopable_attributes_per_family', $volume->getVolumeName());
+        Assert::assertEquals(false, $volume->hasWarning());
+    }
+
+    /**
+     * @param int $numberOfAttributes
+     * @param bool $scopable
+     */
+    private function createFamilyWithAttributes(int $numberOfAttributes, bool $scopable): void
+    {
+        $family = $this->createFamily([
+            'code' => 'family_' . rand()
+        ]);
+
+        $i = 0;
+        while ($i < $numberOfAttributes) {
+            $attribute = $this->createAttribute([
+                'code'     => 'new_attribute_' . rand(),
+                'type'     => 'pim_catalog_textarea',
+                'group'    => 'other',
+                'scopable' => $scopable
+            ]);
+
+            $family->addAttribute($attribute);
+            $i++;
+        }
+        $errors = $this->get('validator')->validate($family);
+        Assert::assertCount(0, $errors);
+
+        $this->get('pim_catalog.saver.family')->save($family);
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxScopableAttributesPerFamilyIntegration.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/AverageMaxScopableAttributesPerFamilyIntegration.php
@@ -12,40 +12,56 @@ class AverageMaxScopableAttributesPerFamilyIntegration extends QueryTestCase
     public function testGetAverageAndMaximumNumberOfAttributesPerFamily()
     {
         $query = $this->get('pim_volume_monitoring.persistence.query.average_max_scopable_attributes_per_family');
-        $this->createFamilyWithAttributes(4, true);
-        $this->createFamilyWithAttributes(8, true);
-        $this->createFamilyWithAttributes(2, false);
+        $this->createFamilyWithScopableAttributes(11, 31);
+        $this->createFamilyWithScopableAttributes(0, 8);
+        $this->createFamilyWithScopableAttributes(5, 6);
 
         $volume = $query->fetch();
 
-        Assert::assertEquals(8, $volume->getMaxVolume());
-        Assert::assertEquals(6, $volume->getAverageVolume());
+        Assert::assertEquals(84, $volume->getMaxVolume());
+        Assert::assertEquals(40, $volume->getAverageVolume());
         Assert::assertEquals('average_max_scopable_attributes_per_family', $volume->getVolumeName());
         Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**
-     * @param int $numberOfAttributes
-     * @param bool $scopable
+     * @param int $numberOfScopAttributes
+     * @param int $numberTotalAttribute
      */
-    private function createFamilyWithAttributes(int $numberOfAttributes, bool $scopable): void
+    private function createFamilyWithScopableAttributes(int $numberOfScopAttributes, int $numberTotalAttribute): void
     {
         $family = $this->createFamily([
             'code' => 'family_' . rand()
         ]);
 
         $i = 0;
-        while ($i < $numberOfAttributes) {
+        while ($i < $numberOfScopAttributes) {
             $attribute = $this->createAttribute([
                 'code'     => 'new_attribute_' . rand(),
                 'type'     => 'pim_catalog_textarea',
                 'group'    => 'other',
-                'scopable' => $scopable
+                'localizable' => false,
+                'scopable' => true
             ]);
 
             $family->addAttribute($attribute);
             $i++;
         }
+
+        //attribute sku is automatically added
+        while ($i < $numberTotalAttribute-1) {
+            $attribute = $this->createAttribute([
+                'code'     => 'new_attribute_' . rand(),
+                'type'     => 'pim_catalog_textarea',
+                'group'    => 'other',
+                'localizable' => false,
+                'scopable' => false
+            ]);
+
+            $family->addAttribute($attribute);
+            $i++;
+        }
+
         $errors = $this->get('validator')->validate($family);
         Assert::assertCount(0, $errors);
 

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/CountUseableAsGridFilterAttributesIntegration.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/CountUseableAsGridFilterAttributesIntegration.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Integration\Persistence\Query;
+
+use PHPUnit\Framework\Assert;
+use Pim\Bundle\CatalogVolumeMonitoringBundle\tests\Integration\Persistence\QueryTestCase;
+
+class CountUseableAsGridFilterAttributesIntegration extends QueryTestCase
+{
+    public function testGetCountOfScopableAttributes()
+    {
+        $query = $this->get('pim_volume_monitoring.persistence.query.count_useable_as_grid_filter_attributes');
+        $this->createUseableAsGridFilterAttributes(5);
+
+        $volume = $query->fetch();
+
+        Assert::assertEquals(5, $volume->getVolume());
+        Assert::assertEquals('count_useable_as_grid_filter_attributes', $volume->getVolumeName());
+        Assert::assertEquals(false, $volume->hasWarning());
+    }
+}

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/CountUseableAsGridFilterAttributesIntegration.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/CountUseableAsGridFilterAttributesIntegration.php
@@ -20,4 +20,24 @@ class CountUseableAsGridFilterAttributesIntegration extends QueryTestCase
         Assert::assertEquals('count_useable_as_grid_filter_attributes', $volume->getVolumeName());
         Assert::assertEquals(false, $volume->hasWarning());
     }
+
+    /**
+     * @param int $numberOfAttributes
+     */
+    protected function createUseableAsGridFilterAttributes(int $numberOfAttributes)
+    {
+        $i = 0;
+        // -1 because sku is automatically added (as filter)
+        while ($i < $numberOfAttributes -1) {
+            $this->createAttribute([
+                'code'     => 'new_attribute_' . rand(),
+                'type'     => 'pim_catalog_text',
+                'group'    => 'other',
+                'localizable' => false,
+                'scopable' => false,
+                'useable_as_grid_filter' => true
+            ]);
+            $i++;
+        }
+    }
 }

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/QueryTestCase.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/QueryTestCase.php
@@ -264,6 +264,26 @@ class QueryTestCase extends TestCase
     }
 
     /**
+     * @param int $numberOfAttributes
+     */
+    protected function createUseableAsGridFilterAttributes(int $numberOfAttributes)
+    {
+        $i = 0;
+        // -1 because sku is automatically added (as filter)
+        while ($i < $numberOfAttributes -1) {
+            $this->createAttribute([
+                'code'     => 'new_attribute_' . rand(),
+                'type'     => 'pim_catalog_text',
+                'group'    => 'other',
+                'localizable' => false,
+                'scopable' => false,
+                'useable_as_grid_filter' => true
+            ]);
+            $i++;
+        }
+    }
+
+    /**
      * @param int $numberOfProductValues
      */
     protected function createProductWithProductValues(int $numberOfProductValues): void

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/QueryTestCase.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/QueryTestCase.php
@@ -264,26 +264,6 @@ class QueryTestCase extends TestCase
     }
 
     /**
-     * @param int $numberOfAttributes
-     */
-    protected function createUseableAsGridFilterAttributes(int $numberOfAttributes)
-    {
-        $i = 0;
-        // -1 because sku is automatically added (as filter)
-        while ($i < $numberOfAttributes -1) {
-            $this->createAttribute([
-                'code'     => 'new_attribute_' . rand(),
-                'type'     => 'pim_catalog_text',
-                'group'    => 'other',
-                'localizable' => false,
-                'scopable' => false,
-                'useable_as_grid_filter' => true
-            ]);
-            $i++;
-        }
-    }
-
-    /**
      * @param int $numberOfProductValues
      */
     protected function createProductWithProductValues(int $numberOfProductValues): void

--- a/tests/features/volume-monitoring/volume_customer_statistics.feature
+++ b/tests/features/volume-monitoring/volume_customer_statistics.feature
@@ -81,3 +81,44 @@ Feature: Volume statistics of the customers
     And a product model with 565 product values
     When statistics of the customer's catalog are collected
     Then Akeneo statistics engine stores an average of 576 product values for this customer
+
+  @acceptance-back
+  Scenario: Gather customers statistics about the average of product values per family
+    Given a family with 25 product values
+    And a family with 45 product values
+    When statistics of the customer's catalog are collected
+    Then Akeneo statistics engine stores an average of 35 product values per family for this customer
+
+  @acceptance-back
+  Scenario: Gather customers statistics about the maximum of product values per family
+    Given a family with 25 product values
+    And a family with 45 product values
+    When statistics of the customer's catalog are collected
+    Then Akeneo statistics engine stores a maximum of 45 product values per family for this customer
+
+  @acceptance-back
+  Scenario: Gather customers statistics about the number of useable as grid filter attribute
+    Given a catalog with 10 useable as grid filter attributes
+    When attribute statistics of the customer's catalog are collected
+    Then Akeneo statistics engine stores a number of 10 useable as grid filter attribute for this customer
+
+  @acceptance-back
+  Scenario: Gather customers statistics about the average of localizable attributes per family
+    Given a family with 10 localizable attributes
+    And a family with 20 localizable attributes
+    When attribute statistics of the customer's catalog are collected
+    Then Akeneo statistics engine stores an average of 15 localizable attributes per family for this customer
+
+  @acceptance-back
+  Scenario: Gather customers statistics about the average of scopable attributes per family
+    Given a family with 10 scopable attributes
+    And a family with 20 scopable attributes
+    When attribute statistics of the customer's catalog are collected
+    Then Akeneo statistics engine stores an average of 15 scopable attributes per family for this customer
+
+  @acceptance-back
+  Scenario: Gather customers statistics about the average of localizable and scopable attributes per family
+    Given a family with 10 localizable and scopable attributes
+    And a family with 20 localizable and scopable attributes
+    When attribute statistics of the customer's catalog are collected
+    Then Akeneo statistics engine stores an average of 15 localizable and scopable attributes per family for this customer

--- a/tests/features/volume-monitoring/volume_customer_statistics.feature
+++ b/tests/features/volume-monitoring/volume_customer_statistics.feature
@@ -61,64 +61,74 @@ Feature: Volume statistics of the customers
   Scenario: Gather customers statistics about the maximum of categories in one category
     Given a catalog with 8 categories in one category
     When statistics of the customer's catalog are collected
-    Then Akeneo statistics engine stores a maximum of 8 categories in one category for this customer
+    Then Akeneo statistics engine stores a maximum number of 8 categories in one category for this customer
 
   @acceptance-back
   Scenario: Gather customers statistics about the maximum of category levels
     Given a catalog with 12 category levels
     When statistics of the customer's catalog are collected
-    Then Akeneo statistics engine stores a maximum of 12 category levels for this customer
+    Then Akeneo statistics engine stores a maximum number of 12 category levels for this customer
 
   @acceptance-back
-  Scenario: Gather customers statistics about the number of product values
+  Scenario: Gather customers statistics about the size of the catalog
+    The size of the catalog is defined by the number of product values`
     Given a catalog with 487520 product values
     When statistics of the customer's catalog are collected
     Then Akeneo statistics engine stores a number of 487520 product values for this customer
 
   @acceptance-back
-  Scenario: Gather customers statistics about the average of product values by product
+  Scenario: Gather customers statistics about the average potential size of the products
+    The potential size of the products is defined by the average number of product values that it could contain
     Given a product with 587 product values
     And a product model with 565 product values
     When statistics of the customer's catalog are collected
-    Then Akeneo statistics engine stores an average of 576 product values for this customer
+    Then Akeneo statistics engine stores an average number of 576 product values for this customer
 
   @acceptance-back
-  Scenario: Gather customers statistics about the average of product values per family
-    Given a family with 25 product values
-    And a family with 45 product values
+  Scenario: Gather customers statistics about the average potential size of the products
+    The potential size of a product is defined by the number of product values that it could contain
+    and the potential number of product values is defined by the attributes in its family
+    Given a channel defined with 2 activated locales
+    And a family with 7 attributes, 8 localizable attributes, 4 scopable attributes and 6 scopable and localizable attributes
+    And a family with 2 attributes, 3 localizable attributes, 1 scopable attributes and 5 scopable and localizable attributes
     When statistics of the customer's catalog are collected
-    Then Akeneo statistics engine stores an average of 35 product values per family for this customer
+    Then Akeneo statistics engine stores an average number of 29 product values per family for this customer
 
   @acceptance-back
-  Scenario: Gather customers statistics about the maximum of product values per family
-    Given a family with 25 product values
-    And a family with 45 product values
+  Scenario: Gather customers statistics about the maximum potential potential size of the products
+    The potential size of a product is defined by the number of product values that it could contain
+    and the potential number of product values is defined by the attributes in its family
+    Given a channel defined with 2 activated locales
+    And a channel defined with 3 activated locales
+    And a family with 2 attributes, 3 localizable attributes, 4 scopable attributes and 6 scopable and localizable attributes
+    And a family with 4 attributes, 3 localizable attributes, 2 scopable attributes and 5 scopable and localizable attributes
     When statistics of the customer's catalog are collected
-    Then Akeneo statistics engine stores a maximum of 45 product values per family for this customer
+    Then Akeneo statistics engine stores a maximum number of 85 product values per family for this customer
 
   @acceptance-back
-  Scenario: Gather customers statistics about the number of useable as grid filter attribute
+  Scenario: Gather customers statistics about the number of attributes useable as grid filter
     Given a catalog with 10 useable as grid filter attributes
     When attribute statistics of the customer's catalog are collected
-    Then Akeneo statistics engine stores a number of 10 useable as grid filter attribute for this customer
+    Then Akeneo statistics engine stores a number of 10 useable as grid filter for this customer
 
   @acceptance-back
-  Scenario: Gather customers statistics about the average of localizable attributes per family
-    Given a family with 10 localizable attributes
-    And a family with 20 localizable attributes
+  Scenario: Gather customers statistics about the average number of localizable attributes per family
+    Given a family with 7 localizable attributes, 8 scopable attributes, 4 localizable and scopable attributes and 6 attributes
+    And a family with 0 localizable attributes, 2 scopable attributes, 2 localizable and scopable attributes and 2 attributes
+    And a family with 3 localizable attributes, 0 scopable attributes, 0 localizable and scopable attributes and 2 attributes
     When attribute statistics of the customer's catalog are collected
-    Then Akeneo statistics engine stores an average of 15 localizable attributes per family for this customer
+    Then Akeneo statistics engine stores an average percentage of 29 localizable attributes per family for this customer
 
   @acceptance-back
-  Scenario: Gather customers statistics about the average of scopable attributes per family
-    Given a family with 10 scopable attributes
-    And a family with 20 scopable attributes
+  Scenario: Gather customers statistics about the average number of scopable attributes per family
+    Given a family with 7 scopable attributes, 8 localizable attributes, 4 localizable and scopable attributes and 6 attributes
+    And a family with 0 scopable attributes, 2 localizable attributes, 2 localizable and scopable attributes and 2 attributes
     When attribute statistics of the customer's catalog are collected
-    Then Akeneo statistics engine stores an average of 15 scopable attributes per family for this customer
+    Then Akeneo statistics engine stores an average percentage of 14 scopable attributes per family for this customer
 
   @acceptance-back
-  Scenario: Gather customers statistics about the average of localizable and scopable attributes per family
-    Given a family with 10 localizable and scopable attributes
-    And a family with 20 localizable and scopable attributes
+  Scenario: Gather customers statistics about the average number of localizable and scopable attributes per family
+    Given a family with 2 localizable and scopable attributes, 4 localizable attributes, 4 scopable attributes and 4 attributes
+    And a family with 0 localizable and scopable attributes, 0 localizable attributes, 5 scopable attributes and 5 attributes
     When attribute statistics of the customer's catalog are collected
-    Then Akeneo statistics engine stores an average of 15 localizable and scopable attributes per family for this customer
+    Then Akeneo statistics engine stores an average percentage of 7 localizable and scopable attributes per family for this customer

--- a/tests/features/volume-monitoring/volume_customer_statistics.feature
+++ b/tests/features/volume-monitoring/volume_customer_statistics.feature
@@ -77,8 +77,8 @@ Feature: Volume statistics of the customers
     Then Akeneo statistics engine stores a number of 487520 product values for this customer
 
   @acceptance-back
-  Scenario: Gather customers statistics about the average potential size of the products
-    The potential size of the products is defined by the average number of product values that it could contain
+  Scenario: Gather customers statistics about the average size of the products
+    The average size of the products is defined by the average number of product values that it contains
     Given a product with 587 product values
     And a product model with 565 product values
     When statistics of the customer's catalog are collected


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

New axes to add : 
* Average percentage of scopable attributes by family: For each family, you count the number of attributes that are only scopable. You divide by the total number of attributes in the family. You compute the average for all families.
* Average percentage of localizable attributes by family: For each family, you count the number of attributes that are only localizable. You divide by the total number of attributes in the family. You compute the average for all families.
* Average percentage of localizable & scopable attributes by family: For each family, you count the number of attributes that are both localizable and scopable at the same time. You divide by the total number of attributes in the family. You compute the average for all families.
* Average number of potential product values per families: For a given family, you count the number of potential product values a product in this family can have. Then you do this operation on all families. To finish, you compute the average on all the families.
* Max number of potential product values in one family: You find the family for which there is the highest number of potential product values in it.
* Number of attributes usable in the grid: The number of attributes usable in the grid. -> We will have to think to remove it in 3.0.

EE : https://github.com/akeneo/pim-enterprise-dev/pull/4632

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | OK
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
