### PR TITLE
PIM-7618: Hide the dashboard "Process tracker" link if no permission

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-7600: Change the default return value of ResetIndexesCommand to true to allow the --no-interaction parameter.
 - PIM-7572: Cross to remove associations displayed at PV level whereas association is done at PM level
+- PIM-7618: Hide the "Process tracker" link in the Dashboard if the user does not have the permission 
 
 # 2.3.5 (2018-08-22)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/common/menu.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/common/menu.yml
@@ -58,6 +58,7 @@ extensions:
     pim-menu-activity-job-tracker:
         module: pim/menu/item
         parent: pim-menu-activity-navigation-block
+        aclResourceId: pim_enrich_job_tracker_index
         position: 110
         config:
             title: pim_menu.item.job_tracker


### PR DESCRIPTION
Remove 'Process tracker' link on the dashboard when user has no "View process tracker" permission

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
