### PR TITLE
APAI-142: Detect only product status switcher

### DIFF
--- a/tests/legacy/features/Context/Page/Product/Edit.php
+++ b/tests/legacy/features/Context/Page/Product/Edit.php
@@ -351,12 +351,12 @@ class Edit extends ProductEditForm
     /**
      * @return NodeElement|null
      */
-    public function getStatusSwitcher()
+    public function getProductStatusSwitcher()
     {
         try {
             $switcher = $this->spin(function () {
-                return $this->find('css', '.status-switcher');
-            }, 'Cannot find ".status-switcher" element');
+                return $this->find('css', '.product-status');
+            }, 'Cannot find ".product-status" element');
         } catch (\Exception $e) {
             $switcher = null;
         }

--- a/tests/legacy/features/Context/WebUser.php
+++ b/tests/legacy/features/Context/WebUser.php
@@ -2751,11 +2751,11 @@ class WebUser extends PimContext
     }
 
     /**
-     * @Then /^I should (not )?see the status-switcher button$/
+     * @Then /^I should (not )?see the product status switcher$/
      */
     public function iShouldSeeTheStatusSwitcherButton($not)
     {
-        $statusSwitcher = $this->getCurrentPage()->getStatusSwitcher();
+        $statusSwitcher = $this->getCurrentPage()->getProductStatusSwitcher();
 
         if ($not) {
             if ($statusSwitcher && $statusSwitcher->isVisible()) {


### PR DESCRIPTION
## Description

### The problem

This PR updates a Behat step. This step is used in one EE scenario to check if the status switcher available in the PEF is hidden as it should be with a particular permission setting.

Problem is, we just introduced a new status switcher on the PEF, in EE only, and as the behat step was using the component class to detect the button, the scenario failed because it couldn't make the difference between the 2 switchers.

### The solution

This PR fixes the issue by detecting the switcher using a CSS class specific to the product status switcher, instead of a generic one.

### Side note

This behat step is quite bad in fact. If you try to see if the switcher is visible, everything's fine. But if, like in the EE scenario that was failing, you try to see if it is **not** visible, then you have to wait for the end of the spin, which on the CI is 50 seconds. That means that this scenario last for about 1 minutes, when it should run in less than 10 seconds…

## Definition Of Done 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
