### PR TITLE
Bugfix/user datetime timezone

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/JobExecutionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/JobExecutionController.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\EnrichBundle\Controller\Rest;
 use Akeneo\Bundle\BatchQueueBundle\Manager\JobExecutionManager;
 use Pim\Bundle\ConnectorBundle\EventListener\JobExecutionArchivist;
 use Pim\Bundle\EnrichBundle\Doctrine\ORM\Repository\JobExecutionRepository;
+use Pim\Bundle\UserBundle\Context\UserContext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -32,25 +33,31 @@ class JobExecutionController
     /** @var JobExecutionRepository */
     protected $jobExecutionRepo;
 
+    /** @var UserContext */
+    protected $userContext;
+
     /**
-     * @param TranslatorInterface    $translator
-     * @param JobExecutionArchivist  $archivist
-     * @param SerializerInterface    $serializer
-     * @param JobExecutionManager    $jobExecutionManager
+     * @param TranslatorInterface $translator
+     * @param JobExecutionArchivist $archivist
+     * @param SerializerInterface $serializer
+     * @param JobExecutionManager $jobExecutionManager
      * @param JobExecutionRepository $jobExecutionRepo
+     * @param UserContext $userContext
      */
     public function __construct(
         TranslatorInterface $translator,
         JobExecutionArchivist $archivist,
         SerializerInterface $serializer,
         JobExecutionManager $jobExecutionManager,
-        JobExecutionRepository $jobExecutionRepo
+        JobExecutionRepository $jobExecutionRepo,
+        UserContext $userContext
     ) {
         $this->translator = $translator;
         $this->archivist = $archivist;
         $this->serializer = $serializer;
         $this->jobExecutionManager = $jobExecutionManager;
         $this->jobExecutionRepo = $jobExecutionRepo;
+        $this->userContext = $userContext;
     }
 
     /**
@@ -81,7 +88,10 @@ class JobExecutionController
 
         $jobExecution = $this->jobExecutionManager->resolveJobExecutionStatus($jobExecution);
 
-        $context = ['limit_warnings' => 100];
+        $context = [
+            'limit_warnings' => 100,
+            'timezone'       => $this->userContext->getUserTimezone(),
+        ];
 
         $jobResponse = $this->serializer->normalize($jobExecution, 'standard', $context);
         $jobResponse['meta'] = [

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/VersioningController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/VersioningController.php
@@ -60,7 +60,10 @@ class VersioningController
         return new JsonResponse(
             $this->normalizer->normalize(
                 $this->versionRepository->getLogEntries($this->FQCNResolver->getFQCN($entityType), $entityId),
-                'internal_api'
+                'internal_api',
+                [
+                    'timezone' => $this->userContext->getUserTimezone()
+                ]
             )
         );
     }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
@@ -5,7 +5,6 @@ namespace Pim\Bundle\EnrichBundle\Normalizer;
 use Akeneo\Component\Localization\Presenter\PresenterInterface;
 use Akeneo\Component\Versioning\Model\Version;
 use Oro\Bundle\UserBundle\Entity\UserManager;
-use Pim\Bundle\UserBundle\Context\UserContext;
 use Pim\Component\Catalog\Localization\Presenter\PresenterRegistryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -36,30 +35,23 @@ class VersionNormalizer implements NormalizerInterface
 
     /** @var PresenterInterface */
     protected $datetimePresenter;
-    /**
-     * @var UserContext
-     */
-    private $userContext;
 
     /**
      * @param UserManager $userManager
      * @param TranslatorInterface $translator
      * @param PresenterInterface $datetimePresenter
      * @param PresenterRegistryInterface $presenterRegistry
-     * @param UserContext $userContext
      */
     public function __construct(
         UserManager $userManager,
         TranslatorInterface $translator,
         PresenterInterface $datetimePresenter,
-        PresenterRegistryInterface $presenterRegistry,
-        UserContext $userContext
+        PresenterRegistryInterface $presenterRegistry
     ) {
         $this->userManager = $userManager;
         $this->translator = $translator;
         $this->datetimePresenter = $datetimePresenter;
         $this->presenterRegistry = $presenterRegistry;
-        $this->userContext = $userContext;
     }
 
     /**
@@ -67,10 +59,7 @@ class VersionNormalizer implements NormalizerInterface
      */
     public function normalize($version, $format = null, array $context = [])
     {
-        $context = array_merge($context, [
-            'locale' => $this->translator->getLocale(),
-            'timezone' => $this->userContext->getUserTimezone()
-        ]);
+        $context = array_merge($context, ['locale' => $this->translator->getLocale()]);
 
         return [
             'id'           => $version->getId(),

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\EnrichBundle\Normalizer;
 use Akeneo\Component\Localization\Presenter\PresenterInterface;
 use Akeneo\Component\Versioning\Model\Version;
 use Oro\Bundle\UserBundle\Entity\UserManager;
+use Pim\Bundle\UserBundle\Context\UserContext;
 use Pim\Component\Catalog\Localization\Presenter\PresenterRegistryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -35,23 +36,30 @@ class VersionNormalizer implements NormalizerInterface
 
     /** @var PresenterInterface */
     protected $datetimePresenter;
+    /**
+     * @var UserContext
+     */
+    private $userContext;
 
     /**
-     * @param UserManager                $userManager
-     * @param TranslatorInterface        $translator
-     * @param PresenterInterface         $datetimePresenter
+     * @param UserManager $userManager
+     * @param TranslatorInterface $translator
+     * @param PresenterInterface $datetimePresenter
      * @param PresenterRegistryInterface $presenterRegistry
+     * @param UserContext $userContext
      */
     public function __construct(
         UserManager $userManager,
         TranslatorInterface $translator,
         PresenterInterface $datetimePresenter,
-        PresenterRegistryInterface $presenterRegistry
+        PresenterRegistryInterface $presenterRegistry,
+        UserContext $userContext
     ) {
         $this->userManager = $userManager;
         $this->translator = $translator;
         $this->datetimePresenter = $datetimePresenter;
         $this->presenterRegistry = $presenterRegistry;
+        $this->userContext = $userContext;
     }
 
     /**
@@ -59,7 +67,10 @@ class VersionNormalizer implements NormalizerInterface
      */
     public function normalize($version, $format = null, array $context = [])
     {
-        $context = array_merge($context, ['locale' => $this->translator->getLocale()]);
+        $context = array_merge($context, [
+            'locale' => $this->translator->getLocale(),
+            'timezone' => $this->userContext->getUserTimezone()
+        ]);
 
         return [
             'id'           => $version->getId(),

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -454,6 +454,7 @@ services:
             - '@pim_serializer'
             - '@akeneo_batch_queue.manager.job_execution_manager'
             - '@pim_enrich.repository.job_execution'
+            - '@pim_user.context.user'
 
     pim_enrich.controller.rest.api_client:
         class: '%pim_enrich.controller.rest.api_client.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/history.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/history.yml
@@ -19,7 +19,7 @@ datagrid:
                 frontend_type: string
             loggedAt:
                 label: Logged at
-                type: property_date
+                type: datetime_with_user_timezone
                 frontend_type: datetime
             changes:
                 label: Changes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/last_executions.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/last_executions.yml
@@ -10,7 +10,7 @@ datagrid:
             date:
                 label:         job_tracker.filter.started_at
                 data_name:     createTime
-                type:          datetime
+                type:          datetime_with_user_timezone
                 frontend_type: datetime
             status:
                 label:         Status

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -129,6 +129,7 @@ services:
             - '@translator'
             - '@pim_catalog.localization.presenter.datetime'
             - '@pim_catalog.localization.presenter.registry'
+            - '@pim_user.context.user'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -129,7 +129,6 @@ services:
             - '@translator'
             - '@pim_catalog.localization.presenter.datetime'
             - '@pim_catalog.localization.presenter.registry'
-            - '@pim_user.context.user'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 


### PR DESCRIPTION
… execution view does not take in account current user timezone

**Description (for Contributor and Core Developer)**

There are several issues related to the date and time displayed in several area of akeneo if the server has a different timezone as the one of the user interface.

The user expect to see a date and time of his own timezone and not the one of the server. Currently, there are difference places in akeneo where the date and time are different, here is a list:

- Profil import/export history grid (date column)
- Job execution detail view (summary, start, end, etc): startedAt, endedAt fields
- Product / Product model history list: loggedAt
- Different history grid tab like in `Settings > Category > History`

The fix provided in this PR fix all related area previously mentioned.

To reproduce the issue:

- Set the server with the `Etc/UTC` timezone
- Configure the logged in user with a different timezone like `Europe/Zurich`
- Navigate through the different history tab of export / import profiles (in Process Tracker view, the display is correct) or form product edit view or even different settings area. You will see that the date and time are the same as the one saved in database, a UTC one and not the one of the user interface.

To resolve the issue, we use mainly the class `\Pim\Bundle\UserBundle\Context\UserContext` and get the user timezone from there.

<!--- (What does this Pull Request do? reference the related issue?) --->

See https://github.com/akeneo/pim-community-dev/issues/8601, the issue is similar but the solution provided here are for more cases.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
