### PR TITLE
PIM-7626: Fix attribute groups order in the product grid's column configurator

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -9,6 +9,7 @@
 - PIM-7600: Change the default return value of ResetIndexesCommand to true to allow the --no-interaction parameter.
 - PIM-7572: Cross to remove associations displayed at PV level whereas association is done at PM level
 - PIM-7618: Hide the "Process tracker" link in the Dashboard if the user does not have the permission 
+- PIM-7626: Fix attribute groups order in the product grid's column configurator
 
 # 2.3.5 (2018-08-22)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/column-list-view.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/common/column-list-view.js
@@ -91,7 +91,7 @@ define([
             var systemColumn = this.collection.where({group: __('system_filter_group')});
 
             var groups = 0 !== systemColumn.length ?
-                [{ position: 0, name: __('system_filter_group'), itemCount: 0 }] :
+                [{ position: -1, name: __('system_filter_group'), itemCount: 0 }] :
                 [];
 
             _.each(this.collection.toJSON(), function (column) {
@@ -100,7 +100,7 @@ define([
                     if (!_.isNumber(position) || !_.isEmpty(_.where(groups, {position: position}))) {
                         position = _.max(groups, function (group) {
                             return group.position;
-                        }) + 1;
+                        }).position + 1;
                     }
 
                     groups.push({


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

The "System" pseudo attribute group had a 0 index, which could mess up the attribute groups display order in the columns configurator in case of an attribute group with sortOrder = 0.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
