### PR TITLE
$this->catalogContext may be null.

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -234,7 +234,7 @@ class ProductNormalizer implements NormalizerInterface
             'structure_version' => $this->structureVersionProvider->getStructureVersion(),
             'completenesses'    => $this->getNormalizedCompletenesses($product),
             'required_missing_attributes' => $incompleteValues,
-            'image'             => $this->normalizeImage($product->getImage(), $this->catalogContext->getLocaleCode()),
+            'image'             => $this->normalizeImage($product->getImage(), $this->catalogContext ? $this->catalogContext->getLocaleCode() : null),
         ] + $this->getLabels($product, $scopeCode) + $this->getAssociationMeta($product);
 
         $normalizedProduct['meta']['ascendant_category_ids'] = $product->isVariant() ?


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

b8dcc498c7ef9c242791ebc341144ac138543aff introduced an (optional) $catalogContext parameter, but it's used unconditionally within normalize(). This is a real problem, because when having a non-localizable, non-scopable image in a product, opening that product now crashes with:
"Call to a member function getLocaleCode() on null" at /srv/pim/vendor/akeneo/pim-community-dev/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php line 237
Maybe the locally provided $context should also be considered?

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
