### PR TITLE
PIM-7484: Search families and family variants regardless of the current locale

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -13,6 +13,7 @@
 - PIM-7631: Fix API filter product and product model on date with between operator
 - PIM-7613: Fix translations of boolean attributes
 - PIM-7609: Handle 'empty' and 'not empty' filter types in string filter
+- PIM-7484: Search families and family variants regardless of the current locale
 
 # 2.3.5 (2018-08-22)
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Repository/FamilyRepository.php
@@ -54,14 +54,9 @@ class FamilyRepository extends EntityRepository implements FamilyRepositoryInter
         $qb = $this->createQueryBuilder('f')->where('f.familyVariants IS NOT EMPTY');
 
         if (null !== $search && '' !== $search) {
-            if (!isset($options['locale'])) {
-                $qb->andWhere('f.code like :search')->setParameter('search', '%' . $search . '%');
-            } else {
-                $qb->leftJoin('f.translations', 'ft');
-                $qb->andWhere('f.code like :search OR (ft.label like :search AND ft.locale = :locale)');
-                $qb->setParameter('search', '%' . $search . '%');
-                $qb->setParameter('locale', $options['locale']);
-            }
+            $qb->leftJoin('f.translations', 'ft');
+            $qb->andWhere('f.code like :search OR ft.label like :search');
+            $qb->setParameter('search', '%' . $search . '%');
         }
 
         if ($limit) {

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
@@ -42,14 +42,9 @@ class FamilySearchableRepository implements SearchableRepositoryInterface
         $qb = $this->entityManager->createQueryBuilder()->select('f')->from($this->entityName, 'f');
 
         if (null !== $search && '' !== $search) {
-            $qb->where('f.code like :search')->setParameter('search', '%' . $search . '%');
-            if (isset($options['locale'])) {
-                $qb->leftJoin('f.translations', 'ft');
-                $qb->orWhere('ft.label like :search AND ft.locale = :locale');
-                $qb->groupBy('f.code');
-                $qb->setParameter('search', '%' . $search . '%');
-                $qb->setParameter('locale', $options['locale']);
-            }
+            $qb->leftJoin('f.translations', 'ft');
+            $qb->andWhere('f.code like :search OR ft.label like :search');
+            $qb->setParameter('search', '%' . $search . '%');
         }
 
         $qb = $this->applyQueryOptions($qb, $options);

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilyVariantSearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilyVariantSearchableRepository.php
@@ -37,13 +37,9 @@ class FamilyVariantSearchableRepository implements SearchableRepositoryInterface
         $qb = $this->entityManager->createQueryBuilder()->select('fv')->from($this->entityName, 'fv');
 
         if (null !== $search && '' !== $search) {
-            $qb->where('fv.code like :search')->setParameter('search', '%' . $search . '%');
-            if (isset($options['catalogLocale'])) {
-                $qb->leftJoin('fv.translations', 'fvt');
-                $qb->orWhere('fvt.label like :search AND fvt.locale = :locale');
-                $qb->setParameter('search', '%' . $search . '%');
-                $qb->setParameter('locale', $options['catalogLocale']);
-            }
+            $qb->leftJoin('fv.translations', 'fvt');
+            $qb->andWhere('fv.code like :search OR fvt.label like :search');
+            $qb->setParameter('search', '%' . $search . '%');
         }
 
         $qb = $this->applyQueryOptions($qb, $options);

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/Repository/FamilySearchableRepositoryIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/Repository/FamilySearchableRepositoryIntegration.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\tests\integration\Repository;
+
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\Model\FamilyInterface;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilySearchableRepositoryIntegration extends TestCase
+{
+    public function test_it_searches_families_by_code()
+    {
+        static::assertCount(1, $this->searchFamily('clothing'));
+        static::assertCount(1, $this->searchFamily('other'));
+    }
+
+    public function test_it_searches_families_by_label()
+    {
+        static::assertCount(2, $this->searchFamily('vetem'));
+        static::assertCount(2, $this->searchFamily('clothes'));
+        static::assertCount(1, $this->searchFamily('alter'));
+        static::assertCount(1, $this->searchFamily('autre'));
+        static::assertCount(0, $this->searchFamily('unexisting'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->initFixtures();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function initFixtures(): void
+    {
+        $channel = $this->get('pim_catalog.repository.channel')->findOneByIdentifier('ecommerce');
+        $locale = $this->get('pim_catalog.repository.locale')->findOneByIdentifier('fr_FR');
+        $channel->addLocale($locale);
+        $this->get('pim_catalog.saver.channel')->save($channel);
+
+        $this->createFamily(
+            [
+                'code' => 'clothing',
+                'labels' => [
+                    'en_US' => 'Clothes',
+                    'fr_FR' => 'Vêtements',
+                ],
+            ]
+        );
+        $this->createFamily(
+            [
+                'code' => 'other',
+                'labels' => [
+                    'en_US' => 'Alternative clothes',
+                    'fr_FR' => 'Autres vêtements',
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @param $data
+     */
+    private function createFamily($data): void
+    {
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $this->get('pim_catalog.updater.family')->update($family, $data);
+
+        $this->get('pim_catalog.saver.family')->save($family);
+    }
+
+    /**
+     * @param string $search
+     *
+     * @return FamilyInterface[]
+     */
+    private function searchFamily(string $search): array
+    {
+        return $this->get('pim_enrich.repository.family.search')->findBySearch($search);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/Repository/FamilyVariantSearchableRepositoryIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/Repository/FamilyVariantSearchableRepositoryIntegration.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\tests\integration\Repository;
+
+use Akeneo\Test\Integration\TestCase;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\FamilyVariantInterface;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyVariantSearchableRepositoryIntegration extends TestCase
+{
+    public function test_it_searches_family_variants_by_code()
+    {
+        static::assertCount(1, $this->searchFamilyVariant('by_size'));
+        static::assertCount(1, $this->searchFamilyVariant('by_color'));
+    }
+
+    public function it_searches_family_variants_by_label()
+    {
+        static::assertCount(2, $this->searchFamilyVariant('By'));
+        static::assertCount(2, $this->searchFamilyVariant('par'));
+        static::assertCount(1, $this->searchFamilyVariant('color'));
+        static::assertCount(1, $this->searchFamilyVariant('taille'));
+        static::assertCount(0, $this->searchFamilyVariant('unexisting'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->initFixtures();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function initFixtures(): void
+    {
+        $channel = $this->get('pim_catalog.repository.channel')->findOneByIdentifier('ecommerce');
+        $locale = $this->get('pim_catalog.repository.locale')->findOneByIdentifier('fr_FR');
+        $channel->addLocale($locale);
+        $this->get('pim_catalog.saver.channel')->save($channel);
+
+        $defaultGroup = $this->get('pim_catalog.repository.attribute_group')->findDefaultAttributeGroup();
+        $this->createAttribute(
+            [
+                'code' => 'size',
+                'type' => AttributeTypes::OPTION_SIMPLE_SELECT,
+                'group' => $defaultGroup->getCode(),
+            ]
+        );
+
+        $this->createAttribute(
+            [
+                'code' => 'color',
+                'type' => AttributeTypes::OPTION_SIMPLE_SELECT,
+                'group' => $defaultGroup->getCode(),
+            ]
+        );
+        $this->createFamily(
+            [
+                'code' => 'clothing',
+                'labels' => [
+                    'en_US' => 'Clothes',
+                    'fr_FR' => 'Vêtements',
+                ],
+                'attributes' => [
+                    'sku',
+                    'size',
+                    'color',
+                ],
+            ]
+        );
+        $this->createFamilyVariant(
+            [
+                'family' => 'clothing',
+                'code' => 'by_size',
+                'labels' => [
+                    'en_US' => 'By size',
+                    'fr_FR' => 'Par taille',
+                ],
+                'variant_attribute_sets' => [
+                    [
+                        'axes' => ['size'],
+                        'attributes' => [],
+                        'level' => 1,
+                    ],
+
+                ],
+            ]
+        );
+        $this->createFamilyVariant(
+            [
+                'family' => 'clothing',
+                'code' => 'by_color',
+                'labels' => [
+                    'en_US' => 'By color',
+                    'fr_FR' => 'Par couleur',
+                ],
+                'variant_attribute_sets' => [
+                    [
+                        'axes' => ['color'],
+                        'attributes' => [],
+                        'level' => 1,
+                    ],
+
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @param array $data
+     */
+    private function createAttribute(array $data): void
+    {
+        $attribute = $this->get('pim_catalog.factory.attribute')->create();
+        $this->get('pim_catalog.updater.attribute')->update($attribute, $data);
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+    }
+
+    /**
+     * @param array $data
+     */
+    private function createFamily(array $data): void
+    {
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $this->get('pim_catalog.updater.family')->update($family, $data);
+        $this->get('pim_catalog.saver.family')->save($family);
+    }
+
+    /**
+     * @param array $data
+     */
+    private function createFamilyVariant(array $data): void
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, $data);
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+    }
+
+    /**
+     * @param string $search
+     *
+     * @return FamilyVariantInterface[]
+     */
+    private function searchFamilyVariant(string $search): array
+    {
+        return $this->get('pim_enrich.repository.family_variant.search')->findBySearch($search);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

This PR allows the user to search for families and family variants on their code and translation labels, regardless of the current locale.
These searches are used by autocomplete selects, mainly in the enrichment context (product grid filters, product/product model creation modals, product mass actions)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
