### PR TITLE
PIM-7609: Handle 'empty' and 'not empty' filter types in string filter

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -12,6 +12,7 @@
 - PIM-7626: Fix attribute groups order in the product grid's column configurator
 - PIM-7631: Fix API filter product and product model on date with between operator
 - PIM-7613: Fix translations of boolean attributes
+- PIM-7609: Handle 'empty' and 'not empty' filter types in string filter
 
 # 2.3.5 (2018-08-22)
 

--- a/src/Oro/Bundle/FilterBundle/spec/Filter/ChoiceFilterSpec.php
+++ b/src/Oro/Bundle/FilterBundle/spec/Filter/ChoiceFilterSpec.php
@@ -4,6 +4,7 @@ namespace spec\Oro\Bundle\FilterBundle\Filter;
 
 use Oro\Bundle\FilterBundle\Filter\FilterInterface;
 use Oro\Bundle\FilterBundle\Filter\FilterUtility;
+use Oro\Bundle\FilterBundle\Form\Type\Filter\ChoiceFilterType;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
@@ -28,8 +29,8 @@ class ChoiceFilterSpec extends ObjectBehavior
     {
         $builder->get('type')->willReturn($builder);
         $builder->getOption('choices')->willReturn(['foo', 'bar']);
-        $factory->createBuilder('oro_type_choice_filter', [], ['csrf_protection' => false])->willReturn($builder);
-        $factory->create('oro_type_choice_filter', [], ['csrf_protection' => false])->willReturn($form);
+        $factory->createBuilder(ChoiceFilterType::class, [], ['csrf_protection' => false])->willReturn($builder);
+        $factory->create(ChoiceFilterType::class, [], ['csrf_protection' => false])->willReturn($form);
         $util->getExcludeParams()->willReturn([]);
         $util->getParamMap()->willReturn([]);
 

--- a/src/Oro/Bundle/FilterBundle/spec/Filter/StringFilterSpec.php
+++ b/src/Oro/Bundle/FilterBundle/spec/Filter/StringFilterSpec.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Oro\Bundle\FilterBundle\Filter;
+
+use Doctrine\ORM\Query\Expr;
+use Oro\Bundle\FilterBundle\Datasource\ExpressionBuilderInterface;
+use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
+use Oro\Bundle\FilterBundle\Filter\FilterInterface;
+use Oro\Bundle\FilterBundle\Filter\FilterUtility;
+use Oro\Bundle\FilterBundle\Filter\StringFilter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class StringFilterSpec extends ObjectBehavior
+{
+    function let(FormFactoryInterface $factory, FilterUtility $util)
+    {
+        $this->beConstructedWith($factory, $util);
+        $this->init('teststring', ['data_name' => 'some_data_name']);
+    }
+
+    function it_is_a_filter()
+    {
+        $this->shouldImplement(FilterInterface::class);
+    }
+
+    function it_is_a_string_filter()
+    {
+        $this->shouldHaveType(StringFilter::class);
+    }
+
+    function it_applies_empty_filter(
+        FilterDatasourceAdapterInterface $ds,
+        ExpressionBuilderInterface $builder
+    ) {
+        $ds->generateParameterName('teststring')->willReturn('teststring1234');
+
+        $isNullExpr = 'teststring IS NULL';
+        $eqExpr = 'teststring = :testrting1234';
+        $orExpr = new Expr\Orx();
+
+        $builder->isNull(Argument::type('string'))->willReturn($isNullExpr);
+        $builder->eq(Argument::type('string'), Argument::type('string'), true)->willReturn($eqExpr);
+        $builder->orX($isNullExpr, $eqExpr)->willReturn($orExpr);
+        $ds->expr()->willReturn($builder);
+
+        $ds->addRestriction($orExpr, 'AND', false)->shouldBeCalled();
+        $ds->setParameter('teststring1234', '')->shouldBeCalled();
+
+        $this->apply($ds, ['type' => 'empty', 'value' => ''])->shouldReturn(true);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

This PR allows to handle the `is empty` and `is not empty` operators in the StringFilter, thus fixing the "Description" filter on the assets grid

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
