### PR TITLE
PIM-7631: Fix API filter product and product model on date with between operator

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -10,6 +10,7 @@
 - PIM-7572: Cross to remove associations displayed at PV level whereas association is done at PM level
 - PIM-7618: Hide the "Process tracker" link in the Dashboard if the user does not have the permission 
 - PIM-7626: Fix attribute groups order in the product grid's column configurator
+- PIM-7631: Fix API filter product and product model on date with between operator
 
 # 2.3.5 (2018-08-22)
 

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -561,8 +561,16 @@ class ProductController
                 $value = isset($filter['value']) ? $filter['value'] : null;
 
                 if (in_array($propertyCode, ['created', 'updated'])) {
-                    //PIM-7541 Create the date with the server timezone configuration. Do not force it to UTC timezone.
-                    $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
+                    if (Operators::BETWEEN === $filter['operator'] && is_array($value)) {
+                        $values = [];
+                        foreach ($value as $date) {
+                            $values[] = \DateTime::createFromFormat('Y-m-d H:i:s', $date);
+                        }
+                        $value = $values;
+                    } else {
+                        //PIM-7541 Create the date with the server timezone configuration. Do not force it to UTC timezone.
+                        $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
+                    }
                 }
 
                 $this->queryParametersChecker->checkPropertyParameters($propertyCode, $filter['operator']);

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
@@ -643,8 +643,16 @@ class ProductModelController
                 $value = isset($filter['value']) ? $filter['value'] : null;
 
                 if (in_array($propertyCode, ['created', 'updated'])) {
-                    //PIM-7541 Create the date with the server timezone configuration. Do not force it to UTC timezone.
-                    $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
+                    if (Operators::BETWEEN === $filter['operator'] && is_array($value)) {
+                        $values = [];
+                        foreach ($value as $date) {
+                            $values[] = \DateTime::createFromFormat('Y-m-d H:i:s', $date);
+                        }
+                        $value = $values;
+                    } else {
+                        //PIM-7541 Create the date with the server timezone configuration. Do not force it to UTC timezone.
+                        $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
+                    }
                 }
 
                 $this->queryParametersChecker->checkPropertyParameters($propertyCode, $filter['operator']);

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -1106,6 +1106,42 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
+    public function testListProductsWithBetweenOnDateAttributesWithPositiveTimeZoneOffset()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        date_default_timezone_set('Pacific/Kiritimati');
+
+        $currentDate = (new \DateTime('now'))->format('Y-m-d H:i:s');
+        $currentDateMinusHalf = (new \DateTime('now'))->modify('- 30 minutes')->format('Y-m-d H:i:s');
+
+        $search = sprintf('{"updated":[{"operator":"BETWEEN","value":["%s", "%s"]}]}', $currentDateMinusHalf, $currentDate );
+        $client->request('GET', 'api/rest/v1/products?pagination_type=page&limit=10&search=' . $search);
+        $searchEncoded = rawurlencode($search);
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [            
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['product_china']},
+            {$standardizedProducts['product_without_category']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
     public function testListProductsWithSearchOnDateAttributesWithNegativeTimeZoneOffset()
     {
         $standardizedProducts = $this->getStandardizedProducts();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

`url/api/rest/v1/product-models?limit=100&pagination_type=search_after&search={"updated":[
{"operator":"BETWEEN","value": ["2018-08-26 22:40:10","2018-08-26 23:40:10"]}]}`

Got this error 
`2018-08-27 00:18:51 request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: DateTime::createFromFormat() expects parameter 2 to be string, array given" at /home/akeneo/releases/20180824090748/akeneo/vendor/akeneo/pim-community-dev/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php line 647`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
