### PR TITLE
PIM-7612 allow scalable frontend architecture for media content delivery

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,10 @@
 
 - PIM-7628: Fix the initialization of the product datagrid identifier filter.
 
+## Enhancements
+
+- PIM-7612: Add the media/cache/{filter}/{path} route support in order to handle scalable frontend architecture for media content delivering
+
 # 2.3.6 (2018-09-06)
 
 ## Enhancements

--- a/src/Pim/Bundle/EnrichBundle/Controller/FileController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/FileController.php
@@ -12,6 +12,8 @@ use Pim\Bundle\EnrichBundle\File\FileTypes;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -92,6 +94,25 @@ class FileController
         }
 
         return $result;
+    }
+
+    /**
+     * In case of multiple frontend architecture, the request that ask the cache generation on one frontend and
+     * the request that ask the generated media could be on another frontend. This action is a "last chance" to get the
+     * media generated in cache and delivered.
+     *
+     * @param Request $request
+     * @param string  $path
+     * @param string  $filter
+     *
+     * @throws \RuntimeException
+     * @throws BadRequestHttpException
+     *
+     * @return RedirectResponse
+     */
+    public function cacheAction(Request $request, $path, $filter)
+    {
+        return $this->imagineController->filterAction($request, $path, $filter);
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/media.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/media.yml
@@ -15,3 +15,10 @@ pim_enrich_default_thumbnail:
     requirements:
         mimeType: "[a-z-]+/[a-z0-9.-]+"
 
+pim_enrich_media_cache:
+    path: /cache/{filter}/{path}
+    defaults: { _controller: pim_enrich.controller.file:cacheAction}
+    methods: [GET]
+    requirements:
+        filter: '[A-z0-9_-]*'
+        path: .+


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**Problem**

On a scalable frontend architecture some image were not delivered properly to the browser that requested the media.

You may have the choice to share the `web/media/cache` folder across several frontend (with whatever shared storage technology (nfs, glusterfs, ...)) but in our case we want each frontend server to have it's own cache.

**Actual behavior**

The true image file is generated on demand with a specific route that handle the image resizing, the storage on `web/media/cache` folder and the response is a http redirect to the real resource.

The following request: `media/show/xxx.jpg/thumbnail_small` (R1) will redirect to `media/cache/thumbnail_small/xxx.jpg` (R2)

In a scalable architecture with :
- a load balancing mechanism with non sticky strategy
- 3 frontend (F1, F2, F3), 

The first request (R1) could be handled by one frontend (F1), but the redirected request (R2) can be handled by another frontend (F3).
The image is generated in F1 filesystem, so the R2 that target directly the cached resource will respond a 404 because the file is not generated on the F3 server.

**Solution**

I've implemented a fallback strategy on the `media/cache/thumbnail_small/xxx.jpg` route.
If the file does not exists on the filesystem, i force the cache to be generated on the frontend that has been requested.

If the file exists on the filesystem, the vhost will deliver directly the resource as usual.

**For the future**

The best solution is to manage a complete decentralized cached storage like google cloud storage and deliver the content through a CDN but it's a project on its own ;)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
