### PR TITLE
Add ProgressBar component in indexer commands

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductModelCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductModelCommand.php
@@ -113,7 +113,6 @@ class IndexProductModelCommand extends ContainerAwareCommand
         $progressBar->start();
         while (!empty($rootProductModels =
             $this->productModelRepository->searchRootProductModelsAfter($lastRootProductModel, self::BULK_SIZE))) {
-
             $this->bulkProductModelIndexer->indexAll($rootProductModels, ['index_refresh' => Refresh::disable()]);
             $this->bulkProductModelDescendantsIndexer->indexAll($rootProductModels, ['index_refresh' => Refresh::disable()]);
             $this->objectManager->clear();

--- a/src/Akeneo/Pim/Enrichment/Bundle/spec/Command/IndexProductCommandSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/spec/Command/IndexProductCommandSpec.php
@@ -12,6 +12,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterfac
 use Prophecy\Argument;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -54,8 +55,13 @@ class IndexProductCommandSpec extends ObjectBehavior
         ProductInterface $product2,
         ProductInterface $product3,
         ProductInterface $product4,
-        ProductInterface $product5
+        ProductInterface $product5,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $container->get('pim_catalog.repository.product')->willReturn($productRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
         $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
@@ -73,9 +79,7 @@ class IndexProductCommandSpec extends ObjectBehavior
         $objectManager->clear()->shouldBeCalledTimes(3);
 
         $output->writeln('<info>5 products to index</info>')->shouldBeCalled();
-        $output->writeln('Indexing products 0 of 5')->shouldBeCalled();
-        $output->writeln('Indexing products 2 of 5')->shouldBeCalled();
-        $output->writeln('Indexing products 4 of 5')->shouldBeCalled();
+        $output->write(Argument::any())->shouldBeCalled();
         $output->writeln('<info>5 products indexed</info>')->shouldBeCalled();
 
         $commandInput = new ArrayInput([
@@ -111,8 +115,13 @@ class IndexProductCommandSpec extends ObjectBehavior
         Application $application,
         HelperSet $helperSet,
         InputDefinition $definition,
-        ProductInterface $productToIndex
+        ProductInterface $productToIndex,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $container->get('pim_catalog.repository.product')->willReturn($productRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
         $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
@@ -123,6 +132,7 @@ class IndexProductCommandSpec extends ObjectBehavior
         $objectManager->clear()->shouldBeCalled();
 
         $output->writeln('<info>1 products found for indexing</info>')->shouldBeCalled();
+        $output->write(Argument::any())->shouldBeCalled();
         $output->writeln('<info>1 products indexed</info>')->shouldBeCalled();
 
         $commandInput = new ArrayInput([
@@ -160,8 +170,13 @@ class IndexProductCommandSpec extends ObjectBehavior
         HelperSet $helperSet,
         InputDefinition $definition,
         ProductInterface $product1,
-        ProductInterface $product2
+        ProductInterface $product2,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $container->get('pim_catalog.repository.product')->willReturn($productRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
         $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
@@ -172,6 +187,7 @@ class IndexProductCommandSpec extends ObjectBehavior
         $objectManager->clear()->shouldBeCalled();
 
         $output->writeln('<info>2 products found for indexing</info>')->shouldBeCalled();
+        $output->write(Argument::any())->shouldBeCalled();
         $output->writeln('<info>2 products indexed</info>')->shouldBeCalled();
 
         $commandInput = new ArrayInput([
@@ -208,8 +224,13 @@ class IndexProductCommandSpec extends ObjectBehavior
         Application $application,
         HelperSet $helperSet,
         InputDefinition $definition,
-        ProductInterface $productToIndex
+        ProductInterface $productToIndex,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $container->get('pim_catalog.repository.product')->willReturn($productRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
         $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
@@ -223,6 +244,7 @@ class IndexProductCommandSpec extends ObjectBehavior
 
         $output->writeln('<error>Some products were not found for the given identifiers: wrong_product</error>')->shouldBeCalled();
         $output->writeln('<info>1 products found for indexing</info>')->shouldBeCalled();
+        $output->write(Argument::any())->shouldBeCalled();
         $output->writeln('<info>1 products indexed</info>')->shouldBeCalled();
 
         $commandInput = new ArrayInput([
@@ -258,8 +280,13 @@ class IndexProductCommandSpec extends ObjectBehavior
         OutputInterface $output,
         Application $application,
         HelperSet $helperSet,
-        InputDefinition $definition
+        InputDefinition $definition,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $container->get('pim_catalog.repository.product')->willReturn($productRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product')->willReturn($productIndexer);
         $container->get('doctrine.orm.default_entity_manager')->willReturn($objectManager);
@@ -299,8 +326,13 @@ class IndexProductCommandSpec extends ObjectBehavior
         InputInterface $input,
         OutputInterface $output,
         HelperSet $helperSet,
-        InputDefinition $definition
+        InputDefinition $definition,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $productClient->hasIndex()->willReturn(false);
         $container->getParameter('product_index_name')->willReturn('foo');
 
@@ -334,8 +366,13 @@ class IndexProductCommandSpec extends ObjectBehavior
         InputInterface $input,
         OutputInterface $output,
         HelperSet $helperSet,
-        InputDefinition $definition
+        InputDefinition $definition,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $productAndProductModelClient->hasIndex()->willReturn(false);
         $container->getParameter('product_index_name')->willReturn('foo');
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/spec/Command/IndexProductModelCommandSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/spec/Command/IndexProductModelCommandSpec.php
@@ -12,6 +12,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductModelRepositoryInt
 use Prophecy\Argument;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -55,8 +56,13 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         ProductModelInterface $productModel2,
         ProductModelInterface $productModel3,
         ProductModelInterface $productModel4,
-        ProductModelInterface $productModel5
+        ProductModelInterface $productModel5,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
         $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
@@ -76,9 +82,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         $objectManager->clear()->shouldBeCalledTimes(3);
 
         $output->writeln('<info>5 product models to index</info>')->shouldBeCalled();
-        $output->writeln('Indexing product models 1 to 2')->shouldBeCalled();
-        $output->writeln('Indexing product models 3 to 4')->shouldBeCalled();
-        $output->writeln('Indexing product models 5 to 5')->shouldBeCalled();
+        $output->write(Argument::any())->shouldBeCalled();
         $output->writeln('<info>5 product models indexed</info>')->shouldBeCalled();
 
         $commandInput = new ArrayInput([
@@ -116,8 +120,13 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         Application $application,
         HelperSet $helperSet,
         InputDefinition $definition,
-        ProductModelInterface $productModelToIndex
+        ProductModelInterface $productModelToIndex,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
         $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
@@ -130,6 +139,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         $objectManager->clear()->shouldBeCalled();
 
         $output->writeln('<info>1 product models found for indexing</info>')->shouldBeCalled();
+        $output->write(Argument::any())->shouldBeCalled();
         $output->writeln('<info>1 product models indexed</info>')->shouldBeCalled();
 
         $commandInput = new ArrayInput([
@@ -169,8 +179,13 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         HelperSet $helperSet,
         InputDefinition $definition,
         ProductModelInterface $productModel1,
-        ProductModelInterface $productModel2
+        ProductModelInterface $productModel2,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
         $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
@@ -187,6 +202,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         $objectManager->clear()->shouldBeCalled();
 
         $output->writeln('<info>2 product models found for indexing</info>')->shouldBeCalled();
+        $output->write(Argument::any())->shouldBeCalled();
         $output->writeln('<info>2 product models indexed</info>')->shouldBeCalled();
 
         $commandInput = new ArrayInput([
@@ -226,8 +242,13 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         HelperSet $helperSet,
         InputDefinition $definition,
         ProductModelInterface $productModel1,
-        ProductModelInterface $productModel2
+        ProductModelInterface $productModel2,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
         $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
@@ -245,6 +266,7 @@ class IndexProductModelCommandSpec extends ObjectBehavior
 
         $output->writeln('<error>Some product models were not found for the given codes: wrong_product_model</error>')->shouldBeCalled();
         $output->writeln('<info>2 product models found for indexing</info>')->shouldBeCalled();
+        $output->write(Argument::any())->shouldBeCalled();
         $output->writeln('<info>2 product models indexed</info>')->shouldBeCalled();
 
         $commandInput = new ArrayInput([
@@ -282,8 +304,13 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         OutputInterface $output,
         Application $application,
         HelperSet $helperSet,
-        InputDefinition $definition
+        InputDefinition $definition,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $container->get('pim_catalog.repository.product_model')->willReturn($productModelRepository);
         $container->get('pim_catalog.elasticsearch.indexer.product_model')->willReturn($productModelIndexer);
         $container->get('pim_catalog.elasticsearch.indexer.product_model_descendance')
@@ -325,8 +352,13 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         InputInterface $input,
         OutputInterface $output,
         HelperSet $helperSet,
-        InputDefinition $definition
+        InputDefinition $definition,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $productClient->hasIndex()->willReturn(false);
         $container->getParameter('product_index_name')->willReturn('foo');
 
@@ -360,8 +392,13 @@ class IndexProductModelCommandSpec extends ObjectBehavior
         InputInterface $input,
         OutputInterface $output,
         HelperSet $helperSet,
-        InputDefinition $definition
+        InputDefinition $definition,
+        OutputFormatter $formatter
     ) {
+        $output->isDecorated()->willReturn(true);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_NORMAL);
+        $output->getFormatter()->willReturn($formatter);
+
         $productAndProductModelClient->hasIndex()->willReturn(false);
         $container->getParameter('product_index_name')->willReturn('foo');
 


### PR DESCRIPTION
Progress status of indexation commands is very annoying, let's get some eye candy for DevOps guys

```
$ bin/console -e=prod pim:product:index --all
133492 products to index
  14300/133492 [==>-------------------------]  10%
```

```
$ bin/console -e=prod pim:product-model:index --all
68279 product models to index
  6900/68279 [>---------------------------]  10%
```
