### PR TITLE
Fix wrong namespace in integration tests

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library("k8s-utils@override")
+@Library("k8s-utils@2.x")
 
 String[] editions = ["ce"]
 String[] legacyFeatures = ["tests/legacy/features"]

--- a/composer.lock
+++ b/composer.lock
@@ -5734,16 +5734,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.2.1",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "e37cbd80da64afe314c72de8d2d2fec0e40d9373"
+                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/e37cbd80da64afe314c72de8d2d2fec0e40d9373",
-                "reference": "e37cbd80da64afe314c72de8d2d2fec0e40d9373",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/b8e9745fb9b06ea6664d8872c4505fb16df4611c",
+                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c",
                 "shasum": ""
             },
             "require": {
@@ -5774,7 +5774,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-08-23T12:00:19+00:00"
+            "time": "2018-08-31T19:07:57+00:00"
         },
         {
             "name": "container-interop/container-interop",

--- a/src/Akeneo/Pim/Enrichment/Bundle/tests/Integration/Doctrine/Common/Saver/ProductSaverIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/tests/Integration/Doctrine/Common/Saver/ProductSaverIntegration.php
@@ -8,7 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 
 /**
  * Integration tests to verify a product is well saved in database.
@@ -99,7 +99,7 @@ class ProductSaverIntegration extends TestCase
     private function createProductModel(string $identifier, string $familyVariantCode): ProductModelInterface
     {
         $familyVariant = $this->get('pim_api.repository.family_variant')->findOneByIdentifier($familyVariantCode);
-        
+
         $model = new ProductModel();
         $model->setCode($identifier);
         $model->setFamilyVariant($familyVariant);

--- a/src/Akeneo/Pim/Enrichment/Component/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Component/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
@@ -6,7 +6,7 @@ use Akeneo\Test\Integration\TestCase;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 
 /**
  * Integration tests to verify data from database are well formatted in the "indexing_product_and_product_model" format

--- a/src/Akeneo/Pim/Enrichment/Component/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Component/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -4,7 +4,7 @@ namespace tests\integration\Pim\Component\Catalog\Normalizer\Indexing;
 
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Indexing\Product\ProductNormalizer;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 
 /**
  * Integration tests to verify data from database are well formatted in the "indexing_product" format

--- a/src/Akeneo/Pim/Enrichment/Component/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Component/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
@@ -6,7 +6,7 @@ use Akeneo\Test\IntegrationTestsBundle\Sanitizer\DateSanitizer;
 use Akeneo\Test\IntegrationTestsBundle\Sanitizer\MediaSanitizer;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 
 /**
  * Integration tests to verify data from database are well formatted in the standard format

--- a/src/Akeneo/Pim/Enrichment/Component/tests/integration/Normalizer/Storage/EntityWithValuesStorageIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Component/tests/integration/Normalizer/Storage/EntityWithValuesStorageIntegration.php
@@ -4,7 +4,7 @@ namespace tests\integration\Pim\Component\Catalog\Normalizer\Storage;
 
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 
 /**
  * Integration tests to verify data from database are well formatted in the storage format

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/CreateProductIntegration.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Tool\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
 class CreateProductIntegration extends AbstractProductTestCase

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
@@ -6,7 +6,7 @@ namespace Akeneo\Tool\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
 use PHPUnit\Framework\Assert;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/GetVariantProductIntegration.php
@@ -7,7 +7,7 @@ namespace Akeneo\Tool\Bundle\ApiBundle\tests\integration\Controller\Product;
 use Akeneo\Test\Integration\Configuration;
 use PHPUnit\Framework\Assert;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductAssociation;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductToVariantIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductToVariantIntegration.php
@@ -6,7 +6,7 @@ namespace Akeneo\Tool\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
 use Symfony\Component\HttpFoundation\Response;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 
 class PartialUpdateProductToVariantIntegration extends AbstractProductTestCase
 {

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/CreateProductModelIntegration.php
@@ -2,7 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\ApiBundle\tests\integration\Controller\ProductModel;
 
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
 class CreateProductModelIntegration extends AbstractProductModelTestCase

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/GetProductModelIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/GetProductModelIntegration.php
@@ -6,7 +6,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelAssociation;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use PHPUnit\Framework\Assert;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
 class GetProductModelIntegration extends ApiTestCase

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListOffsetProductModelIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListOffsetProductModelIntegration.php
@@ -175,7 +175,7 @@ JSON;
         $client = $this->createAuthenticatedClient([], [], null, null, 'mary', 'mary');
 
         $productModels = [];
-        for ($i = 0; $i <= 10001; $i++) {
+        for ($i = 0; $i <= 200; $i++) {
             $productModel = $this->get('pim_catalog.factory.product_model')->create();
             $this->get('pim_catalog.updater.product_model')
                 ->update($productModel, [
@@ -186,7 +186,6 @@ JSON;
         }
 
         $this->get('pim_catalog.saver.product_model')->saveAll($productModels);
-        $this->get('akeneo_elasticsearch.client.product_model')->refreshIndex();
 
         $client->request('GET', 'api/rest/v1/product-models?page=101&limit=100');
 

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateListProductModelIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateListProductModelIntegration.php
@@ -3,7 +3,7 @@
 namespace Akeneo\Tool\Bundle\ApiBundle\tests\integration\Controller\ProductModel;
 
 use Akeneo\Tool\Bundle\ApiBundle\Stream\StreamResourceResponse;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
 class PartialUpdateListProductModelIntegration extends AbstractProductModelTestCase

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateProductModelIntegration.php
@@ -2,7 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\ApiBundle\tests\integration\Controller\ProductModel;
 
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
 class PartialUpdateProductModelIntegration extends AbstractProductModelTestCase

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
@@ -5,7 +5,7 @@ namespace Akeneo\Tool\Component\Api\tests\integration\Normalizer;
 use Akeneo\Test\IntegrationTestsBundle\Sanitizer\MediaSanitizer;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Pim\Component\Catalog\tests\integration\Normalizer\NormalizedProductCleaner;
+use Akeneo\Pim\Enrichment\Component\tests\integration\Normalizer\NormalizedProductCleaner;
 
 /**
  * Integration tests to verify data from database are well formatted in the external api format


### PR DESCRIPTION
## Description

There was an issue with the last pull-up, we messed things on the namespace of a class used in integration tests.

This PR fixes the issue, and fix the new branch `2.x` of the `jenkins-k8s-utils` library in the Jenkinsfile.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
