### PR TITLE
Pim 7637 Completeness not calculated on variant products after bulk action edition on attributes

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7637: Fix computation of completness of variant products when an attribute at product model level is updated on a bulk action
 - PIM-7639: Fix the "forgot password" title visibility 
 
 # 2.0.36 (2018-09-05)

--- a/src/Pim/Bundle/EnrichBundle/Connector/Writer/MassEdit/ProductAndProductModelWriter.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Writer/MassEdit/ProductAndProductModelWriter.php
@@ -2,16 +2,19 @@
 
 namespace Pim\Bundle\EnrichBundle\Connector\Writer\MassEdit;
 
+use Akeneo\Bundle\BatchBundle\Launcher\JobLauncherInterface;
 use Akeneo\Component\Batch\Item\InitializableInterface;
 use Akeneo\Component\Batch\Item\ItemWriterInterface;
 use Akeneo\Component\Batch\Model\StepExecution;
 use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Component\StorageUtils\Cache\CacheClearerInterface;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
 use Pim\Bundle\VersioningBundle\Manager\VersionManager;
 use Pim\Component\Catalog\Model\EntityWithFamilyInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Product and product model writer for mass edit
@@ -37,24 +40,48 @@ class ProductAndProductModelWriter implements ItemWriterInterface, StepExecution
     /** @var CacheClearerInterface */
     protected $cacheClearer;
 
+    /** @var TokenStorageInterface */
+    private $tokenStorage;
+
+    /** @var JobLauncherInterface */
+    private $jobLauncher;
+
+    /** @var IdentifiableObjectRepositoryInterface */
+    private $jobInstanceRepository;
+
+    /** @var string */
+    private $jobName;
+
     /**
      * Constructor
      *
-     * @param VersionManager        $versionManager
-     * @param BulkSaverInterface    $productSaver
-     * @param BulkSaverInterface    $productModelSaver
-     * @param CacheClearerInterface $cacheClearer
+     * @param VersionManager                        $versionManager
+     * @param BulkSaverInterface                    $productSaver
+     * @param BulkSaverInterface                    $productModelSaver
+     * @param CacheClearerInterface                 $cacheClearer
+     * @param TokenStorageInterface                 $tokenStorage
+     * @param JobLauncherInterface                  $jobLauncher
+     * @param IdentifiableObjectRepositoryInterface $jobInstanceRepository
+     * @param string                                $jobName
      */
     public function __construct(
         VersionManager $versionManager,
         BulkSaverInterface $productSaver,
         BulkSaverInterface $productModelSaver,
-        CacheClearerInterface $cacheClearer
+        CacheClearerInterface $cacheClearer,
+        TokenStorageInterface $tokenStorage = null, //TODO remove following nullable before merge on 3.x
+        JobLauncherInterface $jobLauncher = null,
+        IdentifiableObjectRepositoryInterface $jobInstanceRepository = null,
+        string $jobName = null
     ) {
         $this->versionManager = $versionManager;
         $this->productSaver = $productSaver;
         $this->productModelSaver = $productModelSaver;
         $this->cacheClearer = $cacheClearer;
+        $this->tokenStorage = $tokenStorage;
+        $this->jobLauncher = $jobLauncher;
+        $this->jobInstanceRepository = $jobInstanceRepository;
+        $this->jobName = $jobName;
     }
 
     /**
@@ -75,6 +102,11 @@ class ProductAndProductModelWriter implements ItemWriterInterface, StepExecution
 
         $this->productSaver->saveAll($products);
         $this->productModelSaver->saveAll($productModels);
+
+        if (!empty($productModels)) {
+            $this->computeProductModelDescendants($productModels);
+        }
+
         $this->cacheClearer->clear();
     }
 
@@ -106,5 +138,29 @@ class ProductAndProductModelWriter implements ItemWriterInterface, StepExecution
         } else {
             $this->stepExecution->incrementSummaryInfo('create');
         }
+    }
+
+    private function computeProductModelDescendants(array $productModels)
+    {
+        //TODO remove before merge in 3.x
+        if (null === $this->tokenStorage
+        || null === $this->jobInstanceRepository
+        || null === $this->jobLauncher
+        || null === $this->jobName
+        ) {
+            return;
+        }
+
+        $user = $this->tokenStorage->getToken()->getUser();
+        $jobInstance = $this->jobInstanceRepository->findOneByIdentifier($this->jobName);
+
+        $productModelCodes = array_map(
+            function ($productModel) {
+                return $productModel->getCode();
+            },
+            $productModels
+        );
+
+        $this->jobLauncher->launch($jobInstance, $user, ['product_model_codes' => $productModelCodes]);
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/writers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/writers.yml
@@ -9,3 +9,7 @@ services:
             - '@pim_catalog.saver.product'
             - '@pim_catalog.saver.product_model'
             - '@pim_connector.doctrine.cache_clearer'
+            - '@security.token_storage'
+            - '@akeneo_batch_queue.launcher.queue_job_launcher'
+            - '@akeneo_batch.job.job_instance_repository'
+            - '%pim_catalog.compute_product_models_descendants.job_name%'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**Problem**
When edit an attribute that is at product model level on a bulk action, the completeness of the descendants is not computed.

There is a subscriber that handle the completeness computation asynchronously (add a job in the queue) but if its not a "unitary" saved entity its skip the computation. As we are in a bulk action, it's not unitary. 

This check is certainly due to performance needs and i don't think that we have to remove it.

**Solution**

On the bulk action product and product model writer step, if there is product models, i add a job in the queue with all the product models to compute.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
