### PR TITLE
PIM-7635: fix elasticsearch config override

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library("k8s-utils@v2.0.0")
+@Library("k8s-utils@2.x")
 
 String[] editions = ["ce"]
 String[] legacyFeatures = ["tests/legacy/features"]

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 - PIM-7610: Add a command to create users
+- PIM-7635: Fix elasticsearch config override
 
 ## Bug fixes
 

--- a/src/Akeneo/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
@@ -51,13 +51,13 @@ class Loader
             $configuration = $yaml->parse(file_get_contents($configurationFile));
 
             if (isset($configuration['settings'])) {
-                $settings = array_merge_recursive($settings, $configuration['settings']);
+                $settings = array_replace_recursive($settings, $configuration['settings']);
             }
             if (isset($configuration['mappings'])) {
-                $mappings = array_merge_recursive($mappings, $configuration['mappings']);
+                $mappings = array_replace_recursive($mappings, $configuration['mappings']);
             }
             if (isset($configuration['aliases'])) {
-                $aliases = array_merge_recursive($aliases, $configuration['aliases']);
+                $aliases = array_replace_recursive($aliases, $configuration['aliases']);
             }
         }
 


### PR DESCRIPTION
**The problem**
ElasticSearch config is not currently overridable. As contrary to what is said in https://docs.akeneo.com/2.3/maintain_pim/common_issues/index.html#the-limit-of-total-fields-is-reached-in-elasticsearch, it's not currently possible to change the total_fields.limit value.

The problem comes from the use of `array_merge_recursive` with associative arrays. Instead of overriding the first array entry with the second, instead it will create an array containing both values.

Per the [doc](http://php.net/manual/fr/function.array-merge-recursive.php)

> If the input arrays have the same string keys, then the values for these keys are merged together into an array, and this is done recursively

**The solution**

By using `array_replace_recursive`, the config keys are replace and the override is then possible.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
