### PR TITLE
Fix integration test too long to execute

### DIFF
--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListOffsetProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/ListOffsetProductModelIntegration.php
@@ -163,7 +163,7 @@ JSON;
         $client = $this->createAuthenticatedClient([], [], null, null, 'mary', 'mary');
 
         $productModels = [];
-        for ($i = 0; $i <= 10001; $i++) {
+        for ($i = 0; $i <= 201; $i++) {
             $productModel = $this->get('pim_catalog.factory.product_model')->create();
             $this->get('pim_catalog.updater.product_model')
                 ->update($productModel, [
@@ -174,7 +174,6 @@ JSON;
         }
 
         $this->get('pim_catalog.saver.product_model')->saveAll($productModels);
-        $this->get('akeneo_elasticsearch.client.product_model')->refreshIndex();
 
         $client->request('GET', 'api/rest/v1/product-models?page=101&limit=100');
 


### PR DESCRIPTION
## Description

One of the integration tests is way too long to execute (almost 2 minutes) and do not work anymore with the new CI settings. This PR diminish the number of product models generated (10001 were generated when 201 is enough).

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
