### PR TITLE
PIM-7560: add require in conf

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/LoadingMask.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/LoadingMask.less
@@ -34,4 +34,11 @@
   height: 100%;
   z-index: 950;
   background-size: 60px;
+  transition-delay: .1s;
+
+  &--hidden {
+    opacity: 0;
+    height: 0;
+    transition-delay: 0s;
+  }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/QuickEdit.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/QuickEdit.less
@@ -11,4 +11,10 @@
   overflow-y: auto;
   margin-left: 70px;
   align-self: flex-start;
+  transition: .2s ease-in-out opacity, .2s ease-in-out transform;
+
+  &--hidden {
+    opacity: 0;
+    transform: translate(0, -100px);
+  }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

Most of the time, when we do a registry in front (for fetchers or controller) we pass path to the module and then the module require them with `require`
problem with this solution is that `require` is async
So here is a small PR to add a "symfony like" service system that replace any `@my/module/path` by `require('my/module/path')`
what's cool is that, it doesn't make the code bigger, it is totally retro compatible with our current code (and integrator's one) and allow us to remove all those async requires

Allow to define require in the requirejs conf to be able to synchronously require modules by configuration an ease the creation of registries

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
