### PR TITLE
[PIM-7598] Fix locale change on reference data on simple and multi select

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-7628: Fix the initialization of the product datagrid identifier filter.
 - PIM-7594: Fix memory leak in `pim:versioning:purge` command
 - PIM-7635: Fix elasticsearch config override
+- PIM-7598: Fix locale change on reference data on simple and multi select
 
 ## BC breaks
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -38,6 +38,7 @@ define(
             fieldTemplate: _.template(fieldTemplate),
             choicePromise: null,
             promiseIdentifiers: null,
+            choiceUrl: null,
             events: {
                 'change .field-input:first input.select-field': 'updateModel',
                 'click .add-attribute-option': 'createOption'
@@ -128,7 +129,12 @@ define(
                                 UserContext.get('catalogScope')
                             ).data;
 
-                            if (null === this.choicePromise || this.promiseIdentifiers !== identifiers) {
+                            if (
+                                null === this.choicePromise
+                                || this.promiseIdentifiers !== identifiers
+                                || this.choiceUrl !== choiceUrl
+                            ) {
+                                this.choiceUrl = choiceUrl;
                                 this.choicePromise = $.get(choiceUrl, {
                                     options: {
                                         identifiers: identifiers
@@ -150,6 +156,7 @@ define(
 
                                     return _.findWhere(results, {id: choice});
                                 }.bind(this));
+
                                 callback(_.compact(choices));
                             }.bind(this));
                         }.bind(this),

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/simple-select-field.js
@@ -25,6 +25,7 @@ define(
             fieldTemplate: _.template(fieldTemplate),
             choicePromise: null,
             promiseIdentifier: null,
+            choiceUrl: null,
             events: {
                 'change .field-input:first input[type="hidden"].select-field': 'updateModel',
                 'click .add-attribute-option': 'createOption'
@@ -108,7 +109,12 @@ define(
                         initSelection: function (element, callback) {
                             var id = $(element).val();
                             if ('' !== id) {
-                                if (null === this.choicePromise || this.promiseIdentifier !== id) {
+                                if (
+                                    null === this.choicePromise
+                                    || this.promiseIdentifier !== id
+                                    || this.choiceUrl !== choiceUrl
+                                ) {
+                                    this.choiceUrl = choiceUrl;
                                     this.choicePromise = $.get(choiceUrl, {options: {identifiers: [id]}});
                                     this.promiseIdentifier = id;
                                 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The issue is:
- Create a simple/multi ref data
- Do all the stuff to display it in the PEF
- Select a value on the field
- Change locale
- It does not change the value according to the locale.

The bug is:
There is a cache to do not execute the query if it is already done previously. But this query is not re-executed even if the URL has changed. And on the case of the Ref Data, the URL changes to include dataLocale=xx_xx in it.

The fix is:
I added a condition to clear the promise cache if the URL change.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
