### PR TITLE
PIM-7647: Export products various errors

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,7 @@
 # 2.3.x
 
+- PIM-7647: Fix completeness filter on the product export builder
+
 # 2.3.7 (2018-09-11)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/completeness.js
@@ -26,7 +26,7 @@ define([
          * {@inheritdoc}
          */
         configure: function () {
-            this.on('locales:update:after', this.updateState.bind(this));
+            this.listenTo(this.parentForm.getRoot(), 'locales:update:after', this.updateState.bind(this));
             this.listenTo(this.getRoot(), 'pim_enrich:form:entity:pre_update', function (data) {
                 _.defaults(data, {field: this.getCode(), operator: _.first(this.config.operators), value: 100});
             }.bind(this));

--- a/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Pim/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -56,6 +56,8 @@ jobs:
                         field: completeness
                         operator: '>='
                         value: 100
+                        context:
+                            locales: ['fr_FR', 'en_US', 'de_DE']
                 structure:
                     scope: mobile
                     locales:
@@ -336,6 +338,8 @@ jobs:
                         field: completeness
                         operator: '>='
                         value: 100
+                        context:
+                            locales: ['fr_FR', 'en_US', 'de_DE']
                 structure:
                     scope: mobile
                     locales:

--- a/tests/legacy/features/Context/catalog/apparel/jobs.yml
+++ b/tests/legacy/features/Context/catalog/apparel/jobs.yml
@@ -51,6 +51,8 @@ jobs:
                         field: completeness
                         operator: '>='
                         value: 100
+                        context:
+                            locales: ['fr_FR', 'en_US', 'de_DE']
                 structure:
                     scope: ecommerce
                     locales:
@@ -82,6 +84,8 @@ jobs:
                         field: completeness
                         operator: '>='
                         value: 100
+                        context:
+                            locales: ['fr_FR', 'en_US', 'de_DE']
                 structure:
                     scope: tablet
                     locales:
@@ -110,6 +114,8 @@ jobs:
                         field: completeness
                         operator: '>='
                         value: 100
+                        context:
+                            locales: ['fr_FR', 'en_US', 'de_DE']
                 structure:
                     scope: tablet
                     locales:
@@ -139,6 +145,8 @@ jobs:
                         field: completeness
                         operator: '>='
                         value: 100
+                        context:
+                            locales: ['fr_FR', 'en_US', 'de_DE']
                 structure:
                     scope: print
                     locales:

--- a/tests/legacy/features/Context/catalog/catalog_modeling/jobs.yml
+++ b/tests/legacy/features/Context/catalog/catalog_modeling/jobs.yml
@@ -256,6 +256,8 @@ jobs:
                         field: completeness
                         operator: '<='
                         value: 100
+                        context:
+                            locales: ['fr_FR', 'en_US', 'de_DE']
                     -
                         field: collection.code
                         operator: 'IN'
@@ -292,6 +294,8 @@ jobs:
                         field: completeness
                         operator: '<='
                         value: 100
+                        context:
+                            locales: ['fr_FR', 'en_US', 'de_DE']
                     -
                         field: collection.code
                         operator: 'IN'

--- a/tests/legacy/features/Context/catalog/footwear/jobs.yml
+++ b/tests/legacy/features/Context/catalog/footwear/jobs.yml
@@ -35,6 +35,8 @@ jobs:
                         field: completeness
                         operator: '>='
                         value: 100
+                        context:
+                            locales: ['fr_FR', 'en_US', 'de_DE']
                     -
                         field: categories
                         operator: 'IN CHILDREN'


### PR DESCRIPTION
This PR fixes 2 issues:
- First issue is that the Product exports (CSV/XLSX) were not initialized with the right values (the values it can be set by UI)
- Second issue is that the history adds lines even if the user does nothing because the `configuration` is a JSON and the order of its components changes.

So this PR fix it with:
- addition of the missing locales in the completeness. If the completeness is set to "Complete on at least one selected locale", it should set the context-locales to the current locales (fr, en, de).
- update the code it updates the `configuration` field to keep the order of the fields.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
