### PR TITLE
Move PIM-7484 to 2.3.7 patch

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -13,6 +13,7 @@
 - PIM-7594: Fix memory leak in `pim:versioning:purge` command
 - PIM-7635: Fix elasticsearch config override
 - PIM-7598: Fix locale change on reference data on simple and multi select
+- PIM-7484: Search families and family variants regardless of the current locale
 
 ## BC breaks
 
@@ -41,7 +42,6 @@
 - PIM-7631: Fix API filter product and product model on date with between operator
 - PIM-7613: Fix translations of boolean attributes
 - PIM-7609: Handle 'empty' and 'not empty' filter types in string filter
-- PIM-7484: Search families and family variants regardless of the current locale
 
 # 2.3.5 (2018-08-22)
 


### PR DESCRIPTION
PIM-7484 was in 2.3.6 instead of 2.3.7

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
