### PR TITLE
Improve storage and indexation normalization performance by using variadic function

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_storage.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_storage.yml
@@ -34,7 +34,7 @@ services:
     pim_catalog.normalizer.storage.product.product_values:
         class: '%pim_catalog.normalizer.storage.product.product_values.class%'
         arguments:
-            - '@pim_catalog.normalizer.standard.product.product_values'
+            - '@pim_catalog.normalizer.storage.product.product_value'
         tags:
             - { name: pim_storage_serializer.normalizer, priority: 90 }
         lazy: true

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Indexing/Value/ValueCollectionNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Indexing/Value/ValueCollectionNormalizer.php
@@ -28,11 +28,12 @@ class ValueCollectionNormalizer implements NormalizerInterface, SerializerAwareI
      */
     public function normalize($values, $format = null, array $context = [])
     {
-        $result = [];
+        $normalizedValues = [];
         foreach ($values as $value) {
-            $normalizedValue = $this->serializer->normalize($value, $format, $context);
-            $result = array_merge_recursive($result, $normalizedValue);
+            $normalizedValues[] = $this->serializer->normalize($value, $format, $context);
         }
+
+        $result = empty($normalizedValues) ? [] : array_replace_recursive(...$normalizedValues);
 
         return $result;
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Storage/Product/ProductValuesNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Storage/Product/ProductValuesNormalizer.php
@@ -14,26 +14,30 @@ use Symfony\Component\Serializer\SerializerAwareTrait;
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductValuesNormalizer implements NormalizerInterface, SerializerAwareInterface
+class ProductValuesNormalizer implements NormalizerInterface
 {
-    use SerializerAwareTrait;
+    /** @var NormalizerInterface */
+    private $valueNormalizer;
+
+    /**
+     * @param NormalizerInterface $valueNormalizer
+     */
+    public function __construct(NormalizerInterface $valueNormalizer)
+    {
+        $this->valueNormalizer = $valueNormalizer;
+    }
 
     /**
      * {@inheritdoc}
      */
     public function normalize($values, $format = null, array $context = [])
     {
-        $result = [];
+        $normalizedValues = [];
         foreach ($values as $value) {
-            $normalizedValue = $this->serializer->normalize($value, $format, $context);
-            $attributeCode = $value->getAttribute()->getCode();
-
-            if (!isset($result[$attributeCode])) {
-                $result[$attributeCode] = [];
-            }
-
-            $result[$attributeCode] = array_merge_recursive($result[$attributeCode], $normalizedValue[$attributeCode]);
+            $normalizedValues[] = $this->valueNormalizer->normalize($value, $format, $context);
         }
+
+        $result = empty($normalizedValues) ? [] : array_replace_recursive(...$normalizedValues);
 
         return $result;
     }

--- a/src/Akeneo/Pim/Enrichment/Component/spec/Product/Normalizer/Indexing/Value/ValueCollectionNormalizerSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Component/spec/Product/Normalizer/Indexing/Value/ValueCollectionNormalizerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Akeneo\Pim\Enrichment\Component\Product\Normalizer\Indexing\Value;
 
+use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueCollection;
@@ -40,6 +41,10 @@ class ValueCollectionNormalizerSpec extends ObjectBehavior
             ->shouldReturn(false);
         $this->supportsNormalization($valueCollection, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->shouldReturn(true);
+    }
+
+    function it_normalizes_an_empty_value_collection() {
+        $this->normalize(new ValueCollection(), ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX,[])->shouldReturn([]);
     }
 
     function it_normalizes_product_value_collection(


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

### Problem

The normalization of PV is time consuming for the PHP process and the complexity is not linear.

As stated it in this article [No array_merge In Loops](https://github.com/dseguy/clearPHP/blob/master/rules/no-array_merge-in-loop.md), array_merge is inefficient in a loop.

```
$result = [];
foreach ($source as $list) {
  $result = array_merge($result, $list);
}
```

At first loop, array_merge copy the variable `$result` having a size of 1.
At second loop, array_merge copy the variable `$result` having a size of 2.
At third loop, array_merge copy the variable `$result` having a size of 3.... etc


The complexity is `*O(n^2)* (where n is the number of PV).  
Explanation: 1 + 2 + 3 + ....  is a suite. Formula: O(n*(n+1)/2) => O(n^2/2) => O(n^2)

### Solution

Use variadic function to not copy the `$result` array in each loop, but only one time.
The complexity is *O(n)* as seen in the graph.

And proof:
https://gist.github.com/ahocquard/e24346317511c359213bb79ba42652c2

![results_array_merge_10000](https://user-images.githubusercontent.com/1942439/46025582-9389e180-c0e9-11e8-93b6-4f8695968d88.png)

### How I saw that?

When I did a very simple POC to test:
- the limit of the DB
- by normalizing product values
- 1 transaction/product (not the real product of the PIM)
- 5000 PV

Before fix:
- 8 seconds for the saving part of the values in the DB
- 193 seconds for the normalization part (x24!)

After fix:
- 8 seconds for the saving part of the values in the DB
- 8 seconds for the normalization part


### What does it change in import?

I tested it quickly.
For now, almost nothing, as doing other tasks is far most costly due to the number of IO we are doing.
But it costs nothing and it will be a problem after optimisation of the PIM.
Normalisation of the product values is very important and have to be optimised the best we can (for reading and writing).


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Yes
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed



Note: green CI, tests already failing on master