### PR TITLE
Don't dispatch LOAD_FIXTURES events when the fixtures step is not run

### DIFF
--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -125,18 +125,19 @@ class DatabaseCommand extends ContainerAwareCommand
         // TODO: Should be in an event subscriber
         $this->createNotMappedTables($output);
 
-        $this->getEventDispatcher()->dispatch(
-            InstallerEvents::PRE_LOAD_FIXTURES,
-            new InstallerEvent($this->commandExecutor)
-        );
-
         if (false === $input->getOption('withoutFixtures')) {
+            $this->getEventDispatcher()->dispatch(
+                InstallerEvents::PRE_LOAD_FIXTURES,
+                new InstallerEvent($this->commandExecutor)
+            );
+
             $this->loadFixturesStep($input, $output);
+
+            $this->getEventDispatcher()->dispatch(
+                InstallerEvents::POST_LOAD_FIXTURES,
+                new InstallerEvent($this->commandExecutor)
+            );
         }
-        $this->getEventDispatcher()->dispatch(
-            InstallerEvents::POST_LOAD_FIXTURES,
-            new InstallerEvent($this->commandExecutor)
-        );
 
         // TODO: Should be in an event subscriber
         $this->launchCommands();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Don't dispatch PRE_LOAD_FIXTURES and POST_LOAD fixtures during install if the fixtures step is not run.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
