### PR TITLE
PIM-7653: Fix product export builder when completeness should export products complete on at least one locale

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7653: Fix product export builder when completeness should export products complete on at least one locale
+
 # 2.3.8 (2018-09-14)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/Product/CompletenessFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/Product/CompletenessFilter.php
@@ -78,6 +78,9 @@ class CompletenessFilter extends AbstractFieldFilter implements FieldFilterInter
         )) {
             $this->checkOptions($field, $options);
             $localeCodes = $options['locales'];
+        } elseif ($operator === Operators::GREATER_OR_EQUALS_THAN_ON_AT_LEAST_ONE_LOCALE && array_key_exists('locales', $options)) {
+            $this->checkOptions($field, $options);
+            $localeCodes = $options['locales'];
         } else {
             $localeCodes = (null !== $locale) ? [$locale] : $this->getChannelByCode($channel)->getLocaleCodes();
         }

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/Product/CompletenessFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/Product/CompletenessFilterSpec.php
@@ -471,6 +471,28 @@ class CompletenessFilterSpec extends ObjectBehavior
         );
     }
 
+    function it_adds_a_filter_on_GREATER_OR_EQUALS_THAN_ON_AT_LEAST_ONE_LOCALE_operator_with_locales($sqb)
+    {
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['range' => ['completeness.ecommerce.en_US' => ['gte' => 56]]]
+                    ]
+                ]
+            ]
+        )->shouldBeCalled();
+
+        $this->addFieldFilter(
+            'completeness',
+            Operators::GREATER_OR_EQUALS_THAN_ON_AT_LEAST_ONE_LOCALE,
+            56,
+            null,
+            'ecommerce',
+            ['locales' => ['en_US']]
+        );
+    }
+
     function it_adds_a_filter_on_GREATER_OR_EQUALS_THAN_ON_ALL_LOCALES_operator($sqb)
     {
         $sqb->addFilter(

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/Product/CompletenessFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/Product/CompletenessFilterIntegration.php
@@ -209,7 +209,17 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
 
     public function testOperatorGreaterOrEqualThanOnAtLeastOneLocale()
     {
-        $this->doTestOperatorSuperiorOrEqual(Operators::GREATER_OR_EQUALS_THAN_ON_AT_LEAST_ONE_LOCALE);
+        $operator = Operators::GREATER_OR_EQUALS_THAN_ON_AT_LEAST_ONE_LOCALE;
+        $this->doTestOperatorSuperiorOrEqual($operator);
+
+        $result = $this->executeFilter([['completeness', $operator, 100, ['scope' => 'ecommerce', 'locales' => ['en_US']]]]);
+        $this->assert($result, []);
+
+        $result = $this->executeFilter([['completeness', $operator, 100, ['scope' => 'tablet', 'locales' => ['de_DE']]]]);
+        $this->assert($result, []);
+
+        $result = $this->executeFilter([['completeness', $operator, 80, ['scope' => 'tablet', 'locales' => ['en_US', 'de_DE']]]]);
+        $this->assert($result, ['product_two']);
     }
 
     private function doTestOperatorSuperiorOrEqual($operator)

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
@@ -12,7 +12,7 @@ extensions:
         config:
             neverEmpty: true
             operators:
-                - ">="
+                - GREATER OR EQUALS THAN ON AT LEAST ONE LOCALE
                 - ALL
                 - GREATER OR EQUALS THAN ON ALL LOCALES
                 - LOWER THAN ON ALL LOCALES

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en.yml
@@ -888,7 +888,7 @@ pim_enrich:
                     help: Select the products to export by their completeness.
                     operators:
                         ALL: No condition on completeness
-                        ">=": Complete on at least one selected locale
+                        "GREATER OR EQUALS THAN ON AT LEAST ONE LOCALE": Complete on at least one selected locale
                         "GREATER OR EQUALS THAN ON ALL LOCALES": Complete on all selected locales
                         LOWER THAN ON ALL LOCALES: Not complete on all selected locales
                         AT LEAST COMPLETE: At least one child product complete on one selected locale


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

In the product export builder, we can choose what kind of completeness we want, and one of them is "Complete on at least one locale" with the operator `>=` which is a mistake because this operator checks the completeness for all activated locales. 
That's mean if you configure your export builder to export only products completed on the locale `de_DE`, if your product is completed on the locale `fr_FR`, it will be exported.

I changed this operator to `GREATER_OR_EQUALS_THAN_ON_AT_LEAST_ONE_LOCALE` and changed the pqb to be able to add multiple locales (it's validated by PO).



<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
