### PR TITLE
TIP-873: remove EE datagrid bundle

### DIFF
--- a/bin/check-pullup
+++ b/bin/check-pullup
@@ -195,6 +195,7 @@ $pullUpOk = $check(
         ),
         new ForbiddenDirectory('src/PimEnterprise/Bundle/WorkflowBundle', new Moved('src/Akeneo/Pim/WorkOrganization')),
         new ForbiddenDirectory('src/PimEnterprise/Bundle/InstallerBundle', new Moved('src/Akeneo/Platform')),
+        new ForbiddenDirectory('src/PimEnterprise/Bundle/DataGridBundle', Dispatched::mainEnterpriseBusinessTopics()),
 
         // Enterprise Components
         new ForbiddenDirectory('src/PimEnterprise/Component/Api', Dispatched::mainEnterpriseBusinessTopics()),

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/data_sources.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/data_sources.yml
@@ -183,3 +183,5 @@ services:
             - [addProductDatasource, ['pim_datasource_associated_product']]
             - [addProductDatasource, ['pim_datasource_associated_product_model']]
             - [addProductDatasource, ['pim_datasource_group_product']]
+            - [addProductDatasource, ['pimee_datasource_published_product']]
+            - [addProductDatasource, ['pimee_datasource_proposal_product']]

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/extensions.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/extensions.yml
@@ -36,5 +36,6 @@ services:
         calls:
             - [addEligibleDatasource, ['pim_datasource_product']]
             - [addEligibleDatasource, ['pim_datasource_associated_product']]
+            - [addEligibleDatasource, ['pimee_datasource_published_product']]
         tags:
              - { name: oro_datagrid.extension }

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/mass_actions.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/mass_actions.yml
@@ -19,7 +19,7 @@ services:
             - '@oro_datagrid.datagrid.manager'
             - '@oro_datagrid.datagrid.request_params'
             - '@oro_datagrid.mass_action.parameters_parser'
-            - ['product-grid']
+            - ['product-grid', 'proposal-grid', 'published-product-grid']
 
     # Handlers
     pim_datagrid.extension.mass_action.handler.edit:

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/pagers.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/pagers.yml
@@ -17,3 +17,5 @@ services:
                 - 'association-product-model-grid'
                 - 'product-group-grid'
                 - 'association-product-picker-grid'
+                - 'published-product-grid'
+                - 'proposal-grid'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product.yml
@@ -119,7 +119,6 @@ datagrid:
                 type: edit
                 acl_resource: pim_enrich_mass_edit
                 label: pim_datagrid.mass_action.mass_edit
-                handler: product_mass_edit
                 route: pim_enrich_mass_edit_action
                 className: 'AknButton AknButton--action AknButtonList-item'
                 route_parameters:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/requirejs.yml
@@ -331,6 +331,8 @@ config:
                     module: pim/controller/redirect
                 pim_enrich_mass_edit_action:
                     module: pim/controller/mass-edit
+                    config:
+                        route: pim_enrich_mass_edit_rest_get_filter
                     aclResourceId: pim_enrich_mass_edit
                 pim_enrich_family_index:
                     module: pim/controller/common/index

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/mass-edit.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/mass-edit.js
@@ -15,6 +15,13 @@ define(
             /**
              * {@inheritdoc}
              */
+            initialize: function (options) {
+                this.config = options.config;
+            },
+
+            /**
+             * {@inheritdoc}
+             */
             renderForm: function (route, path) {
                 var query = path.replace(route.route.tokens[0][1], '');
                 var parameters = _.chain(query.split('&'))
@@ -32,7 +39,7 @@ define(
                 }).value.replace(new RegExp('_', 'g'), '-');
 
                 return $.ajax({
-                    url: Routing.generate('pim_enrich_mass_edit_rest_get_filter') + query
+                    url: Routing.generate(this.config.route) + query
                 }).then((response) => {
                     const filters = response.filters;
                     const itemsCount = response.itemsCount;


### PR DESCRIPTION
> Isn't it dirty (or at least weird) to add some Enterprise Edition related parameters in the datagrid services?

### TL;DR: 

Yes it is. But decoupling those services per context isn't possible because of the grid architecture. Overriding those services (like it was before this PR) is not acceptable : we want to get rid of the Datagrid Bundle override and enforce context decoupling. So here is the last solution. Please note that the _PimDataGridBundle_ is considered as technical debt.

### Long explanation:

Let's take example of the `pim_datagrid.extension.pager.pager_resolver` service. The logic is more or less the same for the other services. This service is overridden in Enterprise Edition for adding the grids `published-product-grid` and `proposal-grid`.

My first wish was to create a pager service per context:
    - pager A : for the classical grid using the ORM pagination (channels, attributes...)
    - pager B : for the Community products' grids using Elasticsearch (products, associations...)
    - pager C : for the Enterprise workflow's grids (published and proposals)
We end up with 3 pager services.

The main problem is that a grid does not define which pager service it can use (it's called an _extension_ in the grids realm). Instead, a pager defines which grid it can be plugged to (it's called _applicable_ in the grids realm). _All pagers are added to all applicable grids._
Ok so it's easy:
    - pager B is applicable to the grids products, associations and a few others
    - pager C is applicable to the grids published and proposals
    - pager A should be applicable to all other grids <= here is the problem

We have 2 possibilities for the pager A:
    - we give it the grids it should not apply for (ie: products, associations, published, proposals...). Which leads us to the same problem that the current PR.
    - we give it all grids it should apply for (channels, attributes...). We (and integrators/customers) don't have a default pager anymore when we create a new grid. 

That's why I preferred to pollute the Community _PimDataGridBundle_ with those parameters.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
