### PR TITLE
PIM-7652: Fix concurrent edition with the parent of a product or a product model in the UI

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -8,6 +8,7 @@
   - Please, for this fix, if you implemented `Pim\Component\Catalog\Model\AbstractValue` in specific code be warned that
     the `isEqual(ValueInterface $value)` method does not work due to a bug. Please, implement it in your own code for
     your specific business.
+- PIM-7652: Fix concurrent edition with the parent of a product or a product model in the UI
 
 # 2.3.8 (2018-09-14)
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
@@ -16,6 +16,7 @@ use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\ProductModel\Filter\ProductModelAttributeFilter;
 use Pim\Component\Catalog\Repository\FamilyVariantRepositoryInterface;
 use Pim\Component\Catalog\Repository\ProductModelRepositoryInterface;
 use Pim\Component\Enrich\Converter\ConverterInterface;
@@ -84,7 +85,12 @@ class ProductModelController
     /** @var FamilyVariantRepositoryInterface */
     private $familyVariantRepository;
 
+    /** @var ProductModelAttributeFilter */
+    private $productModelAttributeFilter;
+
     /**
+     * TODO: (merge) remove null
+     *
      * @param ProductModelRepositoryInterface   $productModelRepository
      * @param NormalizerInterface               $normalizer
      * @param UserContext                       $userContext
@@ -101,6 +107,7 @@ class ProductModelController
      * @param SimpleFactoryInterface            $productModelFactory
      * @param NormalizerInterface               $violationNormalizer
      * @param FamilyVariantRepositoryInterface  $familyVariantRepository
+     * @param ProductModelAttributeFilter       $productModelAttributeFilter
      */
     public function __construct(
         ProductModelRepositoryInterface $productModelRepository,
@@ -118,7 +125,8 @@ class ProductModelController
         EntityWithFamilyVariantNormalizer $entityWithFamilyVariantNormalizer,
         SimpleFactoryInterface $productModelFactory,
         NormalizerInterface $violationNormalizer,
-        FamilyVariantRepositoryInterface $familyVariantRepository
+        FamilyVariantRepositoryInterface $familyVariantRepository,
+        ProductModelAttributeFilter $productModelAttributeFilter = null
     ) {
         $this->productModelRepository        = $productModelRepository;
         $this->normalizer                    = $normalizer;
@@ -136,6 +144,7 @@ class ProductModelController
         $this->productModelFactory           = $productModelFactory;
         $this->violationNormalizer = $violationNormalizer;
         $this->familyVariantRepository = $familyVariantRepository;
+        $this->productModelAttributeFilter = $productModelAttributeFilter;
     }
 
     /**
@@ -454,6 +463,11 @@ class ProductModelController
             $data = array_replace($data, $dataFiltered);
         } else {
             $data['values'] = [];
+        }
+
+        // TODO : @merge remove null
+        if (!$productModel->isRoot() && null !== $this->productModelAttributeFilter) {
+            $data = $this->productModelAttributeFilter->filter($data);
         }
 
         $this->productModelUpdater->update($productModel, $data);

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -359,7 +359,7 @@ services:
             - '@pim_enrich.converter.enrich_to_standard.product_value'
             - '@pim_enrich.normalizer.product_violation'
             - '@pim_catalog.builder.product'
-            - '@pim_catalog.association.filter.parent_associations'
+            - '@pim_enrich.filter.product_attribute_filter'
 
     pim_enrich.controller.rest.product_model:
         class: '%pim_enrich.controller.rest.product_model.class%'
@@ -380,6 +380,7 @@ services:
             - '@pim_catalog.factory.product_model'
             - '@pim_enrich.normalizer.violation'
             - '@pim_catalog.repository.family_variant'
+            - '@pim_enrich.filter.product_model_attribute_filter'
 
     pim_enrich.controller.rest.product_category:
         class: '%pim_enrich.controller.rest.product_category.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/filters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/filters.yml
@@ -16,3 +16,18 @@ services:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.locale'
             - '@pim_catalog.repository.channel'
+
+    pim_enrich.filter.product_attribute_filter:
+        class: 'Pim\Component\Catalog\ProductModel\Filter\ProductAttributeFilter'
+        arguments:
+            - '@pim_catalog.repository.product_model'
+            - '@pim_catalog.repository.cached_family'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.cached_attribute'
+
+    pim_enrich.filter.product_model_attribute_filter:
+        class: 'Pim\Component\Catalog\ProductModel\Filter\ProductModelAttributeFilter'
+        arguments:
+            - '@pim_catalog.repository.family_variant'
+            - '@pim_catalog.repository.product_model'
+            - '@pim_catalog.repository.cached_attribute'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**


01.	Logged in as Admin, select a product model in the grid 
02. In another browser, logged in as Mary, select a product variant from the product model selected by Admin. 
03. With Admin, edit any product model attributes, SAVE. 
04. With Mary, any product variant attribute, SAVE. 
05. It fails.

The error is due to the fact that we don't filter product values coming from the parent.
As in the import or in the API, we have to filter it.

I reproduced it also with a product model and its parent.

Note: As it's about concurrency, it is not testable (and I think it would be overkill to do that).

Note 2: 
I check in the backend if it's a creation of a product or an update by checking if the product has an id or not.
I do it because when creating a variant product, the frontend does not send the identifier if the identifier is empty. And I need it to filter the values from the parent during an update.
I tried (very hard) to fix the frontend to send the property "identifier" instead of passing it as a product value.
But:
- it does not catch properly errors from the backend because the sku does not match on the the value (`attribute: sku, message:..`.)
- I tried to use the module used for the creation of a simple product: it does not work

I know it's not the best, but I passed a lot of time to find the good solution without understanding how it properly works. So, I stick with this solution for this SLA.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added legacy Behats               | No
| Added acceptance tests            | No
| Added integration tests           | No
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
