### PR TITLE
PIM-7629: Refactor the way we aggregate ES search results for datagrid

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -10,6 +10,7 @@
 
 - PIM-7663: Fix API endpoint that list products updated since N days
 - PIM-7658: Do not expose disabled locale
+- PIM-7629: Fix category filter in product grid
 - PIM-7653: Fix product export builder when completeness should export products complete on at least one locale
 - PIM-7650: Fix Values comparison. Allows to save a variant product with a metric as variant axe.
   - Please, for this fix, if you implemented `Pim\Component\Catalog\Model\AbstractValue` in specific code be warned that

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7629: Fix category filter in product grid
 - PIM-7659: Fix search on the families to get all the results when they have same translations for many locales.
 
 # 2.3.9 (2018-09-25)
@@ -10,7 +11,6 @@
 
 - PIM-7663: Fix API endpoint that list products updated since N days
 - PIM-7658: Do not expose disabled locale
-- PIM-7629: Fix category filter in product grid
 - PIM-7653: Fix product export builder when completeness should export products complete on at least one locale
 - PIM-7650: Fix Values comparison. Allows to save a variant product with a metric as variant axe.
   - Please, for this fix, if you implemented `Pim\Component\Catalog\Model\AbstractValue` in specific code be warned that

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductAndProductModelQueryBuilderIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/ProductAndProductModelQueryBuilderIntegration.php
@@ -705,4 +705,32 @@ class ProductAndProductModelQueryBuilderIntegration extends AbstractProductAndPr
         ];
         $this->assert($result, $expectedResult);
     }
+
+    public function testSearchColorRedInASubCategoryAndHisChildren()
+    {
+        $result = $this->executeFilter(
+            [
+                ['color', Operators::IN_LIST, ['yellow']],
+                [
+                    'categories',
+                    Operators::IN_CHILDREN_LIST,
+                    [
+                        'master_men_blazers'
+                    ],
+                ],
+            ]
+        );
+
+        $expectedResult = [
+            // Are in category "deals" (wich is a child of "Men">"Blazers" categorie) and have Color = "yellow"
+            '1111111213',
+            '1111111214',
+            '1111111215',
+            '1111111216',
+            'apollon_yellow',
+            'ares_yellow'
+        ];
+        $this->assert($result, $expectedResult);
+    }
+
 }

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -31,6 +31,8 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
     /**
      * @param ProductQueryBuilderInterface                $pqb
      * @param ProductAndProductModelSearchAggregator|null $searchAggregator
+     *
+     * @todo @merge - remove null
      */
     public function __construct(
         ProductQueryBuilderInterface $pqb,
@@ -95,6 +97,7 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
             $this->addFilter('parent', Operators::IS_EMPTY, null);
         }
 
+        /** @todo @merge remove null != $this->searchAggregator on master */
         if (!$this->hasRawFilter('field', 'parent') && null !== $this->searchAggregator) {
             $this->searchAggregator->aggregateResults($this->getQueryBuilder(), $this->getRawFilters());
         }

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -25,12 +25,19 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
     /** @var ProductQueryBuilderInterface */
     private $pqb;
 
+    /** @var ProductAndProductModelSearchAggregator */
+    private $searchAggregator;
+
     /**
-     * @param ProductQueryBuilderInterface $pqb
+     * @param ProductQueryBuilderInterface                $pqb
+     * @param ProductAndProductModelSearchAggregator|null $searchAggregator
      */
-    public function __construct(ProductQueryBuilderInterface $pqb)
-    {
+    public function __construct(
+        ProductQueryBuilderInterface $pqb,
+        ProductAndProductModelSearchAggregator $searchAggregator = null
+    ) {
         $this->pqb = $pqb;
+        $this->searchAggregator = $searchAggregator;
     }
 
     /**
@@ -88,8 +95,8 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
             $this->addFilter('parent', Operators::IS_EMPTY, null);
         }
 
-        if (!$this->hasRawFilter('field', 'parent')) {
-            $this->aggregateResults();
+        if (!$this->hasRawFilter('field', 'parent') && null !== $this->searchAggregator) {
+            $this->searchAggregator->aggregateResults($this->getQueryBuilder(), $this->getRawFilters());
         }
 
         return $this->pqb->execute();
@@ -169,113 +176,5 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
         ));
 
         return $hasFilter;
-    }
-
-    /**
-     * Aggregates the results by taking advantage of the raw filters defined on the attributes and the categories.
-     */
-    private function aggregateResults(): void
-    {
-        $clauses = [];
-        $attributeCodes = $this->getAttributeCodes();
-        foreach ($attributeCodes as $attributeCode) {
-            $clauses[] = [
-                'terms' => ['attributes_of_ancestors' => [$attributeCode]],
-            ];
-        }
-
-        $categoryCodes = $this->getCategoryCodes();
-        if (!empty($categoryCodes)) {
-            $clauses[] = [
-                'terms' => ['categories_of_ancestors' => $categoryCodes],
-            ];
-        }
-
-        if (!empty($clauses)) {
-            $this->getQueryBuilder()->addFilter([
-                'bool' => [
-                    'must_not' => [
-                        'bool' => [
-                            'filter' => $clauses,
-                        ],
-                    ],
-                ],
-            ]);
-        }
-
-        $attributeCodesWithIsEmptyOperator = $this->getAttributeCodesWithIsEmptyOperator();
-        if (!empty($attributeCodesWithIsEmptyOperator)) {
-            $this->getQueryBuilder()->addFilter([
-                'terms' => [
-                    'attributes_for_this_level' => $attributeCodesWithIsEmptyOperator,
-                ],
-            ]);
-        }
-    }
-
-    /**
-     * Returns the attribute codes for which there is a filter on.
-     *
-     * @return string[]
-     */
-    private function getAttributeCodes(): array
-    {
-        $attributeFilters = array_filter(
-            $this->getRawFilters(),
-            function ($filter) {
-                return 'attribute' === $filter['type'];
-            }
-        );
-
-        return array_column($attributeFilters, 'field');
-    }
-
-    /**
-     * Returns the category codes for which there is a filter on.
-     *
-     * @return string[]
-     */
-    private function getCategoryCodes(): array
-    {
-        $categoriesFilter = array_filter(
-            $this->getRawFilters(),
-            function ($filter) {
-                return 'field' === $filter['type'] &&
-                    'categories' === $filter['field'] &&
-                    (Operators::IN_LIST === $filter['operator'] || Operators::IN_CHILDREN_LIST === $filter['operator']);
-            }
-        );
-
-        $categoryCodes = [];
-        foreach ($categoriesFilter as $categoryFilter) {
-            $categoryCodes = array_merge($categoryCodes, $categoryFilter['value']);
-        }
-
-        return $categoryCodes;
-    }
-
-    /**
-     * Returns the attribute codes for which there is a filter on with operator IsEmpty
-     *
-     * @return string[]
-     */
-    private function getAttributeCodesWithIsEmptyOperator(): array
-    {
-        $attributeFilters = array_filter(
-            $this->getRawFilters(),
-            function ($filter) {
-                $operator = $filter['operator'];
-
-                return
-                    'attribute' === $filter['type'] &&
-                    (
-                        Operators::IS_EMPTY === $operator ||
-                        Operators::IS_EMPTY_FOR_CURRENCY === $operator ||
-                        Operators::IS_EMPTY_ON_ALL_CURRENCIES === $operator
-                    );
-            }
-        );
-
-        return array_column($attributeFilters, 'field');
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilderFactory.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilderFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\ProductQueryBuilder;
+
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+
+/**
+ * @author    Philippe Mossière <philippe.mossiere@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProductAndProductModelQueryBuilderFactory implements ProductQueryBuilderFactoryInterface
+{
+    /** @var string */
+    private $pqbClass;
+
+    /** @var ProductQueryBuilderFactoryInterface */
+    private $factory;
+
+    /** @var ProductAndProductModelSearchAggregator */
+    private $resultAggregator;
+
+    public function __construct(
+        string $pqbClass,
+        ProductQueryBuilderFactoryInterface $factory,
+        ProductAndProductModelSearchAggregator $resultAggregator = null
+    ) {
+        $this->pqbClass = $pqbClass;
+        $this->factory = $factory;
+        $this->resultAggregator = $resultAggregator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $options = []): ProductQueryBuilderInterface
+    {
+        $basePqb = $this->factory->create($options);
+
+        return new $this->pqbClass($basePqb, $this->resultAggregator);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilderFactory.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilderFactory.php
@@ -21,16 +21,16 @@ class ProductAndProductModelQueryBuilderFactory implements ProductQueryBuilderFa
     private $factory;
 
     /** @var ProductAndProductModelSearchAggregator */
-    private $resultAggregator;
+    private $searchAggregator;
 
     public function __construct(
         string $pqbClass,
         ProductQueryBuilderFactoryInterface $factory,
-        ProductAndProductModelSearchAggregator $resultAggregator = null
+        ProductAndProductModelSearchAggregator $searchAggregator = null
     ) {
         $this->pqbClass = $pqbClass;
         $this->factory = $factory;
-        $this->resultAggregator = $resultAggregator;
+        $this->searchAggregator = $searchAggregator;
     }
 
     /**
@@ -40,6 +40,6 @@ class ProductAndProductModelQueryBuilderFactory implements ProductQueryBuilderFa
     {
         $basePqb = $this->factory->create($options);
 
-        return new $this->pqbClass($basePqb, $this->resultAggregator);
+        return new $this->pqbClass($basePqb, $this->searchAggregator);
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelSearchAggregator.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelSearchAggregator.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\ProductQueryBuilder;
+
+use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * Aggregates the results by taking advantage of the raw filters defined on the attributes and the categories.
+ *
+ * @author    Philippe Mossière <philippe.mossiere@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProductAndProductModelSearchAggregator
+{
+    /** @var CategoryRepositoryInterface */
+    private $categoryRepository;
+
+    /**
+     * @param CategoryRepositoryInterface $categoryRepository
+     */
+    public function __construct(CategoryRepositoryInterface $categoryRepository)
+    {
+        $this->categoryRepository = $categoryRepository;
+    }
+
+    /**
+     * @param SearchQueryBuilder $searchQueryBuilder
+     * @param array              $rawFilters
+     *
+     * @return SearchQueryBuilder
+     */
+    public function aggregateResults(SearchQueryBuilder $searchQueryBuilder, array $rawFilters): SearchQueryBuilder
+    {
+        $clauses = [];
+        $attributeCodes = $this->getAttributeCodes($rawFilters);
+        foreach ($attributeCodes as $attributeCode) {
+            $clauses[] = [
+                'terms' => ['attributes_of_ancestors' => [$attributeCode]],
+            ];
+        }
+
+        $categoryCodes = $this->getCategoryCodes($rawFilters);
+        if (!empty($categoryCodes)) {
+            $clauses[] = [
+                'terms' => ['categories_of_ancestors' => $categoryCodes],
+            ];
+        }
+
+        if (!empty($clauses)) {
+            $searchQueryBuilder->addMustNot(
+                [
+                    'bool' => [
+                        'filter' => $clauses,
+                    ],
+                ]
+            );
+        }
+
+        $attributeCodesWithIsEmptyOperator = $this->getAttributeCodesWithIsEmptyOperator($rawFilters);
+        if (!empty($attributeCodesWithIsEmptyOperator)) {
+            $searchQueryBuilder->addFilter(
+                [
+                    'terms' => [
+                        'attributes_for_this_level' => $attributeCodesWithIsEmptyOperator,
+                    ],
+                ]
+            );
+        }
+
+        return $searchQueryBuilder;
+    }
+
+    /**
+     * Returns the attribute codes for which there is a filter on.
+     *
+     * @param string[] $rawFilters
+     *
+     * @return string[]
+     */
+    private function getAttributeCodes(array $rawFilters): array
+    {
+        $attributeFilters = array_filter(
+            $rawFilters,
+            function ($filter) {
+                return 'attribute' === $filter['type'];
+            }
+        );
+
+        return array_column($attributeFilters, 'field');
+    }
+
+    /**
+     * Returns the category codes for which there is a filter on.
+     *
+     * @param string[] $rawFilters
+     *
+     * @return string[]
+     */
+    private function getCategoryCodes(array $rawFilters): array
+    {
+        $categoriesFilter = array_filter(
+            $rawFilters,
+            function ($filter) {
+                return 'field' === $filter['type'] &&
+                    'categories' === $filter['field'] &&
+                    (Operators::IN_LIST === $filter['operator'] || Operators::IN_CHILDREN_LIST === $filter['operator']);
+            }
+        );
+        $categoryCodes = [];
+        foreach ($categoriesFilter as $categoryFilter) {
+            $categoryCodes = array_merge($categoryCodes, $categoryFilter['value']);
+            if (Operators::IN_CHILDREN_LIST === $categoryFilter['operator']) {
+                $childrenCategory = $this->getAllChildrenCodes($categoryCodes);
+                $categoryCodes = array_merge($categoryCodes, $childrenCategory);
+            }
+        }
+
+        return $categoryCodes;
+    }
+
+    /**
+     * Get children category ids
+     *
+     * @param integer[] $categoryCodes
+     *
+     * @return integer[]
+     */
+    private function getAllChildrenCodes(array $categoryCodes): array
+    {
+        $allChildrenCodes = [];
+        foreach ($categoryCodes as $categoryCode) {
+            $category = $this->categoryRepository->findOneBy(['code' => $categoryCode]);
+            if (null !== $category) {
+                $childrenCodes = $this->categoryRepository->getAllChildrenCodes($category);
+                $childrenCodes[] = $category->getCode();
+                $allChildrenCodes = array_merge($allChildrenCodes, $childrenCodes);
+            }
+        }
+
+        return $allChildrenCodes;
+    }
+
+    /**
+     * Returns the attribute codes for which there is a filter on with operator IsEmpty
+     *
+     * @param string[] $rawFilters
+     *
+     * @return string[]
+     */
+    private function getAttributeCodesWithIsEmptyOperator(array $rawFilters): array
+    {
+        $attributeFilters = array_filter(
+            $rawFilters,
+            function ($filter) {
+                $operator = $filter['operator'];
+
+                return
+                    'attribute' === $filter['type'] &&
+                    (
+                        Operators::IS_EMPTY === $operator ||
+                        Operators::IS_EMPTY_FOR_CURRENCY === $operator ||
+                        Operators::IS_EMPTY_ON_ALL_CURRENCIES === $operator
+                    );
+            }
+        );
+
+        return array_column($attributeFilters, 'field');
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
@@ -3,6 +3,8 @@ parameters:
     pim_enrich.query.elasticsearch.sorter.in_group.class: Pim\Bundle\EnrichBundle\Elasticsearch\Sorter\InGroupSorter
     pim_enrich.elasticsearch.from_size_cursor_factory.class: Pim\Bundle\EnrichBundle\Elasticsearch\FromSizeCursorFactory
     pim_enrich.query.product_and_product_model_query_builder.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelQueryBuilder
+    pim_enrich.query.product_and_product_model_search_aggregator.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelSearchAggregator
+    pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelQueryBuilderFactory
 
 services:
     # Filters
@@ -27,10 +29,11 @@ services:
     # Services used by the products and product models' grid
     # here, products and product models should be gathered by the most top level product model
     pim_enrich.query.product_and_product_model_query_builder_from_size_factory:
-        class: '%pim_catalog.query.elasticsearch.product_and_model_query_builder_factory.class%'
+        class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
         arguments:
             - '%pim_enrich.query.product_and_product_model_query_builder.class%'
             - '@pim_enrich.query.product_query_builder_from_size_factory.with_product_and_product_model_from_size_cursor'
+            - '@pim_enrich.query.product_and_product_model_search_aggregator'
 
     pim_enrich.query.product_query_builder_from_size_factory.with_product_and_product_model_from_size_cursor:
         public: false
@@ -52,3 +55,9 @@ services:
             - '@pim_catalog.repository.product_model'
             - '%pim_job_product_batch_size%'
             - 'pim_catalog_product'
+
+    pim_enrich.query.product_and_product_model_search_aggregator:
+        public: false
+        class: '%pim_enrich.query.product_and_product_model_search_aggregator.class%'
+        arguments:
+            - '@pim_catalog.repository.category'

--- a/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderFactorySpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderFactorySpec.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\ProductQueryBuilder;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelSearchAggregator;
+use Pim\Component\Catalog\Query\ProductAndProductModelQueryBuilder;
+use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
+use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
+
+class ProductAndProductModelQueryBuilderFactorySpec extends ObjectBehavior
+{
+    function let(
+        ProductQueryBuilderFactoryInterface $factory,
+        ProductAndProductModelSearchAggregator $resultAggregator
+    )
+    {
+        $this->beConstructedWith(ProductAndProductModelQueryBuilder::class, $factory, $resultAggregator);
+    }
+
+    function it_is_a_product_query_builder_factory()
+    {
+        $this->shouldImplement(ProductQueryBuilderFactoryInterface::class);
+    }
+
+    function it_creates_a_product_and_product_model_query_builder($factory, ProductQueryBuilderInterface $basePqb)
+    {
+        $factory->create(['default_locale' => 'en_US', 'default_scope' => 'print'])->willReturn($basePqb);
+
+        $this->create(['default_locale' => 'en_US', 'default_scope' => 'print'])->shouldBeAnInstanceOf(
+            ProductAndProductModelQueryBuilder::class
+        );
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
@@ -5,6 +5,7 @@ namespace spec\Pim\Bundle\EnrichBundle\ProductQueryBuilder;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelSearchAggregator;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
@@ -12,9 +13,12 @@ use Prophecy\Argument;
 
 class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 {
-    function let(ProductQueryBuilderInterface $pqb)
+    function let(
+        ProductQueryBuilderInterface $pqb,
+        ProductAndProductModelSearchAggregator $searchAggregator
+    )
     {
-        $this->beConstructedWith($pqb);
+        $this->beConstructedWith($pqb, $searchAggregator);
     }
 
     function it_is_a_product_query_builder()
@@ -52,219 +56,124 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
         $this->setQueryBuilder($searchQb)->shouldReturn($this);
     }
 
-    function it_executes_the_query_by_adding_a_filter_on_attributes($pqb, CursorInterface $cursor, SearchQueryBuilder $sqb)
+    function it_executes_the_query_and_aggregate_results(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb,
+        $searchAggregator
+    )
     {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'foo',
-                    'operator' => 'CONTAINS',
-                    'value'    => '42',
-                    'context'  => [],
-                    'type'     => 'attribute'
-                ],
-                [
-                    'field'    => 'bar',
-                    'operator' => 'IN LIST',
-                    'value'    => ['toto'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-                [
-                    'field'    => 'baz',
-                    'operator' => 'EQUALS',
-                    'value'    => 'sku_893042',
-                    'context'  => [],
-                    'type'     => 'attribute'
-                ],
-            ]
-        );
-
-        $pqb->addFilter('parent', Operators::IS_EMPTY, null, [])->shouldNotBeCalled();
-        $pqb->execute()->willReturn($cursor);
-        $pqb->getQueryBuilder()->willReturn($sqb);
-
-        $sqb->addFilter([
-            'bool' => [
-                'must_not' => [
-                    'bool' => [
-                        'filter' => [
-                            [
-                                'terms' => [ 'attributes_of_ancestors' => ['foo']]
-                            ],
-                            [
-                                'terms' => [ 'attributes_of_ancestors' => ['baz']]
-                            ]
-                        ],
-                    ],
-                ]
-            ]
-        ])->shouldBeCalled();
-
-        $this->execute()->shouldReturn($cursor);
-    }
-
-    function it_executes_the_query_by_adding_a_filter_on_attributes_and_categories($pqb, CursorInterface $cursor, SearchQueryBuilder $sqb)
-    {
-        $pqb->getRawFilters()->willReturn(
-            [
-                [
-                    'field'    => 'foo',
-                    'operator' => 'CONTAINS',
-                    'value'    => '42',
-                    'context'  => [],
-                    'type'     => 'attribute'
-                ],
-                [
-                    'field'    => 'bar',
-                    'operator' => 'IN',
-                    'value'    => ['toto'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-                [
-                    'field'    => 'categories',
-                    'operator' => 'IN',
-                    'value'    => ['category_A'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-            ]
-        );
-
-        $pqb->addFilter('parent', Operators::IS_EMPTY, null, [])->shouldNotBeCalled();
-        $pqb->execute()->willReturn($cursor);
-        $pqb->getQueryBuilder()->willReturn($sqb);
-        $sqb->addFilter([
-            'bool' => [
-                'must_not' => [
-                    'bool' => [
-                        'filter' => [
-                            [
-                                'terms' => [ 'attributes_of_ancestors' => ['foo']]
-                            ],
-                            [
-                                'terms' => [ 'categories_of_ancestors' => ['category_A']]
-                            ]
-                        ],
-                    ],
-                ]
-            ]
-        ])->shouldBeCalled();
-
-        $this->execute()->shouldReturn($cursor);
-    }
-
-    function it_executes_the_query_by_adding_a_default_filter_on_parents($pqb, CursorInterface $cursor)
-    {
-        $pqb->getRawFilters()->willReturn(
-            [
-                [
-                    'field'    => 'bar',
-                    'operator' => 'IN LIST',
-                    'value'    => ['toto'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-            ]
-        );
-
-        $pqb->addFilter('parent', Operators::IS_EMPTY, null, [])->shouldBeCalled();
-        $pqb->execute()->willReturn($cursor);
-
-        $this->execute()->shouldReturn($cursor);
-    }
-
-    function it_executes_the_query_by_adding_a_default_filter_on_parents_when_a_filter_on_category_does_not_trigger_aggregation($pqb, CursorInterface $cursor)
-    {
-        $pqb->getRawFilters()->willReturn(
-            [
-                [
-                    'field'    => 'categories',
-                    'operator' => 'IN OR UNCLASSIFIED',
-                    'value'    => ['toto'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-            ]
-        );
-
-        $pqb->addFilter('parent', Operators::IS_EMPTY, null, [])->shouldBeCalled();
-        $pqb->execute()->willReturn($cursor);
-
-        $this->execute()->shouldReturn($cursor);
-    }
-
-    function it_executes_the_query_with_operator_is_empty_on_an_attribute($pqb, CursorInterface $cursor, SearchQueryBuilder $sqb)
-    {
-        $pqb->getRawFilters()->willReturn(
-            [
-                [
-                    'field'    => 'foo',
-                    'operator' => 'EMPTY',
-                    'value'    => null,
-                    'context'  => [],
-                    'type'     => 'attribute',
-                ],
-                [
-                    'field'    => 'foo_currency1',
-                    'operator' => 'EMPTY FOR CURRENCY',
-                    'value'    => null,
-                    'context'  => [],
-                    'type'     => 'attribute',
-                ],
-                [
-                    'field'    => 'foo_currency2',
-                    'operator' => 'EMPTY ON ALL CURRENCIES',
-                    'value'    => null,
-                    'context'  => [],
-                    'type'     => 'attribute',
-                ],
-                [
-                    'field'    => 'bar',
-                    'operator' => 'IN',
-                    'value'    => ['toto'],
-                    'context'  => [],
-                    'type'     => 'field',
-                ],
-                [
-                    'field'    => 'categories',
-                    'operator' => 'IN',
-                    'value'    => ['category_A'],
-                    'context'  => [],
-                    'type'     => 'field',
-                ],
-            ]
-        );
-
-        $pqb->addFilter('parent', Operators::IS_EMPTY, null, [])->shouldNotBeCalled();
-        $pqb->execute()->willReturn($cursor);
-        $pqb->getQueryBuilder()->willReturn($sqb);
-        $sqb->addFilter([
-            'bool' => [
-                'must_not' => [
-                    'bool' => [
-                        'filter' => [
-                            [
-                                'terms' => ['attributes_of_ancestors' => ['foo']],
-                            ],
-                            [
-                                'terms' => ['attributes_of_ancestors' => ['foo_currency1']],
-                            ],
-                            [
-                                'terms' => ['attributes_of_ancestors' => ['foo_currency2']],
-                            ],
-                            [
-                                'terms' => ['categories_of_ancestors' => ['category_A']],
-                            ],
-                        ],
-                    ],
-                ],
+                'field'    => 'foo',
+                'operator' => 'CONTAINS',
+                'value'    => '42',
+                'context'  => [],
+                'type'     => 'attribute'
             ],
-        ])->shouldBeCalled();
-        $sqb->addFilter([
-            'terms' => ['attributes_for_this_level' => ['foo', 'foo_currency1', 'foo_currency2']],
-        ])->shouldBeCalled();
+            [
+                'field'    => 'bar',
+                'operator' => 'IN LIST',
+                'value'    => ['toto'],
+                'context'  => [],
+                'type'     => 'field'
+            ],
+            [
+                'field'    => 'baz',
+                'operator' => 'EQUALS',
+                'value'    => 'sku_893042',
+                'context'  => [],
+                'type'     => 'attribute'
+            ],
+        ];
+
+        $pqb->getRawFilters()->willReturn($rawFilters);
+
+        $pqb->addFilter('parent', Operators::IS_EMPTY, null, [])->shouldNotBeCalled();
+
+        $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
+
+        $this->execute()->shouldReturn($cursor);
+    }
+
+    function it_executes_the_query_by_adding_a_filter_on_attributes_and_categories(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb,
+        $searchAggregator
+    )
+    {
+        $rawFilters =[
+            [
+                'field'    => 'categories',
+                'operator' => 'IN OR UNCLASSIFIED',
+                'value'    => ['toto'],
+                'context'  => [],
+                'type'     => 'field'
+            ]
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
+
+        $pqb->addFilter('parent', Operators::IS_EMPTY, null, [])->shouldBeCalled();
+        $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
+
+        $this->execute()->shouldReturn($cursor);
+    }
+
+    function it_executes_the_query_with_operator_is_empty_on_an_attribute(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb,
+        $searchAggregator
+    )
+    {
+        $rawFilters = [
+            [
+                'field'    => 'foo',
+                'operator' => 'EMPTY',
+                'value'    => null,
+                'context'  => [],
+                'type'     => 'attribute',
+            ],
+            [
+                'field'    => 'foo_currency1',
+                'operator' => 'EMPTY FOR CURRENCY',
+                'value'    => null,
+                'context'  => [],
+                'type'     => 'attribute',
+            ],
+            [
+                'field'    => 'foo_currency2',
+                'operator' => 'EMPTY ON ALL CURRENCIES',
+                'value'    => null,
+                'context'  => [],
+                'type'     => 'attribute',
+            ],
+            [
+                'field'    => 'bar',
+                'operator' => 'IN',
+                'value'    => ['toto'],
+                'context'  => [],
+                'type'     => 'field',
+            ],
+            [
+                'field'    => 'categories',
+                'operator' => 'IN',
+                'value'    => ['category_A'],
+                'context'  => [],
+                'type'     => 'field',
+            ],
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
+
+        $pqb->addFilter('parent', Operators::IS_EMPTY, null, [])->shouldNotBeCalled();
+        $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
@@ -272,177 +181,207 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_attribute_filter(
         $pqb,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb
+        SearchQueryBuilder $sqb,
+        $searchAggregator
     ) {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'bar',
-                    'operator' => 'IN LIST',
-                    'value'    => ['toto'],
-                    'context'  => [],
-                    'type'     => 'attribute'
-                ],
-            ]
-        );
+                'field'    => 'bar',
+                'operator' => 'IN LIST',
+                'value'    => ['toto'],
+                'context'  => [],
+                'type'     => 'attribute'
+            ],
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
         $pqb->getQueryBuilder()->willReturn($sqb);
-        $sqb->addFilter([
-            'bool' => [
-                'must_not' => [
-                    'bool' => [
-                        'filter' => [
-                            [
-                                'terms' => [ 'attributes_of_ancestors' => ['bar']]
-                            ]
-                        ],
-                    ],
-                ]
-            ]
-        ])->shouldBeCalled();
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_parent_filter($pqb, CursorInterface $cursor)
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_parent_filter(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb,
+        $searchAggregator
+    )
     {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'parent',
-                    'operator' => 'IN LIST',
-                    'value'    => ['toto'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
+                'field'    => 'parent',
+                'operator' => 'IN LIST',
+                'value'    => ['toto'],
+                'context'  => [],
+                'type'     => 'field'
             ]
-        );
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldNotBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_does_not_add_a_default_filter_on_parents_nor_group_when_there_is_a_filter_on_enabled($pqb, CursorInterface $cursor)
+    function it_does_not_add_a_default_filter_on_parents_nor_group_when_there_is_a_filter_on_enabled(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb,
+        $searchAggregator
+    )
     {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'enabled',
-                    'operator' => '=',
-                    'value'    => true,
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
+                'field'    => 'enabled',
+                'operator' => '=',
+                'value'    => true,
+                'context'  => [],
+                'type'     => 'field'
             ]
-        );
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $pqb->addFilter('entity_type', '=', ProductInterface::class, Argument::cetera())->shouldBeCalled();
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldNotBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_id_filter($pqb, CursorInterface $cursor)
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_id_filter(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb,
+        $searchAggregator
+    )
     {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'id',
-                    'operator' => 'IN LIST',
-                    'value'    => ['toto'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-            ]
-        );
+                'field'    => 'id',
+                'operator' => 'IN LIST',
+                'value'    => ['toto'],
+                'context'  => [],
+                'type'     => 'field'
+            ],
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_identifier_filter($pqb, CursorInterface $cursor)
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_identifier_filter(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb,
+        $searchAggregator
+    )
     {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'identifier',
-                    'operator' => 'IN LIST',
-                    'value'    => ['toto'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-            ]
-        );
+                'field'    => 'identifier',
+                'operator' => 'IN LIST',
+                'value'    => ['toto'],
+                'context'  => [],
+                'type'     => 'field'
+            ],
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_entity_type_filter($pqb, CursorInterface $cursor)
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_entity_type_filter(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb,
+        $searchAggregator
+    )
     {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'entity_type',
-                    'operator' => 'EQUALS',
-                    'value'    => 'toto',
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-            ]
-        );
+                'field'    => 'entity_type',
+                'operator' => 'EQUALS',
+                'value'    => 'toto',
+                'context'  => [],
+                'type'     => 'field'
+            ],
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_ancestor_filter($pqb, CursorInterface $cursor)
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_ancestor_filter(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb,
+        $searchAggregator
+    )
     {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'ancestor.id',
-                    'operator' => 'IN LIST',
-                    'value'    => ['toto'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-            ]
-        );
+                'field'    => 'ancestor.id',
+                'operator' => 'IN LIST',
+                'value'    => ['toto'],
+                'context'  => [],
+                'type'     => 'field'
+            ],
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_ancestor_or_self_filter($pqb, CursorInterface $cursor)
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_ancestor_or_self_filter(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb,
+        $searchAggregator
+    )
     {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'self_and_ancestor.id',
-                    'operator' => 'IN LIST',
-                    'value'    => ['toto'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-            ]
-        );
+                'field'    => 'self_and_ancestor.id',
+                'operator' => 'IN LIST',
+                'value'    => ['toto'],
+                'context'  => [],
+                'type'     => 'field'
+            ],
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
@@ -450,23 +389,24 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_filter_on_category_with_operator_IN_LIST(
         $pqb,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb
+        SearchQueryBuilder $sqb,
+        $searchAggregator
     ) {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'categories',
-                    'operator' => 'IN',
-                    'value'    => ['category_A', 'category_B'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-            ]
-        );
+                'field'    => 'categories',
+                'operator' => 'IN',
+                'value'    => ['category_A', 'category_B'],
+                'context'  => [],
+                'type'     => 'field'
+            ],
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
         $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
@@ -474,59 +414,65 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_filter_on_category_with_operator_IN_CHILDREN(
         $pqb,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb
+        SearchQueryBuilder $sqb,
+        $searchAggregator
     ) {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'categories',
-                    'operator' => 'IN CHILDREN',
-                    'value'    => ['category_A', 'category_B'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-            ]
-        );
+                'field'    => 'categories',
+                'operator' => 'IN CHILDREN',
+                'value'    => ['category_A', 'category_B'],
+                'context'  => [],
+                'type'     => 'field'
+            ],
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
         $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
 
-    function it_does_not_aggregate_when_there_is_a_filter_on_parent($pqb, CursorInterface $cursor,  SearchQueryBuilder $sqb)
+    function it_does_not_aggregate_when_there_is_a_filter_on_parent(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb,
+        $searchAggregator
+    )
     {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'parent',
-                    'operator' => '=',
-                    'value'    => 'model-tshirt-divided-blue',
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-                [
-                    'field'    => 'foo',
-                    'operator' => 'CONTAINS',
-                    'value'    => '42',
-                    'context'  => [],
-                    'type'     => 'attribute'
-                ],
-                [
-                    'field'    => 'categories',
-                    'operator' => 'IN LIST',
-                    'value'    => ['category_A', 'category_'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
+                'field'    => 'parent',
+                'operator' => '=',
+                'value'    => 'model-tshirt-divided-blue',
+                'context'  => [],
+                'type'     => 'field'
+            ],
+            [
+                'field'    => 'foo',
+                'operator' => 'CONTAINS',
+                'value'    => '42',
+                'context'  => [],
+                'type'     => 'attribute'
+            ],
+            [
+                'field'    => 'categories',
+                'operator' => 'IN LIST',
+                'value'    => ['category_A', 'category_'],
+                'context'  => [],
+                'type'     => 'field'
             ]
-        );
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $sqb->addFilter(Argument::cetera())->shouldNotBeCalled();
 
         $pqb->execute()->willReturn($cursor);
         $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldNotBeCalled();
         $this->execute()->shouldReturn($cursor);
     }
 }

--- a/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelSearchAggregatorSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelSearchAggregatorSpec.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace spec\Pim\Bundle\EnrichBundle\ProductQueryBuilder;
+
+use Akeneo\Component\Classification\Repository\CategoryRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Prophecy\Argument;
+
+class ProductAndProductModelSearchAggregatorSpec extends ObjectBehavior
+{
+    function let(CategoryRepositoryInterface $categoryRepository)
+    {
+        $this->beConstructedWith($categoryRepository);
+    }
+
+    function it_can_aggregate_results_relative_to_attribute_of_ancestor(CategoryRepositoryInterface $categoryRepository, SearchQueryBuilder $searchQueryBuilder)
+    {
+        $rawFilters = [
+            [
+                'field'    => 'foo',
+                'operator' => 'CONTAINS',
+                'value'    => '42',
+                'context'  => [],
+                'type'     => 'attribute'
+            ],
+            [
+                'field'    => 'bar',
+                'operator' => 'IN LIST',
+                'value'    => ['toto'],
+                'context'  => [],
+                'type'     => 'field'
+            ],
+            [
+                'field'    => 'baz',
+                'operator' => 'EQUALS',
+                'value'    => 'sku_893042',
+                'context'  => [],
+                'type'     => 'attribute'
+            ],
+        ];
+
+        $categoryRepository->findOneBy(["code" => Argument::any()])->shouldNotBeCalled();
+
+        $searchQueryBuilder->addMustNot([
+            'bool' => [
+                'filter' => [
+                    [
+                        'terms' => [ 'attributes_of_ancestors' => ['foo']]
+                    ],
+                    [
+                        'terms' => [ 'attributes_of_ancestors' => ['baz']]
+                    ]
+                ],
+            ]
+        ])->shouldBeCalled();
+
+        $this->aggregateResults($searchQueryBuilder, $rawFilters)->shouldReturn($searchQueryBuilder);
+    }
+
+    function it_aggregate_with_attribute_of_ancestor_and_categories_of_ancestors_with_IN_operator(CategoryRepositoryInterface $categoryRepository, SearchQueryBuilder $searchQueryBuilder)
+    {
+        $rawFilters = [
+            [
+                'field'    => 'foo',
+                'operator' => 'EMPTY',
+                'value'    => null,
+                'context'  => [],
+                'type'     => 'attribute',
+            ],
+            [
+                'field'    => 'foo_currency1',
+                'operator' => 'EMPTY FOR CURRENCY',
+                'value'    => null,
+                'context'  => [],
+                'type'     => 'attribute',
+            ],
+            [
+                'field'    => 'foo_currency2',
+                'operator' => 'EMPTY ON ALL CURRENCIES',
+                'value'    => null,
+                'context'  => [],
+                'type'     => 'attribute',
+            ],
+            [
+                'field'    => 'bar',
+                'operator' => 'IN',
+                'value'    => ['toto'],
+                'context'  => [],
+                'type'     => 'field',
+            ],
+            [
+                'field'    => 'categories',
+                'operator' => 'IN',
+                'value'    => ['category_A'],
+                'context'  => [],
+                'type'     => 'field',
+            ],
+        ];
+
+        $categoryRepository->findOneBy(["code" => Argument::any()])->shouldNotBeCalled();
+
+        $searchQueryBuilder->addMustNot([
+            'bool' => [
+                'filter' => [
+                    [
+                        'terms' => ['attributes_of_ancestors' => ['foo']],
+                    ],
+                    [
+                        'terms' => ['attributes_of_ancestors' => ['foo_currency1']],
+                    ],
+                    [
+                        'terms' => ['attributes_of_ancestors' => ['foo_currency2']],
+                    ],
+                    [
+                        'terms' => ['categories_of_ancestors' => ['category_A']],
+                    ],
+                ],
+            ]
+        ])->shouldBeCalled();
+        $searchQueryBuilder->addFilter([
+            'terms' => ['attributes_for_this_level' => ['foo', 'foo_currency1', 'foo_currency2']],
+        ])->shouldBeCalled();
+
+        $this->aggregateResults($searchQueryBuilder, $rawFilters)->shouldReturn($searchQueryBuilder);
+    }
+
+
+    function it_aggregate_with_attribute_of_ancestor_and_categories_of_ancestors_with_IN_CHILDREN_operator(CategoryRepositoryInterface $categoryRepository, SearchQueryBuilder $searchQueryBuilder)
+    {
+        $rawFilters = [
+            [
+                'field'    => 'foo',
+                'operator' => 'EMPTY',
+                'value'    => null,
+                'context'  => [],
+                'type'     => 'attribute',
+            ],
+            [
+                'field'    => 'categories',
+                'operator' => 'IN CHILDREN',
+                'value'    => ['master_men'],
+                'context'  => [],
+                'type'     => 'field',
+            ]
+        ];
+
+        $categoryRepository->findOneBy(["code" => 'master_men'])->shouldBeCalled();
+
+        $searchQueryBuilder->addMustNot([
+            'bool' => [
+                'filter' => [
+                    [
+                        'terms' => ['attributes_of_ancestors' => ['foo']],
+                    ],
+                    [
+                        'terms' => ['categories_of_ancestors' => ['master_men']],
+                    ],
+                ],
+            ]
+        ])->shouldBeCalled();
+        $searchQueryBuilder->addFilter([
+            'terms' => ['attributes_for_this_level' => ['foo']],
+        ])->shouldBeCalled();
+
+        $this->aggregateResults($searchQueryBuilder, $rawFilters)->shouldReturn($searchQueryBuilder);
+    }
+
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Refactor the way we aggregate ES search results for datagrid, introduce a ProductAndProductModelSearchAggregator.

This aggregator adds all the necessary clauses to remove children when a parent is displayed in search results.

Example:
Model -> in category "headphone"
Variant -> parent "model" -> herited of his parent

When you search on "Audio and video" subcategory, (parent of Headphone), both model & variant appear.

![image](https://user-images.githubusercontent.com/34027529/45497727-ca223c80-b778-11e8-9c5a-7becc8998bde.png)

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
