### PR TITLE
[SLA] PIM-7658: do not expose disabled locale

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7658: Do not expose disabled locale
 - PIM-7653: Fix product export builder when completeness should export products complete on at least one locale
 
 # 2.3.8 (2018-09-14)

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_standard.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_standard.yml
@@ -175,6 +175,8 @@ services:
 
     pim_catalog.normalizer.standard.translation:
         class: '%pim_catalog.normalizer.standard.translation.class%'
+        arguments:
+            - '@pim_catalog.repository.cached_locale'
         tags:
             - { name: pim_serializer.normalizer, priority: 80 }
 

--- a/src/Pim/Component/Catalog/Normalizer/Standard/TranslationNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/TranslationNormalizer.php
@@ -3,6 +3,7 @@
 namespace Pim\Component\Catalog\Normalizer\Standard;
 
 use Akeneo\Component\Localization\Model\TranslatableInterface;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -12,6 +13,14 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class TranslationNormalizer implements NormalizerInterface
 {
+    /** @var IdentifiableObjectRepositoryInterface */
+    private $localeRepository;
+
+    public function __construct(IdentifiableObjectRepositoryInterface $localeRepository = null)
+    {
+        $this->localeRepository = $localeRepository;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -29,6 +38,14 @@ class TranslationNormalizer implements NormalizerInterface
         $method = sprintf('get%s', ucfirst($context['property']));
 
         foreach ($object->getTranslations() as $translation) {
+            // TODO merge: remove null in master
+            if (null !== $this->localeRepository) {
+                $locale = $this->localeRepository->findOneByIdentifier($translation->getLocale());
+                if (null === $locale || !$locale->isActivated()) {
+                    continue;
+                }
+            }
+
             if (false === method_exists($translation, $method)) {
                 throw new \LogicException(
                     sprintf("Class %s doesn't provide method %s", get_class($translation), $method)

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/TranslationNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/TranslationNormalizerSpec.php
@@ -3,11 +3,18 @@
 namespace spec\Pim\Component\Catalog\Normalizer\Standard;
 
 use Akeneo\Component\Localization\Model\TranslatableInterface;
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\AttributeTranslation;
+use Pim\Component\Catalog\Model\LocaleInterface;
 
 class TranslationNormalizerSpec extends ObjectBehavior
 {
+    function let(IdentifiableObjectRepositoryInterface $localeRepository)
+    {
+        $this->beConstructedWith($localeRepository);
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType('Pim\Component\Catalog\Normalizer\Standard\TranslationNormalizer');
@@ -27,9 +34,12 @@ class TranslationNormalizerSpec extends ObjectBehavior
     }
 
     function it_normalizes_translatable_object_using_activated_locales(
+        $localeRepository,
         TranslatableInterface $translatable,
         AttributeTranslation $english,
-        AttributeTranslation $french
+        AttributeTranslation $french,
+        LocaleInterface $enLocale,
+        LocaleInterface $frLocale
     ) {
         $translatable->getTranslations()->willReturn([
             $english, $french
@@ -40,6 +50,11 @@ class TranslationNormalizerSpec extends ObjectBehavior
 
         $french->getLocale()->willReturn('fr_FR');
         $french->getLabel()->willReturn('bar');
+
+        $localeRepository->findOneByIdentifier('en_US')->willReturn($enLocale);
+        $enLocale->isActivated()->willReturn(true);
+        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($frLocale);
+        $frLocale->isActivated()->willReturn(true);
 
         $this->normalize($translatable, 'standard', ['locales' => ['en_US', 'de_DE', 'fr_FR', 'fr_BE']])->shouldReturn(
             [
@@ -95,10 +110,14 @@ class TranslationNormalizerSpec extends ObjectBehavior
     }
 
     function it_provides_all_locales_if_no_list_provided_in_context(
+        $localeRepository,
         TranslatableInterface $translatable,
         AttributeTranslation $english,
         AttributeTranslation $french,
-        AttributeTranslation $german
+        AttributeTranslation $german,
+        LocaleInterface $enLocale,
+        LocaleInterface $frLocale,
+        LocaleInterface $deLocale
     ) {
         $translatable->getTranslations()->willReturn([
             $english, $french, $german
@@ -112,6 +131,13 @@ class TranslationNormalizerSpec extends ObjectBehavior
 
         $german->getLocale()->willReturn('de_DE');
         $german->getLabel()->willReturn('baz');
+
+        $localeRepository->findOneByIdentifier('en_US')->willReturn($enLocale);
+        $enLocale->isActivated()->willReturn(true);
+        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($frLocale);
+        $frLocale->isActivated()->willReturn(true);
+        $localeRepository->findOneByIdentifier('de_DE')->willReturn($deLocale);
+        $deLocale->isActivated()->willReturn(true);
 
         $this->normalize($translatable, 'standard', [
             'locales'  => [],
@@ -126,10 +152,14 @@ class TranslationNormalizerSpec extends ObjectBehavior
     }
 
     function it_throws_an_exception_if_method_not_exists(
+        $localeRepository,
         TranslatableInterface $translatable,
         AttributeTranslation $english,
         AttributeTranslation $french,
-        AttributeTranslation $german
+        AttributeTranslation $german,
+        LocaleInterface $enLocale,
+        LocaleInterface $frLocale,
+        LocaleInterface $deLocale
     ) {
         $translatable->getTranslations()->willReturn([
             $english, $french, $german
@@ -144,9 +174,58 @@ class TranslationNormalizerSpec extends ObjectBehavior
         $german->getLocale()->willReturn('de_DE');
         $german->getLabel()->willReturn('baz');
 
+
+        $localeRepository->findOneByIdentifier('en_US')->willReturn($enLocale);
+        $enLocale->isActivated()->willReturn(true);
+        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($frLocale);
+        $frLocale->isActivated()->willReturn(true);
+        $localeRepository->findOneByIdentifier('de_DE')->willReturn($deLocale);
+        $deLocale->isActivated()->willReturn(true);
+
         $this->shouldThrow('\LogicException')->duringNormalize($translatable, 'standard', [
             'locales'  => [],
             'property' => 'unknown_property'
         ]);
+    }
+
+    function it_does_not_export_disable_locale(
+        $localeRepository,
+        TranslatableInterface $translatable,
+        AttributeTranslation $english,
+        AttributeTranslation $french,
+        AttributeTranslation $german,
+        LocaleInterface $enLocale,
+        LocaleInterface $frLocale,
+        LocaleInterface $deLocale
+    ) {
+        $translatable->getTranslations()->willReturn([
+            $english, $french, $german
+        ]);
+
+        $english->getLocale()->willReturn('en_US');
+        $english->getLabel()->willReturn('foo');
+
+        $french->getLocale()->willReturn('fr_FR');
+        $french->getLabel()->willReturn('bar');
+
+        $german->getLocale()->willReturn('de_DE');
+        $german->getLabel()->willReturn('baz');
+
+        $localeRepository->findOneByIdentifier('en_US')->willReturn($enLocale);
+        $enLocale->isActivated()->willReturn(true);
+        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($frLocale);
+        $frLocale->isActivated()->willReturn(true);
+        $localeRepository->findOneByIdentifier('de_DE')->willReturn($deLocale);
+        $deLocale->isActivated()->willReturn(false);
+
+        $this->normalize($translatable, 'standard', [
+            'locales'  => [],
+            'property' => 'label'
+        ])->shouldReturn(
+            [
+                'en_US' => 'foo',
+                'fr_FR' => 'bar',
+            ]
+        );
     }
 }

--- a/tests/legacy/features/export/export_channels.feature
+++ b/tests/legacy/features/export/export_channels.feature
@@ -16,9 +16,9 @@ Feature: Export channels
     And I should see the text "Written 2"
     And exported file of "csv_footwear_channel_export" should contain:
     """
-    code;label-fr_FR;label-en_US;label-de_DE;conversion_units;currencies;locales;tree
-    mobile;Mobile;Mobile;Mobil;;EUR;en_US,fr_FR;2014_collection
-    tablet;Tablette;Tablet;Tablet;;USD,EUR;en_US;2014_collection
+    code;label-fr_FR;label-en_US;conversion_units;currencies;locales;tree
+    mobile;Mobile;Mobile;;EUR;en_US,fr_FR;2014_collection
+    tablet;Tablette;Tablet;;USD,EUR;en_US;2014_collection
     """
 
   @jira https://akeneo.atlassian.net/browse/PIM-6047
@@ -36,7 +36,7 @@ Feature: Export channels
     And I should see the text "Written 2"
     And exported file of "csv_footwear_channel_export" should contain:
     """
-    code;label-fr_FR;label-en_US;label-de_DE;conversion_units;currencies;locales;tree
-    mobile;Mobile;Mobile;Mobil;;EUR;en_US,fr_FR;2014_collection
-    tablet;Tablette;Tablet;Tablet;;USD,EUR;en_US;2014_collection
+    code;label-fr_FR;label-en_US;conversion_units;currencies;locales;tree
+    mobile;Mobile;Mobile;;EUR;en_US,fr_FR;2014_collection
+    tablet;Tablette;Tablet;;USD,EUR;en_US;2014_collection
     """

--- a/tests/legacy/features/import/import_channels.feature
+++ b/tests/legacy/features/import/import_channels.feature
@@ -39,9 +39,9 @@ Feature: Import channels
     And I should see the text "Written 2"
     And exported file of "csv_footwear_channel_export" should contain:
     """
-    code;label-fr_FR;label-en_US;label-de_DE;conversion_units;currencies;locales;tree
-    mobile;Mobile;Mobile;Mobil;;USD,EUR;en_US,fr_FR;2014_collection
-    tablet;Tablette;Tablet;Tablet;;USD,EUR;en_US;2014_collection
+    code;label-fr_FR;label-en_US;conversion_units;currencies;locales;tree
+    mobile;Mobile;Mobile;;USD,EUR;en_US,fr_FR;2014_collection
+    tablet;Tablette;Tablet;;USD,EUR;en_US;2014_collection
     """
 
   Scenario: Successfully update existing channel and add a new one


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

All is in title, if a locale is disabled, we do not expose it in the standard format (so in UI, API, export).

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
