### PR TITLE
PIM-7663: fix API endpoint to list products updated since N days

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7663: Fix API endpoint that list products updated since N days
 - PIM-7658: Do not expose disabled locale
 - PIM-7653: Fix product export builder when completeness should export products complete on at least one locale
 - PIM-7650: Fix Values comparison. Allows to save a variant product with a metric as variant axe.

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -567,7 +567,7 @@ class ProductController
                             $values[] = \DateTime::createFromFormat('Y-m-d H:i:s', $date);
                         }
                         $value = $values;
-                    } else {
+                    } elseif (!in_array($filter['operator'], [Operators::SINCE_LAST_N_DAYS, Operators::SINCE_LAST_JOB])) {
                         //PIM-7541 Create the date with the server timezone configuration. Do not force it to UTC timezone.
                         $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
                     }

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -6,6 +6,7 @@ namespace Pim\Bundle\ApiBundle\tests\integration\Controller\Product;
 
 use Akeneo\Test\Integration\Configuration;
 use Doctrine\Common\Collections\Collection;
+use Pim\Component\Catalog\Query\Filter\Operators;
 
 /**
  * @group ce
@@ -1152,6 +1153,37 @@ JSON;
         $currentDate = (new \DateTime('now'))->modify("+ 30 minutes")->format('Y-m-d H:i:s');
 
         $search = sprintf('{"updated":[{"operator":"<","value":"%s"}]}', $currentDate);
+        $client->request('GET', 'api/rest/v1/products?pagination_type=page&limit=10&search=' . $search);
+        $searchEncoded = rawurlencode($search);
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [            
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['product_china']},
+            {$standardizedProducts['product_without_category']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsUpdatedSinceLastNDays()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $search = sprintf('{"updated":[{"operator":"%s","value":4}]}', Operators::SINCE_LAST_N_DAYS);
         $client->request('GET', 'api/rest/v1/products?pagination_type=page&limit=10&search=' . $search);
         $searchEncoded = rawurlencode($search);
         $expected = <<<JSON


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Regression from a previous SLA. There must not be no formatting on date filter for the operators SINCE_LAST_N_DAYS and SINCE_LAST_JOB

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
