### PR TITLE
PIM-7659: Fix search on the families to get one result by label

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7659: Fix search on the families to get all the results when they have same translations for many locales.
+
 # 2.3.9 (2018-09-25)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/FamilySearchableRepository.php
@@ -44,6 +44,7 @@ class FamilySearchableRepository implements SearchableRepositoryInterface
         if (null !== $search && '' !== $search) {
             $qb->leftJoin('f.translations', 'ft');
             $qb->andWhere('f.code like :search OR ft.label like :search');
+            $qb->distinct();
             $qb->setParameter('search', '%' . $search . '%');
         }
 

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/Repository/FamilySearchableRepositoryIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/Repository/FamilySearchableRepositoryIntegration.php
@@ -29,6 +29,11 @@ class FamilySearchableRepositoryIntegration extends TestCase
         static::assertCount(0, $this->searchFamily('unexisting'));
     }
 
+    public function test_it_searches_families_with_limit_option()
+    {
+        static::assertCount(3, $this->searchFamily('c', ['limit' => 3, 'page' => 1]));
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -53,6 +58,16 @@ class FamilySearchableRepositoryIntegration extends TestCase
         $channel->addLocale($locale);
         $this->get('pim_catalog.saver.channel')->save($channel);
 
+        $this->createFamily(
+            [
+                'code' => 'accessories',
+                'labels' => [
+                    'en_US' => 'Accessories',
+                    'fr_FR' => 'Accessories',
+                    'fr_BE' => 'Accessories',
+                ],
+            ]
+        );
         $this->createFamily(
             [
                 'code' => 'clothing',
@@ -89,8 +104,8 @@ class FamilySearchableRepositoryIntegration extends TestCase
      *
      * @return FamilyInterface[]
      */
-    private function searchFamily(string $search): array
+    private function searchFamily(string $search, array $options = []): array
     {
-        return $this->get('pim_enrich.repository.family.search')->findBySearch($search);
+        return $this->get('pim_enrich.repository.family.search')->findBySearch($search,$options);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We got an SLA about the search on the families. When we're searching on the family with a limit of element, we couldn't get all the results expected if it has a family with the same translated label on different locales.
For instance : 
  - Two families : 
      { code : accessories, label : {'en_US': 'Accessories', 'fr_FR': 'Accessories', 'fr_BE': 'Accessories'}}
      { code : clothing, label : {'en_US': 'Clothes', 'fr_FR': 'Vêtement'}}
  - we want to make a search on 'c' with a limit of 3 elements
  - we will get only one result (Accessories) instead of two (Accessories and Clothes)

This bug is because of we didn't do a DISTINCT on the query to get only one row by label matched with the search parameter.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
