### PR TITLE
PIM-7619: Fix search on groups for the variant products

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7659: Fix search on the families to get all the results when they have same translations for many locales.
+- PIM-7619: Fix search on groups for the variant products.
 
 # 2.3.9 (2018-09-25)
 

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -122,6 +122,7 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
         $hasEntityTypeFilter = $this->hasRawFilter('field', 'entity_type');
         $hasAncestorsIdsFilter = $this->hasRawFilter('field', 'ancestor.id');
         $hasSelfAndAncestorsIdsFilter = $this->hasRawFilter('field', 'self_and_ancestor.id');
+        $hasGroupsFilter = $this->hasRawFilter('field', 'groups');
         $hasCategoryFilter = $this->hasFilterOnCategoryWhichImplyAggregation();
 
         return !$hasAttributeFilters &&
@@ -131,6 +132,7 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
             !$hasEntityTypeFilter &&
             !$hasAncestorsIdsFilter &&
             !$hasSelfAndAncestorsIdsFilter &&
+            !$hasGroupsFilter &&
             !$hasCategoryFilter;
     }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
@@ -529,4 +529,28 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
         $pqb->getQueryBuilder()->willReturn($sqb);
         $this->execute()->shouldReturn($cursor);
     }
+
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_filter_on_groups(
+        $pqb,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb
+    ) {
+        $pqb->getRawFilters()->willReturn(
+            [
+                [
+                    'field'    => 'groups',
+                    'operator' => 'IN',
+                    'value'    => ['group_A', 'group_B'],
+                    'context'  => [],
+                    'type'     => 'field'
+                ],
+            ]
+        );
+
+        $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
+        $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+
+        $this->execute()->shouldReturn($cursor);
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The product grid does not display product variants when filtering on groups. 

The filter that exclude products having a parent in the PQB must not be added when filtering on groups.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
