### PR TITLE
PIM-7671 : Fix display associated products even if the product limit is reached before to display the product models on the page.

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-7629: Fix category filter in product grid
 - PIM-7659: Fix search on the families to get all the results when they have same translations for many locales.
 - PIM-7619: Fix search on groups for the variant products.
+- PIM-7671: Fix associations tab cannot display more than 24 associated products/product models or 25 groups
 
 # 2.3.9 (2018-09-25)
 

--- a/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
+++ b/src/Pim/Bundle/DataGridBundle/Datasource/AssociatedProductDatasource.php
@@ -88,8 +88,15 @@ class AssociatedProductDatasource extends ProductDatasource
             $scope
         );
 
+        $normalizedAssociatedProducts = $this->normalizeProductsAndProductModels(
+            $associatedProducts,
+            $associatedProductsIdsFromParent,
+            $locale,
+            $scope
+        );
+
         $productModelLimit = $limit - $associatedProducts->count();
-        $associatedProductModels = [];
+        $normalizedAssociatedProductModels = [];
         if ($productModelLimit > 0) {
             $productModelFrom = $from - count($associatedProductsIds) + $associatedProducts->count();
             $associatedProductModels = $this->getAssociatedProductModels(
@@ -99,21 +106,14 @@ class AssociatedProductDatasource extends ProductDatasource
                 $locale,
                 $scope
             );
+
+            $normalizedAssociatedProductModels = $this->normalizeProductsAndProductModels(
+                $associatedProductModels,
+                $associatedProductModelsIdsFromParent,
+                $locale,
+                $scope
+            );
         }
-
-        $normalizedAssociatedProducts = $this->normalizeProductsAndProductModels(
-            $associatedProducts,
-            $associatedProductsIdsFromParent,
-            $locale,
-            $scope
-        );
-
-        $normalizedAssociatedProductModels = $this->normalizeProductsAndProductModels(
-            $associatedProductModels,
-            $associatedProductModelsIdsFromParent,
-            $locale,
-            $scope
-        );
 
         $rows = ['totalRecords' => count($associatedProductsIds) + count($associatedProductModelsIds)];
         $rows['data'] = array_merge($normalizedAssociatedProducts, $normalizedAssociatedProductModels);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We got an SLA on the associated product list. We couldn't display the list when the product limit on the page is already reached before to get the product models associated.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
