### PR TITLE
PIM-7668: Always display datetime according to current user timezone

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,10 +2,11 @@
 
 ## Bug fixes
 
-- PIM-7629: Fix category filter in product grid
+- PIM-7629: Fix category filter in product grid.
 - PIM-7659: Fix search on the families to get all the results when they have same translations for many locales.
 - PIM-7619: Fix search on groups for the variant products.
-- PIM-7671: Fix associations tab cannot display more than 24 associated products/product models or 25 groups
+- PIM-7671: Fix associations tab cannot display more than 24 associated products/product models or 25 groups.
+- PIM-7668: Fix issues with timezone in various screen, to always use current user timezone.
 
 # 2.3.9 (2018-09-25)
 

--- a/composer.lock
+++ b/composer.lock
@@ -1298,16 +1298,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.5",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "54859fabea8b3beecbb1a282888d5c990036b9e3"
+                "reference": "0578b32b30b22de3e8664f797cf846fc9246f786"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/54859fabea8b3beecbb1a282888d5c990036b9e3",
-                "reference": "54859fabea8b3beecbb1a282888d5c990036b9e3",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/0578b32b30b22de3e8664f797cf846fc9246f786",
+                "reference": "0578b32b30b22de3e8664f797cf846fc9246f786",
                 "shasum": ""
             },
             "require": {
@@ -1351,7 +1351,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2018-08-16T20:49:45+00:00"
+            "time": "2018-09-25T20:47:26+00:00"
         },
         {
             "name": "elasticsearch/elasticsearch",
@@ -5904,16 +5904,16 @@
         },
         {
             "name": "friends-of-behat/symfony-extension",
-            "version": "v1.2.2",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfBehat/SymfonyExtension.git",
-                "reference": "291530353b19e9e6cbb759e3d0bbf71475fca965"
+                "reference": "12d4c58ec2ce24b0bf52fc419135249a181c2a1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfBehat/SymfonyExtension/zipball/291530353b19e9e6cbb759e3d0bbf71475fca965",
-                "reference": "291530353b19e9e6cbb759e3d0bbf71475fca965",
+                "url": "https://api.github.com/repos/FriendsOfBehat/SymfonyExtension/zipball/12d4c58ec2ce24b0bf52fc419135249a181c2a1a",
+                "reference": "12d4c58ec2ce24b0bf52fc419135249a181c2a1a",
                 "shasum": ""
             },
             "require": {
@@ -5954,7 +5954,7 @@
                 }
             ],
             "description": "Integrates Behat with Symfony.",
-            "time": "2018-08-01T14:35:39+00:00"
+            "time": "2018-09-25T11:18:21+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/JobExecutionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/JobExecutionNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\Normalizer;
+
+use Akeneo\Component\Batch\Model\JobExecution;
+use Pim\Bundle\UserBundle\Context\UserContext;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class JobExecutionNormalizer implements NormalizerInterface
+{
+    /** @var NormalizerInterface */
+    private $jobExecutionStandardNormalizer;
+
+    /** @var UserContext */
+    private $userContext;
+
+    /**
+     * @param NormalizerInterface $jobExecutionStandardNormalizer
+     * @param UserContext         $userContext
+     */
+    public function __construct(NormalizerInterface $jobExecutionStandardNormalizer, UserContext $userContext)
+    {
+        $this->jobExecutionStandardNormalizer = $jobExecutionStandardNormalizer;
+        $this->userContext = $userContext;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($jobExecution, $format = null, array $context = []): array
+    {
+        try {
+            $timezone = $this->userContext->getUserTimezone();
+        } catch (\RuntimeException $exception) {
+            return $this->jobExecutionStandardNormalizer->normalize($jobExecution, 'standard', $context);
+        }
+
+        return $this->jobExecutionStandardNormalizer->normalize(
+            $jobExecution,
+            'standard',
+            array_merge($context, ['timezone' => $timezone])
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($jobExecution, $format = null): bool
+    {
+        return $jobExecution instanceof JobExecution && 'internal_api' === $format;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
@@ -5,6 +5,7 @@ namespace Pim\Bundle\EnrichBundle\Normalizer;
 use Akeneo\Component\Localization\Presenter\PresenterInterface;
 use Akeneo\Component\Versioning\Model\Version;
 use Oro\Bundle\UserBundle\Entity\UserManager;
+use Pim\Bundle\UserBundle\Context\UserContext;
 use Pim\Component\Catalog\Localization\Presenter\PresenterRegistryInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -40,6 +41,9 @@ class VersionNormalizer implements NormalizerInterface
     /** @var AttributeRepositoryInterface */
     protected $attributeRepository;
 
+    /** @var UserContext */
+    protected $userContext;
+
     const ATTRIBUTE_HEADER_SEPARATOR = "-";
 
     /**
@@ -48,19 +52,24 @@ class VersionNormalizer implements NormalizerInterface
      * @param PresenterInterface           $datetimePresenter
      * @param PresenterRegistryInterface   $presenterRegistry
      * @param AttributeRepositoryInterface $attributeRepository
+     * @param UserContext                  $userContext
+     *
+     * @todo merge: remove the "= null` on master and add to BC breaks
      */
     public function __construct(
         UserManager $userManager,
         TranslatorInterface $translator,
         PresenterInterface $datetimePresenter,
         PresenterRegistryInterface $presenterRegistry,
-        AttributeRepositoryInterface $attributeRepository = null // TODO on master: remove = null
+        AttributeRepositoryInterface $attributeRepository = null, // TODO on master: remove = null
+        UserContext $userContext = null
     ) {
         $this->userManager = $userManager;
         $this->translator = $translator;
         $this->datetimePresenter = $datetimePresenter;
         $this->presenterRegistry = $presenterRegistry;
         $this->attributeRepository = $attributeRepository;
+        $this->userContext = $userContext;
     }
 
     /**
@@ -68,7 +77,10 @@ class VersionNormalizer implements NormalizerInterface
      */
     public function normalize($version, $format = null, array $context = [])
     {
-        $context = array_merge($context, ['locale' => $this->translator->getLocale()]);
+        $context = array_merge($context, [
+            'locale' => $this->translator->getLocale(),
+            'timezone' => $this->userContext->getUserTimezone()
+        ]);
 
         return [
             'id'           => $version->getId(),

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
@@ -61,7 +61,7 @@ class VersionNormalizer implements NormalizerInterface
         TranslatorInterface $translator,
         PresenterInterface $datetimePresenter,
         PresenterRegistryInterface $presenterRegistry,
-        AttributeRepositoryInterface $attributeRepository = null, // TODO on master: remove = null
+        AttributeRepositoryInterface $attributeRepository = null,
         UserContext $userContext = null
     ) {
         $this->userManager = $userManager;
@@ -77,15 +77,13 @@ class VersionNormalizer implements NormalizerInterface
      */
     public function normalize($version, $format = null, array $context = [])
     {
+        $context = array_merge($context, ['locale' => $this->translator->getLocale()]);
+
         try {
             $timezone = $this->userContext->getUserTimezone();
-
-            $context = array_merge($context, [
-                'locale' => $this->translator->getLocale(),
-                'timezone' => $timezone
-            ]);
+            $loggedAtContext = array_merge($context, ['timezone' => $timezone]);
         } catch (\RuntimeException $exception) {
-            $context = array_merge($context, ['locale' => $this->translator->getLocale()]);
+            $loggedAtContext = $context;
         }
 
         return [
@@ -96,7 +94,7 @@ class VersionNormalizer implements NormalizerInterface
             'changeset'    => $this->convertChangeset($version->getChangeset(), $context),
             'context'      => $version->getContext(),
             'version'      => $version->getVersion(),
-            'logged_at'    => $this->datetimePresenter->present($version->getLoggedAt(), $context),
+            'logged_at'    => $this->datetimePresenter->present($version->getLoggedAt(), $loggedAtContext),
             'pending'      => $version->isPending(),
         ];
     }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/VersionNormalizer.php
@@ -77,10 +77,16 @@ class VersionNormalizer implements NormalizerInterface
      */
     public function normalize($version, $format = null, array $context = [])
     {
-        $context = array_merge($context, [
-            'locale' => $this->translator->getLocale(),
-            'timezone' => $this->userContext->getUserTimezone()
-        ]);
+        try {
+            $timezone = $this->userContext->getUserTimezone();
+
+            $context = array_merge($context, [
+                'locale' => $this->translator->getLocale(),
+                'timezone' => $timezone
+            ]);
+        } catch (\RuntimeException $exception) {
+            $context = array_merge($context, ['locale' => $this->translator->getLocale()]);
+        }
 
         return [
             'id'           => $version->getId(),

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -455,6 +455,7 @@ services:
             - '@pim_serializer'
             - '@akeneo_batch_queue.manager.job_execution_manager'
             - '@pim_enrich.repository.job_execution'
+            - '@pim_internal_api_serializer'
 
     pim_enrich.controller.rest.api_client:
         class: '%pim_enrich.controller.rest.api_client.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/last_executions.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/last_executions.yml
@@ -10,7 +10,7 @@ datagrid:
             date:
                 label:         job_tracker.filter.started_at
                 data_name:     createTime
-                type:          datetime
+                type:          datetime_with_user_timezone
                 frontend_type: datetime
             status:
                 label:         Status

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -290,6 +290,14 @@ services:
         tags:
             - { name: pim_internal_api_serializer.normalizer}
 
+    pim_enrich.normalizer.job_execution:
+        class: 'Pim\Bundle\EnrichBundle\Normalizer\JobExecutionNormalizer'
+        arguments:
+            - '@pim_import_export.normalizer.job_execution'
+            - '@pim_user.context.user'
+        tags:
+            - { name: pim_internal_api_serializer.normalizer}
+
     pim_enrich.normalizer.image:
         class: '%pim_enrich.normalizer.image.class%'
         arguments:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -130,6 +130,7 @@ services:
             - '@pim_catalog.localization.presenter.datetime'
             - '@pim_catalog.localization.presenter.registry'
             - '@pim_catalog.repository.attribute'
+            - '@pim_user.context.user'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/JobExecutionNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/JobExecutionNormalizerSpec.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
+
+use Akeneo\Component\Batch\Model\JobExecution;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\EnrichBundle\Normalizer\JobExecutionNormalizer;
+use Pim\Bundle\UserBundle\Context\UserContext;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class JobExecutionNormalizerSpec extends ObjectBehavior
+{
+    function let(NormalizerInterface $jobExecutionStandardNormalizer, UserContext $userContext)
+    {
+        $this->beConstructedWith($jobExecutionStandardNormalizer, $userContext);
+    }
+
+    function it_is_a_job_execution_normalizer()
+    {
+        $this->shouldBeAnInstanceOf(JobExecutionNormalizer::class);
+        $this->shouldImplement(NormalizerInterface::class);
+    }
+
+    function it_is_a_internal_api_normalizer()
+    {
+        $jobExecution = new JobExecution();
+        $this->supportsNormalization($jobExecution, 'internal_api')->shouldReturn(true);
+        $this->supportsNormalization($jobExecution, 'standard')->shouldReturn(false);
+
+        $object = new \stdClass();
+        $this->supportsNormalization($object, 'internal_api')->shouldReturn(false);
+        $this->supportsNormalization($object, 'standard')->shouldReturn(false);
+    }
+
+    function it_normalizes_a_job_execution($jobExecutionStandardNormalizer, $userContext)
+    {
+        $jobExecution = new JobExecution();
+
+        $userContext->getUserTimezone()->willReturn('Europe/Paris');
+
+        $jobExecutionStandardNormalizer
+            ->normalize($jobExecution, 'standard', ['timezone' => 'Europe/Paris'])
+            ->willReturn([
+                'failures'       => ['Such error'],
+                'stepExecutions' => ['**exportExecution**', '**cleanExecution**'],
+                'isRunning'      => true,
+                'status'         => 'COMPLETED',
+                'jobInstance'    => ['Normalized job instance with datetime in user timezone']
+            ]);
+
+        $this->normalize($jobExecution, 'internal_api')->shouldReturn([
+            'failures'       => ['Such error'],
+            'stepExecutions' => ['**exportExecution**', '**cleanExecution**'],
+            'isRunning'      => true,
+            'status'         => 'COMPLETED',
+            'jobInstance'    => ['Normalized job instance with datetime in user timezone']
+        ]);
+    }
+
+    function it_normalizes_a_job_execution_without_user_in_the_user_context($jobExecutionStandardNormalizer, $userContext)
+    {
+        $jobExecution = new JobExecution();
+
+        $userContext->getUserTimezone()->willThrow(\RuntimeException::class);
+
+        $jobExecutionStandardNormalizer
+            ->normalize($jobExecution, 'standard', [])
+            ->willReturn([
+                'failures'       => ['Such error'],
+                'stepExecutions' => ['**exportExecution**', '**cleanExecution**'],
+                'isRunning'      => true,
+                'status'         => 'COMPLETED',
+                'jobInstance'    => ['Normalized job instance with datetime in server timezone']
+            ]);
+
+        $this->normalize($jobExecution, 'internal_api')->shouldReturn([
+            'failures'       => ['Such error'],
+            'stepExecutions' => ['**exportExecution**', '**cleanExecution**'],
+            'isRunning'      => true,
+            'status'         => 'COMPLETED',
+            'jobInstance'    => ['Normalized job instance with datetime in server timezone']
+        ]);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VersionNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VersionNormalizerSpec.php
@@ -67,7 +67,6 @@ class VersionNormalizerSpec extends ObjectBehavior
         $version->getVersion()->willReturn(12);
         $version->getLoggedAt()->willReturn($versionTime);
         $translator->getLocale()->willReturn('en_US');
-        $datetimePresenter->present($versionTime, Argument::any())->willReturn('01/01/1985 09:41 AM');
         $version->isPending()->willReturn(false);
 
         $version->getAuthor()->willReturn('steve');
@@ -82,6 +81,9 @@ class VersionNormalizerSpec extends ObjectBehavior
         ];
 
         $options = [
+            'locale' => 'fr_FR',
+        ];
+        $datetimePresenterOtions = [
             'locale' => 'fr_FR',
             'timezone' => 'Europe/Paris',
         ];
@@ -110,6 +112,7 @@ class VersionNormalizerSpec extends ObjectBehavior
         $numberPresenter->present('', $options + ['versioned_attribute' => 'maximum_frame_rate'])->willReturn('');
         $pricesPresenter->present('', $options)->willReturn('');
         $metricPresenter->present('', $options + ['versioned_attribute' => 'weight'])->willReturn('');
+        $datetimePresenter->present($versionTime, $datetimePresenterOtions)->willReturn('01/01/1985 09:41 AM');
 
         $this->normalize($version, 'internal_api')->shouldReturn([
             'id'          => 12,

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VersionNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VersionNormalizerSpec.php
@@ -6,6 +6,7 @@ use Akeneo\Component\Localization\Presenter\PresenterInterface;
 use Akeneo\Component\Versioning\Model\Version;
 use Oro\Bundle\UserBundle\Entity\UserManager;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\UserBundle\Context\UserContext;
 use Pim\Bundle\UserBundle\Entity\User;
 use Pim\Component\Catalog\Localization\Presenter\PresenterRegistryInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
@@ -19,9 +20,17 @@ class VersionNormalizerSpec extends ObjectBehavior
         TranslatorInterface $translator,
         PresenterInterface $datetimePresenter,
         PresenterRegistryInterface $presenterRegistry,
-        AttributeRepositoryInterface $attributeRepository
+        AttributeRepositoryInterface $attributeRepository,
+        UserContext $userContext
     ) {
-        $this->beConstructedWith($userManager, $translator, $datetimePresenter, $presenterRegistry, $attributeRepository);
+        $this->beConstructedWith(
+            $userManager,
+            $translator,
+            $datetimePresenter,
+            $presenterRegistry,
+            $attributeRepository,
+            $userContext
+        );
     }
 
     function it_supports_versions(Version $version)
@@ -34,6 +43,7 @@ class VersionNormalizerSpec extends ObjectBehavior
         $translator,
         $datetimePresenter,
         $presenterRegistry,
+        $userContext,
         Version $version,
         User $steve,
         PresenterInterface $numberPresenter,
@@ -71,8 +81,12 @@ class VersionNormalizerSpec extends ObjectBehavior
             'weight'             => ['old' => '', 'new' => '10,1234'],
         ];
 
-        $options = ['locale' => 'fr_FR'];
+        $options = [
+            'locale' => 'fr_FR',
+            'timezone' => 'Europe/Paris',
+        ];
         $translator->getLocale()->willReturn('fr_FR');
+        $userContext->getUserTimezone()->willReturn('Europe/Paris');
 
         $attributeRepository
             ->getAttributeTypeByCodes(['maximum_frame_rate', 'price', 'weight'])
@@ -114,6 +128,7 @@ class VersionNormalizerSpec extends ObjectBehavior
         $userManager,
         $translator,
         $datetimePresenter,
+        $userContext,
         Version $version
     ) {
         $versionTime = new \DateTime();
@@ -133,6 +148,8 @@ class VersionNormalizerSpec extends ObjectBehavior
         $userManager->findUserByUsername('steve')->willReturn(null);
 
         $translator->trans('Removed user')->willReturn('Utilisateur supprimé');
+
+        $userContext->getUserTimezone()->willThrow(\RuntimeException::class);
 
         $this->normalize($version, 'internal_api')->shouldReturn([
             'id'          => 12,

--- a/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
@@ -16,8 +16,7 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
     function let(
         ProductQueryBuilderInterface $pqb,
         ProductAndProductModelSearchAggregator $searchAggregator
-    )
-    {
+    ) {
         $this->beConstructedWith($pqb, $searchAggregator);
     }
 
@@ -58,11 +57,10 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_executes_the_query_and_aggregate_results(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
-    )
-    {
+        SearchQueryBuilder $sqb
+    ) {
         $rawFilters = [
             [
                 'field'    => 'foo',
@@ -100,11 +98,10 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_executes_the_query_by_adding_a_filter_on_attributes_and_categories(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
-    )
-    {
+        SearchQueryBuilder $sqb
+    ) {
         $rawFilters =[
             [
                 'field'    => 'categories',
@@ -126,11 +123,10 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_executes_the_query_with_operator_is_empty_on_an_attribute(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
-    )
-    {
+        SearchQueryBuilder $sqb
+    ) {
         $rawFilters = [
             [
                 'field'    => 'foo',
@@ -180,9 +176,9 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_attribute_filter(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
+        SearchQueryBuilder $sqb
     ) {
         $rawFilters = [
             [
@@ -205,11 +201,10 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_parent_filter(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
-    )
-    {
+        SearchQueryBuilder $sqb
+    ) {
         $rawFilters = [
             [
                 'field'    => 'parent',
@@ -231,11 +226,10 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_add_a_default_filter_on_parents_nor_group_when_there_is_a_filter_on_enabled(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
-    )
-    {
+        SearchQueryBuilder $sqb
+    ) {
         $rawFilters = [
             [
                 'field'    => 'enabled',
@@ -258,11 +252,10 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_id_filter(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
-    )
-    {
+        SearchQueryBuilder $sqb
+    ) {
         $rawFilters = [
             [
                 'field'    => 'id',
@@ -284,11 +277,10 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_identifier_filter(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
-    )
-    {
+        SearchQueryBuilder $sqb
+    ) {
         $rawFilters = [
             [
                 'field'    => 'identifier',
@@ -310,11 +302,10 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_entity_type_filter(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
-    )
-    {
+        SearchQueryBuilder $sqb
+    ) {
         $rawFilters = [
             [
                 'field'    => 'entity_type',
@@ -336,11 +327,10 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_ancestor_filter(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
-    )
-    {
+        SearchQueryBuilder $sqb
+    ) {
         $rawFilters = [
             [
                 'field'    => 'ancestor.id',
@@ -362,11 +352,10 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_source_ancestor_or_self_filter(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
-    )
-    {
+        SearchQueryBuilder $sqb
+    ) {
         $rawFilters = [
             [
                 'field'    => 'self_and_ancestor.id',
@@ -388,9 +377,9 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_filter_on_category_with_operator_IN_LIST(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
+        SearchQueryBuilder $sqb
     ) {
         $rawFilters = [
             [
@@ -413,9 +402,9 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_filter_on_category_with_operator_IN_CHILDREN(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
+        SearchQueryBuilder $sqb
     ) {
         $rawFilters = [
             [
@@ -438,11 +427,10 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_aggregate_when_there_is_a_filter_on_parent(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
-        SearchQueryBuilder $sqb,
-        $searchAggregator
-    )
-    {
+        SearchQueryBuilder $sqb
+    ) {
         $rawFilters = [
             [
                 'field'    => 'parent',
@@ -478,24 +466,26 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
     function it_does_not_add_a_default_filter_on_parents_when_there_is_a_filter_on_groups(
         $pqb,
+        $searchAggregator,
         CursorInterface $cursor,
         SearchQueryBuilder $sqb
     ) {
-        $pqb->getRawFilters()->willReturn(
+        $rawFilters = [
             [
-                [
-                    'field'    => 'groups',
-                    'operator' => 'IN',
-                    'value'    => ['group_A', 'group_B'],
-                    'context'  => [],
-                    'type'     => 'field'
-                ],
-            ]
-        );
+                'field'    => 'groups',
+                'operator' => 'IN',
+                'value'    => ['group_A', 'group_B'],
+                'context'  => [],
+                'type'     => 'field'
+            ],
+        ];
+
+        $pqb->getRawFilters()->willReturn($rawFilters);
 
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
         $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }

--- a/src/Pim/Bundle/NotificationBundle/Controller/NotificationController.php
+++ b/src/Pim/Bundle/NotificationBundle/Controller/NotificationController.php
@@ -66,7 +66,8 @@ class NotificationController
         return $this->templating->renderResponse(
             'PimNotificationBundle:Notification:list.json.twig',
             [
-                'userNotifications' => $notifications
+                'userNotifications' => $notifications,
+                'userTimezone' => $this->userContext->getUserTimezone(),
             ],
             new JsonResponse()
         );

--- a/src/Pim/Bundle/NotificationBundle/Resources/views/Notification/list.json.twig
+++ b/src/Pim/Bundle/NotificationBundle/Resources/views/Notification/list.json.twig
@@ -14,7 +14,7 @@
         message: item.notification.message|trans(item.notification.messageParams),
         viewed: item.viewed,
         url: generatedUrl,
-        createdAt: item.notification.created|date("Y-m-d H:i:s"),
+        createdAt: item.notification.created|date("Y-m-d H:i:s", userTimezone),
         actionType: item.notification.context.actionType ? item.notification.context.actionType : null,
         actionTypeMessage: item.notification.context.actionType ? item.notification.context.actionType|trans : null,
         buttonLabel: item.notification.context.buttonLabel is defined ? item.notification.context.buttonLabel|trans : 'pim_notification.report'|trans,

--- a/src/Pim/Bundle/NotificationBundle/spec/Controller/NotificationControllerSpec.php
+++ b/src/Pim/Bundle/NotificationBundle/spec/Controller/NotificationControllerSpec.php
@@ -39,11 +39,13 @@ class NotificationControllerSpec extends ObjectBehavior
         $context->getUser()->willReturn($user);
         $userNotifRepository->findBy(['user' => $user], ['id' => 'DESC'], 10, null)
             ->willReturn([$userNotification]);
+        $context->getUserTimezone()->willReturn('Europe/Paris');
 
         $templating->renderResponse(
             'PimNotificationBundle:Notification:list.json.twig',
             [
-                'userNotifications' => [$userNotification]
+                'userNotifications' => [$userNotification],
+                'userTimezone' => 'Europe/Paris',
             ],
             Argument::type('Symfony\Component\HttpFoundation\JsonResponse')
         )->shouldBeCalled();

--- a/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilyRootProductModelsTaskletSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilyRootProductModelsTaskletSpec.php
@@ -26,9 +26,6 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
- * Allows to configure the context to use in queries you can execute and to ensure that
- * the expected configuration is provided
- *
  * @author    Damien Carcel <damien.carcel@akeneo.com>
  * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)

--- a/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilySubProductModelsTaskletSpec.php
+++ b/src/Pim/Component/Connector/spec/Job/ComputeDataRelatedToFamilySubProductModelsTaskletSpec.php
@@ -26,9 +26,6 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
- * Allows to configure the context to use in queries you can execute and to ensure that
- * the expected configuration is provided
- *
  * @author    Damien Carcel <damien.carcel@akeneo.com>
  * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)


### PR DESCRIPTION
## Description

This PR fixes inconsistencies in the datetime shown in the UI. Several are displayed using the server timezone, when it should use the one defined in the current user settings.

The fixes affect:
- the notifications,
- the product history displayed in the PEF side information => **commit cherry-picked from https://github.com/akeneo/pim-community-dev/pull/8774**,
- import/export start and end time => fixed on the job execution datagrid (in the job profile page) and the job execution detailed view. The process tracker datagrid was already OK.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
