### PR TITLE
PIM-7656: Fix link insertion in wysiwyg mass edit field

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,6 +7,7 @@
 - PIM-7619: Fix search on groups for the variant products.
 - PIM-7671: Fix associations tab cannot display more than 24 associated products/product models or 25 groups.
 - PIM-7668: Fix issues with timezone in various screen, to always use current user timezone.
+- PIM-7656: Fix a bug preventing a link insertion in WYSIWYG mass edit field.
 
 # 2.3.9 (2018-09-25)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -24,7 +24,8 @@ define(
         return Field.extend({
             fieldTemplate: _.template(fieldTemplate),
             events: {
-                'change .field-input:first textarea:first': 'updateModel'
+                'change .field-input:first textarea:first': 'updateModel',
+                'click .note-insert': 'moveModalBackdrop'
             },
 
             /**
@@ -84,6 +85,15 @@ define(
              */
             setFocus: function () {
                 this.$('.field-input:first .note-editable').trigger('focus');
+            },
+
+            /**
+             * Places the modal backdrop in the page itself, and not outside of the body.
+             * This allows the z-index to work properly in the mass-edit form, as it is
+             * itself in a modal with its own z-index.
+             */
+            moveModalBackdrop: function () {
+                $('.modal-backdrop').prependTo('.AknFullPage');
             }
         });
     }


### PR DESCRIPTION
**Description**

A bug prevents from inserting a link when a user mass-edit a text area with the WYSIWYG enabled.
The pop-in window appears, but the "modal-backdrop" mask stays on it.

![modal](https://user-images.githubusercontent.com/5039018/46213414-c8d83e80-c338-11e8-8b5d-02ce9c6bd619.gif)

The pop-in has a higher z-index to stay atop the "modal-backdrop", and this works fine on the PEF.

The problem is that the mass-edit form is in a bootstrap modal, and the pop-in is declared in this modal, but the mask is not (t is not even in the HTML page body, but in a `div` element placed directly at the very end of the `html` tag, after the `body`).

As a result, the mask z-index always win, because even if it is lower than the pop-in z-index, it is higher than the bootstrap modal z-index, so the pop-in one is ignored.

The (very dirty) fix consists in moving the "modal-backdrop" in the bootstrap modal, so its z-index can be applied.

![fixed](https://user-images.githubusercontent.com/5039018/46213416-caa20200-c338-11e8-935e-cef96f93d505.png)

Please note that the ugly pop-in styling has nothing to do with this PR, and is already like that on released tags of the 2.3.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
