### PR TITLE
PIM-7672: Fix the mass edit controller to launch jobs with authentication

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-7676: Add code filter on attribute and family grid
 - PIM-7673: Fix permissions on locales applied on channel settings page
 - PIM-7664: ReferenceDataCollectionValueFactory can now ignore unknown reference data with an optionnal argument and not throw an exception.
+- PIM-7672: Fix the mass edit controller to launch jobs with authentication.
 
 # 2.3.10 (2018-10-01)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -250,7 +250,7 @@ services:
         arguments:
             - '@oro_datagrid.mass_action.parameters_parser'
             - '@pim_datagrid.adapter.oro_to_pim_grid_filter'
-            - '@pim_enrich.mass_edit_action.operation_job_launcher'
+            - '@pim_enrich.mass_edit_action.operation_authenticated_job_launcher'
             - '@pim_enrich.converter.mass_operation'
             - '@pim_datagrid.adapter.items_counter'
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/mass_actions.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/mass_actions.yml
@@ -4,9 +4,17 @@ parameters:
 services:
     # Mass edit action operation registry
 
+    # @todo merge : unused service to remove
     pim_enrich.mass_edit_action.operation_job_launcher:
         class: '%pim_enrich.mass_edit_action.operation_job_launcher.class%'
         arguments:
             - '@akeneo_batch_queue.launcher.queue_job_launcher'
+            - '@akeneo_batch.job.job_instance_repository'
+            - '@security.token_storage'
+
+    pim_enrich.mass_edit_action.operation_authenticated_job_launcher:
+        class: '%pim_enrich.mass_edit_action.operation_job_launcher.class%'
+        arguments:
+            - '@pim_connector.launcher.authenticated_job_launcher'
             - '@akeneo_batch.job.job_instance_repository'
             - '@security.token_storage'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The jobs launched from the UI with the "mass-edit" actions didn't use the authenticated job launcher. So the user was not passed to the job processors. To apply permissions in EE on these actions, an ugly trick was done to overwrite the token with one created from the user that launch the mass edit.

Now, all the jobs launched from the mass edit controller will have the option "is_user_authenticated" to true.

This fix will allow to use the authorization checker without doing the trick. (cf https://github.com/akeneo/pim-enterprise-dev/pull/4700)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
