### PR TITLE
PIM-7624: Remove the clear from product grid about activated locales cache

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/product/index.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/product/index.js
@@ -45,7 +45,6 @@ define(
                 this.selectMenuTab();
 
                 const { gridName, gridExtension } = this.config;
-                fetcherRegistry.getFetcher('locale').clear();
                 fetcherRegistry.getFetcher('datagrid-view').clear();
                 sequentialEditProvider.clear();
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/view-selector.js
@@ -428,6 +428,7 @@ define(
 
                 this.currentView = view;
                 this.trigger('grid:view-selector:view-selected', view);
+                FetcherRegistry.getFetcher('locale').clear();
                 this.reloadPage();
             },
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When requesting the datagrid, there is always a query executed before starting all the other ones:

'http://demo.akeneo.com/configuration/locale/rest?activated=true'
As we deactivate very very barely a locale, we can put in cache this query.
It will save from 60 to 100ms.

=> this call is already in cache, but the product index.js clear this value every time. I just remove this line.

**Definition Of Done (for Core Developer only)**

Merged because has random but CI is green according to @Doodoune.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
