### PR TITLE
PIM-7664: an exception is not thrown anymore when the asset cannot be loaded

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7673: Fix permissions on locales applied on channel settings page
+- PIM-7664: ReferenceDataCollectionValueFactory can now ignore unknown reference data with an optionnal argument and not throw an exception.
 
 # 2.3.10 (2018-10-01)
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/LoadEntityWithValuesSubscriberIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/LoadEntityWithValuesSubscriberIntegration.php
@@ -112,6 +112,9 @@ class LoadEntityWithValuesSubscriberIntegration extends TestCase
                 'sku'    => [
                     ['locale' => null, 'scope' => null, 'data' => 'product_invalid_multi_reference_data'],
                 ],
+                'a_ref_data_multi_select'            => [
+                    ['locale' => null, 'scope' => null, 'data' => ['fabricA']]
+                ],
             ]
         );
         $product = $this->findProductByIdentifier('product_invalid_multi_reference_data');

--- a/src/Pim/Component/Catalog/Factory/Value/ValueFactoryInterface.php
+++ b/src/Pim/Component/Catalog/Factory/Value/ValueFactoryInterface.php
@@ -25,6 +25,8 @@ interface ValueFactoryInterface
      * @param mixed              $data
      *
      * @return ValueInterface
+     *
+     * @todo merge master : add an argument at the end  : "bool $ignoreUnknownData". Cf ReferenceDataCollectionValueFactory class.
      */
     public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data);
 

--- a/src/Pim/Component/Catalog/Factory/ValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ValueCollectionFactory.php
@@ -76,7 +76,7 @@ class ValueCollectionFactory implements ValueCollectionFactoryInterface
                         }
 
                         try {
-                            $values[] = $this->valueFactory->create($attribute, $channelCode, $localeCode, $data);
+                            $values[] = $this->valueFactory->create($attribute, $channelCode, $localeCode, $data, true);
                         } catch (InvalidOptionException $e) {
                             $this->logger->warning(
                                 sprintf(

--- a/src/Pim/Component/Catalog/Factory/ValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ValueFactory.php
@@ -46,12 +46,13 @@ class ValueFactory
      * @param string             $channelCode
      * @param string             $localeCode
      * @param mixed              $data
+     * @param bool               $ignoreUnknownData
      *
      * @throws \LogicException
      *
      * @return ValueInterface
      */
-    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data)
+    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data, $ignoreUnknownData = false)
     {
         try {
             $this->attributeValidatorHelper->validateScope($attribute, $channelCode);
@@ -61,7 +62,7 @@ class ValueFactory
         }
 
         $factory = $this->getFactory($attribute->getType());
-        $value = $factory->create($attribute, $channelCode, $localeCode, $data);
+        $value = $factory->create($attribute, $channelCode, $localeCode, $data, $ignoreUnknownData);
 
         return $value;
     }

--- a/src/Pim/Component/Catalog/spec/Factory/ValueCollectionFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/ValueCollectionFactorySpec.php
@@ -63,15 +63,15 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         $attributeRepository->findOneByIdentifier('sku')->willReturn($sku);
         $attributeRepository->findOneByIdentifier('description')->willReturn($description);
 
-        $valueFactory->create($sku, null, null, 'foo')->willReturn($value1);
+        $valueFactory->create($sku, null, null, 'foo', true)->willReturn($value1);
         $valueFactory
-            ->create($description, 'ecommerce', 'en_US', 'a text area for ecommerce in English')
+            ->create($description, 'ecommerce', 'en_US', 'a text area for ecommerce in English', true)
             ->willReturn($value2);
         $valueFactory
-            ->create($description, 'tablet', 'en_US', 'a text area for tablets in English')
+            ->create($description, 'tablet', 'en_US', 'a text area for tablets in English', true)
             ->willReturn($value3);
         $valueFactory
-            ->create($description, 'tablet', 'fr_FR', 'une zone de texte pour les tablettes en français')
+            ->create($description, 'tablet', 'fr_FR', 'une zone de texte pour les tablettes en français', true)
             ->willReturn($value4);
 
         $actualValues = $this->createFromStorageFormat([
@@ -131,7 +131,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         AttributeInterface $color
     ) {
         $attributeRepository->findOneByIdentifier('color')->willReturn($color);
-        $valueFactory->create($color, null, null, 'red')->willThrow(
+        $valueFactory->create($color, null, null, 'red', true)->willThrow(
             InvalidOptionException::validEntityCodeExpected(
                 'color',
                 'code',
@@ -165,7 +165,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         $color->getCode()->willReturn('code');
         $color->isUnique()->willReturn(false);
         $attributeRepository->findOneByIdentifier('color')->willReturn($color);
-        $valueFactory->create($color, null, null, ['red', 'purple', 'yellow'])->willThrow(
+        $valueFactory->create($color, null, null, ['red', 'purple', 'yellow'], true)->willThrow(
             InvalidOptionsException::validEntityListCodesExpected(
                 'color',
                 'codes',
@@ -201,7 +201,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         AttributeInterface $color
     ) {
         $attributeRepository->findOneByIdentifier('color')->willReturn($color);
-        $valueFactory->create($color, null, null, 'red')->willThrow(
+        $valueFactory->create($color, null, null, 'red', true)->willThrow(
             new InvalidAttributeException('attribute', 'color', static::class)
         );
 
@@ -226,7 +226,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         AttributeInterface $referenceData
     ) {
         $attributeRepository->findOneByIdentifier('image')->willReturn($referenceData);
-        $valueFactory->create($referenceData, null, null, 'my_image')->willThrow(
+        $valueFactory->create($referenceData, null, null, 'my_image', true)->willThrow(
             new InvalidPropertyException('attribute', 'image', static::class)
         );
 
@@ -261,10 +261,10 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         $value1->getAttribute()->willReturn($image);
 
         $attributeRepository->findOneByIdentifier('image')->willReturn($referenceData);
-        $valueFactory->create($referenceData, null, null, 'my_image')->willThrow(
+        $valueFactory->create($referenceData, null, null, 'my_image', true)->willThrow(
             new InvalidPropertyTypeException('attribute', 'image', static::class)
         );
-        $valueFactory->create($referenceData, null, null, 'empty_image')->willReturn($value1);
+        $valueFactory->create($referenceData, null, null, 'empty_image', true)->willReturn($value1);
 
         $logger->warning(
             Argument::containingString('Tried to load a product value for attribute "image" that does not have the good type.')

--- a/src/Pim/Component/Catalog/spec/Factory/ValueFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/ValueFactorySpec.php
@@ -40,7 +40,7 @@ class ValueFactorySpec extends ObjectBehavior
         $attributeValidatorHelper->validateLocale($attribute, null)->shouldBeCalled();
         $attributeValidatorHelper->validateScope($attribute, null)->shouldBeCalled();
 
-        $productValueFactory->create($attribute, null, null, 'foobar')->willReturn($productValue);
+        $productValueFactory->create($attribute, null, null, 'foobar', false)->willReturn($productValue);
 
         $this->create($attribute, null, null, 'foobar')->shouldReturn($productValue);
     }
@@ -66,7 +66,7 @@ class ValueFactorySpec extends ObjectBehavior
         $attributeValidatorHelper->validateScope($attribute, 'ecommerce')->shouldBeCalled();
         $attributeValidatorHelper->validateLocale($attribute, 'en_US')->shouldBeCalled();
 
-        $productValueFactory->create($attribute, 'ecommerce', 'en_US', 'foobar')->willReturn($productValue);
+        $productValueFactory->create($attribute, 'ecommerce', 'en_US', 'foobar', false)->willReturn($productValue);
 
         $this->create($attribute, 'ecommerce', 'en_US', 'foobar')->shouldReturn($productValue);
     }

--- a/src/Pim/Component/ReferenceData/spec/Factory/Value/ReferenceDataCollectionValueFactorySpec.php
+++ b/src/Pim/Component/ReferenceData/spec/Factory/Value/ReferenceDataCollectionValueFactorySpec.php
@@ -206,7 +206,7 @@ class ReferenceDataCollectionValueFactorySpec extends ObjectBehavior
         $this->shouldThrow($exception)->during('create', [$attribute, null, null, ['foo' => ['bar']]]);
     }
 
-    function it_throws_an_exception_when_provided_data_is_not_an_existing_reference_data_code(
+    function it_throws_an_exception_when_reference_data_code_does_not_exist_with_inactive_ignore_unknown_data_option(
         $repositoryResolver,
         ReferenceDataRepositoryInterface $referenceDataRepository,
         AttributeInterface $attribute
@@ -230,7 +230,39 @@ class ReferenceDataCollectionValueFactorySpec extends ObjectBehavior
             'foobar'
         );
 
-        $this->shouldThrow($exception)->during('create', [$attribute, null, null, ['foobar']]);
+        $this->shouldThrow($exception)->during('create', [$attribute, null, null, ['foobar'], false]);
+    }
+
+    function it_does_not_stop_when_provided_data_is_not_an_existing_reference_data_code_with_ignore_unknown_data_option_active(
+        $repositoryResolver,
+        AttributeInterface $attribute,
+        Fabric $silk,
+        ReferenceDataRepositoryInterface $referenceDataRepository
+    ) {
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(false);
+        $attribute->getCode()->willReturn('reference_data_multi_select_attribute');
+        $attribute->getType()->willReturn('pim_reference_data_catalog_multiselect');
+        $attribute->getBackendType()->willReturn('reference_data_options');
+        $attribute->isBackendTypeReferenceData()->willReturn(true);
+        $attribute->getReferenceDataName()->willReturn('fabrics');
+
+        $repositoryResolver->resolve('fabrics')->willReturn($referenceDataRepository);
+        $referenceDataRepository->findOneBy(['code' => 'silk'])->willReturn($silk);
+        $referenceDataRepository->findOneBy(['code' => 'cotton'])->willReturn(null);
+
+        $productValue = $this->create(
+            $attribute,
+            null,
+            null,
+            ['silk', 'cotton'],
+            true
+        );
+
+        $productValue->shouldReturnAnInstanceOf(ReferenceDataCollectionValue::class);
+        $productValue->shouldHaveAttribute('reference_data_multi_select_attribute');
+        $productValue->shouldHaveOnlyOneReferenceData();
+        $productValue->shouldHaveReferenceData([$silk]);
     }
 
     public function getMatchers()
@@ -263,6 +295,9 @@ class ReferenceDataCollectionValueFactorySpec extends ObjectBehavior
                 }
 
                 return $hasFabrics;
+            },
+            'haveOnlyOneReferenceData' => function ($subject) {
+                return 1 === count($subject->getData());
             },
         ];
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

EE PR : https://github.com/akeneo/pim-enterprise-dev/pull/4730

This PR add a fix to prevent an asset collection to be empty on the PEF when one or multiple assets of the collection are deleted. An exception was thrown in the ReferenceDataCollectionValueFactory that stopped the loading of ALL the assets of the attribute asset collection.

I tried a first iteration by just removing the thrown exception, but it broke the rules & product import. So we decided to add an optionnal parameter to choose if we want to ignore unknown reference data or not.
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
