### PR TITLE
PIM-7681: Harmonize entity exports for locales

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7681: Harmonize entity exports for locales
+
 # 2.3.10 (2018-10-01)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_standard.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_standard.yml
@@ -176,7 +176,7 @@ services:
     pim_catalog.normalizer.standard.translation:
         class: '%pim_catalog.normalizer.standard.translation.class%'
         arguments:
-            - '@pim_catalog.repository.cached_locale'
+            - '@pim_catalog.repository.locale'
         tags:
             - { name: pim_serializer.normalizer, priority: 80 }
 


### PR DESCRIPTION
This is a simple implementation of a feature request to normalize the way active locales are present in all exports. 
We want all the active locales to be in the export, whether there is a value for it or not. Some entities already behaved like that, but not all (attributes, family, …). 
In order to do that, I always initialize the translations array with the active locales, and if the object being normalized has a value for it, I'll populate the entry with it. otherwise, it stays `null`.
Note that I still respect the behavior introduced by https://github.com/akeneo/pim-community-dev/pull/8877.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -


