### PR TITLE
PIM-7674: fix Avatar image broken on dashboard

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -6,6 +6,7 @@
 - PIM-7673: Fix permissions on locales applied on channel settings page
 - PIM-7664: ReferenceDataCollectionValueFactory can now ignore unknown reference data with an optionnal argument and not throw an exception.
 - PIM-7672: Fix the mass edit controller to launch jobs with authentication.
+- PIM-7674: fix Avatar image broken on dashboard
 
 # 2.3.10 (2018-10-01)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/media.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/media.yml
@@ -15,6 +15,14 @@ pim_enrich_default_thumbnail:
     requirements:
         mimeType: "[a-z-]+/[a-z0-9.-]+"
 
+pim_enrich_media_cache_resolve:
+    path: /cache/resolve/{filter}/{path}
+    defaults: { _controller: pim_enrich.controller.file:cacheAction}
+    methods: [GET]
+    requirements:
+        filter: '[A-z0-9_-]*'
+        path: .+
+
 pim_enrich_media_cache:
     path: /cache/{filter}/{path}
     defaults: { _controller: pim_enrich.controller.file:cacheAction}

--- a/src/Pim/Bundle/UserBundle/Entity/User.php
+++ b/src/Pim/Bundle/UserBundle/Entity/User.php
@@ -878,7 +878,7 @@ class User implements UserInterface
 
         $suffix = $this->getCreatedAt() ? $this->getCreatedAt()->format('Y-m') : date('Y-m');
 
-        return 'uploads'.$ds.'users'.$ds.$suffix;
+        return ($forWeb ? $ds : '').'uploads'.$ds.'users'.$ds.$suffix;
     }
 
     /**


### PR DESCRIPTION
PIM-7612 introduced a problem with some routing of liip_imagine. This extra route makes it retro-compatible with some generated urls.
Also, the user's avatar URL was missing a leading `/`, which was interpreted by the browser as a relative url, thus breaking the top right avatar image on URLs with sub paths.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

