### PR TITLE
PIM-7655: fix attribute group sort order

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute-group/form/list.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/attribute-group/form/list.js
@@ -8,18 +8,18 @@
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 define([
-        'jquery',
-        'underscore',
-        'oro/translator',
-        'pim/form',
-        'pim/fetcher-registry',
-        'pim/common/property',
-        'routing',
-        'pim/router',
-        'pim/user-context',
-        'pim/i18n',
-        'pim/template/form/attribute-group/list'
-    ],
+    'jquery',
+    'underscore',
+    'oro/translator',
+    'pim/form',
+    'pim/fetcher-registry',
+    'pim/common/property',
+    'routing',
+    'pim/router',
+    'pim/user-context',
+    'pim/i18n',
+    'pim/template/form/attribute-group/list'
+],
     function (
         $,
         _,
@@ -58,8 +58,8 @@ define([
              */
             render: function () {
                 this.$el.html(this.template({
-                    attributeGroups: _.sortBy(_.values(this.attributeGroups), function(attributeGroup) {
-                        return [attributeGroup.sort_order, attributeGroup.code].join('_');
+                    attributeGroups: _.sortBy(_.values(this.attributeGroups), function (attributeGroup) {
+                        return attributeGroup.sort_order;
                     }),
                     i18n: i18n,
                     uiLocale: UserContext.get('catalogLocale')
@@ -70,10 +70,10 @@ define([
                     containment: 'parent',
                     tolerance: 'pointer',
                     update: this.updateAttributeOrders.bind(this),
-                    helper: function(e, tr) {
+                    helper: function (e, tr) {
                         var $originals = tr.children();
                         var $helper = tr.clone();
-                        $helper.children().each(function(index) {
+                        $helper.children().each(function (index) {
                             $(this).width($originals.eq(index).width());
                         });
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
