### PR TITLE
PIM-7718: Fix update of family requirements for existing and non-requ…

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,5 +1,9 @@
 # 1.7.x
 
+## Bug fixes
+
+- PIM-7718: Fix attribute requirements update for a newly created channel
+
 # 1.7.32 (2018-09-07)
 
 ## Improvements

--- a/features/family/define_the_attribute_requirement.feature
+++ b/features/family/define_the_attribute_requirement.feature
@@ -59,7 +59,6 @@ Feature: Define the attribute requirement
     And I should not see the text "There are unsaved changes."
     Then I should not see the "rating" attribute
     When I launched the completeness calculator
-    And I wait for the "compute_completeness_of_products_family" job to finish
     When I am on the "BIGBOOTS" product page
     And I open the "Completeness" panel
     Then I should see the completeness:

--- a/features/family/define_the_attribute_requirement.feature
+++ b/features/family/define_the_attribute_requirement.feature
@@ -67,8 +67,7 @@ Feature: Define the attribute requirement
       | mobile  | en_US  | success |                                            | 100%  |
       | tablet  | en_US  | warning | Description, Weather conditions, Side view | 63%   |
 
-  @javascript
-  @jira https://akeneo.atlassian.net/browse/PIM-7718
+  @javascript @jira https://akeneo.atlassian.net/browse/PIM-7718
   Scenario: Successfully add an attribute requirement for a newly created channel
     Given the following channel:
       | code      | label-en_US | currencies | locales | tree            |

--- a/features/family/define_the_attribute_requirement.feature
+++ b/features/family/define_the_attribute_requirement.feature
@@ -59,9 +59,24 @@ Feature: Define the attribute requirement
     And I should not see the text "There are unsaved changes."
     Then I should not see the "rating" attribute
     When I launched the completeness calculator
+    And I wait for the "compute_completeness_of_products_family" job to finish
     When I am on the "BIGBOOTS" product page
     And I open the "Completeness" panel
     Then I should see the completeness:
       | channel | locale | state   | missing_values                             | ratio |
       | mobile  | en_US  | success |                                            | 100%  |
       | tablet  | en_US  | warning | Description, Weather conditions, Side view | 63%   |
+
+  @javascript
+  @jira https://akeneo.atlassian.net/browse/PIM-7718
+  Scenario: Successfully add an attribute requirement for a newly created channel
+    Given the following channel:
+      | code      | label-en_US | currencies | locales | tree            |
+      | ecommerce | Ecommerce   | EUR,USD    | en_US   | 2014_collection |
+    When I visit the "Attributes" tab
+    Then attribute "name" should be required in channels mobile and tablet
+    But attribute "name" should not be required in channel ecommerce
+    When I switch the attribute "name" requirement in channel "ecommerce"
+    And I save the family
+    Then I should not see the text "There are unsaved changes."
+    And attribute "name" should be required in channel ecommerce

--- a/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/FamilyUpdater.php
@@ -243,7 +243,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
                 $key = array_search($attribute->getCode(), $newRequirements[$channelCode], true);
                 if (false === $key && AttributeTypes::IDENTIFIER !== $attribute->getType()) {
                     $family->removeAttributeRequirement($requirement);
-                } elseif (false !== $key) {
+                } elseif (false !== $key && true === $requirement->isRequired()) {
                     unset($newRequirements[$channelCode][$key]);
                 }
             }
@@ -252,6 +252,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
         foreach ($newRequirements as $channelCode => $requirements) {
             $createdRequirements = $this->createAttributeRequirementsByChannel($family, $requirements, $channelCode);
             foreach ($createdRequirements as $createdRequirement) {
+                $createdRequirement->setRequired(true);
                 $family->addAttributeRequirement($createdRequirement);
             }
         }


### PR DESCRIPTION
Backport of https://github.com/akeneo/pim-community-dev/pull/8002 done in 2.0.

This PR fixes an issue when trying to add an attribute requirement for a family, and the attribute requirement already exists but its required property is set to false (which is the case for newly created channels)


<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
