### PR TITLE
[WIP] decrease build time by using docker layer cache

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -35,7 +35,10 @@ RUN ln -s /usr/sbin/php-fpm7.2 /usr/local/bin/php-fpm \
         libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
         fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils
 
-COPY --from=eu.gcr.io/akeneo-ci/github-akeneo-ci-dependencies-warmer:master /tmp /tmp
+COPY composer.json composer.lock package.json ./
+
+RUN composer install --no-ansi --no-autoloader --no-scripts --no-interaction --no-progress --prefer-dist --no-dev 
+
 COPY . .
 COPY .ci/vhost.conf /etc/apache2/sites-available/000-default.conf
 

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -37,7 +37,7 @@ RUN ln -s /usr/sbin/php-fpm7.2 /usr/local/bin/php-fpm \
 
 COPY composer.json composer.lock package.json ./
 
-RUN composer install --no-ansi --no-autoloader --no-scripts --no-interaction --no-progress --prefer-dist --no-dev 
+RUN composer  $COMPOSER_COMMAND --no-ansi --no-autoloader --no-scripts --no-interaction --no-progress --prefer-dist --no-suggest
 
 COPY . .
 COPY .ci/vhost.conf /etc/apache2/sites-available/000-default.conf

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -154,7 +154,7 @@ stage("Test") {
                 script: "cd /var/www/pim && yarn run webpack-test && yarn run integration"
             )},
             "back-legacy-phpunit-integration-ce": {queue(
-                condition: launchIntegrationTests.equals("yes") && editions.contains("ce"),
+                condition: launchIntegrationTests.equals("yes"),
                 verbose: (verboseOutputs == "yes"),
                 container: tag,
                 containers: pimContainers(image: tag, selenium: false),
@@ -172,7 +172,7 @@ stage("Test") {
 
             // END TO END TESTS
             "legacy-end-to-end-behat-ce": {queue(
-                condition: launchEndToEndTests.equals("yes") && editions.contains("ce"),
+                condition: launchEndToEndTests.equals("yes"),
                 verbose: (verboseOutputs == "yes"),
                 container: tag,
                 containers: pimContainers(image: tag),

--- a/.ci/builder.yaml
+++ b/.ci/builder.yaml
@@ -1,8 +1,10 @@
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['pull', 'eu.gcr.io/akeneo-ci/pim-community-dev:master']
+    waitFor: ['-']   
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '--cache-from', 'eu.gcr.io/akeneo-ci/pim-community-dev:master', '--build-arg', 'COMPOSER_COMMAND=${_COMPOSER_COMMAND}', '-t', '${_IMAGE_TAG}', '.']
+    waitFor: ['pull-cache']
 images: [
   '${_IMAGE_TAG}'
 ]

--- a/.ci/builder.yaml
+++ b/.ci/builder.yaml
@@ -1,5 +1,6 @@
 steps:
-  - name: 'gcr.io/cloud-builders/docker'
+  - id: pull-cache
+    name: 'gcr.io/cloud-builders/docker'
     args: ['pull', 'eu.gcr.io/akeneo-ci/pim-community-dev:master']
     waitFor: ['-']   
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
The goal of this PR is to reduce docker build time when you have no change on composer.json and composer.lock.

If you change the composer.json on your PR the docker build won't use the cache for the composer step.

Otherwise, docker build will reuse the previous layer that match with images built on the master branch (nightly).


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
