### PR TITLE
Pim 7724 / 7726 - Firefox : Error 0 during roles saving and Issue when changing a role's name

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,6 +7,7 @@
 - PIM-7731: check for attribute as label not null in normalizers 
 - PIM-7740: bump summernote version to fix scroll glitches
 - PIM-7727: parent filter search case insensitive
+- PIM-7724: fix role label update and error displayed on permission save action
 
 # 2.3.11 (2018-10-08)
 

--- a/src/Oro/Bundle/UserBundle/Form/Handler/AclRoleHandler.php
+++ b/src/Oro/Bundle/UserBundle/Form/Handler/AclRoleHandler.php
@@ -111,8 +111,7 @@ class AclRoleHandler
                 $appendUsers = $this->form->get('appendUsers')->getData();
                 $removeUsers = $this->form->get('removeUsers')->getData();
 
-                if(empty($role->getRole()))
-                {
+                if (empty($role->getRole())) {
                     $role->setRole(strtoupper(trim(preg_replace('/[^\w\-]/i', '_', $role->getLabel()))));
                 }
 

--- a/src/Oro/Bundle/UserBundle/Form/Handler/AclRoleHandler.php
+++ b/src/Oro/Bundle/UserBundle/Form/Handler/AclRoleHandler.php
@@ -110,7 +110,12 @@ class AclRoleHandler
             if ($this->form->isValid()) {
                 $appendUsers = $this->form->get('appendUsers')->getData();
                 $removeUsers = $this->form->get('removeUsers')->getData();
-                $role->setRole(strtoupper(trim(preg_replace('/[^\w\-]/i', '_', $role->getLabel()))));
+
+                if(empty($role->getRole()))
+                {
+                    $role->setRole(strtoupper(trim(preg_replace('/[^\w\-]/i', '_', $role->getLabel()))));
+                }
+
                 $this->onSuccess($role, $appendUsers, $removeUsers);
 
                 $this->processPrivileges($role);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/role.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/role.js
@@ -35,9 +35,14 @@ define([
              * {@inheritdoc}
              */
             afterSubmit: function () {
+                securityContext.initialize();
+                configProvider.clear();
+
                 FormController.prototype.afterSubmit.apply(this, arguments);
 
-                location.reload();
+                if (!this.$('#entity-updated span').is(':visible')) {
+                    location.reload();
+                }
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/role.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/role.js
@@ -35,14 +35,9 @@ define([
              * {@inheritdoc}
              */
             afterSubmit: function () {
-                securityContext.initialize();
-                configProvider.clear();
-
                 FormController.prototype.afterSubmit.apply(this, arguments);
 
-                if (!this.$('#entity-updated span').is(':visible')) {
-                    location.reload();
-                }
+                location.reload();
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/error/error.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/error/error.html
@@ -1,8 +1,10 @@
 <div class="AknInfoBlock AknInfoBlock--error">
     <img src="/bundles/pimui/images/illustration-error-<%- statusCode >= 400 && statusCode < 500 ? '404' : '503' %>.svg"/>
+    <% if (statusCode > 0) {%>
     <span class="AknInfoBlock-errorNumber AknInfoBlock-errorNumber--<%- statusCode >= 400 && statusCode < 500 ? '400' : '500' %>"><%- statusCode %></span>
     <h1>
         <%- _.__('pim_enrich.error.exception.title', {'status_code': statusCode}) %>
     </h1>
     <div class="AknMessageBox AknMessageBox--danger AknMessageBox--centered"><%- message %></div>
+    <% } %>
 </div>

--- a/src/Pim/Component/User/Updater/RoleUpdater.php
+++ b/src/Pim/Component/User/Updater/RoleUpdater.php
@@ -68,7 +68,10 @@ class RoleUpdater implements ObjectUpdaterInterface
     {
         switch ($field) {
             case 'role':
-                $role->setRole($data);
+                if(empty($role->getRole()))
+                {
+                    $role->setRole($data);
+                }
                 break;
             case 'label':
                 $role->setLabel($data);

--- a/src/Pim/Component/User/Updater/RoleUpdater.php
+++ b/src/Pim/Component/User/Updater/RoleUpdater.php
@@ -68,8 +68,7 @@ class RoleUpdater implements ObjectUpdaterInterface
     {
         switch ($field) {
             case 'role':
-                if(empty($role->getRole()))
-                {
+                if (empty($role->getRole())) {
                     $role->setRole($data);
                 }
                 break;

--- a/src/Pim/Component/User/spec/Updater/RoleUpdaterSpec.php
+++ b/src/Pim/Component/User/spec/Updater/RoleUpdaterSpec.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace spec\Pim\Component\User\Updater;
+
+use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Oro\Bundle\SecurityBundle\Acl\Persistence\AclManager;
+use Oro\Bundle\UserBundle\Entity\Role;
+use PhpSpec\ObjectBehavior;
+use Pim\Component\User\Updater\RoleUpdater;
+use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
+
+class RoleUpdaterSpec extends ObjectBehavior
+{
+    function let(
+        AclManager $aclManager
+    ) {
+        $this->beConstructedWith($aclManager);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldBeAnInstanceOf(RoleUpdater::class);
+    }
+
+    function it_is_an_updater()
+    {
+        $this->shouldImplement(ObjectUpdaterInterface::class);
+    }
+
+    function it_creates_a_role(
+        Role $role,
+        SecurityIdentityInterface $sid,
+        $aclManager
+    )
+    {
+        $role->getRole()->willReturn(null);
+        $role->setRole('ROLE_ADMINISTRATOR')->shouldBeCalled();
+        $role->setLabel('administrator')->shouldBeCalled();
+
+        $aclManager->getSid($role)->willReturn($sid);
+        $aclManager->getAllExtensions()->willReturn([]);
+
+        $aclManager->flush()->shouldBeCalled();
+
+        $this->update(
+            $role,
+            [
+                'role' => 'ROLE_ADMINISTRATOR',
+                'label' => 'administrator'
+            ]
+        );
+    }
+
+    function it_updates_a_role_label_but_never_the_role_code(
+        Role $role,
+        SecurityIdentityInterface $sid,
+        $aclManager
+    )
+    {
+        $role->getRole()->willReturn('ROLE_ADMINISTRATOR');
+        $role->setRole('ROLE_ADMINISTRATOR')->shouldNotBeCalled();
+        $role->setLabel('admin')->shouldBeCalled();
+
+        $role->getRole()->willReturn('ROLE_ADMINISTRATOR');
+        $aclManager->getSid($role)->willReturn($sid);
+        $aclManager->getAllExtensions()->willReturn([]);
+
+        $aclManager->flush()->shouldBeCalled();
+
+        $this->update(
+            $role,
+            [
+                'role' => 'ROLE_ADMINISTRATOR',
+                'label' => 'admin'
+            ]
+        );
+    }
+
+    function it_throws_an_exception_if_tries_to_update_anything_than_a_role()
+    {
+        $this->shouldThrow(InvalidObjectException::class)
+            ->during('update', [new \StdClass(), []]);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Two problems solved in this pull request.

**Problem 1**: "The role label update action (by UI or by Import) lead to an ACL failure"

**Problem 2**: "An error is displayed to the user on permission update even if the change is correctly applied"

Why two fixes in one PR ?
The second problem was put into relief by the first one in the issue raised by the customer. 

### 1 - The role label update action (by UI or by Import) lead to an ACL failure

**Problem:**
In the `oro_access_group` table you've three colums (id, role, label).

The `role` value is used in the code to check if you're granted to do some actions in the pim.

The ACL used to check your permissions is computed and store within your session stored in database. The `role` is used as a code and must be immutable (see https://github.com/akeneo/pim-community-dev/blob/2.3/src/Oro/Bundle/UserBundle/Entity/Role.php#L86)

But in our implementation of the Role, we update the label and the role which lead to a major ACL/Session issue, the pim could'nt be used until you've logged out /logged in to have a "fresh" session with the good `role` identifier.

**Solution:**
Do not call the `$role->setRole(...)` on update actions.

### 2 - An error is displayed to the user on permission update even if the change is correctly applied

**Problem:**
On `System/Role/Permissions` page, when you add/remove a permission and save, an Ajax request (`rest/security`) is fired, but the page is "hard reloaded", the Ajax request does not have the time to finish and an error "A 0 error as occured" is quickly displayed to the user (**only in firefox**)

Why do we "hard reload" this page ? -> as we update permissions, we have to in order to have a clean PIM UI which reflect the users' permissions.

_Example:_
You remove all the permissions of the "Product" entry and save, without "hard reload" the "Product menu entry" is still displayed to the user.

**Solution:**
Check if the status code is an existing one ( > 0 ) before render the error page.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
