### PR TITLE
PIM-7694: fix null options values string casting

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7674: fix Avatar image broken on dashboard
+- PIM-7694: fix option null values crashing PDF
 
 # 2.3.11 (2018-10-08)
 

--- a/src/Pim/Component/Catalog/Value/OptionValue.php
+++ b/src/Pim/Component/Catalog/Value/OptionValue.php
@@ -54,7 +54,11 @@ class OptionValue extends AbstractValue implements OptionValueInterface
         if (null !== $option = $this->getData()) {
             $optionValue = $option->getOptionValue();
 
-            return null !== $optionValue ? $optionValue->getValue() : '['.$option->getCode().']';
+            if (null === $optionValue || null === $optionValue->getValue()) {
+                return '['.$option->getCode().']';
+            }
+
+            return (string) $optionValue->getValue();
         }
 
         return '';

--- a/src/Pim/Component/Catalog/spec/Value/OptionValueSpec.php
+++ b/src/Pim/Component/Catalog/spec/Value/OptionValueSpec.php
@@ -35,6 +35,22 @@ class OptionValueSpec extends ObjectBehavior
         $this->__toString()->shouldReturn('[red]');
     }
 
+    function it_can_be_formatted_as_string_when_there_is_no_value(
+        AttributeInterface $attribute,
+        AttributeOptionInterface $option,
+        AttributeOptionValueInterface $value
+    ) {
+        $attribute->isScopable()->willReturn(true);
+        $attribute->isLocalizable()->willReturn(true);
+        $this->beConstructedWith($attribute, 'ecommerce', 'en_US', $option);
+
+        $option->getOptionValue()->willReturn($value);
+        $value->getValue()->willReturn(null);
+        $option->getCode()->willReturn('red');
+
+        $this->__toString()->shouldReturn('[red]');
+    }
+
     function it_can_be_formatted_as_string_when_there_is_a_translation(
         AttributeInterface $attribute,
         AttributeOptionInterface $option,


### PR DESCRIPTION
Fix null option values string casting.
Null options values should return the option code string instead of `null` in the `__toString` method.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
