### PR TITLE
PIM-7731: check for attribute as label not null

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-7674: fix Avatar image broken on dashboard
 - PIM-7694: fix option null values crashing PDF
+- PIM-7731: check for attribute as label not null in normalizers 
 
 # 2.3.11 (2018-10-08)
 

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -99,7 +99,12 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
             return [];
         }
 
-        $valuePath = sprintf('%s-text', $product->getFamily()->getAttributeAsLabel()->getCode());
+        $attributeAsLabel = $product->getFamily()->getAttributeAsLabel();
+        if (null === $attributeAsLabel) {
+            return [];
+        }
+
+        $valuePath = sprintf('%s-text', $attributeAsLabel->getCode());
         if (!isset($values[$valuePath])) {
             return [];
         }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
@@ -121,7 +121,12 @@ class ProductModelPropertiesNormalizer implements NormalizerInterface, Serialize
             return [];
         }
 
-        $valuePath = sprintf('%s-text', $productModel->getFamily()->getAttributeAsLabel()->getCode());
+        $attributeAsLabel = $productModel->getFamily()->getAttributeAsLabel();
+        if (null === $attributeAsLabel) {
+            return [];
+        }
+
+        $valuePath = sprintf('%s-text', $attributeAsLabel->getCode());
         if (!isset($values[$valuePath])) {
             return [];
         }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizer.php
@@ -111,7 +111,12 @@ class ProductModelPropertiesNormalizer implements NormalizerInterface, Serialize
             return [];
         }
 
-        $valuePath = sprintf('%s-text', $productModel->getFamily()->getAttributeAsLabel()->getCode());
+        $attributeAsLabel = $productModel->getFamily()->getAttributeAsLabel();
+        if (null === $attributeAsLabel) {
+            return [];
+        }
+
+        $valuePath = sprintf('%s-text', $attributeAsLabel->getCode());
         if (!isset($values[$valuePath])) {
             return [];
         }

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabelValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabelValidator.php
@@ -51,7 +51,6 @@ class FamilyAttributeAsLabelValidator extends ConstraintValidator
      */
     protected function doesAttributeAsLabelBelongToFamily(FamilyInterface $family)
     {
-
         $attributeAsLabel = $family->getAttributeAsLabel();
         if (null === $attributeAsLabel) {
             return false;
@@ -67,6 +66,11 @@ class FamilyAttributeAsLabelValidator extends ConstraintValidator
      */
     protected function isAttributeAsLabelTypeValid(FamilyInterface $family)
     {
+        $attributeAsLabel = $family->getAttributeAsLabel();
+        if (null === $attributeAsLabel) {
+            return false;
+        }
+
         return in_array($family->getAttributeAsLabel()->getType(), [
             AttributeTypes::IDENTIFIER,
             AttributeTypes::TEXT,

--- a/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabelValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/FamilyAttributeAsLabelValidator.php
@@ -51,7 +51,13 @@ class FamilyAttributeAsLabelValidator extends ConstraintValidator
      */
     protected function doesAttributeAsLabelBelongToFamily(FamilyInterface $family)
     {
-        return in_array($family->getAttributeAsLabel()->getCode(), $family->getAttributeCodes());
+
+        $attributeAsLabel = $family->getAttributeAsLabel();
+        if (null === $attributeAsLabel) {
+            return false;
+        }
+
+        return in_array($attributeAsLabel->getCode(), $family->getAttributeCodes());
     }
 
     /**
@@ -62,8 +68,8 @@ class FamilyAttributeAsLabelValidator extends ConstraintValidator
     protected function isAttributeAsLabelTypeValid(FamilyInterface $family)
     {
         return in_array($family->getAttributeAsLabel()->getType(), [
-                AttributeTypes::IDENTIFIER,
-                AttributeTypes::TEXT
-            ]);
+            AttributeTypes::IDENTIFIER,
+            AttributeTypes::TEXT,
+        ]);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
@@ -72,18 +72,18 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)->shouldReturn(
             [
-                'id' => '67',
-                'identifier' => 'sku-001',
-                'created' => $now->format('c'),
-                'updated' => $now->format('c'),
-                'family' => null,
-                'enabled' => false,
-                'categories' => [],
-                'groups' => [],
-                'completeness' => [],
-                'values' => [],
-                'label' => [],
-                'ancestors' => ['ids' => [], 'codes' => []],
+                'id'            => '67',
+                'identifier'    => 'sku-001',
+                'created'       => $now->format('c'),
+                'updated'       => $now->format('c'),
+                'family'        => null,
+                'enabled'       => false,
+                'categories'    => [],
+                'groups'        => [],
+                'completeness'  => [],
+                'values'        => [],
+                'label'         => [],
+                'ancestors'     => ['ids' => [], 'codes' => []],
             ]
         );
     }
@@ -132,18 +132,18 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)->shouldReturn(
             [
-                'id' => '67',
-                'identifier' => 'sku-001',
-                'created' => $now->format('c'),
-                'updated' => $now->format('c'),
-                'family' => null,
-                'enabled' => false,
-                'categories' => [],
-                'groups' => [],
-                'completeness' => ['the completenesses'],
-                'values' => [],
-                'label' => [],
-                'ancestors' => ['ids' => [], 'codes' => []],
+                'id'            => '67',
+                'identifier'    => 'sku-001',
+                'created'       => $now->format('c'),
+                'updated'       => $now->format('c'),
+                'family'        => null,
+                'enabled'       => false,
+                'categories'    => [],
+                'groups'        => [],
+                'completeness'  => ['the completenesses'],
+                'values'        => [],
+                'label'         => [],
+                'ancestors'     => ['ids' => [], 'codes' => []],
             ]
         );
     }
@@ -180,7 +180,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $serializer
             ->normalize($family, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
             ->willReturn([
-                'code' => 'family',
+                'code'   => 'family',
                 'labels' => [
                     'fr_FR' => 'Une famille',
                     'en_US' => 'A family',
@@ -201,9 +201,9 @@ class PropertiesNormalizerSpec extends ObjectBehavior
             [
                 'ecommerce' => [
                     'en_US' => [
-                        66,
-                    ],
-                ],
+                        66
+                    ]
+                ]
             ]
         );
 
@@ -292,40 +292,40 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)->shouldReturn(
             [
-                'id' => '67',
-                'identifier' => 'sku-001',
-                'created' => $now->format('c'),
-                'updated' => $now->format('c'),
+                'id'            => '67',
+                'identifier'    => 'sku-001',
+                'created'       => $now->format('c'),
+                'updated'       => $now->format('c'),
                 'family' => [
-                    'code' => 'family',
+                    'code'   => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
-                'enabled' => true,
-                'categories' => ['first_category', 'second_category'],
-                'groups' => ['first_group', 'second_group'],
+                'enabled'       => true,
+                'categories'    => ['first_category', 'second_category'],
+                'groups'        => ['first_group', 'second_group'],
                 'in_group' => [
-                    'first_group' => true,
-                    'second_group' => true,
+                    'first_group'     => true,
+                    'second_group'    => true,
                 ],
-                'completeness' => [
+                'completeness'  => [
                     'ecommerce' => [
                         'en_US' => [
                             66,
                         ],
                     ],
                 ],
-                'values' => [
+                'values'        => [
                     'a_size-decimal' => [
                         '<all_channels>' => [
                             '<all_locales>' => '10.51',
                         ],
                     ],
                 ],
-                'label' => [],
-                'ancestors' => ['ids' => [], 'codes' => []],
+                'label'         => [],
+                'ancestors'     => ['ids' => [], 'codes' => []],
             ]
         );
     }
@@ -382,7 +382,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $serializer
             ->normalize($family, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
             ->willReturn([
-                'code' => 'family',
+                'code'   => 'family',
                 'labels' => [
                     'fr_FR' => 'Une famille',
                     'en_US' => 'A family',
@@ -400,24 +400,24 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)->shouldReturn(
             [
-                'id' => '67',
-                'identifier' => 'sku-001',
-                'created' => $now->format('c'),
-                'updated' => $now->format('c'),
-                'family' => [
-                    'code' => 'family',
+                'id'           => '67',
+                'identifier'   => 'sku-001',
+                'created'      => $now->format('c'),
+                'updated'      => $now->format('c'),
+                'family'       => [
+                    'code'   => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
-                'enabled' => true,
-                'categories' => [],
-                'groups' => [],
+                'enabled'      => true,
+                'categories'   => [],
+                'groups'       => [],
                 'completeness' => [],
-                'values' => [],
-                'label' => [],
-                'ancestors' => ['ids' => ['product_model_2', 'product_model_1'], 'codes' => ['sub_pm_2', 'root_pm_1']],
+                'values'       => [],
+                'label'        => [],
+                'ancestors'    => ['ids' => ['product_model_2', 'product_model_1'], 'codes' => ['sub_pm_2', 'root_pm_1']],
             ]
         );
     }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/Product/PropertiesNormalizerSpec.php
@@ -72,18 +72,18 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)->shouldReturn(
             [
-                'id'            => '67',
-                'identifier'    => 'sku-001',
-                'created'       => $now->format('c'),
-                'updated'       => $now->format('c'),
-                'family'        => null,
-                'enabled'       => false,
-                'categories'    => [],
-                'groups'        => [],
-                'completeness'  => [],
-                'values'        => [],
-                'label'         => [],
-                'ancestors'     => ['ids' => [], 'codes' => []],
+                'id' => '67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => null,
+                'enabled' => false,
+                'categories' => [],
+                'groups' => [],
+                'completeness' => [],
+                'values' => [],
+                'label' => [],
+                'ancestors' => ['ids' => [], 'codes' => []],
             ]
         );
     }
@@ -132,18 +132,18 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)->shouldReturn(
             [
-                'id'            => '67',
-                'identifier'    => 'sku-001',
-                'created'       => $now->format('c'),
-                'updated'       => $now->format('c'),
-                'family'        => null,
-                'enabled'       => false,
-                'categories'    => [],
-                'groups'        => [],
-                'completeness'  => ['the completenesses'],
-                'values'        => [],
-                'label'         => [],
-                'ancestors'     => ['ids' => [], 'codes' => []],
+                'id' => '67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => null,
+                'enabled' => false,
+                'categories' => [],
+                'groups' => [],
+                'completeness' => ['the completenesses'],
+                'values' => [],
+                'label' => [],
+                'ancestors' => ['ids' => [], 'codes' => []],
             ]
         );
     }
@@ -180,7 +180,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $serializer
             ->normalize($family, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
             ->willReturn([
-                'code'   => 'family',
+                'code' => 'family',
                 'labels' => [
                     'fr_FR' => 'Une famille',
                     'en_US' => 'A family',
@@ -201,17 +201,83 @@ class PropertiesNormalizerSpec extends ObjectBehavior
             [
                 'ecommerce' => [
                     'en_US' => [
-                        66
-                    ]
-                ]
+                        66,
+                    ],
+                ],
             ]
         );
 
         $product->isVariant()->willReturn(false);
         $product->getValues()
-            ->shouldBeCalledTimes(2)
+            ->shouldBeCalledTimes(4)
             ->willReturn($valueCollection);
         $valueCollection->isEmpty()->willReturn(false);
+
+        $serializer->normalize($valueCollection, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX, [])
+            ->willReturn(
+                [
+                    'a_size-decimal' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => '10.51',
+                        ],
+                    ],
+                    'sku-text' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => 'sku label',
+                        ],
+                    ],
+                ]
+            );
+
+        $this->normalize($product, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)->shouldReturn(
+            [
+                'id' => '67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => [
+                    'code' => 'family',
+                    'labels' => [
+                        'fr_FR' => 'Une famille',
+                        'en_US' => 'A family',
+                    ],
+                ],
+                'enabled' => true,
+                'categories' => ['first_category', 'second_category'],
+                'groups' => ['first_group', 'second_group'],
+                'in_group' => [
+                    'first_group' => true,
+                    'second_group' => true,
+                ],
+                'completeness' => [
+                    'ecommerce' => [
+                        'en_US' => [
+                            66,
+                        ],
+                    ],
+                ],
+                'values' => [
+                    'a_size-decimal' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => '10.51',
+                        ],
+                    ],
+                    'sku-text' => [
+                        '<all_channels>' => [
+                            '<all_locales>' => 'sku label',
+                        ],
+                    ],
+                ],
+                'label' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => 'sku label',
+                    ],
+                ],
+                'ancestors' => ['ids' => [], 'codes' => []],
+            ]
+        );
+
+        $family->getAttributeAsLabel()->willReturn(null);
 
         $serializer->normalize($valueCollection, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX, [])
             ->willReturn(
@@ -226,40 +292,40 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)->shouldReturn(
             [
-                'id'            => '67',
-                'identifier'    => 'sku-001',
-                'created'       => $now->format('c'),
-                'updated'       => $now->format('c'),
+                'id' => '67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
                 'family' => [
-                    'code'   => 'family',
+                    'code' => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
-                'enabled'       => true,
-                'categories'    => ['first_category', 'second_category'],
-                'groups'        => ['first_group', 'second_group'],
+                'enabled' => true,
+                'categories' => ['first_category', 'second_category'],
+                'groups' => ['first_group', 'second_group'],
                 'in_group' => [
-                    'first_group'     => true,
-                    'second_group'    => true,
+                    'first_group' => true,
+                    'second_group' => true,
                 ],
-                'completeness'  => [
+                'completeness' => [
                     'ecommerce' => [
                         'en_US' => [
                             66,
                         ],
                     ],
                 ],
-                'values'        => [
+                'values' => [
                     'a_size-decimal' => [
                         '<all_channels>' => [
                             '<all_locales>' => '10.51',
                         ],
                     ],
                 ],
-                'label'         => [],
-                'ancestors'     => ['ids' => [], 'codes' => []],
+                'label' => [],
+                'ancestors' => ['ids' => [], 'codes' => []],
             ]
         );
     }
@@ -309,7 +375,6 @@ class PropertiesNormalizerSpec extends ObjectBehavior
             ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX
         )->willReturn($now->format('c'));
 
-
         $product->getFamily()->willReturn($family);
         $family->getAttributeAsLabel()->willReturn($sku);
         $sku->getCode()->willReturn('sku');
@@ -317,7 +382,7 @@ class PropertiesNormalizerSpec extends ObjectBehavior
         $serializer
             ->normalize($family, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)
             ->willReturn([
-                'code'   => 'family',
+                'code' => 'family',
                 'labels' => [
                     'fr_FR' => 'Une famille',
                     'en_US' => 'A family',
@@ -335,24 +400,24 @@ class PropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, ProductNormalizer::INDEXING_FORMAT_PRODUCT_INDEX)->shouldReturn(
             [
-                'id'           => '67',
-                'identifier'   => 'sku-001',
-                'created'      => $now->format('c'),
-                'updated'      => $now->format('c'),
-                'family'       => [
-                    'code'   => 'family',
+                'id' => '67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => [
+                    'code' => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
-                'enabled'      => true,
-                'categories'   => [],
-                'groups'       => [],
+                'enabled' => true,
+                'categories' => [],
+                'groups' => [],
                 'completeness' => [],
-                'values'       => [],
-                'label'        => [],
-                'ancestors'    => ['ids' => ['product_model_2', 'product_model_1'], 'codes' => ['sub_pm_2', 'root_pm_1']],
+                'values' => [],
+                'label' => [],
+                'ancestors' => ['ids' => ['product_model_2', 'product_model_1'], 'codes' => ['sub_pm_2', 'root_pm_1']],
             ]
         );
     }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizerSpec.php
@@ -64,7 +64,8 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         ValueCollectionInterface $productValueCollection,
         FamilyInterface $family,
         AttributeInterface $sku,
-        FamilyVariantInterface $familyVariant
+        FamilyVariantInterface $familyVariant,
+    FamilyInterface $productModelFamily
     ) {
         $productModel->getId()->willReturn(67);
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
@@ -73,7 +74,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $productModel->getId()->willReturn('67');
         $productModel->getCode()->willReturn('sku-001');
-        $productModel->getFamily()->willReturn(null);
+        $productModel->getFamily()->willReturn($productModelFamily);
         $productModel->getCreated()->willReturn($now);
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)
@@ -103,6 +104,34 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $productModel->getCategoryCodes()->willReturn(['category_A', 'category_B']);
 
         $completenessGridFilter->findCompleteFilterData($productModel)->willReturn($completenessGridFilterData);
+
+        $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)->shouldReturn(
+            [
+                'id'             => '67',
+                'identifier'     => 'sku-001',
+                'created'        => $now->format('c'),
+                'updated'        => $now->format('c'),
+                'family'         => 'family_A',
+                'family_variant' => 'family_variant_1',
+                'categories'     => ['category_A', 'category_B'],
+                'parent'         => null,
+                'values'         => [],
+                'all_complete' => [
+                    'ecommerce' => [
+                        'fr_FR' => 0
+                    ]
+                ],
+                'all_incomplete' => [
+                    'ecommerce' => [
+                        'fr_FR' => 0
+                    ]
+                ],
+                'ancestors'     => ['ids' => [], 'codes' => []],
+                'label'          => [],
+            ]
+        );
+
+        $family->getAttributeAsLabel()->willReturn(null);
 
         $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_MODEL_INDEX)->shouldReturn(
             [

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyAttributeAsLabelValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/FamilyAttributeAsLabelValidatorSpec.php
@@ -57,6 +57,22 @@ class FamilyAttributeAsLabelValidatorSpec extends ObjectBehavior
         $this->validate($family, $minimumRequirements);
     }
 
+    function it_invalidates_family_when_attribute_as_label_is_null(
+        $minimumRequirements,
+        $context,
+        FamilyInterface $family,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $family->getAttributeAsLabel()->willReturn(null);
+        $family->getAttributeCodes()->willReturn(['anotherAttribute']);
+
+        $context->buildViolation(Argument::any())->willReturn($violation)->shouldBeCalled();
+        $violation->atPath(Argument::any())->willReturn($violation);
+        $violation->addViolation()->shouldBeCalled();
+
+        $this->validate($family, $minimumRequirements);
+    }
+
     function it_invalidates_family_when_attribute_is_not_text_type(
         $minimumRequirements,
         $context,


### PR DESCRIPTION
In some files, we make a direct call to `$family->getAttributeAsLabel()->getCode()`
without checking that the family has an actual 'attributeAsLabel' (it can be null e.g. if the attribute was deleted)
In the case of the PropertiesNormalizers, this leads to errors during indexation, thus preventing from saving the product/product model.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
