### PR TITLE
PIM-7740: bump summernote version to fix scroll glitches

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-7674: fix Avatar image broken on dashboard
 - PIM-7694: fix option null values crashing PDF
 - PIM-7731: check for attribute as label not null in normalizers 
+- PIM-7740: bump summernote version to fix scroll glitches
 
 # 2.3.11 (2018-10-08)
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "merge-objects": "1.0.5",
     "raw-loader": "0.5.1",
     "regexp-replace-loader": "1.0.0",
-    "summernote": "0.6.5",
+    "summernote": "0.6.16",
     "text-loader": "0.0.1",
     "ts-loader": "^3.5.0",
     "typescript": "^2.7.2",

--- a/tests/legacy/features/Context/Page/Base/ProductEditForm.php
+++ b/tests/legacy/features/Context/Page/Base/ProductEditForm.php
@@ -564,7 +564,7 @@ class ProductEditForm extends Form
 
         if (null === $field || !$field->isVisible()) {
             // the textarea can be hidden (display=none) when using WYSIWYG
-            $div = $subContainer->find('css', '.note-editor > .note-editable');
+            $div = $subContainer->find('css', '.note-editor .note-editable');
 
             return $div->getHtml();
         } else {


### PR DESCRIPTION
In a product edit form, when adding a line (enter) in a text attribute with the option "rich text editor" enabled, the page is scrolled back to the top.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
