### PR TITLE
PIM-7746: Fix issue when an attribute code is numeric

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -6,6 +6,7 @@
 - PIM-7694: fix option null values crashing PDF
 - PIM-7731: check for attribute as label not null in normalizers 
 - PIM-7740: bump summernote version to fix scroll glitches
+- PIM-7746: Fix issue when an attribute code is numeric
 - PIM-7727: parent filter search case insensitive
 
 # 2.3.11 (2018-10-08)

--- a/src/Pim/Component/Catalog/ValuesFiller/EntityWithFamilyVariantValuesFiller.php
+++ b/src/Pim/Component/Catalog/ValuesFiller/EntityWithFamilyVariantValuesFiller.php
@@ -68,7 +68,7 @@ class EntityWithFamilyVariantValuesFiller extends AbstractEntityWithFamilyValues
 
         if (null !== $entity->getParent()) {
             $parentAttributes = $this->getExpectedAttributes($entity->getParent());
-            $attributes = array_merge($attributes, $parentAttributes);
+            $attributes = $parentAttributes + $attributes;
         }
 
         return $attributes;

--- a/src/Pim/Component/Catalog/spec/ValuesFiller/EntityWithFamilyVariantValuesFillerSpec.php
+++ b/src/Pim/Component/Catalog/spec/ValuesFiller/EntityWithFamilyVariantValuesFillerSpec.php
@@ -159,10 +159,12 @@ class EntityWithFamilyVariantValuesFillerSpec extends ObjectBehavior
         AttributeInterface $name,
         AttributeInterface $color,
         AttributeInterface $sku,
+        AttributeInterface $intCodeAttribute,
         ValueInterface $skuValue,
         ValueInterface $nameFRValue,
         ValueInterface $nameENValue,
-        ValueInterface $colorValue
+        ValueInterface $colorValue,
+        ValueInterface $intCodeValue
     ) {
         $sku->getCode()->willReturn('sku');
         $sku->getType()->willReturn('pim_catalog_identifier');
@@ -179,7 +181,12 @@ class EntityWithFamilyVariantValuesFillerSpec extends ObjectBehavior
         $color->isLocalizable()->willReturn(false);
         $color->isScopable()->willReturn(false);
 
-        $expectedParentAttributes = [$name];
+        $intCodeAttribute->getCode()->willReturn('1');
+        $intCodeAttribute->getType()->willReturn('pim_catalog_text');
+        $intCodeAttribute->isLocalizable()->willReturn(false);
+        $intCodeAttribute->isScopable()->willReturn(false);
+
+        $expectedParentAttributes = [$name, $intCodeAttribute];
         $expectedAttributes = [$sku, $color];
 
         $parentEntity->getParent()->willReturn(null);
@@ -188,7 +195,7 @@ class EntityWithFamilyVariantValuesFillerSpec extends ObjectBehavior
         $attributesProvider->getAttributes($parentEntity)->willReturn($expectedParentAttributes);
         $attributesProvider->getAttributes($entity)->willReturn($expectedAttributes);
 
-        $valuesResolver->resolveEligibleValues(['sku' => $sku, 'name' => $name, 'color' => $color])
+        $valuesResolver->resolveEligibleValues(['sku' => $sku, 'name' => $name, 'color' => $color, 1 => $intCodeAttribute])
             ->willReturn([
                 [
                     'attribute' => 'sku',
@@ -213,6 +220,12 @@ class EntityWithFamilyVariantValuesFillerSpec extends ObjectBehavior
                     'type' => 'pim_catalog_simpleselect',
                     'locale' => null,
                     'scope' => null
+                ],
+                [
+                    'attribute' => '1',
+                    'type' => 'pim_catalog_text',
+                    'locale' => null,
+                    'scope' => null
                 ]
             ]);
 
@@ -233,7 +246,11 @@ class EntityWithFamilyVariantValuesFillerSpec extends ObjectBehavior
         $colorValue->getLocale()->willReturn(null);
         $colorValue->getScope()->willReturn(null);
 
-        $entity->getValues()->willReturn([$skuValue, $nameFRValue, $nameENValue, $colorValue]);
+        $intCodeValue->getAttribute()->willReturn($intCodeAttribute);
+        $intCodeValue->getLocale()->willReturn(null);
+        $intCodeValue->getScope()->willReturn(null);
+
+        $entity->getValues()->willReturn([$skuValue, $nameFRValue, $nameENValue, $colorValue, $intCodeValue]);
 
         $entityWithValuesBuilder->addOrReplaceValue(Argument::cetera())->shouldNotBeCalled();
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

If an attribute has a numeric code and is in a family variant, it makes product models creation crash. 
It's because a bad usage of `array_merge`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
