### PR TITLE
PIM-7581: Fix unselect category when its code is numeric

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,5 +1,9 @@
 # 1.7.x
 
+## Bug fixes
+
+PIM-7581: Fix unselect category when its code is numeric
+
 # 1.7.33 (2018-10-10)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/product/category/selector.js
@@ -98,7 +98,7 @@ define(
              * @param {Object} data
              */
             uncheckNode: function (data) {
-                var code = data.rslt.obj.data('code');
+                var code = data.rslt.obj.data('code').toString();
 
                 if ('' !== code) {
                     this.attributes.categories = _.without(this.attributes.categories, code);


### PR DESCRIPTION
It's a back-port of the fix done in 2.0 : https://github.com/akeneo/pim-community-dev/pull/8257

 In export profile edition, a category with a numeric code can be selected, but not unselected.