### PR TITLE
PIM-7747: convert boolean strings in User converter

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -9,6 +9,7 @@
 - PIM-7746: Fix issue when an attribute code is numeric
 - PIM-7727: parent filter search case insensitive
 - PIM-7724: fix role label update and error displayed on permission save action
+- PIM-7747: convert boolean strings in User converter
 
 # 2.3.11 (2018-10-08)
 

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/User.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/User.php
@@ -95,7 +95,7 @@ class User implements ArrayConverterInterface
         if (in_array($field, ['roles', 'groups'])) {
             $convertedItem[$field] = '' !== $data ? explode(',', $data) : [];
         } elseif (in_array($field, ['enabled', 'email_notifications'])) {
-            $convertedItem[$field] = '1' === $data ? true : false;
+            $convertedItem[$field] = '1' == $data ? true : false;
         } elseif (in_array($field, ['timezone'])) {
             $convertedItem[$field] = '' !== $data ? $data : null;
         } else {

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/UserSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/UserSpec.php
@@ -56,4 +56,51 @@ class UserSpec extends ObjectBehavior
             'timezone'       => null,
         ]);
     }
+
+    function it_converts_boolean_strings($checker)
+    {
+        $fields = [
+            'username' => 'julia',
+            'email' => 'Julia@example.com',
+            'password' => 'julia',
+            'first_name' => 'Julia',
+            'last_name' => 'Stark',
+            'catalog_locale' => 'en_US',
+            'user_locale' => 'en_US',
+            'catalog_scope' => 'ecommerce',
+            'default_tree' => 'men_2013',
+            'roles' => 'ROLE_USER',
+            'groups' => 'Redactor',
+            'enabled' => 1,
+            'email_notifications' => 1,
+            'timezone' => '',
+        ];
+
+        $checker->checkFieldsPresence(
+            $fields,
+            ['username', 'email', 'password', 'enabled', 'roles', 'first_name', 'last_name', 'groups']
+        )->shouldBeCalled();
+
+        $checker->checkFieldsFilling(
+            $fields,
+            ['username', 'email', 'password', 'enabled', 'roles', 'first_name', 'last_name']
+        )->shouldBeCalled();
+
+        $this->convert($fields)->shouldReturn([
+            'username' => 'julia',
+            'email' => 'Julia@example.com',
+            'password' => 'julia',
+            'first_name' => 'Julia',
+            'last_name' => 'Stark',
+            'catalog_locale' => 'en_US',
+            'user_locale' => 'en_US',
+            'catalog_scope' => 'ecommerce',
+            'default_tree' => 'men_2013',
+            'roles' => ['ROLE_USER'],
+            'groups' => ['Redactor'],
+            'enabled' => true,
+            'email_notifications' => true,
+            'timezone' => null,
+        ]);
+    }
 }


### PR DESCRIPTION
Boolean conversion is not working for user on the fields `enabled` and `email_notifications`
Other converters (like the `Boolean`) don't make strict string comparison, so we fix this converter by using a loose comparison.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
