### PR TITLE
PIM-7751: Fix filters "Type" and "Status" in the process tracker

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/job_tracker.yml
@@ -62,7 +62,7 @@ datagrid:
                     data_name: j.type
                 status:
                     type:             choice
-                    data_name:        status
+                    data_name:        e.status
                     options:
                         field_options:
                             multiple: true


### PR DESCRIPTION
The filter on status in the process tracker crashes because it needs to be aliased.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
