### PR TITLE
Use parameter for AttributeOption class name

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
@@ -102,7 +102,7 @@ extensions:
         module: pim/filter/attribute/select
         config:
             url: pim_ui_ajaxentity_list
-            entityClass: Akeneo\Pim\Structure\Component\Model\AttributeOption
+            entityClass: "%pim_catalog.entity.attribute_option.class%"
             operators:
                 - IN
                 - EMPTY


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Entities can be overridden, which would result in errors for this hard coded class name in the filters. In one case, it made adding some filters (not all) result in an error that is seen in the browser console and the filter wouldn't be added.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added legacy Behats               | No
| Added acceptance tests            | No
| Added integration tests           | No
| Changelog updated                 | No
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
