### PR TITLE
Fix clear attributes selector decorator in export builder

### DIFF
--- a/features/Pim/Behat/Decorator/Common/AttributeSelectorDecorator.php
+++ b/features/Pim/Behat/Decorator/Common/AttributeSelectorDecorator.php
@@ -64,6 +64,10 @@ class AttributeSelectorDecorator extends ElementDecorator
         }, 'Cannot find the clear button');
 
         $button->click();
+        $this->spin(function () {
+            $selectedAttributes = $this->find('css', '.AknColumnConfigurator-listContainer .AknVerticalList');
+            return false === $selectedAttributes->has('css', 'AknVerticalList-item');
+        }, 'Cannot clear the selected atributes');
     }
 
     /**

--- a/features/Pim/Behat/Decorator/Common/AttributeSelectorDecorator.php
+++ b/features/Pim/Behat/Decorator/Common/AttributeSelectorDecorator.php
@@ -65,8 +65,11 @@ class AttributeSelectorDecorator extends ElementDecorator
 
         $button->click();
         $this->spin(function () {
-            $selectedAttributes = $this->find('css', '.AknColumnConfigurator-listContainer .AknVerticalList');
-            return false === $selectedAttributes->has('css', 'AknVerticalList-item');
+            $selectedAttributes = $this->find(
+                'css',
+                '.selected-attributes .AknColumnConfigurator-listContainer .AknVerticalList'
+            );
+            return false === $selectedAttributes->has('css', '.AknVerticalList-item');
         }, 'Cannot clear the selected atributes');
     }
 

--- a/features/Pim/Behat/Decorator/Common/AttributeSelectorDecorator.php
+++ b/features/Pim/Behat/Decorator/Common/AttributeSelectorDecorator.php
@@ -70,7 +70,7 @@ class AttributeSelectorDecorator extends ElementDecorator
                 '.selected-attributes .AknColumnConfigurator-listContainer .AknVerticalList'
             );
             return false === $selectedAttributes->has('css', '.AknVerticalList-item');
-        }, 'Cannot clear the selected atributes');
+span class="pl-s1">         }, 'Cannot clear the selected attributes');
     }
 
     /**

--- a/features/Pim/Behat/Decorator/Common/AttributeSelectorDecorator.php
+++ b/features/Pim/Behat/Decorator/Common/AttributeSelectorDecorator.php
@@ -70,7 +70,7 @@ class AttributeSelectorDecorator extends ElementDecorator
                 '.selected-attributes .AknColumnConfigurator-listContainer .AknVerticalList'
             );
             return false === $selectedAttributes->has('css', '.AknVerticalList-item');
-span class="pl-s1">         }, 'Cannot clear the selected attributes');
+        }, 'Cannot clear the selected attributes');
     }
 
     /**


### PR DESCRIPTION
The click to clear attributes list in export builder is unstable because it does not wait for the list to be empty.
I added a spin counting the item to ensure that this list is empty.

![image](https://user-images.githubusercontent.com/1516770/47161262-01dd5080-d2f2-11e8-9c99-874c17438daa.png)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
