### PR TITLE
Fix forgotten bc-break to manage

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1136,3 +1136,4 @@
 - Move `Pim\Component\Enrich\Query\AscendantCategoriesInterface` to `Akeneo\Pim\Enrichment\Component\Category\Query\AscendantCategoriesInterface`
 - Move `Pim\Component\Enrich\Model\AvailableAttributes` to `Akeneo\Pim\Structure\Component\Model\AvailableAttributes`
 - Move `Pim\Component\Enrich\Provider\TranslatedLabelsProviderInterface` to `Akeneo\Platform\Bundle\UIBundle\Provider\TranslatedLabelsProviderInterface`
+- Change method `create` of `Akeneo\Pim\Enrichment\Component\Product\Factory\Value\ValueFactoryInterface` To add a boolean parameter to determine if a unknown element of a collection must be ignored or not.

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
@@ -36,7 +36,7 @@ class DateValueFactory implements ValueFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data)
+    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data, $ignoreUnknownData = false)
     {
         $this->checkData($attribute, $data);
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MediaValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MediaValueFactory.php
@@ -46,7 +46,7 @@ class MediaValueFactory implements ValueFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data)
+    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data, $ignoreUnknownData = false)
     {
         $this->checkData($attribute, $data);
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MetricValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MetricValueFactory.php
@@ -41,7 +41,7 @@ class MetricValueFactory implements ValueFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data)
+    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data, $ignoreUnknownData = false)
     {
         $this->checkData($attribute, $data);
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionValueFactory.php
@@ -46,7 +46,7 @@ class OptionValueFactory implements ValueFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data)
+    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data, $ignoreUnknownData = false)
     {
         $this->checkData($attribute, $data);
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionsValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionsValueFactory.php
@@ -45,7 +45,7 @@ class OptionsValueFactory implements ValueFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data)
+    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data, $ignoreUnknownData = false)
     {
         $this->checkData($attribute, $data);
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/PriceCollectionValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/PriceCollectionValueFactory.php
@@ -43,7 +43,7 @@ class PriceCollectionValueFactory implements ValueFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data)
+    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data, $ignoreUnknownData = false)
     {
         $this->checkData($attribute, $data);
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ReferenceDataValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ReferenceDataValueFactory.php
@@ -47,7 +47,7 @@ class ReferenceDataValueFactory implements ValueFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data)
+    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data, $ignoreUnknownData = false)
     {
         $this->checkData($attribute, $data);
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ScalarValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ScalarValueFactory.php
@@ -36,7 +36,7 @@ class ScalarValueFactory implements ValueFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data)
+    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data, $ignoreUnknownData = false)
     {
         $this->checkData($attribute, $data);
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ValueFactoryInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ValueFactoryInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Akeneo\Pim\Enrichment\Component\Product\Factory\Value;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
@@ -23,12 +26,11 @@ interface ValueFactoryInterface
      * @param string             $channelCode
      * @param string             $localeCode
      * @param mixed              $data
+     * @param bool               $ignoreUnknownData
      *
      * @return ValueInterface
-     *
-     * @todo merge master : add an argument at the end  : "bool $ignoreUnknownData". Cf ReferenceDataCollectionValueFactory class.
      */
-    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data);
+    public function create(AttributeInterface $attribute, $channelCode, $localeCode, $data, bool $ignoreUnknownData = false);
 
     /**
      * @param string $attributeType


### PR DESCRIPTION
A "@todo" has been forgotten in the last pull-up  from 2.3

See the original PR : https://github.com/akeneo/pim-community-dev/pull/8918