### PR TITLE
Set explicit white background for light inputs

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
@@ -108,6 +108,7 @@
     border-radius: 0;
     padding: 0;
     font-size: 15px;
+    background: #fff;
 
     &:focus {
       outline: none;


### PR DESCRIPTION
**Because they are grey by default in Firefox.**

## Before
![](https://i.imgur.com/VnpNRGO.png)

## After
![](https://i.imgur.com/rT38PDe.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -