### PR TITLE
PIM-7752: Working spike API using the P&PMQB

### DIFF
--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/SearchAfterSizeCursorFactorySpec.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/SearchAfterSizeCursorFactorySpec.php
@@ -3,7 +3,7 @@
 namespace spec\Akeneo\Bundle\ElasticsearchBundle\Cursor;
 
 use Akeneo\Bundle\ElasticsearchBundle\Client;
-use Akeneo\Bundle\ElasticsearchBundle\Cursor\SearchAfterSizeCursor;
+use Akeneo\Bundle\ElasticsearchBundle\Cursor\ProductAndProductModelSearchAfterSizeCursor;
 use Akeneo\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use Doctrine\Common\Persistence\ObjectManager;
@@ -20,7 +20,7 @@ class SearchAfterSizeCursorFactorySpec extends ObjectBehavior
         $this->beConstructedWith(
             $searchEngine,
             $cursorableRepository,
-            SearchAfterSizeCursor::class,
+            ProductAndProductModelSearchAfterSizeCursor::class,
             self::DEFAULT_BATCH_SIZE,
             'pim_catalog_product'
         );
@@ -28,7 +28,7 @@ class SearchAfterSizeCursorFactorySpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Akeneo\Bundle\ElasticsearchBundle\Cursor\SearchAfterSizeCursorFactory');
+        $this->shouldHaveType('Akeneo\Bundle\ElasticsearchBundle\Cursor\ProductAndProductModelSearchAfterSizeCursorFactory');
         $this->shouldImplement('Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface');
     }
 

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/SearchAfterSizeCursorSpec.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/Cursor/SearchAfterSizeCursorSpec.php
@@ -3,7 +3,7 @@
 namespace spec\Akeneo\Bundle\ElasticsearchBundle\Cursor;
 
 use Akeneo\Bundle\ElasticsearchBundle\Client;
-use Akeneo\Bundle\ElasticsearchBundle\Cursor\SearchAfterSizeCursor;
+use Akeneo\Bundle\ElasticsearchBundle\Cursor\ProductAndProductModelSearchAfterSizeCursor;
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use PhpSpec\ObjectBehavior;
@@ -57,7 +57,7 @@ class SearchAfterSizeCursorSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType(SearchAfterSizeCursor::class);
+        $this->shouldHaveType(ProductAndProductModelSearchAfterSizeCursor::class);
         $this->shouldImplement(CursorInterface::class);
     }
 

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -678,6 +678,7 @@ class ProductController
     ): array {
         $from = isset($queryParameters['page']) ? ($queryParameters['page'] - 1) * $queryParameters['limit'] : 0;
         $pqb = $this->fromSizePqbFactory->create(['limit' => (int) $queryParameters['limit'], 'from' => (int) $from]);
+        $pqb->addFilter('entity_type', Operators::EQUALS, ProductInterface::class);
 
         try {
             $this->setPQBFilters($pqb, $request, $channel);
@@ -751,9 +752,10 @@ class ProductController
             $searchParameterCrypted = $queryParameters['search_after'];
             $searchParameterDecrypted = $this->primaryKeyEncrypter->decrypt($queryParameters['search_after']);
             $pqbOptions['search_after_unique_key'] = $searchParameterDecrypted;
-            $pqbOptions['search_after'] = [$searchParameterDecrypted];
+            $pqbOptions['search_after'] = ['product_' . $searchParameterDecrypted];
         }
         $pqb = $this->searchAfterPqbFactory->create($pqbOptions);
+        $pqb->addFilter('entity_type', Operators::EQUALS, ProductInterface::class);
 
         try {
             $this->setPQBFilters($pqb, $request, $channel);

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductModelController.php
@@ -355,6 +355,7 @@ class ProductModelController
         $from = isset($queryParameters['page']) ? ($queryParameters['page'] - 1) * $queryParameters['limit'] : 0;
 
         $pqb = $this->pqbFromSizeFactory->create(['limit' => (int) $queryParameters['limit'], 'from' => (int) $from]);
+        $pqb->addFilter('entity_type', Operators::EQUALS, ProductModelInterface::class);
 
         try {
             $this->setPQBFilters($pqb, $request, $channel);
@@ -534,9 +535,10 @@ class ProductModelController
             $searchParameterCrypted = $queryParameters['search_after'];
             $searchParameterDecrypted = $this->primaryKeyEncrypter->decrypt($queryParameters['search_after']);
             $pqbOptions['search_after_unique_key'] = $searchParameterDecrypted;
-            $pqbOptions['search_after'] = [$searchParameterDecrypted];
+            $pqbOptions['search_after'] = ['product_model_' . $searchParameterDecrypted];
         }
         $pqb = $this->pqbSearchAfterFactory->create($pqbOptions);
+        $pqb->addFilter('entity_type', Operators::EQUALS, ProductModelInterface::class);
 
         try {
             $this->setPQBFilters($pqb, $request, $channel);

--- a/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -143,7 +143,7 @@ services:
     pim_api.controller.product:
         class: '%pim_api.controller.product.class%'
         arguments:
-            - '@pim_catalog.query.product_query_builder_search_after_size_factory'
+            - '@pim_catalog.query.product_and_product_model_query_builder_search_after_size_factory'
             - '@pim_serializer'
             - '@pim_api.repository.channel'
             - '@pim_api.checker.query_parameters_product'
@@ -161,7 +161,7 @@ services:
             - '@pim_catalog.comparator.filter.product'
             - '@pim_api.stream.product_partial_update_stream'
             - '@pim_api.security.primary_key_encrypter'
-            - '@pim_catalog.query.product_query_builder_from_size_factory'
+            - '@pim_catalog.query.product_and_product_model_query_builder_from_size_factory'
             - '@pim_catalog.builder.product'
             - '@pim_api.filter.product_attribute_filter'
             - '@pim_catalog.entity_with_family_variant.add_parent_to_product'
@@ -171,8 +171,8 @@ services:
         class: '%pim_api.controller.product_model.class%'
         arguments:
             - '@pim_catalog.query.product_model_query_builder_factory'
-            - '@pim_catalog.query.product_model_query_builder_from_size_factory'
-            - '@pim_catalog.query.product_model_query_builder_search_after_size_factory'
+            - '@pim_catalog.query.product_and_product_model_query_builder_from_size_factory'
+            - '@pim_catalog.query.product_and_product_model_query_builder_search_after_size_factory'
             - '@pim_serializer'
             - '@pim_api.repository.channel'
             - '@pim_api.checker.query_parameters_product_model'

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/NumberFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Attribute/NumberFilter.php
@@ -114,12 +114,16 @@ class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInt
                 $this->searchQueryBuilder->addFilter($clause);
                 break;
             case Operators::IS_EMPTY:
-                $clause = [
+                $this->searchQueryBuilder->addMustNot([
                     'exists' => [
                         'field' => $attributePath
                     ]
-                ];
-                $this->searchQueryBuilder->addMustNot($clause);
+                ]);
+                $this->searchQueryBuilder->addFilter([
+                    'term' => [
+                        'attributes_of_family' => $attribute->getCode()
+                    ]
+                ]);
                 break;
             case Operators::IS_NOT_EMPTY:
                 $clause = [

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndProductModelFromSizeCursor.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndProductModelFromSizeCursor.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
+
+use Akeneo\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+
+/**
+ * Bounded cursor to iterate over items where a start and a limit are defined.
+ * Internally, this is implemented with the search after pagination.
+ * {@see https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-search-after.html}
+ *
+ * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductAndProductModelFromSizeCursor implements CursorInterface
+{
+    /** @var Client */
+    protected $esClient;
+
+    /** @var array */
+    protected $esQuery;
+
+    /** @var string */
+    protected $indexType;
+
+    /** @var array */
+    protected $items;
+
+    /** @var int */
+    protected $pageSize;
+
+    /** @var int */
+    protected $count;
+
+    /** @var int */
+    protected $initialFrom;
+
+    /** @var int */
+    protected $from;
+
+    /** @var int */
+    protected $limit;
+
+    /** @var int */
+    protected $to;
+
+    /** @var int */
+    protected $fetchedItemsCount;
+
+    /** @var CursorableRepositoryInterface */
+    protected $productModelRepository;
+
+    /** @var CursorableRepositoryInterface */
+    protected $productRepository;
+
+    /**
+     * @param Client                        $esClient
+     * @param CursorableRepositoryInterface $productRepository
+     * @param CursorableRepositoryInterface $productModelRepository
+     * @param array                         $esQuery
+     * @param string                        $indexType
+     * @param int                           $pageSize
+     * @param int                           $limit
+     * @param int                           $from
+     */
+    public function __construct(
+        Client $esClient,
+        CursorableRepositoryInterface $productRepository,
+        CursorableRepositoryInterface $productModelRepository,
+        array $esQuery,
+        $indexType,
+        $pageSize,
+        $limit,
+        $from = 0
+    ) {
+        $this->esClient = $esClient;
+        $this->productRepository = $productRepository;
+        $this->productModelRepository = $productModelRepository;
+        $this->esQuery = $esQuery;
+        $this->indexType = $indexType;
+        $this->pageSize = $pageSize;
+        $this->limit = $limit;
+        $this->from = $from;
+        $this->initialFrom = $from;
+        $this->to = $this->from + $this->limit;
+    }
+
+    /**
+     * Get the next items (hydrated from doctrine repository).
+     *
+     * @param array $esQuery
+     *
+     * @return array
+     */
+    protected function getNextItems(array $esQuery): array
+    {
+        $identifierResults = $this->getNextIdentifiers($esQuery);
+        if ($identifierResults->isEmpty()) {
+            return [];
+        }
+
+        $hydratedProducts = $this->productRepository->getItemsFromIdentifiers(
+            $identifierResults->getProductIdentifiers()
+        );
+        $hydratedProductModels = $this->productModelRepository->getItemsFromIdentifiers(
+            $identifierResults->getProductModelIdentifiers()
+        );
+        $hydratedItems = array_merge($hydratedProducts, $hydratedProductModels);
+
+        $orderedItems = [];
+
+        foreach ($identifierResults->all() as $identifierResult) {
+            foreach ($hydratedItems as $hydratedItem) {
+                if ($hydratedItem instanceof ProductInterface &&
+                    $identifierResult->isProductIdentifierEquals($hydratedItem->getIdentifier())
+                ) {
+                    $orderedItems[] = $hydratedItem;
+                    break;
+                } elseif ($hydratedItem instanceof ProductModelInterface &&
+                    $identifierResult->isProductModelIdentifierEquals($hydratedItem->getCode())
+                ) {
+                    $orderedItems[] = $hydratedItem;
+                    break;
+                }
+            }
+        }
+
+        return $orderedItems;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * {@see https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-from-size.html}
+     */
+    protected function getNextIdentifiers(array $esQuery): IdentifierResults
+    {
+        $identifiers = new IdentifierResults();
+
+        $size = ($this->to - $this->from) > $this->pageSize ? $this->pageSize : ($this->to - $this->from);
+        $esQuery['size'] = $size;
+
+        if (0 === $esQuery['size']) {
+            return $identifiers;
+        }
+
+        $esQuery['from'] = $this->from;
+
+        $response = $this->esClient->search($this->indexType, $esQuery);
+        $this->count = $response['hits']['total'];
+
+        foreach ($response['hits']['hits'] as $hit) {
+            $identifiers->add($hit['_source']['identifier'], $hit['_source']['document_type']);
+        }
+
+        return $identifiers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        $this->from = $this->initialFrom;
+        $this->to = $this->from + $this->limit;
+        $this->items = $this->getNextItems($this->esQuery);
+        reset($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        if (empty($this->items)) {
+            return null;
+        }
+
+        return current($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function key()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        return key($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function valid()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        return !empty($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        return $this->count;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next()
+    {
+        if (false === next($this->items)) {
+            $this->from += count($this->items);
+            $this->items = $this->getNextItems($this->esQuery);
+            reset($this->items);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndProductModelFromSizeCursorFactory.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndProductModelFromSizeCursorFactory.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
+
+use Akeneo\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface;
+use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Cursor factory to instantiate an elasticsearch bounded cursor
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductAndProductModelFromSizeCursorFactory implements CursorFactoryInterface
+{
+    /** @var Client */
+    protected $searchEngine;
+
+    /** @var int */
+    protected $pageSize;
+
+    /** @var string */
+    protected $indexType;
+
+    /** @var CursorableRepositoryInterface */
+    private $productRepository;
+
+    /** @var CursorableRepositoryInterface */
+    private $productModelRepository;
+
+    /**
+     * @param Client                        $searchEngine
+     * @param CursorableRepositoryInterface $cursorableRepository
+     * @param string                        $cursorClassName
+     * @param int                           $pageSize
+     * @param string                        $indexType
+     */
+    public function __construct(
+        Client $searchEngine,
+        CursorableRepositoryInterface $productRepository,
+        CursorableRepositoryInterface $productModelRepository,
+        $pageSize,
+        $indexType
+    ) {
+        $this->searchEngine = $searchEngine;
+        $this->pageSize = $pageSize;
+        $this->indexType = $indexType;
+        $this->productRepository = $productRepository;
+        $this->productModelRepository = $productModelRepository;
+    }
+
+    public function createCursor($queryBuilder, array $options = [])
+    {
+        $queryBuilder['_source'] = array_merge($queryBuilder['_source'], ['document_type']);
+        $options = $this->resolveOptions($options);
+
+        return new ProductAndProductModelFromSizeCursor(
+            $this->searchEngine,
+            $this->productRepository,
+            $this->productModelRepository,
+            $queryBuilder,
+            $this->indexType,
+            $options['page_size'],
+            $options['limit'],
+            $options['from']
+        );
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    protected function resolveOptions(array $options)
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefined(
+            [
+                'page_size',
+                'limit',
+                'from',
+            ]
+        );
+        $resolver->setDefaults(
+            [
+                'page_size' => $this->pageSize,
+                'from' => 0
+            ]
+        );
+        $resolver->setAllowedTypes('page_size', 'int');
+        $resolver->setAllowedTypes('limit', 'int');
+        $resolver->setAllowedTypes('from', 'int');
+
+        $options = $resolver->resolve($options);
+
+        return $options;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndProductModelSearchAfterCursor.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndProductModelSearchAfterCursor.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
+
+use Akeneo\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+
+/**
+ * Bounded cursor to iterate over items where a start and a limit are defined.
+ * Internally, this is implemented with the search after pagination.
+ * {@see https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-search-after.html}
+ *
+ * @author    Julien Janvier <jjanvier@akeneo.com>
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductAndProductModelSearchAfterCursor implements CursorInterface
+{
+    /** @var string|null */
+    protected $searchAfterUniqueKey;
+
+    /** @var int */
+    protected $limit;
+
+    /** @var int */
+    protected $fetchedItemsCount;
+
+    /** @var array */
+    protected $searchAfter;
+
+    /** @var array */
+    protected $initialSearchAfter;
+
+    /** @var CursorableRepositoryInterface  */
+    protected $productModelRepository;
+
+    /** @var CursorableRepositoryInterface  */
+    protected $productRepository;
+
+    /** @var Client */
+    protected $esClient;
+
+    /** @var array */
+    protected $esQuery;
+
+    /** @var string */
+    protected $indexType;
+
+    /** @var array */
+    protected $items;
+
+    /** @var int */
+    protected $pageSize;
+
+    /** @var int */
+    protected $count;
+
+
+    public function __construct(
+        Client $esClient,
+        CursorableRepositoryInterface $productRepository,
+        CursorableRepositoryInterface $productModelRepository,
+        array $esQuery,
+        array $searchAfter = [],
+        $indexType,
+        $pageSize,
+        $limit,
+        $searchAfterUniqueKey = null
+    ) {
+        $this->productRepository = $productRepository;
+        $this->productModelRepository = $productModelRepository;
+        $this->esClient = $esClient;
+        $this->esQuery = $esQuery;
+        $this->indexType = $indexType;
+        $this->pageSize = $pageSize;
+        $this->limit = $limit;
+        $this->searchAfter = $searchAfter;
+        $this->initialSearchAfter = $this->searchAfter;
+        $this->searchAfterUniqueKey = $searchAfterUniqueKey;
+        $this->fetchedItemsCount = 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next()
+    {
+        if (false === next($this->items)) {
+            $this->fetchedItemsCount += count($this->items);
+            $this->items = $this->getNextItems($this->esQuery);
+            reset($this->items);
+        }
+    }
+
+    /**
+     * Get the next items (hydrated from doctrine repository).
+     *
+     * @param array $esQuery
+     *
+     * @return array
+     */
+    protected function getNextItems(array $esQuery): array
+    {
+        $identifierResults = $this->getNextIdentifiers($esQuery);
+        if ($identifierResults->isEmpty()) {
+            return [];
+        }
+
+        $hydratedProducts = $this->productRepository->getItemsFromIdentifiers(
+            $identifierResults->getProductIdentifiers()
+        );
+        $hydratedProductModels = $this->productModelRepository->getItemsFromIdentifiers(
+            $identifierResults->getProductModelIdentifiers()
+        );
+        $hydratedItems = array_merge($hydratedProducts, $hydratedProductModels);
+
+        $orderedItems = [];
+
+        foreach ($identifierResults->all() as $identifierResult) {
+            foreach ($hydratedItems as $hydratedItem) {
+                if ($hydratedItem instanceof ProductInterface &&
+                    $identifierResult->isProductIdentifierEquals($hydratedItem->getIdentifier())
+                ) {
+                    $orderedItems[] = $hydratedItem;
+                    break;
+                } elseif ($hydratedItem instanceof ProductModelInterface &&
+                    $identifierResult->isProductModelIdentifierEquals($hydratedItem->getCode())
+                ) {
+                    $orderedItems[] = $hydratedItem;
+                    break;
+                }
+            }
+        }
+
+        return $orderedItems;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-search-after.html
+     */
+    protected function getNextIdentifiers(array $esQuery): IdentifierResults
+    {
+        $identifiers = new IdentifierResults();
+
+        $size = $this->limit > $this->pageSize ? $this->pageSize : $this->limit;
+        if ($this->fetchedItemsCount + $size > $this->limit) {
+            $size = $this->limit - $this->fetchedItemsCount;
+        }
+        $esQuery['size'] = $size;
+
+        if (0 === $esQuery['size']) {
+            return $identifiers;
+        }
+
+        if (!empty($this->searchAfter)) {
+            $esQuery['search_after'] = $this->searchAfter;
+        }
+
+        $response = $this->esClient->search($this->indexType, $esQuery);
+        $this->count = $response['hits']['total'];
+
+        foreach ($response['hits']['hits'] as $hit) {
+            $identifiers->add($hit['_source']['identifier'], $hit['_source']['document_type']);
+        }
+
+        $lastResult = end($response['hits']['hits']);
+
+        if (false !== $lastResult) {
+            $this->searchAfter = $lastResult['sort'];
+        }
+
+        return $identifiers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        $this->searchAfter = $this->initialSearchAfter;
+//        if (null !== $this->searchAfterUniqueKey) {
+//            array_push($this->searchAfter, $this->indexType . '#' . $this->searchAfterUniqueKey);
+//        }
+
+        $this->fetchedItemsCount = 0;
+        $this->items = $this->getNextItems($this->esQuery);
+        reset($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        if (empty($this->items)) {
+            return null;
+        }
+
+        return current($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function key()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        return key($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function valid()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        return !empty($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        return $this->count;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndProductModelSearchAfterCursorFactory.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/ProductAndProductModelSearchAfterCursorFactory.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch;
+
+use Akeneo\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Component\StorageUtils\Cursor\CursorFactoryInterface;
+use Akeneo\Component\StorageUtils\Repository\CursorableRepositoryInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Cursor factory to instantiate an elasticsearch bounded cursor
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductAndProductModelSearchAfterCursorFactory implements CursorFactoryInterface
+{
+    /** @var Client */
+    protected $searchEngine;
+
+    /** @var int */
+    protected $pageSize;
+
+    /** @var string */
+    protected $indexType;
+
+    /** @var CursorableRepositoryInterface */
+    protected $cursorableRepository;
+
+    /** @var CursorableRepositoryInterface */
+    private $productRepository;
+
+    /** @var CursorableRepositoryInterface */
+    private $productModelRepository;
+
+    /**
+     * @param Client                        $searchEngine
+     * @param CursorableRepositoryInterface $cursorableRepository
+     * @param string                        $cursorClassName
+     * @param int                           $pageSize
+     * @param string                        $indexType
+     */
+    public function __construct(
+        Client $searchEngine,
+        CursorableRepositoryInterface $productRepository,
+        CursorableRepositoryInterface $productModelRepository,
+        $pageSize,
+        $indexType
+    ) {
+        $this->searchEngine = $searchEngine;
+        $this->pageSize = $pageSize;
+        $this->indexType = $indexType;
+        $this->productRepository = $productRepository;
+        $this->productModelRepository = $productModelRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createCursor($queryBuilder, array $options = [])
+    {
+        $queryBuilder['_source'] = array_merge($queryBuilder['_source'], ['document_type']);
+        $options = $this->resolveOptions($options);
+
+        return new ProductAndProductModelSearchAfterCursor(
+            $this->searchEngine,
+            $this->productRepository,
+            $this->productModelRepository,
+            $queryBuilder,
+            $options['search_after'],
+            $this->indexType,
+            $options['page_size'],
+            $options['limit'],
+            $options['search_after_unique_key']
+        );
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    protected function resolveOptions(array $options)
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefined(
+            [
+                'page_size',
+                'search_after',
+                'search_after_unique_key',
+                'limit'
+            ]
+        );
+        $resolver->setDefaults(
+            [
+                'page_size' => $this->pageSize,
+                'search_after' => [],
+                'search_after_unique_key' => null
+            ]
+        );
+        $resolver->setAllowedTypes('page_size', 'int');
+        $resolver->setAllowedTypes('search_after', 'array');
+        $resolver->setAllowedTypes('search_after_unique_key', ['string', 'null']);
+        $resolver->setAllowedTypes('limit', 'int');
+
+        $options = $resolver->resolve($options);
+
+        return $options;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -128,9 +128,51 @@ services:
             - '@pim_catalog.factory.product_and_product_model_cursor'
             - '@pim_catalog.query.product_query_builder_resolver'
 
+    pim_catalog.query.product_and_product_model_query_builder_search_after_size_factory:
+        public: false
+        class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_query_builder.class%'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.query.filter.product_and_product_model_registry'
+            - '@pim_catalog.query.sorter.registry'
+            - '@pim_catalog.factory.product_and_product_model_search_after_cursor'
+            - '@pim_catalog.elasticsearch.product_query_builder_search_after_resolver'
+
+    pim_catalog.query.product_and_product_model_query_builder_from_size_factory:
+        public: false
+        class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_query_builder.class%'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.query.filter.product_and_product_model_registry'
+            - '@pim_catalog.query.sorter.registry'
+            - '@pim_catalog.factory.product_and_product_model_query_builder_from_size_factory'
+            - '@pim_catalog.elasticsearch.product_query_builder_from_size_resolver'
+
     pim_catalog.factory.product_and_product_model_cursor:
         public: false
         class: '%pim_catalog.elasticsearch.cursor_factory.class%'
+        arguments:
+            - '@akeneo_elasticsearch.client.product_and_product_model'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_model'
+            - '%pim_job_product_batch_size%'
+            - 'pim_catalog_product'
+
+    pim_catalog.factory.product_and_product_model_search_after_cursor:
+        public: false
+        class: Pim\Bundle\CatalogBundle\Elasticsearch\ProductAndProductModelSearchAfterCursorFactory
+        arguments:
+            - '@akeneo_elasticsearch.client.product_and_product_model'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_model'
+            - '%pim_job_product_batch_size%'
+            - 'pim_catalog_product'
+
+    pim_catalog.factory.product_and_product_model_query_builder_from_size_factory:
+        public: false
+        class: Pim\Bundle\CatalogBundle\Elasticsearch\ProductAndProductModelFromSizeCursorFactory
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@pim_catalog.repository.product'
@@ -349,6 +391,7 @@ services:
                 - '<'
                 - 'EMPTY'
         tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
 
     pim_catalog.query.elasticsearch.filter.completeness:

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogMediaIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogMediaIntegration.php
@@ -126,6 +126,11 @@ class PimCatalogMediaIntegration extends AbstractPimCatalogTestCase
                     'must_not' => [
                         'exists' => ['field' => 'values.an_image-media.<all_channels>.<all_locales>'],
                     ],
+                    'filter' => [
+                        'term' => [
+                            'attributes_of_family' => 'an_image'
+                        ]
+                    ]
                 ],
             ],
         ];
@@ -163,6 +168,7 @@ class PimCatalogMediaIntegration extends AbstractPimCatalogTestCase
         $products = [
             [
                 'identifier' => 'product_1',
+                'attributes_of_family' => ['an_image'],
                 'values'     => [
                     'an_image-media' => [
                         '<all_channels>' => [
@@ -181,6 +187,7 @@ class PimCatalogMediaIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_2',
+                'attributes_of_family' => ['an_image'],
                 'values'     => [
                     'an_image-media' => [
                         '<all_channels>' => [
@@ -199,6 +206,7 @@ class PimCatalogMediaIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_3',
+                'attributes_of_family' => ['an_image'],
                 'values'     => [
                     'an_image-media' => [
                         '<all_channels>' => [
@@ -217,6 +225,7 @@ class PimCatalogMediaIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_4',
+                'attributes_of_family' => ['an_image'],
                 'values'     => [
                     'an_image-media' => [
                         '<all_channels>' => [
@@ -235,6 +244,7 @@ class PimCatalogMediaIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_5',
+                'attributes_of_family' => ['an_image'],
                 'values'     => [
                     'an_image-media' => [
                         '<all_channels>' => [
@@ -253,6 +263,7 @@ class PimCatalogMediaIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_6',
+                'attributes_of_family' => ['an_image'],
                 'values'     => [
                     'an_image-media' => [
                         '<all_channels>' => [
@@ -271,6 +282,7 @@ class PimCatalogMediaIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_7',
+                'attributes_of_family' => ['an_image'],
                 'values'     => [
                     'an_image-media' => [
                         '<all_channels>' => [
@@ -288,7 +300,13 @@ class PimCatalogMediaIntegration extends AbstractPimCatalogTestCase
                 ],
             ],
             [
-                'identifier' => 'product_8',
+                'identifier'           => 'product_8',
+                'attributes_of_family' => ['an_image'],
+                'values'               => [],
+            ],
+            [
+                'identifier' => 'product_9',
+                'attributes_of_family' => [],
             ],
         ];
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogMetricIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogMetricIntegration.php
@@ -266,6 +266,11 @@ class PimCatalogMetricIntegration extends AbstractPimCatalogTestCase
                             'field' => 'values.a_metric-metric.<all_channels>.<all_locales>.base_data',
                         ],
                     ],
+                    'filter'   => [
+                        'term' => [
+                            'attributes_of_family' => 'a_metric',
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -366,6 +371,7 @@ class PimCatalogMetricIntegration extends AbstractPimCatalogTestCase
         $products = [
             [
                 'identifier' => 'product_1',
+                'attributes_of_family' => ['a_metric'],
                 'values'     => [
                     'a_metric-metric' => [
                         '<all_channels>' => [
@@ -381,6 +387,7 @@ class PimCatalogMetricIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_2',
+                'attributes_of_family' => ['a_metric'],
                 'values'     => [
                     'a_metric-metric' => [
                         '<all_channels>' => [
@@ -394,6 +401,7 @@ class PimCatalogMetricIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_3',
+                'attributes_of_family' => ['a_metric'],
                 'values'     => [
                     'a_metric-metric' => [
                         '<all_channels>' => [
@@ -408,6 +416,7 @@ class PimCatalogMetricIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_4',
+                'attributes_of_family' => ['a_metric'],
                 'values'     => [
                     'a_metric-metric' => [
                         '<all_channels>' => [
@@ -421,6 +430,7 @@ class PimCatalogMetricIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_5',
+                'attributes_of_family' => ['a_metric'],
                 'values'     => [
                     'a_metric-metric' => [
                         '<all_channels>' => [
@@ -434,6 +444,7 @@ class PimCatalogMetricIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_6',
+                'attributes_of_family' => ['a_metric'],
                 'values'     => [
                     'a_metric-metric' => [
                         '<all_channels>' => [
@@ -447,6 +458,11 @@ class PimCatalogMetricIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_7',
+                'attributes_of_family' => ['a_metric'],
+                'values'     => [],
+            ],
+            [
+                'identifier' => 'product_8',
                 'values'     => [],
             ],
         ];

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogNumberIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogNumberIntegration.php
@@ -268,6 +268,11 @@ class PimCatalogNumberIntegration extends AbstractPimCatalogTestCase
                             'field' => 'values.box_quantity-decimal.<all_channels>.<all_locales>',
                         ],
                     ],
+                    'filter' => [
+                        'term' => [
+                            'attributes_of_family' => 'box_quantity'
+                        ]
+                    ]
                 ],
             ],
         ];
@@ -319,7 +324,7 @@ class PimCatalogNumberIntegration extends AbstractPimCatalogTestCase
 
         $this->assertDocument(
             $productsFound,
-            ['product_2', 'product_5', 'product_6', 'product_1', 'product_4', 'product_3', 'product_7']
+            ['product_2', 'product_5', 'product_6', 'product_1', 'product_4', 'product_3', 'product_7', 'product_8']
         );
     }
 
@@ -343,7 +348,7 @@ class PimCatalogNumberIntegration extends AbstractPimCatalogTestCase
 
         $this->assertDocument(
             $productsFound,
-            ['product_3', 'product_4', 'product_1', 'product_6', 'product_5', 'product_2', 'product_7']
+            ['product_3', 'product_4', 'product_1', 'product_6', 'product_5', 'product_2', 'product_7', 'product_8']
         );
     }
 
@@ -368,6 +373,7 @@ class PimCatalogNumberIntegration extends AbstractPimCatalogTestCase
         $products = [
             [
                 'identifier' => 'product_1',
+                'attributes_of_family' => ['box_quantity'],
                 'values'     => [
                     'box_quantity-decimal' => [
                         '<all_channels>' => [
@@ -378,6 +384,7 @@ class PimCatalogNumberIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_2',
+                'attributes_of_family' => ['box_quantity'],
                 'values'     => [
                     'box_quantity-decimal' => [
                         '<all_channels>' => [
@@ -388,6 +395,7 @@ class PimCatalogNumberIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_3',
+                'attributes_of_family' => ['box_quantity'],
                 'values'     => [
                     'box_quantity-decimal' => [
                         '<all_channels>' => [
@@ -398,6 +406,7 @@ class PimCatalogNumberIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_4',
+                'attributes_of_family' => ['box_quantity'],
                 'values'     => [
                     'box_quantity-decimal' => [
                         '<all_channels>' => [
@@ -408,6 +417,7 @@ class PimCatalogNumberIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_5',
+                'attributes_of_family' => ['box_quantity'],
                 'values'     => [
                     'box_quantity-decimal' => [
                         '<all_channels>' => [
@@ -418,6 +428,7 @@ class PimCatalogNumberIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_6',
+                'attributes_of_family' => ['box_quantity'],
                 'values'     => [
                     'box_quantity-decimal' => [
                         '<all_channels>' => [
@@ -428,6 +439,12 @@ class PimCatalogNumberIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_7',
+                'attributes_of_family' => ['box_quantity'],
+                'values'     => [],
+            ],
+            [
+                'identifier' => 'product_8',
+                'attributes_of_family' => [],
                 'values'     => [],
             ],
         ];

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionIntegration.php
@@ -41,6 +41,11 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
                             'field' => 'values.color-option.<all_channels>.<all_locales>',
                         ],
                     ],
+                    'filter'   => [
+                        'term' => [
+                            'attributes_of_family' => 'color',
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -79,6 +84,11 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
                             'values.color-option.<all_channels>.<all_locales>' => ['black', 'blue'],
                         ],
                     ],
+                    'filter'   => [
+                        'term' => [
+                            'attributes_of_family' => 'color',
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -108,7 +118,17 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
 
         $this->assertSame(
             $productsFound,
-            ['product_3', 'product_1', 'product_4', 'product_5', 'product_2', 'product_6', 'product_7', 'product_8']
+            [
+                'product_3',
+                'product_1',
+                'product_4',
+                'product_5',
+                'product_2',
+                'product_6',
+                'product_7',
+                'product_8',
+                'product_9',
+            ]
         );
     }
 
@@ -132,7 +152,7 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
 
         $this->assertSame(
             $productsFound,
-            ['product_2', 'product_6', 'product_4', 'product_5', 'product_3', 'product_1', 'product_7', 'product_8']
+            ['product_2', 'product_6', 'product_4', 'product_5', 'product_3', 'product_1', 'product_7', 'product_8', 'product_9']
         );
     }
 
@@ -144,6 +164,7 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
         $products = [
             [
                 'identifier' => 'product_1',
+                'attributes_of_family' => ['color'],
                 'values'     => [
                     'color-option' => [
                         '<all_channels>' => [
@@ -154,6 +175,7 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_2',
+                'attributes_of_family' => ['color'],
                 'values'     => [
                     'color-option' => [
                         '<all_channels>' => [
@@ -164,6 +186,7 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_3',
+                'attributes_of_family' => ['color'],
                 'values'     => [
                     'color-option' => [
                         '<all_channels>' => [
@@ -174,6 +197,7 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_4',
+                'attributes_of_family' => ['color'],
                 'values'     => [
                     'color-option' => [
                         '<all_channels>' => [
@@ -184,6 +208,7 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_5',
+                'attributes_of_family' => ['color'],
                 'values'     => [
                     'color-option' => [
                         '<all_channels>' => [
@@ -194,6 +219,7 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_6',
+                'attributes_of_family' => ['color'],
                 'values'     => [
                     'color-option' => [
                         '<all_channels>' => [
@@ -204,10 +230,12 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_7',
+                'attributes_of_family' => ['color'],
                 'values'     => [],
             ],
             [
                 'identifier' => 'product_8',
+                'attributes_of_family' => ['color'],
                 'values'     => [
                     'color-option' => [
                         '<all_channels>' => [
@@ -215,6 +243,11 @@ class PimCatalogOptionIntegration extends AbstractPimCatalogTestCase
                         ],
                     ],
                 ],
+            ],
+            [
+                'identifier' => 'product_9',
+                'attributes_of_family' => [],
+                'values'     => [],
             ],
         ];
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogOptionsIntegration.php
@@ -51,13 +51,18 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
                             'field' => 'values.colors-options.<all_channels>.<all_locales>',
                         ],
                     ],
+                    'filter'   => [
+                        'term' => [
+                            'attributes_of_family' => 'colors',
+                        ],
+                    ],
                 ],
             ],
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
-        $this->assertDocument($productsFound, ['product_7', 'product_8']);
+        $this->assertDocument($productsFound, ['product_8']);
     }
 
     public function testIsNotEmptyOperatorWithOptionValue()
@@ -89,13 +94,18 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
                             'values.colors-options.<all_channels>.<all_locales>' => ['black', 'blue'],
                         ],
                     ],
+                    'filter'   => [
+                        'term' => [
+                            'attributes_of_family' => 'colors',
+                        ],
+                    ],
                 ],
             ],
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
-        $this->assertDocument($productsFound, ['product_6', 'product_7', 'product_8']);
+        $this->assertDocument($productsFound, ['product_6', 'product_8']);
     }
 
     public function testSortAscending()
@@ -154,6 +164,7 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
         $products = [
             [
                 'identifier' => 'product_1',
+                'attributes_of_family' => ['colors'],
                 'values'     => [
                     'colors-options' => [
                         '<all_channels>' => [
@@ -164,6 +175,7 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_2',
+                'attributes_of_family' => ['colors'],
                 'values'     => [
                     'colors-options' => [
                         '<all_channels>' => [
@@ -174,6 +186,7 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_3',
+                'attributes_of_family' => ['colors'],
                 'values'     => [
                     'colors-options' => [
                         '<all_channels>' => [
@@ -184,6 +197,7 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_4',
+                'attributes_of_family' => ['colors'],
                 'values'     => [
                     'colors-options' => [
                         '<all_channels>' => [
@@ -194,6 +208,7 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_5',
+                'attributes_of_family' => ['colors'],
                 'values'     => [
                     'colors-options' => [
                         '<all_channels>' => [
@@ -204,6 +219,7 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_6',
+                'attributes_of_family' => ['colors'],
                 'values'     => [
                     'colors-options' => [
                         '<all_channels>' => [
@@ -214,10 +230,12 @@ class PimCatalogOptionsIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_7',
+                'attributes_of_family' => [],
                 'values'     => [],
             ],
             [
                 'identifier' => 'product_8',
+                'attributes_of_family' => ['colors'],
                 'values'     => [
                     'colors-options' => [
                         '<all_channels>' => [

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogPriceCollectionIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogPriceCollectionIntegration.php
@@ -211,13 +211,18 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
                             'field' => 'values.a_price-prices.<all_channels>.<all_locales>',
                         ],
                     ],
+                    'filter'   => [
+                        'term' => [
+                            'attributes_of_family' => 'a_price',
+                        ],
+                    ],
                 ],
             ],
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
-        $this->assertDocument($productsFound, ['product_5']);
+        $this->assertDocument($productsFound, ['product_8']);
     }
 
     public function testEmptyForCurrencyOperator()
@@ -230,13 +235,18 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
                             'field' => 'values.a_price-prices.<all_channels>.<all_locales>.USD',
                         ],
                     ],
+                    'filter'   => [
+                        'term' => [
+                            'attributes_of_family' => 'a_price',
+                        ],
+                    ],
                 ],
             ],
         ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
-        $this->assertDocument($productsFound, ['product_5', 'product_7']);
+        $this->assertDocument($productsFound, ['product_7', 'product_8']);
 
         $query = [
             'query' => [
@@ -244,6 +254,11 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
                     'must_not' => [
                         'exists' => [
                             'field' => 'values.a_price-prices.<all_channels>.<all_locales>.CNY',
+                        ],
+                    ],
+                    'filter'   => [
+                        'term' => [
+                            'attributes_of_family' => 'a_price',
                         ],
                     ],
                 ],
@@ -254,7 +269,7 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
 
         $this->assertDocument(
             $productsFound,
-            ['product_1', 'product_2', 'product_3', 'product_4', 'product_5', 'product_6']
+            ['product_1', 'product_2', 'product_3', 'product_4', 'product_6', 'product_8']
         );
     }
 
@@ -340,6 +355,7 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
         $products = [
             [
                 'identifier' => 'product_1',
+                'attributes_of_family' => ['a_price'],
                 'values'     => [
                     'a_price-prices' => [
                         '<all_channels>' => [
@@ -353,6 +369,7 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_2',
+                'attributes_of_family' => ['a_price'],
                 'values'     => [
                     'a_price-prices' => [
                         '<all_channels>' => [
@@ -366,6 +383,7 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_3',
+                'attributes_of_family' => ['a_price'],
                 'values'     => [
                     'a_price-prices' => [
                         '<all_channels>' => [
@@ -379,6 +397,7 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_4',
+                'attributes_of_family' => ['a_price'],
                 'values'     => [
                     'a_price-prices' => [
                         '<all_channels>' => [
@@ -392,9 +411,11 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_5',
+                'attributes_of_family' => [],
             ],
             [
                 'identifier' => 'product_6',
+                'attributes_of_family' => ['a_price'],
                 'values'     => [
                     'a_price-prices' => [
                         '<all_channels>' => [
@@ -407,6 +428,7 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_7',
+                'attributes_of_family' => ['a_price'],
                 'values'     => [
                     'a_price-prices' => [
                         '<all_channels>' => [
@@ -416,6 +438,10 @@ class PimCatalogPriceCollectionIntegration extends AbstractPimCatalogTestCase
                         ],
                     ],
                 ],
+            ],
+            [
+                'identifier' => 'product_8',
+                'attributes_of_family' => ['a_price'],
             ],
         ];
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogTextAreaIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogTextAreaIntegration.php
@@ -127,6 +127,11 @@ class PimCatalogTextAreaIntegration extends AbstractPimCatalogTestCase
                     'must_not' => [
                         'exists' => ['field' => 'values.description-textarea.<all_channels>.<all_locales>'],
                     ],
+                    'filter'   => [
+                        'term' => [
+                            'attributes_of_family' => 'description',
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -176,7 +181,7 @@ class PimCatalogTextAreaIntegration extends AbstractPimCatalogTestCase
 
         $this->assertDocument(
             $productsFound,
-            ['product_4', 'product_5', 'product_2', 'product_7', 'product_1', 'product_3', 'product_6']
+            ['product_4', 'product_5', 'product_2', 'product_7', 'product_1', 'product_3', 'product_6', 'product_8']
         );
     }
 
@@ -200,7 +205,7 @@ class PimCatalogTextAreaIntegration extends AbstractPimCatalogTestCase
 
         $this->assertDocument(
             $productsFound,
-            ['product_3', 'product_1', 'product_7', 'product_2', 'product_5', 'product_4', 'product_6']
+            ['product_3', 'product_1', 'product_7', 'product_2', 'product_5', 'product_4', 'product_6', 'product_8']
         );
     }
 
@@ -212,6 +217,7 @@ class PimCatalogTextAreaIntegration extends AbstractPimCatalogTestCase
         $products = [
             [
                 'identifier' => 'product_1',
+                'attributes_of_family' => ['description'],
                 'values'     => [
                     'description-textarea' => [
                         '<all_channels>' => [
@@ -222,6 +228,7 @@ class PimCatalogTextAreaIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_2',
+                'attributes_of_family' => ['description'],
                 'values'     => [
                     'description-textarea' => [
                         '<all_channels>' => [
@@ -232,6 +239,7 @@ class PimCatalogTextAreaIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_3',
+                'attributes_of_family' => ['description'],
                 'values'     => [
                     'description-textarea' => [
                         '<all_channels>' => [
@@ -242,6 +250,7 @@ class PimCatalogTextAreaIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_4',
+                'attributes_of_family' => ['description'],
                 'values'     => [
                     'description-textarea' => [
                         '<all_channels>' => [
@@ -252,6 +261,7 @@ class PimCatalogTextAreaIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_5',
+                'attributes_of_family' => ['description'],
                 'values'     => [
                     'description-textarea' => [
                         '<all_channels>' => [
@@ -262,6 +272,7 @@ class PimCatalogTextAreaIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_6',
+                'attributes_of_family' => ['description'],
             ],
             [
                 'identifier' => 'product_7',
@@ -272,6 +283,10 @@ class PimCatalogTextAreaIntegration extends AbstractPimCatalogTestCase
                         ],
                     ],
                 ],
+            ],
+            [
+                'identifier' => 'product_8',
+                'attributes_of_family' => [],
             ],
         ];
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogTextIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/PimCatalogTextIntegration.php
@@ -172,13 +172,18 @@ class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
                         'must_not' => [
                             'exists' => ['field' => 'values.name-text.<all_channels>.<all_locales>'],
                         ],
+                        'filter'   => [
+                            'term' => [
+                                'attributes_of_family' => 'name',
+                            ],
+                        ],
                     ],
                 ],
             ];
 
         $productsFound = $this->getSearchQueryResults($query);
 
-        $this->assertDocument($productsFound, ['product_4']);
+        $this->assertDocument($productsFound, ['product_4',]);
     }
 
     public function testNotEmptyOperator()
@@ -221,7 +226,17 @@ class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
 
         $this->assertDocument(
             $productsFound,
-            ['product_5', 'product_2', 'product_8', 'product_7', 'product_6', 'product_1', 'product_3', 'product_4']
+            [
+                'product_5',
+                'product_2',
+                'product_8',
+                'product_7',
+                'product_6',
+                'product_1',
+                'product_3',
+                'product_4',
+                'product_9',
+            ]
         );
     }
 
@@ -245,7 +260,17 @@ class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
 
         $this->assertDocument(
             $productsFound,
-            ['product_3', 'product_1', 'product_6', 'product_7', 'product_8', 'product_2', 'product_5', 'product_4']
+            [
+                'product_3',
+                'product_1',
+                'product_6',
+                'product_7',
+                'product_8',
+                'product_2',
+                'product_5',
+                'product_4',
+                'product_9',
+            ]
         );
     }
 
@@ -257,6 +282,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
         $products = [
             [
                 'identifier' => 'product_1',
+                'attributes_of_family' => ['name'],
                 'values'     => [
                     'name-text' => [
                         '<all_channels>' => [
@@ -267,6 +293,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_2',
+                'attributes_of_family' => ['name'],
                 'values'     => [
                     'name-text' => [
                         '<all_channels>' => [
@@ -277,6 +304,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_3',
+                'attributes_of_family' => ['name'],
                 'values'     => [
                     'name-text' => [
                         '<all_channels>' => [
@@ -287,9 +315,11 @@ class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_4',
+                'attributes_of_family' => ['name'],
             ],
             [
                 'identifier' => 'product_5',
+                'attributes_of_family' => ['name'],
                 'values'     => [
                     'name-text' => [
                         '<all_channels>' => [
@@ -300,6 +330,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_6',
+                'attributes_of_family' => ['name'],
                 'values'     => [
                     'name-text' => [
                         '<all_channels>' => [
@@ -310,6 +341,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_7',
+                'attributes_of_family' => ['name'],
                 'values'     => [
                     'name-text' => [
                         '<all_channels>' => [
@@ -320,6 +352,7 @@ class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
             ],
             [
                 'identifier' => 'product_8',
+                'attributes_of_family' => ['name'],
                 'values'     => [
                     'name-text' => [
                         '<all_channels>' => [
@@ -328,6 +361,9 @@ class PimCatalogTextIntegration extends AbstractPimCatalogTestCase
                     ],
                 ],
             ],
+            [
+                'identifier' => 'product_9',
+            ]
         ];
 
         $this->indexDocuments($products);

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -142,7 +142,6 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
         return $date;
     }
 
-
     /**
      * @param ProductInterface $product
      *


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This PR changes the way the Product and Product model API interacts with elasticsearch through PQBs.

**Before this PR:**
For each endpoint, whenever we needed to search, list products (iterating with `searchAfter` or `fromSize`). we would use the right PQB factory of product using the right cursor technique (eg, `searchAfter` or `fromSize`).

We would do the same with product models using exclusively a pqb of pm using the right cursors.

Hence, when searching for products through the API, the PQB would use the index dedicated to products.
When searching for product models through the API, the PQB would use the index dedicated to product models.

**The issue:**
As the documents are not exactly indexed the same between the 3 indexes (product, product model and product_and_product_model), the filters with the IS_EMPTY operator would not work the same.

**Proposed solution:**
Make the API listing products and product models work exclusively with the product_and_product_model index. Therefore, the search between the grid and the API would stay coherent.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
