### PR TITLE
PIM-7758: Fix product and product model deletion

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7759: Date range grid filters should be ignored when no value is set
+- PIM-7758: Fix the product and product model deletion from the grid
 
 # 2.3.12 (2018-10-17)
 

--- a/src/Pim/Component/Enrich/Job/DeleteProductsAndProductModelsTasklet.php
+++ b/src/Pim/Component/Enrich/Job/DeleteProductsAndProductModelsTasklet.php
@@ -90,7 +90,7 @@ class DeleteProductsAndProductModelsTasklet implements TaskletInterface
         $this->stepExecution->addSummaryInfo('deleted_products', 0);
         $this->stepExecution->addSummaryInfo('deleted_product_models', 0);
 
-        $variantProducts = $this->variantProducts();
+        $variantProducts = $this->findVariantProducts();
         $this->delete($variantProducts);
 
         $subProductModels = $this->findSubProductModels();
@@ -100,7 +100,7 @@ class DeleteProductsAndProductModelsTasklet implements TaskletInterface
         $this->delete($productsAndRootProductModels);
     }
 
-    private function variantProducts(): CursorInterface
+    private function findVariantProducts(): CursorInterface
     {
         $filters = $this->stepExecution->getJobParameters()->get('filters');
         $options = ['filters' => $filters];
@@ -126,7 +126,7 @@ class DeleteProductsAndProductModelsTasklet implements TaskletInterface
     /**
      * @return CursorInterface
      */
-    protected function findSimpleProductsAndRootProductModels(): CursorInterface
+    private function findSimpleProductsAndRootProductModels(): CursorInterface
     {
         $filters = $this->stepExecution->getJobParameters()->get('filters');
         $options = ['filters' => $filters];

--- a/src/Pim/Component/Enrich/spec/Job/DeleteProductsAndProductModelsTaskletSpec.php
+++ b/src/Pim/Component/Enrich/spec/Job/DeleteProductsAndProductModelsTaskletSpec.php
@@ -51,8 +51,12 @@ class DeleteProductsAndProductModelsTaskletSpec extends ObjectBehavior
         $cacheClearer,
         StepExecution $stepExecution,
         JobParameters $jobParameters,
-        ProductQueryBuilderInterface $pqb,
-        CursorInterface $cursor,
+        ProductQueryBuilderInterface $rootProductModelPQB,
+        ProductQueryBuilderInterface $subProductModelPQB,
+        ProductQueryBuilderInterface $variantProductsPQB,
+        CursorInterface $rootProductModelCursor,
+        CursorInterface $subProductModelCursor,
+        CursorInterface $variantProductsCursor,
         ProductInterface $product123,
         ProductInterface $product456,
         ProductInterface $product789
@@ -69,21 +73,33 @@ class DeleteProductsAndProductModelsTaskletSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filters')->willReturn($filters);
 
-        $pqbFactory->create(['filters' => $filters])->willReturn($pqb);
-        $pqb->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
-        $pqb->execute()->willReturn($cursor);
+        $pqbFactory->create(['filters' => $filters])
+            ->willReturn($variantProductsPQB, $subProductModelPQB, $rootProductModelPQB);
 
-        $cursor->valid()->willReturn(true, true, true, false);
-        $cursor->current()->willReturn($product123, $product456, $product789);
-        $cursor->next()->shouldBeCalled();
+        $variantProductsPQB->addFilter('entity_type', Operators::EQUALS, ProductInterface::class)->shouldBeCalled();
+        $variantProductsPQB->execute()->willReturn($variantProductsCursor);
+        $variantProductsCursor->valid()->willReturn(true, false);
+        $variantProductsCursor->current()->willReturn($product789);
+        $variantProductsCursor->next()->shouldBeCalled();
+
+        $subProductModelPQB->addFilter('entity_type', Operators::EQUALS, ProductModelInterface::class)->shouldBeCalled();
+        $subProductModelPQB->addFilter('parent', Operators::IS_NOT_EMPTY, null)->shouldBeCalled();
+        $subProductModelPQB->execute()->willReturn($subProductModelCursor);
+        $subProductModelCursor->valid()->willReturn(false);
+
+        $rootProductModelPQB->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
+        $rootProductModelPQB->execute()->willReturn($rootProductModelCursor);
+        $rootProductModelCursor->valid()->willReturn(true, true, false);
+        $rootProductModelCursor->current()->willReturn($product123, $product456);
+        $rootProductModelCursor->next()->shouldBeCalled();
 
         $filter
             ->filterObject(Argument::any(), 'pim.enrich.product.delete')
             ->shouldBeCalled()
             ->willReturn(false);
 
-        $productRemover->removeAll([$product123, $product456])->shouldBeCalled();
         $productRemover->removeAll([$product789])->shouldBeCalled();
+        $productRemover->removeAll([$product123, $product456])->shouldBeCalled();
         $productModelRemover->removeAll([])->shouldBeCalled();
 
         $stepExecution->addSummaryInfo('deleted_products', 0)->shouldBeCalled();
@@ -108,8 +124,12 @@ class DeleteProductsAndProductModelsTaskletSpec extends ObjectBehavior
         $filter,
         StepExecution $stepExecution,
         JobParameters $jobParameters,
-        ProductQueryBuilderInterface $pqb,
-        CursorInterface $cursor,
+        ProductQueryBuilderInterface $rootProductModelPQB,
+        ProductQueryBuilderInterface $subProductModelPQB,
+        ProductQueryBuilderInterface $variantProductsPQB,
+        CursorInterface $rootProductModelCursor,
+        CursorInterface $subProductModelCursor,
+        CursorInterface $variantProductsCursor,
         ProductModelInterface $productModel123,
         ProductModelInterface $productModel456,
         ProductModelInterface $productModel789
@@ -126,13 +146,26 @@ class DeleteProductsAndProductModelsTaskletSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filters')->willReturn($filters);
 
-        $pqbFactory->create(['filters' => $filters])->willReturn($pqb);
-        $pqb->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
-        $pqb->execute()->willReturn($cursor);
+        $pqbFactory->create(['filters' => $filters])
+            ->willReturn($variantProductsPQB, $subProductModelPQB, $rootProductModelPQB);
 
-        $cursor->valid()->willReturn(true, true, true, false);
-        $cursor->current()->willReturn($productModel123, $productModel456, $productModel789);
-        $cursor->next()->shouldBeCalled();
+        $variantProductsPQB->addFilter('entity_type', Operators::EQUALS, ProductInterface::class)->shouldBeCalled();
+        $variantProductsPQB->execute()->willReturn($variantProductsCursor);
+        $variantProductsCursor->valid()->willReturn(false);
+
+        $subProductModelPQB->addFilter('entity_type', Operators::EQUALS, ProductModelInterface::class)->shouldBeCalled();
+        $subProductModelPQB->addFilter('parent', Operators::IS_NOT_EMPTY, null)->shouldBeCalled();
+        $subProductModelPQB->execute()->willReturn($subProductModelCursor);
+        $subProductModelCursor->valid()->willReturn(true, true, false);
+        $subProductModelCursor->current()->willReturn($productModel123, $productModel456);
+        $subProductModelCursor->next()->shouldBeCalled();
+
+
+        $rootProductModelPQB->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
+        $rootProductModelPQB->execute()->willReturn($rootProductModelCursor);
+        $rootProductModelCursor->valid()->willReturn(true, false);
+        $rootProductModelCursor->current()->willReturn($productModel789);
+        $rootProductModelCursor->next()->shouldBeCalled();
 
         $filter
             ->filterObject(Argument::any(), 'pim.enrich.product.delete')
@@ -165,8 +198,12 @@ class DeleteProductsAndProductModelsTaskletSpec extends ObjectBehavior
         $filter,
         StepExecution $stepExecution,
         JobParameters $jobParameters,
-        ProductQueryBuilderInterface $pqb,
-        CursorInterface $cursor,
+        ProductQueryBuilderInterface $rootProductModelPQB,
+        ProductQueryBuilderInterface $subProductModelPQB,
+        ProductQueryBuilderInterface $variantProductsPQB,
+        CursorInterface $rootProductModelCursor,
+        CursorInterface $subProductModelCursor,
+        CursorInterface $variantProductsCursor,
         ProductModelInterface $productModel1,
         ProductModelInterface $productModel2,
         ProductModelInterface $productModel3,
@@ -193,20 +230,27 @@ class DeleteProductsAndProductModelsTaskletSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filters')->willReturn($filters);
 
-        $pqbFactory->create(['filters' => $filters])->willReturn($pqb);
-        $pqb->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
-        $pqb->execute()->willReturn($cursor);
+        $pqbFactory->create(['filters' => $filters])
+            ->willReturn($variantProductsPQB, $subProductModelPQB, $rootProductModelPQB);
 
-        $cursor->valid()->willReturn(true, true, true, true, true, true, false);
-        $cursor->current()->willReturn(
-            $productModel1,
-            $product4,
-            $product5,
-            $product6,
-            $productModel2,
-            $productModel3
-        );
-        $cursor->next()->shouldBeCalled();
+        $variantProductsPQB->addFilter('entity_type', Operators::EQUALS, ProductInterface::class)->shouldBeCalled();
+        $variantProductsPQB->execute()->willReturn($variantProductsCursor);
+        $variantProductsCursor->valid()->willReturn(true, true, false);
+        $variantProductsCursor->current()->willReturn($product4, $product5);
+        $variantProductsCursor->next()->shouldBeCalled();
+
+        $subProductModelPQB->addFilter('entity_type', Operators::EQUALS, ProductModelInterface::class)->shouldBeCalled();
+        $subProductModelPQB->addFilter('parent', Operators::IS_NOT_EMPTY, null)->shouldBeCalled();
+        $subProductModelPQB->execute()->willReturn($subProductModelCursor);
+        $subProductModelCursor->valid()->willReturn(true, true, false);
+        $subProductModelCursor->current()->willReturn($productModel1, $productModel2);
+        $subProductModelCursor->next()->shouldBeCalled();
+
+        $rootProductModelPQB->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
+        $rootProductModelPQB->execute()->willReturn($rootProductModelCursor);
+        $rootProductModelCursor->valid()->willReturn(true, true, false);
+        $rootProductModelCursor->current()->willReturn($productModel3, $product6);
+        $rootProductModelCursor->next()->shouldBeCalled();
 
         $filter
             ->filterObject(Argument::any(), 'pim.enrich.product.delete')
@@ -216,14 +260,14 @@ class DeleteProductsAndProductModelsTaskletSpec extends ObjectBehavior
         $stepExecution->addSummaryInfo('deleted_products', 0)->shouldBeCalled();
         $stepExecution->addSummaryInfo('deleted_product_models', 0)->shouldBeCalled();
 
-        $productRemover->removeAll([$product4])->shouldBeCalled();
-        $productModelRemover->removeAll([$productModel1])->shouldBeCalled();
+        $productRemover->removeAll([$product4, $product5])->shouldBeCalled();
+        $productModelRemover->removeAll([])->shouldBeCalled([]);
 
-        $productRemover->removeAll([$product5, $product6])->shouldBeCalled();
-        $productModelRemover->removeAll([])->shouldBeCalled();
+        $productRemover->removeAll([])->shouldBeCalled();
+        $productModelRemover->removeAll([$productModel1, $productModel2])->shouldBeCalled([]);
 
-        $productRemover->removeAll([])->shouldBeCalled([]);
-        $productModelRemover->removeAll([$productModel2, $productModel3])->shouldBeCalled([]);
+        $productModelRemover->removeAll([$productModel3])->shouldBeCalled();
+        $productRemover->removeAll([$product6])->shouldBeCalled();
 
         $stepExecution->incrementSummaryInfo('deleted_product_models', 1)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('deleted_products', 1)->shouldBeCalled();
@@ -249,8 +293,12 @@ class DeleteProductsAndProductModelsTaskletSpec extends ObjectBehavior
         $filter,
         StepExecution $stepExecution,
         JobParameters $jobParameters,
-        ProductQueryBuilderInterface $pqb,
-        CursorInterface $cursor,
+        ProductQueryBuilderInterface $rootProductModelPQB,
+        ProductQueryBuilderInterface $subProductModelPQB,
+        ProductQueryBuilderInterface $variantProductsPQB,
+        CursorInterface $rootProductModelCursor,
+        CursorInterface $subProductModelCursor,
+        CursorInterface $variantProductsCursor,
         ProductModelInterface $productModel1,
         ProductModelInterface $productModel2,
         ProductInterface $product1,
@@ -273,18 +321,23 @@ class DeleteProductsAndProductModelsTaskletSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filters')->willReturn($filters);
 
-        $pqbFactory->create(['filters' => $filters])->willReturn($pqb);
-        $pqb->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
-        $pqb->execute()->willReturn($cursor);
+        $pqbFactory->create(['filters' => $filters])
+            ->willReturn($variantProductsPQB, $subProductModelPQB, $rootProductModelPQB);
 
-        $cursor->valid()->willReturn(true, true, true, true, false);
-        $cursor->current()->willReturn(
-            $productModel1,
-            $productModel2,
-            $product1,
-            $product2
-        );
-        $cursor->next()->shouldBeCalled();
+        $variantProductsPQB->addFilter('entity_type', Operators::EQUALS, ProductInterface::class)->shouldBeCalled();
+        $variantProductsPQB->execute()->willReturn($variantProductsCursor);
+        $variantProductsCursor->valid()->willReturn(false);
+
+        $subProductModelPQB->addFilter('entity_type', Operators::EQUALS, ProductModelInterface::class)->shouldBeCalled();
+        $subProductModelPQB->addFilter('parent', Operators::IS_NOT_EMPTY, null)->shouldBeCalled();
+        $subProductModelPQB->execute()->willReturn($subProductModelCursor);
+        $subProductModelCursor->valid()->willReturn(false);
+
+        $rootProductModelPQB->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
+        $rootProductModelPQB->execute()->willReturn($rootProductModelCursor);
+        $rootProductModelCursor->valid()->willReturn(true, true, true, true, false);
+        $rootProductModelCursor->current()->willReturn($productModel1, $productModel2, $product1, $product2);
+        $rootProductModelCursor->next()->shouldBeCalled();
 
         $filter
             ->filterObject($productModel1, 'pim.enrich.product.delete')
@@ -325,47 +378,6 @@ class DeleteProductsAndProductModelsTaskletSpec extends ObjectBehavior
         $stepExecution->incrementReadCount()->shouldBeCalledTimes(4);
 
         $cacheClearer->clear()->shouldBeCalledTimes(2);
-
-        $this->execute();
-    }
-
-    function it_deletes_all_products_and_product_model(
-        $pqbFactory,
-        $productRemover,
-        $productModelRemover,
-        $cacheClearer,
-        StepExecution $stepExecution,
-        JobParameters $jobParameters,
-        ProductQueryBuilderInterface $pqb,
-        CursorInterface $cursor,
-        ProductModelInterface $productModel,
-        ProductInterface $product
-    ) {
-        $this->setStepExecution($stepExecution);
-
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('filters')->willReturn([]);
-
-        $pqbFactory->create(['filters' => []])->willReturn($pqb);
-        $pqb->addFilter('parent', Operators::IS_EMPTY, null)->shouldBeCalled();
-        $pqb->execute()->willReturn($cursor);
-
-        $cursor->valid()->willReturn(true, true, false);
-        $cursor->current()->willReturn($productModel, $product);
-        $cursor->next()->shouldBeCalled();
-
-        $stepExecution->addSummaryInfo('deleted_products', 0)->shouldBeCalled();
-        $stepExecution->addSummaryInfo('deleted_product_models', 0)->shouldBeCalled();
-
-        $productRemover->removeAll([$product])->shouldBeCalled();
-        $productModelRemover->removeAll([$productModel])->shouldBeCalled();
-
-        $stepExecution->incrementSummaryInfo('deleted_product_models', 1)->shouldBeCalled();
-        $stepExecution->incrementSummaryInfo('deleted_products', 1)->shouldBeCalled();
-
-        $stepExecution->incrementReadCount()->shouldBeCalledTimes(2);
-
-        $cacheClearer->clear()->shouldBeCalled();
 
         $this->execute();
     }


### PR DESCRIPTION
**Before this PR**:

The deletion of products and product models through the grid is handled
by a Tasklet called `DeleteProductsAndProductModelsTasklet` (https://github.com/akeneo/pim-community-dev/blob/f98e07d7fc7a33bdeb7705c2f927a98395e98c95/src/Pim/Component/Enrich/Job/DeleteProductsAndProductModelsTasklet.php#L128).

The way we fetch the product and product models to delete takes
advantage of the filters the users has set on the grid, passed onto the
tasklet and used along side the PQB.

In this version, we would also add a filter on the 'parent' property
to look for root product models (no parent) and simple products (no
parent as well).

Hence, the deletion would only work for those types of products and
product models.
The deletion of sub-product models and variant product models would
never delete anything.

**Solution**:

As the tasklet also counts the number of products and product models
deleted during its execution, the proposed solution involves deleting
the products/product models of the tree from the bottom up to the root.

Therefore, the deletion is made in 3 steps for the three levels:
1. Delete all the variant products
2. Delete all the sub product models
3. Delete all the root product models and simple products.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
