### PR TITLE
PIM-7759: Date range grid filters should be ignored when no value is set

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7759: Date range grid filters should be ignored when no value is set
+
 # 2.3.12 (2018-10-17)
 
 ## Bug fixes

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductValue/DateTimeRangeFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductValue/DateTimeRangeFilter.php
@@ -35,6 +35,10 @@ class DateTimeRangeFilter extends AbstractDateFilter
      */
     public function parseData($data)
     {
+        if (!$this->isValidData($data)) {
+            return false;
+        }
+
         $userTimeZone = new \DateTimeZone($this->userContext->getUserTimezone());
 
         switch ($data['type']) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

A validation was missing in the `DateTimeRangeFilter` causing a fatal error instead of just ignoring the filter when no value was set.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
