### PR TITLE
PIM-7757: Reduce a lot the risk of inserting duplicate completenesses.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,10 +4,6 @@
 
 - PIM-7757: Fix the risk of inserting duplicate completenesses.
 
-## BC Breaks
-
-- Methods `setRatio()`, `setMissingCount()` and `setRequiredCount()` have been added to `Pim\Component\Catalog\Model\CompletenessInterface`.
-
 # 2.0.41 (2018-10-23)
 
 ## Bug fixes

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,13 @@
 # 2.0.x
 
+## Bug fixes
+
+- PIM-7757: Fix the risk of inserting duplicate completenesses.
+
+## BC Breaks
+
+- Methods `setRatio()`, `setMissingCount()` and `setRequiredCount()` have been added to `Pim\Component\Catalog\Model\CompletenessInterface`.
+
 # 2.0.41 (2018-10-23)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductModelDescendantsSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductModelDescendantsSaver.php
@@ -172,8 +172,6 @@ class ProductModelDescendantsSaver implements SaverInterface
      */
     private function computeCompletenesses(array $products): void
     {
-        $this->completenessManager->bulkSchedule($products);
-
         foreach ($products as $product) {
             $this->completenessManager->generateMissingForProduct($product);
             $this->objectManager->persist($product);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/Common/Saver/ProductSaver.php
@@ -62,7 +62,6 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
 
         $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));
 
-        $this->completenessManager->schedule($product);
         $this->completenessManager->generateMissingForProduct($product);
         $this->uniqueDataSynchronizer->synchronize($product);
 
@@ -93,7 +92,6 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
 
         foreach ($products as $product) {
             $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($product, $options));
-            $this->completenessManager->schedule($product);
             $this->completenessManager->generateMissingForProduct($product);
             $this->uniqueDataSynchronizer->synchronize($product);
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessRemover.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/CompletenessRemover.php
@@ -69,6 +69,8 @@ class CompletenessRemover implements CompletenessRemoverInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Do not use anymore, will be removed in 3.0.
      */
     public function removeForProduct(ProductInterface $product)
     {
@@ -87,6 +89,8 @@ class CompletenessRemover implements CompletenessRemoverInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Do not use anymore, will be removed in 3.0.
      */
     public function removeForProductWithoutIndexing(ProductInterface $product): void
     {
@@ -103,6 +107,8 @@ class CompletenessRemover implements CompletenessRemoverInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Do not use anymore, will be removed in 3.0.
      */
     public function removeForFamily(FamilyInterface $family)
     {

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
@@ -72,8 +72,6 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $cursor->current()->willReturn($variantProduct1, $variantProduct2, $variantProduct1, $variantProduct2);
         $cursor->next()->shouldBeCalled();
 
-        $completenessManager->bulkSchedule([$variantProduct1, $variantProduct2])->shouldBeCalled();
-
         $completenessManager->generateMissingForProduct($variantProduct1)->shouldBeCalled();
         $objectManager->persist($variantProduct1)->shouldBeCalled();
 
@@ -109,7 +107,6 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $pqb->addFilter('identifier', Operators::IN_LIST, [])->shouldBeCalled();
         $pqb->execute()->willReturn($cursor);
 
-        $completenessManager->schedule(Argument::cetera())->shouldNotBeCalled();
         $completenessManager->generateMissingForProduct(Argument::cetera())->shouldNotBeCalled();
 
         $objectManager->persist(Argument::cetera())->shouldNotBeCalled();

--- a/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductSaverSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Doctrine/Common/Saver/ProductSaverSpec.php
@@ -41,7 +41,6 @@ class ProductSaverSpec extends ObjectBehavior
         $uniqueDataSynchronizer,
         ProductInterface $product
     ) {
-        $completenessManager->schedule($product)->shouldBeCalled();
         $completenessManager->generateMissingForProduct($product)->shouldBeCalled();
 
         $objectManager->persist($product)->shouldBeCalled();
@@ -62,8 +61,6 @@ class ProductSaverSpec extends ObjectBehavior
         ProductInterface $product1,
         ProductInterface $product2
     ) {
-        $completenessManager->schedule($product1)->shouldBeCalled();
-        $completenessManager->schedule($product2)->shouldBeCalled();
         $completenessManager->generateMissingForProduct($product1)->shouldBeCalled();
         $completenessManager->generateMissingForProduct($product2)->shouldBeCalled();
 
@@ -102,9 +99,6 @@ class ProductSaverSpec extends ObjectBehavior
         ProductInterface $product1,
         ProductInterface $product2
     ) {
-        $completenessManager->schedule($product1)->shouldBeCalledTimes(1);
-        $completenessManager->schedule($product2)->shouldBeCalled();
-
         $completenessManager->generateMissingForProduct($product1)->shouldBeCalledTimes(1);
         $completenessManager->generateMissingForProduct($product2)->shouldBeCalled();
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessCommandIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Completeness/CalculateCompletenessCommandIntegration.php
@@ -44,6 +44,8 @@ class CalculateCompletenessCommandIntegration extends AbstractCompletenessTestCa
         $this->assertSame(0, $exitCode);
         $this->assertSame(0, $this->getCountRowCompleteness());
 
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+
         $exitCode = $commandLauncher->execute('pim:completeness:calculate');
         $this->assertSame(0, $exitCode);
         $this->assertSame(1, $this->getCountRowCompleteness());

--- a/src/Pim/Component/Catalog/Completeness/CompletenessGenerator.php
+++ b/src/Pim/Component/Catalog/Completeness/CompletenessGenerator.php
@@ -135,10 +135,10 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
 
         $this->updateExistingCompletenesses($completenessCollection, $newCompletenesses);
 
-        $currentLocalesChannels = [];
-        foreach ($completenessCollection as $currentCompleteness) {
-            $currentLocalesChannels[] =
-                $currentCompleteness->getLocale()->getId().'/'.$currentCompleteness->getChannel()->getId();
+        $completenessLocaleAndChannelCodes = [];
+        foreach ($completenessCollection as $updatedCompleteness) {
+            $completenessLocaleAndChannelCodes[] =
+                $updatedCompleteness->getLocale()->getId().'/'.$updatedCompleteness->getChannel()->getId();
         }
 
         $newLocalesChannels = [];
@@ -147,11 +147,21 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
                 $newCompleteness->getLocale()->getId().'/'.$newCompleteness->getChannel()->getId();
         }
 
-        $completenessesToAdd = array_diff($newLocalesChannels, $currentLocalesChannels);
-        $this->addNewCompletenesses($completenessCollection, $newCompletenesses, $completenessesToAdd);
+        $localeAndChannelCodesOfCompletenessesToAdd = array_diff(
+            $newLocalesChannels,
+            $completenessLocaleAndChannelCodes
+        );
+        $this->addNewCompletenesses(
+            $completenessCollection,
+            $newCompletenesses,
+            $localeAndChannelCodesOfCompletenessesToAdd
+        );
 
-        $completenessesToRemove = array_diff($currentLocalesChannels, $newLocalesChannels);
-        $this->removeOutdatedCompletenesses($completenessCollection, $completenessesToRemove);
+        $localeAndChannelCodesOfCompletenessesToRemove = array_diff(
+            $completenessLocaleAndChannelCodes,
+            $newLocalesChannels
+        );
+        $this->removeOutdatedCompletenesses($completenessCollection, $localeAndChannelCodesOfCompletenessesToRemove);
     }
 
     /**
@@ -176,19 +186,19 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
     /**
      * @param Collection              $completenessCollection
      * @param CompletenessInterface[] $newCompletenesses
-     * @param string[]                $completenessesToAdd
+     * @param string[]                $localeAndChannelCodesOfCompletenessesToAdd
      */
     private function addNewCompletenesses(
         Collection $completenessCollection,
         array $newCompletenesses,
-        array $completenessesToAdd
+        array $localeAndChannelCodesOfCompletenessesToAdd
     ) {
-        foreach ($completenessesToAdd as $completenessToAdd) {
-            list($localeId, $channelId) = explode('/', $completenessToAdd);
+        foreach ($localeAndChannelCodesOfCompletenessesToAdd as $completenessLocaleAndChannel) {
+            [$localeCode, $channelCode] = explode('/', $completenessLocaleAndChannel);
 
             foreach ($newCompletenesses as $newCompleteness) {
-                if ($newCompleteness->getLocale()->getId() === (int)$localeId
-                    && $newCompleteness->getChannel()->getId() === (int)$channelId
+                if ($newCompleteness->getLocale()->getId() === (int) $localeCode
+                    && $newCompleteness->getChannel()->getId() === (int) $channelCode
                 ) {
                     $completenessCollection->add($newCompleteness);
                 }
@@ -198,16 +208,18 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
 
     /**
      * @param Collection              $completenessCollection
-     * @param CompletenessInterface[] $completenessesToRemove
+     * @param CompletenessInterface[] $localeAndChannelCodesOfCompletenessesToRemove
      */
-    private function removeOutdatedCompletenesses(Collection $completenessCollection, array $completenessesToRemove)
-    {
-        foreach ($completenessesToRemove as $completenessToRemove) {
-            list($localeId, $channelId) = explode('/', $completenessToRemove);
+    private function removeOutdatedCompletenesses(
+        Collection $completenessCollection,
+        array $localeAndChannelCodesOfCompletenessesToRemove
+    ) {
+        foreach ($localeAndChannelCodesOfCompletenessesToRemove as $completenessLocaleAndChannel) {
+            [$localeCode, $channelCode] = explode('/', $completenessLocaleAndChannel);
 
             foreach ($completenessCollection as $currentCompleteness) {
-                if ($currentCompleteness->getLocale()->getId() === (int)$localeId
-                    && $currentCompleteness->getChannel()->getId() === (int)$channelId
+                if ($currentCompleteness->getLocale()->getId() === (int) $localeCode
+                    && $currentCompleteness->getChannel()->getId() === (int) $channelCode
                 ) {
                     $completenessCollection->removeElement($currentCompleteness);
                 }

--- a/src/Pim/Component/Catalog/Completeness/CompletenessGenerator.php
+++ b/src/Pim/Component/Catalog/Completeness/CompletenessGenerator.php
@@ -53,7 +53,8 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
     /**
      * {@inheritdoc}
      *
-     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
+     * @deprecated as completeness is generated on the fly when a product is saved since 2.x
+     *             Will be removed in 3.0.
      */
     public function generateMissingForProducts(ChannelInterface $channel, array $filters)
     {
@@ -66,7 +67,8 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
     /**
      * {@inheritdoc}
      *
-     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
+     * @deprecated as completeness is generated on the fly when a product is saved since 2.x
+     *             Will be removed in 3.0.
      */
     public function generateMissingForChannel(ChannelInterface $channel)
     {
@@ -79,7 +81,8 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
     /**
      * {@inheritdoc}
      *
-     * @deprecated to remove as it is not used
+     * @deprecated as completeness is generated on the fly when a product is saved since 2.x
+     *             Will be removed in 3.0.
      */
     public function generateMissing()
     {
@@ -103,12 +106,10 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
     ) {
         $defaultFilters = [
             ['field' => 'completeness', 'operator' => Operators::IS_EMPTY, 'value' => null],
-            ['field' => 'family', 'operator' => Operators::IS_NOT_EMPTY, 'value' => null]
+            ['field' => 'family', 'operator' => Operators::IS_NOT_EMPTY, 'value' => null],
         ];
 
-        $options = [
-            'filters' => $filters ?? $defaultFilters
-        ];
+        $options = ['filters' => $filters ?? $defaultFilters];
 
         if (null !== $channel) {
             $options['default_scope'] = $channel->getCode();
@@ -122,8 +123,7 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
 
     /**
      * Calculates current product completenesses.
-     *
-     * Completenesses are updated for the existing ones, others are added / removed.
+     * Completenesses are updated for the existing ones, others are added/removed.
      *
      * @param ProductInterface $product
      */
@@ -138,13 +138,13 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
         $currentLocalesChannels = [];
         foreach ($completenessCollection as $currentCompleteness) {
             $currentLocalesChannels[] =
-                $currentCompleteness->getLocale()->getId() . '/' . $currentCompleteness->getChannel()->getId();
+                $currentCompleteness->getLocale()->getId().'/'.$currentCompleteness->getChannel()->getId();
         }
 
         $newLocalesChannels = [];
         foreach ($newCompletenesses as $newCompleteness) {
             $newLocalesChannels[] =
-                $newCompleteness->getLocale()->getId() . '/' . $newCompleteness->getChannel()->getId();
+                $newCompleteness->getLocale()->getId().'/'.$newCompleteness->getChannel()->getId();
         }
 
         $completenessesToAdd = array_diff($newLocalesChannels, $currentLocalesChannels);
@@ -155,8 +155,8 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
     }
 
     /**
-     * @param Collection $completenessCollection
-     * @param []CompletenessInterface $newCompletenesses
+     * @param Collection              $completenessCollection
+     * @param CompletenessInterface[] $newCompletenesses
      */
     private function updateExistingCompletenesses(Collection $completenessCollection, array $newCompletenesses)
     {
@@ -174,9 +174,9 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
     }
 
     /**
-     * @param Collection $completenessCollection
-     * @param []CompletenessInterface $newCompletenesses
-     * @param []string $completenessesToAdd
+     * @param Collection              $completenessCollection
+     * @param CompletenessInterface[] $newCompletenesses
+     * @param string[]                $completenessesToAdd
      */
     private function addNewCompletenesses(
         Collection $completenessCollection,
@@ -187,8 +187,8 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
             list($localeId, $channelId) = explode('/', $completenessToAdd);
 
             foreach ($newCompletenesses as $newCompleteness) {
-                if ($newCompleteness->getLocale()->getId() === (int) $localeId &&
-                    $newCompleteness->getChannel()->getId() === (int) $channelId
+                if ($newCompleteness->getLocale()->getId() === (int)$localeId
+                    && $newCompleteness->getChannel()->getId() === (int)$channelId
                 ) {
                     $completenessCollection->add($newCompleteness);
                 }
@@ -197,8 +197,8 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
     }
 
     /**
-     * @param Collection $completenessCollection
-     * @param []CompletenessInterface $newCompletenesses
+     * @param Collection              $completenessCollection
+     * @param CompletenessInterface[] $completenessesToRemove
      */
     private function removeOutdatedCompletenesses(Collection $completenessCollection, array $completenessesToRemove)
     {
@@ -206,8 +206,8 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
             list($localeId, $channelId) = explode('/', $completenessToRemove);
 
             foreach ($completenessCollection as $currentCompleteness) {
-                if ($currentCompleteness->getLocale()->getId() === (int) $localeId &&
-                    $currentCompleteness->getChannel()->getId() === (int) $channelId
+                if ($currentCompleteness->getLocale()->getId() === (int)$localeId
+                    && $currentCompleteness->getChannel()->getId() === (int)$channelId
                 ) {
                     $completenessCollection->removeElement($currentCompleteness);
                 }

--- a/src/Pim/Component/Catalog/Completeness/CompletenessGeneratorInterface.php
+++ b/src/Pim/Component/Catalog/Completeness/CompletenessGeneratorInterface.php
@@ -26,14 +26,16 @@ interface CompletenessGeneratorInterface
      *
      * @param ChannelInterface $channel
      *
-     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
+     * @deprecated as completeness is generated on the fly when a product is saved since 2.x
+     *             Will be removed in 3.0.
      */
     public function generateMissingForChannel(ChannelInterface $channel);
 
     /**
      * Generate missing completenesses
      *
-     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
+     * @deprecated as completeness is generated on the fly when a product is saved since 2.x
+     *             Will be removed in 3.0.
      */
     public function generateMissing();
 }

--- a/src/Pim/Component/Catalog/Completeness/CompletenessRemoverInterface.php
+++ b/src/Pim/Component/Catalog/Completeness/CompletenessRemoverInterface.php
@@ -25,6 +25,8 @@ interface CompletenessRemoverInterface
      * Remove completenesses of a product
      *
      * @param ProductInterface $product
+     *
+     * @deprecated Do not use anymore, will be removed in 3.0.
      */
     public function removeForProduct(ProductInterface $product);
 
@@ -32,6 +34,8 @@ interface CompletenessRemoverInterface
      * Remove completeness of a product without indexing it.
      *
      * @param ProductInterface $product
+     *
+     * @deprecated Do not use anymore, will be removed in 3.0.
      */
     public function removeForProductWithoutIndexing(ProductInterface $product): void;
 
@@ -39,6 +43,8 @@ interface CompletenessRemoverInterface
      * Remove completenesses for all product of a family
      *
      * @param FamilyInterface $family
+     *
+     * @deprecated Do not use anymore, will be removed in 3.0.
      */
     public function removeForFamily(FamilyInterface $family);
 

--- a/src/Pim/Component/Catalog/Manager/CompletenessManager.php
+++ b/src/Pim/Component/Catalog/Manager/CompletenessManager.php
@@ -104,6 +104,8 @@ class CompletenessManager
     }
 
     /**
+     * @deprecated Not used anymore.
+     *
      * Schedule recalculation of completenesses for a product
      *
      * @param ProductInterface $product

--- a/src/Pim/Component/Catalog/Manager/CompletenessManager.php
+++ b/src/Pim/Component/Catalog/Manager/CompletenessManager.php
@@ -78,7 +78,8 @@ class CompletenessManager
      * @param ChannelInterface $channel
      * @param array            $filters
      *
-     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
+     * @deprecated as completeness is generated on the fly when a product is saved since 2.x
+     *             Will be removed in 3.0.
      */
     public function generateMissingForProducts(ChannelInterface $channel, array $filters)
     {
@@ -89,7 +90,8 @@ class CompletenessManager
      *
      * @param ChannelInterface $channel
      *
-     * @deprecated to remove as completeness is generated on the fly when a product is saved since 2.x
+     * @deprecated as completeness is generated on the fly when a product is saved since 2.x
+     *             Will be removed in 3.0.
      */
     public function generateMissingForChannel(ChannelInterface $channel)
     {
@@ -97,6 +99,9 @@ class CompletenessManager
 
     /**
      * Insert missing completenesses
+     *
+     * @deprecated Not used anymore.
+     *             Will be removed in 3.0.
      */
     public function generateMissing()
     {
@@ -104,11 +109,12 @@ class CompletenessManager
     }
 
     /**
-     * @deprecated Not used anymore.
-     *
      * Schedule recalculation of completenesses for a product
      *
      * @param ProductInterface $product
+     *
+     * @deprecated Do not use anymore, will be removed in 3.0.
+     *             Use directly the "generateMissingXXX" methods.
      */
     public function schedule(ProductInterface $product)
     {
@@ -134,6 +140,8 @@ class CompletenessManager
      * of a family
      *
      * @param FamilyInterface $family
+     *
+     * @deprecated Not used anymore, will be removed in 3.0.
      */
     public function scheduleForFamily(FamilyInterface $family)
     {

--- a/src/Pim/Component/Catalog/Model/AbstractCompleteness.php
+++ b/src/Pim/Component/Catalog/Model/AbstractCompleteness.php
@@ -98,7 +98,9 @@ abstract class AbstractCompleteness implements CompletenessInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @todo merge master: Add this method to CompletenessInterface and declare it as a BC break.
+     *
+     * @param int $ratio
      */
     public function setRatio(int $ratio): void
     {
@@ -114,7 +116,9 @@ abstract class AbstractCompleteness implements CompletenessInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @todo merge master: Add this method to CompletenessInterface and declare it as a BC break.
+     *
+     * @param int $missingCount
      */
     public function setMissingCount(int $missingCount): void
     {
@@ -122,7 +126,9 @@ abstract class AbstractCompleteness implements CompletenessInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @todo merge master: Add this method to CompletenessInterface and declare it as a BC break.
+     *
+     * @param int $requiredCount
      */
     public function setRequiredCount(int $requiredCount): void
     {

--- a/src/Pim/Component/Catalog/Model/AbstractCompleteness.php
+++ b/src/Pim/Component/Catalog/Model/AbstractCompleteness.php
@@ -98,11 +98,38 @@ abstract class AbstractCompleteness implements CompletenessInterface
     }
 
     /**
+     * @param int $ratio
+     * @return AbstractCompleteness
+     */
+    public function setRatio(int $ratio): self
+    {
+        $this->ratio = $ratio;
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getMissingCount()
     {
         return $this->missingCount;
+    }
+
+    /**
+     * @param int $missingCount
+     */
+    public function setMissingCount(int $missingCount): void
+    {
+        $this->missingCount = $missingCount;
+    }
+
+    /**
+     * @param int $requiredCount
+     */
+    public function setRequiredCount(int $requiredCount): void
+    {
+        $this->requiredCount = $requiredCount;
     }
 
     /**

--- a/src/Pim/Component/Catalog/Model/AbstractCompleteness.php
+++ b/src/Pim/Component/Catalog/Model/AbstractCompleteness.php
@@ -98,14 +98,11 @@ abstract class AbstractCompleteness implements CompletenessInterface
     }
 
     /**
-     * @param int $ratio
-     * @return AbstractCompleteness
+     * {@inheritdoc}
      */
-    public function setRatio(int $ratio): self
+    public function setRatio(int $ratio): void
     {
         $this->ratio = $ratio;
-
-        return $this;
     }
 
     /**
@@ -117,7 +114,7 @@ abstract class AbstractCompleteness implements CompletenessInterface
     }
 
     /**
-     * @param int $missingCount
+     * {@inheritdoc}
      */
     public function setMissingCount(int $missingCount): void
     {
@@ -125,7 +122,7 @@ abstract class AbstractCompleteness implements CompletenessInterface
     }
 
     /**
-     * @param int $requiredCount
+     * {@inheritdoc}
      */
     public function setRequiredCount(int $requiredCount): void
     {

--- a/src/Pim/Component/Catalog/Model/CompletenessInterface.php
+++ b/src/Pim/Component/Catalog/Model/CompletenessInterface.php
@@ -33,11 +33,6 @@ interface CompletenessInterface
     public function getRatio();
 
     /**
-     * @param int $ratio
-     */
-    public function setRatio(int $ratio): void;
-
-    /**
      * Getter locale
      *
      * @return LocaleInterface
@@ -57,16 +52,6 @@ interface CompletenessInterface
      * @return int
      */
     public function getMissingCount();
-
-    /**
-     * @param int $missingCount
-     */
-    public function setMissingCount(int $missingCount): void;
-
-    /**
-     * @param int $requiredCount
-     */
-    public function setRequiredCount(int $requiredCount): void;
 
     /**
      * Getter product

--- a/src/Pim/Component/Catalog/Model/CompletenessInterface.php
+++ b/src/Pim/Component/Catalog/Model/CompletenessInterface.php
@@ -33,6 +33,11 @@ interface CompletenessInterface
     public function getRatio();
 
     /**
+     * @param int $ratio
+     */
+    public function setRatio(int $ratio): void;
+
+    /**
      * Getter locale
      *
      * @return LocaleInterface
@@ -52,6 +57,16 @@ interface CompletenessInterface
      * @return int
      */
     public function getMissingCount();
+
+    /**
+     * @param int $missingCount
+     */
+    public function setMissingCount(int $missingCount): void;
+
+    /**
+     * @param int $requiredCount
+     */
+    public function setRequiredCount(int $requiredCount): void;
 
     /**
      * Getter product

--- a/src/Pim/Component/Catalog/spec/Completeness/CompletenessGeneratorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Completeness/CompletenessGeneratorSpec.php
@@ -3,22 +3,19 @@
 namespace spec\Pim\Component\Catalog\Completeness;
 
 use Akeneo\Component\StorageUtils\Cursor\CursorInterface;
-use Akeneo\Component\StorageUtils\Remover\BulkRemoverInterface;
-use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
-use Akeneo\Component\StorageUtils\Saver\SaverInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Completeness\CompletenessCalculatorInterface;
 use Pim\Component\Catalog\Completeness\CompletenessGenerator;
 use Pim\Component\Catalog\Model\ChannelInterface;
 use Pim\Component\Catalog\Model\CompletenessInterface;
-use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\LocaleInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
-use Prophecy\Argument;
+use Webmozart\Assert\Assert;
 
 class CompletenessGeneratorSpec extends ObjectBehavior
 {
@@ -37,19 +34,30 @@ class CompletenessGeneratorSpec extends ObjectBehavior
     function it_generates_missing_completeness_for_a_product(
         $calculator,
         ProductInterface $product,
-        Collection $completenesses,
         CompletenessInterface $newCompleteness1,
-        CompletenessInterface $newCompleteness2
+        CompletenessInterface $newCompleteness2,
+        LocaleInterface $locale1,
+        LocaleInterface $locale2,
+        ChannelInterface $channel
     ) {
+        $completenesses = new ArrayCollection();
         $product->getCompletenesses()->willReturn($completenesses);
-        $completenesses->isEmpty()->willReturn(true);
+
+        $locale1->getId()->willReturn(1);
+        $locale2->getId()->willReturn(2);
+        $channel->getId()->willReturn(1);
+
+        $newCompleteness1->getLocale()->willReturn($locale1);
+        $newCompleteness1->getChannel()->willReturn($channel);
+
+        $newCompleteness2->getLocale()->willReturn($locale2);
+        $newCompleteness2->getChannel()->willReturn($channel);
 
         $calculator->calculate($product)->willReturn([$newCompleteness1, $newCompleteness2]);
 
-        $completenesses->add($newCompleteness1)->shouldBeCalled();
-        $completenesses->add($newCompleteness2)->shouldBeCalled();
-
         $this->generateMissingForProduct($product);
+;
+        Assert::count($completenesses, 2);
     }
 
     function it_generates_missing_completenesses_for_a_channel(
@@ -60,21 +68,23 @@ class CompletenessGeneratorSpec extends ObjectBehavior
         ProductInterface $product2,
         ChannelInterface $channel,
         CursorInterface $products,
-        Collection $completenesses1,
         CompletenessInterface $newCompleteness1a,
         CompletenessInterface $newCompleteness1b,
-        Collection $completenesses2,
-        CompletenessInterface $newCompleteness2a
+        CompletenessInterface $newCompleteness2a,
+        LocaleInterface $locale1,
+        LocaleInterface $locale2,
+        ChannelInterface $channel1
     ) {
         $products->rewind()->shouldBeCalled();
         $products->valid()->willReturn(true, true, false);
         $products->current()->willReturn($product1, $product2);
         $products->next()->shouldBeCalled();
 
+        $completenesses1 = new ArrayCollection();
+        $completenesses2 = new ArrayCollection();
+
         $product1->getCompletenesses()->willReturn($completenesses1);
-        $completenesses1->isEmpty()->willReturn(true);
         $product2->getCompletenesses()->willReturn($completenesses2);
-        $completenesses2->isEmpty()->willReturn(true);
 
         $channel->getCode()->willReturn('ecommerce');
 
@@ -90,14 +100,25 @@ class CompletenessGeneratorSpec extends ObjectBehavior
 
         $pqb->execute()->willReturn($products);
 
+        $locale1->getId()->willReturn(1);
+        $locale2->getId()->willReturn(2);
+        $channel1->getId()->willReturn(1);
+
+        $newCompleteness1a->getLocale()->willReturn($locale1);
+        $newCompleteness1a->getChannel()->willReturn($channel1);
+        $newCompleteness1b->getLocale()->willReturn($locale2);
+        $newCompleteness1b->getChannel()->willReturn($channel1);
+
+        $newCompleteness2a->getLocale()->willReturn($locale1);
+        $newCompleteness2a->getChannel()->willReturn($channel1);
+
         $calculator->calculate($product1)->willReturn([$newCompleteness1a, $newCompleteness1b]);
         $calculator->calculate($product2)->willReturn([$newCompleteness2a]);
 
-        $completenesses1->add($newCompleteness1a)->shouldBeCalled();
-        $completenesses1->add($newCompleteness1b)->shouldBeCalled();
-        $completenesses2->add($newCompleteness2a)->shouldBeCalled();
-
         $this->generateMissingForChannel($channel);
+
+        Assert::count($completenesses1, 2);
+        Assert::count($completenesses2, 1);
     }
 
     function it_generates_missing_completenesses(
@@ -107,21 +128,23 @@ class CompletenessGeneratorSpec extends ObjectBehavior
         ProductInterface $product1,
         ProductInterface $product2,
         CursorInterface $products,
-        Collection $completenesses1,
         CompletenessInterface $newCompleteness1a,
         CompletenessInterface $newCompleteness1b,
-        Collection $completenesses2,
-        CompletenessInterface $newCompleteness2a
+        CompletenessInterface $newCompleteness2a,
+        LocaleInterface $locale1,
+        LocaleInterface $locale2,
+        ChannelInterface $channel1
     ) {
         $products->rewind()->shouldBeCalled();
         $products->valid()->willReturn(true, true, false);
         $products->current()->willReturn($product1, $product2);
         $products->next()->shouldBeCalled();
 
+        $completenesses1 = new ArrayCollection();
+        $completenesses2 = new ArrayCollection();
+
         $product1->getCompletenesses()->willReturn($completenesses1);
-        $completenesses1->isEmpty()->willReturn(true);
         $product2->getCompletenesses()->willReturn($completenesses2);
-        $completenesses2->isEmpty()->willReturn(true);
 
         $pqbFactory->create(
             [
@@ -134,14 +157,25 @@ class CompletenessGeneratorSpec extends ObjectBehavior
 
         $pqb->execute()->willReturn($products);
 
+        $locale1->getId()->willReturn(1);
+        $locale2->getId()->willReturn(2);
+        $channel1->getId()->willReturn(1);
+
+        $newCompleteness1a->getLocale()->willReturn($locale1);
+        $newCompleteness1a->getChannel()->willReturn($channel1);
+        $newCompleteness1b->getLocale()->willReturn($locale2);
+        $newCompleteness1b->getChannel()->willReturn($channel1);
+
+        $newCompleteness2a->getLocale()->willReturn($locale1);
+        $newCompleteness2a->getChannel()->willReturn($channel1);
+
         $calculator->calculate($product1)->willReturn([$newCompleteness1a, $newCompleteness1b]);
         $calculator->calculate($product2)->willReturn([$newCompleteness2a]);
 
-        $completenesses1->add($newCompleteness1a)->shouldBeCalled();
-        $completenesses1->add($newCompleteness1b)->shouldBeCalled();
-        $completenesses2->add($newCompleteness2a)->shouldBeCalled();
-
         $this->generateMissing();
+
+        Assert::count($completenesses2, 1);
+        Assert::count($completenesses1, 2);
     }
 
     function it_generates_missing_completenesses_for_filtered_products(
@@ -152,21 +186,23 @@ class CompletenessGeneratorSpec extends ObjectBehavior
         ProductInterface $product2,
         ChannelInterface $channel,
         CursorInterface $products,
-        Collection $completenesses1,
         CompletenessInterface $newCompleteness1a,
         CompletenessInterface $newCompleteness1b,
-        Collection $completenesses2,
-        CompletenessInterface $newCompleteness2a
+        CompletenessInterface $newCompleteness2a,
+        LocaleInterface $locale1,
+        LocaleInterface $locale2,
+        ChannelInterface $channel1
     ) {
         $products->rewind()->shouldBeCalled();
         $products->valid()->willReturn(true, true, false);
         $products->current()->willReturn($product1, $product2);
         $products->next()->shouldBeCalled();
 
+        $completenesses1 = new ArrayCollection();
+        $completenesses2 = new ArrayCollection();
+
         $product1->getCompletenesses()->willReturn($completenesses1);
-        $completenesses1->isEmpty()->willReturn(true);
         $product2->getCompletenesses()->willReturn($completenesses2);
-        $completenesses2->isEmpty()->willReturn(true);
 
         $channel->getCode()->willReturn('ecommerce');
 
@@ -183,13 +219,24 @@ class CompletenessGeneratorSpec extends ObjectBehavior
 
         $pqb->execute()->willReturn($products);
 
+        $locale1->getId()->willReturn(1);
+        $locale2->getId()->willReturn(2);
+        $channel1->getId()->willReturn(1);
+
+        $newCompleteness1a->getLocale()->willReturn($locale1);
+        $newCompleteness1a->getChannel()->willReturn($channel1);
+        $newCompleteness1b->getLocale()->willReturn($locale2);
+        $newCompleteness1b->getChannel()->willReturn($channel1);
+
+        $newCompleteness2a->getLocale()->willReturn($locale1);
+        $newCompleteness2a->getChannel()->willReturn($channel1);
+
         $calculator->calculate($product1)->willReturn([$newCompleteness1a, $newCompleteness1b]);
         $calculator->calculate($product2)->willReturn([$newCompleteness2a]);
 
-        $completenesses1->add($newCompleteness1a)->shouldBeCalled();
-        $completenesses1->add($newCompleteness1b)->shouldBeCalled();
-        $completenesses2->add($newCompleteness2a)->shouldBeCalled();
-
         $this->generateMissingForProducts($channel, $filters);
+
+        Assert::count($completenesses2, 1);
+        Assert::count($completenesses1, 2);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Completeness/CompletenessGeneratorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Completeness/CompletenessGeneratorSpec.php
@@ -56,7 +56,7 @@ class CompletenessGeneratorSpec extends ObjectBehavior
         $calculator->calculate($product)->willReturn([$newCompleteness1, $newCompleteness2]);
 
         $this->generateMissingForProduct($product);
-;
+
         Assert::count($completenesses, 2);
     }
 


### PR DESCRIPTION
## Description

### The issue

We have a lot of concurrent `INSERT INTO` to save the completeness in the database that generates SQL errors because of duplicated keys. For example: Integrity constraint violation: 1062. Duplicate entry 'X-XX-XXXXXX' for key 'searchunique_idx'

Currently, when we save a product, we remove all the completeness in the database, we compute it again and we save its all in the database.

### The solution

In this PR, to avoid the concurrent `INSERT INTO` that could generate a duplicated key, we change the behavior of the completeness computing: we don't remove the existing product completenesses, but we update the existing ones by updating their ratio and we add or delete completenesses if we need.

The downside of this is that we had to make mutable the Completeness object.

### Performance measurement

| Tested with Icecat demo dev | Current 2.0 | With this PR |
|-----------------------------|-------------|--------------|
| Install                     |    180 s    |     183 s    |
| Product import              |     52 s    |      46 s    |

Volumetry is very small, but it seems the fix has no perceptible impacts on performances.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
