### PR TITLE
PIM-7765: Add checks channel/currency in PriceCollectionFactory

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -6,6 +6,7 @@
 
 - PIM-7759: Date range grid filters should be ignored when no value is set
 - PIM-7758: Fix the product and product model deletion from the grid
+- PIM-7765: Fix the loading of price values for disabled currencies
 
 # 2.3.12 (2018-10-17)
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/GetProductIntegration.php
@@ -192,7 +192,6 @@ class GetProductIntegration extends AbstractProductTestCase
                         'locale' => null,
                         'scope'  => 'ecommerce',
                         'data'   => [
-                            ['amount' => '15.00', 'currency' => 'EUR'],
                             ['amount' => '20.00', 'currency' => 'USD'],
                         ],
                     ],
@@ -201,7 +200,6 @@ class GetProductIntegration extends AbstractProductTestCase
                         'scope'  => 'tablet',
                         'data'   => [
                             ['amount' => '17.00', 'currency' => 'EUR'],
-                            ['amount' => '24.00', 'currency' => 'USD'],
                         ],
                     ],
                 ],

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/SuccessListProductIntegration.php
@@ -260,7 +260,6 @@ JSON;
                             "locale" : null,
                             "scope"  : "ecommerce",
                             "data"   : [
-                                {"amount" : "78.77", "currency" : "CNY"},
                                 {"amount" : "10.50", "currency" : "EUR"},
                                 {"amount" : "11.50", "currency" : "USD"}
                             ]
@@ -375,7 +374,6 @@ JSON;
                             "locale" : null,
                             "scope"  : "tablet",
                             "data"   : [
-                                {"amount" : "78.77", "currency" : "CNY"},
                                 {"amount" : "10.50", "currency" : "EUR"},
                                 {"amount" : "11.50", "currency" : "USD"}
                             ]
@@ -481,7 +479,6 @@ JSON;
                             "locale" : null,
                             "scope"  : "tablet",
                             "data"   : [
-                                {"amount" : "78.77", "currency" : "CNY"},
                                 {"amount" : "10.50", "currency" : "EUR"},
                                 {"amount" : "11.50", "currency" : "USD"}
                             ]
@@ -658,7 +655,6 @@ JSON;
                             "locale" : null,
                             "scope"  : "tablet",
                             "data"   : [
-                                {"amount" : "78.77", "currency" : "CNY"},
                                 {"amount" : "10.50", "currency" : "EUR"},
                                 {"amount" : "11.50", "currency" : "USD"}
                             ]
@@ -667,7 +663,6 @@ JSON;
                             "locale" : null,
                             "scope"  : "ecommerce",
                             "data"   : [
-                                {"amount" : "78.77", "currency" : "CNY"},
                                 {"amount" : "10.50", "currency" : "EUR"},
                                 {"amount" : "11.50", "currency" : "USD"}
                             ]
@@ -900,7 +895,6 @@ JSON;
                             "locale" : null,
                             "scope"  : "tablet",
                             "data"   : [
-                                {"amount" : "78.77", "currency" : "CNY"},
                                 {"amount" : "10.50", "currency" : "EUR"},
                                 {"amount" : "11.50", "currency" : "USD"}
                             ]
@@ -1466,9 +1460,6 @@ JSON;
             "locale": null,
             "scope": "tablet",
             "data": [{
-                "amount": "78.77",
-                "currency": "CNY"
-            }, {
                 "amount": "10.50",
                 "currency": "EUR"
             }, {
@@ -1479,9 +1470,6 @@ JSON;
             "locale": null,
             "scope": "ecommerce",
             "data": [{
-                "amount": "78.77",
-                "currency": "CNY"
-            }, {
                 "amount": "10.50",
                 "currency": "EUR"
             }, {

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/FindActivatedCurrencies.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/FindActivatedCurrencies.php
@@ -58,12 +58,7 @@ class FindActivatedCurrencies implements FindActivatedCurrenciesInterface
             $this->activatedCurrenciesForChannels = $this->fetchActivatedCurrenciesForAllChannels();
         }
 
-        $currencies = [];
-        foreach ($this->activatedCurrenciesForChannels as $channel => $currenciesForChannel) {
-            $currencies = array_merge($currencies, $currenciesForChannel);
-        }
-
-        return array_unique($currencies);
+        return array_unique(array_merge(...array_values($this->activatedCurrenciesForChannels)));
     }
 
     /**

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/FindActivatedCurrencies.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/FindActivatedCurrencies.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Query;
+
+use Doctrine\DBAL\DBALException;
+use Doctrine\ORM\EntityManagerInterface;
+use Pim\Component\Catalog\Channel\Query\FindActivatedCurrenciesInterface;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FindActivatedCurrencies implements FindActivatedCurrenciesInterface
+{
+    /** @var array */
+    private $activatedCurrenciesForChannels = [];
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /**
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * Method that returns a list of currencies codes activated for the given channel.
+     *
+     * @param string $channelCode
+     *
+     * @return array
+     *
+     * @throws DBALException
+     */
+    public function forChannel(string $channelCode): array
+    {
+        if (empty($this->activatedCurrenciesForChannels)) {
+            $this->activatedCurrenciesForChannels = $this->fetchActivatedCurrenciesForAllChannels();
+        }
+
+        return $this->activatedCurrenciesForChannels[$channelCode] ?? [];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws DBALException
+     */
+    public function forAllChannels(): array
+    {
+        if (empty($this->activatedCurrenciesForChannels)) {
+            $this->activatedCurrenciesForChannels = $this->fetchActivatedCurrenciesForAllChannels();
+        }
+
+        $currencies = [];
+        foreach ($this->activatedCurrenciesForChannels as $channel => $currenciesForChannel) {
+            $currencies = array_merge($currencies, $currenciesForChannel);
+        }
+
+        return array_unique($currencies);
+    }
+
+    /**
+     * @return array
+     *
+     * @throws DBALException
+     */
+    private function fetchActivatedCurrenciesForAllChannels(): array
+    {
+        $sql = <<<SQL
+SELECT ch.code as channel_code, JSON_ARRAYAGG(cu.code) as activated_currencies
+FROM pim_catalog_channel ch
+  INNER JOIN pim_catalog_channel_currency chcu on ch.id = chcu.channel_id
+  INNER JOIN pim_catalog_currency cu on chcu.currency_id = cu.id
+WHERE cu.is_activated IS TRUE
+GROUP BY ch.code;
+SQL;
+        $statement = $this->entityManager->getConnection()->executeQuery($sql);
+
+        $results = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $currenciesIndexedByChannel = [];
+        foreach ($results as $result) {
+            $currenciesIndexedByChannel[$result['channel_code']] = json_decode($result['activated_currencies'], false);
+        }
+
+        return $currenciesIndexedByChannel;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/factories.yml
@@ -198,6 +198,7 @@ services:
             - '@pim_catalog.factory.price'
             - '%pim_catalog.entity.value.price_collection.class%'
             - 'pim_catalog_price_collection'
+            - '@pim_catalog.query.find_activated_currencies'
         tags:
             - { name: pim_catalog.factory.value }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
@@ -51,3 +51,8 @@ services:
         arguments:
             - '@doctrine.orm.entity_manager'
             - '%pim_catalog.entity.association.class%'
+
+    pim_catalog.query.find_activated_currencies:
+        class: Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\FindActivatedCurrencies
+        arguments:
+            - '@doctrine.orm.entity_manager'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/ProductSaverIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/ProductSaverIntegration.php
@@ -30,7 +30,7 @@ class ProductSaverIntegration extends TestCase
         $expectedRawValues = $this->getStorageValuesWithAllAttributes();
         NormalizedProductCleaner::cleanOnlyValues($expectedRawValues);
 
-        $this->assertSame($expectedRawValues, $rawValues);
+        $this->assertEquals($expectedRawValues, $rawValues);
     }
 
     public function testRawValuesForVariantProduct()
@@ -479,14 +479,12 @@ class ProductSaverIntegration extends TestCase
             'a_scopable_price' => [
                 'ecommerce' => [
                     '<all_locales>' => [
-                        ['amount' => '15.00', 'currency' => 'EUR'],
                         ['amount' => '20.00', 'currency' => 'USD'],
                     ],
                 ],
                 'tablet' => [
                     '<all_locales>' => [
                         ['amount' => '17.00', 'currency' => 'EUR'],
-                        ['amount' => '24.00', 'currency' => 'USD'],
                     ],
                 ],
             ],

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/ProductSaverIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/ProductSaverIntegration.php
@@ -1,4 +1,4 @@
-cd <?php
+<?php
 
 namespace tests\integration\Pim\Bundle\CatalogBundle\Doctrine\Common\Saver;
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/ProductSaverIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Common/Saver/ProductSaverIntegration.php
@@ -1,4 +1,4 @@
-<?php
+cd <?php
 
 namespace tests\integration\Pim\Bundle\CatalogBundle\Doctrine\Common\Saver;
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Query/FindActivatedCurrenciesIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/Query/FindActivatedCurrenciesIntegration.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Doctrine\Query;
+
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Pim\Bundle\CatalogBundle\Entity\Channel;
+
+/**
+ * @author    Arnaud Langlade <arnaud.langlade@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FindActivatedCurrenciesIntegration extends TestCase
+{
+    public function testThatItReturnsTheActivatedCurrencyOfAChannel()
+    {
+        Assert::assertSame(
+            $this->get('pim_catalog.query.find_activated_currencies')->forChannel('ecommerce'),
+            ['USD']
+        );
+    }
+
+    public function testThatItReturnsAnEmptyArrayForUnkownChannels()
+    {
+        Assert::assertEmpty(
+            $this->get('pim_catalog.query.find_activated_currencies')->forChannel('unknown_channel')
+        );
+    }
+
+    public function testReturnsMultipleActivatedCurrenciesForAChannel()
+    {
+        $this->addEURToEcommerce();
+        Assert::assertSame(
+            $this->get('pim_catalog.query.find_activated_currencies')->forChannel('ecommerce'),
+            ['USD', 'EUR']
+        );
+    }
+
+    public function testReturnsAllActivatedCurrenciesForAllChannels()
+    {
+        $this->addAdditionalCurrenciesToMobile();
+        Assert::assertSame(
+            $this->get('pim_catalog.query.find_activated_currencies')->forAllChannels('ecommerce'),
+            ['USD', 'EUR', 'ADP', 'AFA']
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function addEURToEcommerce(): void
+    {
+        $eur = $this->get('pim_catalog.repository.currency')->findOneByIdentifier('EUR');
+        $channelRepository = $this->get('pim_catalog.repository.channel');
+        $ecommerce = $channelRepository->findOneBy(['code' => 'ecommerce']);
+        $ecommerce->addCurrency($eur);
+        $this->get('pim_catalog.saver.channel')->save($ecommerce);
+    }
+
+    private function addAdditionalCurrenciesToMobile()
+    {
+        $eur = $this->get('pim_catalog.repository.currency')->findOneByIdentifier('EUR');
+        $adp = $this->get('pim_catalog.repository.currency')->findOneByIdentifier('ADP');
+        $afa = $this->get('pim_catalog.repository.currency')->findOneByIdentifier('AFA');
+        $adp->setActivated(true);
+        $afa->setActivated(true);
+        $this->get('pim_catalog.saver.currency')->saveAll([$adp, $afa]);
+
+        $master = $this->get('pim_catalog.repository.category')->findOneByIdentifier('master');
+
+        $mobile = new Channel();
+        $mobile->setCode('mobile');
+        $mobile->setCurrencies([$eur, $adp, $afa]);
+        $mobile->setCategory($master);
+        $this->get('pim_catalog.saver.channel')->save($mobile);
+    }
+}

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/AbstractExportTestCase.php
@@ -204,7 +204,7 @@ abstract class AbstractExportTestCase extends TestCase
     {
         $csv = $this->jobLauncher->launchExport('csv_product_export', null, $config);
 
-        $this->assertSame($expectedCsv, $csv);
+        $this->assertEquals($expectedCsv, $csv);
     }
 
     /**

--- a/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/ProductQueryBuilder/ExportProductsByFamiliesIntegration.php
+++ b/src/Pim/Bundle/ConnectorBundle/tests/integration/Export/ProductQueryBuilder/ExportProductsByFamiliesIntegration.php
@@ -20,8 +20,8 @@ class ExportProductsByFamiliesIntegration extends AbstractExportTestCase
     public function testProductExportWithFilterOnOneFamily()
     {
         $expectedCsv = <<<CSV
-sku;categories;enabled;family;groups;an_image;a_date;a_file;a_localizable_image-en_US;a_localized_and_scopable_text_area-en_US-tablet;a_metric;a_metric-unit;a_multi_select;a_number_float;a_number_float_negative;a_number_integer;a_price-CNY;a_price-EUR;a_price-USD;a_ref_data_multi_select;a_ref_data_simple_select;a_scopable_price-tablet-CNY;a_scopable_price-tablet-EUR;a_scopable_price-tablet-USD;a_simple_select;a_text;a_text_area;a_yes_no
-product_1;;1;familyA;;;;;;;;;;;;;;;;;;;;;;;;0
+sku;categories;enabled;family;groups;an_image;a_date;a_file;a_localizable_image-en_US;a_localized_and_scopable_text_area-en_US-tablet;a_metric;a_metric-unit;a_multi_select;a_number_float;a_number_float_negative;a_number_integer;a_price-CNY;a_price-EUR;a_price-USD;a_ref_data_multi_select;a_ref_data_simple_select;a_scopable_price-tablet-EUR;a_scopable_price-tablet-USD;a_simple_select;a_text;a_text_area;a_yes_no
+product_1;;1;familyA;;;;;;;;;;;;;;;;;;;;;;;0
 
 CSV;
 
@@ -47,9 +47,9 @@ CSV;
     public function testProductExportWithFilterOnAListOfFamilies()
     {
         $expectedCsv = <<<CSV
-sku;categories;enabled;family;groups;an_image;a_date;a_file;a_localizable_image-en_US;a_localized_and_scopable_text_area-en_US-tablet;a_metric;a_metric-unit;a_multi_select;a_number_float;a_number_float_negative;a_number_integer;a_price-CNY;a_price-EUR;a_price-USD;a_ref_data_multi_select;a_ref_data_simple_select;a_scopable_price-tablet-CNY;a_scopable_price-tablet-EUR;a_scopable_price-tablet-USD;a_simple_select;a_text;a_text_area;a_yes_no
-product_1;;1;familyA;;;;;;;;;;;;;;;;;;;;;;;;0
-product_2;;1;familyA1;;;;;;;;;;;;;;;;;;;;;;;;
+sku;categories;enabled;family;groups;an_image;a_date;a_file;a_localizable_image-en_US;a_localized_and_scopable_text_area-en_US-tablet;a_metric;a_metric-unit;a_multi_select;a_number_float;a_number_float_negative;a_number_integer;a_price-CNY;a_price-EUR;a_price-USD;a_ref_data_multi_select;a_ref_data_simple_select;a_scopable_price-tablet-EUR;a_scopable_price-tablet-USD;a_simple_select;a_text;a_text_area;a_yes_no
+product_1;;1;familyA;;;;;;;;;;;;;;;;;;;;;;;0
+product_2;;1;familyA1;;;;;;;;;;;;;;;;;;;;;;;
 
 CSV;
 
@@ -75,11 +75,11 @@ CSV;
     public function testProductExportWithoutAnyFilterOnFamily()
     {
         $expectedCsv = <<<CSV
-sku;categories;enabled;family;groups;an_image;a_date;a_file;a_localizable_image-en_US;a_localized_and_scopable_text_area-en_US-tablet;a_metric;a_metric-unit;a_multi_select;a_number_float;a_number_float_negative;a_number_integer;a_price-CNY;a_price-EUR;a_price-USD;a_ref_data_multi_select;a_ref_data_simple_select;a_scopable_price-tablet-CNY;a_scopable_price-tablet-EUR;a_scopable_price-tablet-USD;a_simple_select;a_text;a_text_area;a_yes_no
-product_1;;1;familyA;;;;;;;;;;;;;;;;;;;;;;;;0
-product_2;;1;familyA1;;;;;;;;;;;;;;;;;;;;;;;;
-product_3;;1;familyA2;;;;;;;;;;;;;;;;;;;;;;;;
-product_4;;1;;;;;;;;;;;;;;;;;;;;;;;;;
+sku;categories;enabled;family;groups;an_image;a_date;a_file;a_localizable_image-en_US;a_localized_and_scopable_text_area-en_US-tablet;a_metric;a_metric-unit;a_multi_select;a_number_float;a_number_float_negative;a_number_integer;a_price-CNY;a_price-EUR;a_price-USD;a_ref_data_multi_select;a_ref_data_simple_select;a_scopable_price-tablet-EUR;a_scopable_price-tablet-USD;a_simple_select;a_text;a_text_area;a_yes_no
+product_1;;1;familyA;;;;;;;;;;;;;;;;;;;;;;;0
+product_2;;1;familyA1;;;;;;;;;;;;;;;;;;;;;;;
+product_3;;1;familyA2;;;;;;;;;;;;;;;;;;;;;;;
+product_4;;1;;;;;;;;;;;;;;;;;;;;;;;;
 
 CSV;
 

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
@@ -62,10 +62,8 @@ class ProductIntegration extends TestCase
             'a_price_without_decimal-USD' => '-45.00',
             'a_ref_data_multi_select' => 'fabricA,fabricB',
             'a_ref_data_simple_select' => 'colorB',
-            'a_scopable_price-ecommerce-EUR' => '15.00',
             'a_scopable_price-ecommerce-USD' => '20.00',
             'a_scopable_price-tablet-EUR' => '17.00',
-            'a_scopable_price-tablet-USD' => '24.00',
             'a_simple_select' => 'optionB',
             'a_text' => 'this is a text',
             'a_text_area' => 'this is a very very very very very long  text',
@@ -73,12 +71,12 @@ class ProductIntegration extends TestCase
             'an_image' => '1/5/7/5/15757827125efa686c1c0f1e7930ca0c528f1c2c_imageA.jpg',
             'sku' => 'foo',
             '123' => 'a text for an attribute with numerical code',
-            'enabled' => 1,
+            'enabled' => 1
         ];
 
         $expected = $this->sanitizeMediaAttributeData($expected, $mediaAttributes);
 
-        $this->assertSame($flatProduct, $expected);
+        $this->assertEquals($expected, $flatProduct);
     }
 
     /**

--- a/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
+++ b/src/Pim/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
@@ -218,7 +218,6 @@ class ProductNormalizerIntegration extends TestCase
                         'locale' => null,
                         'scope'  => 'ecommerce',
                         'data'   => [
-                            ['amount' => '15.00', 'currency' => 'EUR'],
                             ['amount' => '20.00', 'currency' => 'USD'],
                         ],
                     ],
@@ -227,7 +226,6 @@ class ProductNormalizerIntegration extends TestCase
                         'scope'  => 'tablet',
                         'data'   => [
                             ['amount' => '17.00', 'currency' => 'EUR'],
-                            ['amount' => '24.00', 'currency' => 'USD'],
                         ],
                     ],
                 ],

--- a/src/Pim/Component/Catalog/Channel/Query/FindActivatedCurrenciesInterface.php
+++ b/src/Pim/Component/Catalog/Channel/Query/FindActivatedCurrenciesInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Channel\Query;
+
+interface FindActivatedCurrenciesInterface
+{
+    /**
+     * Method that returns a list of currencies codes activated for the given channel.
+     *
+     * @param string $channelCode
+     *
+     * @return array
+     */
+    public function forChannel(string $channelCode): array;
+
+    /**
+     * Method that returns a list of all currencies codes activated.
+     *
+     * @param string $channelCode
+     *
+     * @return array
+     */
+    public function forAllChannels(): array;
+}

--- a/src/Pim/Component/Catalog/Factory/Value/PriceCollectionValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/Value/PriceCollectionValueFactory.php
@@ -4,6 +4,7 @@ namespace Pim\Component\Catalog\Factory\Value;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Pim\Component\Catalog\Channel\Query\FindActivatedCurrenciesInterface;
 use Pim\Component\Catalog\Factory\PriceFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\PriceCollection;
@@ -28,16 +29,25 @@ class PriceCollectionValueFactory implements ValueFactoryInterface
     /** @var string */
     protected $supportedAttributeType;
 
+    /** @var FindActivatedCurrenciesInterface */
+    protected $findActivatedCurrenciesForChannel;
+
     /**
-     * @param PriceFactory $priceFactory
-     * @param string       $productValueClass
-     * @param string       $supportedAttributeType
+     * @param PriceFactory                     $priceFactory
+     * @param string                           $productValueClass
+     * @param string                           $supportedAttributeType
+     * @param FindActivatedCurrenciesInterface $findActivatedCurrenciesForChannel
      */
-    public function __construct(PriceFactory $priceFactory, $productValueClass, $supportedAttributeType)
-    {
+    public function __construct(
+        PriceFactory $priceFactory,
+        $productValueClass,
+        $supportedAttributeType,
+        FindActivatedCurrenciesInterface $findActivatedCurrenciesForChannel = null
+    ) {
         $this->priceFactory = $priceFactory;
         $this->productValueClass = $productValueClass;
         $this->supportedAttributeType = $supportedAttributeType;
+        $this->findActivatedCurrenciesForChannel = $findActivatedCurrenciesForChannel;
     }
 
     /**
@@ -52,7 +62,10 @@ class PriceCollectionValueFactory implements ValueFactoryInterface
         }
 
         $value = new $this->productValueClass(
-            $attribute, $channelCode, $localeCode, $this->getPrices($attribute, $data)
+            $attribute,
+            $channelCode,
+            $localeCode,
+            $this->getPrices($attribute, $data, $channelCode)
         );
 
         return $value;
@@ -125,11 +138,15 @@ class PriceCollectionValueFactory implements ValueFactoryInterface
      *
      * @return PriceCollection
      */
-    protected function getPrices(AttributeInterface $attribute, array $data)
+    protected function getPrices(AttributeInterface $attribute, array $data, ?string $channelCode)
     {
         $prices = new PriceCollection();
 
         $filteredData = $this->filterByCurrency($data);
+        // TODO: To remove / pull-up
+        if (null !== $this->findActivatedCurrenciesForChannel) {
+            $filteredData = $this->filterByActivatedCurrencies($channelCode, $filteredData);
+        }
         $sortedData = $this->sortByCurrency($filteredData);
         foreach ($sortedData as $price) {
             try {
@@ -222,5 +239,41 @@ class PriceCollectionValueFactory implements ValueFactoryInterface
         }
 
         return $filteredData;
+    }
+
+    /**
+     * filters out the currencies
+     *
+     * @param null|string $channelCode
+     * @param array       $data
+     *
+     * @return array
+     */
+    private function filterByActivatedCurrencies(?string $channelCode, array $data): array
+    {
+        $activatedCurrencies = $this->getActivatedCurrencies($channelCode);
+
+        return array_values(
+            array_filter(
+                $data,
+                function (array $price) use ($activatedCurrencies) {
+                    return in_array($price['currency'], $activatedCurrencies);
+                }
+            )
+        );
+    }
+
+    /**
+     * @param null|string $channelCode
+     *
+     * @return array
+     */
+    private function getActivatedCurrencies(?string $channelCode): array
+    {
+        if (null === $channelCode) {
+            return $this->findActivatedCurrenciesForChannel->forAllChannels();
+        }
+
+        return $this->findActivatedCurrenciesForChannel->forChannel($channelCode);
     }
 }

--- a/src/Pim/Component/Catalog/Factory/Value/PriceCollectionValueFactory.php
+++ b/src/Pim/Component/Catalog/Factory/Value/PriceCollectionValueFactory.php
@@ -42,7 +42,7 @@ class PriceCollectionValueFactory implements ValueFactoryInterface
         PriceFactory $priceFactory,
         $productValueClass,
         $supportedAttributeType,
-        FindActivatedCurrenciesInterface $findActivatedCurrenciesForChannel = null
+        ?FindActivatedCurrenciesInterface $findActivatedCurrenciesForChannel = null
     ) {
         $this->priceFactory = $priceFactory;
         $this->productValueClass = $productValueClass;

--- a/src/Pim/Component/Catalog/spec/Factory/Value/PriceCollectionValueFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/Value/PriceCollectionValueFactorySpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Catalog\Factory\Value;
 
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Channel\Query\FindActivatedCurrenciesInterface;
 use Pim\Component\Catalog\Factory\PriceFactory;
 use Pim\Component\Catalog\Factory\Value\PriceCollectionValueFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -14,9 +15,9 @@ use Prophecy\Argument;
 
 class PriceCollectionValueFactorySpec extends ObjectBehavior
 {
-    function let(PriceFactory $priceFactory)
+    function let(PriceFactory $priceFactory, FindActivatedCurrenciesInterface $findActivatedCurrencies)
     {
-        $this->beConstructedWith($priceFactory, ScalarValue::class, 'pim_catalog_price_collection', $priceFactory);
+        $this->beConstructedWith($priceFactory, ScalarValue::class, 'pim_catalog_price_collection', $findActivatedCurrencies);
     }
 
     function it_is_initializable()
@@ -32,7 +33,8 @@ class PriceCollectionValueFactorySpec extends ObjectBehavior
 
     function it_creates_a_empty_price_collection_product_value(
         $priceFactory,
-        AttributeInterface $attribute
+        AttributeInterface $attribute,
+        FindActivatedCurrenciesInterface $findActivatedCurrencies
     ) {
         $attribute->isScopable()->willReturn(false);
         $attribute->isLocalizable()->willReturn(false);
@@ -40,6 +42,8 @@ class PriceCollectionValueFactorySpec extends ObjectBehavior
         $attribute->getType()->willReturn('pim_catalog_price_collection');
         $attribute->getBackendType()->willReturn('prices');
         $attribute->isBackendTypeReferenceData()->willReturn(false);
+
+        $findActivatedCurrencies->forAllChannels()->willReturn(['EUR', 'USD']);
 
         $priceFactory->createPrice(Argument::cetera())->shouldNotBeCalled();
 
@@ -59,7 +63,8 @@ class PriceCollectionValueFactorySpec extends ObjectBehavior
 
     function it_creates_a_localizable_and_scopable_empty_price_collection_product_value(
         $priceFactory,
-        AttributeInterface $attribute
+        AttributeInterface $attribute,
+        FindActivatedCurrenciesInterface $findActivatedCurrencies
     ) {
         $attribute->isScopable()->willReturn(true);
         $attribute->isLocalizable()->willReturn(true);
@@ -67,6 +72,8 @@ class PriceCollectionValueFactorySpec extends ObjectBehavior
         $attribute->getType()->willReturn('pim_catalog_price_collection');
         $attribute->getBackendType()->willReturn('prices');
         $attribute->isBackendTypeReferenceData()->willReturn(false);
+
+        $findActivatedCurrencies->forChannel('ecommerce')->willReturn(['EUR', 'USD']);
 
         $priceFactory->createPrice(Argument::cetera())->shouldNotBeCalled();
 
@@ -90,7 +97,8 @@ class PriceCollectionValueFactorySpec extends ObjectBehavior
         $priceFactory,
         AttributeInterface $attribute,
         ProductPriceInterface $priceEUR,
-        ProductPriceInterface $priceUSD
+        ProductPriceInterface $priceUSD,
+        FindActivatedCurrenciesInterface $findActivatedCurrencies
     ) {
         $attribute->isScopable()->willReturn(false);
         $attribute->isLocalizable()->willReturn(false);
@@ -101,6 +109,8 @@ class PriceCollectionValueFactorySpec extends ObjectBehavior
 
         $priceFactory->createPrice(42, 'EUR')->willReturn($priceEUR);
         $priceFactory->createPrice(63, 'USD')->willReturn($priceUSD);
+
+        $findActivatedCurrencies->forAllChannels()->willReturn(['EUR', 'USD', 'AFA']);
 
         $productValue = $this->create(
             $attribute,
@@ -120,7 +130,8 @@ class PriceCollectionValueFactorySpec extends ObjectBehavior
         $priceFactory,
         AttributeInterface $attribute,
         ProductPriceInterface $priceEUR,
-        ProductPriceInterface $priceUSD
+        ProductPriceInterface $priceUSD,
+        FindActivatedCurrenciesInterface $findActivatedCurrencies
     ) {
         $attribute->isScopable()->willReturn(false);
         $attribute->isLocalizable()->willReturn(false);
@@ -128,6 +139,8 @@ class PriceCollectionValueFactorySpec extends ObjectBehavior
         $attribute->getType()->willReturn('pim_catalog_price_collection');
         $attribute->getBackendType()->willReturn('prices');
         $attribute->isBackendTypeReferenceData()->willReturn(false);
+
+        $findActivatedCurrencies->forAllChannels()->willReturn(['EUR', 'USD', 'AFA']);
 
         $priceFactory->createPrice(42, 'EUR')->shouldNotBeCalled();
         $priceFactory->createPrice(null, 'EUR')->shouldBeCalled()->willReturn($priceEUR);
@@ -157,7 +170,8 @@ class PriceCollectionValueFactorySpec extends ObjectBehavior
         $priceFactory,
         AttributeInterface $attribute,
         ProductPriceInterface $priceEUR,
-        ProductPriceInterface $priceUSD
+        ProductPriceInterface $priceUSD,
+        FindActivatedCurrenciesInterface $findActivatedCurrencies
     ) {
         $attribute->isScopable()->willReturn(true);
         $attribute->isLocalizable()->willReturn(true);
@@ -165,6 +179,8 @@ class PriceCollectionValueFactorySpec extends ObjectBehavior
         $attribute->getType()->willReturn('pim_catalog_price_collection');
         $attribute->getBackendType()->willReturn('prices');
         $attribute->isBackendTypeReferenceData()->willReturn(false);
+
+        $findActivatedCurrencies->forChannel('ecommerce')->willReturn(['EUR', 'USD', 'AFA']);
 
         $priceFactory->createPrice(42, 'EUR')->willReturn($priceEUR);
         $priceFactory->createPrice(63, 'USD')->willReturn($priceUSD);
@@ -174,6 +190,73 @@ class PriceCollectionValueFactorySpec extends ObjectBehavior
             'ecommerce',
             'en_US',
             [['amount' => 42, 'currency' => 'EUR'], ['amount' => 63, 'currency' => 'USD']]
+        );
+
+        $productValue->shouldReturnAnInstanceOf(ScalarValue::class);
+        $productValue->shouldHaveAttribute('price_collection_attribute');
+        $productValue->shouldBeLocalizable();
+        $productValue->shouldHaveLocale('en_US');
+        $productValue->shouldBeScopable();
+        $productValue->shouldHaveChannel('ecommerce');
+        $productValue->shouldHavePrices();
+    }
+
+    function it_does_not_create_prices_for_non_activated_currencies(
+        $priceFactory,
+        AttributeInterface $attribute,
+        ProductPriceInterface $priceUSD,
+        FindActivatedCurrenciesInterface $findActivatedCurrencies
+    ) {
+        $attribute->isScopable()->willReturn(false);
+        $attribute->isLocalizable()->willReturn(true);
+        $attribute->getCode()->willReturn('price_collection_attribute');
+        $attribute->getType()->willReturn('pim_catalog_price_collection');
+        $attribute->getBackendType()->willReturn('prices');
+        $attribute->isBackendTypeReferenceData()->willReturn(false);
+
+        $findActivatedCurrencies->forAllChannels()->willReturn(['USD']);
+
+        $priceFactory->createPrice(42, 'EUR')->shouldNotBeCalled();
+        $priceFactory->createPrice(63, 'USD')->willReturn($priceUSD);
+
+        $productValue = $this->create(
+            $attribute,
+            null,
+            'en_US',
+            [['amount' => 42, 'currency' => 'EUR'], ['amount' => 63, 'currency' => 'USD'], ['amount' => 12, 'currency' => 'AFA']]
+        );
+
+        $productValue->shouldReturnAnInstanceOf(ScalarValue::class);
+        $productValue->shouldHaveAttribute('price_collection_attribute');
+        $productValue->shouldBeLocalizable();
+        $productValue->shouldHaveLocale('en_US');
+        $productValue->shouldNotBeScopable();
+        $productValue->shouldHavePrices();
+    }
+
+    function it_does_not_create_prices_for_non_activated_currencies_for_the_channel(
+        $priceFactory,
+        AttributeInterface $attribute,
+        ProductPriceInterface $priceUSD,
+        FindActivatedCurrenciesInterface $findActivatedCurrencies
+    ) {
+        $attribute->isScopable()->willReturn(true);
+        $attribute->isLocalizable()->willReturn(true);
+        $attribute->getCode()->willReturn('price_collection_attribute');
+        $attribute->getType()->willReturn('pim_catalog_price_collection');
+        $attribute->getBackendType()->willReturn('prices');
+        $attribute->isBackendTypeReferenceData()->willReturn(false);
+
+        $findActivatedCurrencies->forChannel('ecommerce')->willReturn(['USD']);
+
+        $priceFactory->createPrice(42, 'EUR')->shouldNotBeCalled();
+        $priceFactory->createPrice(63, 'USD')->willReturn($priceUSD);
+
+        $productValue = $this->create(
+            $attribute,
+            'ecommerce',
+            'en_US',
+            [['amount' => 42, 'currency' => 'EUR'], ['amount' => 63, 'currency' => 'USD'], ['amount' => 12, 'currency' => 'AFA']]
         );
 
         $productValue->shouldReturnAnInstanceOf(ScalarValue::class);

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
@@ -474,14 +474,12 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                 'a_scopable_price-prices'                        => [
                     'ecommerce' => [
                         '<all_locales>' => [
-                            'EUR' => '15.00',
                             'USD' => '20.00',
                         ],
                     ],
                     'tablet'    => [
                         '<all_locales>' => [
                             'EUR' => '17.00',
-                            'USD' => '24.00',
                         ],
                     ],
                 ],
@@ -610,6 +608,6 @@ class ProductAndProductModelIndexingIntegration extends TestCase
         NormalizedProductCleaner::clean($actual);
         NormalizedProductCleaner::clean($expected);
 
-        $this->assertSame($expected, $actual);
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductIndexingIntegration.php
@@ -269,14 +269,12 @@ class ProductIndexingIntegration extends TestCase
                 'a_scopable_price-prices'                        => [
                     'ecommerce' => [
                         '<all_locales>' => [
-                            'EUR' => '15.00',
                             'USD' => '20.00',
                         ],
                     ],
                     'tablet'    => [
                         '<all_locales>' => [
                             'EUR' => '17.00',
-                            'USD' => '24.00',
                         ],
                     ],
                 ],
@@ -347,6 +345,6 @@ class ProductIndexingIntegration extends TestCase
         NormalizedProductCleaner::clean($actual);
         NormalizedProductCleaner::clean($expected);
 
-        $this->assertSame($expected, $actual);
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Standard/ProductStandardIntegration.php
@@ -217,7 +217,6 @@ class ProductStandardIntegration extends TestCase
                             'locale' => null,
                             'scope'  => 'ecommerce',
                             'data'   => [
-                                ['amount' => '15.00', 'currency' => 'EUR'],
                                 ['amount' => '20.00', 'currency' => 'USD'],
                             ],
                         ],
@@ -226,7 +225,6 @@ class ProductStandardIntegration extends TestCase
                             'scope'  => 'tablet',
                             'data'   => [
                                 ['amount' => '17.00', 'currency' => 'EUR'],
-                                ['amount' => '24.00', 'currency' => 'USD'],
                             ],
                         ],
                     ],
@@ -281,7 +279,7 @@ class ProductStandardIntegration extends TestCase
         NormalizedProductCleaner::clean($expected);
         NormalizedProductCleaner::clean($result);
 
-        $this->assertSame($expected, $result);
+        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Storage/EntityWithValuesStorageIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Storage/EntityWithValuesStorageIntegration.php
@@ -172,14 +172,12 @@ class EntityWithValuesStorageIntegration extends TestCase
             'a_scopable_price' => [
                 'ecommerce' => [
                     '<all_locales>' => [
-                        ['amount' => '15.00', 'currency' => 'EUR'],
                         ['amount' => '20.00', 'currency' => 'USD'],
                     ],
                 ],
                 'tablet' => [
                     '<all_locales>' => [
                         ['amount' => '17.00', 'currency' => 'EUR'],
-                        ['amount' => '24.00', 'currency' => 'USD'],
                     ],
                 ],
             ],
@@ -235,6 +233,6 @@ class EntityWithValuesStorageIntegration extends TestCase
         NormalizedProductCleaner::cleanOnlyValues($expected);
         NormalizedProductCleaner::cleanOnlyValues($result);
 
-        $this->assertSame($expected, $result);
+        $this->assertEquals($expected, $result);
     }
 }

--- a/tests/legacy/features/import/product/import_products_with_invalid_data.feature
+++ b/tests/legacy/features/import/product/import_products_with_invalid_data.feature
@@ -30,17 +30,15 @@ Feature: Execute a job
     When I am on the "csv_footwear_product_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
-    Then I should see the text "skipped 5"
-    And there should be 3 products
+    Then I should see the text "skipped 3"
+    And there should be 5 products
     And the product "SKU-001" should have the following value:
       | price | 100.00 EUR, 90.00 USD |
     And the product "SKU-002" should have the following value:
       | price | 50.00 EUR |
     And the product "SKU-008" should have the following value:
       | price |  |
-    And I should see the text "price: Property \"currency\" expects a valid code. The currency does not exist, \"invalid\" given."
     And I should see the text "This value should be a valid number.: gruik EUR"
-    And I should see the text "price: Property \"currency\" expects a valid code. The currency does not exist, \"gruik\" given."
 
   Scenario: Skip new products with invalid prices during an import
     Given the following CSV file to import:
@@ -54,9 +52,8 @@ Feature: Execute a job
     When I am on the "csv_footwear_product_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
-    Then I should see the text "skipped 2"
+    Then I should see the text "skipped 1"
     And I should see the text "This value should be a valid number.: EUR"
-    And I should see the text "price: Property \"currency\" expects a valid code. The currency does not exist, \"mouette\" given."
 
   @jira https://akeneo.atlassian.net/browse/PIM-3266
   Scenario: Skip existing products with invalid prices during an import
@@ -87,27 +84,25 @@ Feature: Execute a job
     When I am on the "csv_footwear_product_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
-    Then I should see the text "skipped 5"
+    Then I should see the text "skipped 3"
     And there should be 8 products
     And the product "SKU-001" should have the following value:
       | price | 100.00 EUR, 90.00 USD |
     And the product "SKU-002" should have the following value:
       | price | 50.00 EUR |
     And the product "SKU-003" should have the following value:
-      | price | 12.00 EUR |
+      | price | |
     And the product "SKU-004" should have the following value:
       | price | 98.00 EUR |
     And the product "SKU-005" should have the following value:
-      | price | 32.00 USD |
+      | price | 25.00 EUR |
     And the product "SKU-006" should have the following value:
       | price | 77.00 USD |
     And the product "SKU-007" should have the following value:
       | price | 8.00 EUR |
     And the product "SKU-008" should have the following value:
       | price |  |
-    And I should see the text "price: Property \"currency\" expects a valid code. The currency does not exist, \"invalid\" given."
     And I should see the text "This value should be a valid number.: gruik EUR"
-    And I should see the text "price: Property \"currency\" expects a valid code. The currency does not exist, \"gruik\" given."
 
   @jira https://akeneo.atlassian.net/browse/PIM-3266
   Scenario: Skip new products with invalid metrics during an import
@@ -390,8 +385,8 @@ Feature: Execute a job
     When I am on the "csv_footwear_product_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
-    Then I should see the text "skipped 2"
-    And there should be 1 products
+    Then I should see the text "skipped 1"
+    And there should be 2 products
     And the product "renault-kangoo" should have the following value:
       | publicPrice | 20000.00 EUR |
 
@@ -412,8 +407,8 @@ Feature: Execute a job
     When I am on the "csv_footwear_product_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
-    Then I should see the text "skipped 3"
-    And there should be 1 products
+    Then I should see the text "skipped 2"
+    And there should be 2 products
     And the product "renault-kangoo" should have the following value:
       | publicPrice | 20000.00 EUR |
     And I should see the text "This value should be a valid number.: gruik EUR"

--- a/tests/legacy/features/localization/product/validation/validate_price_attributes.feature
+++ b/tests/legacy/features/localization/product/validation/validate_price_attributes.feature
@@ -28,7 +28,7 @@ Feature: Validate localized price attributes of a product
     And there should be 1 error in the "[other]" tab
 
   Scenario: Validate the decimals allowed constraint of scopable price attribute
-    Given I change the "Prix" to "4,9 USD"
+    Given I change the "Prix" to "4,9 EUR"
     And I save the product
     Then I should see validation tooltip "Cette valeur ne doit pas être un nombre décimal."
     And there should be 1 error in the "[other]" tab
@@ -40,7 +40,7 @@ Feature: Validate localized price attributes of a product
     And there should be 1 error in the "[other]" tab
 
   Scenario: Validate the number min constraint of scopable price attribute
-    Given I change the "Douane" to "9,9 USD"
+    Given I change the "Douane" to "9,9 EUR"
     And I save the product
     Then I should see validation tooltip "Cette valeur doit être supérieure ou égale à 10."
     And there should be 1 error in the "[other]" tab
@@ -52,7 +52,7 @@ Feature: Validate localized price attributes of a product
     And there should be 1 error in the "[other]" tab
 
   Scenario: Validate the number max constraint of scopable price attribute
-    Given I change the "Douane" to "222,2 USD"
+    Given I change the "Douane" to "222,2 EUR"
     And I save the product
     Then I should see validation tooltip "Cette valeur doit être inférieure ou égale à 100."
     And there should be 1 error in the "[other]" tab


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**Problem:**
When showing a product, and ultimately, hydrating its price collection values we do not check if the currencies coming from the database are still activated in the channel. hence, we hydrate those prices regardless.

When the user wants to do a modification on the product and saves it, those "old" prices are sent to the backend alongside with the updates, and a violation error occurs because 🎉  you cannot set a price on a product for a currency not activated by the channel :)

**The user cannot update the price anymore through the UI**

**Proposed solution:**
The solution is to:
- filter out the prices that have a currency not activated in the channel of the value at hydration time (for scopable prices attributes).
- filter out the prices that a currency not activated at hydration time (for non-scopable prices attributes)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
