### PR TITLE
Be able to validate an activated locale when the locale is a string

### DIFF
--- a/src/Pim/Component/Catalog/Validator/Constraints/ActivatedLocale.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/ActivatedLocale.php
@@ -14,4 +14,7 @@ class ActivatedLocale extends Constraint
 {
     /** @var string */
     public $message = 'The locale "%locale%" exists but has to be activated.';
+
+    /** @var string */
+    public $propertyPath = '';
 }

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/ActivatedLocaleValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/ActivatedLocaleValidatorSpec.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints;
+
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Pim\Bundle\CatalogBundle\Entity\Locale;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Validator\Constraints\ActivatedLocale;
+use Pim\Component\Catalog\Validator\Constraints\ActivatedLocaleValidator;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class ActivatedLocaleValidatorSpec extends ObjectBehavior
+{
+    function let(ExecutionContextInterface $context, IdentifiableObjectRepositoryInterface $localeRepository)
+    {
+        $this->beConstructedWith($localeRepository);
+        $this->initialize($context);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ActivatedLocaleValidator::class);
+    }
+
+    function it_adds_violation_if_locale_as_an_entity_not_activated(
+        $context,
+        $localeRepository,
+        ActivatedLocale $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $locale = new Locale();
+        $context->buildViolation(
+            'The locale "%locale%" exists but has to be activated.',
+            ['%locale%' => $locale]
+        )->willReturn($violation);
+
+        $violation->addViolation()->shouldBeCalled();
+        $localeRepository->findOneByIdentifier(Argument::any())->shouldNotBeCalled();
+
+        $this->validate($locale, $constraint)->shouldReturn(null);
+    }
+
+    function it_adds_violation_if_locale_as_a_string_is_not_activated(
+        $context,
+        $localeRepository,
+        ActivatedLocale $constraint,
+        ConstraintViolationBuilderInterface $violation,
+        LocaleInterface $locale
+    ) {
+        $localeCode = 'en_US';
+        $context->buildViolation(
+            'The locale "%locale%" exists but has to be activated.',
+            ['%locale%' => $locale]
+        )->willReturn($violation);
+
+        $violation->addViolation()->shouldBeCalled();
+        $localeRepository->findOneByIdentifier($localeCode)->willReturn($locale);
+
+        $this->validate($localeCode, $constraint)->shouldReturn(null);
+    }
+
+    function it_does_not_add_violation_if_locale_is_activated(
+        $context,
+        $localeRepository,
+        ActivatedLocale $constraint,
+        LocaleInterface $locale
+    ) {
+        $localeCode = 'en_US';
+        $localeRepository->findOneByIdentifier($localeCode)->willReturn($locale);
+        $locale->isActivated()->willReturn(true);
+
+        $context->buildViolation(
+            'The locale "%locale%" exists but has to be activated.',
+            ['%locale%' => $locale]
+        )->shouldNotBeCalled();
+
+        $this->validate($localeCode, $constraint)->shouldReturn(null);
+    }
+
+    function it_does_not_add_violation_if_locale_is_null(
+        $context,
+        $localeRepository,
+        ActivatedLocale $constraint,
+        LocaleInterface $locale
+    ) {
+        $localeCode = null;
+        $localeRepository->findOneByIdentifier($localeCode)->shouldNotBeCalled();
+        $locale->isActivated()->shouldNotBeCalled();
+
+        $context->buildViolation(
+            'The locale "%locale%" exists but has to be activated.',
+            ['%locale%' => $locale]
+        )->shouldNotBeCalled();
+
+        $this->validate($localeCode, $constraint)->shouldReturn(null);
+    }
+
+    function it_does_not_add_violation_if_locale_is_empty(
+        $context,
+        $localeRepository,
+        ActivatedLocale $constraint,
+        LocaleInterface $locale
+    ) {
+        $localeCode = '';
+        $localeRepository->findOneByIdentifier($localeCode)->shouldNotBeCalled();
+        $locale->isActivated()->shouldNotBeCalled();
+
+        $context->buildViolation(
+            'The locale "%locale%" exists but has to be activated.',
+            ['%locale%' => $locale]
+        )->shouldNotBeCalled();
+
+        $this->validate($localeCode, $constraint)->shouldReturn(null);
+    }
+
+    function it_does_not_add_violation_if_locale_is_not_an_instance_of_locale_interface(
+        $context,
+        $localeRepository,
+        ActivatedLocale $constraint,
+        LocaleInterface $locale
+    ) {
+        $localeCode = new \stdClass();
+        $localeRepository->findOneByIdentifier($localeCode)->shouldNotBeCalled();
+        $locale->isActivated()->shouldNotBeCalled();
+
+        $context->buildViolation(
+            'The locale "%locale%" exists but has to be activated.',
+            ['%locale%' => $locale]
+        )->shouldNotBeCalled();
+
+        $this->validate($localeCode, $constraint)->shouldReturn(null);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

For the onboarder, we need validate a supplier which must contain an activated locale. Problem with the ActivatedLocaleValidator, it accepts only a Locale entity, while on the onboarder, we valide a DTO (which contains the locale code)

Edit:
I did not want to add an other validator like `ActivatedLocaleCodeValidator`. Ideally, in the future, we will only validate DTO, so we will have code to validate, not the entity linked

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
