### PR TITLE
PIM-7765: Replace use of `JSON_ARRAYAGG`  by  `GROUP_CONCAT`

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7765: Replace `JSON_ARRAYAGG` by `GROUP_CONCAT`
+
 # 2.3.14 (2018-11-05)
 
 ## Bug fixes


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Replace use of `JSON_ARRAYAGG`  by  `GROUP_CONCAT`,
`JSON_ARRAYAGG` has been introduced in this PR [PIM-7765](https://github.com/akeneo/pim-community-dev/pull/9032)
`JSON_ARRAYAGG` is supported since MySQL 5.7.22, but in our PIM doc we advise to use 5.7.8 minus [doc system requirements](https://docs.akeneo.com/2.3/install_pim/manual/system_requirements/system_requirements.html)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
