### PR TITLE
PIM-7771: Fix refresh versioning command about duplicate version's rule

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7771: Fix refresh versioning command about duplicate version's rule
+
 # 2.3.15 (2018-11-06)
 
 ## Bug fixes

--- a/src/Pim/Bundle/VersioningBundle/Command/RefreshCommand.php
+++ b/src/Pim/Bundle/VersioningBundle/Command/RefreshCommand.php
@@ -117,10 +117,12 @@ class RefreshCommand extends ContainerAwareCommand
 
         if ($version->getChangeset()) {
             $this->getObjectManager()->persist($version);
+            $this->getObjectManager()->flush($version);
 
             return $version;
         } else {
             $this->getObjectManager()->remove($version);
+            $this->getObjectManager()->flush($version);
         }
     }
 


### PR DESCRIPTION
**Description**

When you save some change on a product (with a rule version not refresh on it) during the execution of the versioning command, that create doublon.

Example : 
![capture du 2018-11-06 10-45-47](https://user-images.githubusercontent.com/34027529/48056021-32a5fc80-e1b1-11e8-9f74-3a16a9a1f734.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
