### PR TITLE
PIM-7621: Add average number of attributes per family into System Informations data

### DIFF
--- a/src/Pim/Bundle/AnalyticsBundle/DataCollector/AttributeDataCollector.php
+++ b/src/Pim/Bundle/AnalyticsBundle/DataCollector/AttributeDataCollector.php
@@ -45,8 +45,12 @@ class AttributeDataCollector implements DataCollectorInterface
     /** @var AverageMaxQuery */
     private $localizableAndScopableAttributePerFamilyAverageMaxQuery;
 
+    /** @var AverageMaxQuery */
+    private $attributePerFamilyAverageMaxQuery;
+
     /**
      * @merge TODO - on master - remove '= null'
+     * TODO @merge - on master - remove '= null' on $attributePerFamilyAverageMaxQuery
      * @param CountQuery        $attributeCountQuery
      * @param CountQuery        $localizableAttributeCountQuery
      * @param CountQuery        $scopableAttributeCountQuery
@@ -55,6 +59,8 @@ class AttributeDataCollector implements DataCollectorInterface
      * @param AverageMaxQuery   $localizableAttributePerFamilyAverageMaxQuery
      * @param AverageMaxQuery   $scopableAttributePerFamilyAverageMaxQuery
      * @param AverageMaxQuery   $localizableAndScopableAttributePerFamilyAverageMaxQuery
+     * @param AverageMaxQuery   $attributePerFamilyAverageMaxQuery
+     *
      */
     public function __construct(
         CountQuery $attributeCountQuery,
@@ -64,7 +70,8 @@ class AttributeDataCollector implements DataCollectorInterface
         CountQuery $useableAsGridFilterAttributeCountQuery = null,
         AverageMaxQuery $localizableAttributePerFamilyAverageMaxQuery = null,
         AverageMaxQuery $scopableAttributePerFamilyAverageMaxQuery = null,
-        AverageMaxQuery $localizableAndScopableAttributePerFamilyAverageMaxQuery = null
+        AverageMaxQuery $localizableAndScopableAttributePerFamilyAverageMaxQuery = null,
+        AverageMaxQuery $attributePerFamilyAverageMaxQuery = null
     ) {
         $this->attributeCountQuery = $attributeCountQuery;
         $this->localizableAttributeCountQuery = $localizableAttributeCountQuery;
@@ -75,10 +82,12 @@ class AttributeDataCollector implements DataCollectorInterface
         $this->localizableAttributePerFamilyAverageMaxQuery = $localizableAttributePerFamilyAverageMaxQuery;
         $this->scopableAttributePerFamilyAverageMaxQuery = $scopableAttributePerFamilyAverageMaxQuery;
         $this->localizableAndScopableAttributePerFamilyAverageMaxQuery = $localizableAndScopableAttributePerFamilyAverageMaxQuery;
+        $this->attributePerFamilyAverageMaxQuery = $attributePerFamilyAverageMaxQuery;
     }
 
     /**
      * @merge TODO - on master - remove the if statements & move all inside the "if session" inside $data
+     * @merge TODO: on master - remove the if statements & move all inside the "if session" inside $data for 'avg_number_attributes_per_family'
      * {@inheritdoc}
      */
     public function collect(): array
@@ -103,6 +112,11 @@ class AttributeDataCollector implements DataCollectorInterface
             $numberOfLocalizableAndScopableAttributePerFamilyAverageMaxQuery = $this->localizableAndScopableAttributePerFamilyAverageMaxQuery->fetch()->getAverageVolume();
         }
 
+        $averageNumberOfAttributePerFamily = 0;
+        if (null !== $this->localizableAndScopableAttributePerFamilyAverageMaxQuery) {
+            $averageNumberOfAttributePerFamily = $this->attributePerFamilyAverageMaxQuery->fetch()->getAverageVolume();
+        }
+
         $data = [
             'nb_attributes' => $this->attributeCountQuery->fetch()->getVolume(),
             'nb_scopable_attributes' => $this->scopableAttributeCountQuery->fetch()->getVolume(),
@@ -112,6 +126,7 @@ class AttributeDataCollector implements DataCollectorInterface
             'avg_percentage_scopable_attributes_per_family' => $numberOfScopableAttributePerFamilyAverageMaxQuery,
             'avg_percentage_localizable_attributes_per_family' => $numberOfLocalizableAttributePerFamilyAverageMaxQuery,
             'avg_percentage_scopable_localizable_attributes_per_family' => $numberOfLocalizableAndScopableAttributePerFamilyAverageMaxQuery,
+            'avg_number_attributes_per_family' => $averageNumberOfAttributePerFamily
         ];
 
         return $data;

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
@@ -70,6 +70,7 @@ services:
             - '@pim_volume_monitoring.persistence.query.average_max_localizable_attributes_per_family'
             - '@pim_volume_monitoring.persistence.query.average_max_scopable_attributes_per_family'
             - '@pim_volume_monitoring.persistence.query.average_max_localizable_and_scopable_attributes_per_family'
+            - '@pim_volume_monitoring.persistence.query.average_max_attributes_per_family'
         tags:
             - { name: pim_analytics.data_collector, type: system_info_report }
 

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en.yml
@@ -32,6 +32,7 @@ pim_analytics:
         avg_percentage_scopable_attributes_per_family: Average percentage of scopable attributes per family (%)
         avg_percentage_localizable_attributes_per_family: Average percentage of localizable attributes per family (%)
         avg_percentage_scopable_localizable_attributes_per_family: Average percentage of localizable and scopable attributes per family (%)
+        avg_number_attributes_per_family: Average number of attributes per family
         nb_locales: Number of locales
         nb_families: Number of families
         nb_users: Number of users

--- a/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/AttributeDataCollectorSpec.php
+++ b/src/Pim/Bundle/AnalyticsBundle/spec/DataCollector/AttributeDataCollectorSpec.php
@@ -24,7 +24,8 @@ class AttributeDataCollectorSpec extends ObjectBehavior
         CountQuery $useableAsGridFilterAttributeCountQuery,
         AverageMaxQuery $localizableAttributePerFamilyAverageMaxQuery,
         AverageMaxQuery $scopableAttributePerFamilyAverageMaxQuery,
-        AverageMaxQuery $localizableAndScopableAttributePerFamilyAverageMaxQuery
+        AverageMaxQuery $localizableAndScopableAttributePerFamilyAverageMaxQuery,
+        AverageMaxQuery $attributePerFamilyAverageMaxQuery
     ) {
         $this->beConstructedWith(
             $attributeCountQuery,
@@ -34,7 +35,8 @@ class AttributeDataCollectorSpec extends ObjectBehavior
             $useableAsGridFilterAttributeCountQuery,
             $localizableAttributePerFamilyAverageMaxQuery,
             $scopableAttributePerFamilyAverageMaxQuery,
-            $localizableAndScopableAttributePerFamilyAverageMaxQuery
+            $localizableAndScopableAttributePerFamilyAverageMaxQuery,
+            $attributePerFamilyAverageMaxQuery
         );
     }
 
@@ -56,7 +58,8 @@ class AttributeDataCollectorSpec extends ObjectBehavior
         $useableAsGridFilterAttributeCountQuery,
         $localizableAttributePerFamilyAverageMaxQuery,
         $scopableAttributePerFamilyAverageMaxQuery,
-        $localizableAndScopableAttributePerFamilyAverageMaxQuery
+        $localizableAndScopableAttributePerFamilyAverageMaxQuery,
+        $attributePerFamilyAverageMaxQuery
     ) {
         $attributeCountQuery->fetch()->willReturn(new CountVolume(1000, -1, 'count_attributes'));
         $localizableAttributeCountQuery->fetch()->willReturn(new CountVolume(33, -1, 'count_localizable_attributes'));
@@ -67,6 +70,7 @@ class AttributeDataCollectorSpec extends ObjectBehavior
         $localizableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(12, 7, -1, 'average_max_localizable_attributes_per_family'));
         $scopableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(13, 9, -1, 'average_max_scopable_attributes_per_family'));
         $localizableAndScopableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(10, 7, -1, 'average_max_localizable_and_scopable_attributes_per_family'));
+        $attributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(20, 15, -1, 'avg_number_attributes_per_family'));
 
         $this->collect()->shouldReturn([
             'nb_attributes' => 1000,
@@ -76,7 +80,8 @@ class AttributeDataCollectorSpec extends ObjectBehavior
             'nb_useable_as_grid_filter_attributes' => 12,
             'avg_percentage_scopable_attributes_per_family' => 9,
             'avg_percentage_localizable_attributes_per_family' => 7,
-            'avg_percentage_scopable_localizable_attributes_per_family' => 7
+            'avg_percentage_scopable_localizable_attributes_per_family' => 7,
+            'avg_number_attributes_per_family' => 15
         ]);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add new axis : 
Average number of attributes by family: For each family, you count its number of attributes. Then you compute the average for all the families.

It already exist in the Volume Monitoring Screen so already tested with integration tests. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
