### PR TITLE
PIM-7767: Remove options values label from versioning

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7767: Remove option values label from attribute versioning
 - PIM-7771: Fix refresh versioning command about duplicate version's rule.
 - PIM-7813: Fix a bug that prevents to drag'n'drop an attribute group containing a lot of attributes in the variant family configuration screen.
 

--- a/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/AttributeNormalizer.php
+++ b/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/AttributeNormalizer.php
@@ -95,12 +95,7 @@ class AttributeNormalizer implements NormalizerInterface
             $data = [];
             foreach ($options as $option) {
                 $item = [];
-                foreach ($option->getOptionValues() as $value) {
-                    $label = str_replace('{locale}', $value->getLocale(), self::LOCALIZABLE_PATTERN);
-                    $label = str_replace('{value}', $value->getValue(), $label);
-                    $item[] = $label;
-                }
-                $data[] = 'Code:' . $option->getCode() . self::ITEM_SEPARATOR . implode(self::ITEM_SEPARATOR, $item);
+                $data[] = 'Code:' . $option->getCode();
             }
             $options = implode(self::GROUP_SEPARATOR, $data);
         }

--- a/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/AttributeNormalizerSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/AttributeNormalizerSpec.php
@@ -124,7 +124,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
                 'sort_order'             => 1,
                 'localizable'            => true,
                 'required'               => false,
-                'options'                => 'Code:size,en_US:big,fr_FR:grand',
+                'options'                => 'Code:size',
                 'scope'                  => 'Channel',
             ]
         );

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeIntegration.php
@@ -328,7 +328,7 @@ class AttributeIntegration extends AbstractFlatNormalizerTestCase
             'localizable'            => false,
             'auto_option_sorting'    => false,
             'locale_specific'        => false,
-            'options'                => 'Code:optionA,en_US:Option A|Code:optionB,en_US:Option B',
+            'options'                => 'Code:optionA|Code:optionB',
             'scope'                  => 'Global',
             'required'               => false,
         ];
@@ -661,7 +661,7 @@ class AttributeIntegration extends AbstractFlatNormalizerTestCase
             'localizable'            => false,
             'auto_option_sorting'    => true,
             'locale_specific'        => false,
-            'options'                => 'Code:optionA,en_US:Option A|Code:optionB,en_US:Option B',
+            'options'                => 'Code:optionA|Code:optionB',
             'scope'                  => 'Global',
             'required'               => false,
         ];


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Remove options values label from versioning

**Why?**

After an import of 20000 options for an attribute, it generate 200 new versions of the attribute (1 each 100 options imported),if you look a the 200th attribute history in the `options` sections, you have the 19900 options normalized (code + localized labels) in old values and 20000 options normalized (code + localized labels) in new values, such a big amount of data.
If you import more options you get more and more closer to the MySQL `max_allowed_packet` limit, and you get a warning `Warning: Error while sending QUERY packet.`who make the import failed.

So the first solution is to increase the `max_allowed_packet` and no more warning happends, but functionally speaking it has no interest to keep those data as we can't revert an attribute version.
After discuss with PO's we only keep the option code.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
