### PR TITLE
Remove deprecation notice on CompletenessRemover

### DIFF
--- a/src/Pim/Component/Catalog/Completeness/CompletenessRemoverInterface.php
+++ b/src/Pim/Component/Catalog/Completeness/CompletenessRemoverInterface.php
@@ -25,8 +25,6 @@ interface CompletenessRemoverInterface
      * Remove completenesses of a product
      *
      * @param ProductInterface $product
-     *
-     * @deprecated Do not use anymore, will be removed in 3.0.
      */
     public function removeForProduct(ProductInterface $product);
 
@@ -34,8 +32,6 @@ interface CompletenessRemoverInterface
      * Remove completeness of a product without indexing it.
      *
      * @param ProductInterface $product
-     *
-     * @deprecated Do not use anymore, will be removed in 3.0.
      */
     public function removeForProductWithoutIndexing(ProductInterface $product): void;
 
@@ -43,8 +39,6 @@ interface CompletenessRemoverInterface
      * Remove completenesses for all product of a family
      *
      * @param FamilyInterface $family
-     *
-     * @deprecated Do not use anymore, will be removed in 3.0.
      */
     public function removeForFamily(FamilyInterface $family);
 


### PR DESCRIPTION
**Description**

The completeness remover methods are not to be removed.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
