### PR TITLE
Fix drag'n'drop of huge attribute group in family variant

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,7 +2,8 @@
 
 ## Bug fixes
 
-- PIM-7771: Fix refresh versioning command about duplicate version's rule
+- PIM-7771: Fix refresh versioning command about duplicate version's rule.
+- PIM-7813: Fix a bug that prevents to drag'n'drop an attribute group containing a lot of attributes in the variant family configuration screen.
 
 # 2.3.15 (2018-11-06)
 

--- a/composer.lock
+++ b/composer.lock
@@ -726,16 +726,16 @@
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineCacheBundle.git",
-                "reference": "4c8e363f96427924e7e519c5b5119b4f54512697"
+                "reference": "8b0d579ddef3fa3bc694bba49fba844668b4d382"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineCacheBundle/zipball/4c8e363f96427924e7e519c5b5119b4f54512697",
-                "reference": "4c8e363f96427924e7e519c5b5119b4f54512697",
+                "url": "https://api.github.com/repos/doctrine/DoctrineCacheBundle/zipball/8b0d579ddef3fa3bc694bba49fba844668b4d382",
+                "reference": "8b0d579ddef3fa3bc694bba49fba844668b4d382",
                 "shasum": ""
             },
             "require": {
@@ -748,7 +748,7 @@
                 "instaclick/coding-standard": "~1.1",
                 "instaclick/object-calisthenics-sniffs": "dev-master",
                 "instaclick/symfony2-coding-standard": "dev-remaster",
-                "phpunit/phpunit": "~4|~5",
+                "phpunit/phpunit": "~4.8.36|~5.6|~6.5|~7.0",
                 "predis/predis": "~0.8",
                 "satooshi/php-coveralls": "^1.0",
                 "squizlabs/php_codesniffer": "~1.5",
@@ -772,7 +772,10 @@
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Bundle\\DoctrineCacheBundle\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -805,12 +808,12 @@
                 }
             ],
             "description": "Symfony Bundle for Doctrine Cache",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org",
             "keywords": [
                 "cache",
                 "caching"
             ],
-            "time": "2018-03-27T09:22:12+00:00"
+            "time": "2018-11-08T06:35:24+00:00"
         },
         {
             "name": "doctrine/doctrine-fixtures-bundle",
@@ -7845,16 +7848,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
                 "shasum": ""
             },
             "require": {
@@ -7919,7 +7922,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22T02:43:20+00:00"
+            "time": "2018-11-07T22:31:41+00:00"
         },
         {
             "name": "symfony/polyfill-php72",

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/attribute-set.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family-variant/form/attribute-set.js
@@ -7,7 +7,8 @@
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-define([
+define(
+    [
         'jquery',
         'underscore',
         'oro/translator',
@@ -149,10 +150,8 @@ define([
                             `#attributes-column-level-0,
                             #attributes-column-level-1,
                             #attributes-column-level-2`
-                        )
-                        .sortable({
+                        ).sortable({
                             connectWith: '.connected-sortable',
-                            containment: this.$el,
                             tolerance: 'pointer',
                             cursor: 'move',
                             cancel: 'div.alert',
@@ -164,10 +163,8 @@ define([
                             `#attribute-groups-column-level-0,
                             #attribute-groups-column-level-1,
                             #attribute-groups-column-level-2`
-                        )
-                        .sortable({
+                        ).sortable({
                             connectWith: '.connected-group-sortable',
-                            containment: this.$el,
                             tolerance: 'pointer',
                             cursor: 'move',
                             cancel: 'div.alert',
@@ -202,7 +199,7 @@ define([
                         destinationLevel,
                         movedAttributes
                     );
-                }
+                };
             },
 
             /**
@@ -225,7 +222,7 @@ define([
                         destinationLevel,
                         movedAttributes
                     );
-                }
+                };
             },
 
             /**
@@ -300,7 +297,7 @@ define([
                     __('pim_enrich.entity.family.variant.confirm_attribute_removal.message'),
                     __('pim_enrich.entity.family.variant.confirm_attribute_removal.title'),
                     () => {
-                        var data = this.getFormData();
+                        const data = this.getFormData();
                         data.variant_attribute_sets.forEach((attributeSet) => {
                             if (attributeSet.level === level) {
                                 attributeSet.attributes = attributeSet.attributes.filter(


### PR DESCRIPTION
## Description

In the variant family configuration, at the variant attributes screen, it is not possible to move a group of attributes if the group contains a large number of attributes:

![fails](https://user-images.githubusercontent.com/5039018/48205883-4e560200-e36d-11e8-9f9c-3489731cce2b.gif)

This drag'n'drop is managed by the `sortable` widget from JQuery UI. The issue is fixed by removing the use of its [`containment` option](https://api.jqueryui.com/sortable/#option-containment), as it is useless here: the sortable lists use all the window.

As a result, the drag'n'drop behaves as expected:

![works](https://user-images.githubusercontent.com/5039018/48206094-e522be80-e36d-11e8-992e-f5ed46decdb1.gif)

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
