### PR TITLE
PIM-7710: Add possibility to generate HAL pagination links without limit as query parameter

### DIFF
--- a/src/Akeneo/Tool/Component/Api/Pagination/SearchAfterHalPaginator.php
+++ b/src/Akeneo/Tool/Component/Api/Pagination/SearchAfterHalPaginator.php
@@ -34,6 +34,7 @@ class SearchAfterHalPaginator implements PaginatorInterface
         $this->resolver->setDefaults([
             'uri_parameters'      => [],
             'item_identifier_key' => 'code',
+            'limit'               => null,
         ]);
 
         $this->resolver->setRequired([
@@ -49,6 +50,7 @@ class SearchAfterHalPaginator implements PaginatorInterface
         $this->resolver->setAllowedTypes('search_after', 'array');
         $this->resolver->setAllowedTypes('list_route_name', 'string');
         $this->resolver->setAllowedTypes('item_route_name', 'string');
+        $this->resolver->setAllowedTypes('limit', ['int', 'null']);
 
         $this->router = $router;
     }
@@ -62,6 +64,11 @@ class SearchAfterHalPaginator implements PaginatorInterface
             $parameters = $this->resolver->resolve($parameters);
         } catch (\InvalidArgumentException $e) {
             throw new PaginationParametersException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        $limit = $parameters['query_parameters']['limit'] ?? $parameters['limit'];
+        if (null === $limit) {
+            throw new PaginationParametersException('The limit must be defined.');
         }
 
         $embedded = [];
@@ -83,7 +90,7 @@ class SearchAfterHalPaginator implements PaginatorInterface
             $this->createLink($parameters['list_route_name'], $uriParameters, null, 'first'),
         ];
 
-        if (count($items) === (int) $parameters['query_parameters']['limit']) {
+        if (count($items) === (int) $limit) {
             $links[] = $this->createLink(
                 $parameters['list_route_name'],
                 $uriParameters,

--- a/src/Akeneo/Tool/Component/Api/spec/Pagination/SearchAfterHalPaginatorSpec.php
+++ b/src/Akeneo/Tool/Component/Api/spec/Pagination/SearchAfterHalPaginatorSpec.php
@@ -114,6 +114,94 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
         $this->paginate($standardItems, $parameters, null)->shouldReturn($expectedItems);
     }
 
+    function it_paginates_in_hal_format_without_using_the_limit_as_query_parameter($router)
+    {
+        // links
+        $router
+            ->generate(
+                'attribute_option_list_route',
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => 'a_text'],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&search_after=a_text');
+
+        $router
+            ->generate(
+                'attribute_option_list_route',
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => null],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after');
+
+        $router
+            ->generate(
+                'attribute_option_list_route',
+                ['attributeCode' => 'a_multi_select', 'pagination_type' => 'search_after', 'search_after' => 'another_text'],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&search_after=another_text');
+
+        // embedded
+        $router
+            ->generate('attribute_option_item_route', ['attributeCode' => 'a_multi_select', 'code' => 'optionA', 'search_after' => null], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionA');
+
+        $router
+            ->generate('attribute_option_item_route', ['attributeCode' => 'a_multi_select', 'code' => 'optionB', 'search_after' => null], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionB');
+
+        $standardItems = [
+            ['code'   => 'optionA'],
+            ['code'   => 'optionB'],
+        ];
+
+        $expectedItems = [
+            '_links'       => [
+                'self'     => [
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&search_after=a_text',
+                ],
+                'first'    => [
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after',
+                ],
+                'next'     => [
+                    'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options?pagination_type=search_after&search_after=another_text',
+                ],
+            ],
+            '_embedded'    => [
+                'items' => [
+                    [
+                        '_links' => [
+                            'self' => [
+                                'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionA',
+                            ],
+                        ],
+                        'code'   => 'optionA',
+                    ],
+                    [
+                        '_links' => [
+                            'self' => [
+                                'href' => 'http://akeneo.com/api/rest/v1/attributes/a_multi_select/options/optionB',
+                            ],
+                        ],
+                        'code'   => 'optionB',
+                    ],
+                ],
+            ],
+        ];
+
+        $parameters = [
+            'uri_parameters'      => ['attributeCode' => 'a_multi_select'],
+            'query_parameters'    => ['pagination_type' => 'search_after'],
+            'search_after'        => ['self' => 'a_text', 'next' => 'another_text'],
+            'limit'               => 2,
+            'list_route_name'     => 'attribute_option_list_route',
+            'item_route_name'     => 'attribute_option_item_route',
+            'item_identifier_key' => 'code',
+        ];
+
+        $this->paginate($standardItems, $parameters, null)->shouldReturn($expectedItems);
+    }
+
     function it_paginates_without_next_link_when_last_page($normalizer, $router)
     {
         // links
@@ -224,4 +312,17 @@ class SearchAfterHalPaginatorSpec extends ObjectBehavior
         $this->shouldThrow(PaginationParametersException::class)->during('paginate', [[], [], null]);
     }
 
+    function it_throws_an_exception_when_no_limit_has_been_defined()
+    {
+        $parameters = [
+            'uri_parameters'      => ['attributeCode' => 'a_multi_select'],
+            'query_parameters'    => ['pagination_type' => 'search_after'],
+            'search_after'        => ['self' => null, 'next' => null],
+            'list_route_name'     => 'attribute_option_list_route',
+            'item_route_name'     => 'attribute_option_item_route',
+            'item_identifier_key' => 'code',
+        ];
+
+        $this->shouldThrow(PaginationParametersException::class)->during('paginate', [[], $parameters, null]);
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

For the API end-points of reference entities, we don't want the pagination limit to be a query parameter.

We also want to use `Akeneo\Tool\Component\Api\Pagination\SearchAfterHalPaginator' to generate the links instead of re-write it, so I modify it to accept a new optional parameter to defined the limit outside the query parameters.

To avoid any side effects, the limit in the query parameters has priority on this new parameter.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
