### PR TITLE
PIM-7824: Fix the option filter

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,6 +7,7 @@
 - PIM-7773: Fix routing issues with product status toggle 
 - PIM-7776: Fix injection in the job's label in notification area
 - PIM-7828: Fix ACL on System Info
+- PIM-7824: Fix filter on view with attribute option deleted
 
 # 2.3.16 (2018-11-13)
 

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductValue/ChoiceFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductValue/ChoiceFilter.php
@@ -7,6 +7,8 @@ use Pim\Bundle\FilterBundle\Filter\AjaxChoiceFilter;
 use Pim\Bundle\FilterBundle\Filter\ProductFilterUtility;
 use Pim\Bundle\UserBundle\Context\UserContext;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 
@@ -28,27 +30,32 @@ class ChoiceFilter extends AjaxChoiceFilter
     /** @var AttributeRepositoryInterface */
     protected $attributeRepository;
 
+    /** @var AttributeOptionRepositoryInterface */
+    protected $attributeOptionRepository;
+
     /**
-     * Constructor
-     *
-     * @param FormFactoryInterface         $factory
-     * @param ProductFilterUtility         $util
-     * @param UserContext                  $userContext
-     * @param string                       $optionRepoClass
-     * @param AttributeRepositoryInterface $attributeRepository
+     * TODO @merge remove null on master & delete optionRepoClass
+     * @param FormFactoryInterface               $factory
+     * @param ProductFilterUtility               $util
+     * @param UserContext                        $userContext
+     * @param null|string                        $optionRepoClass
+     * @param AttributeRepositoryInterface       $attributeRepository
+     * @param AttributeOptionRepositoryInterface $attributeOptionRepository
      */
     public function __construct(
         FormFactoryInterface $factory,
         ProductFilterUtility $util,
         UserContext $userContext,
         $optionRepoClass,
-        AttributeRepositoryInterface $attributeRepository
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeOptionRepositoryInterface $attributeOptionRepository = null
     ) {
         parent::__construct($factory, $util);
 
         $this->userContext = $userContext;
         $this->optionRepoClass = $optionRepoClass;
         $this->attributeRepository = $attributeRepository;
+        $this->attributeOptionRepository = $attributeOptionRepository;
     }
 
     /**
@@ -63,11 +70,20 @@ class ChoiceFilter extends AjaxChoiceFilter
 
         $operator = $this->getOperator($data['type']);
 
+        /* TODO @merge remove null condition on master*/
+        if (null !== $this->attributeOptionRepository &&
+            (Operators::IN_LIST === $operator || Operators::NOT_IN_LIST === $operator)
+        ) {
+            $filteredValues = $this->filterOnlyExistingOptions($data['value']);
+        } else {
+            $filteredValues = $data['value'];
+        }
+
         $this->util->applyFilter(
             $ds,
             $this->get(ProductFilterUtility::DATA_NAME_KEY),
             $operator,
-            $data['value']
+            $filteredValues
         );
 
         return true;
@@ -100,19 +116,40 @@ class ChoiceFilter extends AjaxChoiceFilter
     {
         $attribute = $this->getAttribute();
 
+        /* TODO @merge remove null condition on master, optionRepoClass to delete*/
         return array_merge(
             parent::getFormOptions(),
             [
-                'choice_url'        => 'pim_ui_ajaxentity_list',
+                'choice_url' => 'pim_ui_ajaxentity_list',
                 'choice_url_params' => [
-                    'class'        => $this->optionRepoClass,
-                    'dataLocale'   => $this->userContext->getCurrentLocaleCode(),
+                    'class' => null !== $this->attributeOptionRepository
+                        ? $this->attributeOptionRepository->getClassName()
+                        : $this->optionRepoClass,
+                    'dataLocale' => $this->userContext->getCurrentLocaleCode(),
                     'collectionId' => $attribute->getId(),
-                    'options'      => [
+                    'options' => [
                         'type' => 'code',
                     ],
-                ]
+                ],
             ]
         );
+    }
+
+    /**
+     * Filter options value to have only existing option codes
+     *
+     * @param $optionCodes
+     * @return array
+     */
+    private function filterOnlyExistingOptions($optionCodes)
+    {
+        $attribute = $this->getAttribute();
+        $attributeOptions = $this->attributeOptionRepository->findCodesByIdentifiers(
+            $attribute->getCode(),
+            $optionCodes
+        );
+        $existingOptionCodes = array_column($attributeOptions, 'code');
+
+        return array_values(array_intersect($optionCodes, $existingOptionCodes));
     }
 }

--- a/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
+++ b/src/Pim/Bundle/FilterBundle/Resources/config/filters.yml
@@ -139,6 +139,7 @@ services:
             - '@pim_user.context.user'
             - '%pim_catalog.entity.attribute_option.class%'
             - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.repository.attribute_option'
         tags:
             - { name: oro_filter.extension.orm_filter.filter, type: product_value_choice }
 

--- a/src/Pim/Bundle/ReferenceDataBundle/DataGrid/Filter/ReferenceDataFilter.php
+++ b/src/Pim/Bundle/ReferenceDataBundle/DataGrid/Filter/ReferenceDataFilter.php
@@ -2,9 +2,11 @@
 
 namespace Pim\Bundle\ReferenceDataBundle\DataGrid\Filter;
 
+use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Pim\Bundle\FilterBundle\Filter\ProductFilterUtility;
 use Pim\Bundle\FilterBundle\Filter\ProductValue\ChoiceFilter;
 use Pim\Bundle\UserBundle\Context\UserContext;
+use Pim\Component\Catalog\Repository\AttributeOptionRepositoryInterface;
 use Pim\Component\Catalog\Repository\AttributeRepositoryInterface;
 use Pim\Component\ReferenceData\ConfigurationRegistryInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -22,24 +24,47 @@ class ReferenceDataFilter extends ChoiceFilter
     protected $registry;
 
     /**
-     * Constructor
-     *
-     * @param FormFactoryInterface           $factory
-     * @param ProductFilterUtility           $util
-     * @param UserContext                    $userContext
-     * @param AttributeRepositoryInterface   $attributeRepository
-     * @param ConfigurationRegistryInterface $registry
+     * TODO @merge remove optionReposClass (removed in ChoiceFilter), remove null on attributeOptionRepo
+     * @param FormFactoryInterface                    $factory
+     * @param ProductFilterUtility                    $util
+     * @param UserContext                             $userContext
+     * @param AttributeRepositoryInterface            $attributeRepository
+     * @param ConfigurationRegistryInterface          $registry
+     * @param AttributeOptionRepositoryInterface|null $attributeOptionRepository
      */
     public function __construct(
         FormFactoryInterface $factory,
         ProductFilterUtility $util,
         UserContext $userContext,
         AttributeRepositoryInterface $attributeRepository,
-        ConfigurationRegistryInterface $registry
+        ConfigurationRegistryInterface $registry,
+        AttributeOptionRepositoryInterface $attributeOptionRepository = null
     ) {
-        parent::__construct($factory, $util, $userContext, null, $attributeRepository);
+        parent::__construct($factory, $util, $userContext, null, $attributeRepository, $attributeOptionRepository);
 
         $this->registry = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(FilterDatasourceAdapterInterface $ds, $data)
+    {
+        $data = $this->parseData($data);
+        if (!$data) {
+            return false;
+        }
+
+        $operator = $this->getOperator($data['type']);
+
+        $this->util->applyFilter(
+            $ds,
+            $this->get(ProductFilterUtility::DATA_NAME_KEY),
+            $operator,
+            $data['value']
+        );
+
+        return true;
     }
 
     /**

--- a/src/Pim/Bundle/ReferenceDataBundle/Resources/config/datagrid/filters.yml
+++ b/src/Pim/Bundle/ReferenceDataBundle/Resources/config/datagrid/filters.yml
@@ -10,5 +10,6 @@ services:
             - '@pim_user.context.user'
             - '@pim_catalog.repository.attribute'
             - '@pim_reference_data.registry'
+            - '@pim_catalog.repository.attribute_option'
         tags:
             - { name: oro_filter.extension.orm_filter.filter, type: product_value_reference_data }


### PR DESCRIPTION
**Description**

When an attribute option, used in the filter of a view, is removed => the view cannot be loaded.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
