### PR TITLE
PIM-7783: Fix constraint on attribute name

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7783: Fix constraint on attribute name
 - PIM-7767: Remove option values label from attribute versioning
 - PIM-7771: Fix refresh versioning command about duplicate version's rule.
 - PIM-7813: Fix a bug that prevents to drag'n'drop an attribute group containing a lot of attributes in the variant family configuration screen.

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -75,7 +75,7 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
             - Length:
                 max: 255
             - Regex:
-                pattern: /^(?!(id|associationTypes|categories|categoryId|completeness|enabled|family|groups|associations|products|scope|treeId|values|category|parent|label|(.)*_(products|groups)|entity_type)$)/
+                pattern: /^(?!(id|associationTypes|categories|categoryId|completeness|enabled|(?i)\bfamily\b|groups|associations|products|scope|treeId|values|category|parent|label|(.)*_(products|groups)|entity_type)$)/
                 message: This code is not available
         localizable:
             - Type: bool

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/GlobalConstraintsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/GlobalConstraintsIntegration.php
@@ -266,7 +266,7 @@ class GlobalConstraintsIntegration extends AbstractAttributeTestCase
     {
         return [
             ['id'], ['associations'], ['associationTypes'], ['category'], ['categoryId'], ['categories'],
-            ['completeness'], ['enabled'], ['family'], ['groups'], ['products'], ['scope'], ['treeId'], ['values'],
+            ['completeness'], ['enabled'], ['family'], ['FAMILY'], ['FamilY'], ['groups'], ['products'], ['scope'], ['treeId'], ['values'],
             ['my_groups'], ['my_products']
         ];
     }


### PR DESCRIPTION
**Description**

"family" code was known to bug the PIM, but Family (capital F) does the same.
We need to prevent the use of the code family, whatever its case is.
FAmily, faMily, FAMILY, family, Family, famILY...
