### PR TITLE
PIM-7823: Fix product gap between product grid and sequential edit when selecting `All` option

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7823: Fix product gap between product grid and sequential edit when selecting `All` option
 - PIM-7783: Fix constraint on attribute name
 - PIM-7767: Remove option values label from attribute versioning
 - PIM-7771: Fix refresh versioning command about duplicate version's rule.

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/controllers.yml
@@ -259,7 +259,7 @@ services:
         arguments:
             - '@oro_datagrid.mass_action.parameters_parser'
             - '@pim_datagrid.adapter.oro_to_pim_grid_filter'
-            - '@pim_enrich.query.product_query_sequential_edit_builder_factory'
+            - '@pim_enrich.query.product_and_product_model_query_sequential_edit_builder_factory'
 
     pim_enrich.controller.rest.value:
         class: '%pim_enrich.controller.rest.value.class%'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/query_builder.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/query_builder.yml
@@ -19,3 +19,10 @@ services:
             - '%pim_enrich.cursor.sequential_edit_cursor.class%'
             - 1000
             - 'pim_catalog_product'
+
+    pim_enrich.query.product_and_product_model_query_sequential_edit_builder_factory:
+        class: '%pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class%'
+        arguments:
+            - '%pim_enrich.query.product_and_product_model_query_builder.class%'
+            - '@pim_enrich.query.product_query_sequential_edit_builder_factory'
+            - '@pim_enrich.query.product_and_product_model_search_aggregator'

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/query_builders.yml
@@ -4,6 +4,7 @@ parameters:
     pim_enrich.elasticsearch.from_size_cursor_factory.class: Pim\Bundle\EnrichBundle\Elasticsearch\FromSizeCursorFactory
     pim_enrich.query.product_and_product_model_query_builder.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelQueryBuilder
     pim_enrich.query.product_and_product_model_search_aggregator.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelSearchAggregator
+    #TODO rename `pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class` to `pim_enrich.query.elasticsearch.product_and_product_model_query_builder_factory.class`
     pim_enrich.query.elasticsearch.product_and_model_query_builder_factory.class: Pim\Bundle\EnrichBundle\ProductQueryBuilder\ProductAndProductModelQueryBuilderFactory
 
 services:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix product gap between product grid and sequential edit when selecting `All` option.
The sequential edit use a cursor factory that does not take in account the product and product model search aggregator [Introduce here](https://github.com/akeneo/pim-community-dev/pull/8875)
This PR introduce a dedicated `ProductAndProductModelQueryBuilderFactory` for sequential edit
`pim_enrich.query.product_and_model_query_sequential_edit_builder_factory`, in order to have the same behavior as the product grid search


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
