### PR TITLE
PIM-7776: Fix injection in the job's label in notification area

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-7767: Remove option values label from attribute versioning
 - PIM-7771: Fix refresh versioning command about duplicate version's rule.
 - PIM-7813: Fix a bug that prevents to drag'n'drop an attribute group containing a lot of attributes in the variant family configuration screen.
+- PIM-7776: Fix injection in the job's label in notification area
 
 # 2.3.15 (2018-11-06)
 

--- a/src/Pim/Bundle/NotificationBundle/Resources/views/Notification/list.json.twig
+++ b/src/Pim/Bundle/NotificationBundle/Resources/views/Notification/list.json.twig
@@ -8,10 +8,15 @@
         {% set generatedUrl = null %}
     {% endif %}
 
+    {% set sanitizedMessageParams = {} %}
+    {% for labelKey, value in item.notification.messageParams %}
+        {% set sanitizedMessageParams = sanitizedMessageParams|merge({('' ~ labelKey): value|escape}) %}
+    {% endfor %}
+
     {% set notifications = notifications|merge([{
         id: item.id,
         type: item.notification.type,
-        message: item.notification.message|trans(item.notification.messageParams),
+        message: item.notification.message|trans(sanitizedMessageParams),
         viewed: item.viewed,
         url: generatedUrl,
         createdAt: item.notification.created|date("Y-m-d H:i:s", userTimezone),


### PR DESCRIPTION
This PR fixes the injection of HTML code in the notifications template

![selection_022](https://user-images.githubusercontent.com/1590933/48335664-b010b780-e65e-11e8-8741-657803e54066.png)


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -