### PR TITLE
PIM-7774: Fix refresh of grid date filter

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-7767: Remove option values label from attribute versioning
 - PIM-7771: Fix refresh versioning command about duplicate version's rule.
 - PIM-7813: Fix a bug that prevents to drag'n'drop an attribute group containing a lot of attributes in the variant family configuration screen.
+- PIM-7774: Fix refresh of grid date filter
 
 # 2.3.15 (2018-11-06)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/date-filter.js
@@ -160,24 +160,29 @@ function(
          * @inheritDoc
          */
         _renderCriteria: function(el) {
+            const value = this._getDisplayValue();
             $(el).append(
                 this.popupCriteriaTemplate({
                     label: this.label,
                     name: this.name,
                     choices: this.choices,
-                    selectedChoice: this.emptyValue.type,
+                    selectedChoice: value.type,
                     inputClass: this.inputClass,
-                    selectedOperatorLabel: _.findWhere(this.choices, {value: this.emptyValue.type}).label,
+                    selectedOperatorLabel: _.findWhere(this.choices, {value: value.type}).label,
                     operatorLabel: __('pim.grid.choice_filter.operator'),
                     updateLabel: __('Update'),
                     fromLabel: __('from'),
-                    toLabel: __('to')
+                    toLabel: __('to'),
+                    from: value.value.start,
+                    to: value.value.end,
                 })
             );
 
             _.each(this.criteriaValueSelectors.value, function(selector, name) {
                 this.dateWidgets[name] = Datepicker.init(this.$(selector), this.datetimepickerOptions);
             }, this);
+
+            this._displayFilterType(value.type);
 
             return this;
         },

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/date-filter.html
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/date-filter.html
@@ -19,11 +19,11 @@
     </div>
     <div class="AknFilterChoice-dates">
         <span class="AknFilterChoice-date from">
-            <input type="text" value="" class="date-selector <%= inputClass %> add-on" name="start" placeholder="<%- fromLabel %>" size="1">
+            <input type="text" value="<%- from %>" class="date-selector <%= inputClass %> add-on" name="start" placeholder="<%- fromLabel %>" size="1">
         </span>
         <span class="AknFilterChoice-separator separator">-</span>
         <span class="AknFilterChoice-date to">
-            <input type="text" value="" class="date-selector <%= inputClass %> add-on" name="end" placeholder="<%- toLabel %>" size="1">
+            <input type="text" value="<%- to %>" class="date-selector <%= inputClass %> add-on" name="end" placeholder="<%- toLabel %>" size="1">
         </span>
     </div>
     <div class="AknFilterChoice-button">


### PR DESCRIPTION
Fix the fact that the date filter on grids was rendered without any real values and with the default one.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
