### PR TITLE
PIM-7773: Fix routing issues with product status toggle

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-7767: Remove option values label from attribute versioning
 - PIM-7771: Fix refresh versioning command about duplicate version's rule.
 - PIM-7813: Fix a bug that prevents to drag'n'drop an attribute group containing a lot of attributes in the variant family configuration screen.
+- PIM-7773: Fix routing issues with product status toggle 
 
 # 2.3.15 (2018-11-06)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/product.yml
@@ -12,7 +12,7 @@ pim_enrich_product_toggle_status:
     defaults: { _controller: pim_enrich.controller.product:toggleStatusAction }
     requirements:
         id: '[0-9a-f]+'
-    methods: [GET, POST]
+    methods: [POST]
 
 pim_enrich_product_listcategories:
     path: /list-categories/product/{id}/parent/{categoryId}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/datagrid/action/toggle-product-action.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/datagrid/action/toggle-product-action.js
@@ -17,6 +17,13 @@ define(
          */
         isEnabled() {
             return this.model.get('document_type') !== 'product_model';
+        },
+
+        /**
+         * {@inheritdoc}
+         */
+        getMethod: function () {
+            return 'POST';
         }
     });
 });


### PR DESCRIPTION
The URL for toggling status was accessible with a GET method.
I fixed this by disallowing this method, and allowing a POST.

This method was used on the Datagrid, so I changed the method type to allow enable/disable from the grid.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -