### PR TITLE
Increase product import performance by increasing batch size and optimizing association step

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/pim.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/pim.yml
@@ -16,7 +16,7 @@ imports:
     - { resource: '@PimApiBundle/Resources/config/api.yml' }
 
 parameters:
-    pim_job_product_batch_size: 10
+    pim_job_product_batch_size: 100
 
 services:
     oro.cache.abstract:

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -70,6 +70,12 @@ class ProductAssociationProcessor extends AbstractProcessor implements ItemProce
      */
     public function process($item)
     {
+        if (!$this->hasImportedAssociations($item)) {
+            $this->stepExecution->incrementSummaryInfo('product_skipped_no_associations');
+
+            return null;
+        }
+
         $item = array_merge(
             ['associations' => []],
             $item
@@ -95,11 +101,6 @@ class ProductAssociationProcessor extends AbstractProcessor implements ItemProce
 
                 return null;
             }
-        } elseif (!$this->hasImportedAssociations($item)) {
-            $this->detachProduct($product);
-            $this->stepExecution->incrementSummaryInfo('product_skipped_no_associations');
-
-            return null;
         }
 
         try {
@@ -201,7 +202,11 @@ class ProductAssociationProcessor extends AbstractProcessor implements ItemProce
         }
 
         foreach ($item['associations'] as $association) {
-            if (!empty($association['products']) || !empty($association['groups'])) {
+            $hasProductAssoc = !empty($association['products']);
+            $hasGroupAssoc = !empty($association['groups']);
+            $hasProductModelAssoc = !empty($association['product_models']);
+
+            if ($hasProductAssoc || $hasGroupAssoc || $hasProductModelAssoc) {
                 return true;
             }
         }

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductModelAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductModelAssociationProcessor.php
@@ -72,6 +72,12 @@ class ProductModelAssociationProcessor extends AbstractProcessor implements
      */
     public function process($item)
     {
+        if (!$this->hasImportedAssociations($item)) {
+            $this->stepExecution->incrementSummaryInfo('product_model_skipped_no_associations');
+
+            return null;
+        }
+
         $item = array_merge(
             ['associations' => []],
             $item
@@ -97,11 +103,6 @@ class ProductModelAssociationProcessor extends AbstractProcessor implements
 
                 return null;
             }
-        } elseif (!$this->hasImportedAssociations($item)) {
-            $this->detach($entity);
-            $this->stepExecution->incrementSummaryInfo('product_model_skipped_no_associations');
-
-            return null;
         }
 
         try {

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
@@ -316,16 +316,13 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productAssocFilter,
         $stepExecution,
-        $productDetacher,
-        ProductInterface $product,
         JobParameters $jobParameters
     ) {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(false);
 
-        $productRepository->getIdentifierProperties()->willReturn(['sku']);
-        $productRepository->findOneByIdentifier(Argument::any())->willReturn($product);
-        $product->getId()->willReturn(42);
+        $productRepository->getIdentifierProperties()->shouldNotBeCalled();
+        $productRepository->findOneByIdentifier(Argument::any())->shouldNotBeCalled();
 
         $convertedData = [
             'identifier' => 'tshirt',
@@ -339,12 +336,11 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             'associations' => []
         ];
 
-        $productAssocFilter->filter(Argument::any())->shouldNotBeCalled()->willReturn([]);
+        $productAssocFilter->filter(Argument::any())->shouldNotBeCalled();
         $productUpdater->update(Argument::any())->shouldNotBeCalled();
 
         $stepExecution->incrementSummaryInfo('product_skipped_no_associations')->shouldBeCalled();
         $this->setStepExecution($stepExecution);
-        $productDetacher->detach($product)->shouldBeCalled();
         $this->process($convertedData)->shouldReturn(null);
     }
 }

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductModelAssociationProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductModelAssociationProcessorSpec.php
@@ -281,27 +281,24 @@ class ProductModelAssociationProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productAssocFilter,
         $stepExecution,
-        $productDetacher,
-        ProductModelInterface $product,
         JobParameters $jobParameters
     ) {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(false);
 
-        $productRepository->getIdentifierProperties()->willReturn(['code']);
-        $productRepository->findOneByIdentifier(Argument::any())->willReturn($product);
+        $productRepository->getIdentifierProperties()->shouldNotBeCalled();
+        $productRepository->findOneByIdentifier(Argument::any())->shouldNotBeCalled();
 
         $convertedData = [
             'code' => 'tshirt',
             'associations' => []
         ];
 
-        $productAssocFilter->filter(Argument::any())->shouldNotBeCalled()->willReturn([]);
+        $productAssocFilter->filter(Argument::any())->shouldNotBeCalled();
         $productUpdater->update(Argument::any())->shouldNotBeCalled();
 
         $stepExecution->incrementSummaryInfo('product_model_skipped_no_associations')->shouldBeCalled();
         $this->setStepExecution($stepExecution);
-        $productDetacher->detach($product)->shouldBeCalled();
         $this->process($convertedData)->shouldReturn(null);
     }
 }

--- a/tests/legacy/features/import/product/import_products_with_product_model_associations.feature
+++ b/tests/legacy/features/import/product/import_products_with_product_model_associations.feature
@@ -22,3 +22,21 @@ Feature: Execute a job
     And the product "1111111171" should have the following associations:
       | type   | product_models   |
       | UPSELL | brookspink      |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7852
+  Scenario: Successfully import a csv file of products with product model associations using a job with comparison disabled
+    Given the following CSV file to import:
+      """
+      sku;family;X_SELL-product_models;UPSELL-product_models
+      SKU-001;clothing;amor,brooksblue;
+      1111111171;accessories;;brookspink
+      """
+    And the following job "csv_catalog_modeling_product_import" configuration:
+      | enabledComparison | no |
+    When the products are imported via the job csv_catalog_modeling_product_import
+    Then the product "SKU-001" should have the following associations:
+      | type   | product_models   |
+      | X_SELL | amor,brooksblue |
+    And the product "1111111171" should have the following associations:
+      | type   | product_models   |
+      | UPSELL | brookspink      |


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This PR increases product import performances, by
 - increasing the batch size
 - avoiding loading product and comparing in association step when there's no association defined in the file

This PR allows up to 4x performance increase for product imports.

About the batch size: this one was setup at 10 products some month ago following a memory problem. It seems that performance problems are more important now than memory problem with the switch to 10. So we are rolling back on this point.

We will provide a chapter in the troubleshooting section of the documentation, for people to better undrerstand the usage and impact of this parameter.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
