### PR TITLE
PIM-7831 add blacklisted characters validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ npm-debug.log
 !/docker/akeneo-behat.conf
 !/docker/httpd.conf
 docker-compose.yml
+docker-compose.override.yml
 .web-server-pid
 
 yarn.lock

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -12,6 +12,7 @@
 - PIM-7853: Fix unwanted automatic reload of the user page even if there were errors on the form
 - PIM-7841: Allow users to set regional locales for UI (en_NZ, pt_PT and pt_BR)
 - PIM-7791: Suppress warning on attribute option in case of case sensitive codes
+- PIM-7831: Blacklist some characters in user form inputs in order to prevent from malicious injection
 
 # 2.3.16 (2018-11-13)
 

--- a/src/Oro/Bundle/UserBundle/Resources/config/validation.yml
+++ b/src/Oro/Bundle/UserBundle/Resources/config/validation.yml
@@ -8,6 +8,7 @@ Pim\Bundle\UserBundle\Entity\User:
             - Length:
                 min:        3
                 max:        255
+            - Pim\Bundle\UserBundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters: ~
         email:
             - NotBlank:     ~
             - Length:
@@ -28,14 +29,22 @@ Pim\Bundle\UserBundle\Entity\User:
                 min:        1
                 minMessage: "You must select at least {{ limit }} role"
                 groups:     [User]
+        namePrefix:
+            - Pim\Bundle\UserBundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters: ~
         firstName:
             - NotBlank:     ~
             - Length:
                 max:        100
+            - Pim\Bundle\UserBundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters: ~
+        middleName:
+            - Pim\Bundle\UserBundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters: ~
         lastName:
             - NotBlank:     ~
             - Length:
                 max:        100
+            - Pim\Bundle\UserBundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters: ~
+        nameSuffix:
+            - Pim\Bundle\UserBundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters: ~
         birthday:
             - Date:         ~
         imageFile:

--- a/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/CountUsersIntegration.php
+++ b/src/Pim/Bundle/CatalogVolumeMonitoringBundle/tests/Integration/Persistence/Query/CountUsersIntegration.php
@@ -33,8 +33,8 @@ class CountUsersIntegration extends QueryTestCase
             $this->createUser([
                 'username'  => 'new_user_' . rand(),
                 'email'     => 'test_' . rand().'@test.fr',
-                'first_name' => rand(),
-                'last_name' => rand(),
+                'first_name' => 'firstname_' . rand(),
+                'last_name' => 'lastname_' . rand(),
                 'password' => rand(),
                 'catalog_default_locale' => 'en_US',
                 'user_default_locale' => 'en_US'

--- a/src/Pim/Bundle/UserBundle/DependencyInjection/PimUserExtension.php
+++ b/src/Pim/Bundle/UserBundle/DependencyInjection/PimUserExtension.php
@@ -40,6 +40,7 @@ class PimUserExtension extends Extension
         $loader->load('savers.yml');
         $loader->load('twig.yml');
         $loader->load('updaters.yml');
+        $loader->load('validators.yml');
         $loader->load('view_elements.yml');
         $loader->load('view_elements/user.yml');
         $loader->load('view_elements/group.yml');

--- a/src/Pim/Bundle/UserBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/validators.yml
@@ -1,0 +1,5 @@
+services:
+    pim_user.validator.constraints.value_should_not_contains_blacklisted_characters:
+        class: Pim\Bundle\UserBundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharactersValidator
+        tags:
+            - { name: validator.constraint_validator }

--- a/src/Pim/Bundle/UserBundle/Validator/Constraints/ValueShouldNotContainsBlacklistedCharacters.php
+++ b/src/Pim/Bundle/UserBundle/Validator/Constraints/ValueShouldNotContainsBlacklistedCharacters.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Bundle\UserBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+class ValueShouldNotContainsBlacklistedCharacters extends Constraint
+{
+    public $message = 'This value should not contains following characters: {{ items }}.';
+}

--- a/src/Pim/Bundle/UserBundle/Validator/Constraints/ValueShouldNotContainsBlacklistedCharactersValidator.php
+++ b/src/Pim/Bundle/UserBundle/Validator/Constraints/ValueShouldNotContainsBlacklistedCharactersValidator.php
@@ -22,8 +22,7 @@ class ValueShouldNotContainsBlacklistedCharactersValidator extends ConstraintVal
         }
 
         //strpbrk returns a string if one of the characters in second argument string was found
-        if(!empty(strpbrk($value, implode('', self::BLACKLISTED_CHARACTERS))))
-        {
+        if (!empty(strpbrk($value, implode('', self::BLACKLISTED_CHARACTERS)))) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ items }}', implode(', ', self::BLACKLISTED_CHARACTERS))
                 ->addViolation();

--- a/src/Pim/Bundle/UserBundle/Validator/Constraints/ValueShouldNotContainsBlacklistedCharactersValidator.php
+++ b/src/Pim/Bundle/UserBundle/Validator/Constraints/ValueShouldNotContainsBlacklistedCharactersValidator.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Bundle\UserBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class ValueShouldNotContainsBlacklistedCharactersValidator extends ConstraintValidator
+{
+    private const BLACKLISTED_CHARACTERS = ['<', '>', '&', '"'];
+
+    public function validate($value, Constraint $constraint)
+    {
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        //strpbrk returns a string if one of the characters in second argument string was found
+        if(!empty(strpbrk($value, implode('', self::BLACKLISTED_CHARACTERS))))
+        {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ items }}', implode(', ', self::BLACKLISTED_CHARACTERS))
+                ->addViolation();
+        }
+    }
+}

--- a/src/Pim/Bundle/UserBundle/Validator/Constraints/ValueShouldNotContainsBlacklistedCharactersValidator.php
+++ b/src/Pim/Bundle/UserBundle/Validator/Constraints/ValueShouldNotContainsBlacklistedCharactersValidator.php
@@ -7,6 +7,9 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
+/**
+ * Validator for user inputs where some characters are now blacklisted in order to prevent injection of malicious code
+ */
 class ValueShouldNotContainsBlacklistedCharactersValidator extends ConstraintValidator
 {
     private const BLACKLISTED_CHARACTERS = ['<', '>', '&', '"'];

--- a/src/Pim/Bundle/UserBundle/spec/Validator/Constraints/ValueShouldNotContainsBlacklistedCharactersValidatorSpec.php
+++ b/src/Pim/Bundle/UserBundle/spec/Validator/Constraints/ValueShouldNotContainsBlacklistedCharactersValidatorSpec.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace spec\Pim\Bundle\UserBundle\Validator\Constraints;
+
+use Pim\Bundle\UserBundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters;
+use Pim\Bundle\UserBundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharactersValidator;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class ValueShouldNotContainsBlacklistedCharactersValidatorSpec extends ObjectBehavior
+{
+
+    function let(
+        ExecutionContextInterface $context
+    )
+    {
+        $this->initialize($context);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ValueShouldNotContainsBlacklistedCharactersValidator::class);
+    }
+
+    function it_is_a_constraints_validator()
+    {
+        $this->shouldImplement(ConstraintValidatorInterface::class);
+    }
+
+    function it_returns_if_empty_value(
+        ValueShouldNotContainsBlacklistedCharacters $constraint
+    )
+    {
+        $this->validate('', $constraint)->shouldReturn(null);
+    }
+
+    function it_throws_an_unexpected_type_exception_if_not_a_string(
+        ValueShouldNotContainsBlacklistedCharacters $constraint
+    )
+    {
+        $this->shouldThrow(UnexpectedTypeException::class)->during('validate' , [new \StdClass(), $constraint]);
+    }
+
+    function it_does_not_add_violation_if_no_blacklisted_characters_are_present_in_the_string_to_validate(
+        ValueShouldNotContainsBlacklistedCharacters $constraint
+    )
+    {
+        $this->validate('a pretty healthy string', $constraint)->shouldReturn(null);
+    }
+
+    function it_adds_violation_if_blacklisted_characters_are_present_in_the_string_to_validate(
+        $context,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder,
+        ValueShouldNotContainsBlacklistedCharacters $constraint
+    )
+    {
+        $context->buildViolation('This value should not contains following characters: {{ items }}.')->shouldBeCalled()->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setParameter('{{ items }}', '<, >, &, "')->shouldBeCalled()->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate('a non <script>alert("busted");</script> healthy string', $constraint);
+    }
+}

--- a/src/Pim/Bundle/UserBundle/spec/Validator/Constraints/ValueShouldNotContainsBlacklistedCharactersValidatorSpec.php
+++ b/src/Pim/Bundle/UserBundle/spec/Validator/Constraints/ValueShouldNotContainsBlacklistedCharactersValidatorSpec.php
@@ -6,7 +6,6 @@ namespace spec\Pim\Bundle\UserBundle\Validator\Constraints;
 use Pim\Bundle\UserBundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters;
 use Pim\Bundle\UserBundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharactersValidator;
 use PhpSpec\ObjectBehavior;
-use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**Problem**:
Some "dangerous" characters could be persisted in database via user form inputs.

**Solution**:
Add a validator that blacklist some characters `<, >, &, "`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | y
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
