### PR TITLE
PIM-7852 Increase product import performance and fix association model import

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,10 +4,11 @@
 
 - PIM-7774: Fix refresh of grid date filter
 - PIM-7778: Fix ACL on Catalog Volume Monitoring
-- PIM-7773: Fix routing issues with product status toggle 
+- PIM-7773: Fix routing issues with product status toggle
 - PIM-7776: Fix injection in the job's label in notification area
 - PIM-7828: Fix ACL on System Info
 - PIM-7824: Fix filter on view with attribute option deleted
+- PIM-7852: Increase product import performances and fixes model association import when comparison is disabled
 
 # 2.3.16 (2018-11-13)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/pim.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/pim.yml
@@ -15,8 +15,21 @@ imports:
     - { resource: '@PimEnrichBundle/Resources/config/bundles/twig.yml' }
     - { resource: '@PimApiBundle/Resources/config/api.yml' }
 
+# To have more details on the effect of this "pim_job_product_batch_size", on performances
+# memory leak, please have a look at this documentation part:
+# https://docs.akeneo.com/latest/technical_architecture/performances_guide/batch_page_size.html
+#
+# Note to the core developers:
+# The pim_job_product_batch_size has been changed from 100 to 10 at the beginning of 2018
+# already, because of fear of generating memory leak.
+# Now that we have more feedback, it seems to create more problem than real gain in term
+# of performances. Moreover this value was forced at 100 for our cloud customers, so this
+# was creating inconsistency in our installed base. So we are reverting it back to 100.
+#
+# So if you want to change it, do that only for major version and check with the tech team.
+#
 parameters:
-    pim_job_product_batch_size: 10
+    pim_job_product_batch_size: 100
 
 services:
     oro.cache.abstract:

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductAssociationProcessor.php
@@ -70,6 +70,12 @@ class ProductAssociationProcessor extends AbstractProcessor implements ItemProce
      */
     public function process($item)
     {
+        if (!$this->hasImportedAssociations($item)) {
+            $this->stepExecution->incrementSummaryInfo('product_skipped_no_associations');
+
+            return null;
+        }
+
         $item = array_merge(
             ['associations' => []],
             $item
@@ -95,11 +101,6 @@ class ProductAssociationProcessor extends AbstractProcessor implements ItemProce
 
                 return null;
             }
-        } elseif (!$this->hasImportedAssociations($item)) {
-            $this->detachProduct($product);
-            $this->stepExecution->incrementSummaryInfo('product_skipped_no_associations');
-
-            return null;
         }
 
         try {
@@ -189,6 +190,7 @@ class ProductAssociationProcessor extends AbstractProcessor implements ItemProce
 
     /**
      * It there association(s) in new values ?
+     * TODO master: rename hasAssociationToImport
      *
      * @param array $item
      *
@@ -201,7 +203,11 @@ class ProductAssociationProcessor extends AbstractProcessor implements ItemProce
         }
 
         foreach ($item['associations'] as $association) {
-            if (!empty($association['products']) || !empty($association['groups'])) {
+            $hasProductAssoc = isset($association['products']);
+            $hasGroupAssoc = isset($association['groups']);
+            $hasProductModelAssoc = isset($association['product_models']);
+
+            if ($hasProductAssoc || $hasGroupAssoc || $hasProductModelAssoc) {
                 return true;
             }
         }

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductModelAssociationProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductModelAssociationProcessor.php
@@ -72,6 +72,12 @@ class ProductModelAssociationProcessor extends AbstractProcessor implements
      */
     public function process($item)
     {
+        if (!$this->hasImportedAssociations($item)) {
+            $this->stepExecution->incrementSummaryInfo('product_model_skipped_no_associations');
+
+            return null;
+        }
+
         $item = array_merge(
             ['associations' => []],
             $item
@@ -97,11 +103,6 @@ class ProductModelAssociationProcessor extends AbstractProcessor implements
 
                 return null;
             }
-        } elseif (!$this->hasImportedAssociations($item)) {
-            $this->detach($entity);
-            $this->stepExecution->incrementSummaryInfo('product_model_skipped_no_associations');
-
-            return null;
         }
 
         try {
@@ -195,6 +196,7 @@ class ProductModelAssociationProcessor extends AbstractProcessor implements
 
     /**
      * It there association(s) in new values ?
+     * TODO master: rename to hasAssociationToImport
      *
      * @param array $item
      *
@@ -207,9 +209,9 @@ class ProductModelAssociationProcessor extends AbstractProcessor implements
         }
 
         foreach ($item['associations'] as $association) {
-            $hasProductAssoc = !empty($association['products']);
-            $hasGroupAssoc = !empty($association['groups']);
-            $hasProductModelAssoc = !empty($association['product_models']);
+            $hasProductAssoc = isset($association['products']);
+            $hasGroupAssoc = isset($association['groups']);
+            $hasProductModelAssoc = isset($association['product_models']);
 
             if ($hasProductAssoc || $hasGroupAssoc || $hasProductModelAssoc) {
                 return true;

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductAssociationProcessorSpec.php
@@ -316,16 +316,13 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productAssocFilter,
         $stepExecution,
-        $productDetacher,
-        ProductInterface $product,
         JobParameters $jobParameters
     ) {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(false);
 
-        $productRepository->getIdentifierProperties()->willReturn(['sku']);
-        $productRepository->findOneByIdentifier(Argument::any())->willReturn($product);
-        $product->getId()->willReturn(42);
+        $productRepository->getIdentifierProperties()->shouldNotBeCalled();
+        $productRepository->findOneByIdentifier(Argument::any())->shouldNotBeCalled();
 
         $convertedData = [
             'identifier' => 'tshirt',
@@ -339,12 +336,11 @@ class ProductAssociationProcessorSpec extends ObjectBehavior
             'associations' => []
         ];
 
-        $productAssocFilter->filter(Argument::any())->shouldNotBeCalled()->willReturn([]);
+        $productAssocFilter->filter(Argument::any())->shouldNotBeCalled();
         $productUpdater->update(Argument::any())->shouldNotBeCalled();
 
         $stepExecution->incrementSummaryInfo('product_skipped_no_associations')->shouldBeCalled();
         $this->setStepExecution($stepExecution);
-        $productDetacher->detach($product)->shouldBeCalled();
         $this->process($convertedData)->shouldReturn(null);
     }
 }

--- a/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductModelAssociationProcessorSpec.php
+++ b/src/Pim/Component/Connector/spec/Processor/Denormalization/ProductModelAssociationProcessorSpec.php
@@ -281,27 +281,24 @@ class ProductModelAssociationProcessorSpec extends ObjectBehavior
         $productUpdater,
         $productAssocFilter,
         $stepExecution,
-        $productDetacher,
-        ProductModelInterface $product,
         JobParameters $jobParameters
     ) {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('enabledComparison')->willReturn(false);
 
-        $productRepository->getIdentifierProperties()->willReturn(['code']);
-        $productRepository->findOneByIdentifier(Argument::any())->willReturn($product);
+        $productRepository->getIdentifierProperties()->shouldNotBeCalled();
+        $productRepository->findOneByIdentifier(Argument::any())->shouldNotBeCalled();
 
         $convertedData = [
             'code' => 'tshirt',
             'associations' => []
         ];
 
-        $productAssocFilter->filter(Argument::any())->shouldNotBeCalled()->willReturn([]);
+        $productAssocFilter->filter(Argument::any())->shouldNotBeCalled();
         $productUpdater->update(Argument::any())->shouldNotBeCalled();
 
         $stepExecution->incrementSummaryInfo('product_model_skipped_no_associations')->shouldBeCalled();
         $this->setStepExecution($stepExecution);
-        $productDetacher->detach($product)->shouldBeCalled();
         $this->process($convertedData)->shouldReturn(null);
     }
 }

--- a/tests/legacy/features/import/product/import_products_with_associations.feature
+++ b/tests/legacy/features/import/product/import_products_with_associations.feature
@@ -117,6 +117,32 @@ Feature: Execute a job
     And I should see the text "skipped product (no differences) 1"
 
   @javascript
+  Scenario: Successfully skip associations if no association defined
+    Given the following product:
+      | sku     | name-en_US |
+      | SKU-001 | sku-001    |
+      | SKU-002 | sku-002    |
+    And I am logged in as "Julia"
+    When I edit the "SKU-001" product
+    And I visit the "Associations" column tab
+    And I visit the "Cross sell" association type
+    And I press the "Add associations" button
+    Then I check the rows "SKU-002"
+    And I press the "Confirm" button in the popin
+    And the following CSV file to import:
+      """
+      sku
+      SKU-001
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    Then there should be 2 products
+    And I should see the text "skipped product (no associations detected) 1"
+
+  @javascript
   Scenario: Successfully remove associations
     Given the following product:
       | sku     | name-en_US |
@@ -142,6 +168,43 @@ Feature: Execute a job
     When I edit the "SKU-001" product
     And I visit the "Associations" column tab
     And I visit the "Cross sell" association type
+    Then I should see the text "0 product(s), 0 product model(s) and 0 group(s)"
+
+  @javascript
+  Scenario: Successfully remove one association without removing the other
+    Given the following product:
+      | sku     | name-en_US |
+      | SKU-001 | sku-001    |
+      | SKU-002 | sku-002    |
+    And I am logged in as "Julia"
+    When I edit the "SKU-001" product
+    And I visit the "Associations" column tab
+    And I visit the "Cross sell" association type
+    And I press the "Add associations" button
+    Then I check the rows "SKU-002"
+    And I press the "Confirm" button in the popin
+    When I edit the "SKU-001" product
+    And I visit the "Associations" column tab
+    And I visit the "Upsell" association type
+    And I press the "Add associations" button
+    Then I check the rows "SKU-002"
+    And I press the "Confirm" button in the popin
+    And the following CSV file to import:
+      """
+      sku;UPSELL-products
+      SKU-001;
+      """
+    And the following job "csv_footwear_product_import" configuration:
+      | filePath | %file to import% |
+    When I am on the "csv_footwear_product_import" import job page
+    And I launch the import job
+    And I wait for the "csv_footwear_product_import" job to finish
+    When I edit the "SKU-001" product
+    And I visit the "Associations" column tab
+    And I visit the "Cross sell" association type
+    Then I should see the text "1 product(s), 0 product model(s) and 0 group(s)"
+    And I visit the "Associations" column tab
+    And I visit the "Upsell" association type
     Then I should see the text "0 product(s), 0 product model(s) and 0 group(s)"
 
   @jira https://akeneo.atlassian.net/browse/PIM-6019

--- a/tests/legacy/features/import/product/import_products_with_product_model_associations.feature
+++ b/tests/legacy/features/import/product/import_products_with_product_model_associations.feature
@@ -22,3 +22,21 @@ Feature: Execute a job
     And the product "1111111171" should have the following associations:
       | type   | product_models   |
       | UPSELL | brookspink      |
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7852
+  Scenario: Successfully import a csv file of products with product model associations using a job with comparison disabled
+    Given the following CSV file to import:
+      """
+      sku;family;X_SELL-product_models;UPSELL-product_models
+      SKU-001;clothing;amor,brooksblue;
+      1111111171;accessories;;brookspink
+      """
+    And the following job "csv_catalog_modeling_product_import" configuration:
+      | enabledComparison | no |
+    When the products are imported via the job csv_catalog_modeling_product_import
+    Then the product "SKU-001" should have the following associations:
+      | type   | product_models   |
+      | X_SELL | amor,brooksblue |
+    And the product "1111111171" should have the following associations:
+      | type   | product_models   |
+      | UPSELL | brookspink      |

--- a/tests/legacy/features/reference-data/import/import_products.feature
+++ b/tests/legacy/features/reference-data/import/import_products.feature
@@ -89,7 +89,7 @@ Feature: Execute a job
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
     Then I should see the text "processed 1"
-    And I should see the text "skipped product (no differences) 1"
+    And I should see the text "skipped product (no associations detected) 1"
     And there should be 1 product
     And the product "SKU-001" should have the following values:
       | sole_fabric | PVC |


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This PR increases product import performances, by
 - increasing the batch size
 - avoiding loading product and comparing in association step when there's no association defined in the file

This PR allows up to 4x performance increase for product imports.

About the batch size: this one was setup at 10 products some month ago following a memory problem. It seems that performance problems are more important now than memory problem with the switch to 10. So we are rolling back on this point.

We will provide a chapter in the troubleshooting section of the documentation, for people to better undrerstand the usage and impact of this parameter.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
