### PR TITLE
PIM-7853 - do not reload page if there is a form validation error

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -9,6 +9,7 @@
 - PIM-7828: Fix ACL on System Info
 - PIM-7824: Fix filter on view with attribute option deleted
 - PIM-7852: Increase product import performances and fixes model association import when comparison is disabled
+- PIM-7853: Fix unwanted automatic reload of the user page even if there were errors on the form
 
 # 2.3.16 (2018-11-13)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/user.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/user.js
@@ -9,8 +9,11 @@ define([
             /**
              * {@inheritdoc}
              */
-            afterSubmit: function () {
-                window.location.reload(); //TODO nav: reload the page to update the menu
+            afterSubmit: function (xhr) {
+                if(xhr.responseText.indexOf('validation-tooltip') < 0)
+                {
+                    window.location.reload(); //TODO nav: reload the page to update the menu
+                }
 
                 FormController.prototype.afterSubmit.apply(this, arguments);
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/user.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/user.js
@@ -10,8 +10,9 @@ define([
              * {@inheritdoc}
              */
             afterSubmit: function (xhr) {
-                if(xhr.responseText.indexOf('validation-tooltip') < 0)
-                {
+                // If some validation errors are raised by the backend,
+                // do not hard reload the page in order to keep error message displayed to the user.
+                if (xhr.responseText.indexOf('validation-tooltip') < 0) {
                     window.location.reload(); //TODO nav: reload the page to update the menu
                 }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When editing user information, we need to reload the page in order to have fresh information on UI.

**Problem**:
If there is validation errors (minimum number of characters not respected or so), the user is not saved and we want to display to the user that he entered wrong data in the form. But as we automatically reload the page the user didn't have the time to see his mistake.

**Solution**:
Check on the xhr response if we have validation error and reload or not the page.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | y
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
