### PR TITLE
PIM-7791: Suppress warning on attribute option in case of case sensitive codes

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -11,6 +11,7 @@
 - PIM-7852: Increase product import performances and fixes model association import when comparison is disabled
 - PIM-7853: Fix unwanted automatic reload of the user page even if there were errors on the form
 - PIM-7841: Allow users to set regional locales for UI (en_NZ, pt_PT and pt_BR)
+- PIM-7791: Suppress warning on attribute option in case of case sensitive codes
 
 # 2.3.16 (2018-11-13)
 

--- a/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/AttributeOptionUpdater.php
@@ -108,7 +108,7 @@ class AttributeOptionUpdater implements ObjectUpdaterInterface
      */
     protected function setData(AttributeOptionInterface $attributeOption, $field, $data)
     {
-        if ('code' === $field) {
+        if ('code' === $field && $attributeOption->getId() === null) {
             $attributeOption->setCode($data);
         }
 


### PR DESCRIPTION
Before, there was a warning like "unable to update code from xxx to XXX" because of case insensitive on attribute option codes.

This PR fixed it by only updating immutable code if entity is new.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
