### PR TITLE
PIM-7841: Allow users to set regional locales for UI (en_NZ, pt_PT and pt_BR)

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -10,6 +10,7 @@
 - PIM-7824: Fix filter on view with attribute option deleted
 - PIM-7852: Increase product import performances and fixes model association import when comparison is disabled
 - PIM-7853: Fix unwanted automatic reload of the user page even if there were errors on the form
+- PIM-7841: Allow users to set regional locales for UI (en_NZ, pt_PT and pt_BR)
 
 # 2.3.16 (2018-11-13)
 

--- a/src/Akeneo/Bundle/BatchBundle/Resources/translations/validators.en_NZ.yml
+++ b/src/Akeneo/Bundle/BatchBundle/Resources/translations/validators.en_NZ.yml
@@ -1,0 +1,1 @@
+akeneo_batch.job_instance.unknown_job_definition: Failed to create an %job_type% with an unknown job definition

--- a/src/Akeneo/Bundle/MeasureBundle/Resources/translations/jsmessages.en_NZ.yml
+++ b/src/Akeneo/Bundle/MeasureBundle/Resources/translations/jsmessages.en_NZ.yml
@@ -1,0 +1,157 @@
+Area: Area
+ACRE: Acre
+ARE: Are
+ARPENT: Arpent
+CENTIARE: Centiare
+HECTARE: Hectare
+SQUARE_CENTIMETER: Square centimetre
+SQUARE_DECIMETER: Square decimetre
+SQUARE_DEKAMETER: Square dekametre
+SQUARE_FOOT: Square foot
+SQUARE_FURLONG: Square furlong
+SQUARE_HECTOMETER: Square hectometre
+SQUARE_INCH: Square inch
+SQUARE_KILOMETER: Square kilometre
+SQUARE_METER: Square metre
+SQUARE_MIL: Square mil
+SQUARE_MILE: Square mile
+SQUARE_MILLIMETER: Square millimetre
+SQUARE_YARD: Square yard
+Binary: Binary
+BIT: Bit
+BYTE: Byte
+KILOBYTE: Kilobyte
+MEGABYTE: Megabyte
+GIGABYTE: Gigabyte
+TERABYTE: Terabyte
+Decibel: Decibel
+DECIBEL: Decibel
+Frequency: Frequency
+GIGAHERTZ: Gigahertz
+KILOHERTZ: Kilohertz
+MEGAHERTZ: Megahertz
+TERAHERTZ: Terahertz
+HERTZ: Hertz
+Length: Length
+CENTIMETER: Centimetre
+CHAIN: Chain
+DECIMETER: Decimetre
+DEKAMETER: Dekametre
+FEET: Feet
+FURLONG: Furlong
+INCH: Inch
+HECTOMETER: Hectometre
+KILOMETER: Kilometre
+METER: Metre
+MIL: Mil
+MILE: Mile
+MILLIMETER: Millimetre
+YARD: Yard
+Power: Power
+GIGAWATT: Gigawatt
+KILOWATT: Kilowatt
+MEGAWATT: Megawatt
+TERAWATT: Terawatt
+WATT: Watt
+Resistance: Resistence
+MILLIOHM: Milliohm
+CENTIOHM: Centiohm
+DECIOHM: Deciohm
+OHM: Ohm
+DEKAOHM: Dekaohm
+HECTOHM: Hectohm
+KILOHM: Kilohm
+MEGOHM: Megohm
+Voltage: Voltage
+MILLIVOLT: Millivolt
+CENTIVOLT: Centivolt
+DECIVOLT: Decivolt
+VOLT: Volt
+DEKAVOLT: Dekavolt
+HECTOVOLT: Hectovolt
+KILOVOLT: Kilovolt
+Intensity: Intensity
+MILLIAMPERE: Milliampere
+CENTIAMPERE: Centiampere
+DECIAMPERE: Deciampere
+AMPERE: Ampere
+DEKAAMPERE: Dekaampere
+HECTOAMPERE: Hectoampere
+KILOAMPERE: Kiloampere
+MEGAAMPERE: Megaampere
+ElectricCharge: Electric charge
+MILLIAMPEREHOUR: Milliampere hour
+AMPEREHOUR: Ampere hour
+MILLICOULOMB: Millicoulomb
+CENTICOULOMB: Centicoulomb
+DECICOULOMB: Decicoulomb
+COULOMB: Coulomb
+DEKACOULOMB: Dekacoulomb
+HECTOCOULOMB: Hectocoulomb
+KILOCOULOMB: Kilocoulomb
+Duration: Duration
+MILLISECOND: Millisecond
+SECOND: Second
+MINUTE: Minute
+HOUR: Hour
+DAY: Day
+WEEK: Week
+MONTH: Month
+YEAR: Year
+Speed: Speed
+FOOT_PER_SECOND: Foot per second
+FOOT_PER_HOUR: Foot per hour
+KILOMETER_PER_HOUR: Kilometre per hour
+METER_PER_HOUR: Metre per hour
+METER_PER_MINUTE: Metre per minute
+METER_PER_SECOND: Metre per second
+MILE_PER_HOUR: Mile per hour
+YARD_PER_HOUR: Yard per hour
+Temperature: Temperature
+CELSIUS: Celsius
+FAHRENHEIT: Fahrenheit
+KELVIN: Kelvin
+RANKINE: Rankine
+REAUMUR: Reaumur
+Volume: Volume
+BARREL: Barrel
+CENTILITER: Centilitre
+CUBIC_CENTIMETER: Cubic centimetre
+CUBIC_DECIMETER: Cubic decimetre
+CUBIC_FOOT: Cubic foot
+CUBIC_INCH: Cubic inch
+CUBIC_METER: Cubic metre
+CUBIC_MILLIMETER: Cubic millimetre
+CUBIC_YARD: Cubic yard
+DECILITER: Decilitre
+GALLON: Gallon
+LITER: Litre
+MILLILITER: Millilitre
+OUNCE: Ounce
+PINT: Pint
+Weight: Weight
+DENIER: Denier
+GRAIN: Grain
+GRAM: Gram
+KILOGRAM: Kilogram
+LIVRE: Livre
+MARC: Marc
+MILLIGRAM: Milligram
+ONCE: Once
+POUND: Pound
+TON: Ton
+Pressure: Pressure
+BAR: Bar
+PASCAL: Pascal
+HECTOPASCAL: hecto Pascal
+MILLIBAR: milli Bar
+ATM: Atmosphere
+PSI: Pound per square inch
+TORR: Torr
+MMHG: millimetre of Mercury
+Energy: Energy
+KILOCALORIE: kilocalorie
+KILOJOULE: kilojoule
+CaseBox: Packaging
+PIECE: Piece
+DOZEN: Dozen

--- a/src/Akeneo/Bundle/MeasureBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Akeneo/Bundle/MeasureBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,157 @@
+Area: Area
+ACRE: Acre
+ARE: Are
+ARPENT: Arpent
+CENTIARE: Centiare
+HECTARE: Hectare
+SQUARE_CENTIMETER: Square centimetre
+SQUARE_DECIMETER: Square decimetre
+SQUARE_DEKAMETER: Square dekametre
+SQUARE_FOOT: Square foot
+SQUARE_FURLONG: Square furlong
+SQUARE_HECTOMETER: Square hectometre
+SQUARE_INCH: Square inch
+SQUARE_KILOMETER: Square kilometre
+SQUARE_METER: Square meter
+SQUARE_MIL: Square mil
+SQUARE_MILE: Square mile
+SQUARE_MILLIMETER: Square millimetre
+SQUARE_YARD: Square yard
+Binary: Binary
+BIT: Bit
+BYTE: Byte
+KILOBYTE: Kilobyte
+MEGABYTE: Megabyte
+GIGABYTE: Gigabyte
+TERABYTE: Terabyte
+Decibel: Decibel
+DECIBEL: Decibel
+Frequency: Frequency
+GIGAHERTZ: Gigahertz
+KILOHERTZ: Kilohertz
+MEGAHERTZ: Megahertz
+TERAHERTZ: Terahertz
+HERTZ: Hertz
+Length: Length
+CENTIMETER: Centimetre
+CHAIN: Chain
+DECIMETER: Decimetre
+DEKAMETER: Dekametre
+FEET: Feet
+FURLONG: Furlong
+INCH: Inch
+HECTOMETER: Hectometre
+KILOMETER: Kilometre
+METER: Metre
+MIL: Mil
+MILE: Mile
+MILLIMETER: Millimetre
+YARD: Yard
+Power: Power
+GIGAWATT: Gigawatt
+KILOWATT: Kilowatt
+MEGAWATT: Megawatt
+TERAWATT: Terawatt
+WATT: Watt
+Resistance: Resistence
+MILLIOHM: Milliohm
+CENTIOHM: Centiohm
+DECIOHM: Deciohm
+OHM: Ohm
+DEKAOHM: Dekaohm
+HECTOHM: Hectohm
+KILOHM: Kilohm
+MEGOHM: Megohm
+Voltage: Voltage
+MILLIVOLT: Millivolt
+CENTIVOLT: Centivolt
+DECIVOLT: Decivolt
+VOLT: Volt
+DEKAVOLT: Dekavolt
+HECTOVOLT: Hectovolt
+KILOVOLT: Kilovolt
+Intensity: Intensity
+MILLIAMPERE: Milliampere
+CENTIAMPERE: Centiampere
+DECIAMPERE: Deciampere
+AMPERE: Ampere
+DEKAAMPERE: Dekaampere
+HECTOAMPERE: Hectoampere
+KILOAMPERE: Kiloampere
+MEGAAMPERE: Megaampere
+ElectricCharge: Electric charge
+MILLIAMPEREHOUR: Milliampere hour
+AMPEREHOUR: Ampere hour
+MILLICOULOMB: Millicoulomb
+CENTICOULOMB: Centicoulomb
+DECICOULOMB: Decicoulomb
+COULOMB: Coulomb
+DEKACOULOMB: Dekacoulomb
+HECTOCOULOMB: Hectocoulomb
+KILOCOULOMB: Kilocoulomb
+Duration: Duration
+MILLISECOND: Millisecond
+SECOND: Second
+MINUTE: Minute
+HOUR: Hour
+DAY: Day
+WEEK: Week
+MONTH: Month
+YEAR: Year
+Speed: Speed
+FOOT_PER_SECOND: Foot per second
+FOOT_PER_HOUR: Foot per hour
+KILOMETER_PER_HOUR: Kilometer per hour
+METER_PER_HOUR: Metre per hour
+METER_PER_MINUTE: Metre per minute
+METER_PER_SECOND: Metre per second
+MILE_PER_HOUR: Mile per hour
+YARD_PER_HOUR: Yard per hour
+Temperature: Temperature
+CELSIUS: Celsius
+FAHRENHEIT: Fahrenheit
+KELVIN: Kelvin
+RANKINE: Rankine
+REAUMUR: Reaumur
+Volume: Volume
+BARREL: Barrel
+CENTILITER: Centilitre
+CUBIC_CENTIMETER: Cubic centimetre
+CUBIC_DECIMETER: Cubic decimetre
+CUBIC_FOOT: Cubic foot
+CUBIC_INCH: Cubic inch
+CUBIC_METER: Cubic metre
+CUBIC_MILLIMETER: Cubic millimetre
+CUBIC_YARD: Cubic yard
+DECILITER: Decilitre
+GALLON: Gallon
+LITER: Litre
+MILLILITER: Millilitre
+OUNCE: Ounce
+PINT: Pint
+Weight: Weight
+DENIER: Denier
+GRAIN: Grain
+GRAM: Gram
+KILOGRAM: Kilogram
+LIVRE: Livre
+MARC: Marc
+MILLIGRAM: Milligram
+ONCE: Once
+POUND: Pound
+TON: Ton
+Pressure: Pressure
+BAR: Bar
+PASCAL: Pascal
+HECTOPASCAL: hecto Pascal
+MILLIBAR: milli Bar
+ATM: Atmosphere
+PSI: Pound per square inch
+TORR: Torr
+MMHG: millimeter of Mercury
+Energy: Energy
+KILOCALORIE: kilocalorie
+KILOJOULE: kilojoule
+CaseBox: Packaging
+PIECE: Piece
+DOZEN: Dozen

--- a/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/AnalyticsBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,58 @@
+pim_analytics:
+  new_patch_available: New patch available
+  system_config:
+    group:
+      notification.title: Notifications
+      version_update.title: Version updates
+    form:
+      version_update.label: New versions notifications
+      version_update.tooltip: Send request to a distant server to retrieve information about the release of new patchs
+  system_info:
+    title: System information
+    download: TXT
+  info_type:
+    pim_edition: Edition
+    pim_version: Version
+    pim_storage_driver: Storage
+    pim_environment: Environment
+    pim_install_time: Install time
+    registered_bundles: Registered bundles
+    nb_channels: Number of channels
+    nb_products: Number of products
+    nb_product_models: Number of product models
+    nb_variant_products: Number of variant products
+    nb_family_variants: Number of family variants
+    nb_attributes: Number of attributes
+    nb_scopable_attributes: Number of scopable attributes
+    nb_localizable_attributes: Number of localizable attributes
+    nb_scopable_localizable_attributes: Number of localizable and scopable attributes
+    nb_useable_as_grid_filter_attributes: Number of attributes useable as grid filter
+    avg_percentage_scopable_attributes_per_family: Average percentage of scopable attributes per family (%)
+    avg_percentage_localizable_attributes_per_family: Average percentage of localizable attributes per family (%)
+    avg_percentage_scopable_localizable_attributes_per_family: Average percentage of localizable and scopable attributes per family (%)
+    avg_number_attributes_per_family: Average number of attributes per family
+    nb_locales: Number of locales
+    nb_families: Number of families
+    nb_users: Number of users
+    nb_categories: Number of categories
+    nb_category_trees: Number of category trees
+    max_category_in_one_category: Max number of categories in one category
+    max_category_levels: Max number of category levels
+    nb_product_values: Number of product values
+    avg_product_values_by_product: Average number of product values by product
+    avg_product_values_by_family: Average number of potential product values by family
+    max_product_values_by_family: Max number of potential product values by family
+    pim_storage_version: Storage version
+    os_version: OS version
+    php_version: PHP version
+    mysql_version: MySQL version
+    mariadb_version: MariaDB version
+    mongodb_version: MongoDB version
+    server_version: Server version
+    php_extensions: PHP extensions
+  acl:
+    system_info:
+      index: System information
+pim_menu:
+  item:
+    system_info: System information

--- a/src/Pim/Bundle/ApiBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,42 @@
+pim_api:
+  acl:
+    rights: Web API permissions
+    attribute:
+      edit: Create and update attributes
+      list: List attributes
+    attribute_option:
+      edit: Create and update attribute options
+      list: List attribute options
+    attribute_group:
+      edit: Create and update attribute groups
+      list: List attribute groups
+    category:
+      edit: Create and update categories
+      list: List categories
+    family:
+      edit: Create and update families
+      list: List families
+    family_variant:
+      edit: Create and update family variants
+      list: List family variants
+    channel:
+      edit: Create and update channels
+      list: List channels
+    locale.list: List locales
+    currency.list: List currencies
+    association_type:
+      edit: Create and update association types
+      list: List association types
+  acl_group:
+    overall_access: Overall Web API access
+    attribute: Attributes
+    attribute_option: Attribute options
+    attribute_group: Attribute groups
+    category: Categories
+    family: Families
+    family_variant: Family variants
+    channel: Channels
+    locale: Locales
+    currency: Currencies
+    association_type: Association types
+rights.api: Web API permissions

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/measures.en_NZ.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/measures.en_NZ.yml
@@ -1,0 +1,95 @@
+Area: Area
+ACRE: Acre
+ARE: Are
+ARPENT: Arpent
+CENTIARE: Centiare
+HECTARE: Hectare
+SQUARE_CENTIMETER: Square centimetre
+SQUARE_DECIMETER: Square decimetre
+SQUARE_DEKAMETER: Square dekametre
+SQUARE_FOOT: Square foot
+SQUARE_FURLONG: Square furlong
+SQUARE_HECTOMETER: Square hectometre
+SQUARE_INCH: Square inch
+SQUARE_KILOMETER: Square kilometre
+SQUARE_METER: Square metre
+SQUARE_MIL: Square mil
+SQUARE_MILE: Square mile
+SQUARE_MILLIMETER: Square millimetre
+SQUARE_YARD: Square yard
+Binary: Binary
+BIT: Bit
+BYTE: Byte
+KILOBYTE: Kilobyte
+MEGABYTE: Megabyte
+GIGABYTE: Gigabyte
+TERABYTE: Terabyte
+Frequency: Frequency
+GIGAHERTZ: Gigahertz
+KILOHERTZ: Kilohertz
+MEGAHERTZ: Megahertz
+TERAHERTZ: Terahertz
+HERTZ: Hertz
+Length: Length
+CENTIMETER: Centimetre
+CHAIN: Chain
+DECIMETER: Decimetre
+DEKAMETER: Dekametre
+FEET: Feet
+FURLONG: Furlong
+INCH: Inch
+HECTOMETER: Hectometre
+KILOMETER: Kilometre
+METER: Metre
+MIL: Mil
+MILE: Mile
+MILLIMETER: Millimetre
+YARD: Yard
+Power: Power
+GIGAWATT: Gigawatt
+KILOWATT: Kilowatt
+MEGAWATT: Megawatt
+TERAWATT: Terawatt
+WATT: Watt
+Speed: Speed
+FOOT_PER_SECOND: Foot per second
+FOOT_PER_HOUR: Foot per hour
+KILOMETER_PER_HOUR: Kilometre per hour
+METER_PER_HOUR: Metre per hour
+METER_PER_MINUTE: Metre per minute
+METER_PER_SECOND: Metre per second
+MILE_PER_HOUR: Mile per hour
+YARD_PER_HOUR: Yard per hour
+Temperature: Temperature
+CELSIUS: Celsius
+FAHRENHEIT: Fahrenheit
+KELVIN: Kelvin
+RANKINE: Rankine
+REAUMUR: Reaumur
+Volume: Volume
+BARREL: Barrel
+CENTILITER: Centilitre
+CUBIC_CENTIMETER: Cubic centimetre
+CUBIC_DECIMETER: Cubic decimetre
+CUBIC_FOOT: Cubic foot
+CUBIC_INCH: Cubic inch
+CUBIC_METER: Cubic metre
+CUBIC_MILLIMETER: Cubic millimetre
+CUBIC_YARD: Cubic yard
+DECILITER: Decilitre
+GALLON: Gallon
+LITER: Litre
+MILLILITER: Millilitre
+OUNCE: Ounce
+PINT: Pint
+Weight: Weight
+DENIER: Denier
+GRAIN: Grain
+GRAM: Gram
+KILOGRAM: Kilogram
+LIVRE: Livre
+MARC: Marc
+MILLIGRAM: Milligram
+ONCE: Once
+POUND: Pound
+TON: Ton

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,3 @@
+No products to remove: No products to remove
+"dot (.)": dot (.)
+"comma (,)": comma (,)

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en_NZ.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en_NZ.yml
@@ -1,0 +1,83 @@
+An identifier attribute already exists.: An identifier attribute already exists.
+Attribute code may contain only letters, numbers and underscore: Attribute code may contain only letters, numbers and underscore
+Attribute code may contain only letters (at least one), numbers and underscores: Attribute code may contain only letters (at least one), numbers and underscores
+This attribute type can't be used as a grid filter: This attribute type can't be used as a grid filter
+This code is not available: This code is not available
+This attribute type must be required: This attribute type must be required
+This attribute type can't be required: This attribute type can't be required
+This attribute type can't have unique value: This attribute type can't have unique value
+No default value may be specified for this attribute type: No default value may be specified for this attribute type
+This value should be Yes or No: This value should be Yes or No
+This value should not be blank: This value should not be blank
+Option code may contain only letters, numbers and underscores: Option code may contain only letters, numbers and underscores
+Option code may contain only letters (at least one), numbers and underscores: Option code may contain only letters (at least one), numbers and underscores
+This value should not be a decimal.: This value should not be a decimal.
+'The file extension is not allowed (allowed extensions: %extensions%).': 'The file extension is not allowed (allowed extensions: %extensions%).'
+"The value %value% is already set on another product for the unique attribute %attribute%": The value %value% is already set on another product for the unique attribute %attribute%
+The same identifier is already set on another product: The same identifier is already set on another product
+regex.comma_or_semicolon.message: This field should not contain any comma or semicolon.
+file.extensions.message: 'The file extension is not allowed (allowed extensions: %extensions%).'
+"This type of value expects the use of {{ decimal_separator }} to separate decimals.": This type of value expects the use of {{ decimal_separator }} to separate decimals.
+"This type of value expects the use of dot (.) to separate decimals.": This type of value expects the use of a dot (.) to separate decimals.
+"This type of value expects the use of comma (,) to separate decimals.": This type of value expects the use of a comma (,) to separate decimals.
+"This type of value expects the use of arabic decimal separator (٫) to separate decimals.": This type of value expects the use of an arabic decimal separator (٫) to separate decimals.
+"This type of value expects the use of the format {{ date_format }} for dates.": This type of value expects the use of the format {{ date_format }} for dates.
+"The category \"%category%\" has to be a root category.": The category "%category%" has to be a root category.
+"The attribute \"%attributeCode%\" does not exist.": The attribute "%attributeCode%" does not exist.
+"The attribute \"%attributeCode%\" is not a metric attribute.": The attribute "%attributeCode%" is not a metric attribute.
+"The unit \"%unitCode%\" does not exist or does not belong to the default metric family of the given attribute \"%attributeCode%\".": The unit "%unitCode%" does not exist or does not belong to the default metric family of the given attribute "%attributeCode%".
+"The currency \"%currency%\" has to be activated.": The currency "%currency%" has to be activated.
+product_model.code.not_blank.message: The product model code must not be empty.
+product_model.code.unique.message: The same code is already set on another product model.
+product_model.family_variant.not_blank.message: The product model family variant must not be empty.
+pim_catalog:
+  constraint:
+    can_have_family_variant_empty_axis_value: 'Attribute "%attribute%" cannot be empty, as it is defined as an axis for this entity'
+    product_model_with_same_axis_value_already_exists: 'Cannot set value "%values%" for the attribute axis "%attributes%" on product model "%validated_entity%", as the product model "%sibling_with_same_value%" already has this value'
+    variant_product_with_same_axis_value_already_exists: 'Cannot set value "%values%" for the attribute axis "%attributes%" on variant product "%validated_entity%", as the variant product "%sibling_with_same_value%" already has this value'
+    can_have_family_variant_unexpected_attribute: 'Cannot set the property "%attribute%" to this entity as it is not in the attribute set'
+    cannot_have_product_model_as_parent: 'The product model "%product_model%" cannot have the product model "%parent_product_model%" as parent'
+    cannot_have_parent: 'The product model "%product_model%" cannot have a parent'
+    attribute_does_not_belong_to_family: 'Attribute "%attribute%" does not belong to the family "%family%"'
+    variant_product_invalid_family: 'The variant product family must be the same than its parent'
+    not_null_family: The family can't be "null" because your product with the identifier "%sku%" is a variant product.
+    variant_product_has_parent: 'The variant product "%variant_product%" must have a parent'
+    invalid_variant_product_parent: 'The variant product "%variant_product%" cannot have product model "%product_model%" as parent, (this product model can only have other product models as children)'
+    modified_variant_axis_value: 'Variant axis "%variant_axis%" cannot be modified, "%provided_value%" given'
+    family_variant_attributes_unique: Attributes must be unique, "%attributes%" are used several times in variant attributes sets
+    family_variant_axes_unique: Variant axes must be unique, "%attributes%" are used several times in variant attributes sets
+    family_variant_axes_immutable: 'Variant axes cannot be modified for the level "%level%"'
+    family_variant_axes_attribute_type_unique: Variant axes "%axis%" cannot be unique or an identifier
+    family_variant_axes_attribute_type: Variant axes "%axis%" must be a boolean, a simple select, a simple reference data or a metric
+    family_variant_axes_wrong_type: Variant axes "%axis%" cannot be localizable, not scopable and not locale specific
+    family_variant_axes_number_of_axes: 'A variant attribute set cannot have more than %max_axes_number% axes'
+    family_variant_no_axis: There should be at least one attribute defined as axis for the attribute set for level "%level%"
+    family_variant_axis_level: Attribute "%axis%" must be set as attribute in the same variant attribute set it was set as axis
+    family_variant_has_family_attribute: '"%attribute%" attribute cannot be added to "%family_variant%" family variant, as it is not an attribute of the "%family%" family'
+    family_variant_level_do_not_exist: There is no variant attribute set for level "%level%"
+    family_variant_no_level: There should be at least one level defined in the family variant
+    family_variant_maximum_number_of_level: Family variant cannot have more than "%level%" level
+    family_variant_unique_attributes_in_last_level: Unique attribute "%attribute%" must be set at the product level
+    product_identifier: These identifiers "%s" don't exist.
+    0: An unexpected error occurred.
+    100: Non-expected value
+    101: This field expects a boolean value.
+    102: This field expects a float value.
+    103: This field expects an integer value.
+    104: This field expects a numeric value.
+    105: This field expects a string value.
+    106: This field expects an array value.
+    107: This field expects an array of arrays as value.
+    200: An internal error occurred
+    201: An internal error occurred
+    202: This field expects a numeric value.
+    203: This field expects a string value.
+    204: This field expects a string value.
+    205: An internal error occurred
+    300: This field expects a valid entity code.
+    301: This field expects a valid scope and locale.
+    302: This field expects a valid scope.
+    303: This field expects a valid association format.
+    pim_immutable_product_validator: The same identifier is already set on another product
+    pim_immutable_product_model_validator: The same code is already set on another product model.
+

--- a/src/Pim/Bundle/CommentBundle/Resources/translations/jsmessages.en_NZ.yml
+++ b/src/Pim/Bundle/CommentBundle/Resources/translations/jsmessages.en_NZ.yml
@@ -1,0 +1,28 @@
+btn:
+  post: Add a new comment
+  reply: Reply
+  cancel: Cancel
+confirmation:
+  remove:
+    comment: Are you sure you want to delete this comment?
+flash:
+  comment:
+    create:
+      success: Your comment has been created successfully.
+      error: An error occured during the creation of your comment.
+    delete:
+      success: Your comment has been deleted successfully.
+      error: An error occured during the deletion of your comment.
+    reply:
+      success: Your reply has been created successfully.
+      error: An error occured during the creation of your reply.
+comment:
+  index:
+    empty: No comment for now
+    header_comment: '{{ user }} comments the product'
+    header_reply: '{{ user }} replies to the comment'
+  placeholder:
+    new: Write a new comment...
+    reply: Reply to this comment...
+pim_comment:
+  product.panel.comment.title: Comments

--- a/src/Pim/Bundle/CommentBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/CommentBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,25 @@
+btn:
+  post: Add a new comment
+  reply: Reply
+confirmation:
+  remove:
+    comment: Are you sure you want to delete this comment?
+flash:
+  comment:
+    create:
+      success: Your comment has been created successfully.
+      error: An error occured during the creation of your comment.
+    delete:
+      success: Your comment has been deleted successfully.
+      error: An error occured during the deletion of your comment.
+    reply:
+      success: Your reply has been created successfully.
+      error: An error occured during the creation of your reply.
+comment:
+  index:
+    empty: No comment found.
+  placeholder:
+    new: Write a new comment...
+    reply: Reply to this comment...
+pim_comment:
+  product.tab.comment.title: Comments

--- a/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,250 @@
+pim_connector:
+  steps:
+    dummy_reader.title: Dummy reader
+    product_reader.title: Product extraction
+    entity_reader.title: Entity extraction
+    csv_reader:
+      title: CSV reader
+    file_reader:
+      invalid_item_columns_count: 'Expecting to have %totalColumnsCount% columns, actually have %itemColumnsCount% in %filePath%:%lineno%'
+    csv_product_reader.title: CSV product reader
+    csv_category_reader.title: CSV category reader
+    dummy_processor.title: Dummy processor
+    product_processor.title: Product creation
+    category_processor.title: Category creation
+    association_processor.title: Association creation
+    product_association_processor.title: Association creation
+    group_processor.title: Group creation
+    attribute_processor.title: Attribute creation
+    attribute_option_processor.title: Attribute option creation
+    heterogeneous_processor.title: CSV product serializer
+    homogeneous_processor.title: CSV entity serializer
+    transformer_processor.title: Transformation
+    dummy_writer.title: Dummy writer
+    file_writer.title: Output
+    product_writer.title: Product storage
+    category_writer.title: Category storage
+    writer.title: Entity storage
+    csv_writer.title: Csv Writer
+job_execution.summary:
+  read: read
+  write: written
+  skip: skipped
+  create: created
+  process: processed
+  update_products: updated products
+  process_products: processed products
+  skip_products: skipped products
+  displayed: first warnings displayed
+  charset_validator:
+    title: 'File encoding:'
+    skipped: skipped, extension in white list
+  product_skipped_no_diff: skipped product (no differences)
+  product_skipped_no_associations: skipped product (no associations detected)
+  product_model_skipped_no_diff: skipped product model (no differences)
+  item_position: read lines
+  skipped_in_root_product_model: skipped product model with parent
+  skipped_in_sub_product_model: skipped product model without parent
+batch_jobs:
+  csv_product_export:
+    label: Product export in CSV
+    export.label: Product export
+  csv_product_model_export:
+    label: Product model export in CSV
+    export.label: Product model export
+  csv_category_export:
+    label: Category export in CSV
+    export.label: Category export
+  csv_attribute_export:
+    label: Attribute export in CSV
+    export.label: Attribute export
+  csv_attribute_option_export:
+    label: Attribute option export in CSV
+    export.label: Attribute option export
+  csv_association_type_export:
+    label: Association type export in CSV
+    export.label: Association type export
+  csv_group_export:
+    label: Group export in CSV
+    export.label: Group export
+  csv_family_export:
+    label: Family export in CSV
+    export.label: Family export
+  csv_family_variant_export:
+    label: Family variant export in CSV
+    export.label: Family variant export
+  csv_product_import:
+    label: Product import in CSV
+    validation.label: File validation
+    import.label: Product import
+    import_associations.label: Association import
+  csv_product_model_import:
+    label: Product model import in CSV
+    validation.label: File validation
+    import_root_product_model.label: Root product model import
+    import_sub_product_model.label: Sub product model import
+    import_product_model_descendants.label: Compute product model descendants
+  csv_category_import:
+    label: Category import in CSV
+    validation.label: File validation
+    import.label: Category import
+  csv_attribute_import:
+    label: Attribute import in CSV
+    validation.label: File validation
+    import.label: Attribute import
+  csv_attribute_option_import:
+    label: Attribute option import in CSV
+    validation.label: File validation
+    import.label: Attribute option import
+  csv_association_type_import:
+    label: Association type import in CSV
+    validation.label: File validation
+    import.label: Association type import
+  csv_family_import:
+    label: Family import in CSV
+    validation.label: File validation
+    import.label: Family import
+  csv_family_variant_import:
+    label: Family variant import in CSV
+    validation.label: File validation
+    import.label: Family variant import
+  csv_group_import:
+    label: Group import in CSV
+    validation.label: File validation
+    import.label: Group import
+  csv_channel_export:
+    label: Channel export in CSV
+    export.label: Channel export
+  csv_locale_export:
+    label: Locale export in CSV
+    export.label: Locale export
+  csv_attribute_group_export:
+    label: Attribute group export in CSV
+    export.label: Attribute group export
+  csv_currency_export:
+    label: Currency export in CSV
+    export.label: Currency export
+  csv_group_type_export:
+    label: Group type export in CSV
+    export.label: Group type export
+  csv_channel_import:
+    label: Channel import in CSV
+    validation.label: File validation
+    import.label: Channel import
+  csv_locale_import:
+    label: Locale import in CSV
+    validation.label: File validation
+    import.label: Locale import
+  csv_attribute_group_import:
+    label: Attribute group import in CSV
+    validation.label: File validation
+    import.label: Attribute group import
+  csv_currency_import:
+    label: Currency import in CSV
+    validation.label: File validation
+    import.label: Currency import
+  csv_group_type_import:
+    label: Group type import in CSV
+    validation.label: File validation
+    import.label: Group type import
+  xlsx_category_import:
+    label: Category import in XLSX
+    validation.label: File validation
+    import.label: Category import
+  xlsx_association_type_import:
+    label: Association type import in XLSX
+    validation.label: File validation
+    import.label: Association type import
+  xlsx_attribute_import:
+    label: Attribute import in XLSX
+    validation.label: File validation
+    import.label: Attribute import
+  xlsx_attribute_option_import:
+    label: Attribute option import in XLSX
+    validation.label: File validation
+    import.label: Attribute option import
+  xlsx_family_import:
+    label: Family import in XLSX
+    validation.label: File validation
+    import.label: Family import
+  xlsx_family_variant_import:
+    label: Family variant import in XLSX
+    validation.label: File validation
+    import.label: Family variant import
+  xlsx_product_export:
+    label: Product export in XLSX
+    export.label: Product export
+  xlsx_product_model_export:
+    label: Product model export in XLSX
+    export.label: Product model export
+  xlsx_product_import:
+    label: Product import in XLSX
+    validation.label: File validation
+    import.label: Product import
+    import_associations.label: Association import
+  xlsx_product_model_import:
+    label: Product model import in XSLX
+    validation.label: File validation
+    import_root_product_model.label: Root product model import
+    import_sub_product_model.label: Sub product model import
+    import_product_model_descendants.label: Compute product model descendants
+  xlsx_group_export:
+    label: Group export in XLSX
+    export.label: Group export
+  xlsx_group_import:
+    label: Group import in XLSX
+    validation.label: File validation
+    import.label: Group import
+  xlsx_family_export:
+    label: Family export in XLSX
+    export.label: Family export
+  xlsx_family_variant_export:
+    label: Family variant export in XLSX
+    export.label: Family variant export
+  xlsx_category_export:
+    label: Category export in XLSX
+    export.label: Category export
+  xlsx_attribute_export:
+    label: Attribute export in XLSX
+    export.label: Attribute export in XLSX
+  xlsx_attribute_option_export:
+    label: Attribute option export in XLSX
+    export.label: Attribute option export in XLSX
+  xlsx_association_type_export:
+    label: Association type export in XLSX
+    export.label: Association type export in XLSX
+  xlsx_channel_export:
+    label: Channel export in XLSX
+    export.label: Channel export
+  xlsx_locale_export:
+    label: Locale export in XLSX
+    export.label: Locale export
+  xlsx_attribute_group_export:
+    label: Attribute group export in XLSX
+    export.label: Attribute group export
+  xlsx_currency_export:
+    label: Currency export in XLSX
+    export.label: Currency export
+  xlsx_group_type_export:
+    label: Group type export in XLSX
+    export.label: Group type export
+  xlsx_channel_import:
+    label: Channel import in XLSX
+    validation.label: File validation
+    import.label: Channel import
+  xlsx_locale_import:
+    label: Locale import in XLSX
+    validation.label: File validation
+    import.label: Locale import
+  xlsx_attribute_group_import:
+    label: Attribute group import in XLSX
+    validation.label: File validation
+    import.label: Attribute group import
+  xlsx_currency_import:
+    label: Currency import in XLSX
+    validation.label: File validation
+    import.label: Currency import
+  xlsx_group_type_import:
+    label: Group type import in XLSX
+    validation.label: File validation
+    import.label: Group type import

--- a/src/Pim/Bundle/DashboardBundle/Resources/translations/jsmessages.en_NZ.yml
+++ b/src/Pim/Bundle/DashboardBundle/Resources/translations/jsmessages.en_NZ.yml
@@ -1,0 +1,25 @@
+pim_dashboard:
+  widget:
+    last_operations:
+      empty: No operations found
+      status: Status
+      date: Date
+      type: Type
+      profile_name: Profile name
+      details: Details
+      warning_count: Warnings
+      job_type:
+        import: Import
+        export: Export
+        mass_edit: Mass edit
+        quick_export: Quick export
+        compute_product_models_descendants: Compute product models descendants
+        compute_family_variant_structure_changes: Compute family variant structure changes
+        compute_completeness_of_products_family: Compute completeness of products family
+        mass_delete: Mass delete products
+    completeness:
+      load_more: 'Load more...'
+    header:
+      view_all: View all
+page_title:
+  pim_dashboard_index: Dashboard

--- a/src/Pim/Bundle/DashboardBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/DashboardBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,29 @@
+pim_dashboard:
+  title: Dashboard
+  version: Version
+  link.label:
+    product: Manage Products
+    category: Manage Categories
+    attribute: Manage Attributes
+    family: Manage Families
+  widget:
+    error:
+      title: Error while loading widget
+      message: Widget '%alias%' does not exist
+    completeness:
+      title: Completeness Over Channels and Locales
+    last_operations:
+      title: Last operations
+      empty: No operations found
+      status: Status
+      date: Date
+      type: Type
+      "profile name": Profile name
+      details: Details
+      job_type:
+        import: Import
+        export: Export
+        mass_edit: Mass edit
+        quick_export: Quick export
+        compute_product_models_descendants: Compute product models descendants
+        mass_delete: Mass delete products

--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en_NZ.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/jsmessages.en_NZ.yml
@@ -1,0 +1,119 @@
+Item deleted: Item deleted
+Are you sure you want to delete this item?: Are you sure you want to delete this item?
+Delete Error: Delete Error
+Are you sure you want to do remove selected items?: Are you sure you want to do remove selected items?
+Selected items were removed.: Selected items were removed.
+Selected items were not removed.: Selected items were not removed.
+Please, select items to remove.: Please, select items to remove.
+Cannot delete item.: Cannot delete item.
+Refresh Confirmation: Refresh Confirmation
+Your local changes will be lost. Are you sure you want to refresh grid?: Your local changes will be lost. Are you sure you want to refresh grid?
+Reset Confirmation: Reset Confirmation
+Your local changes will be lost. Are you sure you want to reset grid?: Your local changes will be lost. Are you sure you want to reset grid?
+Confirmation: Confirmation
+edit: edit
+copy: copy
+remove: remove
+Status: Status
+All: All
+Per page: Per page
+Mass Action Confirmation: Mass Action Confirmation
+Mass action performed.: Mass action performed.
+Mass action is not performed.: Mass action is not performed.
+Please, select items to perform mass action.: Please, select items to perform mass action.
+Execution Confirmation: Execution Confirmation
+Are you sure you want to do this?: Are you sure you want to do this?
+Action performed.: Action performed.
+Action is not performed.: Action is not performed.
+Please, select item to perform action.: Please, select item to perform action.
+View per page: View per page
+Enabled: Enabled
+Disabled: Disabled
+not_available: N/A
+Yes: true
+No: false
+oro.datagrid.entityHint: Entity
+oro.datagrid.noentities: No records found
+oro.datagrid.noresults: "Sorry, there is no result for your search."
+oro.datagrid.noresults_subTitle: "Try again with new search criteria."
+oro.datagrid.nocolumns: No columns configured for this grid
+oro.datagrid.pagination.label: "Page"
+oro.datagrid.pagination.totalPages: "of {{ totalPages }}"
+oro.datagrid.pagination.totalRecords: "{{ totalRecords }} records"
+oro.datagrid.action.reset: "Reset"
+oro.datagrid.action.refresh: "Refresh"
+oro_datagrid.select.all: "All"
+oro_datagrid.select.visible: "All visible"
+oro_datagrid.select.none: "None"
+oro_datagrid.select.select: "Select"
+pim.grid.ajax_choice_filter.label_empty: is empty
+pim.grid.ajax_choice_filter.label_not_empty: is not empty
+pim:
+  grid:
+    choice_filter:
+      label_contains: contains
+      label_does_not_contain: does not contain
+      label_equal: is equal to
+      label_start_with: starts with
+      label_empty: is empty
+      label_not_empty: is not empty
+      label_in_list: in list
+      operator: Operator
+    price_filter:
+      label: Currency
+    category_filter:
+      done: Done
+Available Columns: Available Columns
+Displayed Columns: Selected Columns
+datagrid_view.columns.min_message: You must select at least one datagrid column to display
+pim_datagrid:
+  column_configurator:
+    label: Columns
+    title: Configure columns
+    all_groups: All groups
+    search: Search
+    clear: Clear
+    displayed_columns: Selected Columns
+    apply: Apply
+    cancel: Cancel
+    remove_column: Remove
+    description: Select the information you want to display as column
+    attribute_groups: Attribute groups
+  mass_action:
+    delete:
+      confirm_title: Confirm deletion
+      confirm_ok: OK
+      empty_selection: No product selected
+pim.grid.mass_action.quick_export.title: Quick Export
+pim.grid.mass_action.quick_export.launched: Quick export has been launched
+pim.grid.action.launch.title: Launch
+pim.grid.action.show.title: Show
+Please select view: Please select view
+Loading...: Loading...
+View: View
+from: from
+to: to
+grid.view_selector:
+  default_view: Default view
+  save_changes: Save this view
+  remove: Delete this view
+  create_view: Create view
+  create: Create
+  search: Search
+  views: Views
+  placeholder: Name of new view
+  choose_label: Choose a label for the view
+  confirmation:
+    remove: Are you sure you want to delete this view?
+    delete: Confirm deletion
+grid.view_selector.flash.updated: Datagrid view successfully updated
+grid.display_selector:
+  label: Display
+  gallery: Gallery
+  list: List
+Client ID: Client ID
+Secret: Secret
+grid.empty_results:
+  associated_product:
+    hint: There are no associated products
+    subHint: 'Click on the button "Add associations" to associate this product'

--- a/src/Pim/Bundle/DataGridBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/DataGridBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,31 @@
+"oro_datagrid.no_data_hint %entityHint%": No %entityHint% exists.
+oro_datagrid.not_found_hint: Sorry, there is no result for your search.
+oro_datagrid.label_add_filter: Manage filters
+oro_datagrid.label_loading_mask: Loading . . .
+oro.grid.mass_action.selected_rows: Selected Rows
+oro.grid.mass_action.confirm_title: Mass Action Confirmation
+oro.grid.mass_action.confirm_content: Are you sure you want to do this?
+oro.grid.mass_action.confirm_ok: Yes, do it
+oro.grid.mass_action.error_title: Mass Action Error
+oro.grid.mass_action.error_content: Cannot perform mass action
+oro.grid.mass_action.delete.label: Delete
+oro.grid.mass_action.delete.confirm_title: Mass Delete Confirmation
+oro.grid.mass_action.delete.confirm_content: Are you sure you want to do delete selected items?
+oro.grid.mass_action.delete.item_limit: You cannot mass delete more than %limit% products (%count% selected)
+oro.grid.datagrid.page_size.all: All
+oro.grid.mass_action.delete.success_message: "{0} No entities were removed|{1} One entity was removed|]1,Inf[ %count% entities were removed"
+datagrid_view:
+  columns:
+    min_message: You must select at least one datagrid column to display
+  label:
+    unique_message: The label must be unique
+    not_blank_message: The label must not be blank
+grid.view_selector.flash:
+  created: Datagrid view successfully created
+  removed: Datagrid view successfully removed
+  not_removable: You don't have the rights to remove this view
+quick_export: Quick Export
+import: Import
+export: Export
+mass_edit: Mass Edit
+mass_delete: Mass Delete

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/init-translator.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/init-translator.js
@@ -11,7 +11,7 @@ define([
     ) {
         return {
             fetch: function () {
-                return $.getJSON('js/translation/' + UserContext.get('uiLocale').split('_')[0] + '.js')
+                return $.getJSON('js/translation/' + UserContext.get('uiLocale') + '.js')
                     .then(function (messages) {
                         Translator.fromJSON(messages);
                     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.ca.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.ca.yml
@@ -1502,3 +1502,5 @@ catalog_volume:
     count_variant_products: Variant de productes
     count_product_models: Models de producte
     warning: Uau! Ha superat un record amb aquest eix! No dubtis a contactar-nos en cas de necessitar ajuda amb aquest tipus de volum.
+  mean: 'Dir:'
+  max: 'Màxim:'

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_NZ.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/jsmessages.en_NZ.yml
@@ -1,0 +1,1506 @@
+confirmation:
+  title: Confirm
+  remove:
+    item: Are you sure you want to delete this item?
+    association_type: Are you sure you want to delete this association type?
+    attribute: Are you sure you want to delete this attribute?
+    attribute_group: Are you sure you want to delete this attribute group?
+    family: Are you sure you want to delete this family?
+    family_variant: Are you sure you want to delete this family variant ?
+    product: Are you sure you want to delete this product?
+    product_model: Are you sure you want to delete this product model? All its children, product models and variant products, will be also deleted.
+    channel: Are you sure you want to delete this channel?
+    group: Are you sure you want to delete this group?
+    group_type: Are you sure you want to delete this group type?
+    import_profile: Are you sure you want to delete this import profile?
+    export_profile: Are you sure you want to delete this export profile?
+    user: Are you sure you want to delete this user?
+    role: Are you sure you want to delete this role?
+    job_instance: Are you sure you want to delete this job instance?
+    api_connection: Are you sure you want to revoke this API connection? All API calls made through this connection will now throw an error.
+    products_and_product_models: Are you sure you want to delete the selected products and product models? All the product models' children will be also deleted.
+pim_datagrid:
+  mass_action_group:
+    bulk_actions:
+      label: Bulk Actions
+    quick_export:
+      label: Quick Export
+  mass_action:
+    delete:
+      label: Delete
+      confirm_content: Are you sure you want to delete the selected products?
+      success: Selected products successfully deleted.
+      error: Error ocurred when trying to delete selected products, please try again.
+  view_selector:
+    view: Views
+    create_view_modal:
+      create: Create
+      confirm: OK
+      cancel: Cancel
+flash:
+  item:
+    removed: Item successfully removed
+  association_type:
+    removed: Association type successfully removed
+  attribute:
+    removed: Attribute successfully removed
+  attribute_group:
+    removed: Attribute group successfully removed
+  family:
+    removed: Family successfully removed
+  family_variant:
+    removed: Family variant successfully removed
+  product:
+    removed: Product successfully removed
+  product_model:
+    removed: Product model successfully removed
+  channel:
+    removed: Channel successfully removed
+  group:
+    removed: Group successfully removed
+  group_type:
+    removed: Group type successfully removed
+  import profile:
+    removed: Import profile successfully removed
+  export profile:
+    removed: Export profile successfully removed
+  user:
+    removed: User successfully removed
+  role:
+    removed: Role successfully removed
+  job_instance:
+    removed: Job instance successfully removed
+  api_connection:
+    removed: API connection successfully revoked
+error:
+  common: An error occured
+  creating:
+    product: No attribute is configured as a product identifier or you don't have the rights to edit it.
+  removing:
+    item: Cannot delete this item
+    association_type: Cannot delete this association type
+    attribute: Cannot delete this attribute
+    family: Cannot delete this family
+    product: Cannot delete this product
+    channel: Cannot delete this channel
+    group: Cannot delete this group
+    group type: Cannot delete this group type
+    import profile: Cannot delete this import profile
+    export profile: Cannot delete this export profile
+    user: Cannot delete this user
+    role: Cannot delete this role
+    attribute_option: Error during deletion of the attribute option
+  saving:
+    attribute_option: Cannot save attribute option
+    export_profile: Cannot save export profile. Please check that all filters are well filled
+alert:
+  attribute_option:
+    error_occured_during_submission: An error occured during the form submission on the server
+    save_before_edit_other: Please register your modifications on other rows before editing this one
+  session_storage:
+    not_available: Your web browser does not seems compatible with sessionStorage. Please contact your administrator
+confirm:
+  attribute_option:
+    cancel_edition_on_new_option_text: Warning, you will lose unsaved data. Are you sure you want to cancel modification on this new option ?
+    cancel_edition_on_new_option_title: Cancel modification
+label:
+  attribute_option:
+    add_option: Add an option
+Code: Code
+Edit: Edit
+Delete: Delete
+Edit attributes of the product: Edit attributes of the product
+Classify the product: Classify the product
+Delete the product: Delete the product
+Change status: Change status
+Toggle status: Toggle status
+mass_delete: Mass delete
+pim:
+  grid:
+    mass_action:
+      quick_export:
+        csv_all: CSV (All attributes)
+        csv_grid_context: CSV (Grid context)
+        xlsx_all: Excel (All attributes)
+        xlsx_grid_context: Excel (Grid context)
+      delete: Delete
+      mass_edit: Bulk actions
+      category_edit: Move products in categories
+      sequential_edit: Sequential edit
+jstree.create: Create
+jstree.done: Done
+switch_on: "Yes"
+switch_off: "No"
+pim_enrich:
+  item:
+    list:
+      delete.label: Delete
+      delete.error: Error during item deletion
+    delete:
+      confirm.content: Are you sure you want to delete this {{ itemName }}? It is not possible to undo this action
+      confirm.title: Delete this {{ itemName }}
+  navigation:
+    link:
+      back_to_grid: Back to grid
+    other_actions: Other actions
+  entity:
+    save:
+      label: Save
+    info:
+      update_failed: Update failed
+      update_successful: Successfully updated
+    create_popin:
+      code: Code
+      label: Label
+      labels:
+        save: Save
+        cancel: Cancel
+    product:
+      navigation: Product navigation
+      infos: Product infos
+      index_title: "] -Inf, 1] {{ count }} result|] 1, Inf [{{ count }} results"
+      title: product
+      locale: Locale
+      category: Category
+      create: Create
+      subTitle: Create product
+      modalTitle: Select your action
+      filters: Filters
+      selected: selected results
+      common: Common
+      btn:
+        enabled: Enabled
+        disabled: Disabled
+        download_pdf: PDF
+        compare_translate: Compare / Translate
+        delete: Delete
+        save: Save
+      history:
+        version: Version
+        author: Author
+        logged_at: Logged at
+        from: From
+        modified: Modified
+        old_value: Old value
+        new_value: New value
+        actions: Actions
+      info:
+        deletion_successful: Product successfully deleted.
+        deletion_failed: The product could not be deleted.
+        update_successful: Product successfully updated.
+        update_failed: The product could not be updated.
+        field_not_ready: "The product cannot be saved right now. The following fields are not ready: {{ fields }}"
+        already_in_upload: A file is already in upload for this attribute in the locale "{{ locale }}" and scope "{{ scope }}"
+      error:
+        upload: An error occured during the file upload
+      meta:
+        created: Created
+        created_by: By
+        updated_by: By
+        updated: Last update
+        family:
+          title: Family
+          none: None
+        family_variant:
+          title: Variant
+          none: None
+        groups:
+          title: Groups
+          modal:
+            title: Group {{ group }}
+            view_group: View group
+            group_label: Label
+            more_products: '{{ count }} more products...'
+            close: Close
+        status: Status
+        scope: Channel
+        locale: Locale
+      copy:
+        select: Select
+        all: All
+        all_visible: All visible
+        none: None
+        copy: Copy
+      optional_attribute:
+        remove: Remove this attribute
+      locale_specific_attribute:
+        unavailable: This locale specific field is not available in this locale
+      localizable:
+        channel_locale_unavailable: This localizable field is not available for locale '{{ locale }}' and channel '{{ channel }}'
+      media:
+        upload: Drag and drop to upload or click here
+      create_popin:
+        type: Product
+        title: Create
+        labels:
+          family: Choose a family
+          family_variant: Choose a family variant
+          save: Save
+          cancel: Cancel
+      message:
+        created: Product successfully created
+      completeness: Complete
+      sequential_edit:
+        item_limit: Only first 1000 items shown in this sequential edit ({{ count }} selected)
+        empty: Your selection is empty, please change your search criteria
+    product_model:
+      create_popin:
+        type: Product model
+        title: Create a product model
+        content: A product model gathers variant products and eases the enrichment of their common properties.
+      info:
+        create_successful: Product model successfully created
+        update_successful: Product model successfully updated. The completeness of its variant products will be recalculated.
+        deletion_successful: Product model successfully deleted.
+        update_failed: The product model could not be updated.
+        field_not_ready: "The product model cannot be saved right now. The following fields are not ready: {{ fields }}"
+      read_only_parent_attribute_from_common: This attribute can be updated in the common attributes.
+      read_only_parent_attribute_from_model: "This attribute can be updated in the attributes by {{ axes }}"
+      variant_axis: Variant axis
+      title: product models
+      add_child:
+        create: Add new
+        cancel: Cancel
+        confirm: Confirm
+        create_label: "Add a new {{ axes }}"
+        fields:
+          required_label: (variant axis)
+          code: Code
+    association_type:
+      info:
+        deletion_successful: Association type successfully deleted.
+        deletion_failed: Association type could not be deleted.
+        update_successful: Association type successfully updated.
+        update_failed: The association type could not be updated.
+        field_not_ready: "The association type cannot be saved right now. The following fields are not ready: {{ fields }}"
+      meta:
+        created: Created
+        created_by: Created by
+        updated: Updated
+        updated_by: Updated by
+      btn:
+        save: Save
+      title: association type
+      create_popin:
+        title: Create
+      message:
+        created: Association type successfully created
+    group_type:
+      info:
+        deletion_successful: Group type successfully deleted.
+        deletion_failed: Group type could not be deleted.
+        update_successful: Group type successfully updated.
+        update_failed: The group type could not be updated.
+        field_not_ready: "The group type cannot be saved right now. The following fields are not ready: {{ fields }}"
+      meta:
+        created: Created
+        created_by: Created by
+        updated: Updated
+        updated_by: Updated by
+      btn:
+        save: Save
+      title: group type
+      create_popin:
+        title: Create
+      message:
+        created: Group type successfully created
+    channel:
+      title: channel
+      info:
+        deletion_successful: Channel successfully deleted.
+        deletion_failed: Channel could not be deleted.
+        update_successful: Channel successfully updated.
+        update_failed: The channel could not be updated.
+        create_successful: Channel successfully created.
+        create_failed: The channel could not be created.
+        field_not_ready: "The channel cannot be saved right now. The following fields are not ready: {{ fields }}"
+      meta:
+        created: Created
+        created_by: Created by
+        updated: Updated
+        updated_by: Updated by
+      btn:
+        save: Save
+    family:
+      title: family
+      selected: selected families
+      info:
+        update_successful: Family successfully updated.
+        create_successful: Channel successfully created.
+        update_failed: An error occured during family update.
+        cant_remove_attribute_as_label: Cannot remove attribute used as label
+        cant_remove_attribute_as_image: Cannot remove attribute used as the main picture
+        attribute_edit_permission_is_not_granted: You have no rights to edit family's attributes
+        cant_remove_attribute_used_as_axis: Cannot remove this attribute used as a variant axis in a family variant
+      meta:
+        created: Created
+        created_by: Created by
+        updated: Updated
+        updated_by: Updated by
+      btn:
+        save: Save
+      create_popin:
+        title: Create
+      message:
+        created: Family successfully created
+      variant:
+        common:
+          title: Common attributes
+          empty: There is no common attributes
+        axis.label: Variant axis
+        level_1.label: Variant attributes level one
+        level_2.label: Variant attributes level two
+        add_variant: Add variant
+        create_label: Create a new family variant
+        create_description: In a family variant, you can define a structure for products with variants. Choose the number of managed variant levels, the attributes used as variant axes for each level, and then define how the attributes are distributed.
+        update_description: Drag & drop attributes to the selected variant level to have these attributes managed at the variant level.
+        update_translation: Translate family variant label
+        create: Create
+        cancel: Cancel
+        code: Code
+        label: Label
+        levels: Variant levels
+        axis_level: Variant axis level
+        required: required
+        confirm_attribute_removal:
+          title: Confirm remove of attributes
+          message: By removing these attributes you will put them back in the common attributes of the family variant and remove the values from the variant products
+    family_variant:
+      info:
+        update_successful: Family variant successfully updated. The products with variants will be updated with your changes.
+    attribute_option:
+      code: Code
+      label: Label
+      actions: Actions
+    group:
+      title: Group
+      info:
+        deletion_successful: Group successfully deleted.
+        deletion_failed: Group could not be deleted.
+        update_successful: Group successfully updated.
+        update_failed: The group could not be updated.
+        field_not_ready: "The group cannot be saved right now. The following fields are not ready: {{ fields }}"
+      btn:
+        save: Save
+      meta:
+        product_count: Products
+        created: Created
+        created_by: Created by
+        updated: Updated
+        updated_by: Updated by
+      create_popin:
+        title: Create
+      message:
+        created: Group successfully created
+    job_instance:
+      title: job profile
+      info:
+        update_failed: The job profile could not be updated.
+        update_successful: The job profile has been successfully updated.
+    attribute:
+      info:
+        deletion_successful: Attribute successfully deleted.
+        deletion_failed: The attribute could not be deleted.
+        update_successful: Attribute successfully updated.
+        update_failed: The attribute could not be updated.
+        create_successful: Attribute successfully created.
+        create_failed: The attribute could not be created.
+        field_not_ready: "The attribute cannot be saved right now. The following fields are not ready: {{ fields }}"
+      scopable: Scopable
+      type:
+        pim_catalog_identifier: Identifier
+        pim_catalog_text: Text
+        pim_catalog_textarea: Text Area
+        pim_catalog_number: Number
+        pim_catalog_price_collection: Price
+        pim_catalog_multiselect: Multi select
+        pim_catalog_simpleselect: Simple select
+        pim_catalog_file: File
+        pim_catalog_image: Image
+        pim_catalog_boolean: "Yes/No"
+        pim_catalog_date: Date
+        pim_catalog_metric: Metric
+        pim_reference_data_simpleselect: Reference data simple select
+        pim_reference_data_multiselect: Reference data multi select
+      validation_rule:
+        email: E-mail
+        regexp: Regular expression
+        url: URL
+      title: attribute
+    attribute_group:
+      info:
+        update_failed: Attribute group could not be updated
+        update_successful: Attribute group successfully updated
+    api_connection:
+      create_popin:
+        title: Create
+      message:
+        created: API connection successfully created
+  confirmation:
+    leave: Are you sure you want to leave this page?
+    discard_changes: You will lose changes to the {{ entity }} if you leave the page.
+    delete_item: Confirm deletion
+    remove_item: Confirm removal
+    remove: Remove
+    delete:
+      attribute: Are you sure you want to delete this attribute from the product?
+      attribute_group: Are you sure you want to remove the attribute {{ attribute }} from this attribute group?
+      product_model: Confirm deletion
+  info:
+    not_applicable: N/A
+    entity:
+      updated: There are unsaved changes.
+  error:
+    upload: An error occured during the upload of the file
+  alert:
+    not_allowed: Forbidden. You are not allowed to access this page
+    error_occured: An error occured during the loading of the page
+  form:
+    required: (required)
+    product_model:
+      choose_product_model: Choose a product model
+      choose_variant: Choose a variant
+      complete_variant_product: variant product
+      complete_variant_products: variant products
+      family_variant: Variant
+      product_model: Product model
+      flash:
+        product_model_added: Product model successfully added to the product model
+        variant_product_added: Variant product successfully added to the product model
+    product:
+      tab:
+        associations:
+          title: Associations
+          info:
+            none_exist: No association types exist.
+            show_products: Display products
+            show_groups: Display groups
+            number_of_associations: "{{ productCount }} product(s), {{ productModelCount }} product model(s) and {{ groupCount }} group(s)"
+          association_type_selector: Association type
+          target: Target
+          manage: Add {{ associationType }} associations
+          manage_description: Select the products you want to associate with the current product
+          add_associations: Add associations
+        attributes:
+          title: Attributes
+          btn:
+            add: Add
+            add_attributes: Add attributes
+          info:
+            search_attributes: Search...
+            no_available_attributes: There are no more attributes to add
+            attributes_selected: "{{ itemsCount }} attribute(s) selected"
+            no_match: No matches found
+            load_more: Loading more results...
+          attribute_group_selector: Attribute group
+          attribute_group_all: All
+          attribute_group.to_fill_count: "{1}1 missing required attribute|]1, Inf [{{ count }} missing required attributes"
+          attribute_filter:
+            display: Display
+            all: All attributes
+            missing_required: All missing required attributes
+            at_this_level: All level specific attributes
+        categories:
+          title: Categories
+      panel:
+        completeness:
+          title: Completeness
+          info:
+            no_family: No family defined. Please define a family to calculate the completeness of this product.
+            no_completeness: You just changed the family of the product. Please save it first to calculate the completeness for the new family.
+          missing_values: "{1}1 missing value|] 1, Inf [{{ count }} missing values"
+        history:
+          title: History
+      switch:
+        "no": "No"
+        "yes": "Yes"
+      sequential_edit:
+        info:
+          products: products
+          previous: Skip back to {{ product }} without saving.
+          next: Skip to {{ product }} without saving.
+        btn:
+          save_and_next: Save and next
+          save_and_finish: Save and finish
+      change_family:
+        modal:
+          title: Change the product family
+          merge_attributes: Current attributes will be merged with the ones in the new family.
+          keep_attributes: No attributes will be removed.
+          change_family_to: Change the family to
+          empty_selection: Choose a family
+      flash:
+        attribute_deletion_error: An error occured during the attribute deletion
+      mass_edit:
+        select_attributes: Select attributes
+        select: Select
+    association_type:
+      tab:
+        properties:
+          title: Properties
+          general: General properties
+          code: Code
+          label_translations: Label translations
+        history:
+          title: History
+    group_type:
+      tab:
+        properties:
+          title: Properties
+          general: General properties
+          code: Code
+          label_translations: Label translations
+        history:
+          title: History
+    channel:
+      tab:
+        history:
+          title: History
+        properties:
+          title: Properties
+          general: General
+          code: Code
+          currencies: Currencies
+          locales: Locales
+          category_tree: Category tree
+          label_translations: Label translations
+          label_conversion_units: Pick a conversion unit for each metric attribute that will be used during product export
+          conversion_unit:
+            do_not_convert: Do not convert
+    family:
+      tab:
+        properties:
+          title: Properties
+          general: General
+          code: Code
+          attribute_as_label: Attribute used as label
+          attribute_as_image: Attribute used as the main picture
+          empty_attribute_as_image: Not selected
+          label_translations: Label translations
+        attributes:
+          title: Attributes
+          label_label: Label
+          toolbox:
+            select_attributes_by_groups: Add by groups
+            select_attributes: Add attributes
+            add: Add
+            attributes_groups_selected: '{{ itemsCount }} group(s) selected'
+          not_required_label: Not required
+          required_label: Required
+        variant:
+          title: Variants
+          flash:
+            family_variant_created: Family variant successfully created
+        history:
+          title: History
+    family_variant:
+      tab:
+        attributes:
+          title: Variant attributes
+        labels:
+          title: Label translations
+    attribute_option:
+      flash:
+        option_created: Attribute option successfully created
+        error_creating_option: An error ocurred when trying to create the attribute option
+      add_option_modal:
+        title: Add attribute option
+        confirm: Add
+        cancel: Cancel
+    entity:
+      switch:
+        "no": "No"
+        "yes": "Yes"
+    group:
+      tab:
+        properties:
+          title: Properties
+          general: General properties
+          code: Code
+          type: Type
+          label_translations: Label translations
+        history:
+          title: History
+        products:
+          title: Products
+    attribute_group:
+      tab:
+        properties:
+          title: Properties
+          general: General properties
+          code: Code
+          label_translations: Label translations
+        attribute:
+          title: Attributes
+          table:
+            name: Name
+            type: Type
+            scopable: Scopable
+            localizable: Localizable
+        history.title: History
+    common:
+      tab:
+        attributes:
+          btn:
+            add: Add
+            add_attributes: Add attributes
+          info:
+            search_attributes: Search...
+            no_available_attributes: There are no more attributes to add
+    job_execution:
+      loading: Loading...
+      title.details: Execution details
+      refreshBtn.title: Refresh
+      meta:
+        status.title: Status
+      button:
+        show_profile.title: Show profile
+        download_log.title: Download log
+        download_file.title: Download generated file
+        download_archive.title: Downlaod generated archive
+      summary:
+        fetching: Collecting data about job execution...
+        warning: Warning
+        header.step: Step
+        header.status: Status
+        header.warnings: Warnings
+        header.summary: Summary
+        header.start: Start
+        header.end: End
+    job_instance:
+      fail:
+        launch: Failed to launch the job profile. Make sure it is valid and that you have right to launch it.
+        save: Failed to save the job profile. Make sure that you have right to edit it.
+      title:
+        import: Import profile
+        export: Export profile
+      button:
+        edit.title: Edit
+        export.title: Export now
+        import.launch: Import now
+        import.upload: Upload and import now
+        import.upload_file: Upload a file
+      meta:
+        job: Job
+        connector: Connector
+      subsection:
+        last_executions: Last executions
+      tab:
+        content:
+          title: Content
+        properties:
+          title: Properties
+          code:
+            title: Code
+          label:
+            title: Label
+          decimal_separator:
+            title: Decimal separator
+            help: Determine the decimal separator
+          date_format:
+            title: Date format
+            help: Determine the format of date fields
+          file_path:
+            title: File path
+            help: Where to write the generated file on the file system
+          delimiter:
+            title: Delimiter
+            help: One character used to set the field delimiter
+          enclosure:
+            title: Enclosure
+            help: One character used to set the field enclosure
+          with_header:
+            title: With header
+            help: Whether or not to print the column name
+          with_media:
+            title: Export files and images
+            help: Whether or not to export product files and images
+          lines_per_file:
+            title: Number of lines per file
+            help: Define the limit number of lines per file
+          upload_allowed:
+            title: Allow file upload
+            help: Whether or not to allow uploading the file directly
+          categories_column:
+            title: Categories column
+            help: Name of the categories column
+          escape:
+            title: Escape
+            help: One character used to set the field escape
+          family_column:
+            title: Family column
+            help: Name of the family column
+          groups_column:
+            title: Groups column
+            help: Name of the groups column
+          enabled:
+            title: Enable the product
+            help: Whether or not imported product should be enabled
+          enabled_comparison:
+            title: Compare values
+            help: Enable the comparison between original values and imported values. Can speed up import if imported values are very similar to original values
+          real_time_versioning:
+            title: Real time history update
+            help: Means that the product history is automatically updated, can be switched off to improve performances
+          family_variant_column:
+            title: Family variant column
+        history:
+          title: History
+      file_path: File path
+    attribute:
+      meta:
+        created: Created
+        created_by: by
+        updated: Last update
+        updated_by: by
+      tab:
+        properties:
+          title: Properties
+          section:
+            common: General parameters
+            type_specific: Type specific parameters
+            validation: Validation parameters
+          label:
+            allowed_extensions: Allowed extensions
+            auto_option_sorting: Sort automatically options by alphabetical order
+            available_locales: Available locales
+            code: Code
+            date_max: Max date
+            date_min: Min date
+            decimals_allowed: Decimal values allowed
+            default_metric_unit: Default metric unit
+            group: Attribute group
+            is_locale_specific: Locale specific
+            localizable: Value per locale
+            max_characters: Max characters
+            max_file_size: Max file size (MB)
+            metric_family: Metric family
+            minimum_input_length: Minimum length for autocompletion
+            negative_allowed: Negative values allowed
+            number_max: Max number
+            number_min: Min number
+            reference_data_name: Reference data type
+            scopable: Value per channel
+            type: Type
+            unique: Unique value
+            useable_as_grid_filter: Usable in grid
+            validation_regexp: Regular expression
+            validation_rule: Validation rule
+            wysiwyg_enabled: Rich text editor enabled
+          default_label:
+            default_metric_unit: Choose a unit
+            group: Choose the attribute group
+            metric_family: Choose a family
+            reference_data_name: Choose the reference data type
+        labels:
+          title: Label translations
+        choices:
+          title: Options
+        history:
+          title: History
+    mass_edit:
+      family:
+        attributes:
+          label_label: Label
+          toolbox:
+            select_attributes_by_groups: Add by groups
+            select_attributes: Add attributes
+            add: Add
+            attributes_groups_selected: '{{ itemsCount }} group(s) selected'
+    basket:
+      title: Basket
+      empty_basket: Basket is empty
+  job:
+    upload: Drop your {{ type }} file here, or click to browse disk
+  export:
+    product:
+      data:
+        title: Filter the products
+      structure:
+        title: Filter the data
+        attributes:
+          title: Attributes
+      filter:
+        channel:
+          title: Channel
+          help: The channel defines the scope for product values, the locales used to select data, and the tree used to select products.
+        locales:
+          title: Locales
+          help: "The locales defines the localized product values to export. Ex: only product information in French."
+        attributes:
+          title: Attributes
+          edit: Edit
+          label: "{0}All attributes|{1}One attribute selected|]1,Inf[{{ count }} attributes selected"
+          help: "Select the product information to export. Ex: only the technical attributes."
+          empty: All attributes will be exported
+          modal:
+            apply: Apply
+            cancel: Cancel
+            title: Attribute selection
+        attributes_selector:
+          attribute_group: Attribute groups
+          attributes: "Search in {{ itemsCount }} attributes"
+          selected: "Selected attributes"
+          clear: Clear
+          all_group: All groups
+          empty_selection: All attributes will be exported
+          title: Attributes
+          description: Select the product information to export
+        family:
+          title: Family
+          help: "Select the products to export by their family. Ex: Export only the shoes and dresses."
+          operators:
+            IN: In list
+            "NOT IN": Not in list
+            EMPTY: Products that don't have a family
+            "NOT EMPTY": Products that have a family
+          empty_selection: No condition on families
+        updated:
+          title: Time condition
+          operators:
+            ALL: No date condition
+            "SINCE LAST N DAYS": Updated products over the last n days (e.g. 6)
+            ">": Updated products since this date
+            "SINCE LAST JOB": Updated products since last export
+        enabled:
+          title: Status
+          help: "Select the products to export by their status. Ex: Export products whatsoever their status."
+          value:
+            all: All
+            enabled: Enabled
+            disabled: Disabled
+        completeness:
+          title: Completeness
+          help: Select the products to export by their completeness.
+          operators:
+            ALL: No condition on completeness
+            "GREATER OR EQUALS THAN ON AT LEAST ONE LOCALE": Complete on at least one selected locale
+            "GREATER OR EQUALS THAN ON ALL LOCALES": Complete on all selected locales
+            LOWER THAN ON ALL LOCALES: Not complete on all selected locales
+            AT LEAST COMPLETE: At least one child product complete on one selected locale
+            ALL COMPLETE: All children products complete on all selected locales
+          empty_selection: Select a family
+        category:
+          title: Category
+          help: Use the product categories in the tree (defined by the channel above) to select the products to export
+        identifier:
+          title: Identifier
+          help: Use the product identifiers to export separated by commas, spaces or line breaks
+        metric:
+          operators:
+            "=": Is equal to
+            "!=": Is not equal to
+            ">=": Greater than or equals
+            ">": Greater than
+            "<=": Lower than or equals
+            "<": Lower than
+            EMPTY: Is empty
+            NOT EMPTY: Is not empty
+        string:
+          operators:
+            ALL: All
+            CONTAINS: Contains
+            DOES NOT CONTAIN: Does not contain
+            "=": Is equal to
+            STARTS WITH: Starts with
+            ENDS WITH: Ends with
+            EMPTY: Is empty
+            NOT EMPTY: Is not empty
+        price-collection:
+          operators:
+            "=": Is equal to
+            "!=": Is not equal to
+            ">=": Greater than or equals
+            ">": Greater than
+            "<=": Lower than or equals
+            "<": Lower than
+            EMPTY: Is empty
+            NOT EMPTY: Is not empty
+        multi_select:
+          operators:
+            IN: In list
+            EMPTY: Is empty
+            NOT EMPTY: Is not empty
+        media:
+          operators:
+            CONTAINS: Contains
+            DOES NOT CONTAIN: Does not contain
+            "=": Is equal to
+            STARTS WITH: Starts with
+            ENDS WITH: Ends with
+            EMPTY: Is empty
+            NOT EMPTY: Is not empty
+        date:
+          operators:
+            ">": Greater than
+            "<": Lower than
+            "=": Is equal to
+            "!=": Is not equal to
+            BETWEEN: Between
+            NOT BETWEEN: Not between
+            EMPTY: Is empty
+            NOT EMPTY: Is not empty
+        number:
+          operators:
+            "=": Is equal to
+            "!=": Is not equal to
+            ">=": Greater than or equals
+            ">": Greater than
+            "<=": Lower than or equals
+            "<": Lower than
+            EMPTY: Is empty
+            NOT EMPTY: Is not empty
+      properties:
+        title: Properties
+      global_settings:
+        title: Global settings
+  mass_edit_action:
+    edit_common_attributes:
+      description: Only the attributes belonging to the families of the selected products will be edited with the following data for the <span class="highlight">{{ locale }}</span> locale and the <span class="highlight">{{ channel }}</span> channel.
+  index:
+    association_type:
+      title: "] -Inf, 1] {{ count }} association type|] 1, Inf [{{ count }} association types"
+      create_btn: Create association type
+    import_profiles:
+      title: "] -Inf, 1] {{ count }} import profile|] 1, Inf [{{ count }} import profiles"
+      create_btn: Create import profile
+      list: Select a job
+      create_popin:
+        title: Create
+      message:
+        created: Import profile successfully created
+    import_history:
+      title: Import reports
+    group:
+      title: "] -Inf, 1] {{ count }} group|] 1, Inf [{{ count }} groups"
+      create_btn: Create group
+    export_profiles:
+      title: "] -Inf, 1] {{ count }} export profile|] 1, Inf [{{ count }} export profiles"
+      create_btn: Create export profile
+      create_popin:
+        title: Create
+      message:
+        created: Export profile successfully created
+    export_history:
+      title: Export reports
+    family:
+      title: "] -Inf, 1] {{ count }} family|] 1, Inf [{{ count }} families"
+      create_btn: Create family
+    grouptype:
+      title: "] -Inf, 1] {{ count }} group type|] 1, Inf [{{ count }} group types"
+      create_btn: Create group type
+    currency:
+      title: "] -Inf, 1] {{ count }} currency|] 1, Inf [{{ count }} currencies"
+    locale:
+      title: "] -Inf, 1] {{ count }} locale|] 1, Inf [{{ count }} locales"
+    user:
+      title: "] -Inf, 1] {{ count }} user|] 1, Inf [{{ count }} users"
+      create_btn: Create user
+    user_role:
+      title: "] -Inf, 1] {{ count }} role|] 1, Inf [{{ count }} roles"
+      create_btn: Create role
+    user_group:
+      title: "] -Inf, 1] {{ count }} group|] 1, Inf [{{ count }} groups"
+      create_btn: Create group
+    process_tracker:
+      title: "] -Inf, 1] {{ count }} operation|] 1, Inf [{{ count }} operations"
+    channel:
+      title: "] -Inf, 1] {{ count }} channel|] 1, Inf [{{ count }} channels"
+      create_btn: Create channel
+    attribute:
+      title: "] -Inf, 1] {{ count }} attribute|] 1, Inf [{{ count }} attributes"
+      create_btn: Create attribute
+      modal_title: Choose the attribute type
+    attribute_group:
+      title: Attribute groups
+      create_btn: Create
+    api_connection:
+      title: "] -Inf, 1] {{ count }} API connection|] 1, Inf [{{ count }} API connections"
+      create_btn: Create
+  mass_edit:
+    next: Next
+    previous: Back
+    cancel: Cancel
+    confirm: Confirm
+    product:
+      title: Products bulk action
+      confirm: "{1}You are about to update a product with the following information, please confirm.|] 1, Inf [You are about to update {{ itemsCount }} products with the following information, please confirm."
+      step:
+        select:
+          label: Choose products
+        choose:
+          title: Products bulk actions
+          label_count: "] 0, Inf [Select your action"
+        configure:
+          label: Configure
+        confirm:
+          label: Confirm
+        launch_error:
+          label: An error occured during the launching of the mass edit operation
+        launched:
+          label: The bulk action "{{ operation }}" has been launched. You will be notified when it is done.
+      operation:
+        change_status:
+          label: Change status
+          label_count: "{1}Change the status of <span class=\"AknFullPage-title--highlight\">1 product</span>|] 1, Inf [Change the status of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
+          description: The selected products will be enabled or disabled.
+          field: To enable
+        edit_common:
+          label: Edit attributes values
+          label_count: "{1}Edit attributes values of <span class=\"AknFullPage-title--highlight\">1 product</span>|] 1, Inf [Edit attributes values of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
+          description: Only the attributes belonging to the families of the selected products will be edited with the following data for the {{ locale }} locale and the {{ scope }} channel.
+        add_attribute_value:
+          label: Add attributes values
+          label_count: "{1}Add attributes values for <span class=\"AknFullPage-title--highlight\">1 product</span>|] 1, Inf [Add attributes values for <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
+          description: Only the multivalued attributes belonging to the families of the products will be edited with the following data for the {{ locale }} locale and the {{ scope }} channel. The attributes values are added, the previous values are kept.
+        change_family:
+          label: Change family
+          label_count: "{1}Change the family of <span class=\"AknFullPage-title--highlight\">1 product</span>|] 1, Inf [Change the family of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
+          description: The family of the selected products will be changed to the chosen family
+          field: Family
+        add_to_group:
+          label: Add to groups
+          label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to groups|] 1, Inf [Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to groups"
+          description: Select the groups in which to add the selected products
+          field: Groups
+        add_to_category:
+          label: Add to categories
+          label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to categories|] 1, Inf [Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to categories"
+          description: The products will be classified into following categories, the existing classification is kept.
+        move_to_category:
+          label: Move between categories
+          label_count: "{1}Move <span class=\"AknFullPage-title--highlight\">1 product</span> between categories|] 1, Inf [Move <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> between categories"
+          description: The products will be classified into following categories, the existing classification is lost.
+        remove_from_category:
+          label: Remove from categories
+          label_count: "{1}Remove <span class=\"AknFullPage-title--highlight\">1 product</span> from categories|] 1, Inf [Remove <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> from categories"
+          description: The products will be removed from the following categories.
+        add_to_existing_product_model:
+          label: Add to an existing product model
+          label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to an existing product model|] 1, Inf [Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to an existing product model"
+          description: The product model selected will gather the products and allows the enrichment of their common properties.
+        associate_to_product_and_product_model:
+          label: Associate
+          label_count: "{1}Associate <span class=\"AknFullPage-title--highlight\">1 product</span> to products or product models|] 1, Inf [Associate <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to products or product models"
+          description: The products selected in the grid will be associated to the selected products and product models for the chosen association type
+          validate: Please add association before going to the next step
+        change_parent_product_model:
+          label: Change the parent product model
+          label_count: "{1}Change parent product model of <span class=\"AknFullPage-title--highlight\">1 product</span>|] 1, Inf [Change parent product model of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
+          description: The parent of the variant products or sub-product models selected in the grid will be changed to the chosen product model.
+    family:
+      title: Families bulk action
+      confirm: "{1}You are about to update a family with the following information, please confirm.|] 1, Inf [You are about to update {{ itemsCount }} families with the following information, please confirm."
+      step:
+        select:
+          label: Choose families
+        choose:
+          title: Families bulk actions
+          label_count: "] 0, Inf [Select your action"
+        configure:
+          label: Configure
+        confirm:
+          label: Confirm
+        launched:
+          label: The bulk action "{{ operation }}" has been launched. You will be notified when it is done.
+      operation:
+        set_requirements:
+          label: Set attributes requirements
+          description: The following attributes requirements will be applied to the selected families
+          label_count: "{1}Set attributes requirements of <span class=\"AknFullPage-title--highlight\">1 family</span>|] 1, Inf [Set attributes requirements of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} families</span>"
+pim_enrich.error:
+  exception.title: Oh snap! A {{ status_code }} error occured...
+  http:
+    403: Forbidden. You are not allowed to access this page
+page_title:
+  oro_default: Dashboard
+  pim_enrich_attributegroup_index: Attribute groups
+  pim_enrich_attributegroup_create: Attribute groups | Create
+  pim_enrich_attributegroup_edit: Attribute group {{ group.label }} | Edit
+  pim_enrich_catalog_volume_index: Catalog volume monitoring
+  pim_enrich_categorytree_index: Category trees
+  pim_enrich_categorytree_create: Category trees | Create
+  pim_enrich_categorytree_edit: Category tree {{ category.label }} | Edit
+  pim_enrich_categorytree_create_tree: Category trees | Create
+  pim_enrich_attribute_index: Attributes
+  pim_enrich_attribute_create: Attributes | Create
+  pim_enrich_attribute_edit: Attribute {{ attribute.label }} | Edit
+  pim_enrich_product_index: Products
+  pim_enrich_product_edit: Product {{ product.label }} | Edit
+  pim_enrich_product_model_edit: Product model {{ product.label }} | Edit
+  pim_enrich_family_index: Families
+  pim_enrich_family_edit: Family {{ family.label }} | Edit
+  pim_enrich_channel_index: Channels
+  pim_enrich_channel_create: Channels | Create
+  pim_enrich_channel_edit: Channel {{ channel.label }} | Edit
+  pim_enrich_currency_index: Currencies
+  pim_enrich_locale_index: Locales
+  pim_enrich_group_index: Groups
+  pim_enrich_group_edit: Group {{ group.label }} | Edit
+  pim_enrich_associationtype_index: Association types
+  pim_enrich_associationtype_edit: Association type {{ association type.label }} | Edit
+  pim_enrich_grouptype_index: Group types
+  pim_enrich_grouptype_edit: Group type {{ group type.label }} | Edit
+  pim_enrich_mass_edit_action_choose: Mass Edit | Choose
+  pim_enrich_mass_edit_action_configure: Mass Edit | Configure
+  pim_enrich_mass_edit_action_perform: Mass Edit | Perform
+  pim_enrich_job_tracker_index: Process tracker
+  pim_enrich_job_tracker_show: Process tracker | Show job
+  pim_enrich_api_connection_index: API connections
+  pim_enrich_api_connection_create: API connections | Create
+  pim_enrich_mass_edit_action: Mass Edit
+  pim_analytics_system_info_index: System information
+batch_jobs:
+  add_product_value:
+    label: Add product value
+    perform:
+      label: Add product value
+  update_product_value:
+    label: Update product value
+    perform:
+      label: Update product value
+  add_to_group:
+    label: Add to group
+    perform:
+      label: Add to group
+  edit_common_attributes:
+    label: Edit attributes
+    perform:
+      label: Edit attributes
+    cleaner:
+      label: Clean files for attributes
+  add_to_category:
+    label: Add to category
+    perform:
+      label: Add to category
+  move_to_category:
+    label: Move to category
+    perform:
+      label: Move to category
+  remove_from_category:
+    label: Remove from category
+    perform:
+      label: Remove from category
+  add_association:
+    label: Associate
+    perform:
+      label: Associate
+  add_to_existing_product_model:
+    label: Add to an existing product model
+    perform:
+      label: Add to an existing product model
+  set_attribute_requirements:
+    label: Set attributes requirements
+    perform:
+      label: Set attributes requirements
+  csv_product_quick_export:
+    quick_export.label: CSV product quick export
+    quick_export_product_model.label: CSV product model quick export
+    perform:
+      label: CSV product quick export
+  csv_product_grid_context_quick_export:
+    quick_export.label: CSV product grid context quick export
+    quick_export_product_model.label: CSV product model grid context quick export
+    perform:
+      label: CSV product grid context quick export
+  xlsx_product_quick_export:
+    quick_export.label: XSLX product quick export
+    quick_export_product_model.label: XSLX product model quick export
+    perform:
+      label: XSLX product quick export
+  xlsx_product_grid_context_quick_export:
+    quick_export.label: XSLX product grid context quick export
+    quick_export_product_model.label: XSLX product model grid context quick export
+    perform:
+      label: XSLX product grid context quick export
+  csv_product_export:
+    label: Product export in CSV
+    export.label: Product export
+  csv_product_model_export:
+    label: Product model export in CSV
+    export.label: Product export
+  csv_category_export:
+    label: Category export in CSV
+    export.label: Category export
+  csv_attribute_export:
+    label: Attribute export in CSV
+    export.label: Attribute export
+  csv_attribute_option_export:
+    label: Attribute option export in CSV
+    export.label: Attribute option export
+  csv_association_type_export:
+    label: Association type export in CSV
+    export.label: Association type export
+  csv_group_export:
+    label: Group export in CSV
+    export.label: Group export
+  csv_family_export:
+    label: Family export in CSV
+    export.label: Family export
+  csv_family_variant_export:
+    label: Family variant export in CSV
+    export.label: Family variant export
+  csv_product_import:
+    label: Product import in CSV
+    validation.label: File validation
+    import.label: Product import
+    import_associations.label: Association import
+  csv_product_model_import:
+    label: Product model import in CSV
+  csv_category_import:
+    label: Category import in CSV
+    validation.label: File validation
+    import.label: Category import
+  csv_attribute_import:
+    label: Attribute import in CSV
+    validation.label: File validation
+    import.label: Attribute import
+  csv_attribute_option_import:
+    label: Attribute option import in CSV
+    validation.label: File validation
+    import.label: Attribute option import
+  csv_association_type_import:
+    label: Association type import in CSV
+    validation.label: File validation
+    import.label: Association type import
+  csv_family_import:
+    label: Family import in CSV
+    validation.label: File validation
+    import.label: Family import
+    compute_data_related_to_family_variants.label: Compute product models data
+    compute_data_related_to_family_root_product_models.label: Compute root product models data
+    compute_data_related_to_family_sub_product_models.label: Compute sub product models data
+    compute_data_related_to_family_products.label: Compute products data
+  csv_family_variant_import:
+    label: Family variant import in CSV
+    validation.label: File validation
+    import.label: Family variant import
+  csv_group_import:
+    label: Group import in CSV
+    validation.label: File validation
+    import.label: Group import
+  csv_channel_export:
+    label: Channel export in CSV
+    export.label: Channel export
+  csv_locale_export:
+    label: Locale export in CSV
+    export.label: Locale export
+  csv_attribute_group_export:
+    label: Attribute group export in CSV
+    export.label: Attribute group export
+  csv_currency_export:
+    label: Currency export in CSV
+    export.label: Currency export
+  csv_group_type_export:
+    label: Group type export in CSV
+    export.label: Group type export
+  csv_channel_import:
+    label: Channel import in CSV
+    validation.label: File validation
+    import.label: Channel import
+  csv_locale_import:
+    label: Locale import in CSV
+    validation.label: File validation
+    import.label: Locale import
+  csv_attribute_group_import:
+    label: Attribute group import in CSV
+    validation.label: File validation
+    import.label: Attribute group import
+  csv_currency_import:
+    label: Currency import in CSV
+    validation.label: File validation
+    import.label: Currency import
+  csv_group_type_import:
+    label: Group type import in CSV
+    validation.label: File validation
+    import.label: Group type import
+  xlsx_category_import:
+    label: Category import in XLSX
+    validation.label: File validation
+    import.label: Category import
+  xlsx_association_type_import:
+    label: Association type import in XLSX
+    validation.label: File validation
+    import.label: Association type import
+  xlsx_attribute_import:
+    label: Attribute import in XLSX
+    validation.label: File validation
+    import.label: Attribute import
+  xlsx_attribute_option_import:
+    label: Attribute option import in XLSX
+    validation.label: File validation
+    import.label: Attribute option import
+  xlsx_family_import:
+    label: Family import in XLSX
+    validation.label: File validation
+    import.label: Family import
+    compute_data_related_to_family_variants.label: Compute product models data
+    compute_data_related_to_family_root_product_models.label: Compute root product models data
+    compute_data_related_to_family_sub_product_models.label: Compute sub product models data
+    compute_data_related_to_family_products.label: Compute products data
+  xlsx_family_variant_import:
+    label: Family variant import in XLSX
+    validation.label: File validation
+    import.label: Family variant import
+  xlsx_product_export:
+    label: Product export in XLSX
+    export.label: Product export
+  xlsx_product_model_export:
+    label: Product model export in XLSX
+    export.label: Product model export
+  xlsx_product_import:
+    label: Product import in XLSX
+    validation.label: File validation
+    import.label: Product import
+    import_associations.label: Association import
+  xlsx_product_model_import:
+    label: Product model import in XSLX
+  xlsx_group_export:
+    label: Group export in XLSX
+    export.label: Group export
+  xlsx_group_import:
+    label: Group import in XLSX
+    validation.label: File validation
+    import.label: Group import
+  xlsx_family_export:
+    label: Family export in XLSX
+    export.label: Family export
+  xlsx_family_variant_export:
+    label: Family variant export in XLSX
+    export.label: Family variant export
+  xlsx_category_export:
+    label: Category export in XLSX
+    export.label: Category export
+  xlsx_attribute_export:
+    label: Attribute export in XLSX
+    export.label: Attribute export in XLSX
+  xlsx_attribute_option_export:
+    label: Attribute option export in XLSX
+    export.label: Attribute option export in XLSX
+  xlsx_association_type_export:
+    label: Association type export in XLSX
+    export.label: Association type export in XLSX
+  xlsx_channel_export:
+    label: Channel export in XLSX
+    export.label: Channel export
+  xlsx_locale_export:
+    label: Locale export in XLSX
+    export.label: Locale export
+  xlsx_attribute_group_export:
+    label: Attribute group export in XLSX
+    export.label: Attribute group export
+  xlsx_currency_export:
+    label: Currency export in XLSX
+    export.label: Currency export
+  xlsx_group_type_export:
+    label: Group type export in XLSX
+    export.label: Group type export
+  xlsx_channel_import:
+    label: Channel import in XLSX
+    validation.label: File validation
+    import.label: Channel import
+  xlsx_locale_import:
+    label: Locale import in XLSX
+    validation.label: File validation
+    import.label: Locale import
+  xlsx_attribute_group_import:
+    label: Attribute group import in XLSX
+    validation.label: File validation
+    import.label: Attribute group import
+  xlsx_currency_import:
+    label: Currency import in XLSX
+    validation.label: File validation
+    import.label: Currency import
+  xlsx_group_type_import:
+    label: Group type import in XLSX
+    validation.label: File validation
+    import.label: Group type import
+job_tracker:
+  download_archive:
+    archive: Download generated archive
+    output: Download generated files
+    input: Download read files
+    invalid_xlsx: Download invalid data
+    invalid_csv: Download invalid data
+pim_menu:
+  tab:
+    activity: Activity
+    imports: Imports
+    products: Products
+    exports: Exports
+    settings: Settings
+    system: System
+    help:
+      title: Help
+      helper: Akeneo Help center
+  item:
+    association_type: Association types
+    attribute: Attributes
+    attribute_group: Attribute groups
+    category: Categories
+    channel: Channels
+    currency: Currencies
+    dashboard: Dashboard
+    family: Families
+    group: Groups
+    group_type: Group types
+    locale: Locales
+    product: Products
+    product_model: Product Models
+    published_product: Published Products
+    export_history: Exports history
+    export_profile: Export profiles
+    import_history: Imports history
+    import_profile: Import profiles
+    configuration: Configuration
+    catalog_volume: Catalog volume monitoring
+    user_management: Users Management
+    user: Users
+    user_group: Groups
+    user_role: Roles
+    info: System information
+    job_tracker: Process tracker
+    api_connection: API connections
+  navigation:
+    activity: Activity navigation
+    system: System navigation
+    user: Users management navigation
+    settings: Settings navigation
+  user:
+    logout: Logout
+    user_account: My Account
+pim_notification:
+  mark_all_as_read: Mark all as read
+  no_notifications: No notifications
+  loading: Loading...
+catalog_volume:
+  product_values: "You have <span>{{values}}</span> product values in your PIM! On average, it's <span>{{average}}</span> product values per product!&nbsp;💪"
+  product_values_description: 'The more product values you have, the more valuable your PIM is, the higher your ROI is! More details <a href="{{link}}" target="_blank">here</a>'
+  section:
+    product_values:
+      hint: 'Did you know that the total number of product values in your PIM is directly linked to the following axes?<br/>To have more details, we invite you to <a href="{{link}}" target="_blank">browse this article</a>.'
+      title: Axes that leverage the number of product values
+    catalog_structure:
+      hint: You may know that a good catalog structure is really important and is a condition to efficient enrichment. Below are the various axes to monitor your catalog structure.
+      title: Axes related to the catalog structure
+    variant_modelling:
+      hint: If you are using the variant modeling, here are the axes to help you monitor your volume.
+      title: Axes regarding the variant modeling
+  axis:
+    count_products: Products
+    average_max_attributes_per_family: Attributes per family
+    count_channels: Channels
+    count_locales: Locales (activated)
+    count_scopable_attributes: Scopable attributes
+    count_localizable_and_scopable_attributes: Localizable and scopable attributes
+    count_localizable_attributes: Localizable attributes
+    count_families: Families
+    count_attributes: Attributes
+    average_max_options_per_attribute: Options by attribute
+    count_categories: Categories
+    count_category_trees: Category trees
+    count_variant_products: Variant products
+    count_product_models: Product models
+    warning: Wow! You hit a record with this axis! Don't hesitate to contact us if you need any help with this kind of volume.
+  mean: 'Mean:'
+  max: 'Max:'

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,876 @@
+pim_enrich:
+  product:
+    tab:
+      attribute.title: Attributes
+      category.title: Categories
+      association.title: Associations
+      completeness.title: Completeness
+      history.title: History
+    no_comparison_locale_available: No other locale is available for comparison
+    no_compared_media: No media available for comparison
+  attribute:
+    tab:
+      parameter.title: Parameters
+      value.title: Values
+      history.title: History
+  attribute_group:
+    tab:
+      property.title: Properties
+      attribute.title: Attributes
+      history.title: History
+  family:
+    info:
+      cant_remove_attribute_used_as_axis: Cannot remove this attribute used as a variant axis in a family variant
+    tab:
+      property.title: Properties
+      attribute.title: Attributes
+      history.title: History
+  association_type:
+    tab:
+      property.title: Properties
+      history.title: History
+  group_type:
+    tab:
+      property.title: Properties
+  category:
+    tab:
+      property.title: Properties
+      history.title: History
+  locale:
+    tab:
+      property.title: Properties
+      permission.title: Permissions
+  group:
+    axis.help: 'Axis define the attributes over which the products of the group should vary. Axis are attributes with options, not localizable and not scoped. They cannot be changed after the creation of the variant group.'
+    type:
+      VARIANT: Variant
+      X_SELL: X-Sell
+      ADDITIONAL: Additional
+      RELATED: Related
+    tab:
+      product.title: Products
+      property.title: Properties
+      history.title: History
+  completeness:
+    progress_bar.title: '%ratio%% complete (1 required value)|%ratio%% complete (%count% required values)'
+    subtitle: '{0} Complete|{1} 1 missing value|]1,Inf] %count% missing values'
+    missing_attributes: Missing value|Missing values
+    legend:
+      locale_not_associated: Locale not associated to this channel
+  mass_edit_action:
+    limit_exceeded: Please choose less than %limit% items to edit
+    product:
+      page_title: Products
+      page_subtitle: Mass Edit (1 product)|Mass Edit (%count% products)
+      title: Choose operation
+      subtitle: Choose the operation you wish to perform on the selected product|Choose the operation you wish to perform on the selected %count% products
+      confirm: You are about to update a product with the following information, please confirm.|You are about to update %count% products with the following information, please confirm.
+      steps:
+        first: Choose products
+        second: Choose operation
+        third: Configure
+        fourth: Confirm
+    family:
+      page_title: Families
+      page_subtitle: Mass Edit (1 family)|Mass Edit (%count% families)
+      title: Choose operation
+      subtitle: Choose the operation you wish to perform on the selected family|Choose the operation you wish to perform on the selected %count% families
+      confirm: You are about to update a family with the following information, please confirm.|You are about to update %count% families with the following information, please confirm.
+      steps:
+        first: Choose families
+        second: Choose operation
+        third: Configure
+        fourth: Confirm
+    change-status:
+      label: Change status
+      description: The selected products will be enabled or disabled.
+      success_flash: Product(s) status have been changed
+      launched_flash: The bulk action "change status" has been launched. You will be notified when it is done.
+    edit-common-attributes:
+      label: Edit attributes
+      description: The selected product's attributes will be edited with the following data for the chosen locale.
+      empty: Please select the attribute(s) you want to edit
+      success_flash: The job updating product(s) status is currently running
+      launched_flash: The bulk action "edit attributes" has been launched. You will be notified when it is done.
+      message:
+        warning: There is no attribute in common for the selected products. Please change your selection.
+        invalid_attribute: Attribute with code "attribute_code" is not common to selected products, attribute skipped.
+        no_valid_attribute: None of selected attribute can be applied on this product.
+    classify-add:
+      label: Add to categories
+      description: The products will be positioned into following categories, the existing placement is kept.
+      success_flash: Product(s) have been classified into selected categories
+      launched_flash: The bulk action "add to categories" has been launched. You will be notified when it is done.
+    classify-move:
+      label: Move between categories
+      description: The products will be positioned into following categories, the existing placement is lost.
+      success_flash: Product(s) have been moved to selected categories
+      launched_flash: The bulk action "move to categories" has been launched. You will be notified when it is done.
+    classify-remove:
+      label: Remove from categories
+      description: The products will be removed from the following categories.
+      success_flash: Product(s) have been removed from the selected categories
+      launched_flash: The bulk action "remove from categories" has been launched. You will be notified when it is done.
+    change-family:
+      label: Change family
+      description: The family of the selected products will be changed to the chosen family
+      success_flash: The family of selected product(s) has been successfully changed
+      launched_flash: The bulk action "change family" has been launched. You will be notified when it is done.
+    add-to-groups:
+      label: Add to groups
+      description: Select the groups in which to add the selected products
+      success_flash: Products were successfully added to the selected groups
+      launched_flash: The bulk action "add to groups" has been launched. You will be notified when it is done.
+      no_group: No group for now. Please start by creating a group.
+    set-attribute-requirements:
+      label: Set attributes requirements
+      description: The following attribute requirements will be applied to the selected families
+      success_flash: Attribute requirements were applied to the selected families
+      launched_flash: The bulk action "set attribute requirements" is launched. You will be notified when it will be done.
+    mass_action:
+      quick_export:
+        launched_flash: The job exporting products is currently running
+  sequential_edit_action:
+    product:
+      previous: Skip back to "%product%" without saving.
+      next: Skip to "%product%" without saving.
+  acl:
+    locale:
+      index: List locales
+    currency:
+      index: List currencies
+      toggle: Toggle currencies
+    product:
+      index: List products
+      create: Create a product
+      edit_attributes: Edit attributes of a product
+      remove: Remove a product
+      add_attribute: Add an attribute to a product
+      remove_attribute: Remove an attribute from a product
+      categories_view: Consult the categories of a product
+      associations_view: View the associations of a product
+      associations_edit: Add associations to a product
+      change_family: Change product family
+      change_state: Change state of product
+      add_to_groups: Add product to groups
+      mass_edit: Product mass edit actions
+      comment: Comment products
+      download: Download the product as PDF
+      history: View product history
+    product_model:
+      create: Create a product model
+      edit_attributes: Edit attributes of a product model
+      categories_view: Consult the categories of a product model
+      history: View product model history
+      remove: Remove a product model
+    category:
+      list: List categories
+      create: Create a category
+      edit: Edit a category
+      remove: Remove a category
+      move: Move category
+      children: See category children
+      products: See category's products
+      history: View category history
+    channel:
+      index: List channels
+      create: Create a channel
+      edit: Edit a channel
+      remove: Remove a channel
+      history: View channel history
+    family:
+      index: List families
+      create: Create a family
+      edit_properties: Edit properties of a family
+      edit_attributes: Edit attributes of a family
+      edit_variants: Edit a family variant
+      remove: Remove a family
+      history: View family history
+    family_variant:
+      remove: Remove a family variant
+    attribute_group:
+      index: List attribute groups
+      create: Create an attribute group
+      edit: Edit an attribute group
+      remove: Remove an attribute group
+      sort: Sort attribute groups
+      add_attribute: Add attribute to a group
+      remove_attribute: Remove attribute from a group
+      history: View attribute group history
+    attribute:
+      index: List attributes
+      create: Create an attribute
+      edit: Edit an attribute
+      remove: Remove an attribute
+      sort: Sort attributes inside attribute groups
+      history: View attribute history
+    group:
+      index: List groups
+      create: Create a group
+      edit: Edit a group
+      remove: Remove a group
+      history: View group history
+    group_type:
+      index: List group types
+      create: Create a group type
+      edit: Edit a group type
+      remove: Remove a group type
+    association_type:
+      index: List association types
+      create: Create an association type
+      edit: Edit an association type
+      remove: Remove an association type
+      history: View association type history
+    association:
+      remove: Remove associations to a product
+    job_tracker:
+      index: View process tracker
+    api_connection:
+      manage: Manage the API connections
+  acl_group:
+    association_type: Association types
+    attribute: Attributes
+    attribute_group: Attribute groups
+    category: Categories
+    channel: Channels
+    currency: Currencies
+    family: Families
+    group: Groups
+    group_type: Group types
+    locale: Locales
+    product: Products
+    product_model: Product models
+  reference_data:
+    empty_value:
+      reference_data_type:
+        label: Choose the reference data type
+  notification:
+    settings:
+      remove_completeness_for_channel_and_locale:
+        start: The locale has been removed from the channel. We are currently cleaning completenesses linked to them.
+        done: Removal of a locale on a channel finished.
+attribute:
+  title: attribute
+  edit: edit attribute
+  create: create attribute
+attribute group:
+  title: attribute group
+  overview: attribute group overview
+  create: create attribute group
+  edit: edit attribute group
+  suggest creation: Please select an attribute group on the left
+  or: or
+  create new: Create a new attribute group
+category:
+  title: category
+  overview: Categories
+  create: create category
+  edit: edit category
+  suggest selection: Please select a category on the left
+  or: or
+  create new: Create a new category
+tree:
+  title: tree
+  create: create tree
+  edit: edit tree
+channel:
+  title: channel
+  overview: channel overview
+  create: create channel
+  edit: edit channel
+currency:
+  title: currency
+  create: create currency
+  edit: edit currency
+family:
+  title: family
+  edit: edit family
+locale:
+  title: locale
+  create: create locale
+  edit: edit locale
+product:
+  title: product
+  overview: product overview
+  create: create product
+  edit: edit product
+group:
+  title: group
+  edit: edit group
+group type:
+  title: group type
+  edit: edit group type
+association type:
+  title: association type
+  create: create association type
+  edit: edit association type
+products: products
+btn:
+  create:
+    attribute: create attribute
+    attribute group: create attribute group
+    category: create category
+    tree: create tree
+    channel: create channel
+    currency: create currency
+    family: create family
+    locale: create locale
+    product: create product
+    group: create group
+    association type: create association type
+    group type: create group type
+    drag_or_upload: Drag and drop to upload or click here
+  edit: edit
+  save: save
+  save and create: save and create new
+  save and next: save and next
+  save and finish: save and finish
+  remove: remove
+  delete: delete
+  cancel: cancel
+  next: next
+  back: back
+  confirm: confirm
+  to grid: back to grid
+  to parent: back to parent
+  download_pdf: PDF
+  download: download
+confirmation:
+  confirm: Confirmation
+  delete: Confirm deletion
+  leave: Are you sure you want to leave this page?
+  discard changes: You will lose changes to the %entity% if you leave the page.
+  remove:
+    item: Are you sure you want to delete this item?
+    attribute: Are you sure you want to delete the attribute %name%?
+    attribute group: Are you sure you want to delete the attribute group %name%?
+    category: Are you sure you want to delete the category %name%?
+    family: Are you sure you want to delete the family %name%?
+    family_variant: Are you sure you want to delete the family variant %name%?
+    product: Are you sure you want to delete the product %name%?
+    group: Are you sure you want to delete the group %name%?
+    group type: Are you sure you want to delete the group type %name%?
+    user: Are you sure you want to delete the user %name%?
+  attribute group:
+    remove attribute: Are you sure you want to remove the attribute %name% from this attribute group?
+  family:
+    remove attribute: Are you sure you want to remove the attribute %name% from this family?
+  product:
+    remove attribute: Are you sure you want to remove the attribute %name% from this product?
+flash:
+  entity:
+    removed: Item was deleted
+  attribute:
+    created: Attribute successfully created
+    updated: Attribute successfully updated
+    removed: Attribute successfully removed
+    identifier_not_removable: Identifier attribute can not be removed
+  attribute group:
+    created: Attribute group successfully created
+    updated: Attribute group successfully updated
+    removed: Attribute group successfully removed
+    attributes added: Attributes successfully added to the attribute group
+    attribute removed: Attribute successfully removed from the attribute group
+    not removed attributes: Attribute group can't be removed as it contains attributes
+    not removed default: Default attribute group can't be removed
+    not removed default attributes: Attribute can't be removed from the default attribute group
+  category:
+    created: Category successfully created
+    updated: Category successfully updated
+    removed: Category successfully removed
+  tree:
+    created: Tree successfully created
+    updated: Tree successfully updated
+    removed: Tree successfully removed
+    not removable: Trees associated to channels cannot be removed.
+  currency:
+    updated: Currency successfully updated
+    error.linked_to_channel: You cannot disable a currency linked to a channel.
+  family:
+    updated: Family successfully updated
+    removed: Family successfully removed
+    identifier not removable: Identifier attribute can not be removed from a family
+    label attribute not removable: This attribute can not be removed because it is used as the label of the family
+    attribute not found: The attribute does not belong to this family
+    attributes added: Attributes successfully added to the family
+    attribute removed: Attribute successfully removed from the family
+  product:
+    created: Product successfully created
+    updated: Product successfully updated
+    removed: Product successfully removed
+    invalid: Please check your entry and try again
+    attributes added: Attributes successfully added to the product
+    attribute removed: Attribute successfully removed from the product
+    attribute not removable: The attribute can not be removed from this product
+    enabled: Product has been enabled
+    disabled: Product has been disabled
+  group:
+    updated: Group successfully updated
+    removed: Group successfully removed
+  group type:
+    created: Group type successfully created
+    updated: Group type successfully updated
+    removed: Group type successfully removed
+    cant remove used: Group type is used by some groups and can't be removed
+  association type:
+    created: Association type successfully created
+    updated: Association type successfully updated
+    removed: Association type successfully removed
+  user:
+    removed: User successfully removed
+  error ocurred: Action failed. Please retry.
+info:
+  updated: There are unsaved changes.
+  category:
+    remove children: All sub-categories will be deleted.
+    keep products: Products in these categories will not be deleted.
+    products limit exceeded: This category contains more products than allowed for this operation (%limit% products maximum)
+  product:
+    no available attributes: There are no more attributes to add
+    no family defined: No family defined
+    change family: Change the product family
+    change family to: Change the family to
+    merge attributes: Current attributes will be merged with the ones in the new family.
+    keep attributes: No attributes will be removed.
+    number of associations: '%productCount% products and %groupCount% groups'
+    enable: Enable
+    enabled: Enabled
+    disable: Disable
+    disabled: Disabled
+  group:
+    axis: 'Variation axis: %attributes%'
+    select products: Please select products that should belong to this group.
+    selectable products: The following selectable products have a defined value for each axis.
+    no group types: No group types exist, click here to create one
+    more products: '%count% more products...'
+  association type:
+    show products: Show products
+    show groups: Show groups
+    remove from products: Deleting the association type will remove it from %count% products.
+    none exist: No association types exist.
+    create one: Click here to create one
+  attribute:
+    auto option sorting: If enabled, options will be sorted automatically by their localized labels
+  completeness:
+    not calculated: Not yet calculated
+Options: Options
+Created at: Created at
+Updated at: Updated at
+Created: Created
+Updated: Updated
+Last update: Last update
+by: By
+N/A: N/A
+Manage products: Manage products
+Manage groups: Manage groups
+Code: Code
+Name: Name
+Type: Type
+Scope: Channel
+Required: Required
+Unique: Unique
+Not required: Not required
+Translatable: Translatable
+Scopable: Scopable
+Localizable: Localizable
+Unique value: Unique value
+Attribute group: Attribute group
+Other: Other
+Variants behavior when edited: Variants behavior when edited
+Edit: Edit
+Remove: Remove
+Delete: Delete
+Parameters: Parameters
+System: System
+Values: Values
+General parameters: General parameters
+Backend parameters: Backend parameters
+Label: Label
+Default label: Default label
+Default value: Default value
+Attributetype: Attribute type
+Attribute type: Attribute type
+Defaultvalue: Default value
+Variant: Variant
+Smart: Smart
+Useable as grid column: Usable as grid column
+Useable as grid filter: Usable in grid
+Family: Family
+Image: Image
+Variant products: Variant products
+Available locales: Available locales
+Locale specific: Locale specific
+default: Default
+Axis: Axis
+Add attributes: Add attributes
+Translate from: Translate from
+switch_on: "Yes"
+switch_off: "No"
+Close: Close
+Search: Search
+Choose the attribute type: Choose the attribute type
+Choose the attribute group: Choose the attribute group
+Drag and drop a file or click here: Drag and drop a file or click here
+Drop an image or click here: Drop an image or click here
+Automatic option sorting: Automatic option sorting
+save_attribute_before_manage_option: To manage options, please save the attribute first
+Please select: Please select
+Active: Active
+Inactive: Inactive
+Do not convert: Do not convert
+Create: Create
+Cancel: Cancel
+Choose a family: Choose a family
+Choose a unit: Choose a unit
+No matches found: No matches found
+Category tree: Category tree
+Completeness: Completeness
+Attribute used as label: Attribute used as label
+Credentials: Credentials
+Global: Global
+Channel: Channel
+Expand all channels: Expand all channels
+Collapse all channels: Collapse all channels
+Always override: Always override
+Ask: Ask
+General Properties: General Properties
+Group values: Group values
+New group: New group
+Groups overview: Groups overview
+'Y-m-d h:i:s': 'Y-m-d h:i:s'
+Max characters: Max characters
+Validation rule: Validation rule
+Validation regexp: Validation regexp
+Wysiwyg enabled: WYSIWYG enabled
+Number min: Min number
+Number max: Max number
+Decimals allowed: Allow decimals
+Negative allowed: Allow negative values
+Date min: Min date
+Date max: Max date
+Metric family: Metric family
+Default metric unit: Default metric unit
+Max file size: Max file size (MB)
+Allowed extensions: Allowed extensions
+None: None
+E-mail: E-mail
+URL: URL
+Regular expression: Regular expression
+Minimum input length: Minimum input length
+Default: Default
+Attributes: Attributes
+Title: Title
+pim_title.attribute_group:
+  index: "Attribute groups"
+  create: "Attribute groups | Create"
+  edit: "Attribute groups %group.label% | Edit"
+pim_title.category:
+  index: "Category trees"
+  create: "Category trees | Create"
+  edit: "Category trees %category.label% | Edit"
+pim_title.attribute:
+  index: "Attributes"
+  create: "Attributes | Create"
+  edit: "Attributes %attribute.label% | Edit"
+pim_title.product:
+  index: "Products"
+  edit: "Products %product.label% | Edit"
+pim_title.family:
+  index: "Families"
+  edit: "Families %family.label% | Edit"
+pim_title.channel:
+  index: "Channels"
+  create: "Channels | Create"
+  edit: "Channels %channel.label% | Edit"
+pim_title.currency:
+  index: "Currencies"
+pim_title.locale:
+  index: "Locales"
+pim_title.group:
+  index: "Groups"
+  edit: "Groups %group.label% | Edit"
+pim_title.association_type:
+  index: "Association types"
+  edit: "Association types %association type.label% | Edit"
+pim_title.group_type:
+  index: "Group types"
+  edit: "Group types %group type.label% | Edit"
+pim_title.mass_edit_product_action:
+  choose: "Mass Edit | Choose"
+  configure: "Mass Edit | Configure"
+pim_title.mass_edit_family_action:
+  choose: "Mass Edit | Choose"
+  configure: "Mass Edit | Configure"
+pim_title.job_tracker:
+  index: Process tracker
+  show: "Process tracker | Show job"
+pim_title.dashboard: "Dashboard"
+pim_catalog_identifier: Identifier
+pim_catalog_text: Text
+pim_catalog_textarea: Text Area
+pim_catalog_number: Number
+pim_catalog_price_collection: Price
+pim_catalog_multiselect: Multi select
+pim_catalog_simpleselect: Simple select
+pim_catalog_file: File
+pim_catalog_image: Image
+pim_catalog_boolean: "Yes/No"
+pim_catalog_date: Date
+pim_catalog_metric: Metric
+pim_reference_data_simpleselect: Reference data simple select
+pim_reference_data_multiselect: Reference data multi select
+Activated: Activated
+Disable: Disable
+pim_enrich.sequential_edit_action:
+  product:
+    previous: Skip back to "%product%" without saving.
+    next: Skip to "%product%" without saving.
+pim_enrich.mass_edit_action:
+  limit_exceeded: Please choose less than %limit% items to edit
+  product:
+    page_title: Products
+    page_subtitle: Mass Edit (1 product)|Mass Edit (%count% products)
+    title: Choose operation
+    subtitle: Choose the operation you wish to perform on the selected product|Choose the operation you wish to perform on the selected %count% products
+    confirm: You are about to update a product with the following information, please confirm.|You are about to update %count% products with the following information, please confirm.
+    steps:
+      first: Choose products
+      second: Choose operation
+      third: Configure
+      fourth: Confirm
+  family:
+    page_title: Families
+    page_subtitle: Mass Edit (1 family)|Mass Edit (%count% families)
+    title: Choose operation
+    subtitle: Choose the operation you wish to perform on the selected family|Choose the operation you wish to perform on the selected %count% families
+    confirm: You are about to update a family with the following information, please confirm.|You are about to update %count% families with the following information, please confirm.
+    steps:
+      first: Choose families
+      second: Choose operation
+      third: Configure
+      fourth: Confirm
+  change-status:
+    label: Change status
+    description: The selected products will be enabled or disabled.
+    success_flash: Product(s) status have been changed
+  edit-common-attributes:
+    label: Edit attributes
+    description: The selected product's attributes will be edited with the following data for the chosen locale.
+    empty: Please select the attribute(s) you want to edit
+    success_flash: Product(s) attribute(s) have been updated
+    message.warning: There is no attribute in common for the selected products. Please change your selection.
+    no_attribute.warning: There is no attribute in common for the selected products. Please change your selection.
+  classify:
+    label: Add to categories
+    description: The products will be positioned into following categories, the existing placement is kept.
+    success_flash: Product(s) have been classified into selected categories
+  change-family:
+    label: Change family
+    description: The family of the selected products will be changed to the chosen family
+    success_flash: The family of selected product(s) has been successfully changed
+    no_family: No family
+  add-to-groups:
+    label: Add to groups
+    description: Select the groups in which to add the selected products
+    success_flash: Products were successfully added to the selected groups
+  set-attribute-requirements:
+    label: Set attributes requirements
+    description: The following attribute requirements will be applied to the selected families
+    success_flash: Attribute requirements were applied to the selected families
+To enable: To enable
+Select attributes: Select attributes
+Select: Select
+Remove this attribute: Remove this attribute
+Copy: Copy
+Current tab: Current tab
+Group: Group
+View group: View group
+Products: Products
+Properties: Properties
+History: History
+pane.accordion:
+  node_values: Node values
+  general_properties: General properties
+  locale_values: Locale values
+  backend_parameters: Backend parameters
+  general_parameters: General parameters
+  validation_parameters: Validation parameters
+  label_translations: Label translations
+  options: Options
+  group_values: Group values
+popin.create:
+  association_type.title: Create a new association type
+  group.title: Create a new group
+  product.title: Create a new product
+  option.title: Create a new option
+In group: In group
+Attribute as label: Attribute as label
+Is associated: Is associated
+Complete: Complete
+Created At: Created at
+Updated At: Updated at
+Enabled: Enabled
+Disabled: Disabled
+Status: Status
+Change History: Change history
+Data Audit: Data audit
+Data Audit - System: 'Data audit - system'
+Action: Action
+Version: Version
+Entity type: Entity type
+Entity name: Entity name
+Entity id: Entity id
+Data: Data
+Author: Author
+Logged at: Logged at
+Deleted: Deleted
+Old values: Old values
+New values: New values
+System configuration: System configuration
+General setup: General setup
+Localization: Localization
+Localization options: Localization options
+Locale: Locale
+Location: Location
+Format address by address country: Format address by address country
+Language: Language
+Timezone: Timezone
+Currency: Currency
+settings: Settings
+oro.locale:
+  address_format:
+    region_name_type:
+      parish: "parish"
+      state: "state"
+      island: "island"
+      county: "county"
+      area: "area"
+      prefecture: "prefecture"
+      department: "department"
+      district: "district"
+      province: "province"
+  form:
+    tooltip:
+      locale: "Select the locale option used to format numbers, addresses, names and dates"
+      location: " Location will be used to format addresses when 'Format address by address country' option is disabled"
+      format_address_by_address_country: "Selecting this option will enabled addresses to be formatted by the country they are in. Disabeling this option will cause the addresses to be formatted in your location address format"
+      language: "Select the system language you wish to use"
+      timezone: "Select the timezone for displaying date and time"
+      currency: "Select the default currency"
+Selected products successfully deleted: Selected products successfully deleted
+pim_mass_edit:
+  notification:
+    mass_edit:
+      error: Mass edit <strong>%label%</strong> failed
+      warning: Mass edit <strong>%label%</strong> finished with some warnings
+      success: Mass edit <strong>%label%</strong> finished
+    quick_export:
+      error: Quick export <strong>%label%</strong> failed
+      warning: Quick export <strong>%label%</strong> finished with some warnings
+      success: Quick export <strong>%label%</strong> finished
+    mass_delete:
+      error: Mass delete <strong>%label%</strong> failed
+      warning: Mass delete <strong>%label%</strong> finished with some warnings
+      success: Mass delete <strong>%label%</strong> finished
+job_execution.summary:
+  mass_edited: Mass edited
+  skip: Skipped
+  skipped_products: Skipped products
+  skipped_attributes: Skipped attributes
+  skipped_families: Skipped families
+  deleted_products: Deleted products
+  deleted_product_models: Deleted product models
+pim_mass_edit_execution_show: Mass edit executions | Details
+edit_common_attributes.steps.edit_common_attributes_processor.title: Edit attributes
+update_product_value.steps.update_product_value_processor.title: Update product value
+remove_product_value.steps.update_product_value_processor.title: Remove product value
+edit_common_attributes: Edit attributes
+edit_common_attributes_clean: Clean files for attributes
+perform.steps.duplicated.title: Duplicated Axis
+perform.steps.excluded.title: Excluded product
+batch_jobs:
+  add_product_value:
+    label: Add product value
+    perform:
+      label: Add product value
+  update_product_value:
+    label: Update product value
+    perform:
+      label: Update product value
+  add_attribute_value:
+    label: Add attributes value
+    perform:
+      label: Add attributes value
+  edit_common_attributes:
+    label: Edit attributes
+    perform:
+      label: Edit attributes
+    clean:
+      label: Clean files for attributes
+    cleaner:
+      label: Clean files for attributes
+  compute_completeness_of_products_family:
+    compute_completeness_of_products_family.label: Compute completeness
+  add_to_category:
+    label: Add to category
+    perform:
+      label: Add to category
+  move_to_category:
+    label: Move to category
+    perform:
+      label: Move to category
+  remove_from_category:
+    label: Remove from category
+    perform:
+      label: Remove from category
+  add_association:
+    label: Associate
+    perform:
+      label: Associate
+  add_to_existing_product_model:
+    label: Add to an existing product model
+    perform:
+      label: Add to an existing product model
+  set_attribute_requirements:
+    label: Set attributes requirements
+    perform:
+      label: Set attributes requirements
+  csv_product_quick_export:
+    quick_export.label: Csv product quick export
+    perform:
+      label: Csv product quick export
+  csv_product_grid_context_quick_export:
+    quick_export.label: Csv product grid context quick export
+    perform:
+      label: Csv product grid context quick export
+  xlsx_product_quick_export:
+    quick_export.label: Xlsx product quick export
+    perform:
+      label: Xlsx product quick export
+  xlsx_product_grid_context_quick_export:
+    quick_export.label: Xlsx product grid context quick export
+    perform:
+      label: Xlsx product grid context quick export
+  delete_products_and_product_models:
+    delete_products_and_product_models.label: Mass delete products
+  change_parent_product:
+    perform:
+      label: Change parent product model
+mass_edit report:
+  overview: Mass edit reports
+job_tracker:
+  tab:
+    title: Process tracker
+  filter:
+    started_at: Started at
+pim_enrich_attribute_form:
+  code: Code
+  type: Attribute Type
+  reference_data_name: Reference data name
+  scopable: Value per channel
+  localizable: Value per locale
+  unique: Unique value
+  availableLocales: Available locales
+  locale_specific: Locale specific
+  group: Attribute group
+  useableAsGridFilter: Usable in grid

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/validators.en_NZ.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/validators.en_NZ.yml
@@ -1,0 +1,3 @@
+mass_edit:
+  edit_common_attributes:
+    invalid_values: There are errors in the attributes form

--- a/src/Pim/Bundle/FilterBundle/Resources/translations/jsmessages.en_NZ.yml
+++ b/src/Pim/Bundle/FilterBundle/Resources/translations/jsmessages.en_NZ.yml
@@ -1,0 +1,14 @@
+Close: Close
+Update: Update
+Now: Now
+Selected Rows: Selected rows
+more than: More than
+less than: Less than
+before: before
+after: after
+from: from
+to: to
+and: and
+system_filter_group: System
+oro_filter.filters.manage: Manage filters
+oro_filter.placeholder.all: All

--- a/src/Pim/Bundle/FilterBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/FilterBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,21 @@
+oro.filter.form.label_type_equal: '='
+oro.filter.form.label_type_greater_equal: '>='
+oro.filter.form.label_type_greater_than: '>'
+oro.filter.form.label_type_less_equal: '<='
+oro.filter.form.label_type_less_than: '<'
+oro.filter.form.label_type_yes: "yes"
+oro.filter.form.label_type_no: "no"
+oro.filter.form.label_type_contains: contains
+oro.filter.form.label_type_not_contains: does not contain
+oro.filter.form.label_type_equals: is equal to
+oro.filter.form.label_type_start_with: starts with
+oro.filter.form.label_type_end_with: ends with
+oro.filter.form.label_type_empty: is empty
+oro.filter.form.label_type_not_empty: is not empty
+oro.filter.form.label_type_in_list: in list
+oro.filter.form.label_date_type_between: between
+oro.filter.form.label_date_type_not_between: not between
+oro.filter.form.label_date_type_more_than: more than
+oro.filter.form.label_date_type_less_than: less than
+oro.filter.form.label_not_selected: Not selected
+oro.filter.form.label_selected: Selected

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_NZ.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_NZ.yml
@@ -1,0 +1,29 @@
+job_execution:
+  summary:
+    display_item: Display item
+    hide_item: Hide item
+pim_connector:
+  export:
+    categories:
+      selector:
+        modal:
+          title: Categories selection
+          cancel: Cancel
+          confirm: Confirm
+        label: "{0} All products|{1} One category selected|]1,Inf[ {{ count }} categories selected"
+        edit: Edit
+        title: Select categories
+    locales:
+      validation:
+        not_blank: One locale must be selected, please choose a locale to export.
+page_title:
+  pim_importexport_export_profile_index: Export profiles management
+  pim_importexport_export_profile_edit: Export profile {{ job.label }} | Edit
+  pim_importexport_export_profile_show: Export profile {{ job.label }} | Show
+  pim_importexport_export_execution_index: Export executions history
+  pim_importexport_export_execution_show: Export executions | Details
+  pim_importexport_import_profile_index: Import profiles management
+  pim_importexport_import_profile_edit: Import profile {{ job.label }} | Edit
+  pim_importexport_import_profile_show: Import profile {{ job.label }} | Show
+  pim_importexport_import_execution_index: Import executions history
+  pim_importexport_import_execution_show: Import executions | Details

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,154 @@
+Job: Job
+Connector: Connector
+pim_import_export:
+  job: Job
+  connector: Connector
+  status:
+    0: Ready
+  batch_status:
+    1: Completed
+    2: Starting
+    3: Started
+    4: Stopping
+    5: Stopped
+    6: Failed
+    7: Abandoned
+    8: Unknown
+  download_archive:
+    archive: download generated archive|download generated archives
+    output: download generated file|download generated files
+    input: download read file|download read files
+    invalid_xlsx: download invalid data
+    invalid_csv: download invalid data
+  notification:
+    export:
+      error: Export <strong>%label%</strong> failed
+      warning: Export <strong>%label%</strong> finished with some warnings
+      success: Export <strong>%label%</strong> finished
+    import:
+      error: Import <strong>%label%</strong> failed
+      warning: Import <strong>%label%</strong> finished with some warnings
+      success: Import <strong>%label%</strong> finished
+  list: Select a job
+  job_profile:
+    tab:
+      property.title: General properties
+      history.title: History
+      job_content.title: Content
+pim_title.export_profile.index: Export profiles management
+pim_title.export_profile.edit: Export profile %job.label% | Edit
+pim_title.export_profile.show: Export profile %job.label% | Show
+pim_title.export_execution.index: Export executions history
+pim_title.export_execution.show: Export executions | Details
+pim_title.import_profile.index: Import profiles management
+pim_title.import_profile.edit: Import profile %job.label% | Edit
+pim_title.import_profile.show: Import profile %job.label% | Show
+pim_title.import_execution.index: Import executions history
+pim_title.import_execution.show: Import executions | Details
+export profile:
+  title: export profile
+  edit: edit export profile
+import profile:
+  title: import profile
+  edit: edit import profile
+pim_importexport:
+  acl:
+    export_profile:
+      index: View export profiles list
+      create: Create an export profile
+      show: Show an export profile
+      edit: Edit an export profile
+      remove: Remove an export profile
+      launch: Launch an export profile
+      property_edit: Edit an export profile general properties
+      property_show: Show an export profile general properties
+      history: View export profile history
+      content_edit: Edit an export profile content
+      content_show: Show an export profile content
+    import_profile:
+      index: View import profiles list
+      create: Create an import profile
+      show: Show an import profile
+      edit: Edit an import profile
+      remove: Remove an import profile
+      launch: Launch an import profile
+      history: View import profile history
+    export_execution:
+      index: View export reports list
+      show: View export report details
+      dl_log: Download export report log
+      dl_files: Download exported files
+    import_execution:
+      index: View import reports list
+      show: View import report details
+      dl_log: Download import report log
+      dl_files: Download imported files
+  acl_group:
+    export: Export profiles
+    import: Import profiles
+btn:
+  create:
+    export profile: create export profile
+    import profile: create import profile
+Upload and import now: Upload and import now
+import now: Import now
+export now: Export now
+confirmation:
+  remove:
+    export profile: Are you sure you want to delete the export profile %name%?
+    import profile: Are you sure you want to delete the import profile %name%?
+flash:
+  export:
+    created: The export has been successfully created
+    removed: The export has been removed
+    updated: The export has been successfully updated
+    running: The export is running
+  import:
+    created: The import has been successfully created
+    removed: The import has been removed
+    updated: The import has been successfully updated
+    running: The import is running
+General properties: General properties
+History: History
+pane.accordion:
+  properties: Properties
+  global_settings: Global settings
+  filters: Filters
+popin.create:
+  export_profile.title: Create a new export profile
+  import_profile.title: Create a new import profile
+'Display item': Display item
+'Hide item': Hide item
+'Collecting data about job execution...': Collecting data about job execution...
+'You must select a file to upload': You must select a file to upload
+Download log: Download log
+Show profile: Show profile
+execution details: execution details
+job_execution.summary:
+  read: read
+  write: written
+  skip: skipped
+  create: created
+  update: updated
+  update_products: updated products
+  skip_products: skipped products
+  displayed: first warnings displayed
+  charset_validator:
+    title: 'File encoding:'
+    skipped: skipped, extension in white list
+Step: Step
+Status: Status
+Warnings: Warnings
+Summary: Summary
+Start: Start
+End: End
+set_attribute_requirements: Set attributes requirements
+COMPLETED: Completed
+STARTING: Starting
+STARTED: Started
+STOPPING: Stopping
+STOPPED: Stopped
+FAILED: Failed
+ABANDONED: Abandoned
+UNKNOWN: Unknown
+warning.label: Warning

--- a/src/Pim/Bundle/ImportExportBundle/Resources/translations/validators.en_NZ.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/translations/validators.en_NZ.yml
@@ -1,0 +1,4 @@
+This directory is not writable: This directory is not writable.
+This directory is not valid: This directory is not valid.
+pim_import_export.job_instance.unknown_job_definition: Failed to create an %job_type% with an unknown job definition
+This code is already taken: This code is already taken

--- a/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
@@ -75,7 +75,8 @@ class AssetsCommand extends ContainerAwareCommand
             ->runCommand('oro:assetic:dump')
             ->runCommand('pim:installer:dump-require-paths')
             ->runCommand('pim:installer:dump-extensions');
-        $defaultLocales = ['en', 'fr', 'nl', 'de', 'ru', 'ja', 'pt', 'it'];
+        // TODO On the merge to master, it will fail; just remove the 2-letters locales.
+        $defaultLocales = ['en', 'fr', 'nl', 'de', 'ru', 'ja', 'pt', 'it', 'en_NZ', 'pt_PT', 'pt_BR'];
         $this->commandExecutor->runCommand('oro:translation:dump', ['locale' => implode(', ', $defaultLocales)]);
 
         if (true === $input->getOption('symlink')) {

--- a/src/Pim/Bundle/NavigationBundle/Resources/translations/jsmessages.en_NZ.yml
+++ b/src/Pim/Bundle/NavigationBundle/Resources/translations/jsmessages.en_NZ.yml
@@ -1,0 +1,4 @@
+"Sorry, page was not loaded correctly": "Sorry, page was not loaded correctly"
+"Your local changes will be lost. Are you sure you want to refresh the page?": "Your local changes will be lost. Are you sure you want to refresh the page?"
+"navigation.message.content.outdated": "Content of {{ title }} page is outdated, please <a href='#' data-action='page-refresh'>refresh the page</a>"
+"Content of pinned page is outdated": "Content of pinned page is outdated"

--- a/src/Pim/Bundle/NotificationBundle/Resources/translations/jsmessages.en_NZ.yml
+++ b/src/Pim/Bundle/NotificationBundle/Resources/translations/jsmessages.en_NZ.yml
@@ -1,0 +1,2 @@
+pim_notification:
+  report: Report

--- a/src/Pim/Bundle/NotificationBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/NotificationBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,3 @@
+pim_notification:
+  no_notifications: No new notifications
+  mark_all_as_read: Mark all as read

--- a/src/Pim/Bundle/UIBundle/Resources/translations/jsmessages.en_NZ.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/translations/jsmessages.en_NZ.yml
@@ -1,0 +1,119 @@
+Close: Close
+Update: Update
+Selected Rows: Selected Rows
+"Yes": "Yes"
+"Yes, Delete": "Yes, Delete"
+"Yes, I Agree": "Yes, I Agree"
+"Yes, do it": "Yes, do it"
+"No": "No"
+"Ok, got it.": "Ok, got it."
+"Cancel": "Cancel"
+"Delete Confirmation": "Delete Confirmation"
+"Edit": "Edit"
+"Unexpected error occured. Please contact system administrator.": "Unexpected error occured. Please contact system administrator."
+"Yes, revoke": "Yes, Revoke"
+"Revoke Confirmation": "Revoke Confirmation"
+Now: Now
+Prev: Prev
+Next: Next
+Today: Today
+Wk: Wk
+Done: Done
+AM: AM
+A: A
+PM: PM
+P: P
+"Choose Time": "Choose Time"
+Time: Time
+Hour: Hour
+Minute: Minute
+Second: Second
+Millisecond: Millisecond
+Microsecond: Microsecond
+"Time Zone": "Time Zone"
+Localized value: Localized value
+Columns: Columns
+Datagrid Configuration: Datagrid Configuration
+Apply: Apply
+Action: Action
+Unit: Unit
+Currency: Currency
+jstree:
+  all: All products
+  unclassified: Unclassified products
+  product:
+    all: All products
+    unclassified: Unclassified products
+  no_tree: No tree available
+  include_sub: Include sub-categories
+  loading: Loading ...
+datetimepicker:
+  days:
+    Sunday: Sunday
+    Monday: Monday
+    Tuesday: Tuesday
+    Wednesday: Wednesday
+    Thursday: Thursday
+    Friday: Friday
+    Saturday: Saturday
+  daysShort:
+    Sun: Sun
+    Mon: Mon
+    Tue: Tue
+    Wed: Wed
+    Thu: Thu
+    Fri: Fri
+    Sat: Sat
+  daysMin:
+    Su: Su
+    Mo: Mo
+    Tu: Tu
+    We: We
+    Th: Th
+    Fr: Fr
+    Sa: Sa
+  months:
+    January: January
+    February: February
+    March: March
+    April: April
+    May: May
+    June: June
+    July: July
+    August: August
+    September: September
+    October: October
+    November: November
+    December: December
+  monthsShort:
+    Jan: Jan
+    Feb: Feb
+    Mar: Mar
+    Apr: Apr
+    May: May
+    Jun: Jun
+    Jul: Jul
+    Aug: Aug
+    Sep: Sep
+    Oct: Oct
+    Nov: Nov
+    Dec: Dec
+oro_config:
+  form:
+    config:
+      title: System configuration
+      tab:
+        system:
+          title: System
+      group:
+        localization:
+          title: Localization
+          system_locale: Language
+        notification:
+          title: Notifications
+          system_notification: New versions notifications
+        loading_message:
+          title: Loading messages
+          label: Enable loading messages
+        loading_messages:
+          label: Available loading messages

--- a/src/Pim/Bundle/UIBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,49 @@
+User: User
+Run demo: Run demo
+Product: Product
+Attribute list: Attribute list
+Attribute Group list: Attribute Group list
+Users: Users
+Roles: Roles
+Groups: Groups
+Configuration: Configuration
+Currency list: Currency list
+Locale list: Locale list
+Logged in as: Logged in as
+Logout: Logout
+Login: Login
+Previous: Previous
+Next: Next
+Channel list: Channel list
+Select file: Select file
+Change file: Change file
+Remove file: Remove file
+Delete: Delete
+Save: Save
+Cancel: Cancel
+Get help: Get help
+My User: My Account
+oro.form.choose_value: Choose a value...
+Read more: Read more
+oro.form.click_here_to_select: Click here to select...
+Add: Add
+"Learn how to use this space": "Learn how to use this space"
+"How To Use Pinbar": "How To Use Pinbar"
+Pinbar: Pinbar
+Favorites: Favorites
+Most Viewed: Most Viewed
+"Add this page to favorites": "Add this page to favorites"
+"Minimize the window to the pinbar": "Minimize the window to the pinbar"
+"Loading ...": "Loading ..."
+"Yes": "Yes"
+"No": "No"
+required: (required)
+pim_ui.system_config:
+  form:
+    loading_message_enabled.label: Enable loading messages
+    loading_message_enabled.tooltip: Display user friendly messages while waiting for a page to load
+    loading_messages.label: Available loading messages
+    loading_messages.tooltip: All available loading messages separated by line breaks
+  group:
+    loading_message.title: Loading messages
+other_actions: Other actions

--- a/src/Pim/Bundle/UserBundle/Resources/translations/config.en_NZ.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/translations/config.en_NZ.yml
@@ -1,0 +1,6 @@
+entity.user.name: User
+entity.user.description: User profile
+entity.role.name: Role
+entity.role.description: user role
+entity.group.name: Group
+entity.group.description: Role group

--- a/src/Pim/Bundle/UserBundle/Resources/translations/messages.en_NZ.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/translations/messages.en_NZ.yml
@@ -1,0 +1,159 @@
+pim_user:
+  user:
+    tab:
+      general.title: General
+      additional.title: Additional
+      group_and_role.title: Groups and Roles
+      password.title: Password
+      business_unit.title: Business Units
+      email_synchronization.title: Email synchronization settings
+      interfaces.title: Interfaces
+  group:
+    tab:
+      general.title: General
+      users.title: Users
+oro.user.controller:
+  group.message.saved: "Group saved"
+  role.message.saved: "Role saved"
+  user.message.saved: "User saved"
+  status.message.saved: "Status saved"
+oro.user.grid.users:
+  columns:
+    username: "Username"
+    email: "Email"
+    firstName: "First name"
+    lastName: "Last name"
+    createdAt: "Created at"
+    updatedAt: "Updated at"
+    enabled: "Status"
+oro.user.grid.roles:
+  columns:
+    label: "Label"
+oro.user.grid.groups:
+  columns:
+    name: "Name"
+pim_title:
+  user.index: Users
+  user_role.index: Roles
+  user_group.index: Groups
+  system_configuration.index: Configuration
+user.title: User
+user.overview: User
+Users Management: Users Management
+Create user: Create user
+btn.create.user: Create user
+New user: New user
+Additional: Additional
+Groups and Roles: Groups and Roles
+Username: Username
+Password: Password
+Password (again): Password (again)
+Re-enter password: Re-enter password
+Name prefix: Name prefix
+First name: First name
+Middle name: Middle name
+Last name: Last name
+Name suffix: Name suffix
+Date of birth: Date of birth
+Avatar: Avatar
+Additional emails: Additional emails
+Add another email: Add another email
+Catalog locale: Catalog locale
+Catalog scope: Catalog scope
+Default tree: Default tree
+Business Units: Business Units
+Email synchronization settings: Email synchronization settings
+Host: Host
+Port: Port
+Ssl: SSL
+Last logged in: Last logged in
+Login count: Login count
+Additional Information: Additional Information
+Interfaces: Interfaces
+Basic Information: Basic Information
+Contact Information: Contact Information
+User name: User name
+Birthday: Birthday
+API key: API key
+Ui locale: UI locale
+UI locale: UI locale
+User salt: User salt
+Current password: Current password
+New password: New password
+Repeat new password: New password (repeat)
+Generate key: Generate key
+Primary: primary
+Removed user: Removed user
+user:
+  product_grid_filters: Product grid filters
+  default_product_grid_view:
+    label: Default product grid view
+  default_grid_view:
+    none: None
+  timezone: Timezone
+Role: Role
+Owner: Owner
+General: General
+Entity: Entity
+Capabilities: Capabilities
+Save and close: Save and close
+Has role: Has role
+role:
+  title: role
+  overview: role
+  edit: Edit role
+  create: Create role
+btn.create.role: Create role
+rights:
+  action: Permissions
+oro_security:
+  acl_group:
+    user: Users
+    role: Roles
+    group: User groups
+  acl:
+    user:
+      view: List users
+      create: Create a user
+      edit: Edit users
+      delete: Remove a user
+    role:
+      view: List roles
+      create: Create a role
+      edit: Edit roles
+      delete: Remove a role
+    group:
+      view: List user groups
+      create: Create a user group
+      edit: Edit user groups
+      delete: Remove a user group
+(default): Default permission on entities
+VIEW: View
+CREATE: Create
+EDIT: Edit
+DELETE: Delete
+ASSIGN: Assign
+SHARE: Share
+oro:
+  security:
+    access-level:
+      BASIC: User
+      LOCAL: Business Unit
+      DEEP: Division
+      GLOBAL: Organization
+      SYSTEM: System
+      NONE: None
+Create group: Create group
+btn.create.user-group: Create group
+Has group: Has group
+Save and Close: Save and close
+user-group.overview: Groups
+Log in: Log in
+Remember me on this computer: Remember me on this computer
+Forgot your password?: Forgot your password?
+Username or Email: Username or Email
+Forgot Password: Forgot Password
+Request: Request
+Check Email: Check Email
+password_reset_email_sent: An email has been sent to the user. It contains a link to reset the password.
+Go to homepage: Go to homepage

--- a/src/Pim/Bundle/UserBundle/Resources/translations/validators.en_NZ.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/translations/validators.en_NZ.yml
@@ -1,0 +1,1 @@
+"The phone has to respect the international format (eg: +33755667788).": "The phone has to respect the international format (eg: +33755667788)."


### PR DESCRIPTION
It's a patch. To not override all the work done on master, we hardcoded locales in 2.3.
In master, the work for treating regional locales is already done!

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -
