### PR TITLE
GITHUB-7532: Fix the prepoluation of textarea field

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # 2.0.x
 
+## Bug fixes
+
+-GITHUB-7532: Fix the prepoluation of textarea field    
+
 # 2.0.42 (2018-11-12)
 
 ## Bug fixes

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
--GITHUB-7532: Fix the prepoluation of textarea field    
+-GITHUB-7532: Fix the prepopulation of textarea field    
 
 # 2.0.42 (2018-11-12)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/textarea.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/form/common/fields/textarea.html
@@ -3,6 +3,4 @@
     class="AknTextareaField"
     name="<%- fieldName %>"
     <% if (readOnly) { %>readonly disabled<% } %>
->
-    <%- value %>
-</textarea>
+><%- value %></textarea>


### PR DESCRIPTION
**Description**

The extra linebreak on the closing textarea tag and the 4 spaces before the <%- cause the textarea to be pre-populated.

Github issue: https://github.com/akeneo/pim-community-dev/issues/7532

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
