### PR TITLE
TIP-897: Redesign user model to allow extension

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -16,6 +16,8 @@
 - TIP-832: Enable regional languages for UI
 
 ## BC breaks
+- Change constructor of `Akeneo\UserManagement\Component\Normalizer\UserNormalizer` to add an Array of `Symfony\Component\Serializer\Normalizer\NormalizerInterface` and a variadic of properties (designed for User)
+- Change constructor of `\Akeneo\UserManagement\Component\Updater\UserUpdater` to add a variadic of properties (designed for User)
 - `AbstractValue->getAttribute()` has been replaced by `AbstractValue->getAttributeCode()`. You will need to inject the AttributeRepository in your service if you need to access the full Attribute object related to the provided attribute code.
 - `AbstractValue->getLocale()` has been renamed to `AbstractValue->getLocaleCode()` to better represent its behaviour
 - `AbstractValue->getScope()` has been renamed to `AbstractValue->getScopeCode()` to better represent its behaviour

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -14,10 +14,11 @@
 ## Enhancements
 
 - TIP-832: Enable regional languages for UI
+- TIP-898: Allow extension for user via a property named "properties", used on the EE by example
 
 ## BC breaks
 - Change constructor of `Akeneo\UserManagement\Component\Normalizer\UserNormalizer` to add an Array of `Symfony\Component\Serializer\Normalizer\NormalizerInterface` and a variadic of properties (designed for User)
-- Change constructor of `\Akeneo\UserManagement\Component\Updater\UserUpdater` to add a variadic of properties (designed for User)
+- Change constructor of `Akeneo\UserManagement\Component\Updater\UserUpdater` to add a variadic of properties (designed for User)
 - `AbstractValue->getAttribute()` has been replaced by `AbstractValue->getAttributeCode()`. You will need to inject the AttributeRepository in your service if you need to access the full Attribute object related to the provided attribute code.
 - `AbstractValue->getLocale()` has been renamed to `AbstractValue->getLocaleCode()` to better represent its behaviour
 - `AbstractValue->getScope()` has been renamed to `AbstractValue->getScopeCode()` to better represent its behaviour

--- a/bin/check-pullup
+++ b/bin/check-pullup
@@ -200,6 +200,7 @@ $pullUpOk = $check(
         new ForbiddenDirectory('src/PimEnterprise/Bundle/WorkflowBundle', new Moved('src/Akeneo/Pim/WorkOrganization')),
         new ForbiddenDirectory('src/PimEnterprise/Bundle/InstallerBundle', new Moved('src/Akeneo/Platform')),
         new ForbiddenDirectory('src/PimEnterprise/Bundle/DataGridBundle', Dispatched::mainEnterpriseBusinessTopics()),
+        new ForbiddenDirectory('src/PimEnterprise/Bundle/UserBundle', Dispatched::mainEnterpriseBusinessTopics()),
 
         // Enterprise Components
         new ForbiddenDirectory('src/PimEnterprise/Component/Api', Dispatched::mainEnterpriseBusinessTopics()),

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/field.js
@@ -83,6 +83,9 @@ define([
             return errors.filter((error) => {
                 const fieldNameParts = this.fieldName.split('.');
                 const lastPart = fieldNameParts[fieldNameParts.length - 1];
+                if (error.path === undefined) {
+                    return lastPart === error.attribute || lastPart === undefined;
+                }
                 const splittedParts = error.path.split(/\[|\]/).filter(part => {
                     return part !== '';
                 });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/field.js
@@ -83,8 +83,13 @@ define([
             return errors.filter((error) => {
                 const fieldNameParts = this.fieldName.split('.');
                 const lastPart = fieldNameParts[fieldNameParts.length - 1];
+                const splittedParts = error.path.split(/\[|\]/).filter(part => {
+                    return part !== '';
+                });
 
-                return lastPart === error.path || lastPart === error.attribute;
+                return lastPart === error.path ||
+                    lastPart === error.attribute ||
+                    JSON.stringify(fieldNameParts) === JSON.stringify(splittedParts);
             });
         },
 

--- a/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
+++ b/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
@@ -405,8 +405,18 @@ class UserContext
             $user = $token->getUser();
             $method = sprintf('get%s', ucfirst($optionName));
 
-            if ($user && is_callable([$user, $method])) {
+            if (null === $user) {
+                return null;
+            }
+
+            if (is_callable([$user, $method])) {
                 $value = $user->$method();
+                if ($value) {
+                    return $value;
+                }
+            } else {
+                $value = $user->getProperty($optionName);
+
                 if ($value) {
                     return $value;
                 }

--- a/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
+++ b/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
@@ -405,7 +405,7 @@ class UserContext
             $user = $token->getUser();
             $method = sprintf('get%s', ucfirst($optionName));
 
-            if (null === $user) {
+            if (null === $user || !is_object($user)) {
                 return null;
             }
 

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
@@ -54,7 +54,7 @@ extensions:
             updateFailureMessage: pim_user_management.entity.user.flash.update.fail
             notReadyMessage: pim_user_management.entity.user.flash.update.fields_not_ready
             url: pim_user_user_rest_post
-            excludedProperties: ['display_proposals_to_review_notification', 'display_proposals_state_notifications', 'last_login', 'login_count', 'password']
+            excludedProperties: ['last_login', 'login_count', 'password']
 
     pim-user-edit-form-secondary-actions:
         module: pim/form/common/secondary-actions

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/User.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/User.orm.yml
@@ -91,6 +91,10 @@ Akeneo\UserManagement\Component\Model\User:
             type: json_array
             nullable: true
             column: product_grid_filters
+        emailNotifications:
+            type: boolean
+            options:
+                default: false
         phone:
             type: string
             nullable: true

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/User.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/User.orm.yml
@@ -91,10 +91,6 @@ Akeneo\UserManagement\Component\Model\User:
             type: json_array
             nullable: true
             column: product_grid_filters
-        emailNotifications:
-            type: boolean
-            options:
-                default: false
         phone:
             type: string
             nullable: true
@@ -103,6 +99,8 @@ Akeneo\UserManagement\Component\Model\User:
             type: string
             nullable: false
             length: 30
+        properties:
+            type: json_array
     manyToMany:
         roles:
             targetEntity: Akeneo\UserManagement\Component\Model\Role

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/normalizers.yml
@@ -10,5 +10,6 @@ services:
             - '@oro_security.security_facade'
             - '@security.token_storage'
             - '@pim_datagrid.repository.datagrid_view'
+            - []
         tags:
             - { name: pim_internal_api_serializer.normalizer }

--- a/src/Akeneo/UserManagement/Component/Factory/DefaultProperty.php
+++ b/src/Akeneo/UserManagement/Component/Factory/DefaultProperty.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\UserManagement\Component\Factory;
+
+use Akeneo\UserManagement\Component\Model\UserInterface;
+
+/**
+ * Interface to mutate User's default property
+ *
+ * @author    Anael Chardan <anael.chardan@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface DefaultProperty
+{
+    public function mutate(UserInterface $user): UserInterface;
+}

--- a/src/Akeneo/UserManagement/Component/Factory/DefaultProperty.php
+++ b/src/Akeneo/UserManagement/Component/Factory/DefaultProperty.php
@@ -14,5 +14,10 @@ use Akeneo\UserManagement\Component\Model\UserInterface;
  */
 interface DefaultProperty
 {
+    /**
+     * @param UserInterface $user
+     *
+     * @return UserInterface
+     */
     public function mutate(UserInterface $user): UserInterface;
 }

--- a/src/Akeneo/UserManagement/Component/Factory/SimpleDefaultProperty.php
+++ b/src/Akeneo/UserManagement/Component/Factory/SimpleDefaultProperty.php
@@ -19,6 +19,10 @@ class SimpleDefaultProperty implements DefaultProperty
     /** @var mixed */
     private $defaultPropertyValue;
 
+    /**
+     * @param string $propertyName
+     * @param mixed $defaultPropertyValue
+     */
     public function __construct(string $propertyName, $defaultPropertyValue)
     {
         $this->propertyName = $propertyName;

--- a/src/Akeneo/UserManagement/Component/Factory/SimpleDefaultProperty.php
+++ b/src/Akeneo/UserManagement/Component/Factory/SimpleDefaultProperty.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Akeneo\UserManagement\Component\Factory;
+
+use Akeneo\UserManagement\Component\Model\UserInterface;
+
+/**
+ * Mutates simple default property of a user
+ *
+ * @author    Anael Chardan <anael.chardan@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SimpleDefaultProperty implements DefaultProperty
+{
+    /** @var string */
+    private $propertyName;
+
+    /** @var mixed */
+    private $defaultPropertyValue;
+
+    public function __construct(string $propertyName, $defaultPropertyValue)
+    {
+        $this->propertyName = $propertyName;
+        $this->defaultPropertyValue = $defaultPropertyValue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mutate(UserInterface $user): UserInterface
+    {
+        $user->addProperty($this->propertyName, $this->defaultPropertyValue);
+
+        return $user;
+    }
+}

--- a/src/Akeneo/UserManagement/Component/Factory/UserFactory.php
+++ b/src/Akeneo/UserManagement/Component/Factory/UserFactory.php
@@ -38,25 +38,31 @@ class UserFactory implements SimpleFactoryInterface
     /** @var string */
     protected $userClass;
 
+    /** @var DefaultProperty[] */
+    private $defaultProperties;
+
     /**
      * @param LocaleRepositoryInterface $localeRepository
      * @param ChannelRepositoryInterface $channelRepository
      * @param CategoryRepositoryInterface $categoryRepository
      * @param GroupRepositoryInterface $groupRepository
      * @param string $userClass
+     * @param DefaultProperty[] $defaultProperties
      */
     public function __construct(
         LocaleRepositoryInterface $localeRepository,
         ChannelRepositoryInterface $channelRepository,
         CategoryRepositoryInterface $categoryRepository,
         GroupRepositoryInterface $groupRepository,
-        string $userClass
+        string $userClass,
+        DefaultProperty ...$defaultProperties
     ) {
         $this->localeRepository = $localeRepository;
         $this->channelRepository = $channelRepository;
         $this->categoryRepository = $categoryRepository;
         $this->groupRepository = $groupRepository;
         $this->userClass = $userClass;
+        $this->defaultProperties = $defaultProperties;
     }
 
     /**
@@ -81,7 +87,9 @@ class UserFactory implements SimpleFactoryInterface
             $user->addGroup($group);
         }
 
-        return $user;
+        return array_reduce($this->defaultProperties, function ($user, DefaultProperty $defaultProperty) {
+            return $defaultProperty->mutate($user);
+        }, $user);
     }
 
     /**

--- a/src/Akeneo/UserManagement/Component/Factory/UserFactory.php
+++ b/src/Akeneo/UserManagement/Component/Factory/UserFactory.php
@@ -38,31 +38,25 @@ class UserFactory implements SimpleFactoryInterface
     /** @var string */
     protected $userClass;
 
-    /** @var IdentifiableObjectRepositoryInterface */
-    protected $assetCategoryRepositoryInterface;
-
     /**
      * @param LocaleRepositoryInterface $localeRepository
      * @param ChannelRepositoryInterface $channelRepository
      * @param CategoryRepositoryInterface $categoryRepository
      * @param GroupRepositoryInterface $groupRepository
      * @param string $userClass
-     * @param IdentifiableObjectRepositoryInterface $assetCategoryRepositoryInterface
      */
     public function __construct(
         LocaleRepositoryInterface $localeRepository,
         ChannelRepositoryInterface $channelRepository,
         CategoryRepositoryInterface $categoryRepository,
         GroupRepositoryInterface $groupRepository,
-        string $userClass,
-        ?IdentifiableObjectRepositoryInterface $assetCategoryRepositoryInterface = null
+        string $userClass
     ) {
         $this->localeRepository = $localeRepository;
         $this->channelRepository = $channelRepository;
         $this->categoryRepository = $categoryRepository;
         $this->groupRepository = $groupRepository;
         $this->userClass = $userClass;
-        $this->assetCategoryRepositoryInterface = $assetCategoryRepositoryInterface;
     }
 
     /**
@@ -85,9 +79,6 @@ class UserFactory implements SimpleFactoryInterface
         }
         if (null !== $group = $this->getDefaultGroup()) {
             $user->addGroup($group);
-        }
-        if (null !== $defaultAssetTree = $this->getDefaultAssetTree()) {
-            $user->setDefaultAssetTree($defaultAssetTree);
         }
 
         return $user;
@@ -141,22 +132,5 @@ class UserFactory implements SimpleFactoryInterface
     private function getDefaultGroup(): ?Group
     {
         return $this->groupRepository->findOneByIdentifier('all');
-    }
-
-    /**
-     * @return CategoryInterface|null when we install the pim
-     */
-    private function getDefaultAssetTree(): ?CategoryInterface
-    {
-        if (null === $this->assetCategoryRepositoryInterface) {
-            return null;
-        }
-
-        $roots = $this->assetCategoryRepositoryInterface->findRoot();
-        if (count($roots) === 0) {
-            return null;
-        }
-
-        return array_values($roots)[0];
     }
 }

--- a/src/Akeneo/UserManagement/Component/Model/User.php
+++ b/src/Akeneo/UserManagement/Component/Model/User.php
@@ -8,6 +8,7 @@ use Akeneo\Tool\Component\Classification\Model\CategoryInterface;
 use Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Inflector\Inflector;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
@@ -1095,6 +1096,8 @@ class User implements UserInterface
      */
     public function addProperty(string $propertyName, $propertyValue): void
     {
+        $propertyName = Inflector::tableize($propertyName);
+
         $this->properties[$propertyName] = $propertyValue;
     }
 
@@ -1103,6 +1106,8 @@ class User implements UserInterface
      */
     public function getProperty(string $propertyName)
     {
+        $propertyName = Inflector::tableize($propertyName);
+
         return $this->properties[$propertyName] ?? null;
     }
 }

--- a/src/Akeneo/UserManagement/Component/Model/User.php
+++ b/src/Akeneo/UserManagement/Component/Model/User.php
@@ -997,6 +997,24 @@ class User implements UserInterface
     /**
      * {@inheritdoc}
      */
+    public function isEmailNotifications()
+    {
+        return $this->emailNotifications;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setEmailNotifications($emailNotifications)
+    {
+        $this->emailNotifications = $emailNotifications;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getProductGridFilters()
     {
         return $this->productGridFilters;

--- a/src/Akeneo/UserManagement/Component/Model/User.php
+++ b/src/Akeneo/UserManagement/Component/Model/User.php
@@ -160,7 +160,7 @@ class User implements UserInterface
     /** @var bool Be notified when the user's proposal has been accepted or rejected */
     protected $proposalsStateNotification = true;
 
-    /** @var array $property bag for proporties extension */
+    /** @var array $property bag for properties extension */
     private $properties = [];
 
     public function __construct()
@@ -1008,24 +1008,6 @@ class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function isEmailNotifications()
-    {
-        return $this->emailNotifications;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setEmailNotifications($emailNotifications)
-    {
-        $this->emailNotifications = $emailNotifications;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getProductGridFilters()
     {
         return $this->productGridFilters;
@@ -1123,90 +1105,16 @@ class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function getAssetDelayReminder()
-    {
-        return $this->assetDelayReminder;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setAssetDelayReminder($assetDelayReminder)
-    {
-        $this->assetDelayReminder = (int) $assetDelayReminder;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultAssetTree()
-    {
-        return $this->defaultAssetTree;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setDefaultAssetTree(CategoryInterface $defaultAssetTree)
-    {
-        $this->defaultAssetTree = $defaultAssetTree;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasProposalsToReviewNotification()
-    {
-        return $this->proposalsToReviewNotification;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setProposalsToReviewNotification($proposalsToReviewNotification)
-    {
-        $this->proposalsToReviewNotification = $proposalsToReviewNotification;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasProposalsStateNotification()
-    {
-        return $this->proposalsStateNotification;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setProposalsStateNotification($proposalsStateNotification)
-    {
-        $this->proposalsStateNotification = $proposalsStateNotification;
-
-        return $this;
-    }
-
-    /**
-     * @param string $propertyName
-     * @param string $propertyValue
-     */
-    public function addProperty(string $propertyName, string $propertyValue): void
+    public function addProperty(string $propertyName, $propertyValue): void
     {
         $this->properties[$propertyName] = $propertyValue;
     }
 
-    public function getProperty(string $propertyName): string
+    /**
+     * {@inheritdoc}
+     */
+    public function getProperty(string $propertyName)
     {
-        if (!isset($this->properties[$propertyName])) {
-            throw new \InvalidArgumentException(sprintf('The property %s does not exist', $propertyName));
-        }
-
-        return $this->properties[$propertyName];
+        return $this->properties[$propertyName] ?? null;
     }
 }

--- a/src/Akeneo/UserManagement/Component/Model/User.php
+++ b/src/Akeneo/UserManagement/Component/Model/User.php
@@ -148,18 +148,6 @@ class User implements UserInterface
     /** @var string */
     protected $timezone;
 
-    /** @var int The delay in days to send an email before the expiration of an asset */
-    protected $assetDelayReminder = 5;
-
-    /** @var CategoryInterface */
-    protected $defaultAssetTree;
-
-    /** @var bool Be notified when the user receives a proposal to review */
-    protected $proposalsToReviewNotification = true;
-
-    /** @var bool Be notified when the user's proposal has been accepted or rejected */
-    protected $proposalsStateNotification = true;
-
     /** @var array $property bag for properties extension */
     private $properties = [];
 

--- a/src/Akeneo/UserManagement/Component/Model/User.php
+++ b/src/Akeneo/UserManagement/Component/Model/User.php
@@ -160,6 +160,9 @@ class User implements UserInterface
     /** @var bool Be notified when the user's proposal has been accepted or rejected */
     protected $proposalsStateNotification = true;
 
+    /** @var array $property bag for proporties extension */
+    private $properties = [];
+
     public function __construct()
     {
         $this->salt = base_convert(sha1(uniqid(mt_rand(), true)), 16, 36);
@@ -1187,5 +1190,23 @@ class User implements UserInterface
         $this->proposalsStateNotification = $proposalsStateNotification;
 
         return $this;
+    }
+
+    /**
+     * @param string $propertyName
+     * @param string $propertyValue
+     */
+    public function addProperty(string $propertyName, string $propertyValue): void
+    {
+        $this->properties[$propertyName] = $propertyValue;
+    }
+
+    public function getProperty(string $propertyName): string
+    {
+        if (!isset($this->properties[$propertyName])) {
+            throw new \InvalidArgumentException(sprintf('The property %s does not exist', $propertyName));
+        }
+
+        return $this->properties[$propertyName];
     }
 }

--- a/src/Akeneo/UserManagement/Component/Model/UserInterface.php
+++ b/src/Akeneo/UserManagement/Component/Model/UserInterface.php
@@ -494,6 +494,17 @@ interface UserInterface extends AdvancedUserInterface, \Serializable, EntityUplo
     public function setDefaultTree(CategoryInterface $defaultTree);
 
     /**
+     * @return bool
+     */
+    public function isEmailNotifications();
+    /**
+     * @param bool $emailNotifications
+     *
+     * @return UserInterface
+     */
+    public function setEmailNotifications($emailNotifications);
+
+    /**
      * @param string the view alias
      *
      * @return DatagridView|null

--- a/src/Akeneo/UserManagement/Component/Model/UserInterface.php
+++ b/src/Akeneo/UserManagement/Component/Model/UserInterface.php
@@ -494,18 +494,6 @@ interface UserInterface extends AdvancedUserInterface, \Serializable, EntityUplo
     public function setDefaultTree(CategoryInterface $defaultTree);
 
     /**
-     * @return bool
-     */
-    public function isEmailNotifications();
-
-    /**
-     * @param bool $emailNotifications
-     *
-     * @return UserInterface
-     */
-    public function setEmailNotifications($emailNotifications);
-
-    /**
      * @param string the view alias
      *
      * @return DatagridView|null
@@ -554,59 +542,15 @@ interface UserInterface extends AdvancedUserInterface, \Serializable, EntityUplo
     public function setTimezone(string $timezone): UserInterface;
 
     /**
-     * @return int
+     * @param string $propertyName
+     * @param mixed $propertyValue
      */
-    public function getAssetDelayReminder();
+    public function addProperty(string $propertyName, $propertyValue): void;
 
     /**
-     * Set delay
+     * @param string $propertyName
      *
-     * @param int $assetDelayReminder
-     *
-     * @return UserInterface
+     * @return mixed
      */
-    public function setAssetDelayReminder($assetDelayReminder);
-
-    /**
-     * @return CategoryInterface
-     */
-    public function getDefaultAssetTree();
-
-    /**
-     * @param CategoryInterface $defaultAssetTree
-     *
-     * @return UserInterface
-     */
-    public function setDefaultAssetTree(CategoryInterface $defaultAssetTree);
-
-    /**
-     * Does the user want to be notified of new proposals to review?
-     *
-     * @return bool
-     */
-    public function hasProposalsToReviewNotification();
-    /**
-     * Set whether the user wants to be notified of new proposals.
-     *
-     * @param bool $proposalsToReviewNotification
-     *
-     * @return UserInterface
-     */
-    public function setProposalsToReviewNotification($proposalsToReviewNotification);
-
-    /**
-     * Does the user want to be notified when his proposals are accepted or rejected?
-     *
-     * @return bool
-     */
-    public function hasProposalsStateNotification();
-
-    /**
-     * Set whether the user wants to be notified when his proposals are accepted or rejected.
-     *
-     * @param bool $proposalsStateNotification
-     *
-     * @return UserInterface
-     */
-    public function setProposalsStateNotification($proposalsStateNotification);
+    public function getProperty(string $propertyName);
 }

--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -95,6 +95,7 @@ class UserNormalizer implements NormalizerInterface
             'user_default_locale'       => $user->getUiLocale()->getCode(),
             'catalog_default_scope'     => $user->getCatalogScope()->getCode(),
             'default_category_tree'     => $user->getDefaultTree()->getCode(),
+            'email_notifications'       => $user->isEmailNotifications(),
             'timezone'                  => $user->getTimezone(),
             'groups'                    => $user->getGroupNames(),
             'roles'                     => $this->getRoleNames($user),

--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -131,7 +131,9 @@ class UserNormalizer implements NormalizerInterface
             return $normalizer->normalize($user, $format, $context);
         }, $this->userNormalizers);
 
-        return array_merge($result, $normalizedProperties, ...$normalizedCompound);
+        $result['properties'] = $normalizedProperties;
+
+        return array_merge_recursive($result, ...$normalizedCompound);
     }
 
     /**

--- a/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
+++ b/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
@@ -88,7 +88,8 @@ class UserUpdater implements ObjectUpdaterInterface
         FileInfoRepositoryInterface $fileInfoRepository,
         FileStorerInterface $fileStorer,
         string $fileStorageFolder,
-        ?IdentifiableObjectRepositoryInterface $categoryAssetRepository = null
+        ?IdentifiableObjectRepositoryInterface $categoryAssetRepository = null,
+        string ...$properties
     ) {
         $this->userManager = $userManager;
         $this->categoryRepository = $categoryRepository;

--- a/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
+++ b/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
@@ -187,6 +187,9 @@ class UserUpdater implements ObjectUpdaterInterface
             case 'default_category_tree':
                 $user->setDefaultTree($this->findCategory($data));
                 break;
+            case 'email_notifications':
+                $user->setEmailNotifications($data);
+                break;
             case 'roles':
                 $roles = [];
                 foreach ($data as $code) {

--- a/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
+++ b/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
@@ -232,7 +232,14 @@ class UserUpdater implements ObjectUpdaterInterface
 
                 $user->setProductGridFilters([]);
                 break;
+            case 'properties':
+                foreach ($data as $propertyName => $propertyValue) {
+                    $user->addProperty($propertyName, $propertyValue);
+                }
+
+                break;
             default:
+                // For compatibilty
                 if (in_array($field, $this->properties)) {
                     $user->addProperty($field, $data);
 

--- a/tests/back/UserManagement/Specification/Component/Factory/SimpleDefaultPropertySpec.php
+++ b/tests/back/UserManagement/Specification/Component/Factory/SimpleDefaultPropertySpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Specification\Akeneo\UserManagement\Component\Factory;
+
+use Akeneo\UserManagement\Component\Factory\DefaultProperty;
+use Akeneo\UserManagement\Component\Factory\SimpleDefaultProperty;
+use Akeneo\UserManagement\Component\Model\User;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use PhpSpec\ObjectBehavior;
+use Webmozart\Assert\Assert;
+
+class SimpleDefaultPropertySpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('a_property', 'a_default_value');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(SimpleDefaultProperty::class);
+    }
+
+    function it_is_a_default_property()
+    {
+        $this->shouldImplement(DefaultProperty::class);
+    }
+
+    function it_mutates_the_user()
+    {
+        $user = new User();
+
+        $this->mutate($user)->shouldReturnAnInstanceOf(UserInterface::class);
+
+        Assert::eq('a_default_value', $user->getProperty('a_property'));
+    }
+}

--- a/tests/back/UserManagement/Specification/Component/Factory/UserFactorySpec.php
+++ b/tests/back/UserManagement/Specification/Component/Factory/UserFactorySpec.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Specification\Akeneo\UserManagement\Component\Factory;
+
+use Akeneo\Channel\Component\Model\Channel;
+use Akeneo\Channel\Component\Model\Locale;
+use Akeneo\Channel\Component\Repository\ChannelRepositoryInterface;
+use Akeneo\Channel\Component\Repository\LocaleRepositoryInterface;
+use Akeneo\Platform\Bundle\UIBundle\UiLocaleProvider;
+use Akeneo\Tool\Component\Classification\Model\Category;
+use Akeneo\Tool\Component\Classification\Repository\CategoryRepositoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\UserManagement\Component\Factory\DefaultProperty;
+use Akeneo\UserManagement\Component\Factory\UserFactory;
+use Akeneo\UserManagement\Component\Model\Group;
+use Akeneo\UserManagement\Component\Model\User;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use Akeneo\UserManagement\Component\Repository\GroupRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class UserFactorySpec extends ObjectBehavior
+{
+    function let(
+        LocaleRepositoryInterface $localeRepository,
+        ChannelRepositoryInterface $channelRepository,
+        CategoryRepositoryInterface $categoryRepository,
+        GroupRepositoryInterface $groupRepository,
+        DefaultProperty $defaultProperty1,
+        DefaultProperty $defaultProperty2
+    ) {
+        $this->beConstructedWith(
+            $localeRepository,
+            $channelRepository,
+            $categoryRepository,
+            $groupRepository,
+            User::class,
+            $defaultProperty1,
+            $defaultProperty2
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UserFactory::class);
+    }
+
+    function it_is_a_default_factory()
+    {
+        $this->shouldImplement(SimpleFactoryInterface::class);
+    }
+
+    function it_creates_a_user(
+        User $user,
+        $localeRepository,
+        $channelRepository,
+        $categoryRepository,
+        $groupRepository,
+        $defaultProperty1,
+        $defaultProperty2
+    ) {
+        $locale = new Locale();
+        $channel = new Channel();
+        $category = new Category();
+        $group = new Group();
+
+        $localeRepository->getActivatedLocales()->willReturn([$locale]);
+        $localeRepository->findOneBy(['code' => UiLocaleProvider::MAIN_LOCALE])->willReturn($locale);
+
+        $channelRepository->findOneBy([])->willReturn($channel);
+
+        $categoryRepository->getTrees()->willReturn([$category]);
+
+        $groupRepository->findOneByIdentifier('all')->willReturn($group);
+
+        $defaultProperty1->mutate(Argument::type(User::class))->willReturn($user);
+        $defaultProperty2->mutate(Argument::type(User::class))->willReturn($user);
+
+        $defaultProperty1->mutate(Argument::type(User::class))->shouldBeCalled();
+        $defaultProperty2->mutate(Argument::type(User::class))->shouldBeCalled();
+
+        $this->create()->shouldReturnAnInstanceOf(User::class);
+    }
+}

--- a/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
@@ -16,5 +16,6 @@ class UserSpec extends ObjectBehavior
     {
         $this->addProperty('propertyName', 'value')->shouldReturn(null);
         $this->getProperty('propertyName')->shouldReturn('value');
+        $this->getProperty('property_name')->shouldReturn('value');
     }
 }

--- a/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
@@ -4,7 +4,6 @@ namespace Specification\Akeneo\UserManagement\Component\Model;
 
 use Akeneo\UserManagement\Component\Model\User;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class UserSpec extends ObjectBehavior
 {
@@ -15,7 +14,12 @@ class UserSpec extends ObjectBehavior
 
     function it_has_properties()
     {
-        $this->addProperties('propertyName', 'value')->shouldReturn(null);
-        $this->get('propertyName')->shouldReturn('value');
+        $this->addProperty('propertyName', 'value')->shouldReturn(null);
+        $this->getProperty('propertyName')->shouldReturn('value');
+    }
+
+    function it_throws_an_exception_if_the_property_does_not_exist()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)->during('getProperty', ['unknown_property']);
     }
 }

--- a/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Specification\Akeneo\UserManagement\Component\Model;
+
+use Akeneo\UserManagement\Component\Model\User;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class UserSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(User::class);
+    }
+
+    function it_has_properties()
+    {
+        $this->addProperties('propertyName', 'value')->shouldReturn(null);
+        $this->get('propertyName')->shouldReturn('value');
+    }
+}

--- a/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
@@ -17,9 +17,4 @@ class UserSpec extends ObjectBehavior
         $this->addProperty('propertyName', 'value')->shouldReturn(null);
         $this->getProperty('propertyName')->shouldReturn('value');
     }
-
-    function it_throws_an_exception_if_the_property_does_not_exist()
-    {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('getProperty', ['unknown_property']);
-    }
 }

--- a/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
@@ -73,6 +73,7 @@ class UserNormalizerSpec extends ObjectBehavior
             'user_default_locale'       => null,
             'catalog_default_scope'     => null,
             'default_category_tree'     => null,
+            'email_notifications'       => false,
             'timezone'                  => 'UTC',
             'groups'                    => [],
             'roles'                     => [],

--- a/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Specification\Akeneo\UserManagement\Component\Normalizer;
+
+use Akeneo\UserManagement\Component\Normalizer\UserNormalizer;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class UserNormalizerSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(
+            'property_name',
+            'other_property_name'
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UserNormalizer::class);
+    }
+
+    function it_is_user_normalizer()
+    {
+        $this->normalize()->shouldReturn([])
+    }
+}

--- a/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
@@ -2,17 +2,39 @@
 
 namespace Specification\Akeneo\UserManagement\Component\Normalizer;
 
+use Akeneo\Channel\Component\Model\Channel;
+use Akeneo\Channel\Component\Model\Locale;
+use Akeneo\Tool\Component\Classification\Model\Category;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Akeneo\UserManagement\Component\Model\User;
 use Akeneo\UserManagement\Component\Normalizer\UserNormalizer;
+use Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class UserNormalizerSpec extends ObjectBehavior
 {
-    function let()
+    function let(
+        DateTimeNormalizer $dateTimeNormalizer,
+        NormalizerInterface $fileNormalizer,
+        SecurityFacade $securityFacade,
+        TokenStorageInterface $tokenStorage,
+        DatagridViewRepositoryInterface $datagridViewRepo,
+        NormalizerInterface $normalizerOne,
+        NormalizerInterface $normalizerTwo
+    )
     {
         $this->beConstructedWith(
-            'property_name',
-            'other_property_name'
+            $dateTimeNormalizer,
+            $fileNormalizer,
+            $securityFacade,
+            $tokenStorage,
+            $datagridViewRepo,
+            [$normalizerOne, $normalizerTwo],
+            'property_name'
         );
     }
 
@@ -21,8 +43,60 @@ class UserNormalizerSpec extends ObjectBehavior
         $this->shouldHaveType(UserNormalizer::class);
     }
 
-    function it_is_user_normalizer()
+    function it_is_user_normalizer($datagridViewRepo, $normalizerOne, $normalizerTwo)
     {
-        $this->normalize()->shouldReturn([]);
+        $user = new User();
+        $user->setCatalogLocale(new Locale());
+        $user->setUiLocale(new Locale());
+        $user->setCatalogScope(new Channel());
+        $user->setDefaultTree(new Category());
+        $user->addProperty('property_name', 'value');
+
+        $datagridViewRepo->getDatagridViewTypeByUser($user)->willReturn([]);
+
+        $result = [
+            'code'                      => null,
+            'enabled'                   => true,
+            'username'                  => null,
+            'email'                     => null,
+            'name_prefix'               => null,
+            'first_name'                => null,
+            'middle_name'               => null,
+            'last_name'                 => null,
+            'name_suffix'               => null,
+            'phone'                     => null,
+            'birthday'                  => null,
+            'image'                     => null,
+            'last_login'                => null,
+            'login_count'               => 0,
+            'catalog_default_locale'    => null,
+            'user_default_locale'       => null,
+            'catalog_default_scope'     => null,
+            'default_category_tree'     => null,
+            'timezone'                  => 'UTC',
+            'groups'                    => [],
+            'roles'                     => [],
+            'product_grid_filters'      => [],
+            'avatar'                    => [
+                'filePath'         => null,
+                'originalFilename' => null,
+            ],
+            'meta'                      => [
+                'id'    => null,
+                'form'  => 'pim-user-show',
+                'image' => [
+                    'filePath' => null
+                ]
+            ],
+            'property_name' => 'value',
+            'property_one' => 'valueOne',
+            'property_two' => 'valueTwo',
+        ];
+
+        $normalizerOne->normalize($user, Argument::cetera())->willReturn(['property_one' => 'valueOne']);
+        $normalizerTwo->normalize($user, Argument::cetera())->willReturn(['property_two' => 'valueTwo']);
+
+
+        $this->normalize($user)->shouldReturn($result);
     }
 }

--- a/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
@@ -23,6 +23,6 @@ class UserNormalizerSpec extends ObjectBehavior
 
     function it_is_user_normalizer()
     {
-        $this->normalize()->shouldReturn([])
+        $this->normalize()->shouldReturn([]);
     }
 }

--- a/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
@@ -89,12 +89,14 @@ class UserNormalizerSpec extends ObjectBehavior
                     'filePath' => null
                 ]
             ],
-            'property_name' => 'value',
-            'property_one' => 'valueOne',
+            'properties' => [
+                'property_name' => 'value',
+                'property_one' => 'valueOne'
+            ],
             'property_two' => 'valueTwo',
         ];
 
-        $normalizerOne->normalize($user, Argument::cetera())->willReturn(['property_one' => 'valueOne']);
+        $normalizerOne->normalize($user, Argument::cetera())->willReturn(['properties' => ['property_one' => 'valueOne']]);
         $normalizerTwo->normalize($user, Argument::cetera())->willReturn(['property_two' => 'valueTwo']);
 
 

--- a/tests/back/UserManagement/Specification/Component/Updater/UserUpdaterSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Updater/UserUpdaterSpec.php
@@ -70,6 +70,22 @@ class UserUpdaterSpec extends ObjectBehavior
         Assert::eq( 'value', $user->getProperty('property_name'));
     }
 
+    function it_updates_user_properties_prefixed_by_properties()
+    {
+        $user = new User();
+        $user->addGroup(new Group('all'));
+
+        $this->update(
+            $user,
+            [
+                'properties.property_name' => 'value',
+                'other_property_name' => 'other_value',
+            ]
+        )->shouldReturn($this);
+
+        Assert::eq( 'value', $user->getProperty('property_name'));
+    }
+
     function it_throws_an_exception_if_it_is_not_a_whitelisted_property()
     {
         $user = new User();

--- a/tests/back/UserManagement/Specification/Component/Updater/UserUpdaterSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Updater/UserUpdaterSpec.php
@@ -2,12 +2,18 @@
 
 namespace Specification\Akeneo\UserManagement\Component\Updater;
 
+use Akeneo\Tool\Component\FileStorage\File\FileStorerInterface;
+use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\UserManagement\Bundle\Manager\UserManager;
+use Akeneo\UserManagement\Component\Model\Group;
+use Akeneo\UserManagement\Component\Model\User;
 use Akeneo\UserManagement\Component\Updater\UserUpdater;
+use Doctrine\Common\Persistence\ObjectRepository;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
+use Webmozart\Assert\Assert;
 
 class UserUpdaterSpec extends ObjectBehavior
 {
@@ -18,7 +24,9 @@ class UserUpdaterSpec extends ObjectBehavior
         IdentifiableObjectRepositoryInterface $channelRepository,
         IdentifiableObjectRepositoryInterface $roleRepository,
         IdentifiableObjectRepositoryInterface $groupRepository,
-        IdentifiableObjectRepositoryInterface $categoryAssetRepository = null
+        ObjectRepository $gridViewRepository,
+        FileInfoRepositoryInterface $fileInfoRepository,
+        FileStorerInterface $fileStorer
     ) {
         $this->beConstructedWith(
             $userManager,
@@ -27,7 +35,10 @@ class UserUpdaterSpec extends ObjectBehavior
             $channelRepository,
             $roleRepository,
             $groupRepository,
-            $categoryAssetRepository,
+            $gridViewRepository,
+            $fileInfoRepository,
+            $fileStorer,
+            'file_storer',
             'property_name',
             'other_property_name'
         );
@@ -45,11 +56,27 @@ class UserUpdaterSpec extends ObjectBehavior
 
     function it_updates_user_properties()
     {
+        $user = new User();
+        $user->addGroup(new Group('all'));
+
         $this->update(
+            $user,
             [
                 'property_name' => 'value',
                 'other_property_name' => 'other_value',
             ]
         )->shouldReturn($this);
+
+        Assert::eq( 'value', $user->getProperty('property_name'));
+    }
+
+    function it_throws_an_exception_if_it_is_not_a_whitelisted_property()
+    {
+        $user = new User();
+        $user->addGroup(new Group('all'));
+
+        $this
+            ->shouldThrow(UnknownPropertyException::class)
+            ->during('update',[$user, ['wrong_property' => 'value']]);
     }
 }

--- a/tests/back/UserManagement/Specification/Component/Updater/UserUpdaterSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Updater/UserUpdaterSpec.php
@@ -70,7 +70,7 @@ class UserUpdaterSpec extends ObjectBehavior
         Assert::eq( 'value', $user->getProperty('property_name'));
     }
 
-    function it_updates_user_properties_prefixed_by_properties()
+    function it_updates_user_properties_in_properties_array()
     {
         $user = new User();
         $user->addGroup(new Group('all'));
@@ -78,7 +78,7 @@ class UserUpdaterSpec extends ObjectBehavior
         $this->update(
             $user,
             [
-                'properties.property_name' => 'value',
+                'properties' => [ 'property_name' => 'value'],
                 'other_property_name' => 'other_value',
             ]
         )->shouldReturn($this);

--- a/tests/back/UserManagement/Specification/Component/Updater/UserUpdaterSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Updater/UserUpdaterSpec.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Specification\Akeneo\UserManagement\Component\Updater;
+
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Akeneo\UserManagement\Bundle\Manager\UserManager;
+use Akeneo\UserManagement\Component\Updater\UserUpdater;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class UserUpdaterSpec extends ObjectBehavior
+{
+    function let(
+        UserManager $userManager,
+        IdentifiableObjectRepositoryInterface $categoryRepository,
+        IdentifiableObjectRepositoryInterface $localeRepository,
+        IdentifiableObjectRepositoryInterface $channelRepository,
+        IdentifiableObjectRepositoryInterface $roleRepository,
+        IdentifiableObjectRepositoryInterface $groupRepository,
+        IdentifiableObjectRepositoryInterface $categoryAssetRepository = null
+    ) {
+        $this->beConstructedWith(
+            $userManager,
+            $categoryRepository,
+            $localeRepository,
+            $channelRepository,
+            $roleRepository,
+            $groupRepository,
+            $categoryAssetRepository,
+            'property_name',
+            'other_property_name'
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UserUpdater::class);
+    }
+
+    function it_is_an_updater()
+    {
+        $this->shouldImplement(ObjectUpdaterInterface::class);
+    }
+
+    function it_updates_user_properties()
+    {
+        $this->update(
+            [
+                'property_name' => 'value',
+                'other_property_name' => 'other_value',
+            ]
+        )->shouldReturn($this);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- [x] EventListener to cut for mapping Doctrine for User properties
- [x] CompilerPass in EE for properties
- [x] UserNormalizer
- [x] UserUpdater
- [x] UserFactory
- [x] UserValidation
- [x] User remove useless methods and add defaults values
- [x] Replace in User the getDefaultAssetTree by a code -> as the code is immutable

<!--- (What does this Pull Request do? reference the related issue?) --->

This PR allows extension in the User without overriding it. 

How we did that ? 
- The user now has a bag of properties which can be added from where you want

What does it implies?
 We have to compose at a lot of places, factory, normalizer, updater in order to make it possible, that's why we had to change them a little bit to make them work.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
