### PR TITLE
PIM-7855: Optional attributes are added when family column is not in the imported product file

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,11 +1,14 @@
 # 2.0.x
 
+## Bug fixes
+
+- PIM-7855: Fix the add of optional attributes on product with family, if imported file doesn't have the family column    
+
 # 2.0.43 (2018-11-27)
 
 ## Bug fixes
 
 - GITHUB-7532: Fix the prepopulation of textarea field - cheers MarieMinasyan, userz58, kanduvisla & oliverde8 !
-- PIM-7855: Fix the add of optional attributes on product with family, if imported file doesn't have the family column    
 
 # 2.0.42 (2018-11-12)
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,7 +4,8 @@
 
 ## Bug fixes
 
--GITHUB-7532: Fix the prepopulation of textarea field - cheers MarieMinasyan, userz58, kanduvisla & oliverde8 !    
+- GITHUB-7532: Fix the prepopulation of textarea field - cheers MarieMinasyan, userz58, kanduvisla & oliverde8 !
+- PIM-7855: Fix the add of optional attributes on product with family, if imported file doesn't have the family column    
 
 # 2.0.42 (2018-11-12)
 

--- a/features/Context/FixturesContext.php
+++ b/features/Context/FixturesContext.php
@@ -127,6 +127,7 @@ class FixturesContext extends BaseFixturesContext
 
         $convertedData = $converter->convert($data);
         $product = $processor->process($convertedData);
+        $this->validate($product);
         $this->getProductSaver()->save($product);
 
         // reset the unique value set to allow to update product values

--- a/features/export/export_products.feature
+++ b/features/export/export_products.feature
@@ -108,22 +108,24 @@ Feature: Export products
     And the following attributes:
       | code                      | type             | localizable | available_locales | group |
       | locale_specific_attribute | pim_catalog_text | 1           | en_US,fr_FR       | other |
+    And the following family:
+      | code                  | requirements-tablet           | requirements-ecommerce | attributes                     |
+      | family_local_specific | sku,locale_specific_attribute | sku                    | name,locale_specific_attribute |
     And the following products:
-      | sku          | family  | categories                   | price                 | size   | color | manufacturer     | material | country_of_manufacture |
-      | tshirt-white | tshirts | men_2013, men_2014, men_2015 | 10 EUR, 15 USD, 9 GBP | size_M | white | american_apparel | cotton   | usa                    |
-      | tshirt-black | tshirts |                              | 10 EUR, 15 USD, 9 GBP | size_L | black | american_apparel | cotton   | usa                    |
+      | sku          | family                | categories                   |
+      | tshirt-white | family_local_specific | men_2013, men_2014, men_2015 |
+      | tshirt-black | family_local_specific |                              |
     And the following product values:
       | product      | attribute                 | value               | locale | scope |
-      | tshirt-white | name                      | White t-shirt       | en_US  |       |
-      | tshirt-white | name                      | White t-shirt       | en_GB  |       |
+      | tshirt-white | name                      | White t-shirt EN    | en_US  |       |
+      | tshirt-white | name                      | White t-shirt GB    | en_GB  |       |
       | tshirt-white | name                      | T-shirt blanc       | fr_FR  |       |
       | tshirt-white | name                      | Weißes T-Shirt      | de_DE  |       |
-      | tshirt-white | locale_specific_attribute | specific attribute  | fr_FR  |       |
-      | tshirt-white | locale_specific_attribute | attribut specifique | en_US  |       |
-      | tshirt-black | name                      | Black t-shirt       | en_US  |       |
-      | tshirt-black | name                      | Black t-shirt       | en_GB  |       |
+      | tshirt-white | locale_specific_attribute | specific attribute  | en_US  |       |
+      | tshirt-white | locale_specific_attribute | attribut specifique | fr_FR  |       |
+      | tshirt-black | name                      | Black t-shirt EN    | en_US  |       |
+      | tshirt-black | name                      | Black t-shirt GB    | en_GB  |       |
       | tshirt-black | name                      | T-shirt noir        | fr_FR  |       |
-      | tshirt-black | name                      | Schwarzes T-Shirt   | de_DE  |       |
       | tshirt-black | name                      | Schwarzes T-Shirt   | de_DE  |       |
     And I launched the completeness calculator
     And I am logged in as "Julia"
@@ -132,8 +134,8 @@ Feature: Export products
     And I wait for the "tablet_product_export" job to finish
     Then exported file of "tablet_product_export" should contain:
     """
-    sku;additional_colors;categories;color;cost-EUR;cost-GBP;cost-USD;country_of_manufacture;customer_rating-tablet;datasheet;description-en_GB-tablet;description-en_US-tablet;enabled;family;groups;handmade;image;legend-en_GB;legend-en_US;locale_specific_attribute-en_US;manufacturer;material;name-en_GB;name-en_US;number_in_stock-tablet;price-EUR;price-GBP;price-USD;release_date-tablet;size;thumbnail;washing_temperature;washing_temperature-unit;weight;weight-unit
-    tshirt-white;;men_2013,men_2014,men_2015;white;;;;usa;;;;;1;tshirts;;0;;;;"attribut specifique";american_apparel;cotton;"White t-shirt";"White t-shirt";;10.00;9.00;15.00;;size_M;;;;;
+    sku;categories;enabled;family;groups;locale_specific_attribute-en_US;name-en_GB;name-en_US
+    tshirt-white;men_2013,men_2014,men_2015;1;family_local_specific;;specific attribute;White t-shirt GB;White t-shirt EN
     """
 
   @jira https://akeneo.atlassian.net/browse/PIM-4182

--- a/features/import/product/import_products_with_optional_values.feature
+++ b/features/import/product/import_products_with_optional_values.feature
@@ -32,11 +32,10 @@ Feature: Import product information with optional values
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
     Then there should be 4 products
-    And attribute opt_att_global of "caterpillar-pim" should be "Pim"
-    And the english localizable value opt_att_local of "caterpillar-pim" should be "PimUS"
-    And the tablet scopable value opt_att_scope of "caterpillar-pim" should be "PimTablet"
     And attribute opt_att_global of "caterpillar-pam" should be "Pam"
     And the tablet scopable value opt_att_scope of "caterpillar-pam" should be "PamTablet"
     And attribute opt_att_global of "caterpillar-poum" should be ""
     And attribute opt_att_global of "caterpillar-pum" should be "PimPamPoum"
+    And the product "caterpillar-pim" should not have the following values:
+      | opt_att_global |
 

--- a/features/localization/export/export_products_with_date.feature
+++ b/features/localization/export/export_products_with_date.feature
@@ -12,22 +12,22 @@ Feature: Export products with localized dates
     And I add available attribute Release date
     And I save the family
     And the following products:
-      | sku           | family  | categories                   |
-      | sandal-white  | sandals | men_2013, men_2014, men_2015 |
-      | sandal-yellow | sandals | men_2013, men_2014, men_2015 |
+      | sku            | family   | categories                   |
+      | sweater-white  | sweaters | men_2013, men_2014, men_2015 |
+      | sweater-yellow | sweaters | men_2013, men_2014, men_2015 |
     And the following product values:
       | product       | attribute    | value                        | locale | scope     |
-      | sandal-white  | name         | Sandale blanche              | fr_FR  |           |
-      | sandal-white  | name         | Weißes Sandal                | de_DE  |           |
-      | sandal-white  | price        | 10.90 EUR,15 USD,9 GBP       |        |           |
-      | sandal-white  | description  | Une Sandale blanche élégante | fr_FR  | ecommerce |
-      | sandal-white  | description  | Ein elegantes weißes Sandal  | de_DE  | ecommerce |
-      | sandal-white  | release_date | 1999-10-28                   |        | ecommerce |
-      | sandal-yellow | name         | Sandale jaune                | fr_FR  |           |
-      | sandal-yellow | name         | Gelb Sandal                  | de_DE  |           |
-      | sandal-yellow | price        | 10.90 EUR,15 USD,9 GBP       |        |           |
-      | sandal-yellow | description  | Une Sandale jaune élégante   | fr_FR  | ecommerce |
-      | sandal-yellow | description  | Ein elegantes gelb Sandal    | de_DE  | ecommerce |
+      | sweater-white  | name         | Sandale blanche              | fr_FR  |           |
+      | sweater-white  | name         | Weißes Sandal                | de_DE  |           |
+      | sweater-white  | price        | 10.90 EUR,15 USD,9 GBP       |        |           |
+      | sweater-white  | description  | Une Sandale blanche élégante | fr_FR  | ecommerce |
+      | sweater-white  | description  | Ein elegantes weißes Sandal  | de_DE  | ecommerce |
+      | sweater-white  | release_date | 1999-10-28                   |        | ecommerce |
+      | sweater-yellow | name         | Sandale jaune                | fr_FR  |           |
+      | sweater-yellow | name         | Gelb Sandal                  | de_DE  |           |
+      | sweater-yellow | price        | 10.90 EUR,15 USD,9 GBP       |        |           |
+      | sweater-yellow | description  | Une Sandale jaune élégante   | fr_FR  | ecommerce |
+      | sweater-yellow | description  | Ein elegantes gelb Sandal    | de_DE  | ecommerce |
 
   Scenario: Export dates attributes in a specified format
     Given the following job "ecommerce_product_export" configuration:
@@ -44,6 +44,6 @@ Feature: Export products with localized dates
     Then exported file of "ecommerce_product_export" should contain:
       """
       sku;categories;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;enabled;family;groups;name-de_DE;name-en_GB;name-en_US;name-fr_FR;price-EUR;price-GBP;price-USD;release_date-ecommerce
-      sandal-white;men_2013,men_2014,men_2015;"Ein elegantes weißes Sandal";;;"Une Sandale blanche élégante";1;sandals;;"Weißes Sandal";;;"Sandale blanche";10.90;9.00;15.00;28/10/1999
-      sandal-yellow;men_2013,men_2014,men_2015;"Ein elegantes gelb Sandal";;;"Une Sandale jaune élégante";1;sandals;;"Gelb Sandal";;;"Sandale jaune";10.90;9.00;15.00;
+      sweater-white;men_2013,men_2014,men_2015;"Ein elegantes weißes Sandal";;;"Une Sandale blanche élégante";1;sandals;;"Weißes Sandal";;;"Sandale blanche";10.90;9.00;15.00;28/10/1999
+      sweater-yellow;men_2013,men_2014,men_2015;"Ein elegantes gelb Sandal";;;"Une Sandale jaune élégante";1;sandals;;"Gelb Sandal";;;"Sandale jaune";10.90;9.00;15.00;
       """

--- a/features/localization/export/export_products_with_date.feature
+++ b/features/localization/export/export_products_with_date.feature
@@ -13,21 +13,30 @@ Feature: Export products with localized dates
     And I save the family
     And the following products:
       | sku            | family   | categories                   |
-      | sweater-white  | sweaters | men_2013, men_2014, men_2015 |
-      | sweater-yellow | sweaters | men_2013, men_2014, men_2015 |
+      | sweater-white  | tshirts  | men_2013, men_2014, men_2015 |
+      | sweater-yellow | tshirts  | men_2013, men_2014, men_2015 |
     And the following product values:
-      | product       | attribute    | value                        | locale | scope     |
-      | sweater-white  | name         | Sandale blanche              | fr_FR  |           |
-      | sweater-white  | name         | Weißes Sandal                | de_DE  |           |
+      | product        | attribute    | value                        | locale | scope     |
+      | sweater-white  | name         | TShirt blanche               | fr_FR  |           |
+      | sweater-white  | name         | Weißes TShirt                | de_DE  |           |
+      | sweater-white  | description  | Un TShirt blanche élégante   | fr_FR  | ecommerce |
+      | sweater-white  | description  | Ein elegantes weißes TShirt  | de_DE  | ecommerce |
       | sweater-white  | price        | 10.90 EUR,15 USD,9 GBP       |        |           |
-      | sweater-white  | description  | Une Sandale blanche élégante | fr_FR  | ecommerce |
-      | sweater-white  | description  | Ein elegantes weißes Sandal  | de_DE  | ecommerce |
+      | sweater-white  | size         | size_M                       |        |           |
+      | sweater-white  | color        | red                          |        |           |
+      | sweater-white  | manufacturer | american_apparel             |        |           |
+      | sweater-white  | material     | leather                      |        |           |
       | sweater-white  | release_date | 1999-10-28                   |        | ecommerce |
-      | sweater-yellow | name         | Sandale jaune                | fr_FR  |           |
-      | sweater-yellow | name         | Gelb Sandal                  | de_DE  |           |
+      | sweater-yellow | name         | TShirt jaune                 | fr_FR  |           |
+      | sweater-yellow | name         | Gelb TShirt                  | de_DE  |           |
+      | sweater-yellow | description  | Un TShirt jaune élégant      | fr_FR  | ecommerce |
+      | sweater-yellow | description  | Ein elegantes gelb TShirt    | de_DE  | ecommerce |
       | sweater-yellow | price        | 10.90 EUR,15 USD,9 GBP       |        |           |
-      | sweater-yellow | description  | Une Sandale jaune élégante   | fr_FR  | ecommerce |
-      | sweater-yellow | description  | Ein elegantes gelb Sandal    | de_DE  | ecommerce |
+      | sweater-yellow | price        | 10.90 EUR,15 USD,9 GBP       |        |           |
+      | sweater-yellow | size         | size_M                       |        |           |
+      | sweater-yellow | color        | red                          |        |           |
+      | sweater-yellow | manufacturer | american_apparel             |        |           |
+      | sweater-yellow | material     | leather                      |        |           |
 
   Scenario: Export dates attributes in a specified format
     Given the following job "ecommerce_product_export" configuration:
@@ -43,7 +52,7 @@ Feature: Export products with localized dates
     And I wait for the "ecommerce_product_export" job to finish
     Then exported file of "ecommerce_product_export" should contain:
       """
-      sku;categories;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;enabled;family;groups;name-de_DE;name-en_GB;name-en_US;name-fr_FR;price-EUR;price-GBP;price-USD;release_date-ecommerce
-      sweater-white;men_2013,men_2014,men_2015;"Ein elegantes weißes Sandal";;;"Une Sandale blanche élégante";1;sandals;;"Weißes Sandal";;;"Sandale blanche";10.90;9.00;15.00;28/10/1999
-      sweater-yellow;men_2013,men_2014,men_2015;"Ein elegantes gelb Sandal";;;"Une Sandale jaune élégante";1;sandals;;"Gelb Sandal";;;"Sandale jaune";10.90;9.00;15.00;
-      """
+      sku;categories;enabled;family;groups;additional_colors;color;cost-EUR;cost-GBP;cost-USD;country_of_manufacture;customer_rating-ecommerce;customs_tax-de_DE-EUR;customs_tax-de_DE-GBP;customs_tax-de_DE-USD;datasheet;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;handmade;image;legend-de_DE;legend-en_GB;legend-en_US;legend-fr_FR;manufacturer;material;name-de_DE;name-en_GB;name-en_US;name-fr_FR;number_in_stock-ecommerce;price-EUR;price-GBP;price-USD;release_date-ecommerce;size;thumbnail;washing_temperature;washing_temperature-unit;weight;weight-unit
+      sweater-white;men_2013,men_2014,men_2015;1;tshirts;;;red;;;;;;;;;;Ein elegantes weißes TShirt;;;Un TShirt blanche élégante;0;;;;;;american_apparel;leather;Weißes TShirt;;;TShirt blanche;;10.90;9.00;15.00;28/10/1999;size_M;;;;;
+      sweater-yellow;men_2013,men_2014,men_2015;1;tshirts;;;red;;;;;;;;;;Ein elegantes gelb TShirt;;;Un TShirt jaune élégant;0;;;;;;american_apparel;leather;Gelb TShirt;;;TShirt jaune;;10.90;9.00;15.00;;size_M;;;;;
+    """

--- a/features/localization/export/export_products_with_decimal.feature
+++ b/features/localization/export/export_products_with_decimal.feature
@@ -15,28 +15,10 @@ Feature: Export products with localized numbers
       | sandal | cotton,metric |
     And the following products:
       | sku           | family  | categories                   | price                    |
-      | sandal-white  | sandals | men_2013, men_2014, men_2015 | 10.90 EUR, 15 USD, 9 GBP |
-      | sandal-black  | sandals | men_2013, men_2014, men_2015 | 10.90 EUR, 15 USD, 9 GBP |
-      | sandal-yellow | sandals | men_2013, men_2014, men_2015 | 10.90 EUR, 15 USD, 9 GBP |
-      | sandal-blue   | sandals | men_2013, men_2014, men_2015 | 10.90 EUR, 15 USD, 9 GBP |
-    And the following product values:
-      | product       | attribute   | value                          | locale | scope     |
-      | sandal-white  | name        | Sandale blanche                | fr_FR  |           |
-      | sandal-white  | name        | Weißes Sandal                  | de_DE  |           |
-      | sandal-white  | description | Une Sandale blanche élégante   | fr_FR  | ecommerce |
-      | sandal-white  | description | Ein elegantes weißes Sandal    | de_DE  | ecommerce |
-      | sandal-black  | name        | Sandale noire                  | fr_FR  |           |
-      | sandal-black  | name        | Schwarzes Sandal               | de_DE  |           |
-      | sandal-black  | description | Une Sandale noire élégante     | fr_FR  | ecommerce |
-      | sandal-black  | description | Ein elegantes schwarzes Sandal | de_DE  | ecommerce |
-      | sandal-yellow | name        | Sandale jaune                  | fr_FR  |           |
-      | sandal-yellow | name        | Gelb Sandal                    | de_DE  |           |
-      | sandal-yellow | description | Une Sandale jaune élégante     | fr_FR  | ecommerce |
-      | sandal-yellow | description | Ein elegantes gelb Sandal      | de_DE  | ecommerce |
-      | sandal-blue   | name        | Sandale bleue                  | fr_FR  |           |
-      | sandal-blue   | name        | Blau Sandal                    | de_DE  |           |
-      | sandal-blue   | description | Un Sandale bleue élégante      | fr_FR  | ecommerce |
-      | sandal-blue   | description | Ein elegantes blau Sandal      | de_DE  | ecommerce |
+      | sandal-white  | sandal | men_2013, men_2014, men_2015 | 10.90 EUR, 15 USD, 9 GBP |
+      | sandal-black  | sandal | men_2013, men_2014, men_2015 | 10.90 EUR, 15 USD, 9 GBP |
+      | sandal-yellow | sandal | men_2013, men_2014, men_2015 | 10.90 EUR, 15 USD, 9 GBP |
+      | sandal-blue   | sandal | men_2013, men_2014, men_2015 | 10.90 EUR, 15 USD, 9 GBP |
     And I am logged in as "Julia"
 
   Scenario: Export number attributes with the correct decimals formatting
@@ -55,11 +37,11 @@ Feature: Export products with localized numbers
     And I wait for the "ecommerce_product_export" job to finish
     Then exported file of "ecommerce_product_export" should contain:
       """
-      sku;categories;cotton;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;enabled;family;groups;name-de_DE;name-en_GB;name-en_US;name-fr_FR;price-EUR;price-GBP;price-USD
-      sandal-white;men_2013,men_2014,men_2015;75,5500;"Ein elegantes weißes Sandal";;;"Une Sandale blanche élégante";1;sandals;;"Weißes Sandal";;;"Sandale blanche";10,90;9,00;15,00
-      sandal-black;men_2013,men_2014,men_2015;75,0000;"Ein elegantes schwarzes Sandal";;;"Une Sandale noire élégante";1;sandals;;"Schwarzes Sandal";;;"Sandale noire";10,90;9,00;15,00
-      sandal-yellow;men_2013,men_2014,men_2015;;"Ein elegantes gelb Sandal";;;"Une Sandale jaune élégante";1;sandals;;"Gelb Sandal";;;"Sandale jaune";10,90;9,00;15,00
-      sandal-blue;men_2013,men_2014,men_2015;75,0000;"Ein elegantes blau Sandal";;;"Un Sandale bleue élégante";1;sandals;;"Blau Sandal";;;"Sandale bleue";10,90;9,00;15,00
+      sku;categories;enabled;family;groups;cotton;metric;metric-unit
+      sandal-white;men_2013,men_2014,men_2015;1;sandal;;75,5500;;
+      sandal-black;men_2013,men_2014,men_2015;1;sandal;;75,0000;;
+      sandal-yellow;men_2013,men_2014,men_2015;1;sandal;;;;
+      sandal-blue;men_2013,men_2014,men_2015;1;sandal;;75,0000;;
       """
 
   Scenario: Export metric attributes with the correct decimals formatting
@@ -78,9 +60,9 @@ Feature: Export products with localized numbers
     And I wait for the "ecommerce_product_export" job to finish
     Then exported file of "ecommerce_product_export" should contain:
       """
-      sku;categories;description-de_DE-ecommerce;description-en_GB-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;enabled;family;groups;metric;metric-unit;name-de_DE;name-en_GB;name-en_US;name-fr_FR;price-EUR;price-GBP;price-USD
-      sandal-white;men_2013,men_2014,men_2015;"Ein elegantes weißes Sandal";;;"Une Sandale blanche élégante";1;sandals;;90,0000;GRAM;"Weißes Sandal";;;"Sandale blanche";10,90;9,00;15,00
-      sandal-black;men_2013,men_2014,men_2015;"Ein elegantes schwarzes Sandal";;;"Une Sandale noire élégante";1;sandals;;95,5500;GRAM;"Schwarzes Sandal";;;"Sandale noire";10,90;9,00;15,00
-      sandal-yellow;men_2013,men_2014,men_2015;"Ein elegantes gelb Sandal";;;"Une Sandale jaune élégante";1;sandals;;85,0000;GRAM;"Gelb Sandal";;;"Sandale jaune";10,90;9,00;15,00
-      sandal-blue;men_2013,men_2014,men_2015;"Ein elegantes blau Sandal";;;"Un Sandale bleue élégante";1;sandals;;-5,0000;GRAM;"Blau Sandal";;;"Sandale bleue";10,90;9,00;15,00
+      sku;categories;enabled;family;groups;cotton;metric;metric-unit
+      sandal-white;men_2013,men_2014,men_2015;1;sandal;;;90,0000;GRAM
+      sandal-black;men_2013,men_2014,men_2015;1;sandal;;;95,5500;GRAM
+      sandal-yellow;men_2013,men_2014,men_2015;1;sandal;;;85,0000;GRAM
+      sandal-blue;men_2013,men_2014,men_2015;1;sandal;;;-5,0000;GRAM
       """

--- a/features/mass-action/edit_common_attributes_channel.feature
+++ b/features/mass-action/edit_common_attributes_channel.feature
@@ -38,7 +38,6 @@ Feature: Edit common attributes of many products at once
       | sneakers  | weight                   | 500 GRAM                |
       | sandals   | weight                   | 500 GRAM                |
       | pump      | weight                   | 500 GRAM                |
-      | highheels | weight                   | 500 GRAM                |
     When I show the filter "description"
     And I switch the scope to "Tablet"
     And I filter by "description" with operator "contains" and value "A beautiful description"
@@ -51,4 +50,4 @@ Feature: Edit common attributes of many products at once
     And I confirm mass edit
     And I wait for the "edit_common_attributes" job to finish
     Then the metric "Weight" of products boots and sneakers should be "600"
-    And the metric "Weight" of products sandals, pump and highheels should be "500"
+    And the metric "Weight" of products sandals and pump should be "500"

--- a/features/mass-action/edit_common_attributes_channel.feature
+++ b/features/mass-action/edit_common_attributes_channel.feature
@@ -38,6 +38,7 @@ Feature: Edit common attributes of many products at once
       | sneakers  | weight                   | 500 GRAM                |
       | sandals   | weight                   | 500 GRAM                |
       | pump      | weight                   | 500 GRAM                |
+      | highheels | weight                   | 500 GRAM                |
     When I show the filter "description"
     And I switch the scope to "Tablet"
     And I filter by "description" with operator "contains" and value "A beautiful description"
@@ -51,3 +52,5 @@ Feature: Edit common attributes of many products at once
     And I wait for the "edit_common_attributes" job to finish
     Then the metric "Weight" of products boots and sneakers should be "600"
     And the metric "Weight" of products sandals and pump should be "500"
+    And the product "highheels" should not have the following values:
+      | weight |

--- a/features/product/remove_attributes_from_product.feature
+++ b/features/product/remove_attributes_from_product.feature
@@ -15,17 +15,6 @@ Feature: Remove an attribute from a product
     Given I am on the "nike" product page
     Then I should not see a remove link next to the "Manufacturer" field
 
-  Scenario: Successfully remove an attribute from a product
-    Given the following product values:
-      | product | attribute  | value       |
-      | nike    | lace_color | laces_black |
-    And I am on the "nike" product page
-    And I visit the "Colors" group
-    When I remove the "Lace color" attribute
-    Then I confirm the deletion
-    And I press the "Save" button
-    And attribute in group "Colors" should be Color
-
   Scenario: Successfully remove a scopable attribute from a product
     Given the following attribute:
       | code            | label-en_US     | scopable | group | type             |

--- a/features/reference-data/export/export_products_with_reference_data.feature
+++ b/features/reference-data/export/export_products_with_reference_data.feature
@@ -13,11 +13,14 @@ Feature: Export products
     And the following "sole_fabric" attribute reference data: Cashmerewool, Neoprene and Silk
     Given the following products:
       | sku      | family   | categories        | price          | size | color    | name-en_US |
-      | SNKRS-1B | sneakers | summer_collection | 50 EUR, 70 USD | 45   | black    | Model 1    |
-      | SNKRS-1R | sneakers | summer_collection | 50 EUR, 70 USD | 45   | red      | Model 1    |
-      | SNKRS-1C | sneakers | summer_collection | 55 EUR, 75 USD | 45   | charcoal | Model 1    |
+      | SNKRS-1B | heels    | summer_collection | 50 EUR, 70 USD | 45   | black    | Model 1    |
+      | SNKRS-1R | heels    | summer_collection | 50 EUR, 70 USD | 45   | red      | Model 1    |
+      | SNKRS-1C | heels    | summer_collection | 55 EUR, 75 USD | 45   | charcoal | Model 1    |
     And the following product values:
       | product  | attribute   | value          |
+      | SNKRS-1B | heel_color  | Red            |
+      | SNKRS-1B | sole_fabric | Silk           |
+      | SNKRS-1B | sole_color  | Blue           |
       | SNKRS-1R | heel_color  | Red            |
       | SNKRS-1R | sole_fabric | Neoprene, Silk |
       | SNKRS-1R | sole_color  | Red            |
@@ -27,8 +30,7 @@ Feature: Export products
     And I wait for the "csv_footwear_product_export" job to finish
     Then exported file of "csv_footwear_product_export" should contain:
     """
-    sku;categories;color;description-en_US-mobile;enabled;family;groups;heel_color;lace_color;manufacturer;name-en_US;price-EUR;price-USD;rating;side_view;size;sole_color;sole_fabric;top_view;weather_conditions
-    SNKRS-1B;summer_collection;black;;1;sneakers;;;;;"Model 1";50.00;70.00;;;45;;;;
-    SNKRS-1R;summer_collection;red;;1;sneakers;;Red;;;"Model 1";50.00;70.00;;;45;Red;Neoprene,Silk;;
-    SNKRS-1C;summer_collection;charcoal;;1;sneakers;;;;;"Model 1";55.00;75.00;;;45;;;;
+    sku;categories;enabled;family;groups;color;description-en_US-mobile;heel_color;manufacturer;name-en_US;price-EUR;price-USD;side_view;size;sole_color;sole_fabric;top_view
+    SNKRS-1B;summer_collection;1;heels;;black;;Red;;Model 1;50.00;70.00;;45;Blue;Silk;
+    SNKRS-1R;summer_collection;1;heels;;red;;Red;;Model 1;50.00;70.00;;45;Red;Neoprene,Silk;
     """

--- a/features/reference-data/product/display_reference_data_in_the_grid.feature
+++ b/features/reference-data/product/display_reference_data_in_the_grid.feature
@@ -35,7 +35,7 @@ Feature: Display reference data in the grid
   Scenario: Successfully edit reference data values to a product with scope
     Given the following products:
       | sku        | family |
-      | high-heels | heels  |
+      | high-heels |        |
     And the following reference data:
       | type   | code   | label  |
       | color  | black  | Black  |

--- a/features/reference-data/product/sorting/sort_products_per_reference_data.feature
+++ b/features/reference-data/product/sorting/sort_products_per_reference_data.feature
@@ -36,8 +36,8 @@ Feature: Sort products
       | whatever | sku                 | sku                    |
     And the following products:
       | sku      | family   |
-      | productA | whatever |
-      | productB | whatever |
+      | productA |          |
+      | productB |          |
     And the following product values:
       | product  | attribute | value |
       | productA | color     | Red   |

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/RemoveOptionalAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/RemoveOptionalAttributeIntegration.php
@@ -15,7 +15,7 @@ class RemoveOptionalAttributeIntegration extends TestCase
     /**
      * @test
      */
-    function remove_an_attribute_on_a_product_without_family()
+    function test_remove_an_attribute_on_a_product_without_family()
     {
         /** @var EntityBuilder $entityBuilder */
         $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/RemoveOptionalAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/RemoveOptionalAttributeIntegration.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Product;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Pim\Bundle\CatalogBundle\tests\fixture\EntityBuilder;
+use Pim\Component\Catalog\Model\ProductInterface;
+
+class RemoveOptionalAttributeIntegration extends TestCase
+{
+    /**
+     * @test
+     */
+    function remove_an_attribute_on_a_product_without_family()
+    {
+        /** @var EntityBuilder $entityBuilder */
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
+        $entityBuilder->createProduct('playstation', '', [
+            'values' => [
+                'a_text' => [['data' => 'A playstation.', 'locale' => null, 'scope' => null]]
+            ]
+        ]);
+
+        /** @var ProductInterface $product */
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('playstation');
+        $this->get('pim_catalog.updater.product')->update($product, ['values' => []]);
+        $this->get('validator')->validate($product);
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        Assert::assertNull($product->getValue('a_text'));
+    }
+
+    /**
+     * @test
+     */
+    function remove_an_optional_attribute_on_a_product_with_family()
+    {
+
+    }
+
+    /**
+     * @test
+     */
+    function cannot_remove_an_attribute_of_a_product_if_attribute_is_in_the_family()
+    {
+
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Product/RemoveOptionalAttributeIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Product/RemoveOptionalAttributeIntegration.php
@@ -34,22 +34,6 @@ class RemoveOptionalAttributeIntegration extends TestCase
         Assert::assertNull($product->getValue('a_text'));
     }
 
-    /**
-     * @test
-     */
-    function remove_an_optional_attribute_on_a_product_with_family()
-    {
-
-    }
-
-    /**
-     * @test
-     */
-    function cannot_remove_an_attribute_of_a_product_if_attribute_is_in_the_family()
-    {
-
-    }
-
     protected function getConfiguration()
     {
         return $this->catalog->useTechnicalCatalog();

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
@@ -104,9 +104,10 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
         $parentProductModelCode = $item['parent'] ?? '';
 
         try {
-            $item = $this->productAttributeFilter->filter($item);
-
             $familyCode = $this->getFamilyCode($item);
+            $item['family'] = $familyCode;
+
+            $item = $this->productAttributeFilter->filter($item);
             $filteredItem = $this->filterItemData($item);
 
             $product = $this->findProductToImport->fromFlatData($identifier, $familyCode, $parentProductModelCode);
@@ -188,7 +189,22 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
      */
     protected function getFamilyCode(array $item): string
     {
-        return $item['family'] ?? '';
+        if (key_exists('family', $item)) {
+            return $item['family'];
+        }
+
+        /** @var ProductInterface $product */
+        $product = $this->repository->findOneByIdentifier($item['identifier']);
+        if (null === $product) {
+            return '';
+        }
+
+        $family = $product->getFamily();
+        if (null === $family) {
+            return '';
+        }
+
+        return $family->getCode();
     }
 
     /**

--- a/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
+++ b/src/Pim/Component/Connector/Processor/Denormalization/ProductProcessor.php
@@ -193,7 +193,6 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
             return $item['family'];
         }
 
-        /** @var ProductInterface $product */
         $product = $this->repository->findOneByIdentifier($item['identifier']);
         if (null === $product) {
             return '';


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Problem: When we import a product and the "family" column is not set, we can bypass the family attributes and are able to set optional attributes to product that have a family (_and thus **should not have optional attributes**_).

Solution: If the `family` column is not set in the imported file, we fetch the product by its identifier and then its family.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
