### PR TITLE
PIM-7865: Improve performances on Product model export

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7775: Security patch: check MIME type to be coherent with extension file. Saving products with incoherent file extension and MIME type is now forbidden.
+- PIM-7865: Improve performances on Product model export
 
 # 2.3.17 (2018-11-15)
 

--- a/src/Pim/Component/Catalog/Model/AbstractProduct.php
+++ b/src/Pim/Component/Catalog/Model/AbstractProduct.php
@@ -224,7 +224,16 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getValue($attributeCode, $localeCode = null, $scopeCode = null)
     {
-        return $this->getValues()->getByCodes($attributeCode, $scopeCode, $localeCode);
+        $value = $this->values->getByCodes($attributeCode, $scopeCode, $localeCode);
+        if (null !== $value) {
+            return $value;
+        }
+
+        if (null === $this->getParent()) {
+            return null;
+        }
+
+        return $this->getParent()->getValue($attributeCode, $localeCode, $scopeCode);
     }
 
     /**

--- a/src/Pim/Component/Catalog/Model/ProductModel.php
+++ b/src/Pim/Component/Catalog/Model/ProductModel.php
@@ -152,7 +152,16 @@ class ProductModel implements ProductModelInterface
      */
     public function getValue($attributeCode, $localeCode = null, $scopeCode = null): ?ValueInterface
     {
-        return $this->getValues()->getByCodes($attributeCode, $scopeCode, $localeCode);
+        $result = $this->values->getByCodes($attributeCode, $scopeCode, $localeCode);
+        if (null !== $result) {
+            return $result;
+        }
+
+        if (null === $this->getParent()) {
+            return null;
+        }
+
+        return $this->getParent()->getValue($attributeCode, $localeCode, $scopeCode);
     }
 
     /**

--- a/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
+++ b/src/Pim/Component/Catalog/spec/Model/ProductModelSpec.php
@@ -101,7 +101,7 @@ class ProductModelSpec extends ObjectBehavior
         $attributeAsLabel->isUnique()->willReturn(false);
         $attributeAsLabel->isScopable()->willReturn(false);
 
-        $values->toArray()->willreturn(['name-<all_channels>-fr_FR' => $nameValue]);
+        $values->getByCodes('name', null, 'fr_FR')->willreturn($nameValue);
 
         $nameValue->getAttribute()->willReturn($attributeAsLabel);
         $nameValue->getScope()->willReturn(null);
@@ -130,20 +130,12 @@ class ProductModelSpec extends ObjectBehavior
         $attributeAsLabel->isUnique()->willReturn(false);
         $attributeAsLabel->isScopable()->willReturn(true);
 
-        $values->toArray()->willreturn([
-            'name-ecommerce-fr_FR' => $ecommerceNameValue,
-            'name-mobile-fr_FR' => $mobileNameValue,
-        ]);
+        $values->getByCodes('name', 'mobile', 'fr_FR')->willreturn($mobileNameValue);
 
         $mobileNameValue->getAttribute()->willReturn($attributeAsLabel);
         $mobileNameValue->getScope()->willReturn('mobile');
         $mobileNameValue->getLocale()->willReturn('fr_FR');
         $mobileNameValue->getData()->willReturn('Petite pelle');
-
-        $ecommerceNameValue->getAttribute()->willReturn($attributeAsLabel);
-        $ecommerceNameValue->getScope()->willReturn('ecommerce');
-        $ecommerceNameValue->getLocale()->willReturn('fr_FR');
-        $ecommerceNameValue->getData()->willReturn('Petit outil agricole authentique');
 
         $this->setFamilyVariant($familyVariant);
         $this->setValues($values);
@@ -179,7 +171,7 @@ class ProductModelSpec extends ObjectBehavior
         $attributeAsLabel->isLocalizable()->willReturn(true);
         $attributeAsLabel->isScopable()->willReturn(false);
 
-        $values->toArray()->willreturn([]);
+        $values->getByCodes('name', null, 'fr_FR')->willreturn(null);
 
         $this->setFamilyVariant($familyVariant);
         $this->setValues($values);
@@ -202,7 +194,7 @@ class ProductModelSpec extends ObjectBehavior
         $attributeAsLabel->isUnique()->willReturn(false);
         $attributeAsLabel->isScopable()->willReturn(false);
 
-        $values->toArray()->willreturn(['name-<all_channels>-fr_FR' => $nameValue]);
+        $values->getByCodes('name', null, 'fr_FR')->willReturn($nameValue);
 
         $nameValue->getAttribute()->willReturn($attributeAsLabel);
         $nameValue->getScope()->willReturn(null);
@@ -231,20 +223,7 @@ class ProductModelSpec extends ObjectBehavior
         $attributeAsLabel->isUnique()->willReturn(false);
         $attributeAsLabel->isScopable()->willReturn(true);
 
-        $values->toArray()->willreturn([
-            'name-ecommerce-fr_FR' => $ecommerceNameValue,
-            'name-mobile-fr_FR' => $mobileNameValue,
-        ]);
-
-        $mobileNameValue->getAttribute()->willReturn($attributeAsLabel);
-        $mobileNameValue->getScope()->willReturn('mobile');
-        $mobileNameValue->getLocale()->willReturn('fr_FR');
-        $mobileNameValue->getData()->willReturn('Petite pelle');
-
-        $ecommerceNameValue->getAttribute()->willReturn($attributeAsLabel);
-        $ecommerceNameValue->getScope()->willReturn('ecommerce');
-        $ecommerceNameValue->getLocale()->willReturn('fr_FR');
-        $ecommerceNameValue->getData()->willReturn('Petit outil agricole authentique');
+        $values->getByCodes('name', null, 'fr_FR')->willreturn(null);
 
         $this->setFamilyVariant($familyVariant);
         $this->setValues($values);
@@ -267,7 +246,7 @@ class ProductModelSpec extends ObjectBehavior
         $attributeAsLabel->isUnique()->willReturn(false);
         $attributeAsLabel->isScopable()->willReturn(false);
 
-        $values->toArray()->willreturn(['name-<all_channels>-fr_FR' => $nameValue]);
+        $values->getByCodes('name', null, null)->willreturn($nameValue);
 
         $nameValue->getAttribute()->willReturn($attributeAsLabel);
         $nameValue->getScope()->willReturn(null);
@@ -293,7 +272,7 @@ class ProductModelSpec extends ObjectBehavior
         $attributeAsImage->getCode()->willReturn('picture');
         $attributeAsImage->isUnique()->willReturn(false);
 
-        $values->toArray()->willreturn(['picture-<all_channels>-<all_locales>' => $pictureValue]);
+        $values->getByCodes('picture', null, null)->willReturn($pictureValue);
 
         $pictureValue->getAttribute()->willReturn($attributeAsImage);
         $pictureValue->getScope()->willReturn(null);
@@ -329,7 +308,7 @@ class ProductModelSpec extends ObjectBehavior
         $family->getAttributeAsImage()->willReturn($attributeAsImage);
         $attributeAsImage->getCode()->willReturn('picture');
 
-        $values->toArray()->willreturn([]);
+        $values->getByCodes('picture', null, null)->willreturn(null);
 
         $this->setFamilyVariant($familyVariant);
         $this->setValues($values);
@@ -397,7 +376,7 @@ class ProductModelSpec extends ObjectBehavior
         $attributeAsLabel->isLocalizable()->willReturn(true);
         $attributeAsLabel->isScopable()->willReturn(false);
 
-        $values->toArray()->willreturn([]);
+        $values->getByCodes('name', null, null)->willReturn(null);
 
         $this->setFamilyVariant($familyVariant);
         $this->setValues($values);


### PR DESCRIPTION
Blackfire report : https://blackfire.io/profiles/258f0dc2-0633-4e68-b8ee-94e2431ee806/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=focused&settings%5BtabPane%5D=nodes&selected=Pim%5CComponent%5CCatalog%5CBuilder%5CEntityWithValuesBuilder%3A%3AaddOrReplaceValue&callname=Pim%5CComponent%5CConnector%5CProcessor%5CNormalization%5CProductProcessor%3A%3Aprocess

Issue was in the fillMissingValues, which was generating a complete ValueCollection for each value to fill (2.618.913 calls)
With this PR, we don't create a value collection anymore and write explicitly to check in this level then in the parent.

For 535 product models:
Previous timing: 21 minutes (0.42 pm/s)
Current timing: 1 minute (8.92 pm/s)
Improvement: 21 times faster.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | y
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
