### PR TITLE
Change `filterOnlyExistingOptions` visibility

### DIFF
--- a/src/Oro/Bundle/PimFilterBundle/Filter/ProductValue/ChoiceFilter.php
+++ b/src/Oro/Bundle/PimFilterBundle/Filter/ProductValue/ChoiceFilter.php
@@ -128,7 +128,7 @@ class ChoiceFilter extends AjaxChoiceFilter
      * @param $optionCodes
      * @return array
      */
-    private function filterOnlyExistingOptions($optionCodes)
+    protected function filterOnlyExistingOptions($optionCodes)
     {
         $attribute = $this->getAttribute();
         $attributeOptions = $this->attributeOptionRepository->findCodesByIdentifiers(


### PR DESCRIPTION
We need to override this method in EE for Reference Entity filter