### PR TITLE
PIM-7885: Allow "0" for non decimal metric value

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-7775: Security patch: check MIME type to be coherent with extension file. Saving products with incoherent file extension and MIME type is now forbidden.
 - PIM-7865: Improve performances on Product model export
+- PIM-7885: Allow "0" for non decimal metric value
 
 # 2.3.17 (2018-11-15)
 

--- a/src/Pim/Component/Catalog/Normalizer/Standard/Product/MetricNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/Product/MetricNormalizer.php
@@ -30,7 +30,7 @@ class MetricNormalizer implements NormalizerInterface
                 ? number_format($amount, static::DECIMAL_PRECISION, '.', '') : (int) $amount;
         }
 
-        if (null == $amount) {
+        if (null === $amount) {
             return [
                 'amount' => null,
                 'unit'   => null,

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/Product/MetricNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/Product/MetricNormalizerSpec.php
@@ -47,6 +47,17 @@ class MetricNormalizerSpec extends ObjectBehavior
         ]);
     }
 
+    function it_normalizes_metric_in_standard_format_with_zero_amount(MetricInterface $metric)
+    {
+        $metric->getUnit()->willReturn('KILOGRAM');
+        $metric->getData()->willReturn('0');
+
+        $this->normalize($metric, 'standard', ['is_decimals_allowed' => false])->shouldReturn([
+            'amount' => 0,
+            'unit'   => 'KILOGRAM'
+        ]);
+    }
+
     function it_returns_data_if_it_is_not_a_numeric(MetricInterface $metric)
     {
         $metric->getUnit()->willReturn('KILOGRAM');


### PR DESCRIPTION
Allow the "0" value in non decimal metric value.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | Todo
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
