### PR TITLE
PIM-7660: get images of product models in the datagrid

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -81,6 +81,7 @@ services:
         arguments:
         - '@database_connection'
         - '@pim_catalog.factory.value_collection'
+        - '@akeneo.pim.enrichment.product.grid.query.product_model_images_from_codes'
 
     akeneo.pim.enrichment.product.grid.query.fetch_product_rows_from_identifiers:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductGrid\FetchProductRowsFromIdentifiers'
@@ -98,3 +99,9 @@ services:
         arguments:
             - !tagged akeneo.pim.enrichment.product.grid.add_additional_product_model_properties
 
+
+    akeneo.pim.enrichment.product.grid.query.product_model_images_from_codes:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductGrid\ProductModelImagesFromCodes'
+        arguments:
+            - '@database_connection'
+            - '@pim_catalog.factory.value_collection'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductGrid;
+
+use Akeneo\Pim\Enrichment\Component\Product\Factory\Value\MediaValueFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\ValueCollectionFactoryInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * When requesting the label of product model in the datagrid, you can get it from:
+ * - the parent product model
+ *      if the attribute as image is at the level 0 and the product model is not root
+ *
+ * - the current product model
+ *      if the attribute as image is at the level 0 and the current product model is root
+ *      OR
+ *      if the attribute as image is at the level 1 and the current product model is a sub product model
+ *
+ * - a sub product model
+ *      if the attribute as image is at the level 1 and the current product model is a root product model
+ *      it will be the image of the oldest sub product model by creation date with a non null image
+ *
+ * - a child variant product:
+ *      if the attribute as image is at the level 2 and the current product model
+ *      it will be the image of the oldest sub product model by creation date with a non null image
+ *
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductModelImagesFromCodes
+{
+    /** @var Connection */
+    private $connection;
+
+    /** @var ValueCollectionFactoryInterface */
+    private $valueCollectionFactory;
+
+    public function __construct(Connection $connection, ValueCollectionFactoryInterface $valueCollectionFactory)
+    {
+        $this->connection = $connection;
+        $this->valueCollectionFactory = $valueCollectionFactory;
+    }
+
+    /**
+     * @param array  $codes
+     * @param string $channelCode
+     * @param string $localeCode
+     *
+     * @return array product model images index by product model code
+     *     [
+     *        'product_model_code' => ['image' => MediaValue]
+     *     ]
+     */
+    public function __invoke(array $codes, string $channelCode, string $localeCode): array
+    {
+        $codesPerImageLevel = $this->codesPerImageLevel($codes);
+
+        $images = array_replace_recursive(
+            $this->getImagesFromCurrentOrParentProductModel(
+                $codesPerImageLevel['image_in_current_or_parent_product_model'],
+                $channelCode,
+                $localeCode
+            ),
+            $this->getImagesFromSubProductModel(
+                $codesPerImageLevel['image_in_sub_product_model'],
+                $channelCode,
+                $localeCode
+            ),
+            $this->getImagesFromVariantProduct(
+                $codesPerImageLevel['image_in_variant_product'],
+                $channelCode,
+                $localeCode
+            )
+        );
+
+        return $images;
+    }
+
+    /**
+     * Compute at which level is the image attribute.
+     * It can be:
+     * - in the current product model or in its parent
+     * - in the sub product model if the product model is a root product model
+     * - in the variant product model
+     *
+     * @param array $codes
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     * @return array
+     *              [
+     *                'image_in_current_or_parent_product_model' => ['product_model_1']
+     *                'image_in_sub_product_model' => ['product_model_2']
+     *                'image_in_variant_product' => ['product_model_3']
+     *              ]
+     *
+     */
+    private function codesPerImageLevel(array $codes): array
+    {
+        $codesPerLevel = [
+            'image_in_sub_product_model' => [],
+            'image_in_variant_product' => [],
+            'image_in_current_or_parent_product_model' => [],
+        ];
+
+        $sql = <<<SQL
+            SELECT 
+                product_model_code,
+                CASE
+                    WHEN product_model_level = 0 AND image_code_level = 1 AND parent_id IS NOT NULL THEN 'image_in_sub_product_model'
+                    WHEN product_model_level = 0 AND image_code_level = 1 AND parent_id IS NULL THEN 'image_in_variant_product'
+                    WHEN product_model_level = 0 AND image_code_level = 2 THEN 'image_in_variant_product'
+                    WHEN product_model_level = 1 AND image_code_level = 1 THEN 'image_in_current_or_parent_product_model'
+                    WHEN product_model_level = 1 AND image_code_level = 2 THEN 'image_in_variant_product'
+                    ELSE 'image_in_current_or_parent_product_model' END 
+                AS image_level
+            FROM (
+                SELECT 
+                    pm.code as product_model_code,
+                    pm.parent_id,
+                    pm.lvl as product_model_level,
+                    fv_set.level as image_code_level
+                FROM
+                    pim_catalog_product_model pm
+                    JOIN pim_catalog_family_variant fv ON fv.id = pm.family_variant_id
+                    JOIN pim_catalog_family f ON f.id = fv.family_id
+                    JOIN pim_catalog_attribute a_image ON a_image.id = f.image_attribute_id
+                    JOIN pim_catalog_family_variant_has_variant_attribute_sets attr_set ON  attr_set.family_variant_id = fv.id
+                    JOIN pim_catalog_family_variant_attribute_set fv_set ON fv_set.id = variant_attribute_sets_id
+                    JOIN pim_catalog_variant_attribute_set_has_attributes attr ON attr.variant_attribute_set_id = fv_set.id AND attr.attributes_id = a_image.id
+                WHERE 
+                    pm.code IN (:codes)
+            ) as product_models
+SQL;
+
+        $rows = $this->connection->executeQuery(
+            $sql,
+            ['codes' => $codes],
+            ['codes' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
+        )->fetchAll();
+
+        foreach ($rows as $row) {
+            $codesPerLevel[$row['image_level']][] = $row['product_model_code'];
+            $key = array_search($row['product_model_code'], $codes);
+            unset($codes[$key]);
+        }
+
+        // product model codes are not returned by the SQL request if the attribute as image is at level 0
+        $codesPerLevel['image_in_current_or_parent_product_model'] = array_merge($codesPerLevel['image_in_current_or_parent_product_model'], $codes);
+
+        return $codesPerLevel;
+    }
+
+    private function getImagesFromCurrentOrParentProductModel(array $codes, string $channelCode, string $localeCode): array
+    {
+        $images = [];
+        foreach ($codes as $code) {
+            $images[$code]['image'] = null;
+        }
+
+        $sql = <<<SQL
+            SELECT 
+                pm.code,
+                a_image.code as attribute_code,
+                a_image.is_localizable,
+                a_image.is_scopable,
+                JSON_MERGE(pm.raw_values, COALESCE(root_pm.raw_values, '{}')) as raw_values 
+            FROM
+                pim_catalog_product_model pm
+                LEFT JOIN pim_catalog_product_model root_pm ON root_pm.id = pm.parent_id
+                JOIN pim_catalog_family_variant fv ON fv.id = pm.family_variant_id
+                JOIN pim_catalog_family f ON f.id = fv.family_id
+                JOIN pim_catalog_attribute a_image ON a_image.id = f.image_attribute_id
+            WHERE 
+                pm.code IN (:codes)
+SQL;
+
+        $rows = $this->connection->executeQuery(
+            $sql,
+            ['codes' => $codes],
+            ['codes' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
+        )->fetchAll();
+
+        foreach ($rows as $row) {
+            $rawValues = json_decode($row['raw_values'], true);
+            $filteredRawValues = array_intersect_key($rawValues, [$row['attribute_code'] => true]);
+            $valueCollection = $this->valueCollectionFactory->createFromStorageFormat($filteredRawValues);
+
+            $images[$row['code']]['image'] = $valueCollection->getByCodes(
+                $row['attribute_code'],
+                $row['is_scopable'] ? $channelCode : null,
+                $row['is_localizable'] ? $localeCode : null
+            );
+        }
+
+        return $images;
+    }
+
+    /**
+     * It gets image from the oldest child product model having a non null image.
+     *
+     * As we can't get easily the first row of each group when doing a group by,
+     * it executes one request per product model.
+     *
+     * @param array  $codes
+     * @param string $channelCode
+     * @param string $localeCode
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     * @return array
+     */
+    private function getImagesFromSubProductModel(array $codes, string $channelCode, string $localeCode): array
+    {
+        $images = [];
+        foreach ($codes as $code) {
+            $images[$code]['image'] = null;
+        }
+
+        $sql = <<<SQL
+            SELECT 
+                pm_root.code,
+                a_image.code as attribute_code,
+                pm_child.raw_values,
+                a_image.is_localizable,
+                a_image.is_scopable,
+                JSON_EXTRACT(
+                    pm_child.raw_values,
+                    CONCAT('$.', a_image.code, '.', IF(is_scopable = 1, '":channel_code"', '"<all_channels>"'), '.', IF(is_localizable = 1, '":locale_code"', '"<all_locales>"'))
+                ) as image_value
+            FROM
+                pim_catalog_product_model pm_root
+                JOIN pim_catalog_product_model pm_child ON pm_child.parent_id = pm_root.id
+                JOIN pim_catalog_family_variant fv ON fv.id = pm_root.family_variant_id
+                JOIN pim_catalog_family f ON f.id = fv.family_id
+                JOIN pim_catalog_attribute a_image ON a_image.id = f.image_attribute_id
+            WHERE
+                pm_root.code = :code
+            HAVING
+                image_value IS NOT NULL AND JSON_TYPE(image_value) != 'NULL'
+            ORDER BY 
+                pm_child.created ASC
+            LIMIT 1
+SQL;
+
+        $images = [];
+        foreach ($codes as $code) {
+            $row = $this->connection->executeQuery(
+                $sql,
+                ['code' => $code, 'channel_code' => $channelCode, 'locale_code' => $localeCode]
+            )->fetch();
+            if (!isset($row['code'])) {
+                continue;
+            }
+
+            $rawValues = json_decode($row['raw_values'], true);
+            $filteredRawValues = array_intersect_key($rawValues, [$row['attribute_code'] => true]);
+            $valueCollection = $this->valueCollectionFactory->createFromStorageFormat($filteredRawValues);
+
+            $images[$row['code']]['image'] = $valueCollection->getByCodes(
+                $row['attribute_code'],
+                $row['is_scopable'] ? $channelCode : null,
+                $row['is_localizable'] ? $localeCode : null
+            );
+        }
+
+        return $images;
+    }
+
+    /**
+     * It gets image from the oldest child variant product having a non null image.
+     *
+     * As we can't get easily the first row of each group when doing a group by,
+     * it executes one request per product model.
+     *
+     * @param array  $codes
+     * @param string $channelCode
+     * @param string $localeCode
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     * @return array
+     */
+    private function getImagesFromVariantProduct(array $codes, string $channelCode, string $localeCode): array
+    {
+        $images = [];
+        foreach ($codes as $code) {
+            $images[$code]['image'] = null;
+        }
+
+        $sql = <<<SQL
+            SELECT 
+                pm_root.code,
+                a_image.code as attribute_code,
+                a_image.is_localizable,
+                a_image.is_scopable,
+                product_child.raw_values,
+                JSON_EXTRACT(
+                    product_child.raw_values,
+                    CONCAT('$.', a_image.code, '.', IF(is_scopable = 1, '":channel_code"', '"<all_channels>"'), '.', IF(is_localizable = 1, '":locale_code"', '"<all_locales>"'))
+                ) as image_value
+            FROM
+                pim_catalog_product_model pm_root
+                LEFT JOIN pim_catalog_product_model pm_child ON pm_child.parent_id = pm_root.id
+                JOIN pim_catalog_product product_child ON product_child.product_model_id = COALESCE(pm_child.id, pm_root.id)
+                JOIN pim_catalog_family_variant fv ON fv.id = pm_root.family_variant_id
+                JOIN pim_catalog_family f ON f.id = fv.family_id
+                JOIN pim_catalog_attribute a_image ON a_image.id = f.image_attribute_id
+            WHERE
+                pm_root.code = :code
+            HAVING
+                image_value IS NOT NULL AND JSON_TYPE(image_value) != 'NULL'
+            ORDER BY 
+                product_child.created ASC
+            LIMIT 1
+SQL;
+
+        foreach ($codes as $code) {
+            $row = $this->connection->executeQuery(
+                $sql,
+                ['code' => $code, 'channel_code' => $channelCode, 'locale_code' => $localeCode]
+            )->fetch();
+
+            if (!isset($row['code'])) {
+                continue;
+            }
+
+            $rawValues = json_decode($row['raw_values'], true);
+            $filteredRawValues = array_intersect_key($rawValues, [$row['attribute_code'] => true]);
+            $valueCollection = $this->valueCollectionFactory->createFromStorageFormat($filteredRawValues);
+
+            $images[$row['code']]['image'] = $valueCollection->getByCodes(
+                $row['attribute_code'],
+                $row['is_scopable'] ? $channelCode : null,
+                $row['is_localizable'] ? $localeCode : null
+            );
+        }
+
+        return $images;
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductGrid/FetchProductAndProductModelRowsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductGrid/FetchProductAndProductModelRowsIntegration.php
@@ -97,9 +97,7 @@ class FetchProductAndProductModelRowsIntegration extends TestCase
                 $rootProductModel->getId(),
                 ['total' => 1, 'complete' => 0],
                 null,
-                new ValueCollection([
-                    MediaValue::value('an_image', $akeneoImage),
-                ])
+                new ValueCollection([])
             ),
         ];
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/AssertRows.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/AssertRows.php
@@ -36,7 +36,7 @@ final class AssertRows
         Assert::assertNotNull($row->created());
 
         null !== $expectedRow->image() ?
-            Assert::assertTrue($expectedRow->image()->isEqual($row->image())):
+            Assert::assertTrue($expectedRow->image()->getData()->getHash() === $row->image()->getData()->getHash()):
             Assert::assertNull($row->image());
 
         Assert::assertSame($expectedRow->label(), $row->label());

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductGridFixturesLoader.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductGridFixturesLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\ProductGrid;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use PHPUnit\Framework\Assert;
 use Psr\Container\ContainerInterface;
 
@@ -23,6 +24,87 @@ final class ProductGridFixturesLoader
     {
         $this->container = $container;
         $this->akeneoImagePath = $akeneoImagePath;
+    }
+
+    public function createProductModelsWithLabelInProduct(): ProductModelInterface
+    {
+        $this->createFamilyVariant();
+        $rootProductModelWithoutSubProductModel = $this->container->get('pim_catalog.factory.product_model')->create();
+        $this->container->get('pim_catalog.updater.product_model')->update($rootProductModelWithoutSubProductModel, [
+            'code' => 'root_product_model_without_sub_product_model',
+            'family_variant' => 'family_variant_image_in_product',
+            'values' => [
+                'a_localizable_image' => [
+                    ['data' => $this->akeneoImagePath, 'locale' => 'en_US', 'scope' => null],
+                    ['data' => $this->akeneoImagePath, 'locale' => 'fr_FR', 'scope' => null],
+                ],
+                'a_scopable_image' => [
+                    ['data' => $this->akeneoImagePath, 'locale' => null, 'scope' => 'ecommerce'],
+                    ['data' => $this->akeneoImagePath, 'locale' => null, 'scope' => 'tablet'],
+                ],
+            ]
+        ]);
+
+        $errors = $this->container->get('pim_catalog.validator.product')->validate($rootProductModelWithoutSubProductModel);
+        Assert::assertCount(0, $errors);
+        $this->container->get('pim_catalog.saver.product_model')->save($rootProductModelWithoutSubProductModel);
+
+        $product = $this->container->get('pim_catalog.builder.product')->createProduct('product_with_image', 'test_family');
+        $this->container->get('pim_catalog.updater.product')->update($product, [
+            'groups' => ['groupA', 'groupB'],
+            'parent' => 'root_product_model_without_sub_product_model',
+            'values' => [
+                'a_yes_no' => [
+                    ['data' => true, 'locale' => null, 'scope' => null]
+                ],
+                'an_image' => [
+                    ['data' => $this->akeneoImagePath, 'locale' => null, 'scope' => null],
+                ],
+            ]
+        ]);
+
+        $errors = $this->container->get('validator')->validate($product);
+        Assert::assertCount(0, $errors);
+
+        $this->container->get('pim_catalog.saver.product')->save($product);
+
+        return $rootProductModelWithoutSubProductModel;
+    }
+
+    public function createProductModelsWithLabelInParentProductModel()
+    {
+        $rootProductModelWithSubProductModel = $this->container->get('pim_catalog.factory.product_model')->create();
+        $this->container->get('pim_catalog.updater.product_model')->update($rootProductModelWithSubProductModel, [
+            'code' => 'root_product_model_with_sub_product_model',
+            'family_variant' => 'family_variant_image_in_parent_product_model',
+            'values' => [
+                'an_image' => [
+                    ['data' => $this->akeneoImagePath, 'locale' => null, 'scope' => null],
+                ],
+            ]
+        ]);
+
+        $errors = $this->container->get('pim_catalog.validator.product')->validate($rootProductModelWithSubProductModel);
+        Assert::assertCount(0, $errors);
+        $this->container->get('pim_catalog.saver.product_model')->save($rootProductModelWithSubProductModel);
+
+        $subProductModel = $this->container->get('pim_catalog.factory.product_model')->create();
+        $this->container->get('pim_catalog.updater.product_model')->update($subProductModel, [
+            'code' => 'sub_product_model',
+            'parent' => 'root_product_model_with_sub_product_model',
+            'family_variant' => 'family_variant_image_in_parent_product_model',
+            'values' => [
+                'a_yes_no' => [
+                    ['data' => true, 'locale' => null, 'scope' => null],
+                ],
+            ]
+        ]);
+
+        $errors = $this->container->get('pim_catalog.validator.product')->validate($subProductModel);
+        Assert::assertCount(0, $errors);
+        $this->container->get('pim_catalog.saver.product_model')->save($subProductModel);
+
+        return $subProductModel;
     }
 
     public function createProductAndProductModels()
@@ -113,5 +195,65 @@ final class ProductGridFixturesLoader
         $this->container->get('pim_catalog.saver.product')->saveAll([$product1, $product2]);
 
         return [$product1, $product2];
+    }
+
+    private function createFamilyVariant(): void
+    {
+        $family = $this->container->get('pim_catalog.factory.family')->create();
+        $this->container->get('pim_catalog.updater.family')->update($family, [
+            'code' => 'test_family',
+            'attributes'  => [
+                'sku',
+                'an_image',
+                'a_yes_no',
+                'a_simple_select_size',
+                'a_localizable_image',
+                'a_scopable_image',
+            ],
+            "attribute_as_image" => "an_image"
+        ]);
+
+        $errors = $this->container->get('validator')->validate($family);
+        Assert::assertCount(0, $errors);
+        $this->container->get('pim_catalog.saver.family')->save($family);
+
+        $familyVariant = $this->container->get('pim_catalog.factory.family_variant')->create();
+        $this->container->get('pim_catalog.updater.family_variant')->update($familyVariant, [
+            'code' => 'family_variant_image_in_product',
+            'family' => 'test_family',
+            'variant_attribute_sets' => [
+                [
+                    'axes' => ['a_yes_no'],
+                    'attributes' => ['an_image'],
+                    'level'=> 1,
+                ]
+            ],
+        ]);
+
+        $errors = $this->container->get('validator')->validate($familyVariant);
+        Assert::assertCount(0, $errors);
+        $this->container->get('pim_catalog.saver.family_variant')->save($familyVariant);
+
+        $familyVariant = $this->container->get('pim_catalog.factory.family_variant')->create();
+        $this->container->get('pim_catalog.updater.family_variant')->update($familyVariant, [
+            'code' => 'family_variant_image_in_parent_product_model',
+            'family' => 'test_family',
+            'variant_attribute_sets' => [
+                [
+                    'axes' => ['a_yes_no'],
+                    'attributes' => [],
+                    'level'=> 1
+                ],
+                [
+                    'axes' => ['a_simple_select_size'],
+                    'attributes' => [],
+                    'level'=> 2
+                ]
+            ],
+        ]);
+
+        $errors = $this->container->get('validator')->validate($familyVariant);
+        Assert::assertCount(0, $errors);
+        $this->container->get('pim_catalog.saver.family_variant')->save($familyVariant);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This is maybe one of the most complicated rule for for the read models.


When you display a product model, you have an image (attribute as image).

As the attribute as image is not necessary in the product model or its parent level, you have to get it from its first created child (a child can be a sub  product model or a variant product, depending of where is the attribute as image).

Our storage is perfect to handle product model feature when getting data from the bottom (variant  product) to the top (root product model).
But it is pretty complicated to do it from top to bottom (actually, it is not designed for it). 

I enumerate in the phpdoc all the possibilities. 

It replaces this "simple" class (but not that much when you dive into the code):
https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Pim/Enrichment/Component/Product/ProductModel/ImageAsLabel.php

It was totally inefficient because it uses a product or a product model entities, loading categories, group, applying permissions, etc...  and using `getImage` function (it should not be in the write model).

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
