### PR TITLE
Sort form extensions pass

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/DependencyInjection/Compiler/RegisterFormExtensionsPass.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/DependencyInjection/Compiler/RegisterFormExtensionsPass.php
@@ -92,6 +92,8 @@ class RegisterFormExtensionsPass implements CompilerPassInterface
             $files = array_merge($files, $this->listConfigFilesInDirectory($directory));
         }
 
+        sort($files);
+
         return $files;
     }
 


### PR DESCRIPTION
# Why

When you load the PIM, it will add all the extensions contained in `form_extensions.yml` files and `form_extensions` folders, bundle per bundle.
The extensions are loaded file by file, using a Symfony finder.
Imagine you have 2 files: `/form_extensions/file1.yml` and `/form_extensions/file2.yml`, in the same bundle, and these 2 files contain a form_extension with exactly the same `code`, but not the same configuration.
You can not know what file will be loaded first, and which extension will be finally used.

# And ?

We already had this previous issue on a previous PR, and the loading order were not the same on a local computer and on the CI computers.
So, locally, it works, but not in the CI. Thanks @sebglon for helping me finding this issue :tada: .

# Solution

The solution is to sort (bundle per bundle) the files in a defined order, to be sure we will have the same loading order in every PIM environments.
