### PR TITLE
AOB-286 - remove useless api test

### DIFF
--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
@@ -70,16 +70,6 @@ class CheckHeadersRequestSubscriberIntegration extends ApiTestCase
         $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode(), 'Header is acceptable');
     }
 
-    public function testSuccessWhenRouteIsOutsideTheAPI()
-    {
-        $client = $this->createAuthenticatedClient();
-
-        $client->request('GET', '/');
-
-        $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode(), 'Page is accessible without error');
-    }
-
     public function testErrorIfContentTypeHeaderIsJsonOnListPatch()
     {
         $client = $this->createAuthenticatedClient();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This integration test was testing that we could access to "/" using an api authenticated user which is not a relevant test.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
