### PR TITLE
PIM-7660: apply permissions on the product datagrid

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductAndProductModelDatasource.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductAndProductModelDatasource.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Oro\Bundle\DataGridBundle\Datasource\ResultRecord;
 use Oro\Bundle\PimDataGridBundle\Extension\Pager\PagerExtension;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * Product datasource for the product grid only.
@@ -30,6 +31,9 @@ class ProductAndProductModelDatasource extends Datasource
     /** @var NormalizerInterface */
     protected $normalizer;
 
+    /** @var ValidatorInterface */
+    protected $validator;
+
     /** @var Query\FetchProductAndProductModelRows */
     private $fetchRows;
 
@@ -37,18 +41,21 @@ class ProductAndProductModelDatasource extends Datasource
      * @param ObjectManager                         $om
      * @param ProductQueryBuilderFactoryInterface   $factory
      * @param NormalizerInterface                   $serializer
+     * @param ValidatorInterface                    $validator
      * @param Query\FetchProductAndProductModelRows $fetchRows
      */
     public function __construct(
         ObjectManager $om,
         ProductQueryBuilderFactoryInterface $factory,
         NormalizerInterface $serializer,
+        ValidatorInterface $validator,
         Query\FetchProductAndProductModelRows $fetchRows
     ) {
         $this->om = $om;
         $this->factory = $factory;
         $this->normalizer = $serializer;
         $this->fetchRows = $fetchRows;
+        $this->validator = $validator;
     }
 
     /**
@@ -67,6 +74,16 @@ class ProductAndProductModelDatasource extends Datasource
             $channelCode,
             $localeCode
         );
+
+        $errors = $this->validator->validate($getRowsQueryParameters);
+        if (count($errors)) {
+            throw new \LogicException(
+                sprintf(
+                    'Invalid query parameters sent to fetch data in the product and product model datagrid: "%s".',
+                    (string) $errors
+                )
+            );
+        }
 
         $rows = ($this->fetchRows)($getRowsQueryParameters);
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/data_sources.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/data_sources.yml
@@ -129,6 +129,7 @@ services:
             - '@pim_catalog.object_manager.product'
             - '@akeneo.pim.enrichment.query.product_and_product_model_query_builder_from_size_factory.with_product_identifier_cursor'
             - '@pim_datagrid_serializer'
+            - '@validator'
             - '@akeneo.pim.enrichment.product.grid.query.fetch_product_and_product_model_rows'
         calls:
             - [ setMassActionRepository, ['@pim_catalog.repository.product_mass_action'] ]


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

We check permission just for security reason, in case of a malicious AJAX request.
UI already filters the locale and attributes according to the permissions of the user.

Here, we just check that the locale and the attributes are visible by the user if we forge the request. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
