### PR TITLE
PIM-7866: do not show delete icon on import/export profile

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7898: Fix tab navigation when the column is collapsed
+- PIM-7866: Do not show delete icon on import/export profile if the user doesn't have the right to delete.
 - PIM-7910: Search parent filter is now case insensitive
 
 ## Elasticsearch

--- a/src/Pim/Bundle/ImportExportBundle/Resources/config/datagrid/job_profile.yml
+++ b/src/Pim/Bundle/ImportExportBundle/Resources/config/datagrid/job_profile.yml
@@ -46,6 +46,7 @@ datagrid:
                 label: Edit
                 link:  edit_link
             delete:
+                acl_resource:  pim_importexport_export_profile_remove
                 launcherOptions:
                     className: AknIconButton AknIconButton--small AknIconButton--trash
                 type:  delete


### PR DESCRIPTION
Do not show delete icon on import/export profile if the user doesn't have the right to delete.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
