### PR TITLE
Fix location of the renderPdf template to recover PDF download

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/renderers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/renderers.yml
@@ -12,7 +12,7 @@ services:
             - '@liip_imagine.cache.manager'
             - '@liip_imagine.filter.manager'
             - '@pim_catalog.repository.cached_attribute'
-            - 'PimPdfGeneratorBundle:Product:renderPdf.html.twig'
+            - 'AkeneoPimEnrichmentBundle:Product:renderPdf.html.twig'
             - '%upload_dir%'
             - '%pim_pdf_generator_font%'
         tags:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Issue: #9193 

PimPdfGeneratorBundle has been removed in Akeneo 3.0 but is still referenced from a configuration of renderers: `Enrichment/Bundle/Resources/config/renderers.yml`.

At the moment, any attempt to generate PDF file lead to 500 error.

This PR fixes this configuration by changing old `PimPdfGeneratorBundle` to `AkeneoPimEnrichmentBundle` in the configuration of the ProductPdfRenderer service.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
