### PR TITLE
PIM-7897: Add cache to fetchAll in attribute group fetcher

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7897: Fix multiple calls to get all attribute groups in the PEF.
+
 # 2.3.19 (2018-12-03)
 
 # 2.3.18 (2018-11-28)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/attribute-group-fetcher.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/fetcher/attribute-group-fetcher.js
@@ -36,18 +36,22 @@ define([
          *
          * {@inheritdoc}
          */
-        fetchAll: function () {
-            if (!_.has(this.options.urls, 'list')) {
-                return $.Deferred().reject().promise();
-            }
+        fetchAll: function (options) {
+            options = options || {};
 
-            this.entityListPromise = $.getJSON(
-                Routing.generate(this.options.urls.list, {
-                    options: {
-                        limit: -1
-                    }
-                })
-            ).then(_.identity).promise();
+            if (null === this.entityListPromise || false === options.cached) {
+                if (!_.has(this.options.urls, 'list')) {
+                    return $.Deferred().reject().promise();
+                }
+
+                this.entityListPromise = $.getJSON(
+                    Routing.generate(this.options.urls.list, {
+                        options: {
+                            limit: -1
+                        }
+                    })
+                ).then(_.identity).promise();
+            }
 
             return this.entityListPromise;
         }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

We have several requests that are sent 3 or 4 times, like this one:
[...]/rest/attribute-group/?options%5Blimit%5D=-1

![screenshot 2018-11-29 at 15 47 02 1](https://user-images.githubusercontent.com/34027529/49375212-f90ad780-f703-11e8-8b25-f687e12833db.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

