### PR TITLE
PIM-7901: Fix memory leak on "compute_family_variant_structure_changes" job

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7901: Fix memory leak on "compute_family_variant_structure_changes" job
+
 # 2.3.20 (2018-12-06)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/jobs.yml
@@ -95,6 +95,7 @@ services:
             - '@pim_catalog.saver.product_model'
             - '@pim_catalog.entity_with_family_variant.keep_only_values_for_variation'
             - '@validator'
+            - '%pim_job_product_batch_size%'
         public: false
 
     pim_catalog.step.compute_family_variant_structure_changes:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The "ComputeFamilyVariantStructureChangesTasklet" try to make a saveAll on the product repository with too many products in memory (for our client is 6500)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
