### PR TITLE
PIM-7900: attribute reference entity read only when no right to edit

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -796,7 +796,7 @@
   &.select2-container {
     .select2-choice {
       height: @recordSelectorHeight;
-      background: white;
+      background-color: white;
 
       .select2-chosen {
         line-height: @recordSelectorHeight;
@@ -812,6 +812,12 @@
         margin-top: 11px;
         background-size: 16px 16px !important;
       }
+    }
+  }
+
+  &.select2-container-disabled {
+    .select2-choice {
+      background-color: #e9ebee;
     }
   }
 


### PR DESCRIPTION
This PR add the CSS to the record selector to make it appear readonly.

https://github.com/akeneo/pim-enterprise-dev/pull/5157/commits

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
