### PR TITLE
PIM-7841: Allow users to set regional locales for UI (en_NZ, pt_PT and pt_BR)

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,16 +1,20 @@
 # 1.7.x
 
+## Bug fixes
+
+-PIM-7841: Allow users to set regional locales for UI (en_NZ, pt_PT and pt_BR)
+
 # 1.7.35 (2018-11-26)
 
 ## Bug fixes
 
-PIM-7870: Fix issue in the case of deletion of attribute used in a user default product grid filter.
+- PIM-7870: Fix issue in the case of deletion of attribute used in a user default product grid filter.
 
 # 1.7.34 (2018-11-12)
 
 ## Bug fixes
 
-PIM-7581: Fix unselect category when its code is numeric
+- PIM-7581: Fix unselect category when its code is numeric
 
 # 1.7.33 (2018-10-10)
 

--- a/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
+++ b/src/Pim/Bundle/InstallerBundle/Command/AssetsCommand.php
@@ -75,7 +75,7 @@ class AssetsCommand extends ContainerAwareCommand
             ->runCommand('assets:install')
             ->runCommand('assetic:dump')
             ->runCommand('oro:assetic:dump');
-        $defaultLocales = ['en', 'fr', 'nl', 'de', 'ru', 'ja', 'pt', 'it'];
+        $defaultLocales = ['en', 'fr', 'nl', 'de', 'ru', 'ja', 'pt', 'it', 'en_NZ', 'pt_PT', 'pt_BR'];
         $this->commandExecutor->runCommand('oro:translation:dump', ['locale' => $defaultLocales]);
 
         if (true === $input->getOption('symlink')) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Allow users to set regional locales for UI (en_NZ, pt_PT and pt_BR)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
