### PR TITLE
PIM-7892: allow to filter on active catalog locale when adding an attribute to the product export filters

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7892: Allow to filter on active catalog locale when adding an attribute to the product export filters
 - PIM-7898: Fix tab navigation when the column is collapsed
 - PIM-7866: Do not show delete icon on import/export profile if the user doesn't have the right to delete.
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/product/edit/content/structure/attributes-selector.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/product/edit/content/structure/attributes-selector.js
@@ -176,7 +176,8 @@ define(
                         options: {
                             excluded_identifiers: this.getSelected(),
                             page: this.attributeListPage,
-                            limit: 20
+                            limit: 20,
+                            locale: userContext.get('catalogLocale')
                         }
                     };
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
