### PR TITLE
PIM-7871 && GITHUB-7932: Backport check port in PimRequirements for 2.0 version

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- GITHUB-7932: Fix the requirements with mysql port - cheers @Schwierig !
 - PIM-7886: Fix translations of boolean attributes
 
 # 2.0.44 (2018-11-29)
@@ -14,7 +15,7 @@
 
 ## Bug fixes
 
-- GITHUB-7532: Fix the prepopulation of textarea field - cheers MarieMinasyan, userz58, kanduvisla & oliverde8 !
+- GITHUB-7532: Fix the prepopulation of textarea field - cheers @MarieMinasyan, @userz58, kanduvisla & @oliverde8 !
 
 # 2.0.42 (2018-11-12)
 

--- a/app/PimRequirements.php
+++ b/app/PimRequirements.php
@@ -243,7 +243,8 @@ class PimRequirements extends SymfonyRequirements
     {
         return new PDO(
             sprintf(
-                'mysql:host=%s',
+                'mysql:port=%s;host=%s',
+                $parameters['parameters']['database_port'],
                 $parameters['parameters']['database_host']
             ),
             $parameters['parameters']['database_user'],


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Backport check port in PimRequirements for 2.0 version (it already exist on 2.3 & master)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
