### PR TITLE
PIM-7886: Fix translations of boolean attributes

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # 2.0.x
 
+## Bug fixes
+
+- PIM-7886: Fix translations of boolean attributes
+
 # 2.0.44 (2018-11-29)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/boolean.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/boolean.html
@@ -1,3 +1,3 @@
-<div class="switch switch-small" tabindex="0" role="checkbox" aria-checked="<%- value && value.data ? 'true' : 'false' %>" data-on-label="<%- _.__('pim_common.yes') %>" data-off-label="<%- _.__('pim_common.no') %>">
+<div class="switch switch-small" tabindex="0" role="checkbox" aria-checked="<%- value && value.data ? 'true' : 'false' %>" data-on-label="<%- _.__('switch_on') %>" data-off-label="<%- _.__('switch_off') %>">
     <input id="<%- fieldId %>" type="checkbox" data-locale="<%- locale %>" data-scope="<%- scope %>" <%- value && value.data ? 'checked' : '' %> <%- editMode === 'view' ? 'disabled' : '' %>>
 </div>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

-- Regression --
Boolean values still appear as pim_common.yes or pim_common.no in PEF and in mass edit.
![screenshot 2018-11-26 at 14 42 51](https://user-images.githubusercontent.com/34027529/49518161-415dfd00-f89e-11e8-824b-72ef78577fb8.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
