### PR TITLE
AOB-283: Add "pim_configuration" table

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1245,3 +1245,4 @@
 - Change constructor of `Oro\Bundle\PimFilterBundle\Filter\ProductValue\ReferenceDataFilter`, add argument `Akeneo\Pim\Structure\Component\Repository\AttributeOptionRepositoryInterface`
 - Change constructor of `Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface\FamilySaver`, remove second argument `Akeneo\Pim\Enrichment\Component\Product\Manager\CompletenessManager`
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\FileValidator` to add an array of string (extension to mime type mapping) 
+- Add `pim_configuration` table. Don't forget to run the `doctrine:migrations:migrate` command.

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -172,18 +172,23 @@ class DatabaseCommand extends ContainerAwareCommand
      */
     protected function createNotMappedTables(OutputInterface $output)
     {
-        $output->writeln('<info>Create session table</info>');
+        $connection = $this->getContainer()->get('database_connection');
 
+        $output->writeln('<info>Create session table</info>');
         $sessionTableSql = "CREATE TABLE pim_session (
                 `sess_id` VARBINARY(128) NOT NULL PRIMARY KEY,
                 `sess_data` BLOB NOT NULL,
                 `sess_time` INTEGER UNSIGNED NOT NULL,
                 `sess_lifetime` MEDIUMINT NOT NULL DEFAULT  '0'
-            ) COLLATE utf8mb4_bin, ENGINE = InnoDB";
+            ) COLLATE utf8mb4_bin, ENGINE = InnoDB;";
+        $connection->exec($sessionTableSql);
 
-        $db = $this->getContainer()->get('doctrine');
-
-        $db->getConnection()->exec($sessionTableSql);
+        $output->writeln('<info>Create configuration table</info>');
+        $configTableSql = "CREATE TABLE pim_configuration (
+                `code` VARCHAR(128) NOT NULL PRIMARY KEY,
+                `values` JSON NOT NULL
+            ) COLLATE utf8mb4_unicode_ci, ENGINE = InnoDB;";
+        $connection->exec($configTableSql);
     }
 
     /**

--- a/upgrades/schema/Version_3_0_20181205151719_add_configuration_table.php
+++ b/upgrades/schema/Version_3_0_20181205151719_add_configuration_table.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Creates the new pim_configuration table.
+ */
+class Version_3_0_20181205151719_add_configuration_table extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->abortIf(
+            'mysql' !== $this->connection->getDatabasePlatform()->getName(),
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        if (!$this->tableAlreadyExists()) {
+            $this->createTable();
+        }
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->abortIf(
+            'mysql' !== $this->connection->getDatabasePlatform()->getName(),
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('DROP TABLE pim_configuration;');
+    }
+
+    private function tableAlreadyExists(): bool
+    {
+        $stmt = $this->connection->executeQuery('SHOW TABLES LIKE \'pim_configuration\';');
+
+        return 1 <= $stmt->rowCount();
+    }
+
+    private function createTable(): void
+    {
+        $this->addSql(
+            'CREATE TABLE pim_configuration (
+                `code` VARCHAR(128) NOT NULL PRIMARY KEY,
+                `values` JSON NOT NULL
+            ) COLLATE utf8mb4_unicode_ci, ENGINE = InnoDB'
+        );
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR introduces a new `pim_configuration` table. A generic way to store configuration. It's a very simple table with a unique key and a JSON field.

For the moment it's only used for the SSO feature but as we want to make more and more features SaaS compatible, we'll need to do that again soon. It doesn't make any sense to create a new specific table for each feature/component with only one record inside.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
