### PR TITLE
PIM-7908: fix variant family creation if an attribute doesn't have a translation for the current locale

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7908: Fix variant family creation if an attribute doesn't have a translation for the current locale
 - PIM-7901: Fix memory leak on "compute_family_variant_structure_changes" job
 
 # 2.3.20 (2018-12-06)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant-fields-container.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/variants/add-family-variant-fields-container.js
@@ -278,7 +278,7 @@ define(
              * @returns {string}
              */
             getEntityLabel(entity, locale) {
-                if (0 === entity.labels.length) {
+                if (0 === entity.labels.length || entity.labels[locale] === undefined) {
                     return '[' + entity.code + ']';
                 }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
