### PR TITLE
PIM-7899: Norm RGPD - Hide the field "Date of Birth"

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,7 +2,7 @@
  
 ## Bug fixes
 
-- PIM-7899: Remove useless field
+- PIM-7899: Remove Date of Birth field
 
 # 2.3.22 (2018-12-21)
 

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,4 +1,8 @@
 # 2.3.x
+ 
+## Bug fixes
+
+- PIM-7899: Norm RGPD - Hide the field "Date of Birth"
 
 # 2.3.22 (2018-12-21)
 
@@ -13,7 +17,7 @@
  ## Elasticsearch
  
  - Please re-index the products and product models by launching the commands `console akeneo:elasticsearch:reset-indexes -e prod` and `pim:product:index --all -e prod`.
- 
+
 # 2.3.21 (2018-12-07)
 
 ## Bug fixes

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,7 +2,7 @@
  
 ## Bug fixes
 
-- PIM-7899: Norm RGPD - Hide the field "Date of Birth"
+- PIM-7899: Remove useless field
 
 # 2.3.22 (2018-12-21)
 

--- a/src/Pim/Bundle/UserBundle/Entity/UserInterface.php
+++ b/src/Pim/Bundle/UserBundle/Entity/UserInterface.php
@@ -46,6 +46,8 @@ interface UserInterface extends AdvancedUserInterface, \Serializable, EntityUplo
     public function getEmail();
 
     /**
+     * @deprecated - Will be removed in 3.0
+     *
      * Return birthday
      *
      * @return DateTime
@@ -193,6 +195,8 @@ interface UserInterface extends AdvancedUserInterface, \Serializable, EntityUplo
     public function getFullName();
 
     /**
+     * @deprecated - Will be removed in 3.0
+     *
      * @param  DateTime $birthday [optional] New birthday value. Null by default.
      *
      * @return UserInterface

--- a/src/Pim/Bundle/UserBundle/Form/Type/UserType.php
+++ b/src/Pim/Bundle/UserBundle/Form/Type/UserType.php
@@ -273,14 +273,6 @@ class UserType extends AbstractType
                 ]
             )
             ->add(
-                'birthday',
-                DateType::class,
-                [
-                    'label'    => 'Date of birth',
-                    'required' => false,
-                ]
-            )
-            ->add(
                 'imageFile',
                 FileType::class,
                 [

--- a/src/Pim/Bundle/UserBundle/Resources/views/User/Tab/general.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/User/Tab/general.html.twig
@@ -9,7 +9,6 @@
         {{ form_row(form.lastName) }}
         {{ form_row(form.nameSuffix) }}
         {{ form_row(form.phone) }}
-        {{ form_row(form.birthday, {class: 'datepicker'}) }}
         {{ form_row(form.imageFile) }}
         {{ form_row(form.email) }}
     </div>

--- a/src/Pim/Bundle/UserBundle/Resources/views/User/view.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/User/view.html.twig
@@ -80,8 +80,7 @@
                         entity.middleName ? UI.attibuteRow('Middle name'|trans, entity.middleName),
                         UI.attibuteRow('Last name'|trans, entity.lastName|default('N/A')),
                         entity.nameSuffix ? UI.attibuteRow('Name suffix'|trans, entity.nameSuffix),
-                        entity.phone ? UI.attibuteRow('Phone'|trans, entity.phone),
-                        UI.attibuteRow('Birthday'|trans, entity.birthday ? entity.birthday|date_presenter : 'N/A')
+                        entity.phone ? UI.attibuteRow('Phone'|trans, entity.phone)
                     ]
                 },
                 {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In order to be in conformity with the new European measures on the protection of personal data RGPD (General Data Protection Regulation), it was decided to hide the field "Date of birth" from the user creation in version 2.3 only.

It will be removed in version 3.0.

EE part: https://github.com/akeneo/pim-enterprise-dev/pull/5277

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
