### PR TITLE
PIM-7911: Export only selected locale for product grid quick export with datagrid context

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -2,7 +2,8 @@
 
 ## Bug fixes
 
--PIM-7841: Allow users to set regional locales for UI (en_NZ, pt_PT and pt_BR)
+- PIM-7841: Allow users to set regional locales for UI (en_NZ, pt_PT and pt_BR)
+- PIM-7911: Product quick export with grid context only exports selected locale 
 
 # 1.7.35 (2018-11-26)
 
@@ -29,6 +30,7 @@
 - PIM-7614: Reduce SQL queries and loading time on the product edit form
 
 ## BC Breaks
+
 - PIM-7614: New method getPresenterByAttributeType() on PresenterRegistryInterface
 
 # 1.7.31 (2018-08-22)

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1598,6 +1598,12 @@ class WebUser extends RawMinkContext
      */
     public function iPressOnTheDropdownButton($item, $button)
     {
+        $this->spin(function () {
+            $loading = $this->getCurrentPage()->find('css', '#loading-wrapper');
+
+            return null === $loading || !$loading->isVisible();
+        }, 'Could press the dropdown buttons because of loading wrapper');
+
         $this
             ->getCurrentPage()
             ->getDropdownButtonItem($item, $button)

--- a/features/Context/WebUser.php
+++ b/features/Context/WebUser.php
@@ -1602,7 +1602,7 @@ class WebUser extends RawMinkContext
             $loading = $this->getCurrentPage()->find('css', '#loading-wrapper');
 
             return null === $loading || !$loading->isVisible();
-        }, 'Could press the dropdown buttons because of loading wrapper');
+        }, 'Could not press the dropdown buttons because of loading wrapper');
 
         $this
             ->getCurrentPage()

--- a/features/mass-action/quick_export_grid_context.feature
+++ b/features/mass-action/quick_export_grid_context.feature
@@ -39,6 +39,39 @@ Feature: Quick export products according to the product grid context
     pump;blue;Pump;;;15;20;41;;;
     """
 
+  @jira https://akeneo.atlassian.net/browse/PIM-7911
+  Scenario: Successfully quick export only current working locale from grid context as a CSV file
+    Given I add the "french" locale to the "tablet" channel
+    And I add the "french" locale to the "mobile" channel
+    And I am on the products page
+    And I create a new product
+    And I fill in the following information in the popin:
+      | SKU             | blue-suede-shoes |
+      | Choose a family | Sneakers         |
+    And I press the "Save" button in the popin
+    And I wait to be on the "blue-suede-shoes" product page
+    And I fill in the following information:
+      | Description | Blue suede shoes |
+    And I switch the locale to "fr_FR"
+    And I fill in the following information:
+      | [description] | Chaussures en suedine bleues |
+    And I press the "Save" button
+    And I should not see the text "There are unsaved changes."
+    And I am on the products page
+    And I switch the locale to "fr_FR"
+    And I display the columns [sku], [description]
+    And I select row blue-suede-shoes
+    And I press "CSV (Grid context)" on the "Quick Export" dropdown button
+    And I wait for the "csv_product_grid_context_quick_export" quick export to finish
+    When I go on the last executed job resume of "csv_product_grid_context_quick_export"
+    Then I should see "COMPLETED"
+    And the name of the exported file of "csv_product_grid_context_quick_export" should be "products_export_grid_context_fr_FR_tablet.csv"
+    And exported file of "csv_product_grid_context_quick_export" should contain:
+    """
+    sku;description-fr_FR-tablet
+    blue-suede-shoes;"Chaussures en suedine bleues"
+    """
+
   Scenario: Successfully quick export products from grid context as a XSLX file
     Given I am on the products page
     And I display the columns SKU, Name, Label, Family, Color, Complete, Groups, Price, Size, Created at, Updated at, Description and Weight

--- a/src/Pim/Bundle/DataGridBundle/Controller/ProductExportController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/ProductExportController.php
@@ -79,6 +79,8 @@ class ProductExportController
      */
     public function indexAction()
     {
+        // If the parameter _displayedColumnOnly is set, it means it's a grid context. We didn't change the name of the
+        // parameter to avoid BC.
         $withGridContext = (bool) $this->request->get('_displayedColumnsOnly');
         $jobCode = $this->request->get('_jobCode');
         $jobInstance = $this->jobInstanceRepo->findOneByIdentifier(['code' => $jobCode]);

--- a/src/Pim/Bundle/DataGridBundle/Controller/ProductExportController.php
+++ b/src/Pim/Bundle/DataGridBundle/Controller/ProductExportController.php
@@ -79,7 +79,7 @@ class ProductExportController
      */
     public function indexAction()
     {
-        $displayedColumnsOnly = (bool) $this->request->get('_displayedColumnsOnly');
+        $withGridContext = (bool) $this->request->get('_displayedColumnsOnly');
         $jobCode = $this->request->get('_jobCode');
         $jobInstance = $this->jobInstanceRepo->findOneByIdentifier(['code' => $jobCode]);
 
@@ -93,7 +93,9 @@ class ProductExportController
         $rawParameters['filePath'] = $this->buildFilePath($rawParameters['filePath'], $contextParameters);
         $dynamicConfiguration = $contextParameters + ['filters' => $filters];
 
-        if ($displayedColumnsOnly) {
+        if ($withGridContext) {
+            $dynamicConfiguration['selected_locales'] = [$this->request->get('dataLocale')];
+
             $gridName = (null !== $this->request->get('gridName')) ? $this->request->get('gridName') : 'product-grid';
             if (isset($this->request->get($gridName)['_parameters'])) {
                 $columns = explode(',', $this->request->get($gridName)['_parameters']['view']['columns']);

--- a/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
@@ -6,6 +6,7 @@ use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Type;
 
 /**
@@ -42,6 +43,7 @@ class ProductQuickExport implements ConstraintCollectionProviderInterface
         $constraintFields = $baseConstraint->fields;
         $constraintFields['filters'] = [];
         $constraintFields['selected_properties'] = null;
+        $constraintFields['selected_locales'] = new Optional(null);
         $constraintFields['with_media'] = new Type('bool');
         $constraintFields['locale'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['scope'] = new NotBlank(['groups' => 'Execution']);

--- a/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Processor/QuickExport/ProductProcessor.php
@@ -188,7 +188,9 @@ class ProductProcessor extends AbstractProcessor
 
         $normalizerContext = [
             'channels'     => [$parameters->get('scope')],
-            'locales'      => $this->getLocaleCodes($parameters->get('scope')),
+            'locales'      => $parameters->has('selected_locales') ?
+                $parameters->get('selected_locales') :
+                $this->getLocaleCodes($parameters->get('scope')),
             'filter_types' => [
                 'pim.transform.product_value.structured',
                 'pim.transform.product_value.structured.quick_export'


### PR DESCRIPTION
Before, it exports every activated locales in a grid context quick export.
Now, it only exports selected one.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | y
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -