### PR TITLE
PIM-7902: Fix unnecessary calls for unread messages count on page navigation

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -4,6 +4,7 @@
 
 - GITHUB-7932: Fix the requirements with mysql port - cheers @Schwierig !
 - PIM-7886: Fix translations of boolean attributes
+- PIM-7902: Fix unnecessary calls for unread messages count on page navigation
 
 # 2.0.44 (2018-11-29)
 

--- a/src/Pim/Bundle/NotificationBundle/Resources/public/js/notifications.js
+++ b/src/Pim/Bundle/NotificationBundle/Resources/public/js/notifications.js
@@ -12,9 +12,7 @@ define(
     function (Backbone, $, _, Routing, NotificationList, Indicator, notificationTpl, notificationFooterTpl) {
         'use strict';
 
-        if ('locked' === sessionStorage.getItem('notificationRefreshLocked')) {
-            sessionStorage.setItem('notificationRefreshLocked', 'available');
-        }
+        const NOTIFICATION_TIMEOUT_ID = 'notifications_timeout_ids';
 
         return Backbone.View.extend({
             options: {
@@ -28,8 +26,6 @@ define(
             },
 
             freezeCount: false,
-
-            refreshTimeout: null,
 
             template: _.template(notificationTpl),
 
@@ -102,21 +98,16 @@ define(
             },
 
             scheduleRefresh: function () {
-                if ('locked' === sessionStorage.getItem('notificationRefreshLocked')) {
-                    return;
-                }
-                if (null !== this.refreshTimeout) {
-                    clearTimeout(this.refreshTimeout);
+                const timeoutId = sessionStorage.getItem(NOTIFICATION_TIMEOUT_ID);
+                if (timeoutId !== null && timeoutId !== '') {
+                    clearTimeout(parseInt(timeoutId));
                 }
 
-                this.refreshTimeout = setTimeout(this.refresh.bind(this), this.options.refreshInterval);
+                const newTimeoutId = setTimeout(this.refresh.bind(this), this.options.refreshInterval);
+                sessionStorage.setItem(NOTIFICATION_TIMEOUT_ID, newTimeoutId + '');
             },
 
             refresh: function () {
-                if ('locked' === sessionStorage.getItem('notificationRefreshLocked')) {
-                    return;
-                }
-                sessionStorage.setItem('notificationRefreshLocked', 'locked');
                 $.getJSON(Routing.generate('pim_notification_notification_count_unread'))
                     .then(_.bind(function (count) {
                         sessionStorage.setItem('notificationRefreshLocked', 'available');


### PR DESCRIPTION
Before, when you navigate between pages, old Timeout were not cleared.
So, if you click on a product then the product grid then a product then the product grid 20 times, you will run 20 timeout, and 30 seconds later, it will raise a tornado of "count_unread" notifications.
To prevent this, we store the setTimeout identifier in the session storage, then stop it before trying to create another timeout.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
