### PR TITLE
PIM-7920: Remove options values label from versioning

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,6 +5,7 @@
 - GITHUB-7932: Fix the requirements with mysql port - cheers @Schwierig !
 - PIM-7886: Fix translations of boolean attributes
 - PIM-7902: Fix unnecessary calls for unread messages count on page navigation
+- PIM-7767: Fix "The EntityManager is closed" error that occured when importing a huge attribute option file (_backport of PIM-7767_)
 
 # 2.0.44 (2018-11-29)
 

--- a/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/AttributeNormalizer.php
+++ b/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/AttributeNormalizer.php
@@ -94,13 +94,7 @@ class AttributeNormalizer implements NormalizerInterface
         } else {
             $data = [];
             foreach ($options as $option) {
-                $item = [];
-                foreach ($option->getOptionValues() as $value) {
-                    $label = str_replace('{locale}', $value->getLocale(), self::LOCALIZABLE_PATTERN);
-                    $label = str_replace('{value}', $value->getValue(), $label);
-                    $item[] = $label;
-                }
-                $data[] = 'Code:' . $option->getCode() . self::ITEM_SEPARATOR . implode(self::ITEM_SEPARATOR, $item);
+                $data[] = 'Code:' . $option->getCode();
             }
             $options = implode(self::GROUP_SEPARATOR, $data);
         }

--- a/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/AttributeNormalizerSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/AttributeNormalizerSpec.php
@@ -124,7 +124,7 @@ class AttributeNormalizerSpec extends ObjectBehavior
                 'sort_order'             => 1,
                 'localizable'            => true,
                 'required'               => false,
-                'options'                => 'Code:size,en_US:big,fr_FR:grand',
+                'options'                => 'Code:size',
                 'scope'                  => 'Channel',
             ]
         );

--- a/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeIntegration.php
+++ b/src/Pim/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/AttributeIntegration.php
@@ -330,7 +330,7 @@ class AttributeIntegration extends AbstractFlatNormalizerTestCase
             'localizable'            => false,
             'auto_option_sorting'    => false,
             'locale_specific'        => false,
-            'options'                => 'Code:optionA,en_US:Option A|Code:optionB,en_US:Option B',
+            'options'                => 'Code:optionA|Code:optionB',
             'scope'                  => 'Global',
             'required'               => false,
         ];
@@ -663,7 +663,7 @@ class AttributeIntegration extends AbstractFlatNormalizerTestCase
             'localizable'            => false,
             'auto_option_sorting'    => true,
             'locale_specific'        => false,
-            'options'                => 'Code:optionA,en_US:Option A|Code:optionB,en_US:Option B',
+            'options'                => 'Code:optionA|Code:optionB',
             'scope'                  => 'Global',
             'required'               => false,
         ];


### PR DESCRIPTION
This is a backport of PIM-7767 (https://github.com/akeneo/pim-community-dev/pull/9080)

**Description (for Contributor and Core Developer)**

Please see description of original fix: https://github.com/akeneo/pim-community-dev/pull/9080

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Fixed
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | Fixed
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -