### PR TITLE
PIM-8176: Fix OnlyExpectedAttributesValidator

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 ## Bug fixes
 
 - PIM-8222: Fix product model issues when code contains `/` (create variant through UI and get product models via API)
+- #9023: `Nesting level too deep – recursive dependency?` for some custom reference_data attributes
 
 # 2.3.33 (2019-03-13)
 

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,8 +4,8 @@
 
 ## Bug fixes
 
+- PIM-8176: `Nesting level too deep – recursive dependency?` for some custom reference_data attributes
 - PIM-8222: Fix product model issues when code contains `/` (create variant through UI and get product models via API)
-- #9023: `Nesting level too deep – recursive dependency?` for some custom reference_data attributes
 
 # 2.3.33 (2019-03-13)
 

--- a/src/Pim/Component/Catalog/Validator/Constraints/OnlyExpectedAttributesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/OnlyExpectedAttributesValidator.php
@@ -57,7 +57,7 @@ class OnlyExpectedAttributesValidator extends ConstraintValidator
                 continue;
             }
 
-            if (!in_array($modelAttribute, $levelAttributes)) {
+            if (!in_array($modelAttribute, $levelAttributes, true)) {
                 $this->context->buildViolation(
                     OnlyExpectedAttributes::ATTRIBUTE_UNEXPECTED, [
                     '%attribute%' => $modelAttribute->getCode()


### PR DESCRIPTION
This PR prevent Nesting level too deep – recursive dependency exception.
Explained in #9023 issue

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
