### PR TITLE
PIM-7910: parent filter is now case insensitive

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,7 +5,12 @@
 - PIM-7892: Allow to filter on active catalog locale when adding an attribute to the product export filters
 - PIM-7898: Fix tab navigation when the column is collapsed
 - PIM-7866: Do not show delete icon on import/export profile if the user doesn't have the right to delete.
+- PIM-7910: Search parent filter is now case insensitive
 
+ ## Elasticsearch
+ 
+ - Please re-index the products and product models by launching the commands `console akeneo:elasticsearch:reset-indexes -e prod` and `pim:product:index --all -e prod`.
+ 
 # 2.3.21 (2018-12-07)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/ParentFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/ParentFilter.php
@@ -53,7 +53,7 @@ class ParentFilter extends AbstractFieldFilter implements FieldFilterInterface
             case Operators::IN_LIST:
                 $clause = [
                     'terms' => [
-                        $field => array_map('strtolower', (array) $value),
+                        $field => $value,
                     ],
                 ];
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -32,6 +32,7 @@ mappings:
                 type: 'keyword'
             parent:
                 type: 'keyword'
+                normalizer: 'identifier_normalizer'
             ancestors.codes:
                 type: 'keyword'
             ancestors.ids:

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/ParentFilterSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/ParentFilterSpec.php
@@ -47,18 +47,6 @@ class ParentFilterSpec extends ObjectBehavior
         $this->supportsField('a_not_supported_field')->shouldReturn(false);
     }
 
-    function it_adds_a_case_insensitive_filter(
-        SearchQueryBuilder $sqb
-    ) {
-        $sqb->addFilter(
-            [
-                'terms' => ['parent' => ['foo', 'bar', 'baz']],
-            ]
-        )->shouldBeCalled();
-        $this->setQueryBuilder($sqb);
-        $this->addFieldFilter('parent', Operators::IN_LIST, ['foo', 'BAR', 'BaZ'], null, null, []);
-    }
-
     function it_adds_a_filter_with_operator_is_empty(
         SearchQueryBuilder $sqb
     ) {

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/ParentFilterIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/ParentFilterIntegration.php
@@ -53,6 +53,28 @@ class ParentFilterIntegration extends AbstractProductAndProductModelQueryBuilder
         $this->assert($result, []);
     }
 
+    public function testQueryParentInListCaseInsensitive()
+    {
+        $entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $productModel = $entityBuilder->createProductModel(
+            'MODEL_test',
+            'clothing_color_size',
+            null,
+            []
+        );
+        $entityBuilder->createVariantProduct(
+            'variant_product',
+            'clothing',
+            'clothing_material_size',
+            $productModel,
+            []
+        );
+        $result = $this->executeFilter([['parent', Operators::IN_LIST, ['mOdEl_TeSt']]]);
+        $this->assert($result, [
+            'variant_product',
+        ]);
+    }
+
     public function testQueryParentEmptyAndAttributesInList()
     {
         $result = $this->executeFilter([


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Basically revert the fix done for the PIM-7727 and fix it with Elasticsearch configuration.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
