### PR TITLE
PIM-7930: use remover to delete user group

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Controller/GroupController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/GroupController.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\UserManagement\Bundle\Controller;
 
+use Akeneo\Tool\Bundle\StorageUtilsBundle\Doctrine\Common\Remover\BaseRemover;
 use Akeneo\UserManagement\Component\Model\Group;
 use Akeneo\UserManagement\Component\UserEvents;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
@@ -57,8 +58,8 @@ class GroupController extends Controller
             throw $this->createNotFoundException(sprintf('Group with id %d could not be found.', $id));
         }
 
-        $em->remove($group);
-        $em->flush();
+        $remover = $this->get('pim_user.remover.user_group');
+        $remover->remove($group);
 
         return new JsonResponse('', 204);
     }

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/removers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/removers.yml
@@ -5,3 +5,10 @@ services:
             - '@doctrine.orm.entity_manager'
             - '@event_dispatcher'
             - '%pim_user.entity.role.class%'
+
+    pim_user.remover.user_group:
+        class: '%pim_catalog.remover.base.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@event_dispatcher'
+            - '%pim_user.entity.group.class%'


### PR DESCRIPTION
This PR introduce the use of the base remover to delete a user group and have access to the the remover's events.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
