### PR TITLE
Do not allow spec/ directory anymore in master

### DIFF
--- a/bin/check-pullup
+++ b/bin/check-pullup
@@ -219,7 +219,7 @@ $pullUpOk = $check(
         new ForbiddenDirectory('src/PimEnterprise/Component/Enrich', Dispatched::mainEnterpriseBusinessTopics()),
 
         //tests folder
-        new ForbiddenDirectory('spec/Akeneo/Pim/Permission', new Moved('tests/back/Pim/Permission/Specification')),
+        new ForbiddenDirectory('spec/', new Dispatched(['tests/back/Pim/**/Specification','tests/back/Pim/**/spec'])),
     ]
 );
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

Now that every specification has been moved, we can check that there should not be any file in the `spec/` directory (especially useful while pulling up 2.3 towards master)

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | TODO
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
