### PR TITLE
TIP-899: Improve product export performance by computing headers at the end

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -17,6 +17,7 @@
 - GITHUB-8234 & GITHUB-8383: Fix constraints on attribute code. Cheers @oliverde8 & @navneetbhardwaj!
 - TIP-1018: Adds a script to check container services instantiability (bin/check-services-instantiability)
 - GITHUB-9333: Fix the storage data collector to consider the port number on system information page. Cheers @nei!
+- TIP-899: Improve product export performance by computing headers at the end
 
 ## Enhancements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -105,3 +105,13 @@ services:
         arguments:
             - '@database_connection'
             - '@pim_catalog.factory.value_collection'
+
+    akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_family_codes:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\Writer\File\Flat\GenerateHeadersFromFamilyCodes'
+        arguments:
+            - '@database_connection'
+
+    akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_attribute_codes:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\Writer\File\Flat\GenerateHeadersFromAttributeCodes'
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/writers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/writers.yml
@@ -57,6 +57,8 @@ services:
             - '@pim_connector.writer.file.product.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
             - '@pim_connector.writer.file.media_exporter_path_generator'
+            - '@akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_family_codes'
+            - '@akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_attribute_codes'
             - ['pim_catalog_file', 'pim_catalog_image']
 
     pim_connector.writer.file.csv_product_model:
@@ -77,6 +79,8 @@ services:
             - '@pim_connector.writer.file.product_quick_export.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
             - '@pim_connector.writer.file.media_exporter_path_generator'
+            - '@akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_family_codes'
+            - '@akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_attribute_codes'
             - ['pim_catalog_file', 'pim_catalog_image']
             - 'filePathProduct'
 
@@ -99,6 +103,8 @@ services:
             - '@pim_connector.writer.file.product.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
             - '@pim_connector.writer.file.media_exporter_path_generator'
+            - '@akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_family_codes'
+            - '@akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_attribute_codes'
             - ['pim_catalog_file', 'pim_catalog_image']
 
     pim_connector.writer.file.xlsx_product_model:
@@ -119,6 +125,8 @@ services:
             - '@pim_connector.writer.file.product_quick_export.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
             - '@pim_connector.writer.file.media_exporter_path_generator'
+            - '@akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_family_codes'
+            - '@akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_attribute_codes'
             - ['pim_catalog_file', 'pim_catalog_image']
             - 'filePathProduct'
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromAttributeCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromAttributeCodes.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\Writer\File\Flat;
+
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromAttributeCodesInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @author    Benoit Jacquemont <benoit@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GenerateHeadersFromAttributeCodes implements GenerateFlatHeadersFromAttributeCodesInterface
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Generate all possible headers from the provided attribute codes
+     *
+     * @return FlatFileHeader[]
+     */
+    public function __invoke(
+        array $attributeCodes,
+        string $channelCode,
+        array $localeCodes
+    ): array {
+        $activatedCurrencyCodes = $this->connection->executeQuery(
+            "SELECT code FROM pim_catalog_currency WHERE is_activated = 1"
+        )->fetchAll(\PDO::FETCH_COLUMN, 0);
+
+        $channelCurrencyCodesSql = <<<SQL
+            SELECT currency.code
+            FROM pim_catalog_channel channel
+              JOIN pim_catalog_channel_currency cc ON cc.channel_id = channel.id
+              JOIN pim_catalog_currency currency ON currency.id = cc.currency_id
+            WHERE channel.code = :channelCode
+SQL;
+        $channelCurrencyCodes = $this->connection->executeQuery(
+            $channelCurrencyCodesSql,
+            ['channelCode' => $channelCode]
+        )->fetchAll(\PDO::FETCH_COLUMN, 0);
+
+        $attributesDataSql = <<<SQL
+            SELECT a.code,
+                   a.is_scopable,
+                   a.is_localizable,
+                   a.attribute_type,
+                   (
+                     SELECT JSON_ARRAYAGG(l.code)
+                     FROM pim_catalog_locale l
+                     JOIN pim_catalog_attribute_locale al ON al.locale_id = l.id
+                     WHERE al.attribute_id = a.id
+                   ) AS specific_to_locales
+            FROM pim_catalog_attribute a
+            WHERE a.code IN (:attributeCodes)
+            GROUP BY a.id;
+SQL;
+
+        $attributesData = $this->connection->executeQuery(
+            $attributesDataSql,
+            ['attributeCodes' => $attributeCodes],
+            ['attributeCodes' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
+        )->fetchAll();
+
+        $headers = [];
+        foreach ($attributesData as $attributeData) {
+            $headers[] = FlatFileHeader::buildFromAttributeData(
+                $attributeData["code"],
+                $attributeData["attribute_type"],
+                ("1" === $attributeData["is_scopable"]),
+                $channelCode,
+                ("1" === $attributeData["is_localizable"]),
+                $localeCodes,
+                $channelCurrencyCodes,
+                $activatedCurrencyCodes,
+                null !== $attributeData['specific_to_locales'] ? json_decode($attributeData['specific_to_locales'], true) : []
+            );
+        }
+
+        return $headers;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromFamilyCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromFamilyCodes.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\Writer\File\Flat;
+
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromFamilyCodesInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @author    Benoit Jacquemont <benoit@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GenerateHeadersFromFamilyCodes implements GenerateFlatHeadersFromFamilyCodesInterface
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Generate all possible headers from the provided family codes
+     *
+     * @return FlatFileHeader[]
+     */
+    public function __invoke(
+        array $familyCodes,
+        string $channelCode,
+        array $localeCodes
+    ): array {
+        $activatedCurrencyCodes = $this->connection->executeQuery(
+            "SELECT code FROM pim_catalog_currency WHERE is_activated = 1"
+        )->fetchAll(\PDO::FETCH_COLUMN, 0);
+
+        $channelCurrencyCodesSql = <<<SQL
+            SELECT currency.code
+            FROM pim_catalog_channel channel
+              JOIN pim_catalog_channel_currency cc ON cc.channel_id = channel.id
+              JOIN pim_catalog_currency currency ON currency.id = cc.currency_id
+            WHERE channel.code = :channelCode
+SQL;
+        $channelCurrencyCodes = $this->connection->executeQuery(
+            $channelCurrencyCodesSql,
+            ['channelCode' => $channelCode]
+        )->fetchAll(\PDO::FETCH_COLUMN, 0);
+
+        $attributesDataSql = <<<SQL
+            SELECT a.code,
+                   a.is_scopable,
+                   a.is_localizable,
+                   a.attribute_type,
+                   (
+                     SELECT JSON_ARRAYAGG(l.code)
+                     FROM pim_catalog_locale l
+                     JOIN pim_catalog_attribute_locale al ON al.locale_id = l.id
+                     WHERE al.attribute_id = a.id
+                   ) AS specific_to_locales
+            FROM pim_catalog_family f
+              JOIN pim_catalog_family_attribute fa ON fa.family_id = f.id
+              JOIN pim_catalog_attribute a ON a.id = fa.attribute_id
+            WHERE f.code IN (:familyCodes)
+            GROUP BY a.id;
+SQL;
+
+        $attributesData = $this->connection->executeQuery(
+            $attributesDataSql,
+            ['familyCodes' => $familyCodes],
+            ['familyCodes' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
+        )->fetchAll();
+
+        $headers = [];
+        foreach ($attributesData as $attributeData) {
+            $headers[] = FlatFileHeader::buildFromAttributeData(
+                $attributeData["code"],
+                $attributeData["attribute_type"],
+                ("1" === $attributeData["is_scopable"]),
+                $channelCode,
+                ("1" === $attributeData["is_localizable"]),
+                $localeCodes,
+                $channelCurrencyCodes,
+                $activatedCurrencyCodes,
+                null !== $attributeData['specific_to_locales'] ? json_decode($attributeData['specific_to_locales'], true) : []
+            );
+        }
+
+        return $headers;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Normalization/ProductProcessor.php
@@ -55,7 +55,7 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
         IdentifiableObjectRepositoryInterface $channelRepository,
         AttributeRepositoryInterface $attributeRepository,
         BulkMediaFetcher $mediaFetcher,
-        EntityWithFamilyValuesFillerInterface $productValuesFiller
+        ?EntityWithFamilyValuesFillerInterface $productValuesFiller = null
     ) {
         $this->normalizer          = $normalizer;
         $this->channelRepository   = $channelRepository;
@@ -72,7 +72,9 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
         $parameters = $this->stepExecution->getJobParameters();
         $structure = $parameters->get('filters')['structure'];
         $channel = $this->channelRepository->findOneByIdentifier($structure['scope']);
-        $this->productValuesFiller->fillMissingValues($product);
+        if ($product instanceof ProductModelInterface) {
+            $this->productValuesFiller->fillMissingValues($product);
+        }
 
         $productStandard = $this->normalizer->normalize(
             $product,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
@@ -2,12 +2,20 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Csv;
 
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromAttributeCodesInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromFamilyCodesInterface;
+use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Item\FlushableInterface;
 use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemWriterInterface;
+use Akeneo\Tool\Component\Batch\Job\JobParameters;
 use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Tool\Component\Buffer\BufferFactory;
+use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Akeneo\Tool\Component\Connector\Writer\File\AbstractItemMediaWriter;
 use Akeneo\Tool\Component\Connector\Writer\File\ArchivableWriterInterface;
+use Akeneo\Tool\Component\Connector\Writer\File\FileExporterPathGeneratorInterface;
+use Akeneo\Tool\Component\Connector\Writer\File\FlatItemBufferFlusher;
 
 /**
  * Write product data into a csv file on the local filesystem
@@ -23,6 +31,121 @@ class ProductWriter extends AbstractItemMediaWriter implements
     StepExecutionAwareInterface,
     ArchivableWriterInterface
 {
+    /** @var array */
+    protected $familyCodes;
+
+    /** @var GenerateFlatHeadersFromFamilyCodesInterface */
+    protected $generateHeadersFromFamilyCodes;
+
+    /** @var GenerateFlatHeadersFromAttributeCodesInterface */
+    protected $generateHeadersFromAttributeCodes;
+
+    public function __construct(
+        ArrayConverterInterface $arrayConverter,
+        BufferFactory $bufferFactory,
+        FlatItemBufferFlusher $flusher,
+        AttributeRepositoryInterface $attributeRepository,
+        FileExporterPathGeneratorInterface $fileExporterPath,
+        GenerateFlatHeadersFromFamilyCodesInterface $generateHeadersFromFamilyCodes,
+        GenerateFlatHeadersFromAttributeCodesInterface $generateHeadersFromAttributeCodes,
+        array $mediaAttributeTypes,
+        string $jobParamFilePath = self::DEFAULT_FILE_PATH
+    ) {
+        parent::__construct(
+            $arrayConverter,
+            $bufferFactory,
+            $flusher,
+            $attributeRepository,
+            $fileExporterPath,
+            $mediaAttributeTypes,
+            $jobParamFilePath
+        );
+
+        $this->generateHeadersFromFamilyCodes = $generateHeadersFromFamilyCodes;
+        $this->generateHeadersFromAttributeCodes = $generateHeadersFromAttributeCodes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize()
+    {
+        $this->familyCodes = [];
+
+        parent::initialize();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write(array $items)
+    {
+        foreach ($items as $item) {
+            if (isset($item['family']) && !in_array($item['family'], $this->familyCodes)) {
+                $this->familyCodes[] = $item['family'];
+            }
+        }
+
+        parent::write($items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        $parameters = $this->stepExecution->getJobParameters();
+
+        if ($parameters->has('withHeader') && true === $parameters->get('withHeader')) {
+            $additionalHeaders = $this->getAdditionalHeaders($parameters);
+            $this->flatRowBuffer->addToHeaders($additionalHeaders);
+        }
+
+        parent::flush();
+    }
+
+    /**
+     * Return additional headers, based on the requested attributes if any,
+     * and from the families definition
+     */
+    protected function getAdditionalHeaders(JobParameters $parameters): array
+    {
+        $filters = $parameters->get('filters');
+
+        $localeCodes = isset($filters['structure']['locales']) ? $filters['structure']['locales'] : [$parameters->get('locale')];
+        $channelCode = isset($filters['structure']['scope']) ? $filters['structure']['scope'] : $parameters->get('scope');
+
+        $attributeCodes = [];
+
+        if (isset($filters['structure']['attributes'])
+            && !empty($filters['structure']['attributes'])) {
+            $attributeCodes = $filters['structure']['attributes'];
+        } elseif ($parameters->has('selected_properties')) {
+            $attributeCodes = $parameters->get('selected_properties');
+        }
+
+        $headers = [];
+        if (!empty($attributeCodes)) {
+            $headers = ($this->generateHeadersFromAttributeCodes)($attributeCodes, $channelCode, $localeCodes);
+        } elseif (!empty($this->familyCodes)) {
+            $headers = ($this->generateHeadersFromFamilyCodes)($this->familyCodes, $channelCode, $localeCodes);
+        }
+
+        $withMedia = (!$parameters->has('with_media') || $parameters->has('with_media') && $parameters->get('with_media'));
+
+        $headerStrings = [];
+        foreach ($headers as $header) {
+            if ($withMedia || !$header->isMedia()) {
+                $headerStrings = array_merge(
+                    $headerStrings,
+                    $header->generateHeaderStrings()
+                );
+            }
+        }
+
+        return $headerStrings;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/FlatFileHeader.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/FlatFileHeader.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File;
+
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+
+/**
+ * @author    Benoit Jacquemont <benoit@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class FlatFileHeader
+{
+    /** @var string */
+    private $code;
+
+    /** @var bool */
+    private $isScopable;
+
+    /** @var string */
+    private $channelCode;
+
+    /** @var bool */
+    private $isLocalizable;
+
+    /** @var array */
+    private $localeCodes;
+
+    /** @var bool */
+    private $isMedia;
+
+    /** @var bool */
+    private $usesUnit;
+
+    /** @var bool */
+    private $usesCurrencies;
+
+    /** @var array */
+    private $channelCurrencyCodes;
+
+    /** @var array */
+    private $allCurrencyCodes;
+
+    /** @var bool */
+    private $isLocaleSpecific;
+
+    /** @var array */
+    private $specificToLocales;
+
+    public function __construct(
+        string $code,
+        ?bool $isScopable = false,
+        ?string $channelCode = null,
+        ?bool $isLocalizable = false,
+        ?array $localeCodes = [],
+        ?bool $isMedia = false,
+        ?bool $usesUnit = false,
+        ?bool $usesCurrencies = false,
+        ?array $channelCurrencyCodes = [],
+        ?array $allCurrencyCodes = [],
+        ?bool $isLocaleSpecific = false,
+        ?array $specificToLocales = []
+    ) {
+        if ($isLocaleSpecific && empty($specificToLocales)) {
+            throw new \InvalidArgumentException(
+                'A list of locales to which the header is specific to must be provided '.
+                'when the header is defined as locale specific'
+            );
+        }
+
+        if ($usesCurrencies && $usesUnit) {
+            throw new \InvalidArgumentException(
+                'A header cannot have both currencies and unit.'
+            );
+        }
+
+        $this->code = $code;
+
+        $this->isScopable = $isScopable;
+        $this->channelCode = $channelCode;
+
+        $this->isLocalizable = $isLocalizable;
+        $this->localeCodes = $localeCodes;
+
+        $this->isMedia = $isMedia;
+        $this->usesUnit = $usesUnit;
+
+        $this->usesCurrencies = $usesCurrencies;
+        $this->channelCurrencyCodes = $channelCurrencyCodes;
+        $this->allCurrencyCodes = $allCurrencyCodes;
+
+        $this->isLocaleSpecific = $isLocaleSpecific;
+        $this->specificToLocales = $specificToLocales;
+    }
+
+    /**
+     * Build a FlatFileHeader from product attribute
+     */
+    public static function buildFromAttributeData(
+        string $attributeCode,
+        string $attributeType,
+        bool $scopable,
+        string $channelCode,
+        bool $localizable,
+        array $localeCodes,
+        array $channelCurrencyCodes,
+        array $activatedCurrencyCodes,
+        array $specificToLocales
+    ): FlatFileHeader {
+        $mediaAttributeTypes = [
+            AttributeTypes::IMAGE,
+            AttributeTypes::FILE
+        ];
+
+        return new FlatFileHeader(
+            $attributeCode,
+            $scopable,
+            $channelCode,
+            $localizable,
+            $localeCodes,
+            (in_array($attributeType, $mediaAttributeTypes)),
+            (AttributeTypes::METRIC === $attributeType),
+            (AttributeTypes::PRICE_COLLECTION === $attributeType),
+            $channelCurrencyCodes,
+            $activatedCurrencyCodes,
+            !empty($specificToLocales),
+            $specificToLocales
+        );
+    }
+
+    /**
+     * Indicate whether the header is associated to a media information
+     */
+    public function isMedia(): bool
+    {
+        return $this->isMedia;
+    }
+
+    /**
+     * Generate headers string contextualized on channel
+     */
+    public function generateHeaderStrings(): array
+    {
+        if ($this->isLocaleSpecific && count(array_intersect($this->localeCodes, $this->specificToLocales)) === 0) {
+            return [];
+        }
+
+        $prefixes = [];
+
+        if ($this->isLocalizable && $this->isScopable) {
+            foreach ($this->localeCodes as $localeCode) {
+                if (!$this->isLocaleSpecific ||
+                    ($this->isLocaleSpecific && in_array($localeCode, $this->specificToLocales))) {
+                    $prefixes[] = sprintf('%s-%s-%s', $this->code, $localeCode, $this->channelCode);
+                }
+            }
+        } elseif ($this->isLocalizable) {
+            foreach ($this->localeCodes as $localeCode) {
+                if (!$this->isLocaleSpecific ||
+                    ($this->isLocaleSpecific && in_array($localeCode, $this->specificToLocales))) {
+                    $prefixes[] = sprintf('%s-%s', $this->code, $localeCode);
+                }
+            }
+        } elseif ($this->isScopable) {
+            $prefixes[] = sprintf('%s-%s', $this->code, $this->channelCode);
+        } else {
+            $prefixes[] = $this->code;
+        }
+
+        $headers = [];
+
+        if ($this->usesCurrencies) {
+            foreach ($prefixes as $prefix) {
+                if ($this->isScopable) {
+                    $currencyCodesToUse = $this->channelCurrencyCodes;
+                } else {
+                    $currencyCodesToUse = $this->allCurrencyCodes;
+                }
+                foreach ($currencyCodesToUse as $currencyCode) {
+                    $headers[] = sprintf('%s-%s', $prefix, $currencyCode);
+                }
+            }
+        } elseif ($this->usesUnit) {
+            foreach ($prefixes as $prefix) {
+                $headers[] = $prefix;
+                $headers[] = sprintf('%s-unit', $prefix);
+            }
+        } else {
+            $headers = $prefixes;
+        }
+
+        return $headers;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/GenerateFlatHeadersFromAttributeCodesInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/GenerateFlatHeadersFromAttributeCodesInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File;
+
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
+
+/**
+ * @author    Benoit Jacquemont <benoit@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GenerateFlatHeadersFromAttributeCodesInterface
+{
+    /**
+     * Generate headers from the provided attribute codes
+     *
+     * @return FlatFileHeader[]
+     */
+    public function __invoke(
+        array $attributeCodes,
+        string $channelCode,
+        array $localeCodes
+    ): array;
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/GenerateFlatHeadersFromFamilyCodesInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/GenerateFlatHeadersFromFamilyCodesInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File;
+
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
+
+/**
+ * @author    Benoit Jacquemont <benoit@akeneo.com>
+ * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GenerateFlatHeadersFromFamilyCodesInterface
+{
+    /**
+     * Generate all possible headers from the provided family codes
+     *
+     * @return FlatFileHeader[]
+     */
+    public function __invoke(
+        array $familyCodes,
+        string $channelCode,
+        array $localeCodes
+    ): array;
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
@@ -2,12 +2,20 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Xlsx;
 
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromAttributeCodesInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromFamilyCodesInterface;
+use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Item\FlushableInterface;
 use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemWriterInterface;
+use Akeneo\Tool\Component\Batch\Job\JobParameters;
 use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Tool\Component\Buffer\BufferFactory;
+use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Akeneo\Tool\Component\Connector\Writer\File\AbstractItemMediaWriter;
 use Akeneo\Tool\Component\Connector\Writer\File\ArchivableWriterInterface;
+use Akeneo\Tool\Component\Connector\Writer\File\FileExporterPathGeneratorInterface;
+use Akeneo\Tool\Component\Connector\Writer\File\FlatItemBufferFlusher;
 
 /**
  * Write product data into a XLSX file on the local filesystem
@@ -23,6 +31,122 @@ class ProductWriter extends AbstractItemMediaWriter implements
     StepExecutionAwareInterface,
     ArchivableWriterInterface
 {
+    /** @var array */
+    protected $familyCodes;
+
+    /** @var GenerateFlatHeadersFromFamilyCodesInterface */
+    protected $generateHeadersFromFamilyCodes;
+
+    /** @var GenerateFlatHeadersFromAttributeCodesInterface */
+    protected $generateHeadersFromAttributeCodes;
+
+    public function __construct(
+        ArrayConverterInterface $arrayConverter,
+        BufferFactory $bufferFactory,
+        FlatItemBufferFlusher $flusher,
+        AttributeRepositoryInterface $attributeRepository,
+        FileExporterPathGeneratorInterface $fileExporterPath,
+        GenerateFlatHeadersFromFamilyCodesInterface $generateHeadersFromFamilyCodes,
+        GenerateFlatHeadersFromAttributeCodesInterface $generateHeadersFromAttributeCodes,
+        array $mediaAttributeTypes,
+        string $jobParamFilePath = self::DEFAULT_FILE_PATH
+    ) {
+        parent::__construct(
+            $arrayConverter,
+            $bufferFactory,
+            $flusher,
+            $attributeRepository,
+            $fileExporterPath,
+            $mediaAttributeTypes,
+            $jobParamFilePath
+        );
+
+        $this->generateHeadersFromFamilyCodes = $generateHeadersFromFamilyCodes;
+        $this->generateHeadersFromAttributeCodes = $generateHeadersFromAttributeCodes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize()
+    {
+        $this->familyCodes = [];
+
+        parent::initialize();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write(array $items)
+    {
+        foreach ($items as $item) {
+            if (isset($item['family']) && !in_array($item['family'], $this->familyCodes)) {
+                $this->familyCodes[] = $item['family'];
+            }
+        }
+
+        parent::write($items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        $parameters = $this->stepExecution->getJobParameters();
+
+        if ($parameters->has('withHeader') && true === $parameters->get('withHeader')) {
+            $additionalHeaders = $this->getAdditionalHeaders($parameters);
+            $this->flatRowBuffer->addToHeaders($additionalHeaders);
+        }
+
+        parent::flush();
+    }
+
+
+    /**
+     * Return additional headers, based on the requested attributes if any,
+     * and from the families definition
+     */
+    protected function getAdditionalHeaders(JobParameters $parameters): array
+    {
+        $filters = $parameters->get('filters');
+
+        $localeCodes = isset($filters['structure']['locales']) ? $filters['structure']['locales'] : [$parameters->get('locale')];
+        $channelCode = isset($filters['structure']['scope']) ? $filters['structure']['scope'] : $parameters->get('scope');
+
+        $attributeCodes = [];
+
+        if (isset($filters['structure']['attributes'])
+            && !empty($filters['structure']['attributes'])) {
+            $attributeCodes = $filters['structure']['attributes'];
+        } elseif ($parameters->has('selected_properties')) {
+            $attributeCodes = $parameters->get('selected_properties');
+        }
+
+        $headers = [];
+        if (!empty($attributeCodes)) {
+            $headers = ($this->generateHeadersFromAttributeCodes)($attributeCodes, $channelCode, $localeCodes);
+        } elseif (!empty($this->familyCodes)) {
+            $headers = ($this->generateHeadersFromFamilyCodes)($this->familyCodes, $channelCode, $localeCodes);
+        }
+
+        $withMedia = (!$parameters->has('with_media') || $parameters->has('with_media') && $parameters->get('with_media'));
+
+        $headerStrings = [];
+        foreach ($headers as $header) {
+            if ($withMedia || !$header->isMedia()) {
+                $headerStrings = array_merge(
+                    $headerStrings,
+                    $header->generateHeaderStrings()
+                );
+            }
+        }
+
+        return $headerStrings;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
@@ -26,7 +26,7 @@ abstract class AbstractItemMediaWriter implements
     FlushableInterface,
     StepExecutionAwareInterface
 {
-    private const DEFAULT_FILE_PATH = 'filePath';
+    protected const DEFAULT_FILE_PATH = 'filePath';
 
     /** @var ArrayConverterInterface */
     protected $arrayConverter;
@@ -269,6 +269,10 @@ abstract class AbstractItemMediaWriter implements
         $identifier = $this->getItemIdentifier($item);
 
         foreach ($mediaAttributeTypes as $attributeCode => $attributeType) {
+            if (!isset($item['values'][$attributeCode])) {
+                continue;
+            }
+
             foreach ($item['values'][$attributeCode] as $index => $value) {
                 if (null !== $value['data']) {
                     $exportDirectory = $this->fileExporterPath->generate($value, [

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/FlatItemBuffer.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/FlatItemBuffer.php
@@ -58,7 +58,7 @@ class FlatItemBuffer extends JSONFileBuffer implements BufferInterface, \Countab
      *
      * @param array $keys
      */
-    protected function addToHeaders(array $keys)
+    public function addToHeaders(array $keys)
     {
         $headers = array_merge($this->headers, $keys);
         $headers = array_unique($headers);

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByPriceCollectionsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByPriceCollectionsIntegration.php
@@ -43,8 +43,8 @@ class ExportProductsByPriceCollectionsIntegration extends AbstractExportTestCase
     public function testProductExportByFilteringOnProductInferiorToAPrice()
     {
         $expectedCsv = <<<CSV
-sku;categories;enabled;family;groups;a_price-CNY;a_price-EUR;a_price-USD
-product_2;;1;;;;20.00;10.00
+sku;categories;enabled;family;groups;a_price-EUR;a_price-USD
+product_2;;1;;;20.00;10.00
 
 CSV;
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/Writer/File/Flat/AssertHeaders.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/Writer/File/Flat/AssertHeaders.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\Connector\Writer\File\Flat;
+
+use PHPUnit\Framework\Assert;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
+
+final class AssertHeaders
+{
+    public static function same(array $expectedHeaders, array $actualHeaders): void
+    {
+        Assert::assertCount(count($expectedHeaders), $actualHeaders);
+
+        $expectedHeaderStrings = [];
+        foreach ($expectedHeaders as $expectedHeader) {
+            $expectedHeaderStrings = array_merge($expectedHeaderStrings, $expectedHeader->generateHeaderStrings());
+        }
+
+        $actualHeaderStrings = [];
+        foreach ($actualHeaders as $actualHeader) {
+            $actualHeaderStrings = array_merge($actualHeaderStrings, $actualHeader->generateHeaderStrings());
+        }
+
+        Assert::assertCount(count($expectedHeaderStrings), $actualHeaderStrings);
+
+        foreach ($expectedHeaderStrings as $expectedHeaderString) {
+            Assert::assertTrue(
+                in_array($expectedHeaderString, $actualHeaderStrings),
+                sprintf('Unable to find %s in actual header strings', $expectedHeaderString)
+            );
+        }
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromAttributeCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromAttributeCodesIntegration.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\Connector\Writer\File\Flat;
+
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+class GenerateHeadersFromAttributeCodesIntegration extends TestCase
+{
+    public function test_generate_headers_from_attributes()
+    {
+        $query = $this->get('akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_attribute_codes');
+        $headers = $query(['sku', 'a_metric', 'a_localizable_image', 'a_scopable_price', 'a_regexp'], 'ecommerce', ['en_US']);
+
+        $expectedHeaders = [
+            new FlatFileHeader('sku'),
+            new FlatFileHeader(
+                'a_metric',
+                false,
+                'ecommerce',
+                false,
+                ['en_US'],
+                false,
+                true
+            ),
+            new FlatFileHeader(
+                'a_localizable_image',
+                false,
+                'ecommerce',
+                true,
+                ['en_US'],
+                true
+            ),
+            new FlatFileHeader(
+                'a_scopable_price',
+                true,
+                'ecommerce',
+                false,
+                ['en_US'],
+                false,
+                false,
+                true,
+                ['USD', 'EUR'],
+                ['USD', 'EUR']
+            ),
+            new FlatFileHeader(
+                'a_regexp',
+                false,
+                'ecommerce',
+                false,
+                ['en_US'],
+                false,
+                false,
+                false,
+                ['USD', 'EUR'],
+                ['USD', 'EUR', 'CNY'],
+                true,
+                ['en_US']
+            ),
+        ];
+
+        AssertHeaders::same($expectedHeaders, $headers);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}
+

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromFamilyCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromFamilyCodesIntegration.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\Connector\Writer\File\Flat;
+
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+class GenerateHeadersFromFamilyCodesIntegration extends TestCase
+{
+    public function test_generate_headers_from_attributes()
+    {
+        $query = $this->get('akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_family_codes');
+        $headers = $query(['familyA1', 'familyA2'], 'ecommerce', ['en_US']);
+
+        $expectedHeaders = [
+            new FlatFileHeader('sku'),
+            new FlatFileHeader('a_date'),
+            new FlatFileHeader(
+                'a_file',
+                false,
+                'ecommerce',
+                false,
+                ['en_US'],
+                true
+            ),
+            new FlatFileHeader(
+                'a_localizable_image',
+                false,
+                'ecommerce',
+                true,
+                ['en_US'],
+                true
+            ),
+            new FlatFileHeader(
+                'a_metric',
+                false,
+                'ecommerce',
+                false,
+                ['en_US'],
+                false,
+                true
+            ),
+            new FlatFileHeader('a_number_float'),
+        ];
+
+        AssertHeaders::same($expectedHeaders, $headers);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}
+

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Processor/Normalization/ProductProcessorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Processor/Normalization/ProductProcessorSpec.php
@@ -10,7 +10,6 @@ use Akeneo\Tool\Component\Batch\Job\JobParameters;
 use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
-use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Channel\Component\Model\ChannelInterface;
@@ -19,7 +18,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueCollectionInterface;
 use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use Akeneo\Channel\Component\Repository\ChannelRepositoryInterface;
-use Akeneo\Pim\Enrichment\Component\Product\ValuesFiller\EntityWithFamilyValuesFillerInterface;
 use Akeneo\Tool\Component\Connector\Processor\BulkMediaFetcher;
 use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -31,17 +29,13 @@ class ProductProcessorSpec extends ObjectBehavior
         ChannelRepositoryInterface $channelRepository,
         AttributeRepositoryInterface $attributeRepository,
         BulkMediaFetcher $mediaFetcher,
-        StepExecution $stepExecution,
-        EntityWithFamilyValuesFillerInterface $productValuesFiller,
-        EntityManagerClearerInterface $clearer
+        StepExecution $stepExecution
     ) {
         $this->beConstructedWith(
             $normalizer,
             $channelRepository,
             $attributeRepository,
-            $mediaFetcher,
-            $productValuesFiller,
-            $clearer
+            $mediaFetcher
         );
 
         $this->setStepExecution($stepExecution);
@@ -64,7 +58,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $channelRepository,
         $stepExecution,
         $mediaFetcher,
-        $productValuesFiller,
         $attributeRepository,
         $clearer,
         ChannelInterface $channel,
@@ -88,8 +81,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $channel->getLocales()->willReturn(new ArrayCollection([$locale]));
         $channel->getCode()->willReturn('foobar');
         $channel->getLocaleCodes()->willReturn(['en_US', 'de_DE']);
-
-        $productValuesFiller->fillMissingValues($product)->shouldBeCalled();
 
         $normalizer->normalize($product, 'standard', ['filter_types' => ['pim.transform.product_value.structured'], 'channels' => ['foobar'], 'locales' => ['en_US']])
             ->willReturn([
@@ -136,7 +127,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $channelRepository,
         $stepExecution,
         $mediaFetcher,
-        $productValuesFiller,
         $clearer,
         ChannelInterface $channel,
         LocaleInterface $locale,
@@ -162,7 +152,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $channel->getCode()->willReturn('foobar');
         $channel->getLocaleCodes()->willReturn(['en_US', 'de_DE']);
 
-        $productValuesFiller->fillMissingValues($product)->shouldBeCalled();
         $product->getIdentifier()->willReturn('AKIS_XS');
         $product->getValues()->willReturn($valuesCollection);
 
@@ -203,7 +192,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $channelRepository,
         $stepExecution,
         $mediaFetcher,
-        $productValuesFiller,
         $clearer,
         ChannelInterface $channel,
         LocaleInterface $locale,
@@ -229,7 +217,6 @@ class ProductProcessorSpec extends ObjectBehavior
         $channel->getCode()->willReturn('foobar');
         $channel->getLocaleCodes()->willReturn(['en_US', 'de_DE']);
 
-        $productValuesFiller->fillMissingValues($product)->shouldBeCalled();
         $product->getIdentifier()->willReturn('AKIS_XS');
         $product->getValues()->willReturn($valuesCollection);
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Writer/File/Csv/ProductWriterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Writer/File/Csv/ProductWriterSpec.php
@@ -3,6 +3,9 @@
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Csv;
 
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Csv\ProductWriter;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromFamilyCodesInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromAttributeCodesInterface;
 use Akeneo\Tool\Component\Batch\Item\ExecutionContext;
 use Akeneo\Tool\Component\Batch\Job\JobInterface;
 use Akeneo\Tool\Component\Batch\Job\JobParameters;
@@ -32,7 +35,9 @@ class ProductWriterSpec extends ObjectBehavior
         BufferFactory $bufferFactory,
         FlatItemBufferFlusher $flusher,
         AttributeRepositoryInterface $attributeRepository,
-        FileExporterPathGeneratorInterface $fileExporterPath
+        FileExporterPathGeneratorInterface $fileExporterPath,
+        GenerateFlatHeadersFromFamilyCodesInterface $generateHeadersFromFamilyCodes,
+        GenerateFlatHeadersFromAttributeCodesInterface $generateHeadersFromAttributeCodes
     ) {
         $this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'spec' . DIRECTORY_SEPARATOR;
         $this->filesystem = new Filesystem();
@@ -44,6 +49,8 @@ class ProductWriterSpec extends ObjectBehavior
             $flusher,
             $attributeRepository,
             $fileExporterPath,
+            $generateHeadersFromFamilyCodes,
+            $generateHeadersFromAttributeCodes,
             ['pim_catalog_file', 'pim_catalog_image']
         );
     }
@@ -301,7 +308,7 @@ class ProductWriterSpec extends ObjectBehavior
         $this->getWrittenFiles()->shouldBeEqualTo([]);
     }
 
-    function it_writes_the_csv_file(
+    function it_writes_the_csv_file_without_headers(
         $bufferFactory,
         $flusher,
         FlatItemBuffer $flatRowBuffer,
@@ -328,6 +335,7 @@ class ProductWriterSpec extends ObjectBehavior
         $jobParameters->get('enclosure')->willReturn('"');
         $jobParameters->get('filePath')->willReturn($this->directory . '%job_label%_product.csv');
         $jobParameters->has('ui_locale')->willReturn(false);
+        $jobParameters->has('withHeader')->willReturn(false);
 
         $bufferFactory->create()->willReturn($flatRowBuffer);
         $flusher->flush(
@@ -341,6 +349,155 @@ class ProductWriterSpec extends ObjectBehavior
         ]);
 
         $this->initialize();
+        $this->flush();
+    }
+
+    function it_writes_the_csv_file_with_headers(
+        $bufferFactory,
+        $flusher,
+        $generateHeadersFromFamilyCodes,
+        FlatItemBuffer $flatRowBuffer,
+        StepExecution $stepExecution,
+        JobParameters $jobParameters,
+        JobExecution $jobExecution,
+        JobInstance $jobInstance,
+        ExecutionContext $executionContext
+    ) {
+        $this->setStepExecution($stepExecution);
+
+        $flusher->setStepExecution($stepExecution)->shouldBeCalled();
+
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTime());
+        $jobExecution->getJobInstance()->willReturn($jobInstance);
+        $jobInstance->getLabel()->willReturn('CSV Product export');
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn($this->directory);
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->has('linesPerFile')->willReturn(false);
+        $jobParameters->get('delimiter')->willReturn(';');
+        $jobParameters->get('enclosure')->willReturn('"');
+        $jobParameters->get('filePath')->willReturn($this->directory . '%job_label%_product.csv');
+        $jobParameters->has('ui_locale')->willReturn(false);
+        $jobParameters->has('decimalSeparator')->willReturn(false);
+        $jobParameters->has('dateFormat')->willReturn(false);
+        $jobParameters->has('with_media')->willReturn(false);
+        $jobParameters->has('selected_properties')->willReturn(false);
+        $jobParameters->has('withHeader')->willReturn(true);
+        $jobParameters->get('withHeader')->willReturn(true);
+        $jobParameters->get('filters')->willReturn(['structure' => ['locales' => ['fr_FR', 'en_US'], 'scope' => 'ecommerce']]);
+
+        $descHeader = new FlatFileHeader(
+            "description",
+            true,
+            'ecommerce',
+            true,
+            ['fr_FR', 'en_US']
+        );
+        $nameHeader = new FlatFileHeader("name", true, "ecommerce");
+        $brandHeader = new FlatFileHeader("brand");
+        $generateHeadersFromFamilyCodes
+            ->__invoke(["family_1", "family_2"], 'ecommerce', ['fr_FR', 'en_US'])
+            ->willReturn([$descHeader, $nameHeader, $brandHeader]);
+
+
+        $bufferFactory->create()->willReturn($flatRowBuffer);
+        $flusher->flush(
+            $flatRowBuffer,
+            Argument::type('array'),
+            Argument::type('string'),
+            -1
+        )->willReturn([
+            $this->directory . 'CSV_Product_export_product1.csv',
+            $this->directory . 'CSV_Product_export_product2.csv'
+        ]);
+
+        $this->initialize();
+        $this->write([
+            [
+                'sku' => 'sku-01',
+                'family' => 'family_1'
+            ],
+            [
+                'sku' => 'sku-02',
+                'family' => 'family_2'
+            ]
+        ]);
+        $this->flush();
+    }
+
+    function it_writes_the_csv_file_with_headers_and_selected_attributes(
+        $bufferFactory,
+        $flusher,
+        $generateHeadersFromAttributeCodes,
+        FlatItemBuffer $flatRowBuffer,
+        StepExecution $stepExecution,
+        JobParameters $jobParameters,
+        JobExecution $jobExecution,
+        JobInstance $jobInstance,
+        ExecutionContext $executionContext
+    ) {
+        $this->setStepExecution($stepExecution);
+
+        $flusher->setStepExecution($stepExecution)->shouldBeCalled();
+
+        $stepExecution->getJobExecution()->willReturn($jobExecution);
+        $stepExecution->getStartTime()->willReturn(new \DateTime());
+        $jobExecution->getJobInstance()->willReturn($jobInstance);
+        $jobInstance->getLabel()->willReturn('CSV Product export');
+        $jobExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get(JobInterface::WORKING_DIRECTORY_PARAMETER)->willReturn($this->directory);
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->has('linesPerFile')->willReturn(false);
+        $jobParameters->get('delimiter')->willReturn(';');
+        $jobParameters->get('enclosure')->willReturn('"');
+        $jobParameters->get('filePath')->willReturn($this->directory . '%job_label%_product.csv');
+        $jobParameters->has('ui_locale')->willReturn(false);
+        $jobParameters->has('decimalSeparator')->willReturn(false);
+        $jobParameters->has('dateFormat')->willReturn(false);
+        $jobParameters->has('with_media')->willReturn(false);
+        $jobParameters->has('selected_properties')->willReturn(true);
+        $jobParameters->get('selected_properties')->willReturn(['name', 'description']);
+        $jobParameters->has('withHeader')->willReturn(true);
+        $jobParameters->get('withHeader')->willReturn(true);
+        $jobParameters->get('filters')->willReturn(['structure' => ['locales' => ['fr_FR', 'en_US'], 'scope' => 'ecommerce']]);
+
+        $descHeader = new FlatFileHeader(
+            "description",
+            true,
+            'ecommerce',
+            true,
+            ['fr_FR', 'en_US']
+        );
+        $nameHeader = new FlatFileHeader("name", true, "ecommerce");
+        $generateHeadersFromAttributeCodes
+            ->__invoke(["name", "description"], 'ecommerce', ['fr_FR', 'en_US'])
+            ->willReturn([$nameHeader, $descHeader]);
+
+        $bufferFactory->create()->willReturn($flatRowBuffer);
+        $flusher->flush(
+            $flatRowBuffer,
+            Argument::type('array'),
+            Argument::type('string'),
+            -1
+        )->willReturn([
+            $this->directory . 'CSV_Product_export_product1.csv',
+            $this->directory . 'CSV_Product_export_product2.csv'
+        ]);
+
+        $this->initialize();
+        $this->write([
+            [
+                'sku' => 'sku-01',
+                'family' => 'family_1'
+            ],
+            [
+                'sku' => 'sku-02',
+                'family' => 'family_2'
+            ]
+        ]);
         $this->flush();
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Writer/File/FlatFileHeaderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Writer/File/FlatFileHeaderSpec.php
@@ -1,0 +1,441 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File;
+
+use  Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class FlatFileHeaderSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->beConstructedWith('my_code');
+
+        $this->shouldHaveType(FlatFileHeader::class);
+    }
+
+    function it_can_be_built_from_attribute_data()
+    {
+        $attributeData = [
+            'description',
+            'pim_catalog_textarea',
+            true,
+            'ecommerce',
+            'true',
+            ['en_US', 'de_DE'],
+            ['USD', 'EUR'],
+            ['USD', 'EUR', 'CNY'],
+            []
+        ];
+
+        $this->beConstructedThrough('buildFromAttributeData', $attributeData);
+
+        $this->shouldHaveType(FlatFileHeader::class);
+    }
+
+    function it_can_be_built_from_attribute_data_and_be_a_media()
+    {
+        $attributeData = [
+            'description',
+            'pim_catalog_image',
+            true,
+            'ecommerce',
+            'true',
+            ['en_US', 'de_DE'],
+            ['USD', 'EUR'],
+            ['USD', 'EUR', 'CNY'],
+            []
+        ];
+
+        $this->beConstructedThrough('buildFromAttributeData', $attributeData);
+
+        $this->isMedia()->shouldReturn(true);
+    }
+
+    function it_must_properly_indicate_if_it_is_a_media()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = false,
+            $channelCode = null,
+            $isLocalizable = false,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = true
+        );
+
+        $this->isMedia()->shouldReturn(true);
+    }
+
+    function it_must_properly_indicate_if_it_is_not_a_media()
+    {
+        $this->beConstructedWith($code = 'my_code');
+
+        $this->isMedia()->shouldReturn(false);
+    }
+
+    function it_must_be_throw_an_exception_when_missing_specific_to_locales_list()
+    {
+        $this->shouldThrow('\InvalidArgumentException')->during(
+            '__construct',
+            [
+                $code = 'my_code',
+                $isScopable = false,
+                $channelCode = null,
+                $isLocalizable = false,
+                $localeCodes = ['en_US', 'fr_FR'],
+                $isMedia = true,
+                $usesUnit = false,
+                $usesCurrencies = false,
+                $channelCurrencies = null,
+                $allCurrencies = null,
+                $isLocaleSpecific = true
+            ]
+        );
+    }
+
+    function it_must_be_throw_an_exception_when_using_unit_and_currencies()
+    {
+        $this->shouldThrow('\InvalidArgumentException')->during(
+            '__construct',
+            [
+                $code = 'my_code',
+                $isScopable = false,
+                $channelCode = null,
+                $isLocalizable = false,
+                $localeCodes = ['en_US', 'fr_FR'],
+                $isMedia = true,
+                $usesUnit = true,
+                $usesCurrencies = true
+            ]
+        );
+    }
+
+    function it_generates_an_empty_header_string_for_non_supported_locales()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = false,
+            $channelCode = null,
+            $isLocalizable = false,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = true,
+            $usesUnit = false,
+            $usesCurrencies = false,
+            $channelCurrencies = null,
+            $allCurrencies = null,
+            $isLocaleSpecific = true,
+            $specificToLocales = ['de_DE']
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([]);
+    }
+
+    function it_generates_a_header_string_if_locales_supported()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = false,
+            $channelCode = null,
+            $isLocalizable = false,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = true,
+            $usesUnit = false,
+            $usesCurrencies = false,
+            $channelCurrencies = null,
+            $allCurrencies = null,
+            $isLocaleSpecific = true,
+            $specificToLocales = ['en_US']
+        );
+
+        $this->generateHeaderStrings()->shouldReturn(['my_code']);
+    }
+
+    function it_generates_header_strings_for_supported_locales_when_localizable()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = false,
+            $channelCode = null,
+            $isLocalizable = true,
+            $localeCodes = ['en_US', 'fr_FR', 'fr_BE'],
+            $isMedia = true,
+            $usesUnit = false,
+            $usesCurrencies = false,
+            $channelCurrencies = null,
+            $allCurrencies = null,
+            $isLocaleSpecific = true,
+            $specificToLocales = ['en_US', 'de_DE', 'fr_BE']
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code-en_US',
+            'my_code-fr_BE'
+        ]);
+    }
+
+    function it_generates_a_header_string_if_locales_supported_with_unit()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = false,
+            $channelCode = null,
+            $isLocalizable = false,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = true,
+            $usesUnit = true,
+            $usesCurrencies = false,
+            $channelCurrencies = null,
+            $allCurrencies = null,
+            $isLocaleSpecific = true,
+            $specificToLocales = ['en_US']
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code',
+            'my_code-unit'
+        ]);
+    }
+
+    function it_generates_a_header_string_if_locales_supported_with_currencies()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = false,
+            $channelCode = null,
+            $isLocalizable = false,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = true,
+            $usesUnit = false,
+            $usesCurrencies = true,
+            $channelCurrencies = ['USD', 'EUR'],
+            $allCurrencies = ['USD', 'EUR', 'GBP'],
+            $isLocaleSpecific = true,
+            $specificToLocales = ['en_US']
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code-USD',
+            'my_code-EUR',
+            'my_code-GBP'
+        ]);
+    }
+
+    function it_generates_a_header_string_for_non_scopable_non_localizable()
+    {
+        $this->beConstructedWith('my_code');
+
+        $this->generateHeaderStrings()->shouldReturn(['my_code']);
+    }
+
+    function it_generates_a_header_string_for_non_scopable_non_localizable_with_unit()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = false,
+            $channelCode = null,
+            $isLocalizable = false,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = true,
+            $usesUnit = true
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code',
+            'my_code-unit'
+        ]);
+    }
+
+    function it_generates_a_header_string_for_non_scopable_non_localizable_with_currencies()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = false,
+            $channelCode = null,
+            $isLocalizable = false,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = false,
+            $usesUnit = false,
+            $usesCurrencies = true,
+            $channelCurrencies = ['USD', 'EUR'],
+            $allCurrencies = ['USD', 'EUR', 'GBP']
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code-USD',
+            'my_code-EUR',
+            'my_code-GBP'
+        ]);
+    }
+
+    function it_generates_a_header_string_for_scopable_non_localizable()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = true,
+            $channelCode = 'ecommerce'
+        );
+
+        $this->generateHeaderStrings()->shouldReturn(['my_code-ecommerce']);
+    }
+
+    function it_generates_a_header_string_for_scopable_non_localizable_with_unit()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = true,
+            $channelCode = 'ecommerce',
+            $isLocalizable = false,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = false,
+            $usesUnit = true
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code-ecommerce',
+            'my_code-ecommerce-unit'
+        ]);
+    }
+
+    function it_generates_a_header_string_for_scopable_non_localizable_with_currencies()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = true,
+            $channelCode = 'ecommerce',
+            $isLocalizable = false,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = false,
+            $usesUnit = false,
+            $usesCurrencies = true,
+            $channelCurrencies = ['USD', 'EUR'],
+            $allCurrencies = ['USD', 'EUR', 'GBP']
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code-ecommerce-USD',
+            'my_code-ecommerce-EUR'
+        ]);
+    }
+
+    function it_generates_headers_string_for_non_scopable_localizable()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = false,
+            $channelCode = null,
+            $isLocalizable = true,
+            $localeCodes = ['en_US', 'fr_FR']
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code-en_US',
+            'my_code-fr_FR'
+        ]);
+    }
+
+    function it_generates_headers_string_for_non_scopable_localizable_with_unit()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = false,
+            $channelCode = null,
+            $isLocalizable = true,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = true,
+            $usesUnit = true
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code-en_US',
+            'my_code-en_US-unit',
+            'my_code-fr_FR',
+            'my_code-fr_FR-unit'
+        ]);
+    }
+
+    function it_generates_headers_string_for_non_scopable_localizable_with_currencies()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = false,
+            $channelCode = null,
+            $isLocalizable = true,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = false,
+            $usesUnit = false,
+            $usesCurrencies = true,
+            $channelCurrencies = ['USD', 'EUR'],
+            $allCurrencies = ['USD', 'EUR', 'GBP']
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code-en_US-USD',
+            'my_code-en_US-EUR',
+            'my_code-en_US-GBP',
+            'my_code-fr_FR-USD',
+            'my_code-fr_FR-EUR',
+            'my_code-fr_FR-GBP'
+        ]);
+    }
+
+    function it_generates_headers_string_for_scopable_localizable()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = true,
+            $channelCode = 'ecommerce',
+            $isLocalizable = true,
+            $localeCodes = ['en_US', 'fr_FR']
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code-en_US-ecommerce',
+            'my_code-fr_FR-ecommerce'
+        ]);
+    }
+
+    function it_generates_headers_string_for_scopable_localizable_with_unit()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = true,
+            $channelCode = 'ecommerce',
+            $isLocalizable = true,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = true,
+            $usesUnit = true
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code-en_US-ecommerce',
+            'my_code-en_US-ecommerce-unit',
+            'my_code-fr_FR-ecommerce',
+            'my_code-fr_FR-ecommerce-unit'
+        ]);
+    }
+
+    function it_generates_headers_string_for_scopable_localizable_with_currencies()
+    {
+        $this->beConstructedWith(
+            $code = 'my_code',
+            $isScopable = true,
+            $channelCode = 'ecommerce',
+            $isLocalizable = true,
+            $localeCodes = ['en_US', 'fr_FR'],
+            $isMedia = true,
+            $usesUnit = false,
+            $usesCurrencies = true,
+            $channelCurrencies = ['USD', 'EUR'],
+            $allCurrencies = ['USD', 'EUR', 'GBP']
+        );
+
+        $this->generateHeaderStrings()->shouldReturn([
+            'my_code-en_US-ecommerce-USD',
+            'my_code-en_US-ecommerce-EUR',
+            'my_code-fr_FR-ecommerce-USD',
+            'my_code-fr_FR-ecommerce-EUR'
+        ]);
+    }
+}

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_grid_context.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_grid_context.feature
@@ -30,10 +30,10 @@ Feature: Quick export products according to the product grid context
     And the names of the exported files of "csv_product_grid_context_quick_export" should be "1_products_export_grid_context_en_US_tablet.csv,2_product_models_export_grid_context_en_US_tablet.csv"
     And first exported file of "csv_product_grid_context_quick_export" should contain:
     """
-    sku;color;description-en_US-tablet;family;groups;name-en_US;price-EUR;price-USD;size
-    boots;black;Mob;boots;;Amazing boots;20;25;40
-    sneakers;white;ylette;sneakers;;Sneakers;50;60;42
-    pump;blue;;;;Pump;15;20;41
+    sku;color;description-en_US-tablet;family;groups;name-en_US;price-EUR;price-USD;size;weight;weight-unit
+    boots;black;Mob;boots;;Amazing boots;20;25;40;;
+    sneakers;white;ylette;sneakers;;Sneakers;50;60;42;;
+    pump;blue;;;;Pump;15;20;41;;
     """
 
   @jira https://akeneo.atlassian.net/browse/PIM-7911
@@ -84,7 +84,7 @@ Feature: Quick export products according to the product grid context
     Then I should see the text "COMPLETED"
     And the names of the exported files of "xlsx_product_grid_context_quick_export" should be "1_products_export_grid_context_en_US_tablet.xlsx,2_product_models_export_grid_context_en_US_tablet.xlsx"
     And exported xlsx file 1 of "xlsx_product_grid_context_quick_export" should contain:
-      | sku      | color | description-en_US-tablet | family   | groups | name-en_US    | price-EUR | price-USD | size |
-      | boots    | black | Mob                      | boots    |        | Amazing boots | 20        | 25        | 40   |
-      | sneakers | white | ylette                   | sneakers |        | Sneakers      | 50        | 60        | 42   |
-      | pump     | blue  |                          |          |        | Pump          | 15        | 20        | 41   |
+      | sku      | color | description-en_US-tablet | family   | groups | name-en_US    | price-EUR | price-USD | size | weight | weight-unit |
+      | boots    | black | Mob                      | boots    |        | Amazing boots | 20        | 25        | 40   |        |             |
+      | sneakers | white | ylette                   | sneakers |        | Sneakers      | 50        | 60        | 42   |        |             |
+      | pump     | blue  |                          |          |        | Pump          | 15        | 20        | 41   |        |             |


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In order to get all possible columns in a flat export file, we fill all the products loaded from the DB with all possible values but with empty data.
This is pretty inefficient, as this creates a lot of value objects that will generate at the end the exact same headers.

This PR changes the algorithm to generate the headers only at the end of the export by collecting all the families of the products exported and when the writer is flushed, by generating all the headers for the collected families attributes information.

The benchmark shows that even with products totally filled this solution is still faster (1.4x times) and goes up to 6x times faster with products lightly filled.

Benchmark result (Reference catalog with 10k products in DB, 8k products exported):
- 5% of product values filled: 6x faster (30s vs 3m30s)
- 50% of product values filled: 1.5x faster (3m56s vs 6m3s)
- 100% of product values filled: 1.4x faster (6m10s vs 8m20s)

About ProductModel support:
This PR still fills empty values for ProductModel by checking ProductModel in the reader, which breaks the genericity of the reader (maybe it should not be generic...).
Anyway; the first draft of this PR had a beginning of support for generating headers for ProductModel, so this line didn't exist.
But including in the same PR support for ProductModel was growing too much, because:
 - the business rules for generating headers for productModel flat files is more complex than with products as only headers belonging to the product model and its parents must be in the file. I cannot put the headers for the whole family, unless I change the functional behavior
 - the current state of the ProductModel and FamilyVariant modelling in DB makes it very difficult to list the attributes belonging to a FamilyVariant, and the tree structure itself of the product model doesn't help to have simple queries doing the job.

So I decided to work on the ProductModel side on another PR. Moreover the pain is mostly on Product export side for the moment, so that's where I put the priority.

TODO:
 - [x] EE PR for permissions on attributes
 - [x] Integration test for the queries
 
**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | Todo
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
