### PR TITLE
APAI-383: Implement InMemoryLocaleRepository "getActivatedLocales"

### DIFF
--- a/tests/back/Acceptance/Locale/InMemoryLocaleRepository.php
+++ b/tests/back/Acceptance/Locale/InMemoryLocaleRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Test\Acceptance\Locale;
 
 use Akeneo\Channel\Component\Model\ChannelInterface;
+use Akeneo\Channel\Component\Model\LocaleInterface;
 use Akeneo\Channel\Component\Repository\LocaleRepositoryInterface;
 use Akeneo\Test\Acceptance\Common\NotImplementedException;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
@@ -81,7 +82,14 @@ final class InMemoryLocaleRepository implements LocaleRepositoryInterface, Saver
      */
     public function getActivatedLocaleCodes()
     {
-        throw new NotImplementedException(__METHOD__);
+        $localeCodes = [];
+        foreach ($this->locales as $locale) {
+            if ($locale->isActivated()) {
+                $localeCodes[] = $locale->getCode();
+            }
+        }
+
+        return $localeCodes;
     }
 
     /**


### PR DESCRIPTION
**Description**

Implements the method `getActivatedLocales` of the `InMemoryLocaleRepository`.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
