### PR TITLE
GITHUB-8482: Fix missing breadcrumbs - cheers @userz58!

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -6,6 +6,7 @@
 - PIM-7898: Fix tab navigation when the column is collapsed
 - PIM-7866: Do not show delete icon on import/export profile if the user doesn't have the right to delete.
 - PIM-7910: Search parent filter is now case insensitive
+- GITHUB-8482: Fix missing breadcrumbs - cheers @userz58!
 
  ## Elasticsearch
  

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/attribute_group/create.yml
@@ -2,6 +2,14 @@ extensions:
     pim-attribute-group-create-form:
         module: pim/form/common/edit-form
 
+    pim-attribute-group-create-form-breadcrumbs:
+        module: pim/common/breadcrumbs
+        parent: pim-attribute-group-create-form
+        targetZone: breadcrumbs
+        config:
+            tab: pim-menu-settings
+            item: pim-menu-settings-attribute-group
+
     pim-attribute-group-create-form-cache-invalidator:
         module: pim/cache-invalidator
         parent: pim-attribute-group-create-form

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/create.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/channel/create.yml
@@ -2,6 +2,14 @@ extensions:
     pim-channel-create-form:
         module: pim/form/common/edit-form
 
+    pim-channel-create-form-breadcrumbs:
+        module: pim/common/breadcrumbs
+        parent: pim-channel-create-form
+        targetZone: breadcrumbs
+        config:
+            tab: pim-menu-settings
+            item: pim-menu-settings-channel
+
     pim-channel-create-form-cache-invalidator:
         module: pim/cache-invalidator
         parent: pim-channel-create-form


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Breadcrumb missing when you create Attribute group or Channel :
http://demo.akeneo.com/#/configuration/attribute-group/create
http://demo.akeneo.com/#/configuration/channel/create

cf https://github.com/akeneo/pim-community-dev/issues/8482

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
