### PR TITLE
PIM-7926 - Set the parent attribute to null instead of an empty string

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7899: Remove Date of Birth field
+- PIM-7926: Fix the parent property setter when "enabled comparison" is set to false in an import job definition
 
 # 2.3.22 (2018-12-21)
 

--- a/src/Pim/Component/Catalog/ProductModel/Filter/ProductAttributeFilter.php
+++ b/src/Pim/Component/Catalog/ProductModel/Filter/ProductAttributeFilter.php
@@ -78,6 +78,10 @@ class ProductAttributeFilter implements AttributeFilterInterface
             $standardProduct['parent'] = $product->getParent()->getCode();
         }
 
+        if (isset($standardProduct['parent']) && '' === $standardProduct['parent']) {
+            $standardProduct['parent'] = null;
+        }
+
         if (isset($standardProduct['parent']) &&
             null !== $parentProductModel = $this->productModelRepository->findOneByIdentifier($standardProduct['parent'])
         ) {

--- a/src/Pim/Component/Catalog/spec/ProductModel/Filter/ProductAttributeFilterSpec.php
+++ b/src/Pim/Component/Catalog/spec/ProductModel/Filter/ProductAttributeFilterSpec.php
@@ -110,6 +110,75 @@ class ProductAttributeFilterSpec extends ObjectBehavior
         )->shouldReturn($expected);
     }
 
+    function it_sets_to_null_an_empty_parent_attribute_value(
+        $familyRepository,
+        $productRepository,
+        $attributeRepository,
+        FamilyInterface $family,
+        ProductInterface $product,
+        Collection $familyAttributes,
+        Collection $familyAttributeCodes,
+        AttributeInterface $attribute
+    ) {
+        $attributeRepository->findOneByIdentifier('sku')->willReturn($attribute);
+        $attributeRepository->findOneByIdentifier('description')->willReturn($attribute);
+
+        $familyRepository->findOneByIdentifier('Summer Tshirt')->willReturn($family);
+        $family->getAttributes()->willReturn($familyAttributes);
+        $familyAttributes->map(Argument::any())->willReturn($familyAttributeCodes);
+        $familyAttributeCodes->toArray()->willReturn(['sku', 'description']);
+
+        $productRepository->findOneByIdentifier('tshirt')->willReturn($product);
+
+        $product->isVariant()->willReturn(false);
+
+        $expected = [
+            'identifier' => 'tshirt',
+            'family' => 'Summer Tshirt',
+            'parent' => null,
+            'values' => [
+                'sku' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'tshirt',
+                    ],
+                ],
+                'description' => [
+                    [
+                        'locale' => 'en_US',
+                        'scope' => 'mobile',
+                        'data' => 'My awesome description',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->filter(
+            [
+                'identifier' => 'tshirt',
+                'family' => 'Summer Tshirt',
+                'parent' => '',
+                'values' => [
+                    'sku' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => 'tshirt',
+                        ],
+                    ],
+                    'description' => [
+                        [
+                            'locale' => 'en_US',
+                            'scope' => 'mobile',
+                            'data' => 'My awesome description',
+                        ],
+                    ],
+                ],
+            ]
+        )->shouldReturn($expected);
+    }
+
     function it_filters_the_attributes_that_does_not_belong_to_a_family_variant(
         $productModelRepository,
         $productRepository,


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In an import product definition you can "enable" or "disable" the comparison of the values of the product you try to update.

In "enable comparison" mode, if the value of an element is identical to the one in database, the product is skipped.

In "disable comparison" mode, we persist the data values as is.

For a regular "product" (not a variant product) the "parent" column in an import file must be absent or when the import file have mixed "product" and "variant product", the column "parent" is here but empty for "products".

**Problem**

When "disable comparison" is set to a product import job definition, and when you import a file containing mixed product, we try to update the product and set the parent value with an empty string.

**Solution**

In the `ProductAttributeFilter` class, if the parent value is empty, we set it's value to `null`.
In the `ParentFieldSetter`, if the value is `null` it's skipped.

I prefered set the value to `null` instead of `unset` the item in the array which have less impacts when dealing with mixed product/variant product.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
