### PR TITLE
PIM-7839: Remove date of birth

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -13,6 +13,7 @@
 - PIM-7660: Improve performance of the product grid by using a dedicated read model
 - PIM-7499: Improve the performance of the completeness widget in the dashboard
 - PIM-7371: Improve the performance of the category tree in the product grid
+- PIM-7839: Remove date of birth
 
 ## Enhancements
 
@@ -1246,3 +1247,4 @@
 - Change constructor of `Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface\FamilySaver`, remove second argument `Akeneo\Pim\Enrichment\Component\Product\Manager\CompletenessManager`
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\FileValidator` to add an array of string (extension to mime type mapping) 
 - Add `pim_configuration` table. Don't forget to run the `doctrine:migrations:migrate` command.
+- Remove methods `getBirthday` and `setBirthday` of `Akeneo\UserManagement\Component\Model\UserInterface` and `Akeneo\UserManagement\Component\Model\User`

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
@@ -179,15 +179,6 @@ extensions:
             fieldName: phone
             label: pim_user_management.entity.user.properties.phone
 
-    pim-user-edit-form-birthday:
-        module: pim/form/common/fields/date
-        parent: pim-user-edit-form-general-tab-content
-        position: 90
-        targetZone: content
-        config:
-            fieldName: birthday
-            label: pim_user_management.entity.user.properties.birthday
-
     pim-user-edit-form-avatar:
         module: pim/form/common/fields/media
         parent: pim-user-edit-form-general-tab-content

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/show.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/show.yml
@@ -147,16 +147,6 @@ extensions:
             label: pim_user_management.entity.user.properties.phone
             readOnly: true
 
-    pim-user-show-birthday:
-        module: pim/form/common/fields/date
-        parent: pim-user-show-general-tab-content
-        position: 90
-        targetZone: content
-        config:
-            fieldName: birthday
-            label: pim_user_management.entity.user.properties.birthday
-            readOnly: true
-
     pim-user-show-avatar:
         module: pim/form/common/fields/media
         parent: pim-user-show-general-tab-content

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/User.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/User.orm.yml
@@ -42,9 +42,6 @@ Akeneo\UserManagement\Component\Model\User:
             length: 255
             nullable: true
             column: name_suffix
-        birthday:
-            type: date
-            nullable: true
         image:
             type: string
             length: 255

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/validation.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/validation.yml
@@ -45,8 +45,6 @@ Akeneo\UserManagement\Component\Model\User:
             - Akeneo\UserManagement\Bundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters: ~
         nameSuffix:
             - Akeneo\UserManagement\Bundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters: ~
-        birthday:
-            - Date:         ~
         imageFile:
             - Image:        ~
         uiLocale:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -51,7 +51,6 @@ pim_user_management:
                 last_name: Last name
                 name_suffix: Name suffix
                 phone: Phone
-                birthday: Birthday
                 avatar: Avatar
                 email: Email
                 catalog_locale: Catalog locale

--- a/src/Akeneo/UserManagement/Component/Model/User.php
+++ b/src/Akeneo/UserManagement/Component/Model/User.php
@@ -47,9 +47,6 @@ class User implements UserInterface
     /** @var string */
     protected $nameSuffix;
 
-    /** @var \DateTime */
-    protected $birthday;
-
     /**
      * Image filename
      *
@@ -290,14 +287,6 @@ class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function getBirthday()
-    {
-        return $this->birthday;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getImage()
     {
         return $this->image;
@@ -504,16 +493,6 @@ class User implements UserInterface
     public function setNameSuffix($nameSuffix)
     {
         $this->nameSuffix = $nameSuffix;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setBirthday(\DateTime $birthday = null)
-    {
-        $this->birthday = $birthday;
-
-        return $this;
     }
 
     /**

--- a/src/Akeneo/UserManagement/Component/Model/UserInterface.php
+++ b/src/Akeneo/UserManagement/Component/Model/UserInterface.php
@@ -43,13 +43,6 @@ interface UserInterface extends AdvancedUserInterface, \Serializable, EntityUplo
     public function getEmail();
 
     /**
-     * Return birthday
-     *
-     * @return \DateTime
-     */
-    public function getBirthday();
-
-    /**
      * {@inheritDoc}
      */
     public function getPlainPassword();
@@ -188,13 +181,6 @@ interface UserInterface extends AdvancedUserInterface, \Serializable, EntityUplo
      * @return string
      */
     public function getFullName();
-
-    /**
-     * @param  \DateTime $birthday [optional] New birthday value. Null by default.
-     *
-     * @return UserInterface
-     */
-    public function setBirthday(\DateTime $birthday = null);
 
     /**
      * @param  string $image [optional] New image file name. Null by default.

--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -87,7 +87,6 @@ class UserNormalizer implements NormalizerInterface
             'last_name'                 => $user->getLastName(),
             'name_suffix'               => $user->getNameSuffix(),
             'phone'                     => $user->getPhone(),
-            'birthday'                  => $user->getBirthday() ? $user->getBirthday()->format('Y-m-d') : null,
             'image'                     => $user->getImagePath(),
             'last_login'                => $user->getLastLogin() ? $user->getLastLogin()->getTimestamp() : null,
             'login_count'               => $user->getLoginCount(),

--- a/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
+++ b/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
@@ -172,9 +172,6 @@ class UserUpdater implements ObjectUpdaterInterface
 
                 $this->userManager->updatePassword($user);
                 break;
-            case 'birthday':
-                $user->setBirthday(new \DateTime($data));
-                break;
             case 'catalog_default_locale':
                 $user->setCatalogLocale($this->findLocale('catalog_default_locale', $data));
                 break;

--- a/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
@@ -65,7 +65,6 @@ class UserNormalizerSpec extends ObjectBehavior
             'last_name'                 => null,
             'name_suffix'               => null,
             'phone'                     => null,
-            'birthday'                  => null,
             'image'                     => null,
             'last_login'                => null,
             'login_count'               => 0,

--- a/tests/front/common/builder/user.js
+++ b/tests/front/common/builder/user.js
@@ -8,7 +8,6 @@ class UserBuilder {
       middleName: null,
       lastName: 'Doe',
       nameSuffix: null,
-      birthday: null,
       image: null,
       lastLogin: 1518092814,
       loginCount: 18,

--- a/upgrades/schema/Version_3_0_20181227141616_remove_birthdate.php
+++ b/upgrades/schema/Version_3_0_20181227141616_remove_birthdate.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version_3_0_20181227141616_remove_birthdate extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE oro_user DROP birthday');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE oro_user ADD birthday DATE DEFAULT NULL');
+    }
+}


### PR DESCRIPTION
In order to be in conformity with the new European measures on the protection of personal data RGPD (General Data Protection Regulation), it was decided to remove the field "Date of birth" from the user creation form in version 3.0 only.

EE part : https://github.com/akeneo/pim-enterprise-dev/pull/5291