### PR TITLE
PIM-7915: Display a modal on deletion error

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Controller/GroupController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/GroupController.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\UserManagement\Bundle\Controller;
 
-use Akeneo\Tool\Bundle\StorageUtilsBundle\Doctrine\Common\Remover\BaseRemover;
 use Akeneo\UserManagement\Component\Model\Group;
 use Akeneo\UserManagement\Component\UserEvents;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
@@ -59,7 +58,12 @@ class GroupController extends Controller
         }
 
         $remover = $this->get('pim_user.remover.user_group');
-        $remover->remove($group);
+
+        try {
+            $remover->remove($group);
+        } catch (\Exception $exception) {
+            return new JsonResponse(['message' => $exception->getMessage()], 500);
+        };
 
         return new JsonResponse('', 204);
     }

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -22,6 +22,7 @@ pim_title:
 confirmation:
     remove:
         user: Are you sure you want to delete this user?
+        group: Are you sure you want to delete this group?
 
 pim_enrich:
     entity:

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/delete-action.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/delete-action.js
@@ -104,23 +104,27 @@ define([
              * @return {oro.Modal}
              */
             getErrorDialog: function(response) {
-                if (!this.errorModal) {
-                    let message = '';
+                let message = '';
+
+                if (typeof response === 'string') {
+                    message = response;
+                } else {
                     try {
                         message = JSON.parse(response).message;
                     } catch(e) {
                         message = __('pim_enrich.entity.' + this.getEntityHint() + '.flash.delete.fail');
                     }
-
-                    this.errorModal = new Modal({
-                        title: __('pim_datagrid.delete_error.title'),
-                        content:
-                            '' === message ?
-                            __('pim_enrich.entity.' + this.getEntityHint() + '.flash.delete.fail'):
-                            message,
-                        cancelText: false
-                    });
                 }
+
+                this.errorModal = new Modal({
+                    title: __('pim_datagrid.delete_error.title'),
+                    content:
+                        '' === message ?
+                        __('pim_enrich.entity.' + this.getEntityHint() + '.flash.delete.fail'):
+                        message,
+                    cancelText: false
+                });
+
                 return this.errorModal;
             }
         });


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
When a user group deletion error occurs, we now display a modal with the error message to the user.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -