### PR TITLE
PIM-7927: Fix constraints on attribute code

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # 2.0.x
 
+## Bug fixes
+
+- GITHUB-8234 & GITHUB-8383: Fix constraints on attribute code. Cheers @oliverde8 & @navneetbhardwaj !
+
 # 2.0.45 (2018-12-18)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -75,7 +75,7 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
             - Length:
                 max: 255
             - Regex:
-                pattern: /^(?!(id|associationTypes|categories|categoryId|completeness|enabled|family|groups|associations|products|scope|treeId|values|category|parent|(.)*_(products|groups)|entity_type)$)/
+                pattern: /^(?!(id|(?i)identifier|associationTypes|categories|categoryId|completeness|enabled|family|groups|associations|products|scope|treeId|values|category|parent|(.)*_(products|groups)|entity_type|attributes)$)/
                 message: This code is not available
         localizable:
             - Type: bool

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/GlobalConstraintsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Validation/Attribute/GlobalConstraintsIntegration.php
@@ -265,9 +265,9 @@ class GlobalConstraintsIntegration extends AbstractAttributeTestCase
     public function reservedCodesProvider()
     {
         return [
-            ['id'], ['associations'], ['associationTypes'], ['category'], ['categoryId'], ['categories'],
+            ['id'], ['identifier'], ['associations'], ['associationTypes'], ['category'], ['categoryId'], ['categories'],
             ['completeness'], ['enabled'], ['family'], ['groups'], ['products'], ['scope'], ['treeId'], ['values'],
-            ['my_groups'], ['my_products']
+            ['my_groups'], ['my_products'], ['attributes']
         ];
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add constraints on attribute code - not allow to create an attribute with code "identifier" (case sensitive) & "attributes".