### PR TITLE
PIM-7940: Fix comparison in versioning system

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -1,5 +1,9 @@
 # 1.7.x
 
+## Bug fixes
+
+- GITHUB-7594: Fix comparison in versioning system. Cheers @mathewrapid !
+
 # 1.7.36 (2018-12-11)
 
 ## Bug fixes

--- a/src/Pim/Bundle/VersioningBundle/Builder/VersionBuilder.php
+++ b/src/Pim/Bundle/VersioningBundle/Builder/VersionBuilder.php
@@ -172,7 +172,7 @@ class VersionBuilder
         return array_filter(
             $changeset,
             function ($item) {
-                return $item['old'] != $item['new'];
+                return $item['old'] !== $item['new'];
             }
         );
     }

--- a/src/Pim/Bundle/VersioningBundle/spec/Builder/VersionBuilderSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Builder/VersionBuilderSpec.php
@@ -52,4 +52,18 @@ class VersionBuilderSpec extends ObjectBehavior
 
         $this->buildPendingVersion($pending);
     }
+
+    function it_compare_versions(Version $pending, Version $previousPending)
+    {
+        $previousPending->getVersion()->willReturn(1);
+        $previousPending->getSnapshot()->willReturn(['test' => '00112233']);
+
+        $pending->setVersion(2)->willReturn($pending);
+        $pending->setSnapshot(['test' => '0112233'])->willReturn($pending);
+        $pending->getChangeset()->willReturn(['test' => '0112233']);
+
+        $pending->setChangeset(['test' => ['old' => '00112233', 'new' => '0112233']])->willReturn($pending);
+
+        $this->buildPendingVersion($pending, $previousPending);
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Versioning does not differentiate between "0123" and "123" in text fields.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
