### PR TITLE
Fix failing test

### DIFF
--- a/tests/back/Integration/TestCase.php
+++ b/tests/back/Integration/TestCase.php
@@ -33,10 +33,6 @@ abstract class TestCase extends KernelTestCase
      */
     protected function setUp()
     {
-        static::bootKernel(['debug' => false]);
-        $authenticator = new SystemUserAuthenticator(static::$kernel->getContainer());
-        $authenticator->createSystemUser();
-
         $this->testKernel = new \AppKernelTest('test', false);
         $this->testKernel->boot();
 
@@ -45,8 +41,13 @@ abstract class TestCase extends KernelTestCase
             $this->testKernel->getContainer()->set('akeneo_integration_tests.catalog.configuration', $this->getConfiguration());
             $fixturesLoader = $this->testKernel->getContainer()->get('akeneo_integration_tests.loader.fixtures_loader');
             $fixturesLoader->load();
-            $this->get('doctrine.orm.default_entity_manager')->clear();
         }
+
+        static::bootKernel(['debug' => false]);
+        $authenticator = new SystemUserAuthenticator(static::$kernel->getContainer());
+        $authenticator->createSystemUser();
+        $this->get('doctrine.orm.default_entity_manager')->clear();
+
     }
 
     /**


### PR DESCRIPTION



<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**


The activated local for the user is the first activated locale in DB.

The problem is that this locale is loaded from the previous test.
Depending of the order of the tests, it can be a problem.


The solution is just to create the user after loading the DB.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
