### PR TITLE
Aob 324 - Username in the PIM doesn't support the '@' and '.' character

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
@@ -134,6 +134,7 @@ class UserController
      */
     public function getAction($identifier): JsonResponse
     {
+        $identifier = urldecode($identifier);
         $user = $this->repository->findOneByIdentifier($identifier);
 
         return new JsonResponse($this->normalizer->normalize($user, 'internal_api'));
@@ -265,6 +266,8 @@ class UserController
 
     private function getUserOr404($username): ?UserInterface
     {
+
+        $username = urldecode($username);
         $user = $this->repository->findOneByIdentifier($username);
 
         if (null === $user) {

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/routing/user.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/routing/user.yml
@@ -4,7 +4,7 @@ pim_user_index:
 pim_user_edit:
     path: /{code}/edit
     requirements:
-        code: '[a-zA-Z0-9_]+'
+        code: '[a-zA-Z0-9_\-\.@%]+'
 
 pim_user_logout_redirect:
     path: /logout/redirect

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/routing/user_rest.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/routing/user_rest.yml
@@ -8,14 +8,14 @@ pim_user_user_rest_get:
     defaults: { _controller: pim_user.controller.user_rest:getAction }
     methods: [GET]
     requirements:
-        identifier: '[a-zA-Z0-9_]+'
+        identifier: '[a-zA-Z0-9_\-\.@%]+'
 
 pim_user_user_rest_post:
     path: /{identifier}
     defaults: { _controller: pim_user.controller.user_rest:postAction }
     methods: [POST]
     requirements:
-        identifier: '[a-zA-Z0-9_]+'
+        identifier: '[a-zA-Z0-9_\-\.@%]+'
 
 pim_user_user_rest_create:
     path: /
@@ -27,4 +27,4 @@ pim_user_user_rest_delete:
     defaults: { _controller: pim_user.controller.user_rest:deleteAction }
     methods: [DELETE]
     requirements:
-        identifier: '[a-zA-Z0-9_]+'
+        identifier: '[a-zA-Z0-9_\-\.@%]+'

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/validation.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/validation.yml
@@ -10,6 +10,9 @@ Akeneo\UserManagement\Component\Model\User:
             - Length:
                 min:        3
                 max:        255
+            - Regex:
+                pattern: '/^[a-zA-Z0-9_\-\.@]+$/'
+                message: 'The username accepts only: alphanumerical, dot (.), dash (-), underscore (_) and at sign (@) characters.'
             - Akeneo\UserManagement\Bundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters: ~
         email:
             - NotBlank:     ~


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Some characters must be allowed into username field in order to ease Peter (the IT guy) administration tasks.

Tested without error:

- Create user (UI)
- Update user (UI)
- Login with username
- Update product (UI / API / Import)
- Create proposal (UI / API)

No errors, no notices, no UI glitches on username display.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
