### PR TITLE
Remove useless unstable tests of thepatch of channels

### DIFF
--- a/tests/back/Channel/EndToEnd/Channel/ExternalApi/PartialUpdateListChannelEndToEnd.php
+++ b/tests/back/Channel/EndToEnd/Channel/ExternalApi/PartialUpdateListChannelEndToEnd.php
@@ -61,163 +61,18 @@ JSON;
         $this->assertSame($expectedChannels['ecommerce_ch'], $ecommerceCh);
     }
 
-    public function testCreateAndUpdateSameChannel()
-    {
-        $data =
-<<<JSON
-{"code": "ecommerce_ch","category_tree": "master", "currencies": ["EUR"], "locales": ["fr_FR"]}
-{"code": "ecommerce_ch", "locales": ["en_US"]}
-JSON;
-
-        $expectedContent =
-<<<JSON
-{"line":1,"code":"ecommerce_ch","status_code":201}
-{"line":2,"code":"ecommerce_ch","status_code":204}
-JSON;
-
-        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/channels', [], [], [], $data);
-        $httpResponse = $response['http_response'];
-
-        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
-        $this->assertSame($expectedContent, $response['content']);
-    }
-
-    public function testPartialUpdateListWithMaxNumberOfResourcesAllowed()
-    {
-        $maxNumberResources = $this->getMaxNumberResources();
-
-        for ($i = 0; $i < $maxNumberResources; $i++) {
-            $data[] = sprintf('{"code": "my_code_%s","category_tree": "master", "currencies": ["EUR"], "locales": ["fr_FR"]}', $i);
-        }
-        $data = implode(PHP_EOL, $data);
-
-        for ($i = 0; $i < $maxNumberResources; $i++) {
-            $expectedContent[] = sprintf('{"line":%s,"code":"my_code_%s","status_code":201}', $i + 1, $i);
-        }
-        $expectedContent = implode(PHP_EOL, $expectedContent);
-
-        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/channels', [], [], [], $data);
-        $httpResponse = $response['http_response'];
-
-        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
-        $this->assertSame($expectedContent, $response['content']);
-    }
-
-    public function testPartialUpdateListWithTooManyResources()
-    {
-        $client = $this->createAuthenticatedClient();
-        $client->setServerParameter('CONTENT_TYPE', StreamResourceResponse::CONTENT_TYPE);
-
-        $maxNumberResources = $this->getMaxNumberResources();
-
-        for ($i = 0; $i < $maxNumberResources + 1; $i++) {
-            $data[] = sprintf('{"identifier": "my_code_%s","category_tree": "master", "currencies": ["EUR"], "locales": ["fr_FR"]}', $i);
-        }
-        $data = implode(PHP_EOL, $data);
-
-        $expectedContent =
-<<<JSON
-    {
-        "code": 413,
-        "message": "Too many resources to process, ${maxNumberResources} is the maximum allowed."
-    }
-JSON;
-
-        $client->request('PATCH', 'api/rest/v1/channels', [], [], [], $data);
-
-        $response = $client->getResponse();
-        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
-        $this->assertSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, $response->getStatusCode());
-    }
-
-    public function testPartialUpdateListWithInvalidAndTooLongLines()
-    {
-        $line = [
-            'invalid_json_1'  => str_repeat('a', $this->getBufferSize() - 1),
-            'invalid_json_2'  => str_repeat('a', $this->getBufferSize()),
-            'invalid_json_3'  => '',
-            'line_too_long_1' => '{"code":"foo"}' . str_repeat('a', $this->getBufferSize()),
-            'line_too_long_2' => '{"code":"foo"}' . str_repeat(' ', $this->getBufferSize()),
-            'line_too_long_3' => str_repeat('a', $this->getBufferSize() + 1),
-            'line_too_long_4' => str_repeat('a', $this->getBufferSize() + 2),
-            'line_too_long_5' => str_repeat('a', $this->getBufferSize() * 2),
-            'line_too_long_6' => str_repeat('a', $this->getBufferSize() * 5),
-            'invalid_json_4'  => str_repeat('a', $this->getBufferSize()),
-        ];
-
-        $data =
-<<<JSON
-${line['invalid_json_1']}
-${line['invalid_json_2']}
-${line['invalid_json_3']}
-${line['line_too_long_1']}
-${line['line_too_long_2']}
-${line['line_too_long_3']}
-${line['line_too_long_4']}
-${line['line_too_long_5']}
-${line['line_too_long_6']}
-${line['invalid_json_4']}
-JSON;
-
-        $expectedContent =
-<<<JSON
-{"line":1,"status_code":400,"message":"Invalid json message received"}
-{"line":2,"status_code":400,"message":"Invalid json message received"}
-{"line":3,"status_code":400,"message":"Invalid json message received"}
-{"line":4,"status_code":413,"message":"Line is too long."}
-{"line":5,"status_code":413,"message":"Line is too long."}
-{"line":6,"status_code":413,"message":"Line is too long."}
-{"line":7,"status_code":413,"message":"Line is too long."}
-{"line":8,"status_code":413,"message":"Line is too long."}
-{"line":9,"status_code":413,"message":"Line is too long."}
-{"line":10,"status_code":400,"message":"Invalid json message received"}
-JSON;
-
-        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/channels', [], [], [], $data);
-        $httpResponse = $response['http_response'];
-
-
-        $this->assertSame($expectedContent, $response['content']);
-        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
-    }
-
-    public function testErrorWhenIdentifierIsMissing()
-    {
-        $data =
-<<<JSON
-    {"identifier": "my_identifier"}
-    {"code": null}
-    {"code": ""}
-    {"code": " "}
-    {}
-JSON;
-
-        $expectedContent =
-<<<JSON
-{"line":1,"status_code":422,"message":"Code is missing."}
-{"line":2,"status_code":422,"message":"Code is missing."}
-{"line":3,"status_code":422,"message":"Code is missing."}
-{"line":4,"status_code":422,"message":"Code is missing."}
-{"line":5,"status_code":422,"message":"Code is missing."}
-JSON;
-
-        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/channels', [], [], [], $data);
-        $httpResponse = $response['http_response'];
-
-        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
-        $this->assertSame($expectedContent, $response['content']);
-    }
-
-    public function testUpdateChannelWhenUpdaterFailed()
+    public function testUpdateChannelWhenValidationFailed()
     {
         $data =
 <<<JSON
     {"code": "foo", "type":"bar"}
+    {"code": "baz,","category_tree": "master", "currencies": ["EUR"], "locales": ["fr_FR"]}
 JSON;
 
         $expectedContent =
 <<<JSON
 {"line":1,"code":"foo","status_code":422,"message":"Property \"type\" does not exist. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_channels__code_"}}}
+{"line":2,"code":"baz,","status_code":422,"message":"Validation failed.","errors":[{"property":"code","message":"Channel code may contain only letters, numbers and underscores"}]}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/channels', [], [], [], $data);
@@ -225,49 +80,6 @@ JSON;
 
         $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
         $this->assertSame($expectedContent, $response['content']);
-    }
-
-    public function testUpdateChannelWhenValidationFailed()
-    {
-        $data =
-<<<JSON
-    {"code": "foo,","category_tree": "master", "currencies": ["EUR"], "locales": ["fr_FR"]}
-JSON;
-
-        $expectedContent =
-<<<JSON
-{"line":1,"code":"foo,","status_code":422,"message":"Validation failed.","errors":[{"property":"code","message":"Channel code may contain only letters, numbers and underscores"}]}
-JSON;
-
-        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/channels', [], [], [], $data);
-        $httpResponse = $response['http_response'];
-
-        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
-        $this->assertSame($expectedContent, $response['content']);
-    }
-
-    public function testPartialUpdateListWithBadContentType()
-    {
-        $data =
-<<<JSON
-    {"code": "my_code"}
-JSON;
-
-        $expectedContent =
-<<<JSON
-    {
-        "code": 415,
-        "message": "\"application\/json\" in \"Content-Type\" header is not valid. Only \"application\/vnd.akeneo.collection+json\" is allowed."
-    }
-JSON;
-
-        $client = $this->createAuthenticatedClient();
-        $client->setServerParameter('CONTENT_TYPE', 'application/json');
-        $client->request('PATCH', 'api/rest/v1/channels', [], [], [], $data);
-
-        $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode());
-        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
     }
 
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This endpoint should not exist.
It is to patch in mass the channel... 

One of the test is unstable because a background process is triggered in the previous (remove completeness of channel and locale).
There is a conflict with the previous test, because it REPLACE a line after deletion of the whole database.
Then, when load the dump, there is a primary key error because the line already exist.

It's very tricky to fix for no value at all.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
