### PR TITLE
PIM-7889: Update ES indexes on category deletion

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # 2.0.x
 
+## Bug fixes
+
+- PIM-7889: Fix product & product model classification in Elasticsearch after a category deletion
+
 # 2.0.46 (2019-01-28)
 
 # 2.0.45 (2018-12-18)
@@ -9,7 +13,7 @@
 - GITHUB-7932: Fix the requirements with mysql port - cheers @Schwierig !
 - PIM-7886: Fix translations of boolean attributes
 - PIM-7902: Fix unnecessary calls for unread messages count on page navigation
-- PIM-7767: Fix "The EntityManager is closed" error that occured when importing a huge attribute option file (_backport of PIM-7767_)
+- PIM-7767: Fix "The EntityManager is closed" error that occurred when importing a huge attribute option file (_backport of PIM-7767_)
 
 # 2.0.44 (2018-11-29)
 

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Client.php
@@ -297,4 +297,16 @@ class Client
             'body' => $body,
         ]);
     }
+
+    /**
+     * @param array $body an array containing a query compatible with https://www.elastic.co/guide/en/elasticsearch/reference/5.5/docs-update-by-query.html
+     */
+    public function updateByQuery(array $body): void
+    {
+        $this->client->updateByQuery([
+            'index'     => $this->indexName,
+            'conflicts' => 'proceed',
+            'body'      => $body,
+        ]);
+    }
 }

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/Category/UpdateIndexesOnCategoryDeletion.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/Category/UpdateIndexesOnCategoryDeletion.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber\Category;
+
+use Akeneo\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Component\Classification\Model\CategoryInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Pim\Component\Catalog\Category\GetDescendentCategoryCodes;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Subscribes to category deletion events and updates all ES indexes accordingly.
+ *
+ * This subscriber has to be stateful for consistency : we need to get all descendent codes before the category is
+ * effectively removed (and the nested set is reindexed), but we also need to not perform the ES indexes update if the
+ * removal fails (because of a database constraint for example).
+ *
+ * Ideally this should be done by working more with domain events and aggregates, but as we don't have this for now and
+ * we heavily rely on database constraints (cascade delete in this case) it's hard to find a clean solution.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class UpdateIndexesOnCategoryDeletion implements EventSubscriberInterface
+{
+    /** @var GetDescendentCategoryCodes */
+    private $getDescendentCategoryCodes;
+
+    /** @var Client */
+    private $productClient;
+
+    /** @var Client */
+    private $productModelClient;
+
+    /** @var Client */
+    private $productAndProductModelClient;
+
+    /** @var string[] */
+    private $categoryCodesToRemove = [];
+
+    public function __construct(
+        GetDescendentCategoryCodes $getDescendentCategoryCodes,
+        Client $productClient,
+        Client $productModelClient,
+        Client $productAndProductModelClient
+    ) {
+        $this->getDescendentCategoryCodes = $getDescendentCategoryCodes;
+        $this->productClient = $productClient;
+        $this->productModelClient = $productModelClient;
+        $this->productAndProductModelClient = $productAndProductModelClient;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            StorageEvents::PRE_REMOVE  => 'storeCategoryCodesToRemove',
+            StorageEvents::POST_REMOVE => 'updateIndexes',
+        ];
+    }
+
+    public function storeCategoryCodesToRemove(GenericEvent $event)
+    {
+        if (!$event->getSubject() instanceof CategoryInterface) {
+            return;
+        }
+
+        $getDescendentCategoryCodes = $this->getDescendentCategoryCodes;
+        $parentCategory = $event->getSubject();
+
+        $this->categoryCodesToRemove = $getDescendentCategoryCodes($parentCategory);
+        $this->categoryCodesToRemove[] = $parentCategory->getCode();
+    }
+
+    public function updateIndexes(GenericEvent $event)
+    {
+        if (!$event->getSubject() instanceof CategoryInterface) {
+            return;
+        }
+
+        $body = [
+            'query' => [
+                'terms' => ['categories' => $this->categoryCodesToRemove],
+            ],
+            'script' => [
+                // WARNING: "inline" will need to be changed to "source" when we'll switch to Elasticsearch 5.6
+                'inline' => 'ctx._source.categories.removeAll(params.categories); if (0 == ctx._source.categories.size()) { ctx._source.remove("categories"); }',
+                'lang'   => 'painless',
+                'params' => ['categories' => $this->categoryCodesToRemove],
+            ],
+        ];
+
+        $this->productClient->updateByQuery($body);
+        $this->productModelClient->updateByQuery($body);
+        $this->productAndProductModelClient->updateByQuery($body);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -191,3 +191,13 @@ services:
         public: false
         tags:
             - { name: doctrine.event_subscriber }
+
+    pim_catalog.event_subscriber.category.update_indexes_on_category_deletion:
+        class: 'Pim\Bundle\CatalogBundle\EventSubscriber\Category\UpdateIndexesOnCategoryDeletion'
+        arguments:
+            - '@pim_catalog.query.get_descendent_category_codes'
+            - '@akeneo_elasticsearch.client.product'
+            - '@akeneo_elasticsearch.client.product_model'
+            - '@akeneo_elasticsearch.client.product_and_product_model'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
@@ -41,3 +41,8 @@ services:
         arguments:
             - '@doctrine.orm.entity_manager'
             - '%pim_catalog.entity.association.class%'
+
+    pim_catalog.query.get_descendent_category_codes:
+        class: Pim\Component\Catalog\Category\GetDescendentCategoryCodes
+        arguments:
+            - '@database_connection'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Classification/UpdateIndexesOnCategoryDeletionIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Classification/UpdateIndexesOnCategoryDeletionIntegration.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\Client;
+
+use Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration\AbstractPimCatalogTestCase;
+
+/**
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class UpdateIndexesOnCategoryDeletionIntegration extends AbstractPimCatalogTestCase
+{
+    /**
+     * @test
+     */
+    public function it_updates_indexes_on_category_deletion()
+    {
+        $categoryToRemove = $this->get('pim_catalog.repository.category')->findOneByIdentifier('categoryA');
+        $this->get('pim_catalog.remover.category')->remove($categoryToRemove);
+        $this->esProductClient->refreshIndex();
+
+        $productsInDeletedCategory = $this->getSearchQueryResults([
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'filter' => [
+                                'terms' => [
+                                    'categories' => ['categoryA'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertEmpty($productsInDeletedCategory);
+
+        $unclassifiedProducts = $this->getSearchQueryResults([
+            'query' => [
+                'constant_score' => [
+                    'filter' => [
+                        'bool' => [
+                            'must_not' => [
+                                'exists' => ['field' => 'categories'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertSame(
+            ['product-3', 'product-1'],
+            $unclassifiedProducts
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function addDocuments()
+    {
+        $this->indexDocuments([
+            [
+                'identifier' => 'product-1',
+                'categories' => ['categoryA'],
+            ],
+            [
+                'identifier' => 'product-2',
+                'categories' => ['categoryA', 'categoryB'],
+            ],
+            [
+                'identifier' => 'product-3',
+                'categories' => ['categoryA1'],
+            ],
+            [
+                'identifier' => 'product-4',
+                'categories' => ['categoryB'],
+            ],
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogTestCase.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogTestCase.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\CatalogBundle\tests\integration\Elasticsearch\IndexConfiguration;
 
 use Akeneo\Bundle\ElasticsearchBundle\Client;
-use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 
 /**

--- a/src/Pim/Component/Catalog/Category/GetDescendentCategoryCodes.php
+++ b/src/Pim/Component/Catalog/Category/GetDescendentCategoryCodes.php
@@ -8,7 +8,7 @@ use Akeneo\Component\Classification\Model\CategoryInterface;
 use Doctrine\DBAL\Connection;
 
 /**
- * Returns codes of all descendent categories of the given category.
+ * Returns codes of all descendents of the given category.
  *
  * @author    Yohan Blain <yohan.blain@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
@@ -29,7 +29,8 @@ final class GetDescendentCategoryCodes
         $sql = <<<SQL
             SELECT category.code as category_code
             FROM pim_catalog_category category 
-            WHERE category.lft >= :parent_category_left AND category.rgt <= :parent_category_right
+            WHERE category.lft > :parent_category_left
+            AND category.rgt < :parent_category_right
             AND category.root = :parent_category_root;
 SQL;
         $rows = $this->connection->executeQuery(

--- a/src/Pim/Component/Catalog/Category/GetDescendentCategoryCodes.php
+++ b/src/Pim/Component/Catalog/Category/GetDescendentCategoryCodes.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Category;
+
+use Akeneo\Component\Classification\Model\CategoryInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Returns codes of all descendent categories of the given category.
+ *
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class GetDescendentCategoryCodes
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function __invoke(CategoryInterface $parentCategory): array
+    {
+        $sql = <<<SQL
+            SELECT category.code as category_code
+            FROM pim_catalog_category category 
+            WHERE category.lft >= :parent_category_left AND category.rgt <= :parent_category_right
+            AND category.root = :parent_category_root;
+SQL;
+        $rows = $this->connection->executeQuery(
+            $sql,
+            [
+                'parent_category_left'  => $parentCategory->getLeft(),
+                'parent_category_right' => $parentCategory->getRight(),
+                'parent_category_root'  => $parentCategory->getRoot(),
+            ]
+        )->fetchAll(\PDO::FETCH_COLUMN);
+
+        return $rows;
+    }
+}

--- a/src/Pim/Component/Catalog/tests/integration/Category/CategoryTreeFixturesLoader.php
+++ b/src/Pim/Component/Catalog/tests/integration/Category/CategoryTreeFixturesLoader.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\tests\integration\Category;
+
+use PHPUnit\Framework\Assert;
+use Psr\Container\ContainerInterface;
+
+class CategoryTreeFixturesLoader
+{
+    /** @var  ContainerInterface */
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function givenTheCategoryTrees(array $categories, ?string $parentCode = null): void
+    {
+        foreach ($categories as $categoryCode => $children) {
+            $category = $this->container->get('pim_catalog.factory.category')->create();
+            $this->container->get('pim_catalog.updater.category')->update($category, [
+                'code' => $categoryCode,
+                'parent' => $parentCode ?? null,
+                'labels' => ['en_US' => ucfirst($categoryCode)]
+            ]);
+            Assert::assertEquals(0, $this->container->get('validator')->validate($category)->count());
+            $this->container->get('pim_catalog.saver.category')->save($category);
+
+            $this->givenTheCategoryTrees($children, $categoryCode);
+        }
+    }
+}

--- a/src/Pim/Component/Catalog/tests/integration/Category/GetDescendentCategoryCodesIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Category/GetDescendentCategoryCodesIntegration.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Category;
+
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Pim\Component\Catalog\Model\CategoryInterface;
+
+/**
+ * @author    Yohan Blain <yohan.blain@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class GetDescendentCategoryCodesIntegration extends TestCase
+{
+    // Validates that only the parent category code itself is returned.
+    public function testGetDescendentCategoryCodesOfALeafCategory()
+    {
+        $parentCategory = $this->fetchCategory('master_accessories_scarves');
+        $descendentCategoryCodes = $this->getDescendantCategoryCodesOf($parentCategory);
+
+        Assert::assertSame(
+            $descendentCategoryCodes,
+            ['master_accessories_scarves']
+        );
+    }
+
+    // Validates that category codes from all levels under the parent are returned.
+    public function testGetDescendentCategoryCodesOfARoot()
+    {
+        $parentCategory = $this->fetchCategory('master');
+        $descendentCategoryCodes = $this->getDescendantCategoryCodesOf($parentCategory);
+
+        Assert::assertSame(
+            $descendentCategoryCodes,
+            [
+                'master',
+                'master_accessories',
+                'master_accessories_belts',
+                'master_accessories_bags',
+                'master_accessories_sunglasses',
+                'master_accessories_hats',
+                'master_accessories_scarves',
+                'master_men',
+                'master_men_blazers',
+                'master_men_blazers_deals',
+                'master_men_pants',
+                'master_men_pants_shorts',
+                'master_men_pants_jeans',
+                'master_men_shoes',
+                'tshirts',
+                'master_women',
+                'master_women_blouses',
+                'master_women_blouses_deals',
+                'master_women_dresses',
+                'master_women_shirts',
+                'master_women_shoes',
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    private function fetchCategory(string $code): CategoryInterface
+    {
+        return $this
+            ->get('pim_catalog.repository.product_category')
+            ->findOneByIdentifier($code)
+        ;
+    }
+
+    private function getDescendantCategoryCodesOf(CategoryInterface $parentCategory): array
+    {
+        return $this->get('pim_catalog.query.get_descendent_category_codes')($parentCategory);
+    }
+}

--- a/src/Pim/Component/Catalog/tests/integration/Category/GetDescendentCategoryCodesIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Category/GetDescendentCategoryCodesIntegration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Pim\Bundle\CatalogBundle\tests\integration\Category;
+namespace Pim\Component\Catalog\tests\integration\Category;
 
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
@@ -15,48 +15,51 @@ use Pim\Component\Catalog\Model\CategoryInterface;
  */
 class GetDescendentCategoryCodesIntegration extends TestCase
 {
-    // Validates that only the parent category code itself is returned.
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $fixturesLoader = new CategoryTreeFixturesLoader($this->testKernel->getContainer());
+        $fixturesLoader->givenTheCategoryTrees([
+            'ecommerce' => [
+                'ecommerce_accessories' => [
+                    'ecommerce_accessories_belts'      => [],
+                    'ecommerce_accessories_bags'       => [],
+                    'ecommerce_accessories_sunglasses' => [],
+                    'ecommerce_accessories_hats'       => [],
+                    'ecommerce_accessories_scarves'    => [],
+                ],
+            ],
+            'print' => [
+                'print_accessories' => [],
+            ],
+        ]);
+    }
+
+    // Validates that nothing is returned when the parent is a leaf.
     public function testGetDescendentCategoryCodesOfALeafCategory()
     {
-        $parentCategory = $this->fetchCategory('master_accessories_scarves');
+        $parentCategory = $this->fetchCategory('ecommerce_accessories_scarves');
         $descendentCategoryCodes = $this->getDescendantCategoryCodesOf($parentCategory);
 
-        Assert::assertSame(
-            $descendentCategoryCodes,
-            ['master_accessories_scarves']
-        );
+        Assert::assertEmpty($descendentCategoryCodes);
     }
 
     // Validates that category codes from all levels under the parent are returned.
     public function testGetDescendentCategoryCodesOfARoot()
     {
-        $parentCategory = $this->fetchCategory('master');
+        $parentCategory = $this->fetchCategory('ecommerce');
         $descendentCategoryCodes = $this->getDescendantCategoryCodesOf($parentCategory);
 
         Assert::assertSame(
             $descendentCategoryCodes,
             [
-                'master',
-                'master_accessories',
-                'master_accessories_belts',
-                'master_accessories_bags',
-                'master_accessories_sunglasses',
-                'master_accessories_hats',
-                'master_accessories_scarves',
-                'master_men',
-                'master_men_blazers',
-                'master_men_blazers_deals',
-                'master_men_pants',
-                'master_men_pants_shorts',
-                'master_men_pants_jeans',
-                'master_men_shoes',
-                'tshirts',
-                'master_women',
-                'master_women_blouses',
-                'master_women_blouses_deals',
-                'master_women_dresses',
-                'master_women_shirts',
-                'master_women_shoes',
+                'ecommerce_accessories',
+                'ecommerce_accessories_belts',
+                'ecommerce_accessories_bags',
+                'ecommerce_accessories_sunglasses',
+                'ecommerce_accessories_hats',
+                'ecommerce_accessories_scarves',
             ]
         );
     }
@@ -66,7 +69,7 @@ class GetDescendentCategoryCodesIntegration extends TestCase
      */
     protected function getConfiguration()
     {
-        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+        return $this->catalog->useMinimalCatalog();
     }
 
     private function fetchCategory(string $code): CategoryInterface


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When a category is deleted the products and product models under it still contains the category in ES, so if it was the last category of the current tree they were linked to, you can never find them again because they won't appear in "unclassified". Same issue for the exports.

This PR fixes that by updating the indexes after the deletion.
For more details about the implementation, see the description of the subscriber.
We chose to call the ES API directly and not do a full save + reindex products because it's way faster and save us from adding a new job (very costly in a patch).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
