### PR TITLE
PIM-7961: Fix localizable assets used as main image for family and added to product product model

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,8 @@
 ## Bug fixes
 
 - PIM-7934: Fix translations of product model import
+- GITHUB-8780: Fix error in product normalizer. Cheers @yunosh!
+- PIM-7961: Fix localizable assets used as main image for family and added to product product model
 
 # 2.3.23 (2019-01-03)
  

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pim\Bundle\EnrichBundle\Normalizer;
 
+use Pim\Bundle\CatalogBundle\Context\CatalogContext;
 use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Completeness\CompletenessCalculatorInterface;
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
@@ -54,8 +55,11 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
     /** @var ImageAsLabel */
     private $imageAsLabel;
 
+    /** @var CatalogContext */
+    private $catalogContext;
 
     /**
+     * TODO @merge on master, remove null on catalog context
      * @param ImageNormalizer                           $imageNormalizer
      * @param LocaleRepositoryInterface                 $localeRepository
      * @param EntityWithFamilyVariantAttributesProvider $attributesProvider
@@ -63,6 +67,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
      * @param CompletenessCalculatorInterface           $completenessCalculator
      * @param VariantProductRatioInterface              $variantProductRatioQuery
      * @param ImageAsLabel                              $imageAsLabel
+     * @param CatalogContext                            $catalogContext
      */
     public function __construct(
         ImageNormalizer $imageNormalizer,
@@ -71,7 +76,8 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
         NormalizerInterface $completenessCollectionNormalizer,
         CompletenessCalculatorInterface $completenessCalculator,
         VariantProductRatioInterface $variantProductRatioQuery,
-        ImageAsLabel $imageAsLabel
+        ImageAsLabel $imageAsLabel,
+        CatalogContext $catalogContext = null
     ) {
         $this->imageNormalizer                  = $imageNormalizer;
         $this->localeRepository                 = $localeRepository;
@@ -80,6 +86,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
         $this->completenessCalculator           = $completenessCalculator;
         $this->variantProductRatioQuery         = $variantProductRatioQuery;
         $this->imageAsLabel                     = $imageAsLabel;
+        $this->catalogContext                   = $catalogContext;
     }
 
     /**
@@ -111,13 +118,16 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
             $image = $entity->getImage();
         }
 
+        // TODO @merge on master, remove condition
+        $localeCode = $this->catalogContext->getLocaleCode() ? $this->catalogContext->getLocaleCode() : null;
+
         return [
             'id'                 => $entity->getId(),
             'identifier'         => $identifier,
             'axes_values_labels' => $this->getAxesValuesLabelsForLocales($entity, $localeCodes),
             'labels'             => $labels,
             'order'              => $this->getOrder($entity),
-            'image'              => $this->normalizeImage($image, $context),
+            'image'              => $this->normalizeImage($image, $localeCode),
             'model_type'         => $entity instanceof ProductModelInterface ? 'product_model' : 'product',
             'completeness'       => $this->getCompletenessDependingOnEntity($entity)
         ];
@@ -133,13 +143,13 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
 
     /**
      * @param ValueInterface $data
-     * @param array          $context
+     * @param string         $localeCode
      *
      * @return array|null
      */
-    private function normalizeImage(?ValueInterface $data, array $context = []): ?array
+    private function normalizeImage(?ValueInterface $data, ?string $localeCode = null): ?array
     {
-        return $this->imageNormalizer->normalize($data, $context['locale']);
+        return $this->imageNormalizer->normalize($data, $localeCode);
     }
 
     /**

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
@@ -118,16 +118,14 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
             $image = $entity->getImage();
         }
 
-        // TODO @merge on master, remove condition
-        $localeCode = $this->catalogContext->getLocaleCode() ? $this->catalogContext->getLocaleCode() : null;
-
+        // TODO @merge on master, remove condition on catalogContext
         return [
             'id'                 => $entity->getId(),
             'identifier'         => $identifier,
             'axes_values_labels' => $this->getAxesValuesLabelsForLocales($entity, $localeCodes),
             'labels'             => $labels,
             'order'              => $this->getOrder($entity),
-            'image'              => $this->normalizeImage($image, $localeCode),
+            'image'              => $this->normalizeImage($image, $this->catalogContext ? $this->catalogContext->getLocaleCode() : null),
             'model_type'         => $entity instanceof ProductModelInterface ? 'product_model' : 'product',
             'completeness'       => $this->getCompletenessDependingOnEntity($entity)
         ];

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductModelNormalizer.php
@@ -208,9 +208,7 @@ class ProductModelNormalizer implements NormalizerInterface
 
         $scopeCode = $context['channel'] ?? null;
 
-        // TODO @merge on master, remove condition
-        $localeCode = $this->catalogContext->getLocaleCode() ? $this->catalogContext->getLocaleCode() : null;
-
+        // TODO @merge on master, remove condition on catalogContext
         $normalizedProductModel['meta'] = [
                 'variant_product_completenesses' => $variantProductCompletenesses->values(),
                 'family_variant'            => $normalizedFamilyVariant,
@@ -221,7 +219,7 @@ class ProductModelNormalizer implements NormalizerInterface
                 'model_type'                => 'product_model',
                 'attributes_for_this_level' => $levelAttributes,
                 'attributes_axes'           => $axesAttributes,
-                'image'                     => $this->normalizeImage($closestImage, $localeCode),
+                'image'                     => $this->normalizeImage($closestImage, $this->catalogContext ? $this->catalogContext->getLocaleCode() : null),
                 'variant_navigation'        => $this->navigationNormalizer->normalize($productModel, $format, $context),
                 'ascendant_category_ids'    => $this->ascendantCategoriesQuery->getCategoryIds($productModel),
                 'required_missing_attributes' => $this->incompleteValuesNormalizer->normalize($productModel, $format, $context),

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -234,7 +234,7 @@ class ProductNormalizer implements NormalizerInterface
             'structure_version' => $this->structureVersionProvider->getStructureVersion(),
             'completenesses'    => $this->getNormalizedCompletenesses($product),
             'required_missing_attributes' => $incompleteValues,
-            'image'             => $this->normalizeImage($product->getImage(), $this->catalogContext->getLocaleCode()),
+            'image'             => $this->normalizeImage($product->getImage(), $this->catalogContext ? $this->catalogContext->getLocaleCode() : null),
         ] + $this->getLabels($product, $scopeCode) + $this->getAssociationMeta($product);
 
         $normalizedProduct['meta']['ascendant_category_ids'] = $product->isVariant() ?

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/ProductNormalizer.php
@@ -225,6 +225,7 @@ class ProductNormalizer implements NormalizerInterface
 
         $normalizedProduct['parent_associations'] = $this->parentAssociationsNormalizer->normalize($product, $format, $context);
 
+        // TODO @merge on master, remove condition on catalogContext
         $normalizedProduct['meta'] = [
             'form'              => $this->formProvider->getForm($product),
             'id'                => $product->getId(),

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/normalizers.yml
@@ -100,6 +100,7 @@ services:
             - '@pim_user.context.user'
             - '@pim_catalog.association.missing_association_adder'
             - '@pim_catalog.normalizer.standard.product.parent_associations'
+            - '@pim_catalog.context.catalog'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 
@@ -214,6 +215,7 @@ services:
             - '@pim_catalog.completeness.calculator'
             - '@pim_catalog.doctrine.query.find_variant_product_completeness'
             - '@pim_catalog.product_models.image_as_label'
+            - '@pim_catalog.context.catalog'
 
     pim_enrich.normalizer.variant_navigation:
         class: '%pim_enrich.normalizer.variant_navigation.class%'

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
 
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Context\CatalogContext;
 use Pim\Bundle\EnrichBundle\Normalizer\ImageNormalizer;
 use Pim\Component\Catalog\Completeness\CompletenessCalculatorInterface;
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
@@ -29,7 +30,8 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         NormalizerInterface $completenessCollectionNormalizer,
         CompletenessCalculatorInterface $completenessCalculator,
         VariantProductRatioInterface $variantProductRatioQuery,
-        ImageAsLabel $imageAsLabel
+        ImageAsLabel $imageAsLabel,
+        CatalogContext $catalogContext
     ) {
         $this->beConstructedWith(
             $imageNormalizer,
@@ -38,7 +40,8 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
             $completenessCollectionNormalizer,
             $completenessCalculator,
             $variantProductRatioQuery,
-            $imageAsLabel
+            $imageAsLabel,
+            $catalogContext
         );
     }
 

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/ProductModelNormalizerSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Context\CatalogContext;
 use Pim\Bundle\EnrichBundle\Normalizer\ImageNormalizer;
 use Pim\Bundle\EnrichBundle\Normalizer\VariantNavigationNormalizer;
 use Pim\Bundle\EnrichBundle\Provider\Form\FormProviderInterface;
@@ -50,7 +51,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
         NormalizerInterface $incompleteValuesNormalizer,
         UserContext $userContext,
         MissingAssociationAdder $missingAssociationAdder,
-        NormalizerInterface $parentAssociationsNormalizer
+        NormalizerInterface $parentAssociationsNormalizer,
+        CatalogContext $catalogContext
     ) {
         $this->beConstructedWith(
             $normalizer,
@@ -70,7 +72,8 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             $incompleteValuesNormalizer,
             $userContext,
             $missingAssociationAdder,
-            $parentAssociationsNormalizer
+            $parentAssociationsNormalizer,
+            $catalogContext
         );
     }
 


### PR DESCRIPTION
**Description**
It is not possible to display the PEF for a product model or a variant product if we have the following conditions:

image as label is an asset collection attribute
asset used in the product model/variant product is localized
selected language for the interface (in the user account) is not one of the activated locale
The issue comes from the "internal_api" normalizers of the product models and variant products:
- Pim\Bundle\EnrichBundle\Normalizer\ProductModelNormalizer
- Pim\Bundle\EnrichBundle\Normalizer\EntityWithFamilyVariantNormalizer
respectively.
The "image" property is normalized using the context locale (the locale of the user interface) when it should use the catalog default locale.

This same issue was already fixed for non-variant products in https://github.com/akeneo/pim-community-dev/pull/8730. The same fix must be applied to the product model and variant product normalizers.

This contribution: https://github.com/akeneo/pim-community-dev/pull/8780 as it fixes an issue of the non variant product fix, I cherry-pick it to add it to the patch.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
