### PR TITLE
TIP-1018: Command to check services instantiability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ composer.phar
 !/bin/console
 !/bin/check-pullup
 !/bin/pim-front.sh
+!/bin/check-services-instantiability
 behat.yml
 /phpspec.yml
 uploads_test/

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -15,6 +15,7 @@
 - PIM-7371: Improve the performance of the category tree in the product grid
 - PIM-7839: Remove date of birth
 - GITHUB-8234 & GITHUB-8383: Fix constraints on attribute code. Cheers @oliverde8 & @navneetbhardwaj !
+- TIP-1018: Adds a script to check container services instantiability (bin/check-services-instantiability)
 
 ## Enhancements
 

--- a/bin/check-services-instantiability
+++ b/bin/check-services-instantiability
@@ -1,0 +1,95 @@
+#!/usr/bin/php
+<?php
+define('EXIT_WRONG_USAGE', 127);
+define('EXIT_SERVICES_NON_INSTANTIABLE', 1);
+
+if (!file_exists('app/AppKernel.php')) {
+    die("Please run this command from your Symfony application root.");
+}
+
+require 'app/autoload.php';
+
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+$inputDefinition = new InputDefinition(array(
+  new InputOption('verbose', 'v', InputOption::VALUE_NONE, 'Verbose mode: list all service ids we tried to instantiate.'. false)
+));
+
+$output = new ConsoleOutput();
+$input = new ArgvInput($argv);
+
+try {
+    $input->bind($inputDefinition);
+    $input->validate();
+} catch (RuntimeException $e) {
+    $output->writeln(
+        sprintf('<error>Wrong usage: %s</error>', $e->getMessage())
+    );
+
+    exit (EXIT_WRONG_USAGE);
+}
+
+$verbosity = $input->getOption('verbose') ? ConsoleOutput::VERBOSITY_VERBOSE : ConsoleOutput::VERBOSITY_NORMAL;
+$output->setVerbosity($verbosity);
+
+
+$kernel = new AppKernel('dev', false);
+$kernel->boot();
+
+$exitStatus = checkServicesInstantiability($kernel->getContainer(), $output);
+
+exit ($exitStatus);
+
+function checkServicesInstantiability(ContainerInterface $container, ConsoleOutput $output): int
+{
+    $serviceIds = $container->getServiceIds();
+
+    $nonInstantiableServices = [];
+
+    foreach ($serviceIds as $serviceId) {
+
+        if ($output->isVerbose()) {
+            $output->writeln("Getting $serviceId");
+        }
+
+        try {
+            $service = $container->get($serviceId);
+            if ($service instanceof \ProxyManager\Proxy\VirtualProxyInterface) {
+                $service->initializeProxy();
+            }
+        } catch (\Throwable $t) {
+            $nonInstantiableServices[$serviceId] = ["error_type" => get_class($t), "error_message" => $t->getMessage()];
+        }
+    }
+
+    if (0 === count($nonInstantiableServices)) {
+        $output->writeln("All services are instantiable!");
+
+        return 0;
+    } else {
+        $output->writeln(
+            sprintf(
+                "<comment>Found %s non instantiable services on a total of %s.</comment>",
+                count($nonInstantiableServices),
+                count($serviceIds)
+            )
+        );
+        foreach ($nonInstantiableServices as $nonInstantiableServiceId => $nonInstantiableServiceReason) {
+            $output->writeln(
+                sprintf('<error>%s</error>',$nonInstantiableServiceId)
+            );
+            $output->write($nonInstantiableServiceReason['error_type']);
+            $output->write(": ");
+            $output->writeln($nonInstantiableServiceReason['error_message']);
+            $output->writeln("------");
+        }
+
+        return EXIT_SERVICES_NON_INSTANTIABLE;
+    }
+}
+


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This PR adds a new command that checks container service instantiability.

A non instantiable service can mean either:
 - dead code: the service is used nowhere, so it can be removed safely (and maybe the associated class)
 - code non covered by tests: it's a real service, but no test uses this part, so the CI didn't failed.

For now, we have 16 dead (non instantiable) services on master.

Note: Maybe this PR should be an external tools as it's clearly not linked to the PIM itself.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
