### PR TITLE
PIM-7953: Fix user profile back button and cancel button link on viewand update user template

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7953: Fix back and cancel button link in user profile view and edit template
 - GITHUB-7594: Fix comparison in versioning system. Cheers @mathewrapid !
 
 # 1.7.36 (2018-12-11)

--- a/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/User/update.html.twig
@@ -630,8 +630,9 @@
             {% endif %}
         {% endset %}
 
+        {% set userBackPath = resource_granted('pim_user_user_index') ? path('oro_user_index') : path('oro_user_profile_view') %}
         {% set back %}
-            {{ elements.backLink(path('oro_user_index')) }}
+            {{ elements.backLink(userBackPath) }}
             <img class="AknTitleContainer-avatar" src="{{ form.vars.value.imagePath ? form.vars.value.imagePath | imagine_filter('avatar_med') : asset('bundles/pimui/images/info-user.png') }}" alt="{{ fullname }}"/>
         {% endset %}
 
@@ -640,7 +641,7 @@
                 {{ elements.deleteLink(
                     path('oro_user_user_delete', {'id': form.vars.value.id}),
                     'pim_user_user_remove',
-                    path('oro_user_index'),
+                    userBackPath,
                     'confirmation.remove.user'|trans({ '%name%': fullname }),
                     'flash.user.removed'|trans,
                     '',
@@ -650,7 +651,7 @@
             {% if form.vars.value.id %}
                 {{ elements.link(
                     'Cancel'|trans,
-                    path('oro_user_index'),
+                    userBackPath,
                     { icon: 'chevron-left', class:'AknButtonList-item AknButton--grey' }
                 ) }}
             {% endif %}

--- a/src/Pim/Bundle/UserBundle/Resources/views/User/view.html.twig
+++ b/src/Pim/Bundle/UserBundle/Resources/views/User/view.html.twig
@@ -3,6 +3,7 @@
 
 {% set fullname = entity.fullName|default('N/A') %}
 {% oro_title_set({params : {"%username%": fullname }}) %}
+{% set userBackPath = resource_granted('pim_user_user_index') ? path('oro_user_index') : path('oro_user_profile_view') %}
 
 {% block navButtons %}
     {% if editRoute is defined %}
@@ -27,7 +28,7 @@
     {% if resource_granted('pim_user_user_remove') and entity.id!=app.user.id %}
         {{ UI.deleteButton({
             'dataUrl': path('oro_user_user_delete', {'id': entity.id}),
-            'dataRedirect': path('oro_user_index'),
+            'dataRedirect': userBackPath,
             'aCss': 'AknButtonList-item remove-button',
             'dataId': entity.id,
             'dataMessage': 'Are you sure you want to delete this user?'|trans,
@@ -41,7 +42,7 @@
 {% block pageHeader %}
     {% set breadcrumbs = {
         'entity':      entity,
-        'indexPath':   path('oro_user_index'),
+        'indexPath':   userBackPath,
         'indexLabel': 'Users'|trans,
         'entityTitle': fullname,
         'hasAvatar':   true,
@@ -67,7 +68,7 @@
 {% endblock stats %}
 
 {% block backButton %}
-    {{ elements.backLink(path('oro_user_index')) }}
+    {{ elements.backLink(userBackPath) }}
 {% endblock %}
 
 {% block content_data %}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
