### PR TITLE
Force to return an array to avoid compilation error if one of the path is null

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumnGroups.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumnGroups.php
@@ -40,9 +40,9 @@ class ListProductGridAvailableColumnGroups implements ListProductGridAvailableCo
         $datagridConfiguration = $this->configurationProvider->getConfiguration('product-grid');
 
         $systemColumns = $datagridConfiguration->offsetGetByPath(
-            sprintf('[%s]', Configuration::COLUMNS_KEY)
+            sprintf('[%s]', Configuration::COLUMNS_KEY), []
         ) + $datagridConfiguration->offsetGetByPath(
-            sprintf('[%s]', Configuration::OTHER_COLUMNS_KEY)
+            sprintf('[%s]', Configuration::OTHER_COLUMNS_KEY), []
         );
 
         $columnGroups = [[

--- a/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumns.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumns.php
@@ -66,11 +66,11 @@ class ListProductGridAvailableColumns implements ListProductGridAvailableColumns
         $datagridConfiguration = $this->configurationProvider->getConfiguration('product-grid');
 
         $propertiesColumns = $datagridConfiguration->offsetGetByPath(
-            sprintf('[%s]', Configuration::COLUMNS_KEY)
+            sprintf('[%s]', Configuration::COLUMNS_KEY), []
         );
 
         $otherColumns = $datagridConfiguration->offsetGetByPath(
-            sprintf('[%s]', Configuration::OTHER_COLUMNS_KEY)
+            sprintf('[%s]', Configuration::OTHER_COLUMNS_KEY), []
         );
 
         return $propertiesColumns + $otherColumns;


### PR DESCRIPTION
When a column is unknown in the datagrid configuration, it returns null by default which is incompatible with the concatenation with the first array. I force the method to return [] if column is not found.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
