### PR TITLE
Fix missing translations on catalog volume screen

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/catalog-volume/section.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/catalog-volume/section.ts
@@ -187,8 +187,8 @@ class SectionView extends BaseView {
         hasWarning: axis.hasWarning,
         title: __(`pim_catalog_volume.axis.${name}`),
         warningText: this.config.warningText,
-        meanLabel: __('catalog_volume.mean'),
-        maxLabel: __('catalog_volume.max'),
+        meanLabel: __('pim_catalog_volume.mean'),
+        maxLabel: __('pim_catalog_volume.max'),
         userLocale: userContext.get('uiLocale').split('_')[0],
       });
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes the incorrect translation key on the catalog volume monitoring screen for mean/max

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
