### PR TITLE
PIM-7939: LabelOrIdentifier filter also on parent code

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/LabelOrIdentifierFilter.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/LabelOrIdentifierFilter.php
@@ -79,6 +79,11 @@ class LabelOrIdentifierFilter extends AbstractFieldFilter
                 'label.<all_channels>.<all_locales>' => sprintf('*%s*', $this->escapeValue($value)),
             ]
         ];
+        $clauses[] = [
+            'wildcard' => [
+                'ancestors.codes' => sprintf('*%s*', $this->escapeValue($value)),
+            ]
+        ];
 
         $this->searchQueryBuilder->addFilter(
             [


### PR DESCRIPTION
When filtering products for mass_edit, if we filter on the parent code `aphrodite`, the only returned product is the product model. And when we try a mass edit with 'All'  in the filter, we expect the 5 variations products to be updated, but there will be none as no variation field matches _aphrodite_ but the parent code.

This PR adds a clause on the parent code to finally return the variations products.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
