### PR TITLE
TIP-1018: Removes SOAP and WSSE, cleanups Imagine and oro user

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -26,6 +26,7 @@
 - TIP-898: Allow extension for user via a property named "properties", used on the EE by example
 
 ## BC breaks
+- TIP-1018: Remove SOAP requirements (not used anymore) and WSSE bundle
 - Remove service `@pim_enrich.provider.structure_version.attribute` in favor of `@pim_structure_version.provider.structure_version.attribute`
 - Remove service `@pim_enrich.provider.structure_version.family_variant` in favor of `@pim_structure_version.provider.structure_version.family_variant`
 - Remove service `@pim_enrich.provider.structure_version.group_type` in favor of `@pim_structure_version.provider.structure_version.group_type`

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -150,7 +150,6 @@ class AppKernel extends Kernel
     {
         return [
             new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
-            new Escape\WSSEAuthenticationBundle\EscapeWSSEAuthenticationBundle(),
             new FOS\JsRoutingBundle\FOSJsRoutingBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),

--- a/bin/check-services-instantiability
+++ b/bin/check-services-instantiability
@@ -16,6 +16,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+$ignoreServiceIds = [
+    'liip_imagine.binary.loader.prototype.filesystem', // Definition is broken on purpose in the Imagine bundle. Not meant to be instantiated by the container.
+];
+
 $inputDefinition = new InputDefinition(array(
   new InputOption('verbose', 'v', InputOption::VALUE_NONE, 'Verbose mode: list all service ids we tried to instantiate.'. false)
 ));
@@ -37,21 +41,24 @@ try {
 $verbosity = $input->getOption('verbose') ? ConsoleOutput::VERBOSITY_VERBOSE : ConsoleOutput::VERBOSITY_NORMAL;
 $output->setVerbosity($verbosity);
 
-
 $kernel = new AppKernel('dev', false);
 $kernel->boot();
 
-$exitStatus = checkServicesInstantiability($kernel->getContainer(), $output);
+$exitStatus = checkServicesInstantiability($kernel->getContainer(), $output, $ignoreServiceIds);
 
 exit ($exitStatus);
 
-function checkServicesInstantiability(ContainerInterface $container, ConsoleOutput $output): int
+function checkServicesInstantiability(ContainerInterface $container, ConsoleOutput $output, array $ignoreServiceIds): int
 {
     $serviceIds = $container->getServiceIds();
 
     $nonInstantiableServices = [];
 
     foreach ($serviceIds as $serviceId) {
+
+        if (in_array($serviceId, $ignoreServiceIds)) {
+            continue;
+        }
 
         if ($output->isVerbose()) {
             $output->writeln("Getting $serviceId");

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
         "doctrine/orm": "2.5.6",
         "dompdf/dompdf" : "0.6.2@dev",
         "elasticsearch/elasticsearch": "^5.1",
-        "escapestudios/wsse-authentication-bundle": "2.2.2",
         "friendsofsymfony/jsrouting-bundle": "1.6.0",
         "friendsofsymfony/oauth-server-bundle": "1.5.2",
         "friendsofsymfony/rest-bundle": "2.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d69587092995684e6769db9596da24d2",
+    "content-hash": "fcfe02847a3be9686f0bb59fff9feb3a",
     "packages": [
         {
             "name": "ass/xmlsecurity",
@@ -1410,60 +1410,6 @@
                 "search"
             ],
             "time": "2019-01-08T18:57:00+00:00"
-        },
-        {
-            "name": "escapestudios/wsse-authentication-bundle",
-            "version": "2.2.2",
-            "target-dir": "Escape/WSSEAuthenticationBundle",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/djoos/EscapeWSSEAuthenticationBundle.git",
-                "reference": "49facf00b4e0b32d9c01bff9ee62d5f4c7adc4d1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/djoos/EscapeWSSEAuthenticationBundle/zipball/49facf00b4e0b32d9c01bff9ee62d5f4c7adc4d1",
-                "reference": "49facf00b4e0b32d9c01bff9ee62d5f4c7adc4d1",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/common": "~2.2",
-                "php": ">=5.3.9",
-                "symfony/framework-bundle": "~2.3|~3.0",
-                "symfony/security-bundle": "~2.3|~3.0"
-            },
-            "require-dev": {
-                "symfony/finder": "~2.3|~3.0",
-                "symfony/phpunit-bridge": "~2.7|~3.0"
-            },
-            "type": "symfony-bundle",
-            "autoload": {
-                "psr-0": {
-                    "Escape\\WSSEAuthenticationBundle": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "David Joos",
-                    "email": "david.joos@escapestudios.com"
-                },
-                {
-                    "name": "Community contributors",
-                    "homepage": "https://github.com/djoos/EscapeWSSEAuthenticationBundle/graphs/contributors"
-                }
-            ],
-            "description": "Symfony2 bundle to implement WSSE authentication",
-            "homepage": "https://github.com/djoos/EscapeWSSEAuthenticationBundle",
-            "keywords": [
-                "Authentication",
-                "bundle",
-                "wsse"
-            ],
-            "time": "2016-09-16T09:21:45+00:00"
         },
         {
             "name": "fig/link-util",

--- a/src/Akeneo/Platform/CommunityRequirements.php
+++ b/src/Akeneo/Platform/CommunityRequirements.php
@@ -35,7 +35,6 @@ class CommunityRequirements
         'gd',
         'intl',
         'pdo_mysql',
-        'soap',
         'xml',
         'zip',
         'exif',

--- a/src/Akeneo/Platform/config/bundles/escape_wsse_authentication.yml
+++ b/src/Akeneo/Platform/config/bundles/escape_wsse_authentication.yml
@@ -1,3 +1,0 @@
-escape_wsse_authentication:
-    authentication_provider_class: Akeneo\UserManagement\Bundle\Security\WsseUserProvider
-    authentication_listener_class: Oro\Bundle\UserBundle\Security\WsseAuthListener

--- a/src/Akeneo/Platform/config/pim.yml
+++ b/src/Akeneo/Platform/config/pim.yml
@@ -3,7 +3,6 @@ imports:
     - { resource: 'bundles/akeneo_api.yml' }
     - { resource: 'bundles/assetic.yml' }
     - { resource: 'bundles/doctrine.yml' }
-    - { resource: 'bundles/escape_wsse_authentication.yml' }
     - { resource: 'bundles/fos_auth_server.yml' }
     - { resource: 'bundles/fos_js_routing.yml' }
     - { resource: 'bundles/fos_rest.yml' }

--- a/src/Oro/Bundle/ConfigBundle/Resources/config/services.yml
+++ b/src/Oro/Bundle/ConfigBundle/Resources/config/services.yml
@@ -4,8 +4,6 @@ parameters:
     oro_config.twig_extension.class:                                             Oro\Bundle\ConfigBundle\Twig\ConfigExtension
     oro_config.provider.system_configuration.form_provider.class:                Oro\Bundle\ConfigBundle\Provider\SystemConfigurationFormProvider
 
-    oro_config.form.config_subscriber.class:                                     Oro\Bundle\ConfigBundle\Form\EventListener\ConfigSubscriber
-
 services:
     oro_config.user:
         class:                        '%oro_config.user.class%'
@@ -26,8 +24,3 @@ services:
         arguments:                    ["@oro_config.global"]
         tags:
             - { name: twig.extension }
-
-    oro_config.form.config_subscriber:
-        class: '%oro_config.form.config_subscriber.class%'
-        arguments:
-          - '@oro_config.user'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR cleanups the following services that are not instantiable:
 - `escape_wsse_authentication`
 - `liip_imagine.binary.loader.prototype.filesystem`
 - `oro_config.form.config_subscriber`

In the case of the WSSE service, we remove as well the bundle and the SOAP requirements. WSSE is an extension of the SOAP protocol in order to secure Webservice access. This is not used by Akeneo PIM.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
