### PR TITLE
PIM-7965: do not call the detacher anymore

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7965: fix families patch endpoint when updating a family with a family variant 
+
 # 2.3.24 (2019-01-10)
  
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -40,6 +40,8 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
      * @param SaverInterface              $familyVariantSaver
      * @param BulkSaverInterface          $bulkFamilyVariantSaver
      * @param BulkObjectDetacherInterface $objectDetacher
+     *
+     * @todo merge master: remove $objectDetacher
      */
     public function __construct(
         ValidatorInterface $validator,
@@ -96,8 +98,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
             $this->familyVariantSaver->save($familyVariant);
         }
 
-        $this->objectDetacher->detachAll($validFamilyVariants);
-
         if (!empty($allViolations)) {
             $errorMessage = $this->getErrorMessage($allViolations);
             throw new \LogicException($errorMessage);
@@ -131,7 +131,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         $allViolations = $validationResponse['violations'];
 
         $this->bulkfamilyVariantSaver->saveAll($validFamilyVariants);
-        $this->objectDetacher->detachAll($validFamilyVariants);
 
         if (!empty($allViolations)) {
             $errorMessage = $this->getErrorMessage($allViolations);

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -56,7 +56,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
     function it_validates_and_saves_family_variants_on_family_update_on_unitary_save(
         $validator,
         $familyVariantSaver,
-        $objectDetacher,
         GenericEvent $event,
         FamilyInterface $family,
         Collection $familyVariants,
@@ -80,7 +79,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 
         $familyVariantSaver->save($familyVariants1)->shouldBeCalled();
         $familyVariantSaver->save($familyVariants2)->shouldBeCalled();
-        $objectDetacher->detachAll([$familyVariants1, $familyVariants2])->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
         $event->hasArgument('unitary')->willReturn(true);
@@ -149,7 +147,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
     function it_validates_and_saves_family_variants_on_family_update_on_bulk_save(
         $validator,
         $bulkFamilyVariantSaver,
-        $objectDetacher,
         GenericEvent $event,
         FamilyInterface $family,
         Collection $familyVariants,
@@ -172,7 +169,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $constraintViolationList->count()->willReturn(0);
 
         $bulkFamilyVariantSaver->saveAll([$familyVariants1, $familyVariants2])->shouldBeCalled();
-        $objectDetacher->detachAll([$familyVariants1, $familyVariants2])->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
         $event->hasArgument('unitary')->willReturn(true);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This fix basically revert the fix done in this PR in the 2.0 branch : https://github.com/akeneo/pim-community-dev/pull/7368.

When a family is saved, a subscriber catch the save event and detach all the family variants, but it has a side effect on the API and generates this error :
```
request.CRITICAL: Uncaught PHP Exception Doctrine\ORM\ORMInvalidArgumentException: "A new entity was found through the relationship 'Pim\Bundle\CatalogBundle\Entity\Family#familyVariants' that was not configured to cascade persist operations for entity: Pim\Component\Catalog\Model\FamilyVariant@0000000053b43252000000001bcb5ec2. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOne(..,cascade={"persist"}). If you cannot find out which entity causes the problem implement 'Pim\Component\Catalog\Model\FamilyVariant#__toString()' to get a clue." at /home/akeneo/pim/vendor/doctrine/orm/lib/Doctrine/ORM/ORMInvalidArgumentException.php line 92 
```
With this PR, the error the PR in the 2.0 fixed cannot be reproduced in the 2.3 branch so the detacher can be safely removed.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
