### PR TITLE
PIM-7969: fix special chars in PDF export

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7967: Fix ACL for asset categories
+- PIM-7969: fix special chars in PDF export
 
 # 2.3.25 (2019-01-17)
 

--- a/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
+++ b/src/Pim/Bundle/PdfGeneratorBundle/Resources/views/Product/renderPdf.html.twig
@@ -14,8 +14,12 @@
             {% endif %}
 
             * {
-                font-family: 'Custom font', Helvetica;
+                font-family: 'Custom font', "DejaVu Sans", monospace;
                 font-weight: 400 !important;
+            }
+
+            body {
+                font-size: 14px;
             }
 
             .header {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Special chars were not correctly displayed (ex: "β" was displayed as a "?"). The HTML generated by the PIM was OK, the unicode support for DOMPDF was enabled. According to DOMPDF documentation, `the PDF needs access to a font that supports the characters used in the document` and Helvetica doesn't seem to support some characters like the "β", at least during the PDF rendering.

So I switched the font to use the recommanded one (DejaVu) and it fixed the problem. The font is very similar to the previous one so there is no real change in the generated PDF.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
