### PR TITLE
Add Webmozart assert library dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,8 @@
         "symfony/polyfill-apcu": "1.4.0",
         "twig/extensions": "1.3.0",
         "twig/twig": "1.36.0",
-        "box/spout": "2.7.2"
+        "box/spout": "2.7.2",
+        "webmozart/assert": "1.3"
     },
     "require-dev": {
         "akeneo/phpspec-skip-example-extension": "2.0.*",


### PR DESCRIPTION
We use this library [here](https://github.com/akeneo/pim-community-dev/blob/master/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductAndProductModelRowNormalizer.php#L10) so we need it as a prod dependency.

**Note**: we didn't see the issue on CI because it is also an indirect dev dependency linked to phpspec.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
