### PR TITLE
PIM-7967: fix ACL on asset categories

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7967: Fix ACL for asset categories
+
 # 2.3.25 (2019-01-17)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/CategoryTree/form.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/CategoryTree/form.html.twig
@@ -47,7 +47,7 @@
                       {% else %}
                           {{ elements.deleteLink(
                               path(route ~ '_categorytree_remove', { id: form.vars.value.id }),
-                              'pim_enrich_product_category_remove',
+                              acl ~ '_category_remove',
                               form.vars.value.parent ? path(route ~ '_categorytree_edit', { id: form.vars.value.parent.id }) : path(route ~ '_categorytree_create'),
                               'confirmation.remove.category'|trans({ '%name%': form.vars.value.label }) ~ '<br />'
                                   ~ 'info.category.remove children'|trans ~ '<br />'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

The twig view is shared for products & assets categories so we need to use the `acl` key to apply the good ACL to the good page. 

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
