### PR TITLE
update changelog 2.3 for PIM-7961

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -9,6 +9,7 @@
 ## Bug fixes
 
 - PIM-7965: fix families patch endpoint when updating a family with a family variant 
+- PIM-7961: Fix localizable assets used as main image for family and added to product product model
 
 # 2.3.24 (2019-01-10)
  
@@ -16,7 +17,6 @@
 
 - PIM-7934: Fix translations of product model import
 - GITHUB-8780: Fix error in product normalizer. Cheers @yunosh!
-- PIM-7961: Fix localizable assets used as main image for family and added to product product model
 
 # 2.3.23 (2019-01-03)
  


### PR DESCRIPTION
Moved - PIM-7961: Fix localizable assets used as main image for family and added to product product model in right version

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
