### PR TITLE
Don't wait 50 seconds when checking filter existence to ensure it is not displayed

### DIFF
--- a/tests/legacy/features/Behat/Context/Domain/Spread/ExportBuilderContext.php
+++ b/tests/legacy/features/Behat/Context/Domain/Spread/ExportBuilderContext.php
@@ -28,32 +28,6 @@ class ExportBuilderContext extends PimContext implements PageObjectAware
     }
 
     /**
-     * Check if the element is visible
-     *
-     * Example:
-     * Then I should not see the "updated since n days" element in the filter "Updated time condition"
-     *
-     * @param string $field
-     * @param string $filterElement
-     *
-     * @throws \Exception
-     *
-     * @Then /^I should not see the "([^"]*)" element in the filter "([^"]*)"$/
-     */
-    public function iShouldNotSeeTheElement($field, $filterElement)
-    {
-        /** @var UpdatedTimeConditionDecorator $filterElement */
-        $filterElement = $this->getElementOnCurrentPage($filterElement);
-
-        if ($filterElement->checkValueElementVisibility($field)) {
-            throw new ExpectationException(
-                sprintf('The element "%s" should not be visible', $field),
-                $this->getSession()->getDriver()
-            );
-        }
-    }
-
-    /**
      * @param string $attributes
      * @param string $gridLabel
      *

--- a/tests/legacy/features/Context/DataGridContext.php
+++ b/tests/legacy/features/Context/DataGridContext.php
@@ -357,17 +357,15 @@ class DataGridContext extends PimContext implements PageObjectAware
     public function iShouldNotSeeTheFilters($filters)
     {
         $filters = $this->getMainContext()->listToArray($filters);
-        foreach ($filters as $filter) {
-            try {
-                $filterNode = $this->getDatagrid()->getFilter($filter);
-                if ($filterNode->isVisible()) {
-                    throw $this->createExpectationException(
-                        sprintf('Filter "%s" should not be visible', $filter)
-                    );
-                }
-            } catch (TimeoutException $e) {
-                // Filter not rendered, all is good
-            }
+        foreach ($filters as $filterName) {
+            $this->spin(function () use ($filterName) {
+                $filterNode = $this
+                    ->getDatagrid()
+                    ->getElement('Body')
+                    ->find('css', sprintf('.filter-item[data-name="%s"]', $filterName));
+
+                return null === $filterNode || !$filterNode->isVisible();
+            }, sprintf('Filter "%s" should not be visible', $filterName));
         }
     }
 

--- a/tests/legacy/features/pim/enrichment/product/export/export_products_by_multiselect.feature
+++ b/tests/legacy/features/pim/enrichment/product/export/export_products_by_multiselect.feature
@@ -71,4 +71,4 @@ Feature: Export products according to multi select values
     And I am on the "csv_footwear_product_export" export job edit page
     And I visit the "Content" tab
     When I hide the filter "weather_conditions.code"
-    Then I should not see the filter "weather_conditions.code"
+    Then I should not see the filter weather_conditions.code

--- a/tests/legacy/features/pim/enrichment/product/export/export_products_by_simpleselect.feature
+++ b/tests/legacy/features/pim/enrichment/product/export/export_products_by_simpleselect.feature
@@ -87,4 +87,4 @@ Feature: Export products according to simple select values
     And I am on the "csv_footwear_product_export" export job edit page
     And I visit the "Content" tab
     When I hide the filter "manufacturer.code"
-    Then I should not see the filter "manufacturer.code"
+    Then I should not see the filter manufacturer.code


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When checking that a filter is not displayed, we were waiting the timeout of the spin (50 seconds).
So, this test took 4 minutes at doing nothing except waiting:

https://github.com/akeneo/pim-community-dev/blob/master/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products.feature#L53

Now it takes, 30 seconds.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
