### PR TITLE
Test circle pit stabilize ee

### DIFF
--- a/tests/legacy/features/Context/Page/Base/Grid.php
+++ b/tests/legacy/features/Context/Page/Base/Grid.php
@@ -673,6 +673,11 @@ class Grid extends Index
         $this->spin(function () use ($filterName) {
             $filterItem = $this->getElement('Body')->find('css', sprintf('.filter-item[data-name="%s"]', $filterName));
 
+            // isVisible is not totally reliable, which mean that
+            // we think we clicked on the filter button but we didn't (DOM not loaded)
+            // sleep is a working dirty hack
+             sleep(1);
+
             if (null === $filterItem || !$filterItem->isVisible()) {
                 $this->clickOnFilterToManage($filterName);
                 return false;

--- a/tests/legacy/features/Context/Page/Base/Grid.php
+++ b/tests/legacy/features/Context/Page/Base/Grid.php
@@ -676,7 +676,7 @@ class Grid extends Index
             // isVisible is not totally reliable, which mean that
             // we think we clicked on the filter button but we didn't (DOM not loaded)
             // sleep is a working dirty hack
-             sleep(1);
+            sleep(1);
 
             if (null === $filterItem || !$filterItem->isVisible()) {
                 $this->clickOnFilterToManage($filterName);

--- a/tests/legacy/features/Context/WebUser.php
+++ b/tests/legacy/features/Context/WebUser.php
@@ -2121,6 +2121,11 @@ class WebUser extends PimContext
 
         $this->getMainContext()->getContainer()->get('pim_connector.doctrine.cache_clearer')->clear();
 
+        $esClients = $this->getMainContext()->getContainer()->get('akeneo_elasticsearch.registry.clients')->getClients();
+        foreach ($esClients as $esClient) {
+            $esClient->refreshIndex();
+        }
+
         return [
             new Step\Then(sprintf('I go on the last executed job resume of "%s"', $code))
         ];


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

### Sleep:
It should stabilize the tests, but not sure. Let's see and delete commit if it's useless.

### Indexation:
After launching a job and then checking something in the UI, ES indexes are sometimes not up to date.
So, the scenario could fail as the result is not as expected.

Ok, that's the why of this fix.

But it's hard to reproduce these problems in local. For example, on my machine, I have to launch the test more than 20 times before failing. And it's hard to know if you really fixed it once you "fixed" it.

Here is a tip to reproduce it:

I modified on the fly the "refresh" parameter of the ES index, during the install of the fixtures:
```
curl -X PUT \
  http://elastic:changeme@localhost:9211/behat_akeneo_pim_product_proposal/_settings \
  -H 'Content-Type: application/json' \
  -d '{                                  
    "index" : {
        "refresh_interval" : "30s"
    }
}'
```

And then,my test was failing everytime... It's like saying to ES: "Commit all the stuff I indexed, every 30 seconds". If your test is not correctly written, it will fail.

Trick: If we want to detect every problems due to ES asynchronicity, we could modify this parameter with a hook before launching the tests (just to stabilize the CI, not permanently).

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
