### PR TITLE
Remove strict typehint on $image attribute as in EE it could be an Asset (ReferenceData)

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Grid/ReadModel/Row.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Grid/ReadModel/Row.php
@@ -6,7 +6,6 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Grid\ReadModel;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueCollectionInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Value\MediaValue;
 
 /**
  * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
@@ -38,7 +37,7 @@ final class Row
     /** @var string */
     private $label;
 
-    /** @var null|MediaValue */
+    /** @var null|object  */
     private $image;
 
     /** @var null|int */
@@ -76,7 +75,7 @@ final class Row
      * @param \DateTimeInterface       $created
      * @param \DateTimeInterface       $updated
      * @param string                   $label
-     * @param null|MediaValue          $image
+     * @param null|object              $image
      * @param null|int                 $completeness
      * @param string                   $documentType
      * @param int                      $technicalId
@@ -95,7 +94,7 @@ final class Row
         \DateTimeInterface $created,
         \DateTimeInterface $updated,
         ?string $label,
-        ?MediaValue $image,
+        ?object $image,
         ?int $completeness,
         string $documentType,
         int $technicalId,
@@ -133,7 +132,7 @@ final class Row
         \DateTimeInterface $created,
         \DateTimeInterface $updated,
         string $label,
-        ?MediaValue $image,
+        ?object $image,
         ?int $completeness,
         int $technicalId,
         ?string $parentCode,
@@ -166,7 +165,7 @@ final class Row
         \DateTimeInterface $created,
         \DateTimeInterface $updated,
         string $label,
-        ?MediaValue $image,
+        ?object $image,
         int $technicalId,
         array $childrenCompleteness,
         ?string $parent,
@@ -275,9 +274,12 @@ final class Row
     }
 
     /**
-     * @return null|MediaValue
+     * This method return a type object because in EE it can return
+     * a MediaValue|ReferenceDataCollectionValue
+     *
+     * @return null|object
      */
-    public function image(): ?MediaValue
+    public function image(): ?object
     {
         return $this->image;
     }


### PR DESCRIPTION
Remove strict typehint on $image attribute as in EE it could be an Asset (ReferenceData)

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
