### PR TITLE
PIM-8007: Content of sortable attribute options are now copyable

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-8007: Content of sortable attribute options is now copyable.
 - PIM-8008: Fix attributes sort order in PEF.
 
 # 2.3.28 (2019-02-01)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/pim-attributeoptionview.js
@@ -289,6 +289,7 @@ define(
             setSortable: function() {
                 this.$el.sortable({
                     items: 'tbody tr',
+                    handle: '.handle',
                     axis: 'y',
                     connectWith: this.$el,
                     containment: this.$el,

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-option/show.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/attribute-option/show.html
@@ -1,5 +1,5 @@
 <td class="AknGrid-bodyCell">
-    <span class="handle ui-sortable-handle"><i class="icon-reorder"></i></span>
+    <span class="handle ui-sortable-handle AknGrid-movableRow"><i class="icon-reorder"></i></span>
     <span class="option-code"><%- item.code %></span>
 </td>
 <% _.each(locales, function (locale) { %>

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -335,6 +335,10 @@
     display: block;
   }
 
+  &-movableRow {
+    cursor: move;
+  }
+
   &-bodyRow--withLayer {
     &:before,
     &:after {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When the attribute options grid is sortable the content of the row was not selectable.
Now to move the row the cursor is on the icon and not on the full row.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
