### PR TITLE
Fix js dependencies

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-7967: Fix ACL for asset categories
 - PIM-7969: fix special chars in PDF export
+- Force the use of ip-regex at 2.1.0 version. Upper version needs nodejs >= 8 but we have to support nodejs >= 6.
 
 # 2.3.25 (2019-01-17)
 

--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
     "webpack-livereload-plugin": "0.11.0",
     "write-file-webpack-plugin": "4.1.0",
     "yamljs": "0.3.0"
+  },
+  "resolutions": {
+    "jest/**/ip-regex":"2.1.0"
   }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

According to the documentation, we have to support nodejs `≥ 6.11.0 - 8.2.1`.
A recent dependency of dependency update needs only nodejs `≥ 8`.

We force this dependency to an older version in order to respect our requirements.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
