### PR TITLE
PIM-7943: Fix duplicate popin mask in family variant edit form

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-7943: Fix duplicate popin mask in family variant edit form.
 - PIM-8007: Content of sortable attribute options is now copyable.
 - PIM-8008: Fix attributes sort order in PEF.
 - PIM-8022: Fix the job status when using the batch command.

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/datagrid/action/edit-in-modal-action.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/datagrid/action/edit-in-modal-action.js
@@ -15,8 +15,10 @@ define(
                 return formModalCreator.createModal(
                     this.model.get(this.propertyCode),
                     this.fetcher,
-                    'modal modal--fullPage modal--alignTop'
-                );
+                    'modal modal--fullPage modal--alignTop modal--large'
+                ).then((modal) => {
+                    modal.$el.find('.modal-footer').remove();
+                });
             }
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/family-variant.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/family-variant.js
@@ -54,8 +54,10 @@ define(
                         formModalCreator.createModal(
                             familyVariant.code,
                             'family-variant',
-                            'modal modal--fullPage modal--alignTop'
-                        );
+                            'modal modal--fullPage modal--alignTop modal--large'
+                        ).then((modal) => {
+                            modal.$el.find('.modal-footer').remove();
+                        });
                     }
                 );
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/modal.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/modal.less
@@ -84,6 +84,10 @@
     justify-content: center;
     flex-direction: column;
 
+    &.modal--large .modal-body{
+      max-height: 100vh;
+    }
+
     .modal-header {
       display: none;
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Before this bug, when you go on the pef and you open a manage asset modal, and then you go on the modal to edit a family variant there were a double cancel button, a big footer and an OK button in it. Those elements were not part of the "normal" modal.

I didn't find the bug but I found a way to remove those elements when they appear.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
