### PR TITLE
Fix order of migration script

### DIFF
--- a/upgrades/schema/Version_3_0_20180717082451_add_file_info_to_user.php
+++ b/upgrades/schema/Version_3_0_20180717082451_add_file_info_to_user.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Schema\Schema;
 /**
  * Add file_info_id column to oro_user tables
  */
-class Version_3_0_20190114122716_add_file_info_to_user extends AbstractMigration
+class Version_3_0_20180717082451_add_file_info_to_user extends AbstractMigration
 {
     /**
      * @param Schema $schema


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR sets the migration script adding the file_info field a little bit earlier as it is needs later.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
