### PR TITLE
Prevent to trigger the approval job  on CircleCI when merging a pull request in master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,12 @@ workflows:
       jobs:
           - wait_for_user_approval:
                 type: approval
+                filters:
+                    branches:
+                        only:
+                            - /^ci.*/ # remove this rule once circle ci is official
+                        ignore:
+                            - master
           - setup:
                 requires:
                     - wait_for_user_approval


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
