### PR TITLE
PIM-8008:Fix attribute sort order in PEF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ composer.phar
 !/bin/docker/pim-dependencies.sh
 !/bin/docker/pim-front.sh
 !/bin/docker/pim-initialize.sh
+!/bin/docker/pim-setup.sh
 !/bin/console
 !/bin/pim-front.sh
 behat.yml

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8008: Fix attributes sort order in PEF.
+
 # 2.3.28 (2019-02-01)
 
 # 2.3.27 (2019-01-29)

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/AttributeCreationSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/AttributeCreationSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * At the creation of an attribute force the attribute sort order.
+ *
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AttributeCreationSubscriber implements EventSubscriberInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            StorageEvents::PRE_SAVE => 'incrementSortOrder'
+        ];
+    }
+
+    /**
+     * @param GenericEvent $event
+     */
+    public function incrementSortOrder(GenericEvent $event): void
+    {
+        $attribute = $event->getSubject();
+        if (!$attribute instanceof AttributeInterface || null !== $attribute->getId()) {
+            return;
+        }
+
+        $attribute->setSortOrder($attribute->getGroup()->getMaxAttributeSortOrder() + 1);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -179,3 +179,8 @@ services:
             - '@pim_catalog.query.product_and_product_model_query_builder_factory'
         tags:
             - { name: kernel.event_subscriber }
+
+    pim_catalog.event_subscriber.attribute_creation:
+        class: 'Pim\Bundle\CatalogBundle\EventSubscriber\AttributeCreationSubscriber'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/AttributeCreationSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/AttributeCreationSubscriberSpec.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Component\StorageUtils\StorageEvents;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\EventSubscriber\AttributeCreationSubscriber;
+use Pim\Component\Catalog\Model\AttributeGroupInterface;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class AttributeCreationSubscriberSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AttributeCreationSubscriber::class);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldImplement(EventSubscriberInterface::class);
+    }
+
+    function it_listens_to_storage_pre_save_event()
+    {
+        $this->getSubscribedEvents()->shouldReturn([
+            StorageEvents::PRE_SAVE => 'incrementSortOrder',
+        ]);
+    }
+
+    function it_does_nothing_if_subject_is_not_an_attribute(GenericEvent $event, AttributeOptionInterface $option)
+    {
+        $event->getSubject()->willReturn($option);
+        $option->getId()->shouldNotBeCalled();
+
+        $this->incrementSortOrder($event);
+    }
+
+    function it_does_nothing_if_subject_is_not_a_new_attribute(GenericEvent $event, AttributeInterface $attribute)
+    {
+        $event->getSubject()->willReturn($attribute);
+        $attribute->getId()->willReturn(42);
+        $attribute->getGroup()->shouldNotBeCalled();
+
+        $this->incrementSortOrder($event);
+    }
+
+    function it_increments_sort_order_of_new_attribute(
+        GenericEvent $event,
+        AttributeInterface $attribute,
+        AttributeGroupInterface $attributeGroup
+    ) {
+        $event->getSubject()->willReturn($attribute);
+        $attribute->getId()->willReturn(null);
+        $attribute->getGroup()->willReturn($attributeGroup);
+        $attributeGroup->getMaxAttributeSortOrder()->willReturn(0);
+
+        $attribute->setSortOrder(1)->shouldBeCalled();
+
+        $this->incrementSortOrder($event);
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/attributes.js
@@ -505,6 +505,18 @@ define(
                 return FetcherRegistry.getFetcher('attribute')
                     .fetchByIdentifiers(Object.keys(values))
                     .then((attributes) => {
+                        attributes.sort((a, b) => {
+                            if (a.sortOrder < b.sortOrder) {
+                                return -1;
+                            }
+
+                            if (a.sortOrder > b.sortOder) {
+                                return 1;
+                            }
+
+                            return (a.meta.id < b.meta.id ? -1 : 1);
+                        });
+
                         return $.when.apply($, attributes.map((attribute) => {
                             return this.createAttributeField(data, attribute.code, values[attribute.code]);
                         }));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When you add attributes in an attribute groups, attributes don't have sort order.
 => Now, when you save a new attribute, by default the sort order is incremented in terms of the higher sort order in the attribute group. It helps to sort by sort order in front.

When you fetch attributes by identifiers in front, at the end of the fetchByIdentifers() method in the base fecther, we do a _.pluck(attributes, identifiers). So the array of attributes it returns is sorted by same order than the order of the identifiers you give.
 => Now we sort attributes we fetched first by sort order. However, sometimes there is no so we sort by id. We sort by id because it is the way attributes are shown in the attribute group when there is no sort order. So the user sees the same order.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
