### PR TITLE
PIM-8024 : Fix displayed locales regarding their permissions in the product grid and form

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/locale-switcher.js
@@ -95,7 +95,10 @@ define(
              * @returns {Promise}
              */
             getDisplayedLocales: function () {
-                return FetcherRegistry.getFetcher('locale').fetchActivated();
+              const localeFetcher = FetcherRegistry.getFetcher('locale');
+              localeFetcher.clear();
+
+              return localeFetcher.fetchActivated();
             },
 
             /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/grid/locale-switcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/grid/locale-switcher.js
@@ -83,6 +83,7 @@ define(
              */
             fetchLocales() {
                 const localeFetcher = FetcherRegistry.getFetcher('locale');
+                localeFetcher.clear();
 
                 return localeFetcher.fetchActivated();
             },


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix to get the displayed locales regarding their permissions without to have to reload the page.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
