### PR TITLE
Fix smallint type for ORO tables like in 2.3

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Group.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Group.orm.yml
@@ -5,7 +5,7 @@ Akeneo\UserManagement\Component\Model\Group:
     repositoryClass: Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\GroupRepository
     fields:
         id:
-            type: integer
+            type: smallint
             id: true
             generator:
                 strategy: AUTO

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Role.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Role.orm.yml
@@ -5,7 +5,7 @@ Akeneo\UserManagement\Component\Model\Role:
     repositoryClass: Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\RoleRepository
     fields:
         id:
-            type: integer
+            type: smallint
             id: true
             generator:
                 strategy: AUTO


### PR DESCRIPTION
Weird regression detected by migrating reference entities.