### PR TITLE
PIM-8025: Bring the user view mode back to life

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Resources/config/datagrid/user.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/datagrid/user.yml
@@ -86,7 +86,6 @@ datagrid:
                 type:          navigate
                 label:         pim_common.update
                 link:          update_link
-                acl_resource:  pim_user_user_edit
                 rowAction:     true
             delete:
                 launcherOptions:

--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -105,7 +105,7 @@ class UserNormalizer implements NormalizerInterface
             ] : $this->fileNormalizer->normalize($user->getAvatar()),
             'meta'                      => [
                 'id'    => $user->getId(),
-                'form'  => $this->isEditGranted($user) ? 'pim-user-edit-form' : 'pim-user-show',
+                'form'  => $this->securityFacade->isGranted('pim_user_user_edit') ? 'pim-user-edit-form' : 'pim-user-show',
                 'image' => [
                     'filePath' => null === $user->getAvatar() ?
                         null :
@@ -153,24 +153,5 @@ class UserNormalizer implements NormalizerInterface
         return $user->getRolesCollection()->map(function (Role $role) {
             return $role->getRole();
         })->toArray();
-    }
-
-    /**
-     * Returns true if the current user has permission to edit user or is the current user.
-     *
-     * @param UserInterface $user
-     *
-     * @return bool
-     */
-    private function isEditGranted($user): bool
-    {
-        if ($this->securityFacade->isGranted('pim_user_user_edit')) {
-            return true;
-        }
-
-        $token = $this->tokenStorage->getToken();
-        $currentUser = $token ? $token->getUser() : null;
-
-        return ($user->getId() && is_object($currentUser) && $currentUser->getId() == $user->getId());
     }
 }

--- a/tests/legacy/features/user-management/user/edit_my_account.feature
+++ b/tests/legacy/features/user-management/user/edit_my_account.feature
@@ -15,16 +15,14 @@ Feature: Change my profile
     Then I should see the flash message "User saved"
     And I should not see the default avatar
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6258
-  Scenario: Successfully edit my own profile even if permissions on profile edition are revoked
+  @jira https://akeneo.atlassian.net/browse/PIM-8025
+  Scenario: I can't edit my own profile if I don't have the permission to edit users
     Given I am on the "Administrator" role page
-    When I visit the "Permissions" tab
+    And I visit the "Permissions" tab
     And I revoke rights to resources Edit users
     And I save the role
-    And I edit the "Peter" user
-    When I attach file "akeneo.jpg" to "Avatar"
-    And I save the user
-    Then I should see the flash message "User saved"
+    When I edit the "Peter" user
+    Then I should not see the text "Save"
 
   @jira https://akeneo.atlassian.net/browse/PIM-6894
   Scenario: Successfully update my password with any characters


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

During the PEFization of the user form, the view mode has been removed. But we need it when the user has the "view user" rights only.

The view form still exists, it's just never used currently. By removing the ACL check on the grid, a user without edit rights can still navigate to the edit route, but the front controller instantiates either the edit form or the view form depending on the permissions. This is possible thanks to the normalizer.

"Sa tombe en marche" like @pierallard would say.

This behavior is different from what was done in < 2.3 where you were forced to pass by the view mode to access the edit form. **Now the view mode is used only when you don't have the edit rights**.
Validated by @bgouraud.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
