### PR TITLE
Fix ROLE_USER removal

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/EventListener/RemoveRoleSubscriber.php
+++ b/src/Akeneo/UserManagement/Bundle/EventListener/RemoveRoleSubscriber.php
@@ -23,11 +23,15 @@ class RemoveRoleSubscriber implements EventSubscriberInterface
         $this->isThereUserWithoutRole = $isThereUserWithoutRole;
     }
 
-    public function checkIfThereIsUserWithoutRole(RemoveEvent $event)
+    public function checkRoleIsRemovable(RemoveEvent $event)
     {
         $role = $event->getSubject();
         if (!$role instanceof RoleInterface) {
             return;
+        }
+
+        if ($role->getRole() === 'ROLE_USER') {
+            throw new ForbiddenToRemoveRoleException('You can not delete this role, this role is the one by default in Akeneo PIM');
         }
 
         $isThereUserWithoutRole = $this->isThereUserWithoutRole;
@@ -43,7 +47,7 @@ class RemoveRoleSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            StorageEvents::PRE_REMOVE => [['checkIfThereIsUserWithoutRole']],
+            StorageEvents::PRE_REMOVE => [['checkRoleIsRemovable']],
         ];
     }
 }

--- a/tests/back/UserManagement/Integration/Bundle/RemoveRoleIntegration.php
+++ b/tests/back/UserManagement/Integration/Bundle/RemoveRoleIntegration.php
@@ -18,9 +18,9 @@ class RemoveRoleIntegration extends TestCase
 
     public function testSuccessfullyToRemoveARole()
     {
-        $adminRole = $this->get('pim_user.repository.role')->findOneByIdentifier('IS_AUTHENTICATED_ANONYMOUSLY');
+        $adminRole = $this->get('pim_user.repository.role')->findOneByIdentifier('ROLE_CATALOG_MANAGER');
         $this->get('pim_user.remover.role')->remove($adminRole);
-        $this->assertNull($this->get('pim_user.repository.role')->findOneByIdentifier('IS_AUTHENTICATED_ANONYMOUSLY'));
+        $this->assertNull($this->get('pim_user.repository.role')->findOneByIdentifier('ROLE_CATALOG_MANAGER'));
     }
 
     /**

--- a/tests/back/UserManagement/Integration/Bundle/RemoveRoleIntegration.php
+++ b/tests/back/UserManagement/Integration/Bundle/RemoveRoleIntegration.php
@@ -18,9 +18,9 @@ class RemoveRoleIntegration extends TestCase
 
     public function testSuccessfullyToRemoveARole()
     {
-        $adminRole = $this->get('pim_user.repository.role')->findOneByIdentifier('ROLE_USER');
+        $adminRole = $this->get('pim_user.repository.role')->findOneByIdentifier('IS_AUTHENTICATED_ANONYMOUSLY');
         $this->get('pim_user.remover.role')->remove($adminRole);
-        $this->assertNull($this->get('pim_user.repository.role')->findOneByIdentifier('ROLE_USER'));
+        $this->assertNull($this->get('pim_user.repository.role')->findOneByIdentifier('IS_AUTHENTICATED_ANONYMOUSLY'));
     }
 
     /**

--- a/upgrades/schema/Version_3_0_20180131154710_add_role_user_if_needed.php
+++ b/upgrades/schema/Version_3_0_20180131154710_add_role_user_if_needed.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\IrreversibleMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Create if needed the ROLE_USER which is mandatory
+ */
+class Version_3_0_20180131154710_add_role_user_if_needed extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $roles = $this->connection->fetchArray("SELECT role FROM oro_access_role WHERE role = 'ROLE_USER'");
+
+        if (false === $roles) {
+            echo "The role ROLE_USER must exists in the PIM, we'll create it for you\n";
+            $this->addSQL("INSERT INTO oro_access_role (role, label) VALUES ('ROLE_USER', 'User')");
+        } else {
+            echo "No need to create a new ROLE\n";
+            $this->addSql('SELECT 1');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        throw new IrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

the ROLE_USER is not removable + we create it in the migration if needed

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
