### PR TITLE
Fix 3.0 composer aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -161,19 +161,7 @@
             }
         },
         "branch-alias": {
-            "dev-master": "3.0.x-dev",
-            "dev-2.3": "2.3.x-dev",
-            "dev-2.2": "2.2.x-dev",
-            "dev-2.1": "2.1.x-dev",
-            "dev-2.0": "2.0.x-dev",
-            "dev-1.7": "1.7.x-dev",
-            "dev-1.6": "1.6.x-dev",
-            "dev-1.5": "1.5.x-dev",
-            "dev-1.4": "1.4.x-dev",
-            "dev-1.3": "1.3.x-dev",
-            "dev-1.2": "1.2.x-dev",
-            "dev-1.1": "1.1.x-dev",
-            "dev-1.0": "1.0.x-dev"
+            "dev-master": "3.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
- Fix the dev-master alias
- We dont' need aliases on **comparable** branches

Documentation: https://getcomposer.org/doc/articles/aliases.md