### PR TITLE
PIM-8020: Fix wrong count on missing required attributes in the completeness

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,3 +1,9 @@
+# 3.0.x
+
+## Bug fixes
+
+- PIM-8020: Fix wrong count on missing required attributes in the completeness
+
 # 3.0
 
 ## Technical improvement

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/CompletenessGenerator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/CompletenessGenerator.php
@@ -136,7 +136,32 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
                     $currentCompleteness->setRatio($newCompleteness->getRatio());
                     $currentCompleteness->setMissingCount($newCompleteness->getMissingCount());
                     $currentCompleteness->setRequiredCount($newCompleteness->getRequiredCount());
+                    $this->updateMissingAttributes(
+                        $currentCompleteness->getMissingAttributes(),
+                        $newCompleteness->getMissingAttributes()
+                    );
                 }
+            }
+        }
+    }
+
+    /**
+     * @param Collection $currentMissingAttributes
+     * @param Collection $newMissingAttributes
+     */
+    private function updateMissingAttributes(
+        Collection $currentMissingAttributes,
+        Collection $newMissingAttributes
+    ): void {
+        foreach ($currentMissingAttributes as $currentMissingAttribute) {
+            if (!$newMissingAttributes->contains($currentMissingAttribute)) {
+                $currentMissingAttributes->removeElement($currentMissingAttribute);
+            }
+        }
+
+        foreach ($newMissingAttributes as $newMissingAttribute) {
+            if (!$currentMissingAttributes->contains($newMissingAttribute)) {
+                $currentMissingAttributes->add($newMissingAttribute);
             }
         }
     }

--- a/tests/back/Pim/Enrichment/Integration/Completeness/AbstractCompletenessTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/AbstractCompletenessTestCase.php
@@ -49,7 +49,9 @@ abstract class AbstractCompletenessTestCase extends TestCase
             return $missingAttribute->getCode();
         }, $missingAttributes->toArray());
 
-        $this->assertEquals(sort($expectedAttributeCodes), sort($missingAttributeCodes));
+        sort($expectedAttributeCodes);
+        sort($missingAttributeCodes);
+        $this->assertEquals($expectedAttributeCodes, $missingAttributeCodes);
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Integration/Completeness/UpdateMissingAttributesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/UpdateMissingAttributesIntegration.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Completeness;
+
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+
+/**
+ * Tests if missing attributes are well updated after product update.
+ *
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UpdateMissingAttributesIntegration extends AbstractCompletenessTestCase
+{
+    public function testMissingAttributesAreUpdated()
+    {
+        $productRepository = $this->get('pim_catalog.repository.product');
+        $this->createFamilyWithRequirement('shoes', 'ecommerce', 'description', AttributeTypes::TEXT);
+        $familyShoes = $this->createFamilyWithRequirement('shoes', 'ecommerce', 'item_story', AttributeTypes::TEXT);
+
+        $pimpedShoes = $this->createProductWithStandardValues(
+            $familyShoes,
+            'pimped_shoes',
+            [
+                'values' => [
+                    'description' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'Pimped shoes you will love.'
+                        ],
+                    ]
+                ]
+            ]
+        );
+
+        $product = $productRepository->findOneByIdentifier('pimped_shoes');
+        $completeness = $this->getCurrentCompleteness($pimpedShoes);
+        $this->assertMissingAttributeCodes($completeness, ['item_story']);
+
+        $this->get('pim_catalog.updater.product')->update(
+            $product,
+            [
+                'values' => [
+                    'item_story' => [
+                        [
+                            'locale' => null,
+                            'scope'  => null,
+                            'data'   => 'See this man wearing these beautiful pimped shoes, he looks so cool!'
+                        ],
+                    ]
+                ]
+            ]
+        );
+
+        $violations = $this->get('validator')->validate($product);
+        $this->assertCount(0, $violations);
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $product = $productRepository->findOneByIdentifier('pimped_shoes');
+        $completeness = $this->getCurrentCompleteness($product);
+        $this->assertMissingAttributeCodes($completeness, []);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix completeness on Product save. Since completeness refactor (we update completeness instead of removing and insert new one) missing attributes were not updated.

Fix `assertMissingAttributeCodes` in integration tests. There was an `assertEquals(sort(something), sort(another))` but sort returns bool so it was always true. :clap: 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
