### PR TITLE
PIM-8018: Move the 'Confirm' button under the warning message in bulk…

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8157: Fix issues on user edit (scroll and groups)
+- PIM-8018: Move Confirm button on mass edit screen
 
 # 3.0.4 (2019-02-20)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/mass-edit/form.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/mass-edit/form.html
@@ -47,7 +47,6 @@
                 <%- confirm %>
             </div>
             <% } %>
-            <div class="step"></div>
             <% if (currentStep === 'confirm') { %>
             <div class="AknButtonList AknButtonList--single">
                 <div class="AknButton AknButtonList-item AknButton--apply wizard-action" data-action-target="validate">
@@ -55,6 +54,7 @@
                 </div>
             </div>
             <% } %>
+            <div class="step"></div>
         </div>
     </div>
     <% } %>


### PR DESCRIPTION
… action modal

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
**Before:**
![before](https://user-images.githubusercontent.com/5301298/52222844-cc5e7200-28a4-11e9-9660-bc6c5a0ebba8.png)

**After:**
![after](https://user-images.githubusercontent.com/5301298/52222851-d1bbbc80-28a4-11e9-862f-2e400ba79cba.png)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
