### PR TITLE
Add composer dev-3.0 alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -161,7 +161,7 @@
             }
         },
         "branch-alias": {
-            "dev-master": "3.1.x-dev"
+            "dev-3.0": "3.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
We need to use the `dev-3.0` alias in our CI builds.