### PR TITLE
PIM-7939: Search on ancestors labels and codes

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,10 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7939: Fix PQB search when an attribute as label is on an ancestor.
+  -> Not mandatory, you can re-index your products and product models to enjoy this fix with commands: `bin/console pim:product:index --all` and `bin/console pim:product-model:index --all`.
+
 # 2.3.29 (2019-02-11)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilterLabelOrIdentifier.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilterLabelOrIdentifier.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
+
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * An ancestor is a product model that is either a parent or a grand parent.
+ * Look for documents having the given ancestor(s).
+ *
+ * Imagine the following tree:
+ *      RPM
+ *         \PM1
+ *            \P11
+ *            \P12
+ *         \PM2
+ *            \P21
+ *
+ * Using this filter with "IN LIST PM1" would return:
+ *         \PM1
+ *            \P11
+ *            \P12
+ *
+ * Contrary to the ancestor filter, here PM1 itself is as well returned.
+ *
+ * @author    Damien Carcel <damien.carcel@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SelfAndAncestorFilterLabelOrIdentifier extends AbstractFieldFilter
+{
+    /**
+     * @param array $supportedFields
+     * @param array $supportedOperators
+     */
+    public function __construct(
+        array $supportedFields,
+        array $supportedOperators
+    ) {
+        $this->supportedFields = $supportedFields;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldFilter($field, $operator, $value, $locale = null, $channel = null, $options = []): void
+    {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        if (!$this->supportsOperator($operator)) {
+            throw InvalidOperatorException::notSupported($operator, SelfAndAncestorFilter::class);
+        }
+
+        $this->checkValue($value);
+
+        $clauses[] = [
+            'wildcard' => [
+                'ancestors.code' => sprintf('*%s*', $this->escapeValue($value)),
+            ]
+        ];
+
+        if (null !== $channel && null !== $locale) {
+            $clauses[] = [
+                'wildcard' => [
+                    sprintf('ancestors.label.%s.%s', $channel, $locale) => sprintf(
+                        '*%s*',
+                        $this->escapeValue($value)
+                    ),
+                ]
+            ];
+        }
+
+        if (null !== $channel) {
+            $clauses[] = [
+                'wildcard' => [
+                    sprintf('ancestors.label.%s.<all_locales>', $channel) => sprintf(
+                        '*%s*',
+                        $this->escapeValue($value)
+                    ),
+                ]
+            ];
+        }
+
+        if (null !== $locale) {
+            $clauses[] = [
+                'wildcard' => [
+                    sprintf('ancestors.label.<all_channels>.%s', $locale) => sprintf(
+                        '*%s*',
+                        $this->escapeValue($value)
+                    ),
+                ]
+            ];
+        }
+
+        $clauses[] = [
+            'wildcard' => [
+                'ancestors.label.<all_channels>.<all_locales>' => sprintf('*%s*', $this->escapeValue($value)),
+            ]
+        ];
+
+        $this->searchQueryBuilder->addFilter(
+            [
+                'bool' => [
+                    'should' => $clauses,
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @param string $value
+     */
+    protected function checkValue(string $value): void
+    {
+        FieldFilterHelper::checkString('self_and_ancestor.label_or_identifier', $value, static::class);
+    }
+
+    /**
+     * Escapes particular values prior than doing a search query escaping whitespace or newlines.
+     *
+     * This is useful when using ES 'query_string' clauses in a search query.
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
+     *
+     * TODO: TIP-706 - This may move somewhere else
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    protected function escapeValue(string $value): string
+    {
+        $regex = '#[-+=|! &(){}\[\]^"~*<>?:/\\\]#';
+
+        return preg_replace($regex, '\\\$0', $value);
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilterLabelOrIdentifier.php
+++ b/src/Pim/Bundle/CatalogBundle/Elasticsearch/Filter/Field/SelfAndAncestorFilterLabelOrIdentifier.php
@@ -6,7 +6,6 @@ namespace Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
 
 use Pim\Component\Catalog\Exception\InvalidOperatorException;
 use Pim\Component\Catalog\Query\Filter\FieldFilterHelper;
-use Pim\Component\Catalog\Query\Filter\Operators;
 
 /**
  * An ancestor is a product model that is either a parent or a grand parent.
@@ -33,14 +32,8 @@ use Pim\Component\Catalog\Query\Filter\Operators;
  */
 class SelfAndAncestorFilterLabelOrIdentifier extends AbstractFieldFilter
 {
-    /**
-     * @param array $supportedFields
-     * @param array $supportedOperators
-     */
-    public function __construct(
-        array $supportedFields,
-        array $supportedOperators
-    ) {
+    public function __construct(array $supportedFields, array $supportedOperators)
+    {
         $this->supportedFields = $supportedFields;
         $this->supportedOperators = $supportedOperators;
     }
@@ -55,21 +48,34 @@ class SelfAndAncestorFilterLabelOrIdentifier extends AbstractFieldFilter
         }
 
         if (!$this->supportsOperator($operator)) {
-            throw InvalidOperatorException::notSupported($operator, SelfAndAncestorFilter::class);
+            throw InvalidOperatorException::notSupported($operator, SelfAndAncestorFilterLabelOrIdentifier::class);
         }
 
         $this->checkValue($value);
 
         $clauses[] = [
             'wildcard' => [
-                'ancestors.code' => sprintf('*%s*', $this->escapeValue($value)),
+                'ancestors.codes' => sprintf('*%s*', $this->escapeValue($value)),
+            ]
+        ];
+        $clauses[] = [
+            'wildcard' => [
+                'identifier' => sprintf('*%s*', $this->escapeValue($value)),
             ]
         ];
 
         if (null !== $channel && null !== $locale) {
             $clauses[] = [
                 'wildcard' => [
-                    sprintf('ancestors.label.%s.%s', $channel, $locale) => sprintf(
+                    sprintf('ancestors.labels.%s.%s', $channel, $locale) => sprintf(
+                        '*%s*',
+                        $this->escapeValue($value)
+                    ),
+                ]
+            ];
+            $clauses[] = [
+                'wildcard' => [
+                    sprintf('label.%s.%s', $channel, $locale) => sprintf(
                         '*%s*',
                         $this->escapeValue($value)
                     ),
@@ -80,7 +86,15 @@ class SelfAndAncestorFilterLabelOrIdentifier extends AbstractFieldFilter
         if (null !== $channel) {
             $clauses[] = [
                 'wildcard' => [
-                    sprintf('ancestors.label.%s.<all_locales>', $channel) => sprintf(
+                    sprintf('ancestors.labels.%s.<all_locales>', $channel) => sprintf(
+                        '*%s*',
+                        $this->escapeValue($value)
+                    ),
+                ]
+            ];
+            $clauses[] = [
+                'wildcard' => [
+                    sprintf('label.%s.<all_locales>', $channel) => sprintf(
                         '*%s*',
                         $this->escapeValue($value)
                     ),
@@ -91,7 +105,15 @@ class SelfAndAncestorFilterLabelOrIdentifier extends AbstractFieldFilter
         if (null !== $locale) {
             $clauses[] = [
                 'wildcard' => [
-                    sprintf('ancestors.label.<all_channels>.%s', $locale) => sprintf(
+                    sprintf('ancestors.labels.<all_channels>.%s', $locale) => sprintf(
+                        '*%s*',
+                        $this->escapeValue($value)
+                    ),
+                ]
+            ];
+            $clauses[] = [
+                'wildcard' => [
+                    sprintf('label.<all_channels>.%s', $locale) => sprintf(
                         '*%s*',
                         $this->escapeValue($value)
                     ),
@@ -101,7 +123,12 @@ class SelfAndAncestorFilterLabelOrIdentifier extends AbstractFieldFilter
 
         $clauses[] = [
             'wildcard' => [
-                'ancestors.label.<all_channels>.<all_locales>' => sprintf('*%s*', $this->escapeValue($value)),
+                'ancestors.labels.<all_channels>.<all_locales>' => sprintf('*%s*', $this->escapeValue($value)),
+            ]
+        ];
+        $clauses[] = [
+            'wildcard' => [
+                'label.<all_channels>.<all_locales>' => sprintf('*%s*', $this->escapeValue($value)),
             ]
         ];
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/query_builders.yml
@@ -406,6 +406,14 @@ services:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
 
+    pim_catalog.query.elasticsearch.filter.self_and_ancestor_label_or_identifier:
+        class: 'Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\SelfAndAncestorFilterLabelOrIdentifier'
+        arguments:
+            - ['self_and_ancestor.label_or_identifier']
+            - ['CONTAINS']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
+
     # Attributes filters
     pim_catalog.query.elasticsearch.filter.identifier_attribute:
         class: '%pim_catalog.query.elasticsearch.filter.identifier_attribute.class%'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_indexing.yml
@@ -146,6 +146,8 @@ services:
         class: '%pim_catalog.normalizer.indexing_product_and_product_model.product_model.properties.class%'
         arguments:
             - '@pim_catalog.doctrine.query.complete_filter'
+            - '@pim_catalog.repository.channel'
+            - '@pim_catalog.repository.locale'
         tags:
             - { name: pim_serializer.normalizer, priority: 40 }
 
@@ -159,7 +161,8 @@ services:
 
     pim_catalog.normalizer.indexing_product_and_product_model.product.properties:
         class: '%pim_catalog.normalizer.indexing_product_and_product_model.product.properties.class%'
+        arguments:
+            - '@pim_catalog.repository.channel'
+            - '@pim_catalog.repository.locale'
         tags:
             - { name: pim_serializer.normalizer, priority: 40 }
-
-

--- a/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/SelfAndAncestorFilterLabelOrIdentifierSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Elasticsearch/Filter/Field/SelfAndAncestorFilterLabelOrIdentifierSpec.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\AbstractFieldFilter;
+use Pim\Bundle\CatalogBundle\Elasticsearch\Filter\Field\SelfAndAncestorFilterLabelOrIdentifier;
+use Pim\Bundle\CatalogBundle\Elasticsearch\SearchQueryBuilder;
+use Pim\Component\Catalog\Exception\InvalidOperatorException;
+use Pim\Component\Catalog\Query\Filter\FieldFilterInterface;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+class SelfAndAncestorFilterLabelOrIdentifierSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $this->beConstructedWith(['self_and_ancestor.label_or_identifier'], ['CONTAINS']);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(SelfAndAncestorFilterLabelOrIdentifier::class);
+    }
+
+    function it_is_a_field_filter()
+    {
+        $this->shouldImplement(FieldFilterInterface::class);
+        $this->shouldBeAnInstanceOf(AbstractFieldFilter::class);
+    }
+
+    function it_supports_operator()
+    {
+        $this->getOperators()->shouldReturn(['CONTAINS']);
+        $this->supportsOperator('CONTAINS')->shouldReturn(true);
+        $this->supportsOperator('=')->shouldReturn(false);
+    }
+
+    function it_supports_field()
+    {
+        $this->supportsField('self_and_ancestor.label_or_identifier')->shouldReturn(true);
+        $this->supportsField('not_supported_field')->shouldReturn(false);
+    }
+
+    function it_adds_field_filter_on_value_localizable_and_scopable(SearchQueryBuilder $sqb)
+    {
+        $locale = 'en_US';
+        $channel = 'ecommerce';
+        $value = 'shoes';
+
+        $clauses = [
+            ['wildcard' => ['ancestors.codes' => sprintf('*%s*', $value)]],
+            ['wildcard' => ['identifier' => sprintf('*%s*', $value)]],
+            ['wildcard' => [sprintf('ancestors.labels.%s.%s', $channel, $locale) => sprintf('*%s*', $value)]],
+            ['wildcard' => [sprintf('label.%s.%s', $channel, $locale) => sprintf('*%s*', $value)]],
+            ['wildcard' => [sprintf('ancestors.labels.%s.<all_locales>', $channel) => sprintf('*%s*', $value)]],
+            ['wildcard' => [sprintf('label.%s.<all_locales>', $channel) => sprintf('*%s*', $value)]],
+            ['wildcard' => [sprintf('ancestors.labels.<all_channels>.%s', $locale) => sprintf('*%s*', $value)]],
+            ['wildcard' => [sprintf('label.<all_channels>.%s', $locale) => sprintf('*%s*', $value)]],
+            ['wildcard' => ['ancestors.labels.<all_channels>.<all_locales>' => sprintf('*%s*', $value)]],
+            ['wildcard' => ['label.<all_channels>.<all_locales>' => sprintf('*%s*', $value)]],
+        ];
+
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => $clauses,
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter(
+            'self_and_ancestors.label_or_identifier',
+            Operators::CONTAINS,
+            $value,
+            $locale,
+            $channel,
+            []
+        );
+    }
+
+    function it_adds_field_filter_on_value(SearchQueryBuilder $sqb)
+    {
+        $value = 'shoes';
+        $clauses = [
+            ['wildcard' => ['ancestors.codes' => sprintf('*%s*', $value)]],
+            ['wildcard' => ['identifier' => sprintf('*%s*', $value)]],
+            ['wildcard' => ['ancestors.labels.<all_channels>.<all_locales>' => sprintf('*%s*', $value)]],
+            ['wildcard' => ['label.<all_channels>.<all_locales>' => sprintf('*%s*', $value)]],
+        ];
+
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => $clauses,
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter(
+            'self_and_ancestors.label_or_identifier',
+            Operators::CONTAINS,
+            $value,
+            null,
+            null,
+            []
+        );
+    }
+
+    function it_adds_field_filter_on_value_localizable(SearchQueryBuilder $sqb)
+    {
+        $locale = 'en_US';
+        $value = 'shoes';
+
+        $clauses = [
+            ['wildcard' => ['ancestors.codes' => sprintf('*%s*', $value)]],
+            ['wildcard' => ['identifier' => sprintf('*%s*', $value)]],
+            ['wildcard' => [sprintf('ancestors.labels.<all_channels>.%s', $locale) => sprintf('*%s*', $value)]],
+            ['wildcard' => [sprintf('label.<all_channels>.%s', $locale) => sprintf('*%s*', $value)]],
+            ['wildcard' => ['ancestors.labels.<all_channels>.<all_locales>' => sprintf('*%s*', $value)]],
+            ['wildcard' => ['label.<all_channels>.<all_locales>' => sprintf('*%s*', $value)]],
+        ];
+
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => $clauses,
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter(
+            'self_and_ancestors.label_or_identifier',
+            Operators::CONTAINS,
+            $value,
+            $locale,
+            null,
+            []
+        );
+    }
+
+    function it_adds_field_filter_on_value_scopable(SearchQueryBuilder $sqb)
+    {
+        $channel = 'ecommerce';
+        $value = 'shoes';
+
+        $clauses = [
+            ['wildcard' => ['ancestors.codes' => sprintf('*%s*', $value)]],
+            ['wildcard' => ['identifier' => sprintf('*%s*', $value)]],
+            ['wildcard' => [sprintf('ancestors.labels.%s.<all_locales>', $channel) => sprintf('*%s*', $value)]],
+            ['wildcard' => [sprintf('label.%s.<all_locales>', $channel) => sprintf('*%s*', $value)]],
+            ['wildcard' => ['ancestors.labels.<all_channels>.<all_locales>' => sprintf('*%s*', $value)]],
+            ['wildcard' => ['label.<all_channels>.<all_locales>' => sprintf('*%s*', $value)]],
+        ];
+
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => $clauses,
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter(
+            'self_and_ancestors.label_or_identifier',
+            Operators::CONTAINS,
+            $value,
+            null,
+            $channel,
+            []
+        );
+    }
+
+    function it_throws_an_exception_when_the_search_query_builder_is_not_initialized()
+    {
+        $this->shouldThrow(
+            new \LogicException('The search query builder is not initialized in the filter.')
+        )->during(
+            'addFieldFilter',
+            [
+                'self_and_ancestors.label_or_identifier',
+                Operators::CONTAINS,
+                'shoes',
+                null,
+                null,
+                []
+            ]
+        );
+    }
+
+    function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
+        SearchQueryBuilder $sqb
+    ) {
+        $this->setQueryBuilder($sqb);
+        $this->shouldThrow(
+            InvalidOperatorException::notSupported(
+                'IN CHILDREN',
+                SelfAndAncestorFilterLabelOrIdentifier::class
+            )
+        )->during(
+            'addFieldFilter',
+            [
+                'self_and_ancestors.label_or_identifier',
+                Operators::IN_CHILDREN_LIST,
+                'shoes',
+                null,
+                null,
+                []
+            ]
+        );
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/SelfAndAncestorFilterLabelOrIdentifierIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/PQB/Filter/Field/SelfAndAncestorFilterLabelOrIdentifierIntegration.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\PQB\Filter\Field;
+
+use Pim\Bundle\CatalogBundle\tests\integration\PQB\AbstractProductAndProductModelQueryBuilderTestCase;
+use Pim\Component\Catalog\Query\Filter\Operators;
+
+/**
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SelfAndAncestorFilterLabelOrIdentifierIntegration extends AbstractProductAndProductModelQueryBuilderTestCase
+{
+    public function testQueryProductsContainingLabel()
+    {
+        $results = $this->executeFilter([['self_and_ancestor.label_or_identifier', Operators::CONTAINS, 'di']]);
+        $this->assert(
+            $results,
+            [
+                '1111111114',
+                '1111111115',
+                '1111111116',
+                '1111111117',
+                '1111111118',
+                '1111111205',
+                '1111111206',
+                '1111111207',
+                '1111111208',
+                '1111111209',
+                '1111111210',
+                '1111111211',
+                '1111111212',
+                '1111111213',
+                '1111111214',
+                '1111111215',
+                '1111111216',
+                'aphrodite',
+                'diana',
+                'diana_pink',
+                'diana_red',
+                'dionysos',
+                'model-tshirt-divided',
+                'model-tshirt-divided-battleship-grey',
+                'model-tshirt-divided-crimson-red',
+                'model-tshirt-divided-navy-blue',
+                'tshirt-divided-navy-blue-xxs',
+                'tshirt-divided-navy-blue-m',
+                'tshirt-divided-navy-blue-l',
+                'tshirt-divided-navy-blue-xxxl',
+                'tshirt-divided-crimson-red-xxs',
+                'tshirt-divided-crimson-red-m',
+                'tshirt-divided-crimson-red-l',
+                'tshirt-divided-crimson-red-xxxl',
+                'tshirt-divided-battleship-grey-xxs',
+                'tshirt-divided-battleship-grey-m',
+                'tshirt-divided-battleship-grey-l',
+                'tshirt-divided-battleship-grey-xxxl',
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredProductAndProductModelReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/FilteredProductAndProductModelReader.php
@@ -168,6 +168,10 @@ class FilteredProductAndProductModelReader implements
                     $filter['field'] = 'self_and_ancestor.id';
                 }
 
+                if ('label_or_identifier' === $filter['field']) {
+                    $filter['field'] = 'self_and_ancestor.label_or_identifier';
+                }
+
                 return $filter;
             }, $filters);
         }

--- a/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/ProductAndProductModelReader.php
+++ b/src/Pim/Bundle/EnrichBundle/Connector/Reader/MassEdit/ProductAndProductModelReader.php
@@ -164,6 +164,10 @@ class ProductAndProductModelReader implements
                     $filter['field'] = 'self_and_ancestor.id';
                 }
 
+                if ('label_or_identifier' === $filter['field']) {
+                    $filter['field'] = 'self_and_ancestor.label_or_identifier';
+                }
+
                 return $filter;
             }, $filters);
         }

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/CountImpactedProducts.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Query/CountImpactedProducts.php
@@ -147,6 +147,12 @@ class CountImpactedProducts
         $filters = $this->adaptGridCompletenessFilter($filters);
         $filters = $this->removeIdFilter($filters);
 
+        foreach ($filters as $index => $filter) {
+            if ('label_or_identifier' === $filter['field']) {
+                $filters[$index]['field'] = 'self_and_ancestor.label_or_identifier';
+            }
+        }
+
         $filters[] = ['field' => 'entity_type', 'operator' => '=', 'value' => ProductInterface::class];
 
         $pqb = $this->productAndProductModelQueryBuilderFactory->create(['filters' => $filters]);

--- a/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Pim/Bundle/EnrichBundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -132,6 +132,10 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
         $hasEntityTypeFilter = $this->hasRawFilter('field', 'entity_type');
         $hasAncestorsIdsFilter = $this->hasRawFilter('field', 'ancestor.id');
         $hasSelfAndAncestorsIdsFilter = $this->hasRawFilter('field', 'self_and_ancestor.id');
+        $hasSelfAndAncestorsLabelOrIdentifierFilter = $this->hasRawFilter(
+            'field',
+            'self_and_ancestor.label_or_identifier'
+        );
         $hasGroupsFilter = $this->hasRawFilter('field', 'groups');
         $hasCategoryFilter = $this->hasFilterOnCategoryWhichImplyAggregation();
 
@@ -142,6 +146,7 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
             !$hasEntityTypeFilter &&
             !$hasAncestorsIdsFilter &&
             !$hasSelfAndAncestorsIdsFilter &&
+            !$hasSelfAndAncestorsLabelOrIdentifierFilter &&
             !$hasGroupsFilter &&
             !$hasCategoryFilter;
     }

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/FilteredProductAndProductModelReaderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/FilteredProductAndProductModelReaderSpec.php
@@ -21,12 +21,25 @@ use Prophecy\Promise\ReturnPromise;
 
 class FilteredProductAndProductModelReaderSpec extends ObjectBehavior
 {
-    function it_is_initializable()
-    {
+    function it_is_initializable(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager,
+        MetricConverter $metricConverter
+    ) {
+        $this->beConstructedWith(
+            $pqbFactory,
+            $channelRepository,
+            $completenessManager,
+            $metricConverter,
+            true,
+            false
+        );
+
         $this->shouldHaveType(FilteredProductAndProductModelReader::class);
     }
 
-    function let(
+    function it_sets_step_execution(
         ProductQueryBuilderFactoryInterface $pqbFactory,
         ChannelRepositoryInterface $channelRepository,
         CompletenessManager $completenessManager,
@@ -42,21 +55,15 @@ class FilteredProductAndProductModelReaderSpec extends ObjectBehavior
             false
         );
 
-        $this->setStepExecution($stepExecution);
-    }
-
-    function it_set_step_execution(
-        $stepExecution
-    ) {
         $this->setStepExecution($stepExecution)->shouldReturn(null);
     }
 
     function it_reads_products_only_and_not_product_models(
-        $pqbFactory,
-        $channelRepository,
-        $metricConverter,
-        $stepExecution,
-        $completenessManager,
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager,
+        MetricConverter $metricConverter,
+        StepExecution $stepExecution,
         ChannelInterface $channel,
         ProductQueryBuilderInterface $pqb,
         CursorInterface $cursor,
@@ -68,23 +75,34 @@ class FilteredProductAndProductModelReaderSpec extends ObjectBehavior
         ProductInterface $product3,
         JobParameters $jobParameters
     ) {
+        $this->beConstructedWith(
+            $pqbFactory,
+            $channelRepository,
+            $completenessManager,
+            $metricConverter,
+            true,
+            false
+        );
+
+        $this->setStepExecution($stepExecution);
+
         $filters = [
-            'data'      => [
+            'data' => [
                 [
-                    'field'    => 'enabled',
+                    'field' => 'enabled',
                     'operator' => '=',
-                    'value'    => true,
+                    'value' => true,
                 ],
                 [
-                    'field'    => 'family',
+                    'field' => 'family',
                     'operator' => 'IN',
-                    'value'    => [
+                    'value' => [
                         'camcorder',
                     ],
                 ],
             ],
             'structure' => [
-                'scope'   => 'mobile',
+                'scope' => 'mobile',
                 'locales' => ['fr_FR', 'en_US'],
             ],
         ];
@@ -120,6 +138,104 @@ class FilteredProductAndProductModelReaderSpec extends ObjectBehavior
         $productModel3->getCode()->willReturn('product_model_3');
         $stepExecution->addWarning('This bulk action doesn\'t support Product models entities yet.', Argument::cetera())
             ->shouldBeCalledTimes(3);
+
+        $this->initialize();
+        $this->read()->shouldReturn($product1);
+        $this->read()->shouldReturn($product2);
+        $this->read()->shouldReturn($product3);
+        $this->read()->shouldReturn(null);
+    }
+
+    function it_reads_products_only_and_not_product_models_with_children(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager,
+        MetricConverter $metricConverter,
+        StepExecution $stepExecution,
+        ChannelInterface $channel,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $cursor,
+        ProductModelInterface $productModel1,
+        ProductModelInterface $productModel2,
+        ProductModelInterface $productModel3,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3,
+        JobParameters $jobParameters
+    ) {
+        $this->beConstructedWith(
+            $pqbFactory,
+            $channelRepository,
+            $completenessManager,
+            $metricConverter,
+            true,
+            true
+        );
+
+        $this->setStepExecution($stepExecution);
+
+        $filters = [
+            'data' => [
+                [
+                    'field' => 'id',
+                    'operator' => 'NOT IN',
+                    'value' => [1, 2, 3, 4, 42],
+                ],
+                [
+                    'field' => 'label_or_identifier',
+                    'operator' => 'CONTAINS',
+                    'value' => 'something',
+                ],
+            ],
+            'structure' => [
+                'scope' => 'mobile',
+                'locales' => ['fr_FR', 'en_US'],
+            ],
+        ];
+        $readChildrenFiltersData = [
+            [
+                'field' => 'self_and_ancestor.id',
+                'operator' => 'NOT IN',
+                'value' => [1, 2, 3, 4, 42],
+            ],
+            [
+                'field' => 'self_and_ancestor.label_or_identifier',
+                'operator' => 'CONTAINS',
+                'value' => 'something',
+            ],
+        ];
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filters')->willReturn($filters);
+
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getCode()->willReturn('mobile');
+
+        $pqbFactory->create(['filters' => $readChildrenFiltersData, 'default_scope' => 'mobile'])
+            ->shouldBeCalled()
+            ->willReturn($pqb);
+        $pqb->execute()
+            ->shouldBeCalled()
+            ->willReturn($cursor);
+
+        $completenessManager->generateMissingForChannel($channel)->shouldBeCalled();
+        $products = [$productModel1, $product1, $productModel2, $product2, $product3, $productModel3];
+        $productsCount = count($products);
+        $cursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $cursor->current()->will(new ReturnPromise($products));
+        $cursor->next()->shouldBeCalledTimes(5);
+
+        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(3);
+        $metricConverter->convert(Argument::any(), $channel)->shouldBeCalledTimes(3);
+
+        $productModel1->getCode()->willReturn('product_model_1');
+        $productModel2->getCode()->willReturn('product_model_2');
+        $productModel3->getCode()->willReturn('product_model_3');
+        $stepExecution->addWarning(Argument::cetera())->shouldNotBeCalled();
 
         $this->initialize();
         $this->read()->shouldReturn($product1);

--- a/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/ProductAndProductModelReaderSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Connector/Reader/MassEdit/ProductAndProductModelReaderSpec.php
@@ -18,12 +18,22 @@ use Prophecy\Promise\ReturnPromise;
 
 class ProductAndProductModelReaderSpec extends ObjectBehavior
 {
-    function it_is_initializable()
-    {
+    function it_is_initializable(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager
+    ) {
+        $this->beConstructedWith(
+            $pqbFactory,
+            $channelRepository,
+            $completenessManager,
+            true
+        );
+
         $this->shouldHaveType(ProductAndProductModelReader::class);
     }
 
-    function let(
+    function it_sets_step_execution(
         ProductQueryBuilderFactoryInterface $pqbFactory,
         ChannelRepositoryInterface $channelRepository,
         CompletenessManager $completenessManager,
@@ -36,20 +46,14 @@ class ProductAndProductModelReaderSpec extends ObjectBehavior
             true
         );
 
-        $this->setStepExecution($stepExecution);
-    }
-
-    function it_set_step_execution(
-        $stepExecution
-    ) {
         $this->setStepExecution($stepExecution)->shouldReturn(null);
     }
 
     function it_reads_products_and_product_models(
-        $pqbFactory,
-        $channelRepository,
-        $stepExecution,
-        $completenessManager,
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager,
+        StepExecution $stepExecution,
         ChannelInterface $channel,
         ProductQueryBuilderInterface $pqb,
         CursorInterface $cursor,
@@ -61,23 +65,31 @@ class ProductAndProductModelReaderSpec extends ObjectBehavior
         ProductInterface $product3,
         JobParameters $jobParameters
     ) {
+        $this->beConstructedWith(
+            $pqbFactory,
+            $channelRepository,
+            $completenessManager,
+            false
+        );
+
+        $this->setStepExecution($stepExecution);
         $filters = [
-            'data'      => [
+            'data' => [
                 [
-                    'field'    => 'enabled',
+                    'field' => 'enabled',
                     'operator' => '=',
-                    'value'    => true,
+                    'value' => true,
                 ],
                 [
-                    'field'    => 'family',
+                    'field' => 'family',
                     'operator' => 'IN',
-                    'value'    => [
+                    'value' => [
                         'camcorder',
                     ],
                 ],
             ],
             'structure' => [
-                'scope'   => 'mobile',
+                'scope' => 'mobile',
                 'locales' => ['fr_FR', 'en_US'],
             ],
         ];
@@ -88,6 +100,102 @@ class ProductAndProductModelReaderSpec extends ObjectBehavior
         $channel->getCode()->willReturn('mobile');
 
         $pqbFactory->create(['filters' => $filters['data'], 'default_scope' => 'mobile'])
+            ->shouldBeCalled()
+            ->willReturn($pqb);
+        $pqb->execute()
+            ->shouldBeCalled()
+            ->willReturn($cursor);
+
+        $completenessManager->generateMissingForChannel($channel)->shouldBeCalled();
+        $products = [$productModel1, $product1, $productModel2, $product2, $product3, $productModel3];
+        $productsCount = count($products);
+        $cursor->valid()->will(
+            function () use (&$productsCount) {
+                return $productsCount-- > 0;
+            }
+        );
+        $cursor->current()->will(new ReturnPromise($products));
+        $cursor->next()->shouldBeCalledTimes(5);
+
+        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(6);
+
+        $productModel1->getCode()->willReturn('product_model_1');
+        $productModel2->getCode()->willReturn('product_model_2');
+        $productModel3->getCode()->willReturn('product_model_3');
+
+        $this->initialize();
+        $this->read()->shouldReturn($productModel1);
+        $this->read()->shouldReturn($product1);
+        $this->read()->shouldReturn($productModel2);
+        $this->read()->shouldReturn($product2);
+        $this->read()->shouldReturn($product3);
+        $this->read()->shouldReturn($productModel3);
+        $this->read()->shouldReturn(null);
+    }
+
+    function it_reads_products_and_product_models_with_read_children(
+        ProductQueryBuilderFactoryInterface $pqbFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CompletenessManager $completenessManager,
+        StepExecution $stepExecution,
+        ChannelInterface $channel,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $cursor,
+        ProductModelInterface $productModel1,
+        ProductModelInterface $productModel2,
+        ProductModelInterface $productModel3,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3,
+        JobParameters $jobParameters
+    ) {
+        $this->beConstructedWith(
+            $pqbFactory,
+            $channelRepository,
+            $completenessManager,
+            true
+        );
+
+        $this->setStepExecution($stepExecution);
+
+        $filters = [
+            'data' => [
+                [
+                    'field' => 'id',
+                    'operator' => 'NOT IN',
+                    'value' => [1, 2, 3, 4, 42],
+                ],
+                [
+                    'field' => 'label_or_identifier',
+                    'operator' => 'CONTAINS',
+                    'value' => 'something',
+                ],
+            ],
+            'structure' => [
+                'scope' => 'mobile',
+                'locales' => ['fr_FR', 'en_US'],
+            ],
+        ];
+        $readChildrenFiltersData = [
+            [
+                'field' => 'self_and_ancestor.id',
+                'operator' => 'NOT IN',
+                'value' => [1, 2, 3, 4, 42],
+            ],
+            [
+                'field' => 'self_and_ancestor.label_or_identifier',
+                'operator' => 'CONTAINS',
+                'value' => 'something',
+            ],
+        ];
+
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('filters')->willReturn($filters);
+
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
+        $channel->getCode()->willReturn('mobile');
+
+        $pqbFactory->create(['filters' => $readChildrenFiltersData, 'default_scope' => 'mobile'])
             ->shouldBeCalled()
             ->willReturn($pqb);
         $pqb->execute()

--- a/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Query/CountImpactedProductsSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Doctrine/ORM/Query/CountImpactedProductsSpec.php
@@ -9,7 +9,6 @@ use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Query\Filter\Operators;
 use Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface;
 use Pim\Component\Catalog\Query\ProductQueryBuilderInterface;
-use Prophecy\Argument;
 
 class CountImpactedProductsSpec extends ObjectBehavior
 {
@@ -34,6 +33,28 @@ class CountImpactedProductsSpec extends ObjectBehavior
         $pqbFilters = [];
 
         $productAndProductModelQueryBuilderFactory->create(['filters' => [
+            ['field' => 'entity_type', 'operator' => "=", 'value' => ProductInterface::class]
+        ]])->willReturn($pqb);
+        $pqb->execute()->willReturn($countable);
+        $countable->count()->willReturn(2500);
+
+        $productQueryBuilderFactory->create()->shouldNotBeCalled();
+
+        $this->count($pqbFilters)->shouldReturn(2500);
+    }
+
+    function it_returns_the_catalog_products_count_when_a_user_selects_all_products_in_the_grid_with_a_label_search(
+        $productAndProductModelQueryBuilderFactory,
+        $productQueryBuilderFactory,
+        ProductQueryBuilderInterface $pqb,
+        \Countable $countable
+    ) {
+        $pqbFilters = [
+            ['field' => 'label_or_identifier', 'operator' => 'CONTAINS', 'value' => 'something']
+        ];
+
+        $productAndProductModelQueryBuilderFactory->create(['filters' => [
+            ['field' => 'self_and_ancestor.label_or_identifier', 'operator' => 'CONTAINS', 'value' => 'something'],
             ['field' => 'entity_type', 'operator' => "=", 'value' => ProductInterface::class]
         ]])->willReturn($pqb);
         $pqb->execute()->willReturn($countable);

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/Doctrine/ORM/Query/CountImpactedProductsIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/Doctrine/ORM/Query/CountImpactedProductsIntegration.php
@@ -72,6 +72,14 @@ class CountImpactedProductsIntegration extends TestCase
         $this->assertProductsCountInSelection($pqbFilters, 242);
     }
 
+    public function testUserSelectedAllEntitiesAndFilteredByLabel()
+    {
+        $pqbFilters = [
+            ['field' => 'label_or_identifier', 'operator' => 'CONTAINS', 'value' => 'di', 'type' => 'field']
+        ];
+        $this->assertProductsCountInSelection($pqbFilters, 29);
+    }
+
     public function testUserSelectedAllEntitiesAndUnselectsProducts()
     {
         $pqbFilters = [

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -142,7 +142,6 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
         return $date;
     }
 
-
     /**
      * @param ProductInterface $product
      *
@@ -152,14 +151,18 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
     {
         $ancestorsIds = [];
         $ancestorsCodes = [];
+        $ancestorsLabels = [];
+
         if ($product->isVariant()) {
             $ancestorsIds = $this->getAncestorsIds($product);
             $ancestorsCodes = $this->getAncestorsCodes($product);
+            $ancestorsLabels = $this->getAncestorsLabels($product);
         }
 
         $ancestors = [
-            'ids'   => $ancestorsIds,
+            'ids' => $ancestorsIds,
             'codes' => $ancestorsCodes,
+            'labels' => $ancestorsLabels,
         ];
 
         return $ancestors;
@@ -195,5 +198,35 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
         }
 
         return $ancestorsCodes;
+    }
+
+    /**
+     * @param EntityWithFamilyVariantInterface $entityWithFamilyVariant
+     *
+     * @return array
+     */
+    private function getAncestorsLabels(EntityWithFamilyVariantInterface $entityWithFamilyVariant): array
+    {
+        $ancestorsLabels = [];
+        while (null !== $parent = $entityWithFamilyVariant->getParent()) {
+            $attributeAsLabel = $parent->getFamily()->getAttributeAsLabel();
+            if (null === $attributeAsLabel) {
+                return [];
+            }
+
+            $values = $parent->getValuesForVariation();
+
+            // $ancestorsLabels[] = get all the labels for all locales... from the values;
+
+            // We will need to inject the locale repository to have the activated locales.
+            // Same new indexed values to do in the 3 other properties normalizers:
+            // - src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
+            // - src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
+            // - src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizer.php
+
+            $entityWithFamilyVariant = $parent;
+        }
+
+        return $ancestorsLabels;
     }
 }

--- a/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Indexing/Product/PropertiesNormalizer.php
@@ -151,18 +151,14 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
     {
         $ancestorsIds = [];
         $ancestorsCodes = [];
-        $ancestorsLabels = [];
-
         if ($product->isVariant()) {
             $ancestorsIds = $this->getAncestorsIds($product);
             $ancestorsCodes = $this->getAncestorsCodes($product);
-            $ancestorsLabels = $this->getAncestorsLabels($product);
         }
 
         $ancestors = [
             'ids' => $ancestorsIds,
             'codes' => $ancestorsCodes,
-            'labels' => $ancestorsLabels,
         ];
 
         return $ancestors;
@@ -198,35 +194,5 @@ class PropertiesNormalizer implements NormalizerInterface, SerializerAwareInterf
         }
 
         return $ancestorsCodes;
-    }
-
-    /**
-     * @param EntityWithFamilyVariantInterface $entityWithFamilyVariant
-     *
-     * @return array
-     */
-    private function getAncestorsLabels(EntityWithFamilyVariantInterface $entityWithFamilyVariant): array
-    {
-        $ancestorsLabels = [];
-        while (null !== $parent = $entityWithFamilyVariant->getParent()) {
-            $attributeAsLabel = $parent->getFamily()->getAttributeAsLabel();
-            if (null === $attributeAsLabel) {
-                return [];
-            }
-
-            $values = $parent->getValuesForVariation();
-
-            // $ancestorsLabels[] = get all the labels for all locales... from the values;
-
-            // We will need to inject the locale repository to have the activated locales.
-            // Same new indexed values to do in the 3 other properties normalizers:
-            // - src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizer.php
-            // - src/Pim/Component/Catalog/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
-            // - src/Pim/Component/Catalog/Normalizer/Indexing/ProductModel/ProductModelPropertiesNormalizer.php
-
-            $entityWithFamilyVariant = $parent;
-        }
-
-        return $ancestorsLabels;
     }
 }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductModelPropertiesNormalizerSpec.php
@@ -8,10 +8,13 @@ use Pim\Component\Catalog\Model\FamilyInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
 use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelPropertiesNormalizer;
 use Pim\Component\Catalog\ProductAndProductModel\Query\CompleteFilterData;
 use Pim\Component\Catalog\ProductAndProductModel\Query\CompleteFilterInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -20,9 +23,11 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
     function let(
         SerializerInterface $serializer,
         CompleteFilterInterface $completenessGridFilter,
-        CompleteFilterData $completenessGridFilterData
+        CompleteFilterData $completenessGridFilterData,
+        ChannelRepositoryInterface $channelRepository,
+        LocaleRepositoryInterface $localeRepository
     ) {
-        $this->beConstructedWith($completenessGridFilter);
+        $this->beConstructedWith($completenessGridFilter, $channelRepository, $localeRepository);
 
         $completenessGridFilterData->allIncomplete()->willReturn([
             'ecommerce' => [
@@ -45,7 +50,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $this->shouldHaveType(ProductModelPropertiesNormalizer::class);
     }
 
-    function it_support_product_models(
+    function it_supports_product_models(
         ProductModelInterface $productModel
     ) {
         $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
@@ -73,8 +78,11 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $productModel->getCode()->willReturn('sku-001');
         $productModel->getFamily()->willReturn($family);
+        $productModel->getValue('sku')->willReturn(null);
         $family->getAttributeAsLabel()->willReturn($sku);
         $sku->getCode()->willReturn('sku');
+        $sku->isScopable()->willReturn(false);
+        $sku->isLocalizable()->willReturn(false);
         $productModel->getCreated()->willReturn($now);
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
@@ -105,17 +113,17 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn(
             [
-                'id'                      => 'product_model_67',
-                'identifier'              => 'sku-001',
-                'created'                 => $now->format('c'),
-                'updated'                 => $now->format('c'),
-                'family'                  => 'family_A',
-                'family_variant'          => 'family_variant_1',
-                'categories'              => ['category_A', 'category_B'],
+                'id' => 'product_model_67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => 'family_A',
+                'family_variant' => 'family_variant_1',
+                'categories' => ['category_A', 'category_B'],
                 'categories_of_ancestors' => [],
-                'parent'         => null,
-                'values'         => [],
-                'all_complete'   => [
+                'parent' => null,
+                'values' => [],
+                'all_complete' => [
                     'ecommerce' => [
                         'fr_FR' => 0,
                     ],
@@ -125,11 +133,12 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                         'fr_FR' => 0,
                     ],
                 ],
-                'ancestors'      => [
-                    'ids'   => [],
+                'ancestors' => [
+                    'ids' => [],
                     'codes' => [],
+                    'labels' => [],
                 ],
-                'label'          => [],
+                'label' => [],
             ]
         );
     }
@@ -149,8 +158,11 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $productModel->getId()->willReturn(67);
         $productModel->getCode()->willReturn('sku-001');
         $productModel->getFamily()->willReturn($family);
+        $productModel->getValue('sku')->willReturn(null);
         $family->getAttributeAsLabel()->willReturn($sku);
         $sku->getCode()->willReturn('sku');
+        $sku->isScopable()->willReturn(false);
+        $sku->isLocalizable()->willReturn(false);
 
         $productModel->getParent()->willReturn(null);
 
@@ -200,57 +212,64 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn(
             [
-                'id'                      => 'product_model_67',
-                'identifier'              => 'sku-001',
-                'created'                 => $now->format('c'),
-                'updated'                 => $now->format('c'),
-                'family'                  => [
-                    'code'   => 'family',
+                'id' => 'product_model_67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => [
+                    'code' => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
-                'family_variant'          => 'family_variant_B',
-                'categories'              => ['category_A', 'category_B'],
+                'family_variant' => 'family_variant_B',
+                'categories' => ['category_A', 'category_B'],
                 'categories_of_ancestors' => [],
-                'parent'                  => null,
-                'values'                  => [
+                'parent' => null,
+                'values' => [
                     'a_size-decimal' => [
                         '<all_channels>' => [
                             '<all_locales>' => '10.51',
                         ],
                     ],
                 ],
-                'all_complete'            => [
+                'all_complete' => [
                     'ecommerce' => [
                         'fr_FR' => 0,
                     ],
                 ],
-                'all_incomplete'          => [
+                'all_incomplete' => [
                     'ecommerce' => [
                         'fr_FR' => 0,
                     ],
                 ],
-                'ancestors'               => [
-                    'ids'   => [],
+                'ancestors' => [
+                    'ids' => [],
                     'codes' => [],
+                    'labels' => [],
                 ],
-                'label'                   => [],
+                'label' => [],
             ]
         );
     }
 
-    function it_normalizes_a_product_model_fields_and_values_with_its_parents_values(
+    function it_normalizes_a_product_model_fields_and_values_with_its_parents_values_and_a_localizable_scopable_label(
         $serializer,
         $completenessGridFilter,
         $completenessGridFilterData,
+        $localeRepository,
+        $channelRepository,
         ProductModelInterface $productModel,
         ProductModelInterface $parent,
         ValueCollectionInterface $valueCollection,
         FamilyInterface $family,
         AttributeInterface $sku,
-        FamilyVariantInterface $familyVariant
+        FamilyVariantInterface $familyVariant,
+        ValueInterface $frEcomSku,
+        ValueInterface $frPrintSku,
+        ValueInterface $enEcomSku,
+        ValueInterface $enPrintSku
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
@@ -259,6 +278,8 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $productModel->getFamily()->willReturn($family);
         $family->getAttributeAsLabel()->willReturn($sku);
         $sku->getCode()->willReturn('sku');
+        $sku->isScopable()->willReturn(true);
+        $sku->isLocalizable()->willReturn(true);
 
         $productModel->getParent()->willReturn($parent);
         $parent->getCode()->willReturn('parent_A');
@@ -284,7 +305,7 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn([
-                'code'   => 'family',
+                'code' => 'family',
                 'labels' => [
                     'fr_FR' => 'Une famille',
                     'en_US' => 'A family',
@@ -299,12 +320,12 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
         $serializer->normalize($valueCollection, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX, [])
             ->willReturn(
                 [
-                    'a_size-decimal'         => [
+                    'a_size-decimal' => [
                         '<all_channels>' => [
                             '<all_locales>' => '10.51',
                         ],
                     ],
-                    'a_date-date'            => [
+                    'a_date-date' => [
                         '<all_channels>' => [
                             '<all_locales>' => '2017-05-05',
                         ],
@@ -319,30 +340,45 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
 
         $completenessGridFilter->findCompleteFilterData($productModel)->willReturn($completenessGridFilterData);
 
+        $localeRepository->getActivatedLocaleCodes()->willReturn(['fr_FR', 'en_US']);
+        $channelRepository->getChannelCodes()->willReturn(['ecommerce', 'print']);
+
+        $productModel->getValue('sku', 'fr_FR', 'ecommerce')->willReturn($frEcomSku);
+        $frEcomSku->getData()->willReturn('Un sku FR ecommerce');
+
+        $productModel->getValue('sku', 'fr_FR', 'print')->willReturn($frPrintSku);
+        $frPrintSku->getData()->willReturn('Un sku FR print');
+
+        $productModel->getValue('sku', 'en_US', 'ecommerce')->willReturn($enEcomSku);
+        $enEcomSku->getData()->willReturn('Sku EN ecommerce');
+
+        $productModel->getValue('sku', 'en_US', 'print')->willReturn($enPrintSku);
+        $enPrintSku->getData()->willReturn('Sku EN print');
+
         $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn(
             [
-                'id'             => 'product_model_67',
-                'identifier'     => 'sku-001',
-                'created'        => $now->format('c'),
-                'updated'        => $now->format('c'),
-                'family'         => [
-                    'code'   => 'family',
+                'id' => 'product_model_67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => [
+                    'code' => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
                 'family_variant' => 'family_variant_B',
-                'categories'     => ['category_A', 'category_B'],
+                'categories' => ['category_A', 'category_B'],
                 'categories_of_ancestors' => ['category_A'],
-                'parent'         => 'parent_A',
-                'values'         => [
-                    'a_size-decimal'         => [
+                'parent' => 'parent_A',
+                'values' => [
+                    'a_size-decimal' => [
                         '<all_channels>' => [
                             '<all_locales>' => '10.51',
                         ],
                     ],
-                    'a_date-date'            => [
+                    'a_date-date' => [
                         '<all_channels>' => [
                             '<all_locales>' => '2017-05-05',
                         ],
@@ -366,6 +402,244 @@ class ProductModelPropertiesNormalizerSpec extends ObjectBehavior
                 'ancestors' => [
                     'ids' => ['product_model_1'],
                     'codes' => ['parent_A'],
+                    'labels' => [
+                        'ecommerce' => [
+                            'fr_FR' => 'Un sku FR ecommerce',
+                            'en_US' => 'Sku EN ecommerce',
+                        ],
+                        'print' => [
+                            'fr_FR' => 'Un sku FR print',
+                            'en_US' => 'Sku EN print',
+                        ]
+                    ],
+                ],
+                'label' => []
+            ]
+        );
+    }
+
+    function it_normalizes_a_product_model_fields_and_values_with_its_parents_values_and_a_localizable_label(
+        $serializer,
+        $completenessGridFilter,
+        $completenessGridFilterData,
+        $localeRepository,
+        ProductModelInterface $productModel,
+        ProductModelInterface $parent,
+        ValueCollectionInterface $valueCollection,
+        FamilyInterface $family,
+        AttributeInterface $sku,
+        FamilyVariantInterface $familyVariant,
+        ValueInterface $frSku,
+        ValueInterface $enSku
+    ) {
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $productModel->getId()->willReturn(67);
+        $productModel->getCode()->willReturn('sku-001');
+        $productModel->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
+        $sku->isScopable()->willReturn(false);
+        $sku->isLocalizable()->willReturn(true);
+
+        $productModel->getParent()->willReturn($parent);
+        $parent->getCode()->willReturn('parent_A');
+        $parent->getId()->willReturn(1);
+        $parent->getParent()->willReturn(null);
+        $parent->getCategoryCodes()->willReturn(['category_A']);
+
+        $productModel->getCreated()->willReturn($now);
+        $serializer->normalize(
+            $productModel->getWrappedObject()->getCreated(),
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+        )->willReturn($now->format('c'));
+
+        $productModel->getUpdated()->willReturn($now);
+        $serializer->normalize(
+            $productModel->getWrappedObject()->getUpdated(),
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+        )->willReturn($now->format('c'));
+
+        $familyVariant->getCode()->willReturn('family_variant_B');
+        $familyVariant->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $serializer
+            ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn([
+                'code' => 'family',
+                'labels' => [
+                    'fr_FR' => 'Une famille',
+                    'en_US' => 'A family',
+                ],
+            ]);
+
+        $productModel->getValues()->willReturn($valueCollection);
+        $valueCollection->isEmpty()->willReturn(true);
+
+        $productModel->getCategoryCodes()->willReturn(['category_A', 'category_B']);
+
+        $completenessGridFilter->findCompleteFilterData($productModel)->willReturn($completenessGridFilterData);
+
+        $localeRepository->getActivatedLocaleCodes()->willReturn(['fr_FR', 'en_US']);
+
+        $productModel->getValue('sku', 'fr_FR')->willReturn($frSku);
+        $frSku->getData()->willReturn('fr_FR SKU');
+
+        $productModel->getValue('sku', 'en_US')->willReturn($enSku);
+        $enSku->getData()->willReturn('en_US SKU');
+
+        $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn(
+            [
+                'id' => 'product_model_67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => [
+                    'code' => 'family',
+                    'labels' => [
+                        'fr_FR' => 'Une famille',
+                        'en_US' => 'A family',
+                    ],
+                ],
+                'family_variant' => 'family_variant_B',
+                'categories' => ['category_A', 'category_B'],
+                'categories_of_ancestors' => ['category_A'],
+                'parent' => 'parent_A',
+                'values' => [],
+                'all_complete' => [
+                    'ecommerce' => [
+                        'fr_FR' => 0
+                    ]
+                ],
+                'all_incomplete' => [
+                    'ecommerce' => [
+                        'fr_FR' => 0
+                    ]
+                ],
+                'ancestors' => [
+                    'ids' => ['product_model_1'],
+                    'codes' => ['parent_A'],
+                    'labels' => [
+                        '<all_channels>' => [
+                            'fr_FR' => 'fr_FR SKU',
+                            'en_US' => 'en_US SKU',
+                        ],
+                    ],
+                ],
+                'label' => []
+            ]
+        );
+    }
+
+    function it_normalizes_a_product_model_fields_and_values_with_its_parents_values_and_a_scopable_label(
+        $serializer,
+        $completenessGridFilter,
+        $completenessGridFilterData,
+        $channelRepository,
+        ProductModelInterface $productModel,
+        ProductModelInterface $parent,
+        ValueCollectionInterface $valueCollection,
+        FamilyInterface $family,
+        AttributeInterface $sku,
+        FamilyVariantInterface $familyVariant,
+        ValueInterface $ecommerceSku,
+        ValueInterface $printSku
+    ) {
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $productModel->getId()->willReturn(67);
+        $productModel->getCode()->willReturn('sku-001');
+        $productModel->getFamily()->willReturn($family);
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
+        $sku->isScopable()->willReturn(true);
+        $sku->isLocalizable()->willReturn(false);
+
+        $productModel->getParent()->willReturn($parent);
+        $parent->getCode()->willReturn('parent_A');
+        $parent->getId()->willReturn(1);
+        $parent->getParent()->willReturn(null);
+        $parent->getCategoryCodes()->willReturn(['category_A']);
+
+        $productModel->getCreated()->willReturn($now);
+        $serializer->normalize(
+            $productModel->getWrappedObject()->getCreated(),
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+        )->willReturn($now->format('c'));
+
+        $productModel->getUpdated()->willReturn($now);
+        $serializer->normalize(
+            $productModel->getWrappedObject()->getUpdated(),
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+        )->willReturn($now->format('c'));
+
+        $familyVariant->getCode()->willReturn('family_variant_B');
+        $familyVariant->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $serializer
+            ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn([
+                'code' => 'family',
+                'labels' => [
+                    'fr_FR' => 'Une famille',
+                    'en_US' => 'A family',
+                ],
+            ]);
+
+        $productModel->getValues()->willReturn($valueCollection);
+        $valueCollection->isEmpty()->willReturn(true);
+
+        $productModel->getCategoryCodes()->willReturn(['category_A', 'category_B']);
+
+        $completenessGridFilter->findCompleteFilterData($productModel)->willReturn($completenessGridFilterData);
+
+        $channelRepository->getChannelCodes()->willReturn(['ecommerce', 'print']);
+
+        $productModel->getValue('sku', null, 'ecommerce')->willReturn($ecommerceSku);
+        $ecommerceSku->getData()->willReturn('ecommerce SKU');
+
+        $productModel->getValue('sku', null, 'print')->willReturn($printSku);
+        $printSku->getData()->willReturn('print SKU');
+
+        $this->normalize($productModel, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn(
+            [
+                'id' => 'product_model_67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => [
+                    'code' => 'family',
+                    'labels' => [
+                        'fr_FR' => 'Une famille',
+                        'en_US' => 'A family',
+                    ],
+                ],
+                'family_variant' => 'family_variant_B',
+                'categories' => ['category_A', 'category_B'],
+                'categories_of_ancestors' => ['category_A'],
+                'parent' => 'parent_A',
+                'values' => [],
+                'all_complete' => [
+                    'ecommerce' => [
+                        'fr_FR' => 0
+                    ]
+                ],
+                'all_incomplete' => [
+                    'ecommerce' => [
+                        'fr_FR' => 0
+                    ]
+                ],
+                'ancestors' => [
+                    'ids' => ['product_model_1'],
+                    'codes' => ['parent_A'],
+                    'labels' => [
+                        'ecommerce' => [
+                            '<all_locales>' => 'ecommerce SKU',
+                        ],
+                        'print' => [
+                            '<all_locales>' => 'print SKU',
+                        ]
+                    ],
                 ],
                 'label' => []
             ]

--- a/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizerSpec.php
@@ -10,15 +10,23 @@ use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueCollectionInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
 use Pim\Component\Catalog\Normalizer\Indexing\ProductAndProductModel\ProductPropertiesNormalizer;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class ProductPropertiesNormalizerSpec extends ObjectBehavior
 {
-    function let(SerializerInterface $serializer)
-    {
+    function let(
+        SerializerInterface $serializer,
+        ChannelRepositoryInterface $channelRepository,
+        LocaleRepositoryInterface $localeRepository
+    ) {
+        $this->beConstructedWith($channelRepository, $localeRepository);
+
         $serializer->implement(NormalizerInterface::class);
         $this->setSerializer($serializer);
     }
@@ -83,29 +91,33 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         $product->getCompletenesses()->willReturn($completenesses);
         $completenesses->isEmpty()->willReturn(false);
 
-        $serializer->normalize($completenesses, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX,
-            [])->willReturn(['the completenesses']);
+        $serializer->normalize(
+            $completenesses,
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX,
+            []
+        )->willReturn(['the completenesses']);
 
         $this->normalize($product, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn(
             [
-                'id'                      => 'product_67',
-                'identifier'              => 'sku-001',
-                'created'                 => $now->format('c'),
-                'updated'                 => $now->format('c'),
-                'family'                  => null,
-                'enabled'                 => false,
-                'categories'              => [],
+                'id' => 'product_67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => null,
+                'enabled' => false,
+                'categories' => [],
                 'categories_of_ancestors' => [],
-                'groups'                  => [],
-                'completeness'            => ['the completenesses'],
-                'family_variant'          => null,
-                'parent'                  => null,
-                'values'                  => [],
-                'ancestors'               => [
-                    'ids'   => [],
+                'groups' => [],
+                'completeness' => ['the completenesses'],
+                'family_variant' => null,
+                'parent' => null,
+                'values' => [],
+                'ancestors' => [
+                    'ids' => [],
                     'codes' => [],
+                    'labels' => [],
                 ],
-                'label'                   => [],
+                'label' => [],
             ]
         );
     }
@@ -188,60 +200,68 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $this->normalize($product, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn(
             [
-                'id'                      => 'product_67',
-                'identifier'              => 'sku-001',
-                'created'                 => $now->format('c'),
-                'updated'                 => $now->format('c'),
-                'family'                  => [
-                    'code'   => 'family',
+                'id' => 'product_67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => [
+                    'code' => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
-                'enabled'                 => true,
-                'categories'              => ['first_category', 'second_category'],
+                'enabled' => true,
+                'categories' => ['first_category', 'second_category'],
                 'categories_of_ancestors' => [],
-                'groups'                  => ['first_group', 'second_group', 'another_group'],
-                'in_group'                => [
-                    'first_group'   => true,
-                    'second_group'  => true,
+                'groups' => ['first_group', 'second_group', 'another_group'],
+                'in_group' => [
+                    'first_group' => true,
+                    'second_group' => true,
                     'another_group' => true,
                 ],
-                'completeness'            => [
+                'completeness' => [
                     'ecommerce' => [
                         'en_US' => [
                             66,
                         ],
                     ],
                 ],
-                'family_variant'          => null,
-                'parent'                  => null,
-                'values'                  => [
+                'family_variant' => null,
+                'parent' => null,
+                'values' => [
                     'a_size-decimal' => [
                         '<all_channels>' => [
                             '<all_locales>' => '10.51',
                         ],
                     ],
                 ],
-                'ancestors'               => [
-                    'ids'   => [],
+                'ancestors' => [
+                    'ids' => [],
                     'codes' => [],
+                    'labels' => [],
                 ],
-                'label'                   => [],
+                'label' => [],
             ]
         );
     }
 
     function it_normalizes_variant_product_properties_with_fields_and_values(
         $serializer,
+        $localeRepository,
+        $channelRepository,
+        AttributeInterface $sku,
         ProductInterface $variantProduct,
         ValueCollectionInterface $valueCollection,
         FamilyInterface $family,
         FamilyVariantInterface $familyVariant,
         Collection $completenesses,
         ProductModelInterface $subProductModel,
-        ProductModelInterface $rootProductModel
+        ProductModelInterface $rootProductModel,
+        ValueInterface $frEcomSku,
+        ValueInterface $frPrintSku,
+        ValueInterface $enEcomSku,
+        ValueInterface $enPrintSku
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
@@ -265,7 +285,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn([
-                'code'   => 'family',
+                'code' => 'family',
                 'labels' => [
                     'fr_FR' => 'Une famille',
                     'en_US' => 'A family',
@@ -283,14 +303,28 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
 
         $completenesses->isEmpty()->willReturn(false);
         $variantProduct->getCompletenesses()->willReturn($completenesses);
-        $serializer->normalize($completenesses, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX,
-            [])->willReturn(
+        $serializer->normalize(
+            $completenesses,
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX,
+            []
+        )->willReturn(
             [
                 'ecommerce' => [
                     'en_US' => [
                         66,
                     ],
+                    'fr_FR' => [
+                        66,
+                    ],
                 ],
+                'print' => [
+                    'en_US' => [
+                        66,
+                    ],
+                    'fr_FR' => [
+                        66,
+                    ],
+                ]
             ]
         );
 
@@ -320,56 +354,90 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         $rootProductModel->getCode()->willReturn('model-tshirt');
         $rootProductModel->getParent()->willReturn(null);
 
+        $family->getAttributeAsLabel()->willReturn($sku);
+        $sku->getCode()->willReturn('sku');
+        $sku->isScopable()->willReturn(true);
+        $sku->isLocalizable()->willReturn(true);
+
+        $localeRepository->getActivatedLocaleCodes()->willReturn(['fr_FR', 'en_US']);
+        $channelRepository->getChannelCodes()->willReturn(['ecommerce', 'print']);
+
+        $variantProduct->getValue('sku', 'fr_FR', 'ecommerce')->willReturn($frEcomSku);
+        $frEcomSku->getData()->willReturn('Un sku FR ecommerce');
+
+        $variantProduct->getValue('sku', 'fr_FR', 'print')->willReturn($frPrintSku);
+        $frPrintSku->getData()->willReturn('Un sku FR print');
+
+        $variantProduct->getValue('sku', 'en_US', 'ecommerce')->willReturn($enEcomSku);
+        $enEcomSku->getData()->willReturn('Sku EN ecommerce');
+
+        $variantProduct->getValue('sku', 'en_US', 'print')->willReturn($enPrintSku);
+        $enPrintSku->getData()->willReturn('Sku EN print');
+
         $this->normalize($variantProduct,
             ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn(
             [
-                'id'                      => 'product_67',
-                'identifier'              => 'sku-001',
-                'created'                 => $now->format('c'),
-                'updated'                 => $now->format('c'),
-                'family'                  => [
-                    'code'   => 'family',
+                'id' => 'product_67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => [
+                    'code' => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
-                'enabled'                 => true,
-                'categories'              => ['first_category', 'second_category'],
+                'enabled' => true,
+                'categories' => ['first_category', 'second_category'],
                 'categories_of_ancestors' => ['second_category'],
-                'groups'                  => ['first_group', 'second_group', 'another_group'],
-                'in_group'                => [
-                    'first_group'   => true,
-                    'second_group'  => true,
+                'groups' => ['first_group', 'second_group', 'another_group'],
+                'in_group' => [
+                    'first_group' => true,
+                    'second_group' => true,
                     'another_group' => true,
                 ],
-                'completeness'            => [
+                'completeness' => [
                     'ecommerce' => [
-                        'en_US' => [
-                            66,
-                        ],
+                        'en_US' => [66],
+                        'fr_FR' => [66],
                     ],
+                    'print' => [
+                        'en_US' => [66],
+                        'fr_FR' => [66],
+                    ]
                 ],
-                'family_variant'          => null,
-                'parent'                  => 'model-tshirt-xs',
-                'values'                  => [
+                'family_variant' => null,
+                'parent' => 'model-tshirt-xs',
+                'values' => [
                     'a_size-decimal' => [
                         '<all_channels>' => [
                             '<all_locales>' => '10.51',
                         ],
                     ],
                 ],
-                'ancestors'               => [
-                    'ids'   => ['product_model_4', 'product_model_1'],
+                'ancestors' => [
+                    'ids' => ['product_model_4', 'product_model_1'],
                     'codes' => ['model-tshirt-xs', 'model-tshirt'],
+                    'labels' => [
+                        'ecommerce' => [
+                            'fr_FR' => 'Un sku FR ecommerce',
+                            'en_US' => 'Sku EN ecommerce',
+                        ],
+                        'print' => [
+                            'fr_FR' => 'Un sku FR print',
+                            'en_US' => 'Sku EN print',
+                        ]
+                    ],
                 ],
-                'label'                   => [],
+                'label' => [],
             ]
         );
     }
 
     function it_normalizes_variant_product_properties_with_minimum_filled_fields_and_values(
         $serializer,
+        $channelRepository,
         ProductInterface $variantProduct,
         ValueCollectionInterface $valueCollection,
         Collection $completenesses,
@@ -377,7 +445,9 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         AttributeInterface $sku,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $subProductModel,
-        ProductModelInterface $rootProductModel
+        ProductModelInterface $rootProductModel,
+        ValueInterface $ecommerceSku,
+        ValueInterface $printSku
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
@@ -387,6 +457,8 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         $variantProduct->getFamily()->willReturn($family);
         $family->getAttributeAsLabel()->willReturn($sku);
         $sku->getCode()->willReturn('sku');
+        $sku->isScopable()->willReturn(true);
+        $sku->isLocalizable()->willReturn(false);
 
         $variantProduct->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -412,7 +484,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         $serializer->normalize($family,
             ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->willReturn(
             [
-                'code'   => 'family',
+                'code' => 'family',
                 'labels' => [
                     'fr_FR' => 'Une famille',
                     'en_US' => 'A family',
@@ -434,45 +506,64 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         $rootProductModel->getCode()->willReturn('model-tshirt');
         $rootProductModel->getParent()->willReturn(null);
 
+        $channelRepository->getChannelCodes()->willReturn(['ecommerce', 'print']);
+
+        $variantProduct->getValue('sku', null, 'ecommerce')->willReturn($ecommerceSku);
+        $ecommerceSku->getData()->willReturn('ecommerce SKU');
+
+        $variantProduct->getValue('sku', null, 'print')->willReturn($printSku);
+        $printSku->getData()->willReturn('print SKU');
+
         $this->normalize($variantProduct,
             ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
-                'id'                      => 'product_67',
-                'identifier'              => 'sku-001',
-                'created'                 => $now->format('c'),
-                'updated'                 => $now->format('c'),
-                'family'                  => [
-                    'code'   => 'family',
+                'id' => 'product_67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => [
+                    'code' => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
-                'enabled'                 => false,
-                'categories'              => [],
+                'enabled' => false,
+                'categories' => [],
                 'categories_of_ancestors' => [],
-                'groups'                  => [],
-                'completeness'            => ['the completenesses'],
-                'family_variant'          => 'family_variant_A',
-                'parent'                  => 'model-tshirt-xs',
-                'values'                  => [],
-                'ancestors'               => [
-                    'ids'   => ['product_model_4', 'product_model_1'],
+                'groups' => [],
+                'completeness' => ['the completenesses'],
+                'family_variant' => 'family_variant_A',
+                'parent' => 'model-tshirt-xs',
+                'values' => [],
+                'ancestors' => [
+                    'ids' => ['product_model_4', 'product_model_1'],
                     'codes' => ['model-tshirt-xs', 'model-tshirt'],
+                    'labels' => [
+                        'ecommerce' => [
+                            '<all_locales>' => 'ecommerce SKU',
+                        ],
+                        'print' => [
+                            '<all_locales>' => 'print SKU',
+                        ]
+                    ],
                 ],
-                'label'                   => [],
+                'label' => [],
             ]
         );
     }
 
     function it_normalizes_variant_product_properties_with_fields_and_values_and_its_parents_values(
         $serializer,
+        $localeRepository,
         ProductInterface $variantProduct,
         ValueCollectionInterface $valueCollection,
         Collection $completenesses,
         FamilyInterface $family,
         AttributeInterface $sku,
         FamilyVariantInterface $familyVariant,
-        ProductModelInterface $rootProductModel
+        ProductModelInterface $rootProductModel,
+        ValueInterface $frSku,
+        ValueInterface $enSku
     ) {
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
@@ -482,6 +573,8 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         $variantProduct->getFamily()->willReturn($family);
         $family->getAttributeAsLabel()->willReturn($sku);
         $sku->getCode()->willReturn('sku');
+        $sku->isScopable()->willReturn(false);
+        $sku->isLocalizable()->willReturn(true);
 
         $variantProduct->getCreated()->willReturn($now);
         $serializer->normalize(
@@ -499,7 +592,7 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         $serializer
             ->normalize($family, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn([
-                'code'   => 'family',
+                'code' => 'family',
                 'labels' => [
                     'fr_FR' => 'Une famille',
                     'en_US' => 'A family',
@@ -539,12 +632,12 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
             [])
             ->willReturn(
                 [
-                    'a_size-decimal'         => [
+                    'a_size-decimal' => [
                         '<all_channels>' => [
                             '<all_locales>' => '10.51',
                         ],
                     ],
-                    'a_date-date'            => [
+                    'a_date-date' => [
                         '<all_channels>' => [
                             '<all_locales>' => '2017-05-05',
                         ],
@@ -563,45 +656,53 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
         $rootProductModel->getParent()->willReturn(null);
         $rootProductModel->getCategoryCodes()->willReturn(['first_category']);
 
+        $localeRepository->getActivatedLocaleCodes()->willReturn(['fr_FR', 'en_US']);
+
+        $variantProduct->getValue('sku', 'fr_FR')->willReturn($frSku);
+        $frSku->getData()->willReturn('fr_FR SKU');
+
+        $variantProduct->getValue('sku', 'en_US')->willReturn($enSku);
+        $enSku->getData()->willReturn('en_US SKU');
+
         $this->normalize($variantProduct,
             ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn(
             [
-                'id'                      => 'product_67',
-                'identifier'              => 'sku-001',
-                'created'                 => $now->format('c'),
-                'updated'                 => $now->format('c'),
-                'family'                  => [
-                    'code'   => 'family',
+                'id' => 'product_67',
+                'identifier' => 'sku-001',
+                'created' => $now->format('c'),
+                'updated' => $now->format('c'),
+                'family' => [
+                    'code' => 'family',
                     'labels' => [
                         'fr_FR' => 'Une famille',
                         'en_US' => 'A family',
                     ],
                 ],
-                'enabled'                 => true,
-                'categories'              => ['first_category', 'second_category'],
+                'enabled' => true,
+                'categories' => ['first_category', 'second_category'],
                 'categories_of_ancestors' => ['first_category'],
-                'groups'                  => ['first_group', 'second_group', 'another_group'],
-                'in_group'                => [
-                    'first_group'   => true,
-                    'second_group'  => true,
+                'groups' => ['first_group', 'second_group', 'another_group'],
+                'in_group' => [
+                    'first_group' => true,
+                    'second_group' => true,
                     'another_group' => true,
                 ],
-                'completeness'            => [
+                'completeness' => [
                     'ecommerce' => [
                         'en_US' => [
                             66,
                         ],
                     ],
                 ],
-                'family_variant'          => 'family_variant_A',
-                'parent'                  => 'model-tshirt',
-                'values'                  => [
-                    'a_size-decimal'         => [
+                'family_variant' => 'family_variant_A',
+                'parent' => 'model-tshirt',
+                'values' => [
+                    'a_size-decimal' => [
                         '<all_channels>' => [
                             '<all_locales>' => '10.51',
                         ],
                     ],
-                    'a_date-date'            => [
+                    'a_date-date' => [
                         '<all_channels>' => [
                             '<all_locales>' => '2017-05-05',
                         ],
@@ -612,11 +713,17 @@ class ProductPropertiesNormalizerSpec extends ObjectBehavior
                         ],
                     ],
                 ],
-                'ancestors'               => [
-                    'ids'   => ['product_model_1'],
+                'ancestors' => [
+                    'ids' => ['product_model_1'],
                     'codes' => ['model-tshirt'],
+                    'labels' => [
+                        '<all_channels>' => [
+                            'fr_FR' => 'fr_FR SKU',
+                            'en_US' => 'en_US SKU',
+                        ],
+                    ],
                 ],
-                'label'                   => [],
+                'label' => [],
             ]
         );
     }

--- a/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
+++ b/src/Pim/Component/Catalog/tests/integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
@@ -30,12 +30,12 @@ class ProductAndProductModelIndexingIntegration extends TestCase
         );
 
         $expected = [
-            'id'             => 'product_model_150',
-            'identifier'     => 'qux',
-            'created'        => $date->format('c'),
-            'updated'        => $date->format('c'),
-            'family'        => [
-                'code'   => 'familyA',
+            'id' => 'product_model_150',
+            'identifier' => 'qux',
+            'created' => $date->format('c'),
+            'updated' => $date->format('c'),
+            'family' => [
+                'code' => 'familyA',
                 'labels' => [
                     'de_DE' => null,
                     'en_US' => 'A family A',
@@ -46,8 +46,8 @@ class ProductAndProductModelIndexingIntegration extends TestCase
             'categories' => ['categoryA'],
             'categories_of_ancestors' => [],
             'parent' => null,
-            'values'         => [
-                'a_text-text'            => [
+            'values' => [
+                'a_text-text' => [
                     '<all_channels>' => [
                         '<all_locales>' => 'this is a text',
                     ],
@@ -58,8 +58,9 @@ class ProductAndProductModelIndexingIntegration extends TestCase
             'ancestors' => [
                 'ids' => [],
                 'codes' => [],
+                'labels' => [],
             ],
-            'label'         => [],
+            'label' => [],
             'document_type' => ProductModelInterface::class,
             'attributes_of_ancestors' => [],
             'attributes_for_this_level' => [
@@ -83,7 +84,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                 'an_image',
                 'sku',
             ],
-            'associations'              => null,
+            'associations' => null,
         ];
 
         $this->assertProductModelIndexingFormat('qux', $expected);
@@ -98,24 +99,24 @@ class ProductAndProductModelIndexingIntegration extends TestCase
         );
 
         $expected = [
-            'id'                      => 'product_model_151',
-            'identifier'              => 'quux',
-            'created'                 => $date->format('c'),
-            'updated'                 => $date->format('c'),
-            'family'                  => [
-                'code'   => 'familyA',
+            'id' => 'product_model_151',
+            'identifier' => 'quux',
+            'created' => $date->format('c'),
+            'updated' => $date->format('c'),
+            'family' => [
+                'code' => 'familyA',
                 'labels' => [
                     'de_DE' => null,
                     'en_US' => 'A family A',
                     'fr_FR' => 'Une famille A',
                 ],
             ],
-            'family_variant'          => 'familyVariantA1',
-            'categories'              => ['categoryA', 'categoryA1', 'categoryB'],
+            'family_variant' => 'familyVariantA1',
+            'categories' => ['categoryA', 'categoryA1', 'categoryB'],
             'categories_of_ancestors' => ['categoryA'],
-            'parent'                  => 'qux',
-            'values'                  => [
-                'a_text-text'            => [
+            'parent' => 'qux',
+            'values' => [
+                'a_text-text' => [
                     '<all_channels>' => [
                         '<all_locales>' => 'this is a text',
                     ],
@@ -126,14 +127,15 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ],
                 ],
             ],
-            'all_complete'            => [],
-            'all_incomplete'          => [],
-            'ancestors'               => [
-                'ids'   => ['product_model_150'],
+            'all_complete' => [],
+            'all_incomplete' => [],
+            'ancestors' => [
+                'ids' => ['product_model_150'],
                 'codes' => ['qux'],
+                'labels' => [],
             ],
-            'label'                   => [],
-            'document_type'           => ProductModelInterface::class,
+            'label' => [],
+            'document_type' => ProductModelInterface::class,
             'attributes_of_ancestors' => [
                 'a_date',
                 'a_file',
@@ -171,27 +173,27 @@ class ProductAndProductModelIndexingIntegration extends TestCase
         );
 
         $expected = [
-            'id'             => 'product_50',
-            'identifier'     => 'qux',
-            'created'        => $date->format('c'),
-            'updated'        => $date->format('c'),
-            'family'         => [
-                'code'   => 'familyA',
+            'id' => 'product_50',
+            'identifier' => 'qux',
+            'created' => $date->format('c'),
+            'updated' => $date->format('c'),
+            'family' => [
+                'code' => 'familyA',
                 'labels' => [
                     'de_DE' => null,
                     'en_US' => 'A family A',
                     'fr_FR' => 'Une famille A',
                 ],
             ],
-            'enabled'        => true,
-            'categories'     => ['categoryA', 'categoryA1', 'categoryA2', 'categoryB'],
+            'enabled' => true,
+            'categories' => ['categoryA', 'categoryA1', 'categoryA2', 'categoryB'],
             'categories_of_ancestors' => ['categoryA', 'categoryA1', 'categoryB'],
-            'groups'         => [],
-            'completeness'   => [],
+            'groups' => [],
+            'completeness' => [],
             'family_variant' => 'familyVariantA1',
-            'parent'         => 'quux',
-            'values'         => [
-                'a_text-text'            => [
+            'parent' => 'quux',
+            'values' => [
+                'a_text-text' => [
                     '<all_channels>' => [
                         '<all_locales>' => 'this is a text',
                     ],
@@ -201,12 +203,12 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                         '<all_locales>' => 'optionB',
                     ],
                 ],
-                'a_yes_no-boolean'       => [
+                'a_yes_no-boolean' => [
                     '<all_channels>' => [
                         '<all_locales>' => true,
                     ],
                 ],
-                'sku-text'       => [
+                'sku-text' => [
                     '<all_channels>' => [
                         '<all_locales>' => 'qux',
                     ],
@@ -215,8 +217,13 @@ class ProductAndProductModelIndexingIntegration extends TestCase
             'ancestors' => [
                 'ids' => ['product_model_151', 'product_model_150'],
                 'codes' => ['quux', 'qux'],
+                'labels' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => 'qux',
+                    ],
+                ],
             ],
-            'label'         => [
+            'label' => [
                 '<all_channels>' => [
                     '<all_locales>' => 'qux',
                 ],
@@ -259,31 +266,32 @@ class ProductAndProductModelIndexingIntegration extends TestCase
         );
 
         $expected = [
-            'id'                        => 'product_47',
-            'identifier'                => 'bar',
-            'created'                   => $date->format('c'),
-            'updated'                   => $date->format('c'),
-            'family'                    => null,
-            'enabled'                   => false,
-            'categories'                => [],
-            'categories_of_ancestors'   => [],
-            'groups'                    => [],
-            'completeness'              => [],
-            'family_variant'            => null,
-            'parent'                    => null,
-            'values'                    => [
+            'id' => 'product_47',
+            'identifier' => 'bar',
+            'created' => $date->format('c'),
+            'updated' => $date->format('c'),
+            'family' => null,
+            'enabled' => false,
+            'categories' => [],
+            'categories_of_ancestors' => [],
+            'groups' => [],
+            'completeness' => [],
+            'family_variant' => null,
+            'parent' => null,
+            'values' => [
                 'sku-text' => [
                     '<all_channels>' => [
                         '<all_locales>' => 'bar'
                     ]
                 ]
             ],
-            'ancestors'                 => [
-                'ids'   => [],
+            'ancestors' => [
+                'ids' => [],
                 'codes' => [],
+                'labels' => [],
             ],
-            'label'                     => [ ],
-            'document_type'             => ProductInterface::class,
+            'label' => [],
+            'document_type' => ProductInterface::class,
             'attributes_of_ancestors' => [],
             'attributes_for_this_level' => ['sku'],
         ];
@@ -300,149 +308,149 @@ class ProductAndProductModelIndexingIntegration extends TestCase
         );
 
         $expected = [
-            'id'                      => 'product_49',
-            'identifier'              => 'foo',
-            'created'                 => $date->format('c'),
-            'updated'                 => $date->format('c'),
-            'family'                  => [
-                'code'   => 'familyA',
+            'id' => 'product_49',
+            'identifier' => 'foo',
+            'created' => $date->format('c'),
+            'updated' => $date->format('c'),
+            'family' => [
+                'code' => 'familyA',
                 'labels' => [
                     'de_DE' => null,
                     'en_US' => 'A family A',
                     'fr_FR' => 'Une famille A',
                 ],
             ],
-            'enabled'                 => true,
-            'categories'              => ['categoryA1', 'categoryB'],
+            'enabled' => true,
+            'categories' => ['categoryA1', 'categoryB'],
             'categories_of_ancestors' => [],
-            'groups'                  => ['groupA', 'groupB'],
-            'in_group'                => [
+            'groups' => ['groupA', 'groupB'],
+            'in_group' => [
                 'groupA' => true,
                 'groupB' => true,
             ],
-            'completeness'            => [
+            'completeness' => [
                 'ecommerce' => ['en_US' => 100],
-                'tablet'    => ['de_DE' => 89, 'en_US' => 100, 'fr_FR' => 100],
+                'tablet' => ['de_DE' => 89, 'en_US' => 100, 'fr_FR' => 100],
             ],
-            'family_variant'          => null,
-            'parent'                  => null,
-            'values'                  => [
-                'a_date-date'                                    => [
+            'family_variant' => null,
+            'parent' => null,
+            'values' => [
+                'a_date-date' => [
                     '<all_channels>' => [
                         '<all_locales>' => '2016-06-13',
                     ],
                 ],
-                'a_file-media'                                   => [
+                'a_file-media' => [
                     '<all_channels>' => [
                         '<all_locales>' => [
-                            'extension'         => 'txt',
-                            'hash'              => '6545089471ba53d660d22d7b8dc8dd67904b1e28',
-                            'key'               => '8/b/5/c/8b5cf9bfd2e7e4725fd581e03251133ada1b2c99_fileA.txt',
-                            'mime_type'         => 'text/plain',
+                            'extension' => 'txt',
+                            'hash' => '6545089471ba53d660d22d7b8dc8dd67904b1e28',
+                            'key' => '8/b/5/c/8b5cf9bfd2e7e4725fd581e03251133ada1b2c99_fileA.txt',
+                            'mime_type' => 'text/plain',
                             'original_filename' => 'fileA.txt',
-                            'size'              => 1048576,
-                            'storage'           => 'catalogStorage',
+                            'size' => 1048576,
+                            'storage' => 'catalogStorage',
 
                         ],
                     ],
                 ],
-                'a_localizable_image-media'                      => [
+                'a_localizable_image-media' => [
                     '<all_channels>' => [
                         'en_US' => [
-                            'extension'         => 'jpg',
-                            'hash'              => '16850b6741c6e0d7622edb29465488571a2e63df',
-                            'key'               => '7/1/3/3/713380965740f8838834cd58505aa329fcf448a5_imageB_en_US.jpg',
-                            'mime_type'         => 'image/jpeg',
+                            'extension' => 'jpg',
+                            'hash' => '16850b6741c6e0d7622edb29465488571a2e63df',
+                            'key' => '7/1/3/3/713380965740f8838834cd58505aa329fcf448a5_imageB_en_US.jpg',
+                            'mime_type' => 'image/jpeg',
                             'original_filename' => 'imageB-en_US.jpg',
-                            'size'              => 1048576,
-                            'storage'           => 'catalogStorage',
+                            'size' => 1048576,
+                            'storage' => 'catalogStorage',
                         ],
                         'fr_FR' => [
-                            'extension'         => 'jpg',
-                            'hash'              => '058c6f380b0888afadf7341f8baaf58b538e5774',
-                            'key'               => '0/5/1/9/05198fcf21b2b0d4596459f172e2e62b1a70bfd0_imageB_fr_FR.jpg',
-                            'mime_type'         => 'image/jpeg',
+                            'extension' => 'jpg',
+                            'hash' => '058c6f380b0888afadf7341f8baaf58b538e5774',
+                            'key' => '0/5/1/9/05198fcf21b2b0d4596459f172e2e62b1a70bfd0_imageB_fr_FR.jpg',
+                            'mime_type' => 'image/jpeg',
                             'original_filename' => 'imageB-fr_FR.jpg',
-                            'size'              => 1048576,
-                            'storage'           => 'catalogStorage',
+                            'size' => 1048576,
+                            'storage' => 'catalogStorage',
                         ],
                     ],
                 ],
-                'a_localized_and_scopable_text_area-textarea'    => [
+                'a_localized_and_scopable_text_area-textarea' => [
                     'ecommerce' => [
                         'en_US' => 'a text area for ecommerce in English',
                     ],
-                    'tablet'    => [
+                    'tablet' => [
                         'en_US' => 'a text area for tablets in English',
                         'fr_FR' => 'une zone de texte pour les tablettes en français',
                     ],
                 ],
-                'a_metric-metric'                                => [
+                'a_metric-metric' => [
                     '<all_channels>' => [
                         '<all_locales>' => [
                             'base_data' => '987654321987123.4000',
                             'base_unit' => 'WATT',
-                            'data'      => '987654321987.1234',
-                            'unit'      => 'KILOWATT',
+                            'data' => '987654321987.1234',
+                            'unit' => 'KILOWATT',
                         ],
                     ],
                 ],
-                'a_metric_negative-metric'                       => [
+                'a_metric_negative-metric' => [
                     '<all_channels>' => [
                         '<all_locales>' => [
                             'base_data' => '252.650000000000',
                             'base_unit' => 'KELVIN',
-                            'data'      => '-20.5000',
-                            'unit'      => 'CELSIUS',
+                            'data' => '-20.5000',
+                            'unit' => 'CELSIUS',
                         ],
                     ],
                 ],
-                'a_metric_without_decimal-metric'                => [
+                'a_metric_without_decimal-metric' => [
                     '<all_channels>' => [
                         '<all_locales>' => [
                             'base_data' => '0.98',
-                            'data'      => '98',
+                            'data' => '98',
                             'base_unit' => 'METER',
-                            'unit'      => 'CENTIMETER',
+                            'unit' => 'CENTIMETER',
                         ],
                     ],
                 ],
-                'a_metric_without_decimal_negative-metric'       => [
+                'a_metric_without_decimal_negative-metric' => [
                     '<all_channels>' => [
                         '<all_locales>' => [
                             'base_data' => '253.150000000000',
-                            'data'      => '-20',
+                            'data' => '-20',
                             'base_unit' => 'KELVIN',
-                            'unit'      => 'CELSIUS',
+                            'unit' => 'CELSIUS',
                         ],
                     ],
                 ],
-                'a_multi_select-options'                         => [
+                'a_multi_select-options' => [
                     '<all_channels>' => [
                         '<all_locales>' => ['optionA', 'optionB'],
                     ],
                 ],
-                'a_number_float-decimal'                         => [
+                'a_number_float-decimal' => [
                     '<all_channels>' => [
                         '<all_locales>' => '12.5678',
                     ],
                 ],
-                'a_number_float_negative-decimal'                => [
+                'a_number_float_negative-decimal' => [
                     '<all_channels>' => [
                         '<all_locales>' => '-99.8732',
                     ],
                 ],
-                'a_number_integer-decimal'                       => [
+                'a_number_integer-decimal' => [
                     '<all_channels>' => [
                         '<all_locales>' => '42',
                     ],
                 ],
-                'a_number_integer_negative-decimal'              => [
+                'a_number_integer_negative-decimal' => [
                     '<all_channels>' => [
                         '<all_locales>' => '-42',
                     ],
                 ],
-                'a_price-prices'                                 => [
+                'a_price-prices' => [
                     '<all_channels>' => [
                         '<all_locales>' => [
                             'EUR' => '56.53',
@@ -450,7 +458,7 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                         ],
                     ],
                 ],
-                'a_price_without_decimal-prices'                 => [
+                'a_price_without_decimal-prices' => [
                     '<all_channels>' => [
                         '<all_locales>' => [
                             'EUR' => '56',
@@ -471,53 +479,53 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                         '<all_locales>' => 'colorB',
                     ],
                 ],
-                'a_scopable_price-prices'                        => [
+                'a_scopable_price-prices' => [
                     'ecommerce' => [
                         '<all_locales>' => [
                             'USD' => '20.00',
                         ],
                     ],
-                    'tablet'    => [
+                    'tablet' => [
                         '<all_locales>' => [
                             'EUR' => '17.00',
                         ],
                     ],
                 ],
-                'a_simple_select-option'                         => [
+                'a_simple_select-option' => [
                     '<all_channels>' => [
                         '<all_locales>' => 'optionB',
                     ],
                 ],
-                'a_text-text'                                    => [
+                'a_text-text' => [
                     '<all_channels>' => [
                         '<all_locales>' => 'this is a text',
                     ],
                 ],
-                '123-text'                                       => [
+                '123-text' => [
                     '<all_channels>' => [
                         '<all_locales>' => 'a text for an attribute with numerical code',
                     ],
                 ],
-                'a_text_area-textarea'                           => [
+                'a_text_area-textarea' => [
                     '<all_channels>' => [
                         '<all_locales>' => 'this is a very very very very very long  text',
                     ],
                 ],
-                'a_yes_no-boolean'                               => [
+                'a_yes_no-boolean' => [
                     '<all_channels>' => [
                         '<all_locales>' => true,
                     ],
                 ],
-                'an_image-media'                                 => [
+                'an_image-media' => [
                     '<all_channels>' => [
                         '<all_locales>' => [
-                            'extension'         => 'jpg',
-                            'hash'              => 'a9453e6ce89dbfd776ecae609e1c23e9cfad8277',
-                            'key'               => '3/b/5/5/3b5548f9764c0535db2ac92f047fa448cb7cea76_imageA.jpg',
-                            'mime_type'         => 'image/jpeg',
+                            'extension' => 'jpg',
+                            'hash' => 'a9453e6ce89dbfd776ecae609e1c23e9cfad8277',
+                            'key' => '3/b/5/5/3b5548f9764c0535db2ac92f047fa448cb7cea76_imageA.jpg',
+                            'mime_type' => 'image/jpeg',
                             'original_filename' => 'imageA.jpg',
-                            'size'              => 1048576,
-                            'storage'           => 'catalogStorage',
+                            'size' => 1048576,
+                            'storage' => 'catalogStorage',
 
                         ],
                     ],
@@ -528,16 +536,17 @@ class ProductAndProductModelIndexingIntegration extends TestCase
                     ]
                 ]
             ],
-            'ancestors'               => [
-                'ids'   => [],
+            'ancestors' => [
+                'ids' => [],
                 'codes' => [],
+                'labels' => [],
             ],
-            'label'                   => [
+            'label' => [
                 '<all_channels>' => [
                     '<all_locales>' => 'foo'
                 ]
             ],
-            'document_type'           => ProductInterface::class,
+            'document_type' => ProductInterface::class,
             'attributes_of_ancestors' => [],
             'attributes_for_this_level' => [
                 'a_date',


### PR DESCRIPTION
## Description

### The problem

When searching on "label or identifier" in the datagrid, and selecting all the results for a mass-action, the filters used are passed as they are to the batch job that will perform the mass action.

We then face an issue with product models and variant products, as the datagrid PQB returns only the elements of one level: those containing the value you are searching for.

But in the mass edit, we need to return both the element containing the value and its children, as the effect of the mass action could be performed on them (for instance, the search returns a product model, but the action is to activate products, so it will be performed on the variant products, not on their parents).

For instance, consider that the following example, where the label is on the sub product model:

| Data we search on | Root product model | Sub product model   | Variant product |
|-------------------|--------------------|---------------------|-----------------|
| code              | root               | sub                 | product         |
| label             |                    | A label not at root |                 |

- Search for "root":
    - datagrid will return the root product model (even if it is present in the label of the sub product model, it is also  the code of the root product model, so the highest level is returned)
    - mass edit should return everything
- Search for "label":
    - datagrid will return the sub product model
    - mass edit should return it along with all its children

### Solution

We already faced the same issue with IDs in the past (when selecting product models one by one or all visible) and introduced the "SelfAndAncestorFilter".

The same thing is done for "label or identifier" in this PR. This also implied indexing those new values in ES.

## Definition Of Done

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | OK 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
