### PR TITLE
Remove weird 200 error

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/router.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/router.js
@@ -125,6 +125,8 @@ define(
                     case 401:
                         window.location = this.generate('oro_user_security_login');
                         break;
+                    case 200:
+                        break;
                     default:
                         this.errorPage(xhr);
                         break;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

PR to avoid this kind of comments... https://twitter.com/jonathan_pollak/status/1093458003108478978

Right now, we catch every exceptions happening during the rendering of a page to display a custom error. Problem is: if an error occurs during runtime (but not linked to the http request itself) it can create 200 errors (which doesn't makes sense)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
