### PR TITLE
PIM-8050: Fix ElasticSearch mappings loader

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,6 +7,7 @@
 - PIM-8007: Content of sortable attribute options is now copyable.
 - PIM-8008: Fix attributes sort order in PEF.
 - PIM-8022: Fix the job status when using the batch command.
+- PIM-8050: Fix ElasticSearch mappings loader
 
 # 2.3.28 (2019-02-01)
 

--- a/src/Akeneo/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
@@ -54,7 +54,7 @@ class Loader
                 $settings = array_replace_recursive($settings, $configuration['settings']);
             }
             if (isset($configuration['mappings'])) {
-                $mappings = array_replace_recursive($mappings, $configuration['mappings']);
+                $mappings = $this->mergeMappings($mappings, $configuration['mappings']);
             }
             if (isset($configuration['aliases'])) {
                 $aliases = array_replace_recursive($aliases, $configuration['aliases']);
@@ -62,5 +62,45 @@ class Loader
         }
 
         return new IndexConfiguration($settings, $mappings, $aliases);
+    }
+
+    /**
+     * Mappings must be merged considering three cases:
+     * - 'properties' is an associative array and new definitions must replace old ones if they have the same key
+     * - 'dynamic_templates' is an indexed array and new definitions must always be added
+     * - other keys, merged with array_replace policy
+     */
+    private function mergeMappings(array $originalMappings, array $additionalMappings): array
+    {
+        foreach ($additionalMappings as $indexName => $definitions) {
+            if (isset($definitions['properties'])) {
+                $originalProperties = isset($originalMappings[$indexName]['properties']) ?
+                    $originalMappings[$indexName]['properties'] : [];
+
+                $originalMappings[$indexName]['properties'] = array_replace_recursive(
+                    $originalProperties,
+                    $definitions['properties']
+                );
+            }
+            if (isset($definitions['dynamic_templates'])) {
+                $originalTemplates = isset($originalMappings[$indexName]['dynamic_templates']) ?
+                    $originalMappings[$indexName]['dynamic_templates'] : [];
+
+                $originalMappings[$indexName]['dynamic_templates'] = array_merge_recursive(
+                    $originalTemplates,
+                    $definitions['dynamic_templates']
+                );
+            }
+            // hacky stuff to merge all other mappings
+            $otherMappings = $definitions;
+            unset($otherMappings['properties']);
+            unset($otherMappings['dynamic_templates']);
+            $originalMappings[$indexName] = array_replace_recursive(
+                $originalMappings[$indexName] ?? [],
+                $otherMappings
+            );
+        }
+
+        return $originalMappings;
     }
 }

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/IndexConfiguration/LoaderSpec.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/IndexConfiguration/LoaderSpec.php
@@ -16,31 +16,53 @@ class LoaderSpec extends ObjectBehavior
                 'analysis' => [
                     'char_filter' => [
                         'newline_pattern' => [
-                            'type'        => 'pattern_replace',
-                            'pattern'     => '\\n',
-                            'replacement' => ''
-                        ]
-                    ]
-                ]
+                            'type' => 'pattern_replace',
+                            'pattern' => '\\n',
+                            'replacement' => '',
+                        ],
+                    ],
+                ],
             ]
         );
         $indexConfiguration->getMappings()->shouldReturn(
             [
                 'an_index_type1' => [
                     'properties' => [
-                        'name'    => [
+                        'name' => [
                             'properties' => [
                                 'last' => [
-                                    'type' => 'text'
-                                ]
-                            ]
+                                    'type' => 'text',
+                                ],
+                            ],
                         ],
                         'user_id' => [
-                            'type'         => 'keyword',
+                            'type' => 'keyword',
                             'ignore_above' => 100,
                         ],
-                    ]
-                ]
+                    ],
+                    'dynamic_templates' => [
+                        [
+                            'my_dynamic_template_1' => [
+                                'path_match' => '*foo*',
+                                'match_mapping_type' => 'object',
+                                'mapping' =>
+                                    [
+                                        'type' => 'object',
+                                    ],
+                            ],
+                        ],
+                        [
+                            'my_dynamic_template_2' => [
+                                'path_match' => '*bar*',
+                                'mapping' =>
+                                    [
+                                        'type' => 'keyword',
+                                        'index' => 'not_analyzed',
+                                    ],
+                            ],
+                        ],
+                    ],
+                ],
             ]
         );
         $indexConfiguration->getAliases()->shouldReturn([]);
@@ -62,42 +84,71 @@ class LoaderSpec extends ObjectBehavior
                 'analysis' => [
                     'char_filter' => [
                         'newline_pattern' => [
-                            'type'        => 'pattern_replace',
-                            'pattern'     => '\\n',
-                            'replacement' => ''
-                        ]
-                    ]
+                            'type' => 'pattern_replace',
+                            'pattern' => '\\n',
+                            'replacement' => '',
+                        ],
+                    ],
                 ],
-                'index'    => [
-                    'number_of_shards'   => 3,
+                'index' => [
+                    'number_of_shards' => 3,
                     'number_of_replicas' => 2,
-                ]
+                ],
             ]
         );
         $indexConfiguration->getMappings()->shouldReturn(
             [
                 'an_index_type1' => [
-                    'properties'           => [
-                        'name'                  => [
+                    'properties' => [
+                        'name' => [
                             'properties' => [
                                 'last' => [
-                                    'type' => 'text'
-                                ]
-                            ]
+                                    'type' => 'text',
+                                ],
+                            ],
                         ],
-                        'user_id'               => [
-                            'type'         => 'keyword',
+                        'user_id' => [
+                            'type' => 'keyword',
                             'ignore_above' => 100,
                         ],
-                        'just_another_property' => null
+                        'just_another_property' => null,
                     ],
-                    'just_another_mapping' => null
+                    'dynamic_templates' => [
+                        [
+                            'my_dynamic_template_1' => [
+                                'path_match' => '*foo*',
+                                'match_mapping_type' => 'object',
+                                'mapping' => [
+                                    'type' => 'object',
+                                ],
+                            ],
+                        ],
+                        [
+                            'my_dynamic_template_2' => [
+                                'path_match' => '*bar*',
+                                'mapping' => [
+                                    'type' => 'keyword',
+                                    'index' => 'not_analyzed',
+                                ],
+                            ],
+                        ],
+                        [
+                            'my_dynamic_template_3' => [
+                                'path_match' => '*foo3*',
+                                'match_mapping_type' => 'object',
+                                'mapping' => [
+                                    'type' => 'object',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'just_another_mapping' => null,
                 ],
                 'an_index_type2' => [
-                    'just_a_mapping' => null
+                    'just_a_mapping' => null,
                 ],
                 'an_index_type3' => [
-                    'just_a_mapping' => null
+                    'just_a_mapping' => null,
                 ],
             ]
         );
@@ -105,12 +156,12 @@ class LoaderSpec extends ObjectBehavior
             [
                 'alias_1' => [],
                 'alias_2' => [
-                    'filter'  => [
+                    'filter' => [
                         'term' => [
-                            'user' => 'kimchy'
-                        ]
+                            'user' => 'kimchy',
+                        ],
                     ],
-                    'routing' => 'kimchy'
+                    'routing' => 'kimchy',
                 ],
             ]
         );
@@ -128,60 +179,87 @@ class LoaderSpec extends ObjectBehavior
 
         $indexConfiguration = $this->load();
         $indexConfiguration->buildAggregated()->shouldReturn([
-            'settings' =>
-                [
-                    'analysis' => [
-                        'char_filter' => [
-                            'newline_pattern' => [
-                                'type'        => 'pattern_replace',
-                                'pattern'     => '\\n',
-                                'replacement' => ''
-                            ]
-                        ]
-                    ],
-                    'index'    => [
-                        'number_of_shards'   => 3,
-                        'number_of_replicas' => 2,
-                    ]
-                ],
-            'mappings' =>
-                [
-                    'an_index_type1' => [
-                        'properties'           => [
-                            'name'                  => [
-                                'properties' => [
-                                    'last' => [
-                                        'type' => 'text'
-                                    ]
-                                ]
-                            ],
-                            'user_id'               => [
-                                'type'         => 'keyword',
-                                'ignore_above' => 100,
-                            ],
-                            'just_another_property' => null
+            'settings' => [
+                'analysis' => [
+                    'char_filter' => [
+                        'newline_pattern' => [
+                            'type' => 'pattern_replace',
+                            'pattern' => '\\n',
+                            'replacement' => '',
                         ],
-                        'just_another_mapping' => null
-                    ],
-                    'an_index_type2' => [
-                        'just_a_mapping' => null
-                    ],
-                    'an_index_type3' => [
-                        'just_a_mapping' => null
                     ],
                 ],
+                'index' => [
+                    'number_of_shards' => 3,
+                    'number_of_replicas' => 2,
+                ],
+            ],
+            'mappings' => [
+                'an_index_type1' => [
+                    'properties' => [
+                        'name' => [
+                            'properties' => [
+                                'last' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                        ],
+                        'user_id' => [
+                            'type' => 'keyword',
+                            'ignore_above' => 100,
+                        ],
+                        'just_another_property' => null,
+                    ],
+                    'dynamic_templates' => [
+                        [
+                            'my_dynamic_template_1' => [
+                                'path_match' => '*foo*',
+                                'match_mapping_type' => 'object',
+                                'mapping' => [
+                                    'type' => 'object',
+                                ],
+                            ],
+                        ],
+                        [
+                            'my_dynamic_template_2' => [
+                                'path_match' => '*bar*',
+                                'mapping' => [
+                                    'type' => 'keyword',
+                                    'index' => 'not_analyzed',
+                                ],
+                            ],
+                        ],
+                        [
+                            'my_dynamic_template_3' => [
+                                'path_match' => '*foo3*',
+                                'match_mapping_type' => 'object',
+                                'mapping' => [
+                                    'type' => 'object',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'just_another_mapping' => null,
+                ],
+                'an_index_type2' => [
+                    'just_a_mapping' => null,
+                ],
+                'an_index_type3' => [
+                    'just_a_mapping' => null,
+                ],
+            ],
             'aliases' =>
                 [
                     'alias_1' => [],
                     'alias_2' => [
-                        'filter'  => [
+                        'filter' => [
                             'term' => [
-                                'user' => 'kimchy'
-                            ]
+                                'user' => 'kimchy',
+                            ],
                         ],
-                        'routing' => 'kimchy'
+                        'routing' => 'kimchy',
                     ],
-                ]
+                ],
         ]);
     }
 

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf1.yml
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf1.yml
@@ -16,3 +16,16 @@ mappings:
             user_id:
                 type: keyword
                 ignore_above: 100
+        dynamic_templates:
+            -
+                my_dynamic_template_1:
+                    path_match: '*foo*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
+            -
+                my_dynamic_template_2:
+                    path_match: '*bar*'
+                    mapping:
+                        type: 'keyword'
+                        index: 'not_analyzed'

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf2.yml
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf2.yml
@@ -7,4 +7,11 @@ mappings:
     an_index_type1:
         properties:
             just_another_property: ~
+        dynamic_templates:
+            -
+                my_dynamic_template_3:
+                    path_match: '*foo3*'
+                    match_mapping_type: 'object'
+                    mapping:
+                        type: 'object'
         just_another_mapping: ~


### PR DESCRIPTION
ES config loader is not correct when merging mappings configuration (from extensions for example):
- properties must be replaced to allow override
- dynamic_templates must be appended to allow adding attribute types

It's a backport of #9423 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
