### PR TITLE
Upgrade Doctrine ORM to latest patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "doctrine/doctrine-fixtures-bundle": "2.3.0",
         "doctrine/doctrine-migrations-bundle": "1.2.1",
         "doctrine/migrations": "1.5.0",
-        "doctrine/orm": "2.5.6",
+        "doctrine/orm": "2.5.14",
         "dompdf/dompdf" : "0.6.2@dev",
         "elasticsearch/elasticsearch": "^6.1",
         "friendsofsymfony/jsrouting-bundle": "1.6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8af860f5b0fad1e790ee4973128b7f0",
+    "content-hash": "b43795faed85d204c35d62b8193c2967",
     "packages": [
         {
             "name": "ass/xmlsecurity",
@@ -1184,31 +1184,31 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.5.6",
+            "version": "v2.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "e6c434196c8ef058239aaa0724b4aadb0107940b"
+                "reference": "810a7baf81462a5ddf10e8baa8cb94b6eec02754"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/e6c434196c8ef058239aaa0724b4aadb0107940b",
-                "reference": "e6c434196c8ef058239aaa0724b4aadb0107940b",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/810a7baf81462a5ddf10e8baa8cb94b6eec02754",
+                "reference": "810a7baf81462a5ddf10e8baa8cb94b6eec02754",
                 "shasum": ""
             },
             "require": {
                 "doctrine/cache": "~1.4",
                 "doctrine/collections": "~1.2",
-                "doctrine/common": ">=2.5-dev,<2.8-dev",
-                "doctrine/dbal": ">=2.5-dev,<2.6-dev",
-                "doctrine/instantiator": "~1.0.1",
+                "doctrine/common": ">=2.5-dev,<2.9-dev",
+                "doctrine/dbal": ">=2.5-dev,<2.7-dev",
+                "doctrine/instantiator": "^1.0.1",
                 "ext-pdo": "*",
                 "php": ">=5.4",
-                "symfony/console": "~2.5|~3.0"
+                "symfony/console": "~2.5|~3.0|~4.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.0",
-                "symfony/yaml": "~2.3|~3.0"
+                "symfony/yaml": "~2.3|~3.0|~4.0"
             },
             "suggest": {
                 "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
@@ -1256,7 +1256,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2016-12-18T15:42:34+00:00"
+            "time": "2017-12-17T02:57:51+00:00"
         },
         {
             "name": "dompdf/dompdf",


### PR DESCRIPTION
As stated [here](https://github.com/doctrine/orm/releases/tag/v2.6.0), 2.5.14 is and will be the last patch of Doctrine ORM 2.5.

That would be cool if our 3.0 LTS could benefit of it.

Wait for https://github.com/akeneo/pim-community-dev/pull/9528 to be merged (To not conflict with the `composer.lock`)