### PR TITLE
DAPI-19: ProductPropertiesNormalizer accepts optional normalizers to be able to index additional product properties

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Technical improvement
+
+- DAPI-19: Update `Akeneo\Pim\Enrichment\Component\Product\Normalizer\Indexing\ProductAndProductModel\ProductPropertiesNormalizer` to accept optional normalizers
+
 # 3.0.4 (2019-02-20)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_indexing.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_indexing.yml
@@ -170,6 +170,8 @@ services:
 
     pim_catalog.normalizer.indexing_product_and_product_model.product.properties:
         class: '%pim_catalog.normalizer.indexing_product_and_product_model.product.properties.class%'
+        arguments:
+            - !tagged pim_catalog.normalizer.indexing_product_and_product_model.product.additional_properties
         tags:
             - { name: pim_indexing_serializer.normalizer, priority: 40 }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Indexing/ProductAndProductModel/ProductPropertiesNormalizer.php
@@ -32,6 +32,14 @@ class ProductPropertiesNormalizer implements NormalizerInterface, SerializerAwar
     private const FIELD_ANCESTORS = 'ancestors';
     private const FIELD_CATEGORIES_OF_ANCESTORS = 'categories_of_ancestors';
 
+    /** @var NormalizerInterface[] */
+    private $additionalDataNormalizers;
+
+    public function __construct(iterable $additionalDataNormalizers = [])
+    {
+        $this->additionalDataNormalizers = $additionalDataNormalizers;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -106,6 +114,10 @@ class ProductPropertiesNormalizer implements NormalizerInterface, SerializerAwar
             $data[StandardPropertiesNormalizer::FIELD_VALUES],
             $product
         );
+
+        foreach ($this->additionalDataNormalizers as $normalizer) {
+            $data = array_merge($data, $normalizer->normalize($product, $format, $context));
+        }
 
         return $data;
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR adds a way to index additional product properties without having to extends or rewrite the existing product properties normalizer. We needed this to index the franklin insights status of products (subscribed or not) and be able to filter on this data in the search form.

Everything is done by the dependency injection of Symfony : any service with the correct tag will be injected in the product properties normalizer. With this way there is no BC break in the community and it will allow us in the future to index more properties.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
