### PR TITLE
PIM-8019: Fix broken bulk product association modal

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,7 @@
 - PIM-8020: Fix wrong count on missing required attributes in the completeness
 - PIM-8028: Fix translations on boolean values
 - PIM-8057: Fix error during "forgot password" process
+- PIM-8019: Fix broken bulk product association modal
 
 # 3.0.1 (2019-02-06)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/product/associate.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/product/associate.js
@@ -22,7 +22,8 @@ define(
         'oro/loading-mask',
         'oro/messenger',
         'pim/template/mass-edit/product/associate/pick',
-        'pim/template/mass-edit/product/associate/confirm'
+        'pim/template/mass-edit/product/associate/confirm',
+        'pim/template/common/modal-centered'
     ],
     function (
         $,
@@ -39,12 +40,14 @@ define(
         LoadingMask,
         messenger,
         pickTemplate,
-        confirmTemplate
+        confirmTemplate,
+        modalTemplate
     ) {
         return BaseOperation.extend({
             className: 'AknGridContainer--withoutNoDataPanel',
             pickTemplate: _.template(pickTemplate),
             confirmTemplate: _.template(confirmTemplate),
+            modalTemplate: _.template(modalTemplate),
             errors: null,
             formPromise: null,
             events: {
@@ -245,22 +248,23 @@ define(
                         .getFetcher('association-type')
                         .fetch(this.getCurrentAssociationTypeCode())
                         .then((associationType) => {
-                            form.setCustomTitle(__('pim_enrich.entity.product.module.associations.manage', {
-                                associationType: associationType.labels[UserContext.get('catalogLocale')]
-                            }));
-
                             let modal = new Backbone.BootstrapModal({
-                                className: 'modal modal--fullPage modal--topButton',
                                 modalOptions: {
                                     backdrop: 'static',
                                     keyboard: false
                                 },
+                                innerDescription:
+                                __('pim_enrich.entity.product.module.associations.manage_description'),
                                 allowCancel: true,
                                 okCloses: false,
-                                title: '',
+                                title: __('pim_enrich.entity.product.module.associations.manage', {
+                                    associationType: associationType.labels[UserContext.get('catalogLocale')]
+                                }),
                                 content: '',
                                 cancelText: ' ',
-                                okText: __('pim_common.confirm')
+                                okText: __('pim_common.confirm'),
+                                template: this.modalTemplate,
+                                innerClassName: 'AknFullPage--full',
                             });
                             modal.open();
                             modal.on('cancel', deferred.reject);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR updates the template for the mass action product association modal to fix the broken display. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
