### PR TITLE
GITHUB-9451: Use PHPUnit to list tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
           - run:
                 name: PHPunit Integration
                 command: |
-                    TESTFILES=$(circleci tests glob "tests/back/**/*Integration.php" "src/**/*Integration.php" | circleci tests split)
+                    TESTFILES=$(docker-compose exec -T fpm .circleci/find_phpunit.sh PIM_Integration_Test | circleci tests split)
                     .circleci/run_phpunit.sh $TESTFILES
           - store_test_results:
                 path: var/tests/phpunit

--- a/.circleci/find_phpunit.sh
+++ b/.circleci/find_phpunit.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eu
+
+if [[ -z "$1}" ]]; then
+    echo "Provide the argument SUITES you want to list-tests as first argument"
+fi
+
+SUITES=$@
+
+# Here is the output of phpunit
+
+# it gives a header + The namespaces of the test and the test so as we launch by file we have to work a little bit on it
+
+#PHPUnit 6.5.3 by Sebastian Bergmann and contributors.
+#
+#Available test(s):
+# - Akeneo\Bundle\RuleEngineBundle\tests\integration\ExecuteRuleWithoutPermissionsAppliedIntegration::testRuleExecutionOnAllProducts
+# - tests\integration\Akeneo\Bundle\RuleEngineBundle\Normalizer\Standard\RuleIntegration::testRule
+# - PimEnterprise\Bundle\ApiBundle\tests\EndToEnd\Controller\Asset\CreateAssetIntegration::testCreationOfAnAsset
+# - PimEnterprise\Bundle\ApiBundle\tests\EndToEnd\Controller\Asset\CreateAssetIntegration::testResponseWhenContentIsEmpty
+# - PimEnterprise\Bundle\ApiBundle\tests\EndToEnd\Controller\Asset\CreateAssetIntegration::testResponseWhenValidationFailed
+
+vendor/bin/phpunit -c app --testsuite=$SUITES --list-tests | tail -n +4 | cut -c4- | cut -d ':' -f 1 | sort | uniq | sed -e 's/\\/\\\\/g'

--- a/.circleci/find_phpunit.sh
+++ b/.circleci/find_phpunit.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [[ -z "$1}" ]]; then
+if [[ -z "${1}" ]]; then
     echo "Provide the argument SUITES you want to list-tests as first argument"
 fi
 

--- a/.circleci/find_phpunit.sh
+++ b/.circleci/find_phpunit.sh
@@ -22,4 +22,4 @@ SUITES=$@
 # - PimEnterprise\Bundle\ApiBundle\tests\EndToEnd\Controller\Asset\CreateAssetIntegration::testResponseWhenContentIsEmpty
 # - PimEnterprise\Bundle\ApiBundle\tests\EndToEnd\Controller\Asset\CreateAssetIntegration::testResponseWhenValidationFailed
 
-vendor/bin/phpunit -c app --testsuite=$SUITES --list-tests | tail -n +4 | cut -c4- | cut -d ':' -f 1 | sort | uniq | head -n10
+vendor/bin/phpunit -c app --testsuite=$SUITES --list-tests | tail -n +4 | cut -c4- | cut -d ':' -f 1 | sort | uniq | sed -e 's/\\/\\\\/g'

--- a/.circleci/find_phpunit.sh
+++ b/.circleci/find_phpunit.sh
@@ -2,8 +2,9 @@
 
 set -eu
 
-if [[ -z "${1}" ]]; then
+if [ -z "$1" ]; then
     echo "Provide the argument SUITES you want to list-tests as first argument"
+    exit 1
 fi
 
 SUITES=$@
@@ -21,4 +22,4 @@ SUITES=$@
 # - PimEnterprise\Bundle\ApiBundle\tests\EndToEnd\Controller\Asset\CreateAssetIntegration::testResponseWhenContentIsEmpty
 # - PimEnterprise\Bundle\ApiBundle\tests\EndToEnd\Controller\Asset\CreateAssetIntegration::testResponseWhenValidationFailed
 
-vendor/bin/phpunit -c app --testsuite=$SUITES --list-tests | tail -n +4 | cut -c4- | cut -d ':' -f 1 | sort | uniq | sed -e 's/\\/\\\\/g'
+vendor/bin/phpunit -c app --testsuite=$SUITES --list-tests | tail -n +4 | cut -c4- | cut -d ':' -f 1 | sort | uniq | head -n10

--- a/.circleci/run_phpunit.sh
+++ b/.circleci/run_phpunit.sh
@@ -6,7 +6,7 @@ TESTFILES=$@
 fail=0
 for TESTFILE in $TESTFILES; do
     echo $TESTFILE
-    docker-compose exec -T fpm ./vendor/bin/phpunit -c app --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml $TESTFILE
+    docker-compose exec -T fpm ./vendor/bin/phpunit -c app --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml --filter $TESTFILE
     fail=$(($fail + $?))
 done
 

--- a/.circleci/run_phpunit.sh
+++ b/.circleci/run_phpunit.sh
@@ -6,7 +6,7 @@ TESTFILES=$@
 fail=0
 for TESTFILE in $TESTFILES; do
     echo $TESTFILE
-    docker-compose exec -T fpm ./vendor/bin/phpunit -c app --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml --filter $TESTFILE
+    docker-compose exec -T fpm ./vendor/bin/phpunit -c app --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml --filter '$TESTFILE'
     fail=$(($fail + $?))
 done
 

--- a/.circleci/run_phpunit.sh
+++ b/.circleci/run_phpunit.sh
@@ -6,7 +6,7 @@ TESTFILES=$@
 fail=0
 for TESTFILE in $TESTFILES; do
     echo $TESTFILE
-    docker-compose exec -T fpm ./vendor/bin/phpunit -c app --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml --filter '$TESTFILE'
+    docker-compose exec -T fpm ./vendor/bin/phpunit -c app --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml --filter $TESTFILE
     fail=$(($fail + $?))
 done
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9be2789303356d67d7673e434a52a891",
+    "content-hash": "47e23b284a64632c86b2271bdfef6348",
     "packages": [
         {
             "name": "ass/xmlsecurity",
@@ -2942,16 +2942,16 @@
         },
         {
             "name": "ocramius/package-versions",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f"
+                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/4489d5002c49d55576fa0ba786f42dbb009be46f",
-                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
+                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
                 "shasum": ""
             },
             "require": {
@@ -2960,6 +2960,7 @@
             },
             "require-dev": {
                 "composer/composer": "^1.6.3",
+                "doctrine/coding-standard": "^5.0.1",
                 "ext-zip": "*",
                 "infection/infection": "^0.7.1",
                 "phpunit/phpunit": "^7.0.0"
@@ -2987,7 +2988,7 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2018-02-05T13:05:30+00:00"
+            "time": "2019-02-21T12:16:21+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -4202,7 +4203,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -5814,32 +5815,32 @@
         },
         {
             "name": "friends-of-behat/context-service-extension",
-            "version": "v1.3.0",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfBehat/ContextServiceExtension.git",
-                "reference": "850299407ff45d3a71b1639f6a1975ed898975db"
+                "reference": "52a19fae67cc1ada4f4b566830bf03431d7fa01e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfBehat/ContextServiceExtension/zipball/850299407ff45d3a71b1639f6a1975ed898975db",
-                "reference": "850299407ff45d3a71b1639f6a1975ed898975db",
+                "url": "https://api.github.com/repos/FriendsOfBehat/ContextServiceExtension/zipball/52a19fae67cc1ada4f4b566830bf03431d7fa01e",
+                "reference": "52a19fae67cc1ada4f4b566830bf03431d7fa01e",
                 "shasum": ""
             },
             "require": {
                 "behat/behat": "^3.1",
                 "php": "^7.1",
-                "symfony/dependency-injection": "^3.4|^4.1"
+                "symfony/dependency-injection": "^3.3|^4.0"
             },
             "require-dev": {
                 "friends-of-behat/cross-container-extension": "^1.0",
                 "friends-of-behat/test-context": "^1.0",
-                "phpspec/phpspec": "^5.0"
+                "phpspec/phpspec": "^4.0"
             },
             "suggest": {
                 "friends-of-behat/cross-container-extension": "^1.0",
                 "ocramius/proxy-manager": "^2.0",
-                "symfony/proxy-manager-bridge": "^3.4|^4.2"
+                "symfony/proxy-manager-bridge": "^3.0"
             },
             "type": "library",
             "autoload": {
@@ -5860,7 +5861,7 @@
             ],
             "description": "Allows to declare and use contexts services in scenario scoped container.",
             "abandoned": "friends-of-behat/symfony-extension",
-            "time": "2019-01-21T17:12:48+00:00"
+            "time": "2018-02-13T18:49:22+00:00"
         },
         {
             "name": "friends-of-behat/cross-container-extension",


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

We now decided to use PHPUnit to generate the tests we want to execute because by using "*Integration.php" it is very unconvenient, you can't have abstract that is named the same etc... And, moreover what is better than PHPUnit to list PHPUnit tests to launch? :P

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
