### PR TITLE
PIM-8129: Fix default system locale

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8129: Fix default system locale
+
 # 3.0.3 (2019-02-18)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->arrayNode('language')
                         ->children()
-                            ->scalarNode('value')->defaultValue('en')->end()
+                            ->scalarNode('value')->defaultValue('en_US')->end()
                             ->scalarNode('scope')->defaultValue('app')->end()
                         ->end()
                     ->end()
@@ -39,7 +39,7 @@ class Configuration implements ConfigurationInterface
             $rootNode,
             [
                 'loading_message_enabled' => ['value' => false],
-                'language' => ['value' => 'en']
+                'language' => ['value' => 'en_US']
             ]
         );
 


### PR DESCRIPTION
Previously, default system locale was "Catalan", because "en" was not found.
Now, default system locale is "en_US" to be able to show "English (United States)" again.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -