### PR TITLE
PIM-8144: Fix space on label required

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8144: Fix spaces on field labels and required note
+
 # 3.0.3 (2019-02-18)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/base/general.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/base/general.less
@@ -142,6 +142,10 @@ input[type=checkbox] {
   }
 }
 
+label > em {
+  padding-left: 3px;
+}
+
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Notes
 button::-moz-focus-inner {
   padding: 0;


### PR DESCRIPTION
The space disappeared in the labels because the font is too small.
I manually added a padding between label and emphasis elements.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
