### PR TITLE
PIM-8147: Fix design issue on boolean fields

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,7 @@
 - PIM-8145: Fix design on variant navigation
 - PIM-8144: Fix spaces on field labels and required note
 - PIM-8143: Fix missing translations
+- PIM-8147: Fix design issue on boolean fields
 
 # 3.0.3 (2019-02-18)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/bootstrap.switch.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/bootstrap.switch.less
@@ -10,6 +10,7 @@
   width: @switchSize * 2;
   border: none;
   overflow: initial;
+  margin-right: @AknMaxFormWidth - 100px;
 
   label,
   label:active {


### PR DESCRIPTION
Boolean fields and info box were in the same place
https://drive.google.com/open?id=1utf3RXSQH7dv7GPfvRHqlQjy0sHXw4Kc
I added a space on the right to align with every other fields.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -