### PR TITLE
PIM-8146: Fix centered alignment on drag & drop fields

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,7 @@
 - PIM-8145: Fix design on variant navigation
 - PIM-8144: Fix spaces on field labels and required note
 - PIM-8143: Fix missing translations
+- PIM-8146: Fix centered alignment on drag & drop fields
 
 # 3.0.3 (2019-02-18)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FormContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FormContainer.less
@@ -16,7 +16,7 @@
     width: 100%;
   }
 
-  &--withPadding:not(:empty) {
+  &--withPadding:not(:empty):not(&--centered) {
     margin: 20px 0 10px;
   }
 


### PR DESCRIPTION
There was 2 rules defined eating themselves.
I added a constraint to avoid this.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Migration script                  | -
| Tech Doc                          | -

