### PR TITLE
Fix avatars migration

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -9,6 +9,7 @@
 - PIM-8147: Fix design issue on boolean fields
 - PIM-8146: Fix centered alignment on drag & drop fields
 - PIM-8017: Fix PDF generation
+- PIM-8060: Fix avatars migration 2.3 -> 3.0
 
 # 3.0.3 (2019-02-18)
 

--- a/upgrades/schema/Version_3_0_20180717082452_migrate_avatars.php
+++ b/upgrades/schema/Version_3_0_20180717082452_migrate_avatars.php
@@ -2,12 +2,12 @@
 
 namespace Pim\Upgrade\Schema;
 
+use Akeneo\Pim\Enrichment\Component\FileStorage;
 use Akeneo\Tool\Component\FileStorage\Exception\FileRemovalException;
 use Akeneo\Tool\Component\FileStorage\Exception\FileTransferException;
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Migrations\IrreversibleMigrationException;
 use Doctrine\DBAL\Schema\Schema;
-use Pim\Component\Catalog\FileStorage;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Finder\Finder;

--- a/upgrades/schema/Version_3_0_20180717082452_migrate_avatars.php
+++ b/upgrades/schema/Version_3_0_20180717082452_migrate_avatars.php
@@ -65,7 +65,6 @@ class Version_3_0_20180717082452_migrate_avatars extends AbstractMigration imple
                 $userId = $userWithAvatar['id'];
                 $fileName = $userWithAvatar['image'];
 
-
                 $finder = new Finder();
                 $finder->files()->in($uploadDir)->name($fileName);
                 if ($finder->count()) {
@@ -77,7 +76,10 @@ class Version_3_0_20180717082452_migrate_avatars extends AbstractMigration imple
                         $file = $fileStorer->store($firstFile, FileStorage::CATALOG_STORAGE_ALIAS);
                         $this->connection->update(
                             self::USERS_TABLE,
-                            ['file_info_id' => $file->getId()],
+                            [
+                                'file_info_id' => $file->getId(),
+                                'image' => null,
+                            ],
                             ['id' => $userId]
                         );
                     } else {

--- a/upgrades/schema/Version_3_0_20180823184342_switch_to_utf8mb4.php
+++ b/upgrades/schema/Version_3_0_20180823184342_switch_to_utf8mb4.php
@@ -108,9 +108,7 @@ class Version_3_0_20180823184342_switch_to_utf8mb4 extends AbstractMigration
             );
         }
 
-        $this->addSql(
-            sprintf('ALTER TABLE pim_session CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin', $tableName)
-        );
+        $this->addSql('ALTER TABLE pim_session CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin');
     }
 
     /**


### PR DESCRIPTION
We cannot update the user because of a migration error.
The `image` should be replaced by `file_info_id` and set to null.