### PR TITLE
Fix category tree label

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # 2.0.x
 
+## Bug fixes
+
+- PIM-8158: Improve the label category tree creation button label
+
 # 2.0.48 (2019-02-18)
 
 ## Bug fixes

--- a/features/category/list_categories.feature
+++ b/features/category/list_categories.feature
@@ -11,7 +11,7 @@ Feature: List categories
     Then I should see the text "2014 collection"
     And I should see the text "Summer collection"
     And I should see the text "Winter collection"
-    And I should see the text "Please select a category on the left or Create a new category"
+    And I should see the text "Please select a category on the left or Create a new category tree"
 
   Scenario: Click on a category without the right permissions do nothing
     Given a "footwear" catalog configuration

--- a/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/translations/messages.en.yml
@@ -296,11 +296,11 @@ category:
     edit:     edit category
     suggest selection: Please select a category on the left
     or: or
-    create new: Create a new category
+    create new: Create a new category tree
 
 tree:
     title:    tree
-    create:   create tree
+    create:   create category tree
     edit:     edit tree
 channel:
     title:    channel
@@ -343,7 +343,7 @@ btn:
         attribute:        create attribute
         attribute group:  create attribute group
         category:         create category
-        tree:             create tree
+        tree:             create category tree
         channel:          create channel
         currency:         create currency
         family:           create family


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix the label of the category tree creation button.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | Ok
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
