### PR TITLE
PIM-8053: Various fixes on Avatars

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -10,6 +10,7 @@
 - PIM-8146: Fix centered alignment on drag & drop fields
 - PIM-8017: Fix PDF generation
 - PIM-8060: Fix avatars migration 2.3 -> 3.0
+- PIM-8053: Fix avatar deletion and avatar update on dashboard page and user navigation
 
 # 3.0.3 (2019-02-18)
 

--- a/src/Akeneo/Platform/Bundle/DashboardBundle/Resources/views/Dashboard/index.html.twig
+++ b/src/Akeneo/Platform/Bundle/DashboardBundle/Resources/views/Dashboard/index.html.twig
@@ -3,14 +3,6 @@
 {% block content %}
 
     <div class="AknDefault-mainContent">
-
-        {% set image %}
-            <img
-                class="AknTitleContainer-image"
-                src="{{ app.user.imagePath ? app.user.imagePath | imagine_filter('thumbnail_small') : asset('bundles/pimui/images/info-user.png') }}"
-            >
-        {% endset %}
-
         {{ elements.page_header(
             {
                 title: 'pim_dashboard.title'|trans,
@@ -30,12 +22,14 @@
             [
                 'pim/common/breadcrumbs',
                 'pim/fetcher-registry',
-                'pim/form-builder'
+                'pim/form-builder',
+                'pim/form/common/user-main-image'
             ],
             function(
                 Breadcrumbs,
                 FetcherRegistry,
-                FormBuilder
+                FormBuilder,
+                UserMainImage
             ) {
                 $(function() {
                     var breadcrumbs = new Breadcrumbs({
@@ -55,6 +49,10 @@
                             form.render();
                         }.bind(this));
                     });
+
+                    const userMainImage = new UserMainImage({ config: {} });
+                    $('*[data-drop-zone="main-image"]').append(userMainImage.el);
+                    userMainImage.render();
                 });
             }
         );

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
@@ -944,6 +944,7 @@ config:
     pim/form/common/meta:                                pimui/js/form/common/meta
     pim/form/common/subsection:                          pimui/js/form/common/subsection
     pim/form/common/main-image:                          pimui/js/form/common/main-image
+    pim/form/common/user-main-image:                     pimui/js/form/common/user-main-image
     pim/form/common/meta/created:                        pimui/js/form/common/meta/created
     pim/form/common/meta/updated:                        pimui/js/form/common/meta/updated
     pim/form/common/meta/status:                         pimui/js/form/common/meta/status

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/user.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/user.js
@@ -37,17 +37,21 @@ define([
                             let previousDefaultCategoryTree = user.default_category_tree;
                             let previousUserLocale = user.user_default_locale;
                             let previousCatalogLocale = user.catalog_default_locale;
+                            let previousAvatarFilePath = user.avatar ? user.avatar.filePath : null;
                             form.on('pim_enrich:form:entity:post_save', (data) => {
+                                const dataAvatarFilePath = data.avatar ? data.avatar.filePath : null;
                                 if (data.user_default_locale !== previousUserLocale ||
                                     data.catalog_default_locale !== previousCatalogLocale ||
                                     data.catalog_default_scope !== previousCatalogScope ||
-                                    data.default_category_tree !== previousDefaultCategoryTree
+                                    data.default_category_tree !== previousDefaultCategoryTree ||
+                                    dataAvatarFilePath !== previousAvatarFilePath
                                 ) {
                                     previousUserLocale = data.user_default_locale;
                                     previousCatalogLocale = data.catalog_default_locale;
                                     previousCatalogScope = data.catalog_default_scope;
                                     previousDefaultCategoryTree = data.default_category_tree;
-                                    // Reload the page to reload new language
+                                    previousAvatarFilePath = dataAvatarFilePath;
+                                    // Reload the page to reload new user interface variables
                                     location.reload();
                                 }
                             });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/user-main-image.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/user-main-image.ts
@@ -1,0 +1,26 @@
+const MainImage = require('pim/form/common/main-image');
+const UserContext = require('pim/user-context');
+const MediaUrlGenerator = require('pim/media-url-generator');
+
+/**
+ * Display main image with user avatar
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UserMainImage extends MainImage {
+  /**
+   * @{inheritdoc}
+   */
+  getPath() {
+    const filePath = UserContext.get('avatar').filePath;
+    if (null === filePath || undefined === filePath) {
+      return 'bundles/pimui/images/info-user.png';
+    }
+
+    return MediaUrlGenerator.getMediaShowUrl(UserContext.get('avatar').filePath, 'thumbnail_small');
+  }
+}
+
+export = UserMainImage

--- a/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
+++ b/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
@@ -419,24 +419,25 @@ class UserUpdater implements ObjectUpdaterInterface
      */
     private function setAvatar($user, $data)
     {
-        if ($data['filePath'] === null || $data['filePath'] === '') {
-            return;
-        }
+        $fileInfo = null;
 
-        $fileInfo = $this->fileInfoRepository->findOneBy([
-            'key' => str_replace($this->fileStorageFolder, '', $data['filePath']),
-        ]);
+        if ($data['filePath'] !== null && $data['filePath'] !== '') {
+            $fileInfo = $this->fileInfoRepository->findOneBy([
+                'key' => str_replace($this->fileStorageFolder, '', $data['filePath']),
+            ]);
 
-        if (null === $fileInfo) {
-            $rawFile = new \SplFileInfo($data['filePath']);
-            if (!$rawFile->isFile()) {
-                throw InvalidPropertyException::validPathExpected(
-                    'avatar',
-                    static::class,
-                    $data['filePath']
-                );
+            if (null === $fileInfo) {
+                $rawFile = new \SplFileInfo($data['filePath']);
+                if (!$rawFile->isFile()) {
+                    throw InvalidPropertyException::validPathExpected(
+                        'avatar',
+                        static::class,
+                        $data['filePath']
+                    );
+                }
+                $fileInfo = $this->fileStorer->store($rawFile, 'catalogStorage');
+
             }
-            $fileInfo = $this->fileStorer->store($rawFile, 'catalogStorage');
         }
 
         $user->setAvatar($fileInfo);

--- a/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
+++ b/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
@@ -436,7 +436,6 @@ class UserUpdater implements ObjectUpdaterInterface
                     );
                 }
                 $fileInfo = $this->fileStorer->store($rawFile, 'catalogStorage');
-
             }
         }
 


### PR DESCRIPTION
This PR fixes 3 bugs:
- User can now delete its avatar (before, it does nothing)
- When user changes its avatar, it's not mandatory to reload the page to show changes on user navigation button
- It displays the user image in Dashboard page.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -