### PR TITLE
PIM-8157: Errors on user edit

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -14,6 +14,7 @@
 - PIM-8060: Fix avatars migration 2.3 -> 3.0
 - PIM-8053: Fix avatar deletion and avatar update on dashboard page and user navigation
 - PIM-8149: Fix design of the cross deletion in the Item Picker
+- PIM-8157: Fix issues on user edit (scroll and groups)
 
 # 3.0.3 (2019-02-18)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/edit-form.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/edit-form.js
@@ -38,19 +38,6 @@ define([
          */
         getType: function () {
             return this.type;
-        },
-
-        /**
-         * {@inheritdoc}
-         *
-         * Little hack to restore the scroll position after a complete re-render of the form.
-         */
-        render: function () {
-            var scrollPosition = this.$el.find('.edit-form').scrollTop();
-
-            BaseEditForm.prototype.render.apply(this, arguments);
-
-            this.$el.find('.edit-form').scrollTop(scrollPosition);
         }
     });
 });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/user.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/user.js
@@ -51,6 +51,8 @@ define([
                                     previousCatalogScope = data.catalog_default_scope;
                                     previousDefaultCategoryTree = data.default_category_tree;
                                     previousAvatarFilePath = dataAvatarFilePath;
+                                    // Prevent warning message (Firefox only)
+                                    form.getExtension('state').collectAndRender();
                                     // Reload the page to reload new user interface variables
                                     location.reload();
                                 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/edit-form.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/edit-form.js
@@ -80,6 +80,8 @@ define(
                 if (!this.configured) {
                     return this;
                 }
+                const scrollPosition = this.$el.find('.edit-form').scrollTop();
+
                 this.getRoot().trigger('pim_enrich:form:render:before');
 
                 this.$el.html(this.template());
@@ -87,6 +89,8 @@ define(
                 this.renderExtensions();
 
                 this.getRoot().trigger('pim_enrich:form:render:after');
+
+                this.$el.find('.edit-form').scrollTop(scrollPosition);
             },
 
             /**

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
@@ -79,6 +79,14 @@ extensions:
                 fail: pim_enrich.entity.user.flash.delete.fail
             redirect: pim_user_index
 
+    pim-user-edit-form-state:
+        module: pim/form/common/state
+        parent: pim-user-edit-form
+        targetZone: state
+        position: 900
+        config:
+            entity: pim_user_management.entity.user.label
+
     pim-user-edit-form-form-tabs:
         module: pim/form/common/form-tabs
         parent: pim-user-edit-form

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -38,6 +38,7 @@ pim_enrich:
 pim_user_management:
     entity:
         user:
+            label: user
             flash:
                 update:
                     success: User successfully updated.

--- a/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
+++ b/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
@@ -200,9 +200,7 @@ class UserUpdater implements ObjectUpdaterInterface
                 foreach ($data as $code) {
                     $groups[] = $this->findGroup($code);
                 }
-                if (count($groups) > 0) {
-                    $user->setGroups($groups);
-                }
+                $user->setGroups($groups);
                 break;
             case 'phone':
                 $user->setPhone($data);

--- a/tests/legacy/features/user-management/role/edit_user_role_assignations.feature
+++ b/tests/legacy/features/user-management/role/edit_user_role_assignations.feature
@@ -21,7 +21,8 @@ Feature: Edit a user groups and roles
     And I fill in the following information:
       | Roles | |
     And I save the user
-    Then I should not see the text "There are unsaved changes."
+    Then I should see the text "There are unsaved changes."
+    And I should see the text "You must select at least 1 role"
     And the user "admin" should still have 2 roles
 
   Scenario: Assign a role to a user from the role page


### PR DESCRIPTION
- Groups are not mandatory (a user can have 0 group)
- State was missing
- Avoid scrolltop when form is re-rendered (to be validated with PO)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
