### PR TITLE
PIM-8135: Fix cursor paginator sequence

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -12,6 +12,7 @@
 - PIM-8153: Fix locale specific field to allow multiple locales 
 - PIM-8017: Fix PDF generation
 - PIM-8060: Fix avatars migration 2.3 -> 3.0
+- PIM-8135: Fix cursor paginator sequence
 - PIM-8053: Fix avatar deletion and avatar update on dashboard page and user navigation
 - PIM-8149: Fix design of the cross deletion in the Item Picker
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/command.yml
@@ -3,4 +3,4 @@ services:
         class: 'Akeneo\Tool\Component\StorageUtils\Cursor\PaginatorFactory'
         arguments:
             - 'Akeneo\Tool\Component\StorageUtils\Cursor\Paginator'
-            - '1000'
+            - '%pim_job_product_batch_size%'

--- a/src/Akeneo/Tool/Component/StorageUtils/Cursor/Paginator.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Cursor/Paginator.php
@@ -130,12 +130,14 @@ class Paginator implements PaginatorInterface
         $result = [];
         $pageSize = 0;
         do {
+            if ($this->pageNumber > 0 || $pageSize > 0) {
+                $this->cursor->next();
+            }
             $current = $this->cursor->current();
             if (null !== $current && false !== $current) {
                 $result[] = $current;
             }
             $pageSize++;
-            $this->cursor->next();
         } while ($pageSize < $this->pageSize && null !== $current && false !== $current);
 
         if (empty($result)) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The cursor paginator used to mass publish products called the method `$cursor->next()` at a bad moment. It resulted that a product entity was hydrated but not returned by the paginator between each loop. The Doctrine entity manager is cleared between each page, so this product is detached when it should not, because it's returned in the next page.

I took the opportunity to fix the definition of the Paginator factory to use the same value for the page size that the cursor factory.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
