### PR TITLE
PIM-8131 labels cannot be used for search in bulk action

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-8131: Labels cannot be used for search in bulk actions
 - PIM-7939: Fix PQB search when an attribute as label is on an ancestor.
   -> Not mandatory, you can re-index your products and product models to enjoy this fix with commands: `bin/console pim:product:index --all` and `bin/console pim:product-model:index --all`.
 

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,16 @@ init-pim: clean docker-compose.yml app/config/parameters.yml app/config/paramete
 up: docker-compose.yml app/config/parameters.yml app/config/parameters_test.yml
 	$(DOCKER_COMPOSE) up -d --remove-orphan
 
+.PHONY: xdebug-on
+xdebug-on: docker-compose.yml app/config/parameters.yml app/config/parameters_test.yml
+	sed -i "s/XDEBUG_ENABLED: 0/XDEBUG_ENABLED: 1/g" docker-compose.yml
+	$(DOCKER_COMPOSE) up -d --remove-orphan
+
+.PHONY: xdebug-off
+xdebug-off: docker-compose.yml app/config/parameters.yml app/config/parameters_test.yml
+	sed -i "s/XDEBUG_ENABLED: 1/XDEBUG_ENABLED: 0/g" docker-compose.yml
+	$(DOCKER_COMPOSE) up -d --remove-orphan
+
 .PHONY: down ## Stop docker containers, remove volumes and networks.
 down:
 	$(DOCKER_COMPOSE) down -v

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
@@ -145,10 +145,14 @@ class AttributeController
      */
     public function indexAction(Request $request)
     {
-        $options = [];
+        $options = $request->request->get(
+            'options',
+            ['limit' => SearchableRepositoryInterface::FETCH_LIMIT, 'locale' => null]
+        );
 
         if ($request->request->has('identifiers')) {
             $options['identifiers'] = array_unique(explode(',', $request->request->get('identifiers')));
+            $options['limit'] = count($options['identifiers']);
         }
 
         if ($request->request->has('types')) {
@@ -159,12 +163,6 @@ class AttributeController
             $options['attribute_groups'] = explode(',', $request->request->get('attribute_groups'));
         }
 
-        if (empty($options)) {
-            $options = $request->request->get(
-                'options',
-                ['limit' => SearchableRepositoryInterface::FETCH_LIMIT, 'locale' => null]
-            );
-        }
         if ($request->request->has('rights')) {
             $options['rights'] = (bool) $request->request->get('rights');
         }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

I don't know why it was put at the end, but if the parameters `options` was passed to the controller in addition of another option if wasn't taken in account.

No spec existed before (should I add some?). I won't add behat as it is not critical at all.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
