### PR TITLE
GITHUB-9628: make the shell script failing when a shell command return a non zero code

### DIFF
--- a/bin/docker/pim-dependencies.sh
+++ b/bin/docker/pim-dependencies.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
-docker-compose exec fpm php -d memory_limit=3G /usr/local/bin/composer update && \
+docker-compose exec fpm php -d memory_limit=3G /usr/local/bin/composer update
 docker-compose run --rm node yarn install

--- a/bin/docker/pim-front.sh
+++ b/bin/docker/pim-front.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 docker-compose exec fpm rm -rf var/cache/*
 

--- a/bin/docker/pim-initialize.sh
+++ b/bin/docker/pim-initialize.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 docker-compose exec fpm rm -rf var/cache/*
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**


I fixed shell scripts as well to fail as soon as a command fail (`set -e`).
It is a best practice in shell (better than `&&` for each command).

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
