### PR TITLE
PIM-8141: Fix attribute filter selection in export profile edition

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8158: Improve the label category tree creation button label
+- PIM-8141: Fix attribute filter selection in export profile edition
 
 # 2.0.48 (2019-02-18)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/filter/attribute/attribute.js
@@ -120,7 +120,7 @@ define([
             var container = $('<span class="AknFieldContainer-contextContainer AknButtonList filter-context">');
 
             if (attribute.scopable) {
-                var scopeSwitcher = new ScopeSwitcher();
+                var scopeSwitcher = new ScopeSwitcher({config: {context: 'base_product'}});
                 scopeSwitcher.setDisplayInline(false);
                 scopeSwitcher.setDisplayLabel(false);
 
@@ -141,7 +141,7 @@ define([
             }
 
             if (attribute.localizable) {
-                var localeSwitcher = new LocaleSwitcher();
+                var localeSwitcher = new LocaleSwitcher({config: {context: 'base_product'}});
                 localeSwitcher.setDisplayInline(false);
                 localeSwitcher.setDisplayLabel(false);
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When you add a filter on a localisable attribute in the export builder, you cannot change the selected locale.

It's a backport of a fix done in 2.3 : https://github.com/akeneo/pim-community-dev/commit/629258992516c37964ccd1e63a4565ccdea07b56#diff-630631ab716dc8283c33f67b00849fbf

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
