### PR TITLE
PIM-8164: Always show cross on modals

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8157: Fix issues on user edit (scroll and groups)
+- PIM-8164: Always display cancel cross on popins
 
 # 3.0.4 (2019-02-20)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -311,7 +311,7 @@ pim_enrich.mass_edit.product:
             label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to groups|]1, Inf[Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to groups"
             description: Select the groups in which to add the selected products
             field: Groups
-            no_update: Please select a group before continue
+            no_update: Please select a group before to continue
         add_to_category:
             label: Add to categories
             label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to categories|]1, Inf[Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to categories"

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -328,7 +328,7 @@ pim_enrich.mass_edit.product:
             label: Add to an existing product model
             label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to an existing product model|]1, Inf[Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to an existing product model"
             description: The product model selected will gather the products and allows the enrichment of their common properties.
-            no_update: Please select a product model before continue
+            no_update: Please select a product model before to continue
         associate_to_product_and_product_model:
             label: Associate
             label_count: "{1}Associate <span class=\"AknFullPage-title--highlight\">1 product</span> to products or product models|]1, Inf[Associate <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to products or product models"

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -297,6 +297,7 @@ pim_enrich.mass_edit.product:
             label: Edit attributes values
             label_count: "{1}Edit attributes values of <span class=\"AknFullPage-title--highlight\">1 product</span>|]1, Inf[Edit attributes values of <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
             description: Only the attributes belonging to the families of the selected products will be edited with the following data for the {{ locale }} locale and the {{ scope }} channel.
+            no_update: Please select at least one field to update
         add_attribute_value:
             label: Add attributes values
             label_count: "{1}Add attributes values for <span class=\"AknFullPage-title--highlight\">1 product</span>|]1, Inf[Add attributes values for <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span>"
@@ -310,6 +311,7 @@ pim_enrich.mass_edit.product:
             label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to groups|]1, Inf[Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to groups"
             description: Select the groups in which to add the selected products
             field: Groups
+            no_update: Please select a group before continue
         add_to_category:
             label: Add to categories
             label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to categories|]1, Inf[Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to categories"
@@ -326,6 +328,7 @@ pim_enrich.mass_edit.product:
             label: Add to an existing product model
             label_count: "{1}Add <span class=\"AknFullPage-title--highlight\">1 product</span> to an existing product model|]1, Inf[Add <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to an existing product model"
             description: The product model selected will gather the products and allows the enrichment of their common properties.
+            no_update: Please select a product model before continue
         associate_to_product_and_product_model:
             label: Associate
             label_count: "{1}Associate <span class=\"AknFullPage-title--highlight\">1 product</span> to products or product models|]1, Inf[Associate <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> to products or product models"

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/form-modal.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/form-modal.js
@@ -81,7 +81,6 @@ define(
              * UI modal parameters
              */
             modalParameters: {
-                allowCancel: true,
                 okCloses:    false,
                 content:     '',
                 title:       '[modal_title]',

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/product/associate.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/product/associate.js
@@ -255,7 +255,6 @@ define(
                                 },
                                 innerDescription:
                                 __('pim_enrich.entity.product.module.associations.manage_description'),
-                                allowCancel: true,
                                 okCloses: false,
                                 title: __('pim_enrich.entity.product.module.associations.manage', {
                                     associationType: associationType.labels[UserContext.get('catalogLocale')]

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/pim-dialog.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/pim-dialog.js
@@ -62,7 +62,6 @@ define(
             redirect: function (content, title, okText, location) {
                 if (!_.isUndefined(Backbone.BootstrapModal)) {
                     var redirectModal = new Backbone.BootstrapModal({
-                        allowCancel: true,
                         title: title,
                         content: content,
                         okText: okText,

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/meta/groups.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/meta/groups.js
@@ -141,7 +141,6 @@ define(
                     ).done(function (productList, identifierAttribute) {
                         loadingMask.remove();
                         this.groupModal = new Backbone.BootstrapModal({
-                            allowCancel: true,
                             okText: __('pim_enrich.entity.product.module.show_group.view_group'),
                             cancelText: __('pim_common.cancel'),
                             title: __(

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap-modal/bootstrap-modal.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap-modal/bootstrap-modal.js
@@ -45,9 +45,7 @@
         </div>\
       </div>\
     </div>\
-    <% if (typeof cancelText === undefined && (typeof allowCancel === \'undefined\' || allowCancel)) { %>\
-      <div class="AknFullPage-cancel cancel"></div>\
-    <%\ } %>\
+    <div class="AknFullPage-cancel cancel"></div>\
   ');
 
   var Modal = Backbone.View.extend({
@@ -117,7 +115,7 @@
         template: template
       }, options);
     },
-
+    
     /**
      * Creates the DOM element
      *


### PR DESCRIPTION
Some crosses were deleted in 3.0.
The rule is that we always show the cross. So we removed the condition.

This PR includes some missing translations (boyscoutism)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -