### PR TITLE
PIM-8155: Fix bad ACL set on xlsx product export edit form

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -6,6 +6,7 @@
 - PIM-8131: Labels cannot be used for search in bulk actions
 - PIM-7939: Fix PQB search when an attribute as label is on an ancestor.
   -> Not mandatory, you can re-index your products and product models to enjoy this fix with commands: `bin/console pim:product:index --all` and `bin/console pim:product-model:index --all`.
+- PIM-8155: Fix bad ACL set on xlsx product export edit form
 
 # 2.3.29 (2019-02-11)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
@@ -277,7 +277,6 @@ extensions:
         module: pim/job/product/edit/content/data/add-select/attribute
         parent: pim-job-instance-xlsx-product-export-edit-content-data
         targetZone: headings
-        aclResourceId: pim_enrich_product_add_attribute
         position: 90
 
     pim-job-instance-xlsx-product-export-edit-validation:


### PR DESCRIPTION
Removing an ACL that has nothing to do with exports