### PR TITLE
PIM-8056: Remove bad ACL on the internal API end-point that get an association-type

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8056: Remove bad ACL on the internal API end-point that get an association-type
+
 # 2.3.30 (2019-02-21)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AssociationTypeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AssociationTypeController.php
@@ -98,8 +98,6 @@ class AssociationTypeController
      * @param string $identifier
      *
      * @return JsonResponse
-     *
-     * @AclAncestor("pim_enrich_associationtype_index")
      */
     public function getAction($identifier)
     {


### PR DESCRIPTION
The ACL on the internal API end-point to get an association type prevents to add associations on a product if the user doesn't have the right.

Seen with PO, this ACL shouldn't be applied on this end-point.