### PR TITLE
DAPI-22: Add sticky Modifier and Element on HorizontalNavtab style

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/HorizontalNavtab.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/HorizontalNavtab.less
@@ -78,4 +78,36 @@
     border-bottom: 3px solid @AknLightPurple;
     color: @AknLightPurple;
   }
+
+  &--sticky {
+    position: sticky;
+    top: 136px;
+    z-index: 1;
+    background-color: white;
+  }
+
+  &-stickyElement {
+    position: sticky;
+    top: 202px;
+    z-index: 1;
+    background-color: white;
+
+    &::before {
+      position: absolute;
+      top: -20px;
+      width: 100%;
+      height: 20px;
+      content: "";
+      background-color: white;
+    }
+
+    &::after {
+      position: absolute;
+      bottom: -20px;
+      width: 100%;
+      height: 20px;
+      content: "";
+      background-color: white;
+    }
+  }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Add a new sticky Modifier and Element on the HorizontalNavtab styles.

Used by Franklin Insights attributes mapping page.

`::before` and `::after` are there to set a `background-color` on the Element `padding`.
Hard-coded `top` values are specifics to the attributes mapping page for now, awaiting a generic solution.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
