### PR TITLE
PIM-8167: register command "pim:reference-data:check"

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -6,7 +6,7 @@
 - PIM-8164: Always display cancel cross on popins
 - PIM-8165: Increase font sizes
 - PIM-8018: Move Confirm button on mass edit screen
-- PIM-8167: regsiter command "pim:installer:check-requirements"
+- PIM-8167: register missing command "pim:reference-data:check"
 
 # 3.0.4 (2019-02-20)
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -6,6 +6,7 @@
 - PIM-8164: Always display cancel cross on popins
 - PIM-8165: Increase font sizes
 - PIM-8018: Move Confirm button on mass edit screen
+- PIM-8167: regsiter command "pim:installer:check-requirements"
 
 # 3.0.4 (2019-02-20)
 

--- a/src/Akeneo/Pim/Structure/Bundle/DependencyInjection/AkeneoPimStructureExtension.php
+++ b/src/Akeneo/Pim/Structure/Bundle/DependencyInjection/AkeneoPimStructureExtension.php
@@ -47,5 +47,6 @@ class AkeneoPimStructureExtension extends Extension
         $loader->load('job_defaults.yml');
         $loader->load('jobs.yml');
         $loader->load('steps.yml');
+        $loader->load('commands.yml');
     }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/commands.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/commands.yml
@@ -1,0 +1,6 @@
+services:
+
+  Akeneo\Pim\Structure\Bundle\ReferenceData\Command\CheckRequirementsCommand:
+    tags:
+      - { name: 'console.command' }
+


### PR DESCRIPTION
The command is not registered anymore because it has been moved to better reflect the bounded contexts. I chose to not move the command to keep the good organisation and I register it as a service.