### PR TITLE
Add screenshots, logs and improve test render for Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,12 +77,15 @@ jobs:
           - run:
                 name: PhpCsFixer
                 command: docker-compose exec -T fpm vendor/bin/php-cs-fixer fix --diff --dry-run --config=.php_cs.php
+                when: always
           - run:
                 name: PhpCouplingDetector
                 command: docker-compose run -T fpm vendor/bin/php-coupling-detector detect --config-file=.php_cd.php src
+                when: always
           - run:
                 name: Acceptance back
                 command: docker-compose exec fpm vendor/bin/behat --strict -p acceptance -vv
+                when: always
           - store_test_results:
                 path: var/tests
           - store_artifacts:
@@ -173,9 +176,11 @@ jobs:
         - run:
             name: Front unit tests
             command: docker-compose run --rm node yarn run unit
+            when: always
         - run:
             name: Front acceptance tests
             command: MAX_RANDOM_LATENCY_MS=100 docker-compose run --rm node yarn run acceptance ./tests/features
+            when: always
 workflows:
     version: 2
     pull_request:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,14 @@ jobs:
           command: |
             TESTFILES=$(docker-compose exec -T fpm vendor/bin/behat --list-scenarios -p legacy | circleci tests split)
             .circleci/run_behat.sh $TESTFILES
+      - run:
+          name: Gather Junit test result files in the same directory to improve the render of failing tests
+          command: |
+              set -e
+              cd var/tests/behat
+              sudo chmod -R 777 .
+              for subdir in */*; do mv "${subdir}" "${subdir/\//_}"; done
+          when: always
       - store_test_results:
           path: var/tests/behat
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             command: cp .circleci/docker-compose.override.yml.dist docker-compose.override.yml
       - run:
           name: Setup tests results folder and log folder
-          command: mkdir -p var/tests/phpunit var/tests/behat var/tests/phpspec var/tests/csfixer var/logs
+          command: mkdir -p var/tests/phpunit var/tests/behat var/tests/phpspec var/tests/csfixer var/logs var/tests/screenshots
       - run:
           name: Setup the parameters.yml files
           command: ./bin/docker/pim-setup.sh
@@ -90,6 +90,8 @@ jobs:
                 path: var/tests
           - store_artifacts:
                 path: var/tests
+          - store_artifacts:
+                path: var/logs
 
   back_phpunit_integration:
       machine:
@@ -119,6 +121,8 @@ jobs:
                 path: var/tests/phpunit
           - store_artifacts:
                 path: var/tests/phpunit
+          - store_artifacts:
+                path: var/logs
 
   back_behat_legacy:
     machine:
@@ -156,6 +160,10 @@ jobs:
           path: var/tests/behat
       - store_artifacts:
           path: var/tests/behat
+      - store_artifacts:
+            path: var/tests/screenshots
+      - store_artifacts:
+          path: var/logs
 
   front_static_acceptance_and_integration:
       machine:

--- a/.circleci/docker-compose.override.yml.dist
+++ b/.circleci/docker-compose.override.yml.dist
@@ -5,3 +5,7 @@ services:
     tmpfs:
       - '/tmp'
       - '/var/lib/mysql'
+
+  fpm:
+    environment:
+      BEHAT_SCREENSHOT_PATH: '/srv/pim/var/tests/screenshots'

--- a/.circleci/run_behat.sh
+++ b/.circleci/run_behat.sh
@@ -9,10 +9,9 @@ total=$(($(echo $TESTFILES | grep -o ' ' | wc -l) + 1))
 
 for TESTFILE in $TESTFILES; do
     echo "$TESTFILE ($counter/$total):"
-    uuid=$(uuidgen)
-    echo $uuid
-    docker-compose exec -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/behat_${uuid} --format pretty --out std --colors -p legacy $TESTFILE || \
-    docker-compose exec -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/behat_${uuid} --format pretty --out std --colors -p legacy $TESTFILE
+    output=$(basename $TESTFILE)_$(uuidgen)
+    docker-compose exec -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy $TESTFILE || \
+    docker-compose exec -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy $TESTFILE
     fail=$(($fail + $?))
     counter=$(($counter + 1))
 done

--- a/.circleci/run_behat.sh
+++ b/.circleci/run_behat.sh
@@ -10,6 +10,7 @@ total=$(($(echo $TESTFILES | grep -o ' ' | wc -l) + 1))
 for TESTFILE in $TESTFILES; do
     echo "$TESTFILE ($counter/$total):"
     uuid=$(uuidgen)
+    echo $uuid
     docker-compose exec -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/behat_${uuid} --format pretty --out std --colors -p legacy $TESTFILE || \
     docker-compose exec -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/behat_${uuid} --format pretty --out std --colors -p legacy $TESTFILE
     fail=$(($fail + $?))


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Execute php cs and acceptance tests even if phpspec step is failing**
As documented in Circle CI, a failing step prevent the next one to be executed.
So we add this key to prevent that behavior:
 ```
when: always
````

**https://github.com/akeneo/pim-community-dev/issues/9506 https://github.com/akeneo/pim-community-dev/issues/9507 Improve the naming of the junit files by using scenario name instead of only an uuid**

Note: We still use uuid to avoid any conflict if some feature files have the same name. 

Before:
![scenario_junit_before](https://user-images.githubusercontent.com/1942439/53305612-dd871700-3883-11e9-8b76-a1312c39f2d2.png)

After:
![scenario_junit](https://user-images.githubusercontent.com/1942439/53305540-ee835880-3882-11e9-9a17-869f5ea4b08b.png)



**https://github.com/akeneo/pim-community-dev/issues/9466 Improve the render of the behat scenarios by putting all junit files in the same directory**


See screenshot above to know how it works.
Note: with the new suite Franklin in 3.0, behat generates two files `all.xml` and `franklin.xml`. It is already supported here.


Before this PR:

![scenario_results_before](https://user-images.githubusercontent.com/1942439/53305573-694c7380-3883-11e9-8403-464037fe9177.png)

After:
![scenario_results_after](https://user-images.githubusercontent.com/1942439/53305554-268a9b80-3883-11e9-9546-f5ce94e3d3f6.png)

**https://github.com/akeneo/pim-community-dev/issues/9458 Add logs in the artifacts**

![logs](https://user-images.githubusercontent.com/1942439/53305732-63579200-3885-11e9-9ab9-ccb74dd51178.png)

**https://github.com/akeneo/pim-community-dev/issues/9459 Add screenshots in the artifact**

![screenshots](https://user-images.githubusercontent.com/1942439/53305753-8eda7c80-3885-11e9-9358-21b308dee4f5.png)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
