### PR TITLE
Update CHANGELOG-2.3.md

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8056: Remove bad ACL on the internal API end-point that get an association-type
+- PIM-8155: Fix bad ACL set on xlsx product export edit form
 
 # 2.3.30 (2019-02-21)
 
@@ -12,7 +13,6 @@
 - PIM-8131: Labels cannot be used for search in bulk actions
 - PIM-7939: Fix PQB search when an attribute as label is on an ancestor.
   -> Not mandatory, you can re-index your products and product models to enjoy this fix with commands: `bin/console pim:product:index --all` and `bin/console pim:product-model:index --all`.
-- PIM-8155: Fix bad ACL set on xlsx product export edit form
 
 # 2.3.29 (2019-02-11)
 


### PR DESCRIPTION
fix changelog 2.3: - PIM-8155: Fix bad ACL set on xlsx product export edit form will be available in 2.3.31

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
