### PR TITLE
PIM-8051: display the image value of a product model when the image is in a subproduct model

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,6 +4,10 @@
 
 ## Bug fixes
 
+- PIM-8051: Fix display of product model images in the datagrid when "Attribute used as main picture" is at the variant attributes level one
+
+## Bug fixes
+
 - PIM-8157: Fix issues on user edit (scroll and groups)
 - PIM-8164: Always display cancel cross on popins
 - PIM-8165: Increase font sizes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductGrid;
 
-use Akeneo\Pim\Enrichment\Component\Product\Factory\Value\MediaValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\ValueCollectionFactoryInterface;
 use Doctrine\DBAL\Connection;
 
@@ -108,8 +107,8 @@ final class ProductModelImagesFromCodes
             SELECT 
                 product_model_code,
                 CASE
-                    WHEN product_model_level = 0 AND image_code_level = 1 AND parent_id IS NOT NULL THEN 'image_in_sub_product_model'
-                    WHEN product_model_level = 0 AND image_code_level = 1 AND parent_id IS NULL THEN 'image_in_variant_product'
+                    WHEN product_model_level = 0 AND image_code_level = 1 AND number_level = 2 THEN 'image_in_sub_product_model'
+                    WHEN product_model_level = 0 AND image_code_level = 1 AND number_level = 1 THEN 'image_in_variant_product'
                     WHEN product_model_level = 0 AND image_code_level = 2 THEN 'image_in_variant_product'
                     WHEN product_model_level = 1 AND image_code_level = 1 THEN 'image_in_current_or_parent_product_model'
                     WHEN product_model_level = 1 AND image_code_level = 2 THEN 'image_in_variant_product'
@@ -118,7 +117,7 @@ final class ProductModelImagesFromCodes
             FROM (
                 SELECT 
                     pm.code as product_model_code,
-                    pm.parent_id,
+                    COUNT(all_attribute_sets.family_variant_id) as number_level,
                     pm.lvl as product_model_level,
                     fv_set.level as image_code_level
                 FROM
@@ -129,8 +128,10 @@ final class ProductModelImagesFromCodes
                     JOIN pim_catalog_family_variant_has_variant_attribute_sets attr_set ON  attr_set.family_variant_id = fv.id
                     JOIN pim_catalog_family_variant_attribute_set fv_set ON fv_set.id = variant_attribute_sets_id
                     JOIN pim_catalog_variant_attribute_set_has_attributes attr ON attr.variant_attribute_set_id = fv_set.id AND attr.attributes_id = a_image.id
+                    JOIN pim_catalog_family_variant_has_variant_attribute_sets all_attribute_sets ON  all_attribute_sets.family_variant_id = fv.id
                 WHERE 
                     pm.code IN (:codes)
+                GROUP BY pm.code, all_attribute_sets.family_variant_id, fv_set.level
             ) as product_models
 SQL;
 
@@ -243,7 +244,6 @@ SQL;
             LIMIT 1
 SQL;
 
-        $images = [];
         foreach ($codes as $code) {
             $row = $this->connection->executeQuery(
                 $sql,

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodesIntegration.php
@@ -84,10 +84,11 @@ class FetchProductModelRowsFromCodesIntegration extends TestCase
 
         $fixturesLoader = new ProductGridFixturesLoader(static::$kernel->getContainer(), $this->getFixturePath('akeneo.jpg'));
         $rootProductModelWithLabelInProduct = $fixturesLoader->createProductModelsWithLabelInProduct();
+        $rootProductModelWithLabelInSubProductModel = $fixturesLoader->createProductModelsWithLabelInSubProductModel();
         $subProductModelWithLabelInParent = $fixturesLoader->createProductModelsWithLabelInParentProductModel();
 
         $query = $this->get('akeneo.pim.enrichment.product.grid.query.fetch_product_model_rows_from_codes');
-        $rows = $query(['root_product_model_without_sub_product_model', 'sub_product_model'], [], 'ecommerce', 'en_US', $userId);
+        $rows = $query(['root_product_model_without_sub_product_model', 'root_product_model_with_image_in_sub_product_model', 'sub_product_model'], [], 'ecommerce', 'en_US', $userId);
 
         $akeneoImage = current($this
             ->get('akeneo_file_storage.repository.file_info')
@@ -104,6 +105,18 @@ class FetchProductModelRowsFromCodesIntegration extends TestCase
                 MediaValue::value('an_image', $akeneoImage),
                 $rootProductModelWithLabelInProduct->getId(),
                 ['total' => 1, 'complete' => 1],
+                null,
+                new ValueCollection([])
+            ),
+            Row::fromProductModel(
+                'root_product_model_with_image_in_sub_product_model',
+                '[test_family]',
+                $rootProductModelWithLabelInSubProductModel->getCreated(),
+                $rootProductModelWithLabelInSubProductModel->getUpdated(),
+                '[root_product_model_with_image_in_sub_product_model]',
+                MediaValue::value('an_image', $akeneoImage),
+                $rootProductModelWithLabelInSubProductModel->getId(),
+                ['total' => 0, 'complete' => 0],
                 null,
                 new ValueCollection([])
             ),

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductGridFixturesLoader.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductGridFixturesLoader.php
@@ -107,6 +107,41 @@ final class ProductGridFixturesLoader
         return $subProductModel;
     }
 
+    public function createProductModelsWithLabelInSubProductModel()
+    {
+        $rootProductModelWithoutSubProductModel = $this->container->get('pim_catalog.factory.product_model')->create();
+        $this->container->get('pim_catalog.updater.product_model')->update($rootProductModelWithoutSubProductModel, [
+            'code' => 'root_product_model_with_image_in_sub_product_model',
+            'family_variant' => 'family_variant_image_in_sub_product_model',
+            'values' => []
+        ]);
+
+        $errors = $this->container->get('pim_catalog.validator.product')->validate($rootProductModelWithoutSubProductModel);
+        Assert::assertCount(0, $errors);
+        $this->container->get('pim_catalog.saver.product_model')->save($rootProductModelWithoutSubProductModel);
+
+        $subProductModel = $this->container->get('pim_catalog.factory.product_model')->create();
+        $this->container->get('pim_catalog.updater.product_model')->update($subProductModel, [
+            'code' => 'sub_product_model_with_image_in_sub_product_model',
+            'parent' => 'root_product_model_with_image_in_sub_product_model',
+            'family_variant' => 'family_variant_image_in_sub_product_model',
+            'values' => [
+                'a_yes_no' => [
+                    ['data' => true, 'locale' => null, 'scope' => null],
+                ],
+                'an_image' => [
+                    ['data' => $this->akeneoImagePath, 'locale' => null, 'scope' => null],
+                ],
+            ]
+        ]);
+
+        $errors = $this->container->get('pim_catalog.validator.product')->validate($subProductModel);
+        Assert::assertCount(0, $errors);
+        $this->container->get('pim_catalog.saver.product_model')->save($subProductModel);
+
+        return $rootProductModelWithoutSubProductModel;
+    }
+
     public function createProductAndProductModels()
     {
         return [
@@ -242,6 +277,28 @@ final class ProductGridFixturesLoader
                 [
                     'axes' => ['a_yes_no'],
                     'attributes' => [],
+                    'level'=> 1
+                ],
+                [
+                    'axes' => ['a_simple_select_size'],
+                    'attributes' => [],
+                    'level'=> 2
+                ]
+            ],
+        ]);
+
+        $errors = $this->container->get('validator')->validate($familyVariant);
+        Assert::assertCount(0, $errors);
+        $this->container->get('pim_catalog.saver.family_variant')->save($familyVariant);
+
+        $familyVariant = $this->container->get('pim_catalog.factory.family_variant')->create();
+        $this->container->get('pim_catalog.updater.family_variant')->update($familyVariant, [
+            'code' => 'family_variant_image_in_sub_product_model',
+            'family' => 'test_family',
+            'variant_attribute_sets' => [
+                [
+                    'axes' => ['a_yes_no'],
+                    'attributes' => ['an_image'],
                     'level'=> 1
                 ],
                 [


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
We display images in the datagrid.
Images is the image of the value in the attribute "attribute as main picture", defined in the family.

When we have product models, the problem is pretty complex as the attribute can be at any level.

Here the different combination:
- if attribute as main picture is in common attributes, we display the images of the root product model (with 1 or 2 levels) :heavy_check_mark:  
- if it's at level 1, and there are 2 levels, we display the image of the first product model having an image :red_circle: 
- if it's in at level 1, and there are 1 level, we display the image of the variant product (because level 1 is variant product) :heavy_check_mark: 
- if it's in at level 2, and there are 2 levels, we display the image of the variant product (because level 1 is product model and level 2 the variant product) :heavy_check_mark: 


The problem is that it's complicated to know how many levels there are when we have the code of a product model.
We only know the level of the product model, not the total number of level.
It is necessary to know the number of levels to do the JOIN.

To fix that, we count the number of levels by counting the number of sets. I don't see a better solution with the actual table architecture.

Note: It will not impact the performance, as the new JOIN multiple only by 1 or two the total number of rows (which is then flatten by the GROUP BY).

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
