### PR TITLE
PIM-8152: accept spaces in kernel root dir when executing commands

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -10,6 +10,7 @@
 - PIM-8018: Move Confirm button on mass edit screen
 - PIM-8167: register missing command "pim:reference-data:check"
 - PIM-8168: accept MySql version with suffix in requirements check
+- PIM-8152: accept spaces in kernel root dir when executing commands
 
 # 3.0.4 (2019-02-20)
 

--- a/src/Akeneo/Tool/Component/Console/CommandLauncher.php
+++ b/src/Akeneo/Tool/Component/Console/CommandLauncher.php
@@ -56,7 +56,7 @@ class CommandLauncher
         return sprintf(
             '%s %s%sconsole --env=%s %s',
             $this->getPhp(),
-            sprintf('%s%s..%sbin', $this->rootDir, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR),
+            sprintf('%s%s..%sbin', escapeshellarg($this->rootDir), DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR),
             DIRECTORY_SEPARATOR,
             $this->environment,
             $command


### PR DESCRIPTION
If we have spaces in kernel root, the command launcher try to launch the bad command, like 

`/usr/bin/php /srv/pim pim/bin/console my:command`

After the fix, the command will be:

`/usr/bin/php '/srv/pim pim'/bin/console my:command` which is executable.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
