### PR TITLE
DAPI-19: ProductPropertiesNormalizer accepts optional normalizers to be able to index additional product properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Technical improvement
 
+- DAPI-19: Update `Akeneo\Pim\Enrichment\Component\Product\Normalizer\Indexing\ProductAndProductModel\ProductPropertiesNormalizer` to accept optional normalizers
+
 ## BC breaks
 
 - Twig extension `get_attribute_label_from_code` has been removed with the class `Akeneo\Pim\Structure\Bundle\Twig\AttributeExtension`.

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_indexing.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_indexing.yml
@@ -175,6 +175,7 @@ services:
         arguments:
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.repository.locale'
+            - !tagged pim_catalog.normalizer.indexing_product_and_product_model.product.additional_properties
         tags:
             - { name: pim_indexing_serializer.normalizer, priority: 40 }
 

--- a/tests/back/Pim/Enrichment/Integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Normalizer/Indexing/ProductAndProductModelIndexingIntegration.php
@@ -10,6 +10,8 @@ use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 
 /**
  * Integration tests to verify data from database are well formatted in the "indexing_product_and_product_model" format
+ * 
+ * @group ce
  */
 class ProductAndProductModelIndexingIntegration extends TestCase
 {


### PR DESCRIPTION
This PR adds a way to index additional product properties without having to extends or rewrite the existing product properties normalizer. We needed this to index the franklin insights status of products (subscribed or not) and be able to filter on this data in the search form.

Everything is done by the dependency injection of Symfony : any service with the correct tag will be injected in the product properties normalizer. With this way there is no BC break in the community and it will allow us in the future to index more properties.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
