### PR TITLE
GITHUB-9511: generate an error in Circle CI when there is a JS error in a behat and split by timing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
       - run:
           name: Behat
           command: |
-            TESTFILES=$(docker-compose exec -T fpm vendor/bin/behat --list-scenarios -p legacy | circleci tests split)
+            TESTFILES=$(docker-compose exec -T fpm vendor/bin/behat --list-scenarios -p legacy | circleci tests split --split-by=timings)
             .circleci/run_behat.sh $TESTFILES
       - run:
           name: Gather Junit test result files in the same directory to improve the render of failing tests

--- a/tests/legacy/features/Pim/Behat/Extension/PimFormatter/Output/Node/Printer/PimScenarioPrinter.php
+++ b/tests/legacy/features/Pim/Behat/Extension/PimFormatter/Output/Node/Printer/PimScenarioPrinter.php
@@ -68,6 +68,7 @@ final class PimScenarioPrinter
 
         $outputPrinter->addTestcase([
             'name'   => $fileAndLine,
+            'file' => $fileAndLine,
             'status' => $this->resultConverter->convertResultToString($result),
             'time' => $this->durationListener->getDuration($scenario),
         ]);

--- a/tests/legacy/features/Pim/Behat/Extension/PimFormatter/Output/Node/Printer/PimScenarioPrinter.php
+++ b/tests/legacy/features/Pim/Behat/Extension/PimFormatter/Output/Node/Printer/PimScenarioPrinter.php
@@ -68,7 +68,7 @@ final class PimScenarioPrinter
 
         $outputPrinter->addTestcase([
             'name'   => $fileAndLine,
-            'file' => $fileAndLine,
+            'file' => $fileAndLine, // allow to split by timing the scenarios to execute in Circle CI
             'status' => $this->resultConverter->convertResultToString($result),
             'time' => $this->durationListener->getDuration($scenario),
         ]);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Sorry, two PR in one but it's the same files to modify and it's pretty long to test.

**https://github.com/akeneo/pim-community-dev/issues/9511 generate an error in Circle CI when there is a JS error**

When there is a JS error, the build is red in circle CI, because the return code of the command is 1.
But the error is not displayed at all in the result and it seems that there are no failed behat.
This i confusing as the build is red... so you have to search in the logs the error.

This is  because Circle CI does not parse correctly the Junit output files.

Correctly parsed:
```
<testcase name="tests/legacy/features/update/add_association.feature:6"  file="tests/legacy/features/update/add_association.feature:6" status="failed" time="3.787">
     <failure message="Then I should get the following products after apply the following updater to it"></failure>
</testcase>
```

Not correctly parsed:
```
<testcase name="tests/legacy/features/update/add_association.feature:6"  file="tests/legacy/features/update/add_association.feature:6" status="failed" time="3.787">
</testcase>
```

The failure node is missing. This failure node exist only when there are some failed steps.
But a step is not considered as failed when we trigger an exception in a hook. Just skipped.
You can read the Phpdoc, it explains the problem.


After the PR, this is the result:

![screenshot from 2019-02-27 21-02-17](https://user-images.githubusercontent.com/1942439/53521959-b6298780-3ad9-11e9-9358-f606272df6e8.png)

**https://github.com/akeneo/pim-community-dev/issues/9463 Split by timing the tests**

It's only 2 lines of codes but this feature is not very well documented in Circle CI, so I needed to reverse engineer it.
How it works? 
First, we list all the scenarios with `list-scenarios`:
```
tests/legacy/features/security/csrf_attacks/allow_only_xhr_requests_for_job_profiles.feature:9
tests/legacy/features/security/csrf_attacks/allow_only_xhr_requests_for_job_profiles.feature:15
...
```
In theory, to use split by timing, it should a path, but here, it's a path + line. Split by timing feature is not built to behave like that and we will have to understand how it works to "hack" it.

After listing all the files, it does (pseudocode):
```
durationPerFile = []
foreach testfiles as testfile:
    testcases= getAllTestCasesForThis(testfile) // get it from previous Green CI builds
    durationForThisFile=sumTime(testcases)
    durationPerFile[file] = durationForThisFile
end
```


So, Circle CI has the duration time per file. As said before, the problem is that we don't execute per file but by scenario. So, we want the time per scenario, not per file.

So,  to achieve that, we have to print `file=tests/legacy/features/security/csrf_attacks/allow_only_xhr_requests_for_job_profiles.feature:9`, with the line number.
This way, each testcase has a unique filename.

Therefore, Circle CI has a time per scenario.

```
<testsuites name="all">
  <testsuite name="Allow only XHR requests for some job profiles actions" tests="1" skipped="0" failures="0" errors="0">
    <testcase name="tests/legacy/features/security/csrf_attacks/allow_only_xhr_requests_for_job_profiles.feature:9" file="tests/legacy/features/security/csrf_attacks/allow_only_xhr_requests_for_job_profiles.feature:9" status="passed" time="2.61"/>
  </testsuite>
</testsuites>
```

Before:
![screenshot from 2019-02-28 00-12-32](https://user-images.githubusercontent.com/1942439/53529680-a9169380-3aed-11e9-9ef6-05be4c3743ef.png)

After (5 minutes gain, 14%):
![screenshot from 2019-02-28 00-12-49](https://user-images.githubusercontent.com/1942439/53529702-b0d63800-3aed-11e9-8633-1ec66fa2efcc.png)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
