### PR TITLE
PIM-8174: Fix too long URI for multi-select with a lots of options

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -6,6 +6,7 @@
 
 - PIM-8158: Improve the label category tree creation button label
 - PIM-8141: Fix attribute filter selection in export profile edition
+- PIM-8174: Fix too long URI for multi-select with a lots of options
 
 # 2.0.48 (2019-02-18)
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeOptionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeOptionController.php
@@ -37,6 +37,8 @@ class AttributeOptionController
     /**
      * Return the attribute option array
      *
+     * TODO in 2.3 pull up: this action should only respond to POST method
+     *
      * @param Request $request
      * @param int     $identifier
      *

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/attributeoption.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/attributeoption.yml
@@ -40,4 +40,4 @@ pim_enrich_attributeoption_get:
     defaults: { _controller: pim_enrich.controller.rest.attribute_option:getAction, _format: json }
     requirements:
         identifier: '[a-zA-Z0-9_]+'
-    methods: [GET]
+    methods: [GET, POST]

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/multi-select-field.js
@@ -129,7 +129,7 @@ define(
                             ).data;
 
                             if (null === this.choicePromise || this.promiseIdentifiers !== identifiers) {
-                                this.choicePromise = $.get(choiceUrl, {
+                                this.choicePromise = $.post(choiceUrl, {
                                     options: {
                                         identifiers: identifiers
                                     }


### PR DESCRIPTION
When we have a lots of options in the multi-select attribute, we can have an error because of the URI being too long. 

This fix aims to change the call for options from http GET to POST, when we will not have this kind of limitation.

Related to #3876

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
