### PR TITLE
Use the power of makefile to install the pim assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,40 +80,6 @@ vendor: composer.lock
 node_modules: package.json
 	$(YARN_EXEC) install
 
-## Instal the PIM asset: copy asset from src to web, generate require path, form extension and translation
-.PHONY: install-asset
-install-asset: vendor node_modules
-	$(PHP_RUN) bin/console --env=prod pim:installer:assets --symlink --clean
-	$(YARN_EXEC) run less
-	$(YARN_EXEC) run webpack-dev
-	$(YARN_EXEC) run webpack-test
-
-## Initialize the PIM database depending on an environment
-.PHONY: install-database-test
-install-database-test: docker-compose.override.yml app/config/parameters_test.yml vendor
-	$(PHP_EXEC) bin/console --env=behat pim:installer:db
-
-.PHONY: install-database-prod
-install-database-prod: docker-compose.override.yml app/config/parameters.yml vendor
-	$(PHP_EXEC) bin/console --env=prod pim:installer:db
-
-## Initialize the PIM: install database (behat/prod) and run webpack
-.PHONY: install-pim
-install-pim: app/config/parameters.yml app/config/parameters_test.yml vendor node_modules clean install-asset install-database-test install-database-prod
-
-##
-## PIM installation
-##
-
-composer.lock: composer.json
-	$(PHP_RUN) /usr/local/bin/composer update
-
-vendor: composer.lock
-	$(PHP_RUN) /usr/local/bin/composer install
-
-node_modules: package.json
-	$(YARN_EXEC) install
-
 web/css/pim.css: $(LESS_FILES)
 	$(YARN_EXEC) run less
 
@@ -168,7 +134,7 @@ install-pim: app/config/parameters.yml app/config/parameters_test.yml vendor nod
 ## Start docker containers
 .PHONY: up
 up: .env docker-compose.override.yml app/config/parameters.yml app/config/parameters_test.yml
-	PHP_XDEBUG_ENABLED=0 $(DOCKER_COMPOSE) up -d --remove-orphan
+	$(DOCKER_COMPOSE) up -d --remove-orphan
 
 ## Stop docker containers, remove volumes and networks
 .PHONY: down


### PR DESCRIPTION
Before reviewing this PR you should have a look to https://github.com/akeneo/pim-community-dev/pull/9677

**Description**

What the command pim:installer:asset does ?
* Dump require JS paths
* Dump JS form extensions
* Copy all assets from bundles to web folder
* Dump JS translations
* Dump js routes

Do I need to run these commands every time? No!
* I only need to dump require JS paths if I changed/added any `requirejs.yml` file.
* I only need to dump JS form extensions if I changed/added any `form_extensions.yml` file.
* I only need to dump copy assets if I changed/added any file located `/Resources/public/` from my bundle.
* I only need to dump JS translations if I changed/added any `jsmessages*.yml`
* It depends on the routes stored in the Symfony container, so unfortunately we need to run this command all time to be sure the routes are up to date.

We can use the power of makefile to avoid to run command when it is not necessary. A target won't be executed if the prerequisite did not change. 

Let's take a simple example: dumping require JS path. First I will create a new target to dump them.
```
web/js/require-paths.js:
	$(PHP_EXEC) bin/console pim:installer:dump-require-paths
```

But, I want to update the `web/js/require-paths.js` file only if I made some changes in any `requirejs.yml` files. If my target has every `requirejs.yml`files as prerequisite the command `pim:installer:dump-require-paths` will be only run when a `requirejs.yml` file has been changed. Thanks to the shell command `find . -name "requirejs.yml"` I am able to find them.

```
web/js/require-paths.js: $(shell find . -name "requirejs.yml")
	$(PHP_EXEC) bin/console pim:installer:dump-require-paths
```

Now my require js path are dump when it is needed thank to makefile!

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
