### PR TITLE
PIM-8175: add the possiblity to filter on one or several index names when resetting ES indexes

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Improvement
+
+- PIM-8175: add the possibility to filter on one or several index names when resetting ES indexes
+
 # 2.3.31 (2019-02-28)
 
 ## Bug fixes

--- a/src/Akeneo/Bundle/ElasticsearchBundle/Command/ResetIndexesCommand.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/Command/ResetIndexesCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Bundle\ElasticsearchBundle\Command;
 
+use Akeneo\Bundle\ElasticsearchBundle\Client;
 use Pim\Bundle\CatalogBundle\Command\IndexProductCommand;
 use Pim\Bundle\CatalogBundle\Command\IndexProductModelCommand;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -32,8 +33,9 @@ class ResetIndexesCommand extends ContainerAwareCommand
                 'reset-indexes',
                 true,
                 InputOption::VALUE_NONE,
-                'Resets all registered ES indexes prior to reindex'
+                'Resets registered ES indexes prior to reindex'
             )
+            ->addOption('index', 'i', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'ES index name to reset')
             ->setDescription('Resets all registered ES indexes');
     }
 
@@ -46,7 +48,7 @@ class ResetIndexesCommand extends ContainerAwareCommand
             return;
         }
 
-        $esClients = $this->getEsClients();
+        $esClients = $this->getFilteredEsClients($input);
         $this->resetIndexes($output, $esClients);
 
         if (!$this->areIndexesExisting($output, $esClients)) {
@@ -64,7 +66,16 @@ class ResetIndexesCommand extends ContainerAwareCommand
      */
     private function userConfirmation(InputInterface $input, OutputInterface $output): bool
     {
-        $output->writeln('<info>This action will entirely reset all indexes registered in the PIM.</info>');
+        $esClients = $this->getFilteredEsClients($input);
+        if (empty($esClients)) {
+            $output->writeln('<info>There is not any index to reset. Maybe you provided an index to reset that does not exist.</info>');
+        }
+
+        $output->writeln('<info>This action will entirely reset the following indexes in the PIM:</info>');
+        foreach ($esClients as $esClient) {
+            $output->writeln(sprintf('<info>%s</info>', $esClient->getIndexName()));
+        }
+
         $question = new ConfirmationQuestion(
             '<question>Are you sure you want to proceed ?</question> (Y/n)',
             true
@@ -79,6 +90,27 @@ class ResetIndexesCommand extends ContainerAwareCommand
         }
 
         return true;
+    }
+
+    /**
+     * Gets the clients to reset filtered by those provided in the arguments of the function.
+     *
+     * @return Client[]
+     */
+    private function getFilteredEsClients(InputInterface $input): array
+    {
+        $esClients = $this->getEsClients();
+        $selectedIndexes = $input->getOption('index');
+
+        if (empty($selectedIndexes)) {
+            return $esClients;
+        }
+
+        $filteredEsClients = array_filter($esClients, function (Client $client) use ($selectedIndexes) {
+            return in_array($client->getIndexName(), $selectedIndexes);
+        });
+
+        return $filteredEsClients;
     }
 
     /**
@@ -145,7 +177,7 @@ class ResetIndexesCommand extends ContainerAwareCommand
     protected function showSuccessMessages(OutputInterface $output): void
     {
         $output->writeln('');
-        $output->writeln('<info>All the registered indexes have been successfully reset!</info>');
+        $output->writeln('<info>All the indexes have been successfully reset!</info>');
         $output->writeln('');
         $output->writeln(
             sprintf(

--- a/src/Akeneo/Bundle/ElasticsearchBundle/spec/Command/ResetIndexesCommandSpec.php
+++ b/src/Akeneo/Bundle/ElasticsearchBundle/spec/Command/ResetIndexesCommandSpec.php
@@ -49,6 +49,8 @@ class ResetIndexesCommandSpec extends ObjectBehavior
         $container->get('akeneo_elasticsearch.registry.clients')->willReturn($clientRegistry);
         $clientRegistry->getClients()->willReturn([$client1, $client2]);
 
+        $input->getOption('index')->willReturn([]);
+
         $client1->resetIndex()->shouldBeCalled();
         $client1->getIndexName()->willReturn('index_1');
         $client1->hasIndex()->willReturn(true);
@@ -57,7 +59,11 @@ class ResetIndexesCommandSpec extends ObjectBehavior
         $client2->resetIndex()->shouldBeCalled();
         $client2->hasIndex()->willReturn(true);
 
-        $output->writeln('<info>This action will entirely reset all indexes registered in the PIM.</info>')->shouldBeCalled();
+        $output->writeln('<info>This action will entirely reset the following indexes in the PIM:</info>')->shouldBeCalled();
+        $output->writeln('<info>index_1</info>')->shouldBeCalled();
+        $output->writeln('<info>index_2</info>')->shouldBeCalled();
+
+
         $helperSet->get('question')->willReturn($questionHelper);
         $questionHelper->ask($input, $output, Argument::cetera())->willReturn(true);
 
@@ -66,7 +72,70 @@ class ResetIndexesCommandSpec extends ObjectBehavior
         $output->writeln('')->shouldBeCalled();
 
         $output->writeln('')->shouldBeCalled();
-        $output->writeln('<info>All the registered indexes have been successfully reset!</info>')
+        $output->writeln('<info>All the indexes have been successfully reset!</info>')
+            ->shouldBeCalled();
+        $output->writeln('')->shouldBeCalled();
+        $output->writeln('<info>You can now use the command pim:product:index and pim:product-model:index to start re-indexing your product and product models.</info>')
+            ->shouldBeCalled();
+
+        $commandInput = new ArrayInput([
+            'command'    => 'pim:indexes:reset',
+            '--all'      => true,
+            '--no-debug' => true,
+        ]);
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->run($commandInput, $output)->willReturn(0);
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+        $this->run($input, $output);
+    }
+
+    function it_resets_an_index_provided_int_the_option_of_the_command_line(
+        ContainerInterface $container,
+        ClientRegistry $clientRegistry,
+        Client $client1,
+        Client $client2,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition,
+        QuestionHelper $questionHelper
+    ) {
+        $container->get('akeneo_elasticsearch.registry.clients')->willReturn($clientRegistry);
+        $clientRegistry->getClients()->willReturn([$client1, $client2]);
+
+        $input->getOption('index')->willReturn(['index_1']);
+
+        $client1->resetIndex()->shouldBeCalled();
+        $client1->getIndexName()->willReturn('index_1');
+        $client1->hasIndex()->willReturn(true);
+
+        $client2->getIndexName()->willReturn('index_2');
+        $client2->resetIndex()->shouldNotBeCalled();
+
+        $output->writeln('<info>This action will entirely reset the following indexes in the PIM:</info>')->shouldBeCalled();
+        $output->writeln('<info>index_1</info>')->shouldBeCalled();
+        $output->writeln('<info>index_2</info>')->shouldNotBeCalled();
+
+
+        $helperSet->get('question')->willReturn($questionHelper);
+        $questionHelper->ask($input, $output, Argument::cetera())->willReturn(true);
+
+        $output->writeln('<info>Resetting the index: index_1</info>')->shouldBeCalled();
+        $output->writeln('')->shouldBeCalled();
+
+        $output->writeln('')->shouldBeCalled();
+        $output->writeln('<info>All the indexes have been successfully reset!</info>')
             ->shouldBeCalled();
         $output->writeln('')->shouldBeCalled();
         $output->writeln('<info>You can now use the command pim:product:index and pim:product-model:index to start re-indexing your product and product models.</info>')
@@ -100,18 +169,26 @@ class ResetIndexesCommandSpec extends ObjectBehavior
         Application $application,
         HelperSet $helperSet,
         InputDefinition $definition,
-        QuestionHelper $questionHelper
+        QuestionHelper $questionHelper,
+        ClientRegistry $clientRegistry,
+        Client $client1,
+        Client $client2
     ) {
-        $output->writeln('<info>This action will entirely reset all indexes registered in the PIM.</info>')
-            ->shouldBeCalled();
+        $input->getOption('index')->willReturn([]);
+        $container->get('akeneo_elasticsearch.registry.clients')->willReturn($clientRegistry);
+        $clientRegistry->getClients()->willReturn([$client1, $client2]);
+        $client1->getIndexName()->willReturn('index_1');
+        $client2->getIndexName()->willReturn('index_2');
+
+        $output->writeln('<info>This action will entirely reset the following indexes in the PIM:</info>')->shouldBeCalled();
+        $output->writeln('<info>index_1</info>')->shouldBeCalled();
+        $output->writeln('<info>index_2</info>')->shouldBeCalled();
 
         $helperSet->get('question')->willReturn($questionHelper);
         $questionHelper->ask($input, $output, Argument::cetera())->willReturn(false);
 
         $output->writeln('<info>Operation aborted. Nothing has been done.</info>')
             ->shouldBeCalled();
-
-        $container->get('akeneo_elasticsearch.registry.clients')->shouldNotBeCalled();
 
         $commandInput = new ArrayInput([
             'command'    => 'pim:indexes:reset',
@@ -146,6 +223,8 @@ class ResetIndexesCommandSpec extends ObjectBehavior
         InputDefinition $definition,
         QuestionHelper $questionHelper
     ) {
+        $input->getOption('index')->willReturn([]);
+
         $container->get('akeneo_elasticsearch.registry.clients')->willReturn($clientRegistry);
         $clientRegistry->getClients()->willReturn([$client1, $client2]);
 
@@ -157,7 +236,10 @@ class ResetIndexesCommandSpec extends ObjectBehavior
         $client2->resetIndex()->shouldBeCalled();
         $client2->hasIndex()->willReturn(false);
 
-        $output->writeln('<info>This action will entirely reset all indexes registered in the PIM.</info>')->shouldBeCalled();
+        $output->writeln('<info>This action will entirely reset the following indexes in the PIM:</info>')->shouldBeCalled();
+        $output->writeln('<info>index_1</info>')->shouldBeCalled();
+        $output->writeln('<info>index_2</info>')->shouldBeCalled();
+
         $helperSet->get('question')->willReturn($questionHelper);
         $questionHelper->ask($input, $output, Argument::cetera())->willReturn(true);
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

A customer has a problem on its proposal.
In order to fix that, we need to re-index all the ES of the PIM.

But he has several thousands of products and the problem is not on the product.
So, we added the possibility to re-index only a specific index to fix this kind of problems on a production environment.


```
bin/console akeneo:elasticsearch:reset-indexes -i akeneo_pim_product -i akeneo_pim_product_model
```

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
