### PR TITLE
PIM-8178: fix family attributes selector

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8178: Fix Attribute search on family edit page
+
 # 3.0.5 (2019-02-25)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AttributeSearchableRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AttributeSearchableRepository.php
@@ -69,7 +69,7 @@ class AttributeSearchableRepository implements SearchableRepositoryInterface
                 'is_locale_specific'     => null,
                 'useable_as_grid_filter' => null,
                 'families'               => null,
-                'exclude_identifiers_from_family' => null,
+                'excluded_family'        => null,
             ]
         );
         $resolver->setAllowedTypes('identifiers', 'array');
@@ -87,7 +87,7 @@ class AttributeSearchableRepository implements SearchableRepositoryInterface
         $resolver->setAllowedTypes('is_locale_specific', ['bool', 'null']);
         $resolver->setAllowedTypes('useable_as_grid_filter', ['bool', 'null']);
         $resolver->setAllowedTypes('families', ['array', 'null']);
-        $resolver->setAllowedTypes('exclude_identifiers_from_family', ['string', 'null']);
+        $resolver->setAllowedTypes('excluded_family', ['string', 'null']);
 
         $options = $resolver->resolve($options);
 
@@ -126,10 +126,10 @@ class AttributeSearchableRepository implements SearchableRepositoryInterface
 
         if (null !== $search) {
             $qb->leftJoin('a.translations', 'at');
-            $qb->where('a.code like :search')->setParameter('search', '%'.$search.'%');
+            $qb->where('a.code like :search')->setParameter('search', '%' . $search . '%');
             if (null !== $localeCode = $options['locale']) {
                 $qb->orWhere('at.label like :search AND at.locale like :locale');
-                $qb->setParameter('search', '%'.$search.'%');
+                $qb->setParameter('search', '%' . $search . '%');
                 $qb->setParameter('locale', $localeCode);
             }
         }
@@ -187,10 +187,10 @@ class AttributeSearchableRepository implements SearchableRepositoryInterface
             $qb->setParameter('families', $options['families']);
         }
 
-        if (null !== $options['exclude_identifiers_from_family']) {
+        if (null !== $options['excluded_family']) {
             $qb->leftJoin('a.families', 'xf');
             $qb->andWhere('xf.code IS NULL OR xf.code <> :excluded_family');
-            $qb->setParameter('excluded_family', $options['exclude_identifiers_from_family']);
+            $qb->setParameter('excluded_family', $options['excluded_family']);
         }
 
         $qb->leftJoin('a.group', 'ag');

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute/select.js
@@ -30,7 +30,15 @@ define(
                     .then(function (familyCode) {
                         searchParameters.options.exclude_identifiers_from_family = familyCode;
 
-                        return FetcherRegistry.getFetcher(this.mainFetcher).search(searchParameters);
+                        return FetcherRegistry.getFetcher(this.mainFetcher).search(searchParameters)
+                            .then(function (attributes) {
+                                const groupCodes = _.unique(_.pluck(attributes, 'group'));
+
+                                return FetcherRegistry.getFetcher('attribute-group').fetchByIdentifiers(groupCodes)
+                                    .then(function (attributeGroups) {
+                                        return this.populateGroupProperties(attributes, attributeGroups);
+                                    }.bind(this));
+                            }.bind(this));
                     }.bind(this));
             },
 
@@ -45,7 +53,7 @@ define(
              * {@inheritdoc}
              */
             addItems: function () {
-                this.getRoot().trigger(this.addEvent, { codes: this.selection });
+                this.getRoot().trigger(this.addEvent, {codes: this.selection});
             },
 
             /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute/select.js
@@ -28,7 +28,7 @@ define(
             fetchItems: function (searchParameters) {
                 return this.getItemsToExclude()
                     .then(function (familyCode) {
-                        searchParameters.options.exclude_identifiers_from_family = familyCode;
+                        searchParameters.options.excluded_family = familyCode;
 
                         return FetcherRegistry.getFetcher(this.mainFetcher).search(searchParameters)
                             .then(function (attributes) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute/select.js
@@ -23,11 +23,7 @@ define(
         return AddAttributeSelect.extend({
 
             /**
-             * Fetches items from the backend.
-             *
-             * @param {Object} searchParameters
-             *
-             * @return {Promise}
+             * {@inheritdoc}
              */
             fetchItems: function (searchParameters) {
                 return this.getItemsToExclude()

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute/select.js
@@ -11,24 +11,38 @@ define(
     [
         'jquery',
         'underscore',
-        'pim/product/add-select/attribute'
+        'pim/product/add-select/attribute',
+        'pim/fetcher-registry'
     ],
     function (
         $,
         _,
-        AddAttributeSelect
+        AddAttributeSelect,
+        FetcherRegistry
     ) {
         return AddAttributeSelect.extend({
+
+            /**
+             * Fetches items from the backend.
+             *
+             * @param {Object} searchParameters
+             *
+             * @return {Promise}
+             */
+            fetchItems: function (searchParameters) {
+                return this.getItemsToExclude()
+                    .then(function (familyCode) {
+                        searchParameters.options.exclude_identifiers_from_family = familyCode;
+
+                        return FetcherRegistry.getFetcher(this.mainFetcher).search(searchParameters);
+                    }.bind(this));
+            },
+
             /**
              * {@inheritdoc}
              */
             getItemsToExclude: function () {
-                return $.Deferred().resolve(
-                    _.pluck(
-                        this.getFormData().attributes,
-                        'code'
-                    )
-                );
+                return $.Deferred().resolve(this.getFormData().code);
             },
 
             /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/mass-edit/toolbar/add-select/attribute/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/mass-edit/toolbar/add-select/attribute/select.js
@@ -24,6 +24,18 @@ define(
             /**
              * {@inheritdoc}
              */
+            fetchItems: function (searchParameters) {
+                return this.getItemsToExclude()
+                    .then(function (identifiersToExclude) {
+                        searchParameters.options.excluded_identifiers = identifiersToExclude;
+
+                        return FetcherRegistry.getFetcher(this.mainFetcher).search(searchParameters);
+                    }.bind(this));
+            },
+
+            /**
+             * {@inheritdoc}
+             */
             getItemsToExclude: function () {
                 return FetcherRegistry.getFetcher(this.mainFetcher)
                     .getIdentifierAttribute()
@@ -43,4 +55,3 @@ define(
         });
     }
 );
-

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/i18n.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/i18n.ts
@@ -27,5 +27,5 @@ export const getFlag = (locale: string, displayLanguage: boolean = true): string
 };
 
 export const getLabel = (labels: {[locale: string]: string}, locale: string, fallback: string): string => {
-  return labels[locale] ? labels[locale] : `[${fallback}]`;
+  return (labels && labels[locale]) ? labels[locale] : `[${fallback}]`;
 };


### PR DESCRIPTION
When adding new attribute(s) to a family by search, we sent a request with the search term AND all the attributes already in the family in an `excluded_identifiers` array. But when there are a lot of attributes in the family, we end up with a very large array of POST parameters that goes beyond the PHP `max_input_vars` limit.

This PR will fix the issue by sending only the family code instead of all the family attributes. The attributes are then excluded server side.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
