### PR TITLE
AOB-376: Modify Oro Assetic to be able to compile several css stylesheets

### DIFF
--- a/src/Oro/Bundle/AsseticBundle/Command/OroAsseticDumpCommand.php
+++ b/src/Oro/Bundle/AsseticBundle/Command/OroAsseticDumpCommand.php
@@ -84,7 +84,7 @@ class OroAsseticDumpCommand extends ContainerAwareCommand
     protected function dumpAssets($output)
     {
         foreach ($this->am->getAssets() as $node) {
-            foreach ($node->getCompressAssets() as $asset){
+            foreach ($node->getCompressAssets() as $asset) {
                 $this->doDump($asset, $output);
             }
         }

--- a/src/Oro/Bundle/AsseticBundle/Command/OroAsseticDumpCommand.php
+++ b/src/Oro/Bundle/AsseticBundle/Command/OroAsseticDumpCommand.php
@@ -83,9 +83,10 @@ class OroAsseticDumpCommand extends ContainerAwareCommand
      */
     protected function dumpAssets($output)
     {
-        foreach ($this->am->getAssets() as $asset) {
-            /** @var  $asset \Oro\Bundle\AsseticBundle\Node\OroAsseticNode */
-            $this->doDump($asset->getCompressAsset(), $output);
+        foreach ($this->am->getAssets() as $node) {
+            foreach ($node->getCompressAssets() as $asset){
+                $this->doDump($asset, $output);
+            }
         }
     }
 

--- a/src/Oro/Bundle/AsseticBundle/Factory/OroAssetManager.php
+++ b/src/Oro/Bundle/AsseticBundle/Factory/OroAssetManager.php
@@ -144,7 +144,7 @@ class OroAssetManager
     {
         $assets = [];
         if ($node instanceof OroAsseticNode) {
-            $assets[$node->getNameUnCompress()] = $node;
+            $assets[] = $node;
         }
 
         foreach ($node as $child) {

--- a/src/Oro/Bundle/AsseticBundle/Resources/views/Assets/oro_css.html.twig
+++ b/src/Oro/Bundle/AsseticBundle/Resources/views/Assets/oro_css.html.twig
@@ -2,15 +2,21 @@
 
 {% set hasLess = false %}
 
-{% oro_css filter='cssrewrite, lessphp' output='css/pim.css' %}
+{% oro_css filter='cssrewrite, lessphp' %}
     {% set isLess = ('less' in asset_url|split('.')) %}
     {% set hasLess = isLess ? true : hasLess %}
 
-    <link rel="{% if isLess %}stylesheet/less{% else %}stylesheet{% endif %}" media="all" href="{{ asset(asset_url, 'frontend') }}" />
+    <link rel="{% if isLess %}stylesheet/less{% else %}stylesheet{% endif %}"
+          type="text/css"
+          media="all"
+          href="{{ asset(asset_url, 'frontend') }}"
+          data-name="{{ name }}"
+    />
+    <script>document.querySelector('link[data-name="{{ name }}"]').disabled = {{ isMain ? 'false' : 'true' }};</script>
 {% endoro_css %}
 
 {% if hasLess %}
-    <script type="text/javascript">localStorage.clear();</script>
-    <script type="text/javascript" src="{{ asset('bundles/oroassetic/lib/less-1.3.3.min.js') }}"></script>
-    <script type="text/javascript">less.watch();</script>
+    <script>localStorage.clear();</script>
+    <script src="{{ asset('bundles/oroassetic/lib/less-1.3.3.min.js') }}"></script>
+    <script>less.watch();</script>
 {% endif %}

--- a/src/Pim/Bundle/EnrichBundle/Resources/views/index.html.twig
+++ b/src/Pim/Bundle/EnrichBundle/Resources/views/index.html.twig
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="shortcut icon" href="favicon.ico" />
 
-        <link rel="stylesheet" href="{{asset('css/pim.css', 'frontend')}}"/>
+        {% include 'OroAsseticBundle:Assets:oro_css.html.twig' %}
 
         <script type="text/javascript" src="{{asset('dist/manifest.min.js', 'frontend')}} "></script>
         <script type="text/javascript" src="{{asset('dist/lib.min.js', 'frontend')}} "></script>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

To move the Onboarder UI to the pim-onboarder bundle we need to apply two different styles on the PIM (with different colors, etc.), the overridden style being in the bundle.
We didn't want to add a top-level css class because it would mean to duplicate the less in the bundle.
We chose instead to find a way to build several stylesheets (one with the native style, and another with the native style plus some overrides) and switch between them when needed.

The issue is that the less compilation is handled by the Oro Assetic bundle and has been designed to always generate only one css file from the less.
I chose to twist a concept introduced by Oro Assetic : the asset groups. Originally it's used for debugging purpose. You can specify some files to be in debug mode (so they won't be compressed in the final css file but dumped and linked as is). Spoiler alert : we never used that in the PIM.

Now these groups can also be used to define in which css file they will be compiled. For example if you have the following configuration :
```
css:
    group_one:
      - file_a.less
      - file_b.less
    group_two:
      - file_c.less

stylesheets:
    pim:
        groups: [group_one]
    michel:
        groups: [group_one, group_two]
```
You will get a `pim.css` file containing compiled less from `file_a.less` and `file_b.less`, and a `michel.css` file containing the compiled less from all three files.
Both css files will be dumped by the `oro:assetic:dump` command and linked from the Twig template in `<link...>` tags. Only the first stylesheet will be active by default. To switch the active stylesheet a bit of js will be needed.

**Drawbacks**
- If new groups are added or the existing groups are reorganized in the PIM we'll have to change the conf in the bundle, but we can expect it doesn't happen very often.
- It's not great to modify the native code for such a specific use case, but it's not a behavior we could have implemented in the bundle.
- It's complex.

**Advantages**
- Nothing will be duplicated in the bundle.
- It doesn't introduce any BC breaks. If no `stylesheets` entry is found in the conf the behavior will be the same as before.
- It works.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
