### PR TITLE
DAPI-29: Add loadingMask Element to ProjectWidget styles

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ProjectWidget.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ProjectWidget.less
@@ -4,6 +4,7 @@
   &-boxes {
     display: flex;
     justify-content: space-between;
+    min-height: 50px;
   }
 
   &-boxContainer {
@@ -148,5 +149,11 @@
   &-link {
     color: @AknPurple;
     cursor: pointer;
+  }
+
+  &-loadingMask {
+    top: auto;
+    z-index: auto;
+    height: 50px;
   }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Add a loadingMask Element to the ProjectWidget styles.

Required by: https://github.com/akeneo/pim-enterprise-dev/pull/5806

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
