### PR TITLE
GITHUB-9700: fix unstable test

### DIFF
--- a/tests/legacy/features/pim/structure/attribute-group/list_attribute_groups.feature
+++ b/tests/legacy/features/pim/structure/attribute-group/list_attribute_groups.feature
@@ -108,14 +108,13 @@ Feature: List attribute groups
   Scenario: Successfully display attribute group labels translated from the catalog locale
     Given the "footwear" catalog configuration
     And I am logged in as "Julia"
-    And I am on the "tablet" channel page
     And I add the "german" locale to the "tablet" channel
-    And I save the channel
     And I edit the "Julia" user
     And I visit the "Additional" tab
     And I fill in the following information:
       | Catalog locale | German (Germany) |
     And I save the user
+    And I should not see the text "There are unsaved changes"
     When I am on the attribute groups page
     Then I should see the text "[marketing]"
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Fix https://github.com/akeneo/pim-community-dev/issues/9700

**Problem:**

- Step 1 : We go on the channel page in the UI.
- Step 2 We add german locale to the channel, but not through the UI!  `And I add the "german" locale to the "tablet" call directly the channel repository and saver.
- Step 3: Then we save the channel through the UI, but the "german" locale is not in the channel in the UI, reverting what is done at the previous step...

Then, we try to use the german locale a the locale of the user.
Most of the time it works, because steps 3 is not finished in the background, so the channel has the locale...


**How to reproduce:**
Impossible to reproduce the problem (even in an infinite loop).
I had to carefully read the code.

We just need to wait the end of the save of the channel:

    Given the "footwear" catalog configuration
    And I am logged in as "Julia"
    And I am on the "tablet" channel page
    And I add the "german" locale to the "tablet" channel
    And I save the channel
    **And I should not see the text "There are unsaved changes"**
    And I edit the "Julia" user
    And I visit the "Additional" tab
    And I fill in the following information:
      | Catalog locale | German (Germany) |
    And I save the user
    When I am on the attribute groups page
    Then I should see the text "[marketing]"

**How to fix:**

Just delete what is done through the UI.

Note: I also add a check after saving the user, to ensure it's correctly saved.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
