### PR TITLE
PIM-8189: Fix display of new patch availability on dashboard

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8178: Fix Attribute search on family edit page
+- PIM-8189: Fix new patch availability display
 
 # 3.0.5 (2019-02-25)
 

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/Update/last_patch.html.twig
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/Update/last_patch.html.twig
@@ -10,7 +10,7 @@
                         var updateServerUrl = '{{ get_update_server_url() }}';
                         Fetcher.fetch(updateServerUrl).then(function (patch) {
                             var currentVersionName = $('.current-version:first span:last').text();
-                            var currentVersion = currentVersionName.split(' ')[0];
+                            var currentVersion = currentVersionName.split(' ')[1];
                             if (patch !== null && currentVersion < patch) {
                                 $('.last-version span:last').text(patch);
                             } else {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Also see https://github.com/akeneo/pim-enterprise-dev/pull/5812

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
