### PR TITLE
PIM-7966: Fix variant product order on variant product navigation in case of metric variations

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7966: Fix variant product order on variant product navigation in case of metric variations
+
 # 2.3.32 (2019-03-07)
 
 ## Improvement

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
@@ -236,7 +236,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
      * Generate an array for the given $entity to represent its order among all its axes values.
      *
      * For example, if its axes values are "Blue, 10 CENTIMETER" and Blue is an option with a sort order equals to 4,
-     * it will return [4, blue, 10 CENTIMETER].
+     * it will return [4, "blue", "CENTIMETER", 10].
      *
      * It allows to sort on front-end to respect sort orders of attribute options.
      *
@@ -255,6 +255,10 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
                 $option = $value->getData();
                 $orderArray[] = $option->getSortOrder();
                 $orderArray[] = $option->getCode();
+            } else if (AttributeTypes::METRIC === $axisAttribute->getType()) {
+                $data = $value->getData();
+                $orderArray[] = $data->getUnit();
+                $orderArray[] = floatval($data->getData());
             } else {
                 $orderArray[] = (string) $value;
             }

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
@@ -255,7 +255,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
                 $option = $value->getData();
                 $orderArray[] = $option->getSortOrder();
                 $orderArray[] = $option->getCode();
-            } else if (AttributeTypes::METRIC === $axisAttribute->getType()) {
+            } elseif (AttributeTypes::METRIC === $axisAttribute->getType()) {
                 $data = $value->getData();
                 $orderArray[] = $data->getUnit();
                 $orderArray[] = floatval($data->getData());

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/EntityWithFamilyVariantNormalizerSpec.php
@@ -12,6 +12,7 @@ use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\AttributeOptionValueInterface;
 use Pim\Component\Catalog\Model\CompletenessInterface;
+use Pim\Component\Catalog\Model\MetricInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
@@ -19,6 +20,7 @@ use Pim\Component\Catalog\ProductModel\ImageAsLabel;
 use Pim\Component\Catalog\ProductModel\Query\CompleteVariantProducts;
 use Pim\Component\Catalog\ProductModel\Query\VariantProductRatioInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Pim\Component\Catalog\Value\MetricValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
@@ -61,8 +63,11 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         ProductInterface $variantProduct,
         AttributeInterface $colorAttribute,
         AttributeInterface $sizeAttribute,
+        AttributeInterface $weightAttribute,
         ValueInterface $colorValue,
         ValueInterface $sizeValue,
+        MetricValueInterface $weightValue,
+        MetricInterface $weightData,
         AttributeOptionInterface $colorAttributeOption,
         AttributeOptionValueInterface $colorAttributeOptionValue,
         CompletenessInterface $completeness1,
@@ -83,15 +88,24 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
 
         $attributesProvider->getAxes($variantProduct)->willReturn([
             $colorAttribute,
-            $sizeAttribute
+            $sizeAttribute,
+            $weightAttribute,
         ]);
 
         $colorAttribute->getCode()->willReturn('color');
         $colorAttribute->getType()->willReturn('pim_catalog_simpleselect');
         $sizeAttribute->getCode()->willReturn('size');
         $sizeAttribute->getType()->willReturn('pim_catalog_text');
+        $weightAttribute->getCode()->willReturn('weight');
+        $weightAttribute->getType()->willReturn('pim_catalog_metric');
         $variantProduct->getValue('color')->willReturn($colorValue);
         $variantProduct->getValue('size')->willReturn($sizeValue);
+        $variantProduct->getValue('weight')->willReturn($weightValue);
+        $weightValue->getData()->willReturn($weightData);;
+        $weightValue->getAmount()->willReturn(10);
+        $weightValue->getUnit()->willReturn('KILOGRAM');
+        $weightData->getUnit()->willReturn('KILOGRAM');
+        $weightData->getData()->willReturn(10);
 
         $colorValue->getData()->willReturn($colorAttributeOption);
         $colorAttributeOption->setLocale('fr_FR')->shouldBeCalled();
@@ -116,14 +130,14 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
             'id'                 => 42,
             'identifier'         => 'tshirt_white_s',
             'axes_values_labels' => [
-                'fr_FR' => 'Blanc, S',
-                'en_US' => 'White, S',
+                'fr_FR' => 'Blanc, S, 10 KILOGRAM',
+                'en_US' => 'White, S, 10 KILOGRAM',
             ],
             'labels'             => [
                 'fr_FR' => 'Tshirt Blanc S',
                 'en_US' => 'Tshirt White S',
             ],
-            'order'              => [2, 'white', 'S'],
+            'order'              => [2, 'white', 'S', 'KILOGRAM', 10.0],
             'image'              => null,
             'model_type'         => 'product',
             'completeness'       => ['NORMALIZED_COMPLETENESS']


### PR DESCRIPTION
Before, the order for metric values was only do by string comparison.
["10 Kilogram"] was < ["100 Kilogram"].
Now, the quantity is extracted as a float, so it's ordered like this:
["Kilogram", 10] > ["Kilogram", 100]



| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | y
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
