### PR TITLE
PIM-8197 Use ZipArchive::addFile to avoid too much ram consumption

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8177: Remove pages not accessible in case of product number higher than maximum ES window limit (10.000 by default) and add warning message on the last page
+- PIM-8197: Use ZipArchive::addFile to avoid too much ram consumption
 
 # 2.3.32 (2019-03-07)
 

--- a/src/Pim/Component/Connector/Archiver/ArchivableFileWriterArchiver.php
+++ b/src/Pim/Component/Connector/Archiver/ArchivableFileWriterArchiver.php
@@ -57,7 +57,7 @@ class ArchivableFileWriterArchiver extends AbstractFilesystemArchiver
                 );
 
                 foreach ($writer->getWrittenFiles() as $fullPath => $localPath) {
-                    $filesystem->put($localPath, file_get_contents($fullPath));
+                    $filesystem->putStream($localPath, fopen($fullPath, 'r'));
                 }
             }
         }

--- a/src/Pim/Component/Connector/Archiver/WriteStreamZipArchiveAdapter.php
+++ b/src/Pim/Component/Connector/Archiver/WriteStreamZipArchiveAdapter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Pim\Component\Connector\Archiver;
+
+use League\Flysystem\Config;
+use League\Flysystem\ZipArchive\ZipArchiveAdapter;
+
+class WriteStreamZipArchiveAdapter extends ZipArchiveAdapter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function writeStream($path, $resource, Config $config)
+    {
+        $location = $this->applyPathPrefix($path);
+
+        $metadata = stream_get_meta_data($resource);
+        $uri = $metadata['uri'];
+
+        return $this->archive->addFile($uri, $location);
+    }
+}

--- a/src/Pim/Component/Connector/Archiver/ZipFilesystemFactory.php
+++ b/src/Pim/Component/Connector/Archiver/ZipFilesystemFactory.php
@@ -3,7 +3,7 @@
 namespace Pim\Component\Connector\Archiver;
 
 use League\Flysystem\Filesystem;
-use League\Flysystem\ZipArchive\ZipArchiveAdapter;
+use Pim\Component\Connector\Archiver\WriteStreamZipArchiveAdapter;
 
 /**
  * Factory of Flysystem Filesystem configured with the Zip adapter
@@ -27,6 +27,6 @@ class ZipFilesystemFactory
             throw new \InvalidArgumentException(sprintf('The provided path "%s" is not a valid directory', $absolutePath));
         }
 
-        return new Filesystem(new ZipArchiveAdapter($absolutePath));
+        return new Filesystem(new WriteStreamZipArchiveAdapter($absolutePath));
     }
 }

--- a/src/Pim/Component/Connector/spec/Archiver/ArchivableFileWriterArchiverSpec.php
+++ b/src/Pim/Component/Connector/spec/Archiver/ArchivableFileWriterArchiverSpec.php
@@ -150,8 +150,8 @@ class ArchivableFileWriterArchiverSpec extends ObjectBehavior
         $filesystem->createDir('type/my_job_name/12/archive')->shouldBeCalled();
 
         $factory->createZip(Argument::any())->willReturn($filesystem);
-        $filesystem->put('file1', '')->shouldBeCalled();
-        $filesystem->put('file2', '')->shouldBeCalled();
+        $filesystem->putStream('file1', Argument::type('resource'))->shouldBeCalled();
+        $filesystem->putStream('file2', Argument::type('resource'))->shouldBeCalled();
 
         $this->archive($jobExecution);
 


### PR DESCRIPTION
> Note: we used feedback of @mmetayer on his previous work on this: no close/reopen, no memory leak; so it seems we found the best of both worlds here.

We override the flysystem/zip-archive-adapter to use `ZipArchive::addFile` (which internally uses https://github.com/nih-at/libzip/blob/4c612cb79672016c0f077b9c511e77df82b35023/lib/zip_source_filep.c#L484

Tested by trying to import a 100MB file using 1MB of max php ram:

```
dd if=/dev/urandom bs=10M count=10 of=/tmp/test
php -d memory_limit=1M zip.php
```

```php
// zip.php
<?php

use Pim\Component\Connector\Archiver\WriteStreamZipArchiveAdapter;
use League\Flysystem\Config;

require(__DIR__.'/vendor/autoload.php');

$a = new WriteStreamZipArchiveAdapter('/tmp/test.zip');

$a->writeStream('test', fopen('/tmp/test', 'r'), new Config);
$a->writeStream('test2', fopen('/tmp/test', 'r'), new Config);
```

## manual tests using `Csv quick export (all attributes)`:

### 1026 products (icecat_demo catalog) with 40 images between 6KB and 1.5MB:

| type | old code | new code |
| ----- | ------------ | ------------- |
| ram | 253MB (linear increase) | 210MB (stable) |
| time | 8.470s | 8.838s |

### 1049 products (icecat_demo catalog) with 242 images between 6KB and 1.5MB:

| type | old code | new code |
| ----- | ------------ | ------------- |
| ram | 46208264 B (linear increase) | 33306472 B (stable) |
| time | 13.582s | 13.081s |



PS: this could worth a PR on https://github.com/thephpleague/flysystem-ziparchive

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | Todo
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

