### PR TITLE
PIM-8210: Fix twig variable not defined

### DIFF
--- a/src/Akeneo/Platform/Bundle/DashboardBundle/Resources/views/Dashboard/index.html.twig
+++ b/src/Akeneo/Platform/Bundle/DashboardBundle/Resources/views/Dashboard/index.html.twig
@@ -6,7 +6,7 @@
         {{ elements.page_header(
             {
                 title: 'pim_dashboard.title'|trans,
-                image: image
+                image: image is defined ? image : ''
             }
         ) }}
 


### PR DESCRIPTION
Very minor bug to fix. In dev mode, we can have a 500 error because a twig variable is not defined.
After the fix, no error anymore, but a screen not very usefull anyway

![image](https://user-images.githubusercontent.com/1516770/54189419-0a594200-44b2-11e9-8e9b-506867e14a03.png)
