### PR TITLE
DAPI-20: run ListProductGridAvailableColumnGroupsIntegration and ListProductGridAvailableColumnsIntegration integration tests only in CE

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Query/Sql/ListProductGridAvailableColumnGroupsIntegration.php
+++ b/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Query/Sql/ListProductGridAvailableColumnGroupsIntegration.php
@@ -7,6 +7,9 @@ namespace Oro\Bundle\PimDataGridBundle\tests\Integration\Query\Sql;
 use Akeneo\Pim\Structure\Component\Model\Attribute;
 use Akeneo\Test\Integration\TestCase;
 
+/**
+ * @group ce
+ */
 class ListProductGridAvailableColumnGroupsIntegration extends TestCase
 {
     /**

--- a/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Query/Sql/ListProductGridAvailableColumnsIntegration.php
+++ b/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Query/Sql/ListProductGridAvailableColumnsIntegration.php
@@ -7,6 +7,9 @@ namespace Oro\Bundle\PimDataGridBundle\tests\Integration\Query\Sql;
 use Akeneo\Pim\Structure\Component\Model\Attribute;
 use Akeneo\Test\Integration\TestCase;
 
+/**
+ * @group ce
+ */
 class ListProductGridAvailableColumnsIntegration extends TestCase
 {
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Those tests must not be ran with the EE dependency injection because the EE adds a new column in the datagrid and has dedicated tests.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
