### PR TITLE
add missing entityClass to reference data filter

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/filters.yml
@@ -112,6 +112,7 @@ extensions:
         module: pim/filter/attribute/select
         config:
             url: pim_ui_ajaxentity_list
+            entityClass: PimCatalogBundle:AttributeOption
             operators:
                 - IN
                 - EMPTY


### PR DESCRIPTION
Try to add attribute filter (reference data)  to product exporter

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
