### PR TITLE
PIM-8212: Allow mass edition of hundreds of manually selected elements in a grid (prevent 414 Too Long URI)

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-8217: Allow mass edition of hundreds of manually selected elements in a grid (prevent 414 Too Long URI)
+- PIM-8212: Allow mass edition of hundreds of manually selected elements in a grid (prevent 414 Too Long URI)
 
 # 2.0.50 (2019-03-01)
 

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,9 @@
 # 2.0.x
 
+## Bug fixes
+
+- PIM-8217: Allow mass edition of hundreds of manually selected elements in a grid (prevent 414 Too Long URI)
+
 # 2.0.50 (2019-03-01)
 
 ## Bug fixes

--- a/src/Oro/Bundle/DataGridBundle/Extension/MassAction/MassActionParametersParser.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/MassAction/MassActionParametersParser.php
@@ -16,7 +16,7 @@ class MassActionParametersParser
         $inset = $request->get('inset', true);
         $inset = !empty($inset) && 'false' !== $inset;
 
-        $values = $request->get('values', '');
+        $values = $request->request->get('values', '');
         if (!is_array($values)) {
             $values = $values !== '' ? explode(',', $values) : [];
         }

--- a/src/Oro/Bundle/DataGridBundle/Extension/MassAction/MassActionParametersParser.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/MassAction/MassActionParametersParser.php
@@ -16,7 +16,7 @@ class MassActionParametersParser
         $inset = $request->get('inset', true);
         $inset = !empty($inset) && 'false' !== $inset;
 
-        $values = $request->request->get('values', '');
+        $values = $request->get('values', '');
         if (!is_array($values)) {
             $values = $values !== '' ? explode(',', $values) : [];
         }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/mass_edit/rest.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/mass_edit/rest.yml
@@ -1,7 +1,7 @@
 pim_enrich_mass_edit_rest_get_filter:
-    path: '/'
+    path: '/get-filter'
     defaults: { _controller: pim_enrich.controller.rest.mass_edit:getFilterAction }
-    methods: [GET]
+    methods: [POST]
 
 pim_enrich_mass_edit_rest_launch:
     path: '/'

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/mass-edit.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/mass-edit.js
@@ -31,8 +31,18 @@ define(
                     return 'actionName' === parameter.key;
                 }).value.replace(new RegExp('_', 'g'), '-');
 
+                /*
+                 The `values` parameter can raise a 414 Too Long URI when we select more than 650 products in
+                 the grid. We use POST request to send the values to the backend to avoid these exceptions.
+                 */
+                const values = _.find(parameters, function (parameter) {
+                    return 'values' === parameter.key;
+                }).value.split('%2C'); // %2C = ,
+                const queryWithoutValues = query.replace(/&values=[^&]+/, '');
                 return $.ajax({
-                    url: Routing.generate('pim_enrich_mass_edit_rest_get_filter') + query
+                    url: Routing.generate('pim_enrich_mass_edit_rest_get_filter') + queryWithoutValues,
+                    method: 'POST',
+                    data: { values },
                 }).then((response) => {
                     const filters = response.filters;
                     const itemsCount = response.itemsCount;

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/mass-edit.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/controller/mass-edit.js
@@ -39,10 +39,11 @@ define(
                     return 'values' === parameter.key;
                 }).value.split('%2C'); // %2C = ,
                 const queryWithoutValues = query.replace(/&values=[^&]+/, '');
+
                 return $.ajax({
                     url: Routing.generate('pim_enrich_mass_edit_rest_get_filter') + queryWithoutValues,
                     method: 'POST',
-                    data: { values },
+                    data: { values }
                 }).then((response) => {
                     const filters = response.filters;
                     const itemsCount = response.itemsCount;


### PR DESCRIPTION
It's a "simple" GET to POST query change. A little bit crappy, but no other solution were found.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | y
| Migration script                  | -
| Tech Doc                          | -
