### PR TITLE
PIM-8128: Fix the display of reset password confirmation message

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,6 +4,7 @@
 
 - PIM-8217: Fix missing translations on product grid (Filters, Done, Yes and No)
 - PIM-8221: Fix missing translations on family attributes tab (Required, Not required)
+- PIM-8128: Fix display of reset password confirmation message
 
 # 3.0.7 (2019-03-13)
 

--- a/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
@@ -20,6 +20,8 @@ class ResetController extends Controller
 
     /**
      * Request reset user password
+     *
+     * @Template
      */
     public function sendEmailAction(Request $request)
     {
@@ -27,12 +29,7 @@ class ResetController extends Controller
         $user = $this->get('pim_user.manager')->findUserByUsernameOrEmail($username);
 
         if (null === $user) {
-            $this->get('session')->getFlashBag()->add(
-                'success',
-                'An email has been sent to the user. It contains a link to reset the password.'
-            );
-
-            return $this->redirect($this->generateUrl('pim_user_reset_request'));
+            return [];
         }
 
         if ($user->isPasswordRequestNonExpired($this->container->getParameter('pim_user.reset.ttl'))) {
@@ -66,12 +63,7 @@ class ResetController extends Controller
         $this->get('mailer')->send($message);
         $this->get('pim_user.manager')->updateUser($user);
 
-        $this->get('session')->getFlashBag()->add(
-            'success',
-            'An email has been sent to the user. It contains a link to reset the password.'
-        );
-
-        return $this->redirect($this->generateUrl('pim_user_reset_request'));
+        return [];
     }
 
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
