### PR TITLE
PIM-8222: do not accept /draft in a product SKU

### DIFF
--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/product_model.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/product_model.yml
@@ -8,7 +8,7 @@ pim_api_product_model_get:
     defaults: { _controller: pim_api.controller.product_model:getAction, _format: json }
     methods: [GET]
     requirements:
-        code: (.(?!/draft$))+
+        code: (.+$)(?<!/draft|/proposal)
 
 pim_api_product_model_create:
     path: /product-models

--- a/src/Pim/Bundle/ApiBundle/Resources/config/routing/product_model.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/routing/product_model.yml
@@ -8,7 +8,7 @@ pim_api_product_model_get:
     defaults: { _controller: pim_api.controller.product_model:getAction, _format: json }
     methods: [GET]
     requirements:
-        code: .+
+        code: (.(?!/draft$))+
 
 pim_api_product_model_create:
     path: /product-models


### PR DESCRIPTION
This route is in conflict with an API route on EE: `pimee_api_product_model_draft_get`
The fix is quite ugly and will not allow the use of a draft suffix in SKU, but i cannot change an API route.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
