### PR TITLE
PIM-8136: Fix display order of datepicker

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -6,6 +6,7 @@
 - PIM-8221: Fix missing translations on family attributes tab (Required, Not required)
 - PIM-8223: Fix missing translation on family variant deletion
 - PIM-8224: Fix missing translations in process tracker (Compute completeness, Compute family variant and Compute product model descendants)
+- PIM-8136: Fix display order of datepicker
 
 # 3.0.7 (2019-03-13)
 
@@ -44,7 +45,7 @@
 - PIM-8147: Fix design issue on boolean fields
 - PIM-8146: Fix centered alignment on drag & drop fields
 - PIM-8156: Fix multiselect field alignment
-- PIM-8153: Fix locale specific field to allow multiple locales 
+- PIM-8153: Fix locale specific field to allow multiple locales
 - PIM-8017: Fix PDF generation
 - PIM-8060: Fix avatars migration 2.3 -> 3.0
 - PIM-8135: Fix cursor paginator sequence

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/dropdown.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/dropdown.less
@@ -14,7 +14,7 @@
 .dropdown-menu {
   margin-top:-1px;
   border-radius: 0;
-  z-index: 900;
+  z-index: 1050;
 }
 
 .dropdown-menu {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes the 'missing' datepicker on the mass edit of date attributes. This bug was caused by the modal z-index being greater than the datepicker one (changed here: https://github.com/akeneo/pim-community-dev/commit/e979b5d4ee3f07285478e89564f45970348d18e4#diff-29deae46280c716e5de2e4532c7dff32R13).

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
