### PR TITLE
PIM-8228: fix incorrect completeness

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/CompletenessGenerator.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/CompletenessGenerator.php
@@ -171,12 +171,12 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
                 'requiredCount' => $requiredCount,
                 'ratio'         => $ratio,
                 'channel'       => $normalizedReqs[$missingComp]['channel'],
-                'locale'        => $normalizedReqs[$missingComp]['locale']
+                'locale'        => $normalizedReqs[$missingComp]['locale'],
             ];
 
             $completenesses[$missingComp] = [
                 'object' => $compObject,
-                'ratio'  => $ratio
+                'ratio'  => $ratio,
             ];
         }
 
@@ -263,7 +263,7 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
 
                 $collection->update($query, $compObject, $options);
 
-                $normalizedComp = ['$set' => ['normalizedData.completenesses.'.$key => $value['ratio']]];
+                $normalizedComp = ['$set' => ['normalizedData.completenesses.' . $key => $value['ratio']]];
                 $collection->update($query, $normalizedComp, $options);
             }
         }
@@ -378,6 +378,9 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
             $channels = [];
 
             foreach ($family->getAttributeRequirements() as $attributeReq) {
+                if (!$attributeReq->isRequired()) {
+                    continue;
+                }
                 $channel = $attributeReq->getChannel();
 
                 $channels[$channel->getCode()] = $channel;
@@ -410,7 +413,7 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
         $fields = [];
         foreach ($channels as $channel) {
             foreach ($channel->getLocales() as $locale) {
-                $expectedCompleteness = $channel->getCode().'-'.$locale->getCode();
+                $expectedCompleteness = $channel->getCode() . '-' . $locale->getCode();
                 $fields[$expectedCompleteness] = [];
                 $fields[$expectedCompleteness]['channel'] = $channel->getId();
                 $fields[$expectedCompleteness]['locale'] = $locale->getId();
@@ -488,7 +491,7 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
             if (!empty($combinations)) {
                 foreach ($combinations as $combination) {
                     $expr = new Expr();
-                    $expr->field('normalizedData.completenesses.'.$combination)->exists(false);
+                    $expr->field('normalizedData.completenesses.' . $combination)->exists(false);
                     $productsQb->addOr($expr);
                 }
             }
@@ -519,7 +522,7 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
         foreach ($channels as $channel) {
             $locales = $channel->getLocales();
             foreach ($locales as $locale) {
-                $combinations[] = $channel->getCode().'-'.$locale->getCode();
+                $combinations[] = $channel->getCode() . '-' . $locale->getCode();
             }
         }
 
@@ -559,8 +562,8 @@ class CompletenessGenerator implements CompletenessGeneratorInterface
         $productQb = $this->documentManager->createQueryBuilder($this->productClass);
 
         $pullExpr = $productQb->expr()
-                ->addAnd($productQb->expr()->field('channel')->equals($channel->getId()))
-                ->addAnd($productQb->expr()->field('locale')->equals($locale->getId()));
+            ->addAnd($productQb->expr()->field('channel')->equals($channel->getId()))
+            ->addAnd($productQb->expr()->field('locale')->equals($locale->getId()));
 
         $productQb
             ->update()

--- a/src/Pim/Component/Catalog/Model/FamilyInterface.php
+++ b/src/Pim/Component/Catalog/Model/FamilyInterface.php
@@ -58,7 +58,7 @@ interface FamilyInterface extends TranslatableInterface, ReferableInterface, Ver
     /**
      * Get attributes
      *
-     * @return AttributeInterface[]|ArrayCollection
+     * @return AttributeInterface[]
      */
     public function getAttributes();
 
@@ -125,7 +125,7 @@ interface FamilyInterface extends TranslatableInterface, ReferableInterface, Ver
     /**
      * Get attribute requirements
      *
-     * @return array
+     * @return AttributeRequirementInterface[]
      */
     public function getAttributeRequirements();
 

--- a/src/Pim/Component/Catalog/Repository/FamilyRepositoryInterface.php
+++ b/src/Pim/Component/Catalog/Repository/FamilyRepositoryInterface.php
@@ -35,7 +35,7 @@ interface FamilyRepositoryInterface extends
      * @param FamilyInterface  $family
      * @param ChannelInterface $channel
      *
-     * @return array
+     * @return FamilyInterface[]
      */
     public function getFullFamilies(FamilyInterface $family = null, ChannelInterface $channel = null);
 


### PR DESCRIPTION
When we change the requirement of an attribute in a family, it is not always removed from the table. It can be present with a `required = false` property.
But when we fetch requirements for completeness, we didn't test for `required` and these non required attributes were taken into account in the completeness.

This PR solves the issue by testing for the `required` property before adding the attribute in the completeness calculation.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
