### PR TITLE
PIM-8230: Show on hover information for a read-only text in product edit form

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8230: Show on hover information for a read-only text in product edit form
+
 # 2.3.34 (2019-03-18)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/text.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/field/text.html
@@ -9,5 +9,6 @@
     data-locale="<%- locale %>"
     data-scope="<%- scope %>"
     value="<%- value ? value.data : null %>"
+    title="<%- value ? value.data : null %>"
     <%- editMode === 'view' ? 'disabled' : '' %>
 />


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When the text field is disabled and the text too long we can not see all the text. We added a title to be able to see the full text on hover.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
