### PR TITLE
PIM-8227: Get columns by code/name in selector

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -8,6 +8,7 @@
 - PIM-8223: Fix missing translation on family variant deletion
 - PIM-8224: Fix missing translations in process tracker (Compute completeness, Compute family variant and Compute product model descendants)
 - PIM-8136: Fix display order of datepicker
+- PIM-8227: Fix disappearing columns when saving view columns
 
 # 3.0.7 (2019-03-13)
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/column-selector.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/column-selector.ts
@@ -474,7 +474,7 @@ class ColumnSelector extends BaseView {
     this.setColumnSortOrder();
 
     const columns = this.getColumnsBySelected();
-    const selected = Object.values(_.mapObject(columns, 'code'))
+    const selected = Object.keys(columns)
       .sort((a, b) => {
         return columns[a].sortOrder - columns[b].sortOrder;
       })


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a bug where columns that were loaded by a view disappeared when the user added a new column using the selector on the datagrid. 

When a view is loaded, we take the columns loaded from the datagrid metadata which don't include a 'code' property but instead a 'name'. In the available-columns endpoint this property is called 'code'. We normalize it in the column selector but the normalized value was not being used when the data was merged. So in the end, adding a column updated the datagrid state with something like `name, updated, image,,,,` because some columns had an undefined code. 


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
