### PR TITLE
PIM-8196: Fix long channel labels on completeness widget

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+# Bug fixes
+
+- PIM-8196: Fix long channel labels on completeness widget
+
 # 3.0.8 (2019-03-20)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/CompletenessPanel.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/CompletenessPanel.less
@@ -14,16 +14,20 @@
 
   &-header {
     border-bottom: 1px solid @AknBorderColor;
-    height: @AknBigButtonSize;
-    line-height: @AknBigButtonSize;
+    min-height: @AknBigButtonSize;
+    line-height: 28px;
+    height: auto;
     display: flex;
     color: @AknDarkBlue;
     font-size: @AknFontSizeBig;
+    padding-top: 5px;
+    padding-bottom: 5px;
   }
 
   &-headerLocale {
     text-transform: uppercase;
     flex-grow: 1;
+    padding-right: 16px;
   }
 
   &-headerStats {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes the display of long channel labels in the completeness widget on the dashboard.

Before
![Screenshot (14)](https://user-images.githubusercontent.com/1336344/54693376-cf48b580-4b26-11e9-9bcf-96fb968cffce.png)

After
![Screenshot (15)](https://user-images.githubusercontent.com/1336344/54693382-d2dc3c80-4b26-11e9-80e8-990f1b65a110.png)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
