### PR TITLE
PIM-8237: Fix the query params on search attributes

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,6 +4,7 @@
 
 - PIM-8196: Fix long channel labels on completeness widget
 - PXD-89: Update illustrations with new colors
+- PIM-8237: Fix ignored query params "options" on the internal API: search attribute
 
 # 3.0.8 (2019-03-20)
 

--- a/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeController.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeController.php
@@ -145,13 +145,17 @@ class AttributeController
      */
     public function indexAction(Request $request)
     {
-        $options = $request->request->get(
-            'options',
-            ['limit' => SearchableRepositoryInterface::FETCH_LIMIT, 'locale' => null]
-        );
+        $options = $request->get('options', []);
+        $options['locale'] = $options['locale'] ?? null;
+        $options['limit'] = $options['limit'] ?? SearchableRepositoryInterface::FETCH_LIMIT;
+        $options['identifiers'] = $options['identifiers'] ?? [];
 
+        // If 'identifiers=' is used, any 'options[identifiers][]=' passed will be overwritten.
         if ($request->get('identifiers', null) !== null) {
             $options['identifiers'] = array_unique(explode(',', $request->get('identifiers')));
+        }
+
+        if (count($options['identifiers']) > 0) {
             $options['limit'] = count($options['identifiers']);
         }
 
@@ -161,8 +165,8 @@ class AttributeController
                 explode(',', $request->get('types'));
         }
 
-        if ($request->request->has('attribute_groups')) {
-            $options['attribute_groups'] = explode(',', $request->request->get('attribute_groups'));
+        if ($request->get('attribute_groups', null) !== null) {
+            $options['attribute_groups'] = array_unique(explode(',', $request->get('attribute_groups')));
         }
 
         if ($request->get('localizable', null) !== null) {
@@ -185,14 +189,8 @@ class AttributeController
             $options['families'] = $request->get('families');
         }
 
-        if (empty($options)) {
-            $options = $request->get(
-                'options',
-                ['limit' => SearchableRepositoryInterface::FETCH_LIMIT, 'locale' => null]
-            );
-        }
-        if ($request->request->has('rights')) {
-            $options['rights'] = (bool) $request->request->get('rights');
+        if ($request->get('rights', null) !== null) {
+            $options['rights'] = (bool) $request->get('rights');
         }
 
         $token = $this->tokenStorage->getToken();

--- a/tests/back/Pim/Structure/EndToEnd/Attribute/InternalApi/SearchAttributeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/Attribute/InternalApi/SearchAttributeEndToEnd.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace AkeneoTest\Pim\Structure\EndToEnd\Attribute\InternalApi;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @group ce
+ */
+class SearchAttributeEndToEnd extends ApiTestCase
+{
+    const ENDPOINT_URL = 'rest/attribute/';
+
+    /**
+     * Search attributes by identifiers with query param '?identifiers='.
+     */
+    public function testByIdentifiers(): void
+    {
+        $params = [
+            'identifiers' => 'sku,a_metric'
+        ];
+
+        $standardizedAttributes = $this->getStandardizedAttributes();
+        $expected = <<<JSON
+        [
+            {$standardizedAttributes['sku']},
+            {$standardizedAttributes['a_metric']}
+        ]
+JSON;
+
+        // GET
+        $client = self::createSearchAttributeClient();
+        $client->request('GET', self::ENDPOINT_URL, $params);
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+
+        // POST
+        $client = self::createSearchAttributeClient();
+        $client->request('POST', self::ENDPOINT_URL, $params);
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+    }
+
+    /**
+     * Search attributes by identifiers with query param '?options[identifiers][]='.
+     */
+    public function testByIdentifiersWithOptionsParam(): void
+    {
+        $params = [
+            'options' => [
+                'identifiers' => ['sku', 'a_metric']
+            ]
+        ];
+
+        $standardizedAttributes = $this->getStandardizedAttributes();
+        $expected = <<<JSON
+        [
+            {$standardizedAttributes['sku']},
+            {$standardizedAttributes['a_metric']}
+        ]
+JSON;
+
+        // GET
+        $client = self::createSearchAttributeClient();
+        $client->request('GET', self::ENDPOINT_URL, $params);
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+
+        // POST
+        $client = self::createSearchAttributeClient();
+        $client->request('POST', self::ENDPOINT_URL, $params);
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+    }
+
+    /**
+     * Search attributes by types with query param '?types='.
+     */
+    public function testByTypes(): void
+    {
+        $params = [
+            'types' => 'pim_catalog_identifier'
+        ];
+
+        $standardizedAttributes = $this->getStandardizedAttributes();
+        $expected = <<<JSON
+        [
+            {$standardizedAttributes['sku']}
+        ]
+JSON;
+
+        // GET
+        $client = self::createSearchAttributeClient();
+        $client->request('GET', self::ENDPOINT_URL, $params);
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+
+        // POST
+        $client = self::createSearchAttributeClient();
+        $client->request('POST', self::ENDPOINT_URL, $params);
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private static function createSearchAttributeClient(): Client
+    {
+        return self::createClient([], [
+            'PHP_AUTH_USER' => self::PASSWORD,
+            'PHP_AUTH_PW'   => self::USERNAME,
+        ]);
+    }
+
+    private function getStandardizedAttributes(): array
+    {
+        $standardizedAttributes = [];
+
+        $standardizedAttributes['sku'] = <<<'JSON'
+        {
+            "code": "sku",
+            "type": "pim_catalog_identifier",
+            "group": "attributeGroupA",
+            "unique": true,
+            "useable_as_grid_filter": true,
+            "allowed_extensions": [],
+            "metric_family": null,
+            "default_metric_unit": null,
+            "reference_data_name": null,
+            "available_locales": [],
+            "max_characters": null,
+            "validation_rule": null,
+            "validation_regexp": null,
+            "wysiwyg_enabled": null,
+            "number_min": null,
+            "number_max": null,
+            "decimals_allowed": null,
+            "negative_allowed": null,
+            "date_min": null,
+            "date_max": null,
+            "max_file_size": null,
+            "minimum_input_length": null,
+            "sort_order": 0,
+            "localizable": false,
+            "scopable": false,
+            "labels": [],
+            "auto_option_sorting": null,
+            "empty_value": null,
+            "field_type": "akeneo-text-field",
+            "filter_types": {
+                "product-export-builder": "akeneo-attribute-identifier-filter"
+            },
+            "is_locale_specific": false,
+            "meta": {
+                "id": 2
+            }
+        }
+JSON;
+
+        $standardizedAttributes['a_metric'] = <<<'JSON'
+        {
+            "code": "a_metric",
+            "type": "pim_catalog_metric",
+            "group": "attributeGroupB",
+            "unique": false,
+            "useable_as_grid_filter": false,
+            "allowed_extensions": [],
+            "metric_family": "Power",
+            "default_metric_unit": "KILOWATT",
+            "reference_data_name": null,
+            "available_locales": [],
+            "max_characters": null,
+            "validation_rule": null,
+            "validation_regexp": null,
+            "wysiwyg_enabled": null,
+            "number_min": null,
+            "number_max": null,
+            "decimals_allowed": true,
+            "negative_allowed": false,
+            "date_min": null,
+            "date_max": null,
+            "max_file_size": null,
+            "minimum_input_length": null,
+            "sort_order": 0,
+            "localizable": false,
+            "scopable": false,
+            "labels": [],
+            "auto_option_sorting": null,
+            "empty_value": {
+                "amount": null,
+                "unit": "KILOWATT"
+            },
+            "field_type": "akeneo-metric-field",
+            "filter_types": {
+                "product-export-builder": "akeneo-attribute-metric-filter"
+            },
+            "is_locale_specific": false,
+            "meta": {
+                "id": 6
+            }
+        }
+JSON;
+
+        return $standardizedAttributes;
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Query params for `options` are not working on the internal API that fetch the attribute collection.

Example:
Any call to `/rest/attribute` with a query param of `options[identifiers][]=name` will not get a result for the name identifier only, but will get a list of all the attributes.

Linked to #9621
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
