### PR TITLE
DAPI-145: Fix events state reset of save-buttons.js

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/save-buttons.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/save-buttons.js
@@ -33,6 +33,7 @@ define(
                 this.model = new Backbone.Model({
                     buttons: []
                 });
+                this.events = {};
 
                 this.on('save-buttons:add-button', this.addButton.bind(this));
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

Fix the `initialize` method of `save-buttons.js` to correctly reset its internal state.
The internal `events` object was keeping dangling references to previously added events.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
