### PR TITLE
PIM-8245: Fix initialize of save-buttons extension

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8230: Show on hover information for a read-only text in product edit form
+- PIM-8245: Fix the save-buttons extension (js) incorrectly resetting its internal state between calls.
 
 # 2.3.34 (2019-03-18)
 
@@ -71,18 +72,18 @@
 
 ## Bug fixes
 
-- PIM-7965: fix families patch endpoint when updating a family with a family variant 
+- PIM-7965: fix families patch endpoint when updating a family with a family variant
 - PIM-7961: Fix localizable assets used as main image for family and added to product product model
 
 # 2.3.24 (2019-01-10)
- 
+
 ## Bug fixes
 
 - PIM-7934: Fix translations of product model import
 - PIM-7961: Fix localizable assets used as main image for family and added to product product model
 
 # 2.3.23 (2019-01-03)
- 
+
 ## Bug fixes
 
 - PIM-7899: Remove Date of Birth field
@@ -99,7 +100,7 @@
 - PIM-7936: Missing breadcrumb when you create Attribute group or Channel
 
  ## Elasticsearch
- 
+
  - Please re-index the products and product models by launching the commands `console akeneo:elasticsearch:reset-indexes -e prod` and `pim:product:index --all -e prod`.
 
 # 2.3.21 (2018-12-07)
@@ -177,7 +178,7 @@ PIM-7810: Fix to mass delete products and product models
 
 - PIM-7674: fix Avatar image broken on dashboard
 - PIM-7694: fix option null values crashing PDF
-- PIM-7731: check for attribute as label not null in normalizers 
+- PIM-7731: check for attribute as label not null in normalizers
 - PIM-7740: bump summernote version to fix scroll glitches
 - PIM-7746: Fix issue when an attribute code is numeric
 - PIM-7727: parent filter search case insensitive

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/save-buttons.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/save-buttons.js
@@ -33,6 +33,7 @@ define(
                 this.model = new Backbone.Model({
                     buttons: []
                 });
+                this.events = {};
 
                 this.on('save-buttons:add-button', this.addButton.bind(this));
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

Fix the initialize method of save-buttons.js to correctly reset its internal state.
The internal events object was keeping dangling references to previously added events.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
