### PR TITLE
Pim 8235

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8230: Show on hover information for a read-only text in product edit form
+- PIM-8235: Do not store duplicate media file
 
 # 2.3.34 (2019-03-18)
 

--- a/src/Akeneo/Bundle/FileStorageBundle/DependencyInjection/AkeneoFileStorageExtension.php
+++ b/src/Akeneo/Bundle/FileStorageBundle/DependencyInjection/AkeneoFileStorageExtension.php
@@ -28,6 +28,7 @@ class AkeneoFileStorageExtension extends Extension
         $loader->load('models.yml');
         $loader->load('removers.yml');
         $loader->load('repositories.yml');
+        $loader->load('queries.yml');
         $loader->load('savers.yml');
     }
 }

--- a/src/Akeneo/Bundle/FileStorageBundle/Doctrine/ORM/Query/FindKeyByHashQuery.php
+++ b/src/Akeneo/Bundle/FileStorageBundle/Doctrine/ORM/Query/FindKeyByHashQuery.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Akeneo\Bundle\FileStorageBundle\Doctrine\ORM\Query;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Find a FileInfo model by its hash value
+ *
+ * @author JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FindKeyByHashQuery
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function fetchKey(string $hash): ?string
+    {
+        $qb = $this->connection->createQueryBuilder()
+            ->select('file_key')
+            ->from('akeneo_file_storage_file_info')
+            ->where('hash = :hash')
+            ->setParameter(':hash', $hash, \PDO::PARAM_STR);
+
+        $fileKey = $qb->execute()->fetchColumn();
+
+        return empty($fileKey) ? null : $fileKey;
+    }
+}

--- a/src/Akeneo/Bundle/FileStorageBundle/Doctrine/ORM/Repository/FileInfoRepository.php
+++ b/src/Akeneo/Bundle/FileStorageBundle/Doctrine/ORM/Repository/FileInfoRepository.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Bundle\FileStorageBundle\Doctrine\ORM\Repository;
 
+use Akeneo\Component\FileStorage\Model\FileInfo;
 use Akeneo\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use Doctrine\ORM\EntityRepository;
 
@@ -23,7 +24,7 @@ class FileInfoRepository extends EntityRepository implements FileInfoRepositoryI
     }
 
     /**
-     * {@inheritdoc}
+     * @return FileInfo | null
      */
     public function findOneByIdentifier($identifier)
     {

--- a/src/Akeneo/Bundle/FileStorageBundle/Resources/config/file_storage.yml
+++ b/src/Akeneo/Bundle/FileStorageBundle/Resources/config/file_storage.yml
@@ -14,6 +14,7 @@ services:
             - '@oneup_flysystem.mount_manager'
             - '@akeneo_file_storage.saver.file'
             - '@akeneo_file_storage.file_storage.file_info_factory'
+            - '@akeneo_file_storage.query.find_key_by_hash'
 
     akeneo_file_storage.file_storage.file.file_fetcher:
         class: '%akeneo_file_storage.file_storage.file.file_fetcher.class%'

--- a/src/Akeneo/Bundle/FileStorageBundle/Resources/config/model/doctrine/FileInfo.orm.yml
+++ b/src/Akeneo/Bundle/FileStorageBundle/Resources/config/model/doctrine/FileInfo.orm.yml
@@ -10,7 +10,6 @@ Akeneo\Component\FileStorage\Model\FileInfo:
         key:
             type: string
             length: 255
-            unique: true
             column: file_key
         originalFilename:
             type: string

--- a/src/Akeneo/Bundle/FileStorageBundle/Resources/config/queries.yml
+++ b/src/Akeneo/Bundle/FileStorageBundle/Resources/config/queries.yml
@@ -1,0 +1,5 @@
+services:
+    akeneo_file_storage.query.find_key_by_hash:
+        class: 'Akeneo\Bundle\FileStorageBundle\Doctrine\ORM\Query\FindKeyByHashQuery'
+        arguments:
+            - '@database_connection'


### PR DESCRIPTION
When we upload assets and when a file is stored, a FileInfo object is created. 

We must check for an existing one by sha1. If the file already exists, we will not store the physical file and the created FileInfo will be updated with the existing key. 

We will still have a new FileInfo and a new ID linked to the corresponding entity so that we can remove a FileInfo line without any impact on another entity.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
