### PR TITLE
Fix load order of pim/model/attribute in requirejs

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,7 @@
 - PIM-8196: Fix long channel labels on completeness widget
 - PXD-89: Update illustrations with new colors
 - PIM-8237: Fix ignored query params "options" on the internal API: search attribute
+- PIM-8248: Fix load order of pim/model/attribute in requirejs
 
 # 3.0.8 (2019-03-20)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
@@ -687,6 +687,7 @@ config:
     pim/association-type-edit-form/delete: pimui/js/association-type/form/delete
 
     # Attribute group
+    pim/model/attribute:                  pimui/js/model/attribute.ts
     pim/model/attribute-group:            pimui/js/model/attribute-group.ts
     pim/attribute-group-edit-form/delete: pimui/js/attribute-group/form/delete
     pim/attribute-group-edit-form/list:   pimui/js/attribute-group/form/list
@@ -897,7 +898,6 @@ config:
     pim/group-edit-form/save:                   pimui/js/group/form/save
 
     # Attribute
-    pim/model/attribute:                                    pimui/js/model/attribute.ts
     pim/attribute-edit-form/tab/choices:                    pimui/js/attribute/form/choices
     pim/attribute-edit-form/choices/options-grid:           pimui/js/attribute/form/choices/options-grid
     pim/attribute-edit-form/delete:                         pimui/js/attribute/form/delete


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes an issue where `pim/model/attribute` was not found if it was declared after `pim/model/attribute-group`. We had a similar issue for JS files which was solved by using `$` to denote an exact match for searching module aliases. We have the same issue with TS files now. This fix will allow the installation to work while we fix the underlying problem. At the moment this problem breaks installations that depend on pim-enterprise-standard. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
