### PR TITLE
PIM-8241: Do not reset filter display when adding a new filter in the product datagrid

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+# Bug fixes
+
+- PIM-8241: Do not reset filter display when adding a new filter
+
 # 3.0.9 (2019-03-26)
 
 # Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-selector.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-selector.ts
@@ -12,6 +12,7 @@ interface FilterModule extends Backbone.View<any> {
   disable: () => FilterModule;
   isEmpty: () => boolean;
   getValue: () => FilterValue;
+  reset: () => FilterModule;
   setValue: (value: FilterValue | number) => FilterModule;
   extend: (filterDefinition: FilterDefinition) => any;
   moveFilter?: (collection: any, element: any) => void;
@@ -146,6 +147,7 @@ class FiltersSelector extends BaseView {
 
       if (filterValue) {
         try {
+          filterModule.reset()
           filterModule.setValue(filterValue);
           filterModule.enabled = true;
         } catch (e) {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**Problem:**

Filter on families in the product grid.
Filter on identifier in the product grid.
Add a new filter: filters on families and identifier are reset on the screen (but still applied for the research).

**Technical explanation:**
When adding a filter in 3.0, we trigger the global render of all enabled filters.
There are two main steps:
1. the filter module render https://github.com/akeneo/pim-community-dev/blob/3.0/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-selector.ts#L108
2. the restore of the filter state https://github.com/akeneo/pim-community-dev/blob/3.0/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-selector.ts#L132

When doing the first step, sometime, it changes the DOM and so, the displayed content (text-filter, select2-choice-filter, etc). 
So, the state of the application and the view are not up-to-date and consistent. 

Example:
https://github.com/akeneo/pim-community-dev/blob/3.0/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/text-filter.js#L190

But under the hood, on some filters, this rendering is also modifying the DOM (and reset with default values). That's why identifier filter and family filter are reset.

Then, we restore the filter state.
We set the value of the filter, but we have a check to not update the DOM if the state is not modified:
https://github.com/akeneo/pim-community-dev/blob/3.0/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/abstract-filter.js#L235

So, as the state on family filter and identifier filter is not modified when we add a new filter, nothing is triggered. But at first... we reset the DOM. So the DOM is not up-to-date with the current state...

**Solution**

Just reset the state of the filters before setting the value.
It forces the update of the DOM.


**Tests**

I don't think it's useful for such thing as it's not possible with the current architecture.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
