### PR TITLE
Fix PHPUnit deprecations

### DIFF
--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Command/CreateClientIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Command/CreateClientIntegration.php
@@ -25,10 +25,10 @@ class CreateClientIntegration extends KernelTestCase
         ]);
         $output = $commandTester->getDisplay();
 
-        $this->assertContains('A new client has been added.', $output);
-        $this->assertContains('client_id:', $output);
-        $this->assertContains('secret:', $output);
-        $this->assertContains('label: Magento connector', $output);
+        $this->assertStringContainsString('A new client has been added.', $output);
+        $this->assertStringContainsString('client_id:', $output);
+        $this->assertStringContainsString('secret:', $output);
+        $this->assertStringContainsString('label: Magento connector', $output);
 
         $this->assertSame(0, $commandTester->getStatusCode());
     }
@@ -37,7 +37,6 @@ class CreateClientIntegration extends KernelTestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Not enough arguments (missing: "label").');
-
 
         self::bootKernel();
         $application = new Application(self::$kernel);

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Command/CreateClientIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Command/CreateClientIntegration.php
@@ -33,12 +33,12 @@ class CreateClientIntegration extends KernelTestCase
         $this->assertSame(0, $commandTester->getStatusCode());
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Not enough arguments (missing: "label").
-     */
     public function testResponseWhenMissingLabel()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "label").');
+
+
         self::bootKernel();
         $application = new Application(self::$kernel);
         $application->add(new CreateClientCommand());

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Command/JobQueueConsumerCommandIntegration.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Command/JobQueueConsumerCommandIntegration.php
@@ -51,7 +51,7 @@ class JobQueueConsumerCommandIntegration extends TestCase
 
         $standardOutput = $output->fetch();
 
-        $this->assertContains(sprintf('Job execution "%s" is finished.', $jobExecution->getId()), $standardOutput);
+        $this->assertStringContainsString(sprintf('Job execution "%s" is finished.', $jobExecution->getId()), $standardOutput);
 
         $row = $this->getJobExecutionDatabaseRow($jobExecution);
 

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Command/PublishJobToQueueCommandIntegration.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Command/PublishJobToQueueCommandIntegration.php
@@ -119,13 +119,13 @@ class PublishJobToQueueCommandIntegration extends TestCase
     public function testLaunchJobWithInvalidJobInstance()
     {
         $output = $this->pushJob(['code' => 'unknown_command']);
-        $this->assertContains('Could not find job instance "unknown_command".', $output->fetch());
+        $this->assertStringContainsString('Could not find job instance "unknown_command".', $output->fetch());
     }
 
     public function testLaunchJobWithInvalidEmail()
     {
         $output = $this->pushJob(['--email' => 'email']);
-        $this->assertContains('Email "email" is invalid', $output->fetch());
+        $this->assertStringContainsString('Email "email" is invalid', $output->fetch());
     }
 
     /**

--- a/tests/back/Channel/Integration/Channel/UpdaterIntegration.php
+++ b/tests/back/Channel/Integration/Channel/UpdaterIntegration.php
@@ -2,169 +2,158 @@
 
 namespace AkeneoTest\Pim\Channel\Integration\Channel;
 
-use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 
 class UpdaterIntegration extends TestCase
 {
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException
-     * @expectedExceptionMessage Expects a "Akeneo\Channel\Component\Model\ChannelInterface", "stdClass" given.
-     */
     public function testUpdateObjectInChannelUpdater()
     {
+        $this->expectException(InvalidObjectException::class);
+        $this->expectExceptionMessage('Expects a "Akeneo\Channel\Component\Model\ChannelInterface", "stdClass" given.');
+
         $this->getUpdater()->update(new \stdClass(), []);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "labels" expects an array as data, "NULL" given.
-     */
     public function testChannelUpdateWithNullLabels()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "labels" expects an array as data, "NULL" given.');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['labels' => null]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "locales" expects an array as data, "NULL" given.
-     */
     public function testChannelUpdateWithNullLocales()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "locales" expects an array as data, "NULL" given.');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['locales' => null]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "currencies" expects an array as data, "NULL" given.
-     */
     public function testChannelUpdateWithNullCurrencies()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "currencies" expects an array as data, "NULL" given.');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['currencies' => null]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "conversion_units" expects an array as data, "NULL" given.
-     */
     public function testChannelUpdateWithNullConversionUnits()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "conversion_units" expects an array as data, "NULL" given.');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['conversion_units' => null]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage one of the "labels" values is not a scalar
-     */
     public function testChannelUpdateWithNonScalarLabels()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('one of the "labels" values is not a scalar');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['labels' => ['en_US' => []]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage one of the "locales" values is not a scalar
-     */
     public function testChannelUpdateWithNonScalarLocales()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('one of the "locales" values is not a scalar');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['locales' => [[]]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage one of the "currencies" values is not a scalar
-     */
     public function testChannelUpdateWithNonScalarCurrencies()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('one of the "currencies" values is not a scalar');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['currencies' => ['EUR', []]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage one of the "conversion_units" values is not a scalar
-     */
     public function testChannelUpdateWithNonScalarConversionUnits()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('one of the "conversion_units" values is not a scalar');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['conversion_units' => ['weight' => 'GRAM', 'display_diagonal' => []]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "code" expects a scalar as data, "array" given.
-     */
     public function testChannelUpdateWithNonScalarCode()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "code" expects a scalar as data, "array" given.');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['code' => []]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "category_tree" expects a scalar as data, "array" given.
-     */
     public function testChannelUpdateWithNonScalarCategoryTree()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "category_tree" expects a scalar as data, "array" given.');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['category_tree' => []]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "category_tree" expects a valid code. The category does not exist, "category_tree" given.
-     */
     public function testChannelUpdateWithUnknownCategoryTree()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "category_tree" expects a valid code. The category does not exist, "category_tree" given.');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['category_tree' => 'category_tree']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "currencies" expects a valid code. The currency does not exist, "YOLO" given.
-     */
     public function testChannelUpdateWithUnknownCurrency()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "currencies" expects a valid code. The currency does not exist, "YOLO" given.');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['currencies' => ['YOLO']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "locales" expects a valid code. The locale does not exist, "YOLO" given.
-     */
     public function testChannelUpdateWithUnknownLocale()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "locales" expects a valid code. The locale does not exist, "YOLO" given.');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['locales' => ['YOLO']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException
-     * @expectedExceptionMessage Property "unknown_property" does not exist.
-     */
     public function testChannelUpdateWithUnknownProperty()
     {
+        $this->expectException(UnknownPropertyException::class);
+        $this->expectExceptionMessage('Property "unknown_property" does not exist.');
+
         $channel = $this->createChannel();
 
         $this->getUpdater()->update($channel, ['unknown_property' => null]);

--- a/tests/back/Integration/integration/BatchBundle/Command/BatchCommandIntegration.php
+++ b/tests/back/Integration/integration/BatchBundle/Command/BatchCommandIntegration.php
@@ -88,8 +88,8 @@ class BatchCommandIntegration extends TestCase
     {
         $output = $this->launchJob(['-vvv' => true]);
         $outputContent = $output->fetch();
-        $this->assertContains('DEBUG', $outputContent);
-        $this->assertContains('Export csv_product_export has been successfully executed.', $outputContent);
+        $this->assertStringContainsString('DEBUG', $outputContent);
+        $this->assertStringContainsString('Export csv_product_export has been successfully executed.', $outputContent);
     }
 
     public function testLaunchJobWithValidEmail()
@@ -101,19 +101,19 @@ class BatchCommandIntegration extends TestCase
     public function testLaunchJobWithInvalidJobInstance()
     {
         $output = $this->launchJob(['code' => 'unknown_command']);
-        $this->assertContains('Could not find job instance "unknown_command".', $output->fetch());
+        $this->assertStringContainsString('Could not find job instance "unknown_command".', $output->fetch());
     }
 
     public function testLaunchJobWithInvalidEmail()
     {
         $output = $this->launchJob(['--email' => 'email']);
-        $this->assertContains('Email "email" is invalid', $output->fetch());
+        $this->assertStringContainsString('Email "email" is invalid', $output->fetch());
     }
 
     public function testLaunchJobWithInvalidJobExecutionCode()
     {
         $output = $this->launchJob(['execution' => '1']);
-        $this->assertContains('Could not find job execution "1"', $output->fetch());
+        $this->assertStringContainsString('Could not find job execution "1"', $output->fetch());
     }
 
     public function testLaunchJobAlreadyStarted()
@@ -124,19 +124,19 @@ class BatchCommandIntegration extends TestCase
         $this->assertEquals(BatchStatus::COMPLETED, $jobExecution['status']);
 
         $output = $this->launchJob(['execution' => $jobExecution['id']]);
-        $this->assertContains(sprintf('Job execution "%s" has invalid status: COMPLETED', $jobExecution['id']), $output->fetch());
+        $this->assertStringContainsString(sprintf('Job execution "%s" has invalid status: COMPLETED', $jobExecution['id']), $output->fetch());
     }
 
     public function testLaunchJobExecutionWithConfigOverridden()
     {
         $output = $this->launchJob(['execution' => '1', '--config' => ['filePath' => '/tmp/foo']]);
-        $this->assertContains('Configuration option cannot be specified when launching a job execution.', $output->fetch());
+        $this->assertStringContainsString('Configuration option cannot be specified when launching a job execution.', $output->fetch());
     }
 
     public function testLaunchJobExecutionWithUsernameOverridden()
     {
         $output = $this->launchJob(['execution' => '1', '--username' => 'mary']);
-        $this->assertContains('Username option cannot be specified when launching a job execution', $output->fetch());
+        $this->assertStringContainsString('Username option cannot be specified when launching a job execution', $output->fetch());
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Query/FindActivatedCurrenciesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Query/FindActivatedCurrenciesIntegration.php
@@ -83,13 +83,6 @@ class FindActivatedCurrenciesIntegration extends TestCase
 
     private function assertSameWithoutOrder(array $expected, array $actual): void
     {
-        Assert::assertEquals(
-            $expected,
-            $actual,
-            '',
-            0.0,
-            10,
-            true
-        );
+        Assert::assertEqualsCanonicalizing($expected, $actual);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/ScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Date;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -118,21 +119,19 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, []);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_date" expects a scope, none given.
-     */
     public function testErrorMetricScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_date" expects a scope, none given.');
+
         $this->executeFilter([['a_scopable_date', Operators::NOT_EQUAL, '2016-09-23']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_date" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_date" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_scopable_date', Operators::NOT_EQUAL, '2016-09-23', ['scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableScopableFilterIntegration.php
@@ -3,6 +3,7 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Media;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -103,39 +104,35 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         $this->assert($result, ['product_one', 'product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_image" expects a locale, none given.
-     */
     public function testErrorLocale()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_image" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_scopable_image', Operators::NOT_EQUAL, '2016-09-23']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_image" expects a scope, none given.
-     */
     public function testErrorScope()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_image" expects a scope, none given.');
+
         $this->executeFilter([['a_localizable_scopable_image', Operators::NOT_EQUAL, '2016-09-23', ['locale' => 'fr_FR']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_image" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_image" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_scopable_image', Operators::NOT_EQUAL, 'akeneo.jpg', ['locale' => 'NOT_FOUND']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_image" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_image" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_scopable_image', Operators::NOT_EQUAL, 'akeneo.jpg', ['locale' => 'fr_FR', 'scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/MediaFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/MediaFilterIntegration.php
@@ -2,7 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Media;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -92,21 +94,19 @@ class MediaFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['akeneo', 'ziggy']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "an_image" expects a string as data, "array" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "an_image" expects a string as data, "array" given.');
+
         $this->executeFilter([['an_image', Operators::CONTAINS, []]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "an_image" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "an_image" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['an_image', Operators::BETWEEN, 'ziggy.png']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/ScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Media;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -111,12 +112,11 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_one', 'product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_image" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_image" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_scopable_image', Operators::NOT_EQUAL, '2016-09-23', ['scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Metric;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -126,21 +127,19 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_metric" expects a locale, none given.
-     */
     public function testErrorMetricLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_metric" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_metric', Operators::NOT_EQUAL, ['amount' => 250, 'unit' => 'KILOWATT']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_metric" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_metric" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_metric', Operators::NOT_EQUAL, ['amount' => 10, 'unit' => 'KILOWATT'], ['locale' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Metric;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -189,39 +190,35 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         $this->assert($result, ['product_one']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_localizable_metric" expects a locale, none given.
-     */
     public function testErrorMetricLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_localizable_metric" expects a locale, none given.');
+
         $this->executeFilter([['a_scopable_localizable_metric', Operators::NOT_EQUAL, ['amount' => 250, 'unit' => 'KILOWATT']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_localizable_metric" expects a scope, none given.
-     */
     public function testErrorMetricScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_localizable_metric" expects a scope, none given.');
+
         $this->executeFilter([['a_scopable_localizable_metric', Operators::NOT_EQUAL, ['amount' => 250, 'unit' => 'KILOWATT'], ['locale' => 'fr_FR']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_localizable_metric" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_localizable_metric" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_scopable_localizable_metric', Operators::NOT_EQUAL, ['amount' => 250, 'unit' => 'KILOWATT'], ['locale' => 'NOT_FOUND']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_localizable_metric" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_localizable_metric" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_scopable_localizable_metric', Operators::NOT_EQUAL, ['amount' => 250, 'unit' => 'KILOWATT'], ['locale' => 'en_US', 'scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/MetricFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/MetricFilterIntegration.php
@@ -2,7 +2,10 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Metric;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -152,48 +155,43 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_one']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_metric" expects an array as data, "string" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_metric" expects an array as data, "string" given.');
+
         $this->executeFilter([['a_metric', Operators::NOT_EQUAL, 'string']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_metric" expects an array with the key "amount".
-     */
     public function testErrorAmountIsMissing()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_metric" expects an array with the key "amount".');
+
         $this->executeFilter([['a_metric', Operators::NOT_EQUAL, ['unit' => 'WATT']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_metric" expects an array with the key "unit".
-     */
     public function testErrorCurrencyIsMissing()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_metric" expects an array with the key "unit".');
+
         $this->executeFilter([['a_metric', Operators::NOT_EQUAL, ['amount' => '']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage The unit does not exist in the attribute's family "Power"
-     */
     public function testErrorUnitNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('The unit does not exist in the attribute\'s family "Power"');
+
         $this->executeFilter([['a_metric', Operators::NOT_EQUAL, ['amount' => 10, 'unit' => 'NOT_FOUND']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "a_metric" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "a_metric" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['a_metric', Operators::BETWEEN, ['amount' => 15, 'unit' => 'KILOWATT']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/ScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Metric;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -124,21 +125,19 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_one']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_metric" expects a scope, none given.
-     */
     public function testErrorMetricScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_metric" expects a scope, none given.');
+
         $this->executeFilter([['a_scopable_metric', Operators::NOT_EQUAL, ['amount' => 250, 'unit' => 'KILOWATT']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_metric" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_metric" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_scopable_metric', Operators::NOT_EQUAL, ['amount' => 10, 'unit' => 'KILOWATT'], ['scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Number;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -124,21 +125,19 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, []);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_number" expects a locale, none given.
-     */
     public function testErrorLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_number" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_number', Operators::NOT_EQUAL, 12]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_number" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_number" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_number', Operators::NOT_EQUAL, 12, ['locale' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Number;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -122,39 +123,35 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         $this->assert($result, ['product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_number" expects a locale, none given.
-     */
     public function testErrorLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_number" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_scopable_number', Operators::NOT_EQUAL, 12]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_number" expects a scope, none given.
-     */
     public function testErrorScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_number" expects a scope, none given.');
+
         $this->executeFilter([['a_localizable_scopable_number', Operators::NOT_EQUAL, 12, ['locale' => 'fr_FR']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_number" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_number" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_scopable_number', Operators::NOT_EQUAL, 12, ['locale' => 'NOT_FOUND']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_number" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_number" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_scopable_number', Operators::NOT_EQUAL, 12, ['locale' => 'fr_FR', 'scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/NumberFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/NumberFilterIntegration.php
@@ -2,7 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Number;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -131,21 +133,19 @@ class NumberFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_number_float_negative" expects a numeric as data, "string" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_number_float_negative" expects a numeric as data, "string" given.');
+
         $this->executeFilter([['a_number_float_negative', Operators::NOT_EQUAL, 'string']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "a_number_float_negative" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "a_number_float_negative" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['a_number_float_negative', Operators::BETWEEN, '-15.5']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/ScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Number;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -112,21 +113,19 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, []);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_number" expects a scope, none given.
-     */
     public function testErrorScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_number" expects a scope, none given.');
+
         $this->executeFilter([['a_scopable_number', Operators::NOT_EQUAL, 12]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_number" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_number" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_scopable_number', Operators::NOT_EQUAL, 12, ['scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Option;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -88,21 +89,19 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['empty_product', 'product_one']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_simple_select" expects a locale, none given.
-     */
     public function testErrorOptionLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_simple_select" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_simple_select', Operators::IN_LIST, ['orange']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_simple_select" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_simple_select" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_simple_select', Operators::IN_LIST, ['orange'], ['locale' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Option;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -92,39 +93,35 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         $this->assert($result, ['empty_product', 'product_one']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_simple_select" expects a locale, none given.
-     */
     public function testErrorOptionLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_simple_select" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_scopable_simple_select', Operators::IN_LIST, ['orange']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_simple_select" expects a scope, none given.
-     */
     public function testErrorOptionScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_simple_select" expects a scope, none given.');
+
         $this->executeFilter([['a_localizable_scopable_simple_select', Operators::IN_LIST, ['orange'], ['locale' => 'fr_FR']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_simple_select" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_simple_select" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_scopable_simple_select', Operators::IN_LIST, ['orange'], ['locale' => 'NOT_FOUND']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_simple_select" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_simple_select" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_scopable_simple_select', Operators::IN_LIST, ['orange'], ['locale' => 'en_US', 'scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/OptionFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/OptionFilterIntegration.php
@@ -2,7 +2,10 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Option;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -78,30 +81,27 @@ class OptionFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['empty_product','product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_simple_select" expects an array as data, "string" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_simple_select" expects an array as data, "string" given.');
+
         $this->executeFilter([['a_simple_select', Operators::IN_LIST, 'string']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException
-     * @expectedExceptionMessage Object "option" with code "NOT_FOUND" does not exist
-     */
     public function testErrorOptionNotFound()
     {
+        $this->expectException(ObjectNotFoundException::class);
+        $this->expectExceptionMessage('Object "option" with code "NOT_FOUND" does not exist');
+
         $this->executeFilter([['a_simple_select', Operators::IN_LIST, ['NOT_FOUND']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "a_simple_select" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "a_simple_select" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['a_simple_select', Operators::BETWEEN, ['NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/ScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Option;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -87,21 +88,19 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['empty_product','product_one']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_select_scopable_simple_select" expects a scope, none given.
-     */
     public function testErrorOptionScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_select_scopable_simple_select" expects a scope, none given.');
+
         $this->executeFilter([['a_select_scopable_simple_select', Operators::IN_LIST, ['orange']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_select_scopable_simple_select" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_select_scopable_simple_select" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_select_scopable_simple_select', Operators::IN_LIST, ['orange'], ['scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Options;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -93,21 +94,19 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['empty_product', 'product_one']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_multi_select" expects a locale, none given.
-     */
     public function testErrorOptionLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_multi_select" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_multi_select', Operators::IN_LIST, ['orange']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_multi_select" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_multi_select" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_multi_select', Operators::IN_LIST, ['orange'], ['locale' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Options;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -97,39 +98,35 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         $this->assert($result, ['empty_product', 'product_one']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_multi_select" expects a locale, none given.
-     */
     public function testErrorOptionLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_multi_select" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_scopable_multi_select', Operators::IN_LIST, ['orange']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_multi_select" expects a scope, none given.
-     */
     public function testErrorOptionScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_multi_select" expects a scope, none given.');
+
         $this->executeFilter([['a_localizable_scopable_multi_select', Operators::IN_LIST, ['orange'], ['locale' => 'fr_FR']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_multi_select" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_multi_select" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_scopable_multi_select', Operators::IN_LIST, ['orange'], ['locale' => 'NOT_FOUND']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_multi_select" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_multi_select" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_scopable_multi_select', Operators::IN_LIST, ['orange'], ['locale' => 'fr_FR', 'scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/OptionsFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/OptionsFilterIntegration.php
@@ -2,7 +2,10 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Options;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -86,30 +89,27 @@ class OptionsFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['empty_product', 'product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_multi_select" expects an array as data, "string" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_multi_select" expects an array as data, "string" given.');
+
         $this->executeFilter([['a_multi_select', Operators::IN_LIST, 'string']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException
-     * @expectedExceptionMessage Object "options" with code "NOT_FOUND" does not exist
-     */
     public function testErrorOptionNotFound()
     {
+        $this->expectException(ObjectNotFoundException::class);
+        $this->expectExceptionMessage('Object "options" with code "NOT_FOUND" does not exist');
+
         $this->executeFilter([['a_multi_select', Operators::IN_LIST, ['NOT_FOUND']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "a_multi_select" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "a_multi_select" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['a_multi_select', Operators::BETWEEN, ['orange', 'black']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/ScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Options;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -95,21 +96,19 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['empty_product', 'product_one']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_multi_select" expects a scope, none given.
-     */
     public function testErrorOptionScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_multi_select" expects a scope, none given.');
+
         $this->executeFilter([['a_scopable_multi_select', Operators::IN_LIST, ['orange']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_multi_select" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_multi_select" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_scopable_multi_select', Operators::IN_LIST, ['orange'], ['scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -322,21 +323,19 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_price" expects a locale, none given.
-     */
     public function testErrorPriceLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_price" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_price', Operators::NOT_EQUAL, ['amount' => 250, 'currency' => 'USD']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_price" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_price" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([
             [
                 'a_localizable_price',

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -368,12 +369,11 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         $this->assert($result, ['product_one', 'product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_localizable_price" expects a locale, none given.
-     */
     public function testErrorPriceLocalizableAndScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_localizable_price" expects a locale, none given.');
+
         $this->executeFilter([
             [
                 'a_scopable_localizable_price',
@@ -383,12 +383,11 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_localizable_price" expects a scope, none given.
-     */
     public function testErrorPriceLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_localizable_price" expects a scope, none given.');
+
         $this->executeFilter([
             [
                 'a_scopable_localizable_price',
@@ -399,12 +398,11 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_localizable_price" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_localizable_price" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([
             [
                 'a_scopable_localizable_price',
@@ -415,12 +413,11 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_localizable_price" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_localizable_price" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([
             [
                 'a_scopable_localizable_price',

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/PriceFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/PriceFilterIntegration.php
@@ -2,7 +2,10 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -154,48 +157,43 @@ class PriceFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_one']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_price" expects an array as data, "string" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_price" expects an array as data, "string" given.');
+
         $this->executeFilter([['a_price', Operators::NOT_EQUAL, 'string']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_price" expects an array with the key "amount".
-     */
     public function testErrorAmountIsMissing()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_price" expects an array with the key "amount".');
+
         $this->executeFilter([['a_price', Operators::NOT_EQUAL, ['currency' => 'USD']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_price" expects an array with the key "currency".
-     */
     public function testErrorCurrencyIsMissing()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_price" expects an array with the key "currency".');
+
         $this->executeFilter([['a_price', Operators::NOT_EQUAL, ['amount' => 2]]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "a_price" expects a valid currency. The currency does not exist, "NOT_FOUND" given.
-     */
     public function testErrorCurrencyNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "a_price" expects a valid currency. The currency does not exist, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_price', Operators::NOT_EQUAL, ['amount' => 10, 'currency' => 'NOT_FOUND']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "a_price" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "a_price" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['a_price', Operators::BETWEEN, ['amount' => 15, 'currency' => 'EUR']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/ScopableFilterIntegration.php
@@ -3,6 +3,7 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -334,21 +335,19 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_price" expects a scope, none given.
-     */
     public function testErrorPriceScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_price" expects a scope, none given.');
+
         $this->executeFilter([['a_scopable_price', Operators::NOT_EQUAL, ['amount' => 250, 'currency' => 'EUR']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_price" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_price" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([
             [
                 'a_scopable_price',

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataMultiSelectFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataMultiSelectFilterIntegration.php
@@ -2,7 +2,10 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\ReferenceData;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -106,30 +109,27 @@ class ReferenceDataMultiSelectFilterIntegration extends AbstractProductQueryBuil
         $this->assert($result, ['product_one', 'product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_ref_data_multi_select" expects an array as data, "string" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_ref_data_multi_select" expects an array as data, "string" given.');
+
         $this->executeFilter([['a_ref_data_multi_select', Operators::IN_LIST, 'string']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "a_ref_data_multi_select" expects a valid code. No reference data "fabrics" with code "NOT_FOUND" has been found, "NOT_FOUND" given.
-     */
     public function testErrorOptionNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "a_ref_data_multi_select" expects a valid code. No reference data "fabrics" with code "NOT_FOUND" has been found, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_ref_data_multi_select', Operators::IN_LIST, ['NOT_FOUND']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "a_ref_data_multi_select" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "a_ref_data_multi_select" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['a_ref_data_multi_select', Operators::BETWEEN, ['NOT_FOUND']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
@@ -2,7 +2,10 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\ReferenceData;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -74,30 +77,27 @@ class ReferenceDataSimpleSelectFilterIntegration extends AbstractProductQueryBui
         $this->assert($result, ['product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_ref_data_simple_select" expects an array as data, "string" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_ref_data_simple_select" expects an array as data, "string" given.');
+
         $this->executeFilter([['a_ref_data_simple_select', Operators::IN_LIST, 'string']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "a_ref_data_simple_select" expects a valid code. No reference data "color" with code "NOT_FOUND" has been found, "NOT_FOUND" given.
-     */
     public function testErrorOptionNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "a_ref_data_simple_select" expects a valid code. No reference data "color" with code "NOT_FOUND" has been found, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_ref_data_simple_select', Operators::IN_LIST, ['NOT_FOUND']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "a_ref_data_simple_select" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "a_ref_data_simple_select" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['a_ref_data_simple_select', Operators::BETWEEN, ['NOT_FOUND']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Text;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -117,21 +118,19 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['cat', 'cattle']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_text" expects a locale, none given.
-     */
     public function testErrorLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_text" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_text', Operators::NOT_EQUAL, 'data']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_text" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_text" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_text', Operators::NOT_EQUAL, 'text', ['locale' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Text;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -138,12 +139,11 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         $this->assert($result, ['cat', 'cattle']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_text" expects a locale, none given.
-     */
     public function testErrorLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_text" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_scopable_text', Operators::NOT_EQUAL, 'data']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/ScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Text;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -117,21 +118,19 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['cat', 'cattle']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_text" expects a scope, none given.
-     */
     public function testErrorScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_text" expects a scope, none given.');
+
         $this->executeFilter([['a_scopable_text', Operators::NOT_EQUAL, 'data']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_text" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_text" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_scopable_text', Operators::NOT_EQUAL, 'text', ['scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/TextFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/TextFilterIntegration.php
@@ -2,7 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Text;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -167,21 +169,19 @@ class TextFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['cat', 'cattle', 'dog', 'best_dog']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_text" expects a string as data, "array" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_text" expects a string as data, "array" given.');
+
         $this->executeFilter([['a_text', Operators::NOT_EQUAL, [[]]]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "a_text" is not supported or does not support operator ">="
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "a_text" is not supported or does not support operator ">="');
+
         $this->executeFilter([['a_text', Operators::GREATER_OR_EQUAL_THAN, 'dog']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\TextArea;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -132,21 +133,19 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['cat', 'cattle']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_text_area" expects a locale, none given.
-     */
     public function testErrorLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_text_area" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_text_area', Operators::NOT_EQUAL, 'data']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_text_area" expects an existing and activated locale, "NOT_FOUND" given.
-     */
     public function testLocaleNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_text_area" expects an existing and activated locale, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_localizable_text_area', Operators::NOT_EQUAL, 'text', ['locale' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\TextArea;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -138,12 +139,11 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         $this->assert($result, ['cat', 'cattle']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_localizable_scopable_text_area" expects a locale, none given.
-     */
     public function testErrorLocalizable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_localizable_scopable_text_area" expects a locale, none given.');
+
         $this->executeFilter([['a_localizable_scopable_text_area', Operators::NOT_EQUAL, 'data']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/ScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\TextArea;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -117,21 +118,19 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['cat', 'cattle']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_text_area" expects a scope, none given.
-     */
     public function testErrorScopable()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_text_area" expects a scope, none given.');
+
         $this->executeFilter([['a_scopable_text_area', Operators::NOT_EQUAL, 'data']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Attribute "a_scopable_text_area" expects an existing scope, "NOT_FOUND" given.
-     */
     public function testScopeNotFound()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Attribute "a_scopable_text_area" expects an existing scope, "NOT_FOUND" given.');
+
         $this->executeFilter([['a_scopable_text_area', Operators::NOT_EQUAL, 'text', ['scope' => 'NOT_FOUND']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/TextAreaFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/TextAreaFilterIntegration.php
@@ -2,7 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\TextArea;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -233,21 +235,19 @@ class TextAreaFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['cat', 'cattle', 'dog', 'best_cat', 'best_dog']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "a_text_area" expects a string as data, "array" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_text_area" expects a string as data, "array" given.');
+
         $this->executeFilter([['a_text_area', Operators::NOT_EQUAL, [[]]]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "a_text_area" is not supported or does not support operator ">="
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "a_text_area" is not supported or does not support operator ">="');
+
         $this->executeFilter([['a_text_area', Operators::GREATER_OR_EQUAL_THAN, 'dog']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/CategoryFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/CategoryFilterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -83,12 +84,11 @@ class CategoryFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['bar', 'baz']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "categories" is not supported or does not support operator ">="
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "categories" is not supported or does not support operator ">="');
+
         $this->executeFilter([['categories', Operators::GREATER_OR_EQUAL_THAN, ['categoryA1']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/DateTimeFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/DateTimeFilterIntegration.php
@@ -2,7 +2,10 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -128,30 +131,27 @@ class DateTimeFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['bar', 'baz', 'foo']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "updated" expects an array with valid data, should contain 2 strings with the format "yyyy-mm-dd H:i:s".
-     */
     public function testErrorDataIsMalformedWithEmptyArray()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "updated" expects an array with valid data, should contain 2 strings with the format "yyyy-mm-dd H:i:s".');
+
         $this->executeFilter([['updated', Operators::BETWEEN, []]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "updated" expects a string with the format "yyyy-mm-dd H:i:s" as data, "2016-12-12T00:00:00" given.
-     */
     public function testErrorDataIsMalformedWithISODate()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "updated" expects a string with the format "yyyy-mm-dd H:i:s" as data, "2016-12-12T00:00:00" given.');
+
         $this->executeFilter([['updated', Operators::EQUALS, '2016-12-12T00:00:00']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "updated" is not supported or does not support operator "IN CHILDREN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "updated" is not supported or does not support operator "IN CHILDREN"');
+
         $this->executeFilter([['updated', Operators::IN_CHILDREN_LIST, ['2016-08-29 00:00:01']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/FamilyFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/FamilyFilterIntegration.php
@@ -2,7 +2,10 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -61,30 +64,27 @@ class FamilyFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['foo']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "family" expects an array as data, "string" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "family" expects an array as data, "string" given.');
+
         $this->executeFilter([['family', Operators::IN_LIST, 'string']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException
-     * @expectedExceptionMessage Object "family" with code "UNKNOWN_FAMILY" does not exist
-     */
     public function testErrorValueNotFound()
     {
+        $this->expectException(ObjectNotFoundException::class);
+        $this->expectExceptionMessage('Object "family" with code "UNKNOWN_FAMILY" does not exist');
+
         $this->executeFilter([['family', Operators::IN_LIST, ['UNKNOWN_FAMILY']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "family" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "family" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['family', Operators::BETWEEN, 'familyA']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/GridCompletenessFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/GridCompletenessFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\Assert\AssertEntityWithValues;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -115,22 +116,23 @@ class GridCompletenessFilterIntegration extends AbstractProductQueryBuilderTestC
 
     /**
      * The filter expect a non empty locale
-     *
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "completeness" expects a valid locale.
      */
     public function testErrorLocaleIsNotMissing()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "completeness" expects a valid locale.');
+
+
         $this->executeFilter([['completeness', Operators::AT_LEAST_COMPLETE, null, ['scope' => 'ecommerce']]]);
     }
     /**
      * The filter expect a non empty channel
-     *
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "completeness" expects a valid channel.
      */
     public function testErrorChannelIsNotMissing()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "completeness" expects a valid channel.');
+
         $this->executeFilter([['completeness', Operators::AT_LEAST_COMPLETE, null, ['locale' => 'en_US']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/GroupsFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/GroupsFilterIntegration.php
@@ -2,7 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -67,21 +69,19 @@ class GroupsFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['foo']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "groups" expects an array as data, "string" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "groups" expects an array as data, "string" given.');
+
         $this->executeFilter([['groups', Operators::IN_LIST, 'string']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "groups" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupportedForGroups()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "groups" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['groups', Operators::BETWEEN, 'groupB']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/IdFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/IdFilterIntegration.php
@@ -2,7 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -76,57 +78,51 @@ class IdFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "id" expects a string as data, "array" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "id" expects a string as data, "array" given.');
+
         $this->executeFilter([['id', Operators::EQUALS, ['string']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "id" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "id" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['id', Operators::BETWEEN, 'foo']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "id" expects an array as data, "string" given.
-     */
     public function testDataIsMalformedForOperatorInList()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "id" expects an array as data, "string" given.');
+
         $this->executeFilter([['id', Operators::IN_LIST, 'foo']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "id" expects an array with valid data, one of the value is not string.
-     */
     public function testDataIsNotAListOfStringForOperatorInList()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "id" expects an array with valid data, one of the value is not string.');
+
         $this->executeFilter([['id', Operators::IN_LIST, [12, 'foo']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "id" expects an array as data, "string" given.
-     */
     public function testDataIsMalformedForOperatorNotInList()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "id" expects an array as data, "string" given.');
+
         $this->executeFilter([['id', Operators::NOT_IN_LIST, 'foo']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "id" expects an array with valid data, one of the value is not string.
-     */
     public function testDataIsNotAListOfStringForOperatorNotInList()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "id" expects an array with valid data, one of the value is not string.');
+
         $this->executeFilter([['id', Operators::NOT_IN_LIST, [12, 'foo']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/IdentifierFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/IdentifierFilterIntegration.php
@@ -2,7 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -140,48 +142,43 @@ class IdentifierFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "identifier" expects a string as data, "array" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "identifier" expects a string as data, "array" given.');
+
         $this->executeFilter([['identifier', Operators::STARTS_WITH, ['string']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "identifier" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "identifier" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['identifier', Operators::BETWEEN, 'foo']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "identifier" expects an array as data, "string" given.
-     */
     public function testDataIsMalformedForOperatorInList()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "identifier" expects an array as data, "string" given.');
+
         $this->executeFilter([['identifier', Operators::IN_LIST, 'foo']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "identifier" expects an array as data, "string" given.
-     */
     public function testDataIsMalformedForOperatorNotInList()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "identifier" expects an array as data, "string" given.');
+
         $this->executeFilter([['identifier', Operators::NOT_IN_LIST, 'foo']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "identifier" expects a string as data, "array" given.
-     */
     public function testErrorDataIsMalformedWithAttributeIdentifierCode()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "identifier" expects a string as data, "array" given.');
+
         $this->executeFilter([['identifier', Operators::STARTS_WITH, ['string']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/CompletenessFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/CompletenessFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Field\Product;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -409,39 +411,35 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['product_two']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "completeness" expects an array with the key "locales".
-     */
     public function testErrorLocalesIsMissing()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "completeness" expects an array with the key "locales".');
+
         $this->executeFilter([['completeness', Operators::LOWER_OR_EQUALS_THAN_ON_ALL_LOCALES, 75, ['scope' => 'ecommerce']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "completeness" expects an array of arrays as data.
-     */
     public function testErrorLocalesIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "completeness" expects an array of arrays as data.');
+
         $this->executeFilter([['completeness', Operators::LOWER_OR_EQUALS_THAN_ON_ALL_LOCALES, 75, ['scope' => 'ecommerce', 'locales' => 'string']]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "completeness" expects a valid scope.
-     */
     public function testErrorScopeIsMissing()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "completeness" expects a valid scope.');
+
         $this->executeFilter([['completeness', Operators::LOWER_OR_EQUALS_THAN_ON_ALL_LOCALES, 75]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "completeness" expects a numeric as data, "string" given.
-     */
     public function testErrorDataIsNotAnNumeric()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "completeness" expects a numeric as data, "string" given.');
+
         $this->executeFilter([['completeness', Operators::LOWER_OR_EQUALS_THAN_ON_ALL_LOCALES, 'string']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/StatusFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/StatusFilterIntegration.php
@@ -2,7 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -41,21 +43,19 @@ class StatusFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['foo']);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "enabled" expects a boolean as data, "string" given.
-     */
     public function testErrorDataIsMalformed()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "enabled" expects a boolean as data, "string" given.');
+
         $this->executeFilter([['enabled', Operators::EQUALS, 'string']]);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException
-     * @expectedExceptionMessage Filter on property "enabled" is not supported or does not support operator "BETWEEN"
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->expectExceptionMessage('Filter on property "enabled" is not supported or does not support operator "BETWEEN"');
+
         $this->executeFilter([['enabled', Operators::BETWEEN, false]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/BooleanSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/BooleanSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Boolean;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -54,12 +55,11 @@ class BooleanSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['yes', 'no', 'null_product', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_yes_no', 'A_BAD_DIRECTION']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/LocalizableScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Boolean;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -72,12 +73,11 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         $this->assertOrder($result, ['product_one', 'product_two','empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_localizable_scopable_yes_no', 'A_BAD_DIRECTION', ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/LocalizableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Boolean;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -68,12 +69,11 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_localizable_yes_no', 'A_BAD_DIRECTION', ['locale' => 'fr_FR']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/ScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Boolean;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -68,12 +69,11 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_scopable_yes_no', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/CompletenessSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/CompletenessSorterIntegration.php
@@ -2,7 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -84,36 +86,33 @@ class CompletenessSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['empty_product', 'product_one', 'product_two', 'product_three', 'no_family']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter(
             [['completeness', 'A_BAD_DIRECTION']],
             ['default_locale' => 'en_US', 'default_scope' => 'ecommerce']
         );
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "locale" does not expect an empty value.
-     */
     public function testErrorLocaleNotEmpty()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "locale" does not expect an empty value.');
+
         $this->executeSorter(
             [['completeness', Directions::ASCENDING]],
             ['default_scope' => 'ecommerce']
         );
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "scope" does not expect an empty value.
-     */
     public function testErrorScopeNotEmpty()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "scope" does not expect an empty value.');
+
         $this->executeSorter(
             [['completeness', Directions::ASCENDING]],
             ['default_locale' => 'en_US']

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/DateSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/DateSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Date;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -26,12 +27,11 @@ class DateSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_date', 'A_BAD_DIRECTION']]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/LocalizableScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Date;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -35,12 +36,11 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'product_four', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([[
             'a_localizable_scopable_date',
             'A_BAD_DIRECTION',

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/LocalizableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Date;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -27,12 +28,11 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_localizable_date', 'A_BAD_DIRECTION', ['locale' => 'fr_FR']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/ScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Date;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -27,12 +28,11 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_scopable_date', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/DateTimeSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/DateTimeSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -38,12 +39,11 @@ class DateTimeSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['baz', 'bar', 'foo']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['updated', 'A_BAD_DIRECTION']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/DateTimeSorterWithDifferentTimezoneIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/DateTimeSorterWithDifferentTimezoneIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -48,12 +49,11 @@ class DateTimeSorterWithDifferentTimezoneIntegration extends AbstractProductQuer
         $this->assertOrder($result, ['baz', 'bar', 'foo']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['updated', 'A_BAD_DIRECTION']]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/FamilySorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/FamilySorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -55,12 +56,11 @@ class FamilySorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['fooA', 'fooA1', 'fooA2', 'baz']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['family', 'A_BAD_DIRECTION']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/IdSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/IdSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -41,12 +42,11 @@ class IdSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['BAZAR', 'BARISTA', 'baz', 'bar', 'foo']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['identifier', 'A_BAD_DIRECTION']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/IdentifierSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/IdentifierSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -44,12 +45,11 @@ class IdentifierSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['foo', 'BAZAR', 'baz', 'BARISTA', 'bar']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['identifier', 'A_BAD_DIRECTION']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/LocalizableScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Metric;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -78,12 +79,11 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         $this->assertOrder($result, ['product_two', 'product_one', 'product_three', 'product_four']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_localizable_scopable_metric', 'A_BAD_DIRECTION', ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/LocalizableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Metric;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -72,12 +73,11 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_two', 'product_one', 'product_three', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_localizable_metric', 'A_BAD_DIRECTION', ['locale' => 'fr_FR']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/MetricSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/MetricSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Metric;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -60,12 +61,11 @@ class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_two', 'product_one', 'product_three', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_metric', 'A_BAD_DIRECTION']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/ScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Metric;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -72,12 +73,11 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_two', 'product_one', 'product_three', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_scopable_metric', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/LocalizableScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Number;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -76,12 +77,11 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         $this->assertOrder($result, ['product_two', 'product_one', 'product_three']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_localizable_scopable_number', 'A_BAD_DIRECTION', ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/LocalizableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Number;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -76,12 +77,11 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_two', 'product_one', 'product_three']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_localizable_number', 'A_BAD_DIRECTION', ['locale' => 'en_US']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/NumberSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/NumberSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Number;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -60,12 +61,11 @@ class NumberSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_one', 'product_two', 'product_three', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_number_float_negative', 'A_BAD_DIRECTION']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/ScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Number;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -70,12 +71,11 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_scopable_number', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/LocalizableScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Option;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -102,12 +103,11 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([
             [
                 'a_localizable_scopable_simple_select',

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/LocalizableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Option;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -90,12 +91,11 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_localizable_simple_select', 'A_BAD_DIRECTION', ['locale' => 'en_US']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/OptionSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/OptionSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Option;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -62,12 +63,11 @@ class OptionSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_two', 'product_one', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_simple_select', 'A_BAD_DIRECTION']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/ScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Option;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -78,12 +79,11 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_select_scopable_simple_select', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/ReferenceData/ReferenceDataSimpleSelectSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/ReferenceData/ReferenceDataSimpleSelectSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\ReferenceData;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -58,12 +59,11 @@ class ReferenceDataSimpleSelectSorterIntegration extends AbstractProductQueryBui
         $this->assert($result, ['product_two', 'product_one', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_ref_data_simple_select', 'A_BAD_DIRECTION']]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/StatusSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/StatusSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -38,12 +39,11 @@ class StatusSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['foo', 'baz', 'bar', 'foobar', 'foobaz']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['enabled', 'A_BAD_DIRECTION']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/LocalizableScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Text;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -92,12 +93,11 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([
             [
                 'a_localizable_scopable_text',

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/LocalizableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Text;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -80,12 +81,11 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_localizable_text', 'A_BAD_DIRECTION', ['locale' => 'en_US']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/ScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Text;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -68,12 +69,11 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['product_one', 'product_two', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_scopable_text', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/TextSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/TextSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Text;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -62,12 +63,11 @@ class TextSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['dog', 'cat', 'best_cat', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_text', 'A_BAD_DIRECTION']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/LocalizableScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\TextArea;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -95,12 +96,11 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         $this->assertOrder($result, ['cat', 'cattle', 'dog', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_localizable_scopable_text_area', 'A_BAD_DIRECTION', ['locale' => 'fr_FR', 'scope' => 'tablet']]]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/LocalizableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\TextArea;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -77,12 +78,11 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['dog', 'cattle', 'cat', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_localizable_text_area', 'A_BAD_DIRECTION', ['locale' => 'fr_FR']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/ScopableSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\TextArea;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -77,12 +78,11 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['cat', 'dog', 'cattle', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_scopable_text_area', 'A_BAD_DIRECTION', ['scope' => 'ecommerce']]]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/TextAreaSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/TextAreaSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\TextArea;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -76,12 +77,11 @@ class TextAreaSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['best_dog', 'super_dog', 'best_cat', 'cat', 'empty_product']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['a_text_area', 'A_BAD_DIRECTION']]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Product/UpdateProductModelIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/UpdateProductModelIntegration.php
@@ -6,6 +6,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Product;
 
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Exception\ImmutablePropertyException;
 
 /**
  * @author    Damien Carcel (damien.carcel@akeneo.com)
@@ -16,22 +17,21 @@ class UpdateProductModelIntegration extends TestCase
 {
     /**
      * TODO: This will become possible in PIM-6344.
-     *
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\ImmutablePropertyException
-     * @expectedExceptionMessage Property "family_variant" cannot be modified, "shoes_size" given.
      */
     public function testTheFamilyVariantCannotBeChanged(): void
     {
+        $this->expectException(ImmutablePropertyException::class);
+        $this->expectExceptionMessage('Property "family_variant" cannot be modified, "shoes_size" given.');
+
         $productModel = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('apollon_blue');
         $this->get('pim_catalog.updater.product_model')->update($productModel, ['family_variant' => 'shoes_size',]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\ImmutablePropertyException
-     * @expectedExceptionMessage Property "family_variant" cannot be modified, "shoes_size" given.
-     */
     public function testTheFamilyVariantIsTheSameThanTheParent(): void
     {
+        $this->expectException(ImmutablePropertyException::class);
+        $this->expectExceptionMessage('Property "family_variant" cannot be modified, "shoes_size" given.');
+
         $productModel = $this->get('pim_catalog.factory.product_model')->create();
         $this->get('pim_catalog.updater.product_model')->update($productModel, [
             'code' => 'model-running-shoes-l',

--- a/tests/back/Pim/Enrichment/Integration/Product/UpdateVariantProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/UpdateVariantProductIntegration.php
@@ -6,6 +6,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Product;
 
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 
 /**
  * @author    Damien Carcel (damien.carcel@akeneo.com)
@@ -14,12 +15,11 @@ use Akeneo\Test\Integration\TestCase;
  */
 class UpdateVariantProductIntegration extends TestCase
 {
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "parent" expects a valid parent code. The parent product model does not exist, "" given.
-     */
     public function testTheParentCannotBeRemoved(): void
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "parent" expects a valid parent code. The parent product model does not exist, "" given.');
+
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_blue_xl');
         $this->get('pim_catalog.updater.product')->update($product, ['parent' => '']);
     }

--- a/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/Sorter/InGroupSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/Sorter/InGroupSorterIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\ProductQueryBuilder\Sorter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -24,12 +25,11 @@ class InGroupSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['foo', 'bar', 'empty', 'baz']);
     }
 
-    /**
-     * @expectedException \Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException
-     * @expectedExceptionMessage Direction "A_BAD_DIRECTION" is not supported
-     */
     public function testErrorOperatorNotSupported()
     {
+        $this->expectException(InvalidDirectionException::class);
+        $this->expectExceptionMessage('Direction "A_BAD_DIRECTION" is not supported');
+
         $this->executeSorter([['in_group_3', 'A_BAD_DIRECTION']]);
     }
 

--- a/tests/back/Pim/Structure/Integration/Family/CreateFamilyVariantIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Family/CreateFamilyVariantIntegration.php
@@ -7,6 +7,8 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\Common\Collections\Collection;
 
 class CreateFamilyVariantIntegration extends TestCase
@@ -299,12 +301,11 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->assertSame('This value is too long. It should have 100 characters or less.', $violations->get(0)->getMessage());
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "family" expects a valid family code. The family does not exist, "unknown_family" given
-     */
     public function testCreateFamilyVariantUnknownFamily()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "family" expects a valid family code. The family does not exist, "unknown_family" given');
+
         $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
         $this->get('pim_catalog.updater.family_variant')->update(
             $familyVariant,
@@ -398,12 +399,11 @@ class CreateFamilyVariantIntegration extends TestCase
         $this->assertSame('There should be at least one level defined in the family variant', $violations->get(0)->getMessage());
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "variant_attribute_sets" expects an array of objects as data.
-     */
     public function testCreateFamilyVariantWithVariantAttributeSetAsString()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "variant_attribute_sets" expects an array of objects as data.');
+
         $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
         $this->get('pim_catalog.updater.family_variant')->update(
             $familyVariant,
@@ -418,12 +418,11 @@ class CreateFamilyVariantIntegration extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "variant_attribute_sets" expects an array of objects as data.
-     */
     public function testCreateFamilyVariantWithVariantAttributeSetAsArrayOfString()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "variant_attribute_sets" expects an array of objects as data.');
+
         $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
         $this->get('pim_catalog.updater.family_variant')->update(
             $familyVariant,
@@ -959,12 +958,12 @@ class CreateFamilyVariantIntegration extends TestCase
 
     /**
      * Validation: The attribute set attributes must exists
-     *
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "attribute_set_1" expects a valid attribute code. The attribute does not exist, "weather" given.
      */
     public function testAttributesExist()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "attribute_set_1" expects a valid attribute code. The attribute does not exist, "weather" given.');
+
         $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
 
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
@@ -990,12 +989,12 @@ class CreateFamilyVariantIntegration extends TestCase
 
     /**
      * Validation: The attribute set attributes must exists
-     *
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "attribute_set_1" expects a valid attribute code. The attribute does not exist, "weather" given.
      */
     public function testAxisAttributesExist()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "attribute_set_1" expects a valid attribute code. The attribute does not exist, "weather" given.');
+
         $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
 
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [

--- a/tests/back/Pim/Structure/Integration/Family/UpdateFamilyVariantIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Family/UpdateFamilyVariantIntegration.php
@@ -7,6 +7,7 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Exception\ImmutablePropertyException;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
@@ -199,12 +200,12 @@ class UpdateFamilyVariantIntegration extends TestCase
 
     /**
      * Validation: The number of level of the family variant cannot be changed
-     *
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\ImmutablePropertyException
-     * @expectedExceptionMessage The number of variant attribute sets cannot be changed.
      */
     public function testTheFamilyVariantLevelNumberImmutability()
     {
+        $this->expectException(ImmutablePropertyException::class);
+        $this->expectExceptionMessage('The number of variant attribute sets cannot be changed.');
+
         $familyVariant = $this->getFamilyVariant('shoes_size');
 
         $this->get('pim_catalog.updater.family_variant')->update(

--- a/tests/back/Pim/Structure/Integration/Remover/AttributeOptionRemoverIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Remover/AttributeOptionRemoverIntegration.php
@@ -36,12 +36,11 @@ class AttributeOptionRemoverIntegration extends TestCase
         $this->assertNull($result);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Attribute option "optionA" could not be removed as it is used as variant axis value.
-     */
     public function test_fail_to_remove_attribute_option_if_option_is_used_as_attribute_axes()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Attribute option "optionA" could not be removed as it is used as variant axis value.');
+
         $this->addAdditionalFixtures();
 
         $attributeOptionRepository = $this->get('pim_catalog.repository.attribute_option');

--- a/tests/back/Pim/Structure/Integration/Updater/AssociationTypeUpdaterIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Updater/AssociationTypeUpdaterIntegration.php
@@ -2,60 +2,57 @@
 
 namespace AkeneoTest\Pim\Structure\Integration\Updater;
 
-use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
 use Akeneo\Pim\Structure\Component\Model\AssociationTypeInterface;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
 
 class AssociationTypeUpdaterIntegration extends TestCase
 {
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException
-     * @expectedExceptionMessage Expects a "Akeneo\Pim\Structure\Component\Model\AssociationTypeInterface", "stdClass" given.
-     */
     public function testUpdateObjectInAssociationTypeUpdater()
     {
+        $this->expectException(InvalidObjectException::class);
+        $this->expectExceptionMessage('Expects a "Akeneo\Pim\Structure\Component\Model\AssociationTypeInterface", "stdClass" given.');
+
         $this->getUpdater()->update(new \stdClass(), []);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "code" expects a scalar as data, "array" given.
-     */
     public function testAssociationTypeUpdateWithNonScalarCode()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "code" expects a scalar as data, "array" given.');
+
         $associationType = $this->createAssociationType();
 
         $this->getUpdater()->update($associationType, ['code' => []]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "labels" expects an array as data, "NULL" given.
-     */
     public function testAssociationTypeUpdateWithNullLabels()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "labels" expects an array as data, "NULL" given.');
+
         $associationType = $this->createAssociationType();
 
         $this->getUpdater()->update($associationType, ['labels' => null]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage one of the "labels" values is not a scalar
-     */
     public function testAssociationTypeUpdateWithNonScalarLabels()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('one of the "labels" values is not a scalar');
+
         $associationType = $this->createAssociationType();
 
         $this->getUpdater()->update($associationType, ['labels' => ['en_US' => []]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException
-     * @expectedExceptionMessage Property "unknown_property" does not exist.
-     */
     public function testAssociationTypeUpdateWithUnknownProperty()
     {
+        $this->expectException(UnknownPropertyException::class);
+        $this->expectExceptionMessage('Property "unknown_property" does not exist.');
+
         $associationType = $this->createAssociationType();
 
         $this->getUpdater()->update($associationType, ['unknown_property' => null]);

--- a/tests/back/Pim/Structure/Integration/Updater/AttributeGroupUpdaterIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Updater/AttributeGroupUpdaterIntegration.php
@@ -2,105 +2,99 @@
 
 namespace AkeneoTest\Pim\Structure\Integration\Updater;
 
-use Akeneo\Test\Integration\Configuration;
-use Akeneo\Test\Integration\TestCase;
 use Akeneo\Pim\Structure\Component\Model\AttributeGroupInterface;
 use Akeneo\Pim\Structure\Component\Updater\AttributeGroupUpdater;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
 
 class AttributeGroupUpdaterIntegration extends TestCase
 {
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException
-     * @expectedExceptionMessage Expects a "Akeneo\Pim\Structure\Component\Model\AttributeGroupInterface", "stdClass" given.
-     */
     public function testUpdateObjectInAttributeGroupUpdater()
     {
+        $this->expectException(InvalidObjectException::class);
+        $this->expectExceptionMessage('Expects a "Akeneo\Pim\Structure\Component\Model\AttributeGroupInterface", "stdClass" given.');
+
         $this->getUpdater()->update(new \stdClass(), []);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "labels" expects an array as data, "NULL" given.
-     */
     public function testAttributeGroupUpdateWithNullLabels()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "labels" expects an array as data, "NULL" given.');
+
         $attributeGroup = $this->createAttributeGroup();
 
         $this->getUpdater()->update($attributeGroup, ['labels' => null]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "attributes" expects an array as data, "NULL" given.
-     */
     public function testAttributeGroupUpdateWithNullAttributes()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "attributes" expects an array as data, "NULL" given.');
+
         $attributeGroup = $this->createAttributeGroup();
 
         $this->getUpdater()->update($attributeGroup, ['attributes' => null]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage one of the "labels" values is not a scalar
-     */
     public function testAttributeGroupUpdateWithNonScalarLabels()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('one of the "labels" values is not a scalar');
+
         $attributeGroup = $this->createAttributeGroup();
 
         $this->getUpdater()->update($attributeGroup, ['labels' => ['en_US' => []]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage one of the "attributes" values is not a scalar
-     */
     public function testAttributeGroupUpdateWithNonScalarAttributess()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('one of the "attributes" values is not a scalar');
+
         $attributeGroup = $this->createAttributeGroup();
 
         $this->getUpdater()->update($attributeGroup, ['attributes' => [[]]]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "code" expects a scalar as data, "array" given.
-     */
     public function testAttributeGroupUpdateWithNonScalarCode()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "code" expects a scalar as data, "array" given.');
+
         $attributeGroup = $this->createAttributeGroup();
 
         $this->getUpdater()->update($attributeGroup, ['code' => []]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException
-     * @expectedExceptionMessage Property "sort_order" expects a scalar as data, "array" given.
-     */
     public function testAttributeGroupUpdateWithNonScalarSortOrder()
     {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "sort_order" expects a scalar as data, "array" given.');
+
         $attributeGroup = $this->createAttributeGroup();
 
         $this->getUpdater()->update($attributeGroup, ['sort_order' => []]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException
-     * @expectedExceptionMessage Property "unknown_property" does not exist.
-     */
     public function testAttributeGroupUpdateWithUnknownProperty()
     {
+        $this->expectException(UnknownPropertyException::class);
+        $this->expectExceptionMessage('Property "unknown_property" does not exist.');
+
         $attributeGroup = $this->createAttributeGroup();
 
         $this->getUpdater()->update($attributeGroup, ['unknown_property' => null]);
     }
 
-    /**
-     * @expectedException \Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException
-     * @expectedExceptionMessage Property "attributes" expects a valid attribute code. The attribute does not exist, "unknown_attribute" given.
-     */
     public function testAttributeGroupUpdateWithNonExistingAttributes()
     {
+        $this->expectException(InvalidPropertyException::class);
+        $this->expectExceptionMessage('Property "attributes" expects a valid attribute code. The attribute does not exist, "unknown_attribute" given.');
+
         $attributeGroup = $this->createAttributeGroup();
 
         $this->getUpdater()->update($attributeGroup, ['code' => 'attributeGroupA', 'attributes' => ['unknown_attribute']]);

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Command/AggregateVolumesCommandIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Command/AggregateVolumesCommandIntegration.php
@@ -23,6 +23,6 @@ class AggregateVolumesCommandIntegration extends KernelTestCase
 
         $output = $commandTester->getDisplay();
 
-        $this->assertContains('Catalog volumes aggregation done.', $output);
+        $this->assertStringContainsString('Catalog volumes aggregation done.', $output);
     }
 }

--- a/tests/back/UserManagement/Integration/Bundle/RemoveRoleIntegration.php
+++ b/tests/back/UserManagement/Integration/Bundle/RemoveRoleIntegration.php
@@ -3,15 +3,15 @@
 namespace AkeneoTest\UserManagement\Integration\Bundle;
 
 use Akeneo\Test\Integration\TestCase;
+use Akeneo\UserManagement\Component\Exception\ForbiddenToRemoveRoleException;
 
 class RemoveRoleIntegration extends TestCase
 {
-    /**
-     * @expectedException \Akeneo\UserManagement\Component\Exception\ForbiddenToRemoveRoleException
-     * @expectedExceptionMessage You can not delete this role, otherwise some users will no longer have a role.
-     */
     public function testUnableToRemoveARoleIfUsersWillNoLongerHaveRole()
     {
+        $this->expectException(ForbiddenToRemoveRoleException::class);
+        $this->expectExceptionMessage('You can not delete this role, otherwise some users will no longer have a role.');
+
         $adminRole = $this->get('pim_user.repository.role')->findOneByIdentifier('ROLE_ADMINISTRATOR');
         $this->get('pim_user.remover.role')->remove($adminRole);
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes deprecation notices issued by PHPUnit (mostly `@expectedException` annotations)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
