### PR TITLE
PIM-8251: display variant family code in sidebar if no translated label

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,18 +1,24 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8251: display variant family code in sidebar if no translated label
+
 # 2.3.35 (2019-03-26)
 
 ## Bug fixes
 
 - PIM-8230: Show on hover information for a read-only text in product edit form
 - PIM-8245: Fix the save-buttons extension (js) incorrectly resetting its internal state between calls.
+- PIM-8176: `Nesting level too deep – recursive dependency?` for some custom reference_data attributes
 
 # 2.3.34 (2019-03-18)
 
 ## Bug fixes
 
-- PIM-8176: `Nesting level too deep – recursive dependency?` for some custom reference_data attributes
 - PIM-8222: Fix product model issues when code contains `/` (create variant through UI and get product models via API)
+- PIM-8187: Add the possibility to fetch descendant products and product models
+- PIM-8214: Be able to save and launch job even if filter values refer to deleted entities.
 
 # 2.3.33 (2019-03-13)
 
@@ -21,14 +27,12 @@
 - PIM-7966: Fix variant product order on variant product navigation in case of metric variations
 - PIM-8177: Remove pages not accessible in case of product number higher than maximum ES window limit (10.000 by default) and add warning message on the last page
 - PIM-8197: Use ZipArchive::addFile to avoid too much ram consumption
-- PIM-8214: Be able to save and launch job even if filter values refer to deleted entities.
 
 # 2.3.32 (2019-03-07)
 
 ## Improvement
 
 - PIM-8175: add the possibility to filter on one or several index names when resetting ES indexes
-- PIM-8187: Add the possibility to fetch descendant products and product models
 
 # 2.3.31 (2019-02-28)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/family-variant.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/meta/family-variant.js
@@ -58,7 +58,7 @@ define(
                 label = i18n.getLabel(
                     familyVariant.labels,
                     UserContext.get('catalogLocale'),
-                    entity.family_variant
+                    entity.meta.family_variant.code
                 );
 
                 this.$el.html(


### PR DESCRIPTION
Fixes "undefined" displayed in the product form if the variant family does not have a label for the selected context locale.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
