### PR TITLE
PIM-8258: Fix missing translation for "copy none"

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+# Bug fixes
+
+- PIM-8258: Fix missing translation for "copy none"
+
 # 3.0.10 (2019-03-28)
 
 # Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/tab/attributes/copy.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/tab/attributes/copy.html
@@ -11,7 +11,7 @@
                     <li class="AknDropdown-menuTitle"><%- _.__('pim_enrich.entity.product.module.copy.select') %></li>
                     <li><a class="AknDropdown-menuLink select-all"><%- _.__('pim_common.all') %></a></li>
                     <li><a class="AknDropdown-menuLink select-all-visible"><%- _.__('pim_enrich.entity.product.module.copy.all_visible') %></a></li>
-                    <li><a class="AknDropdown-menuLink select-none"><%- _.__('pim_common.copy.none') %></a></li>
+                    <li><a class="AknDropdown-menuLink select-none"><%- _.__('pim_common.none') %></a></li>
                 </ul>
             </div>
             <div class="AknButtonList-item AknButton AknButton--small AknButton--apply copy"><%- _.__('pim_enrich.entity.product.module.copy.copy') %></div>


### PR DESCRIPTION
All is in the title :wink: 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
