### PR TITLE
PIM-8252: Add ACL on the edit import/export profile button

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,6 +4,7 @@
 
 - PIM-8258: Fix missing translation for "copy none"
 - PXD-98: Fix panel content size for filters selector column
+- PIM-8252: Add ACL on the edit import/export profile button
 
 # 3.0.10 (2019-03-28)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_export_show.yml
@@ -47,6 +47,7 @@ extensions:
         parent: pim-job-instance-csv-base-export-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_export_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_export_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
@@ -111,6 +111,7 @@ extensions:
         parent: pim-job-instance-csv-base-import-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_import_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_import_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
@@ -47,6 +47,7 @@ extensions:
         parent: pim-job-instance-csv-product-export-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_export_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_export_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
@@ -111,6 +111,7 @@ extensions:
         parent: pim-job-instance-csv-product-import-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_import_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_import_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_show.yml
@@ -47,6 +47,7 @@ extensions:
         parent: pim-job-instance-csv-product-model-export-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_export_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_export_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
@@ -109,6 +109,7 @@ extensions:
         parent: pim-job-instance-csv-product-model-import-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_import_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_import_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
@@ -47,6 +47,7 @@ extensions:
         parent: pim-job-instance-xlsx-base-export-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_export_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_export_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
@@ -110,6 +110,7 @@ extensions:
         parent: pim-job-instance-xlsx-base-import-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_import_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_import_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
@@ -47,6 +47,7 @@ extensions:
         parent: pim-job-instance-xlsx-product-export-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_export_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_export_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
@@ -109,6 +109,7 @@ extensions:
         parent: pim-job-instance-xlsx-product-import-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_import_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_import_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_show.yml
@@ -47,6 +47,7 @@ extensions:
         parent: pim-job-instance-xlsx-product-model-export-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_export_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_export_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
@@ -107,6 +107,7 @@ extensions:
         parent: pim-job-instance-xlsx-product-model-import-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_import_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_import_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
@@ -47,6 +47,7 @@ extensions:
         parent: pim-job-instance-yml-base-export-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_export_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_export_profile_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
@@ -111,6 +111,7 @@ extensions:
         parent: pim-job-instance-yml-base-import-show
         targetZone: buttons
         position: 100
+        aclResourceId: pim_importexport_import_profile_edit
         config:
             label: pim_common.edit
             route: pim_importexport_import_profile_edit


### PR DESCRIPTION
The button to edit an import/export profile must not be displayed if the user has not the permission to edit.

I didn't add tests for that. The only way to do it would be to add end-to-end tests, and it's not a critical use case.