### PR TITLE
PIM-8259: add a max width and a title attribute to the label field in the product grid

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -9,6 +9,7 @@
 - PIM-8252: Add ACL on the edit import/export profile button and grid buttons
 - PIM-8267: Fix user's group delete translation
 - PIM-8271: Fix import/export delete translation
+- PIM-8259: add a max width and a title attribute to the label field in the product grid
 
 # 3.0.10 (2019-03-28)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -42,7 +42,6 @@
     line-height: 20px;
     padding: 12px 4px;
     transition: background 0.1s ease;
-    max-width: 100vh;
 
     &--tight {
       width: 1px;
@@ -87,6 +86,10 @@
 
   &-bodyCell {
     cursor: pointer;
+    white-space: nowrap;
+    max-width: 15vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     &--flex {
       display: flex;

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/cell/product-and-product-model-label-cell.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/cell/product-and-product-model-label-cell.js
@@ -9,7 +9,6 @@ define(['oro/datagrid/string-cell'],
          * @extends oro.datagrid.StringCell
          */
         return StringCell.extend({
-
             /**
              * {@inheritdoc}
              */
@@ -21,6 +20,17 @@ define(['oro/datagrid/string-cell'],
                 }
 
                 return className;
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            render: function () {
+                StringCell.prototype.render.apply(this, arguments);
+                const columnValue = this.model.get(this.column.get('name'));
+                this.$el.attr('title', columnValue);
+
+                return this;
             }
         });
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This PR add a max size on the product grid columns. If the cell content is too long, the content is truncated. The full content is however available on the cell rollover (using a title HTML attribute)

Before : 
![before](https://user-images.githubusercontent.com/1978756/55337317-b7feb600-549e-11e9-8dad-fe8a64e4b33b.png)

After :
![after](https://user-images.githubusercontent.com/1978756/55337327-bdf49700-549e-11e9-8ec4-b5572587e012.png)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
