### PR TITLE
DAPI-58: Make the grid filter column not specific to product

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
@@ -121,6 +121,8 @@ extensions:
         module: oro/datafilter/filters-column
         parent: pim-product-index-column-inner
         targetZone: manage-filters-button
+        config:
+          attributeFiltersRoute: pim_datagrid_productgrid_attributes_filters
 
     pim-product-index-grid-filters-list:
         module: oro/datafilter/filters-selector

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Column.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Column.less
@@ -148,8 +148,10 @@
     }
 
     &--filter:not(:empty) {
-      margin-top: 14px;
+      margin-top: -1px;
       padding-bottom: 16px;
+      border-top: 1px solid @AknBorderColor;
+      padding-top: 14px;
     }
   }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -111,7 +111,7 @@
     display: block;
     color: @AknGrey;
     text-transform: uppercase;
-    font-size: @AknDefaultFontSize;
+    font-size: @AknFontSizeSmall;
     white-space: nowrap;
   }
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/requirejs.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/requirejs.yml
@@ -176,6 +176,8 @@ config:
         pim/template/datagrid/filter/date-filter:        pimdatagrid/templates/filter/date-filter.html
         pim/template/datagrid/filter/metric-filter:      pimdatagrid/templates/filter/metric-filter.html
         pim/template/datagrid/filter/search-filter:      pimdatagrid/templates/filter/search-filter.html
+        pim/template/datagrid/filter-column:             pimdatagrid/templates/filter/filter-column.html
+        pim/template/datagrid/filter-group:              pimdatagrid/templates/filter/filter-group.html
         pim/template/datagrid/cell/credentials-cell:     pimdatagrid/templates/datagrid/cell/credentials-cell.html
         pim/template/datagrid/cell/history-diff-cell:    pimdatagrid/templates/datagrid/cell/history-diff-cell.html
         pim/template/datagrid/cell/expand-history-cell:  pimdatagrid/templates/datagrid/cell/expand-history-cell.html

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/label_or_identifier-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/label_or_identifier-filter.js
@@ -18,8 +18,8 @@ define(
             inputValueSelector: 'input[name="value"]',
 
             events: {
-                'keydown input[name="value"]': 'runTimeout',
-                'keypress input[name="value"]': 'runTimeout'
+                'keydown input[name=value]': 'runTimeout',
+                'keypress input[name=value]': 'runTimeout'
             },
 
             emptyValue: {
@@ -45,6 +45,8 @@ define(
                         label: __('pim_datagrid.search', {label: this.label})
                     })
                 );
+
+                this.delegateEvents();
             },
 
             /**
@@ -95,12 +97,17 @@ define(
 
             /**
              * Appends filter to a grid
-            * */
+             * If .search-zone is not in the element that is to say it could be somewhere in the page.
+             */
             moveFilter: function(collection, element) {
-                if (element) {
+                if (element.$('.search-zone').length !== 0) {
                     element.$('.search-zone')
                     .empty()
                     .append(this.$el.get(0));
+                } else if ($('.edit-form .search-zone').length !== 0) {
+                    $('.edit-form .search-zone')
+                        .empty()
+                        .append(this.$el.get(0));
                 }
             }
         });

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-manager.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-manager.js
@@ -480,7 +480,8 @@ define(
          */
         _getOffsetWidth() {
             const headerWidth = $('.AknHeader').width();
-            const mainColumnWidth = $('.AknDefault-contentWithColumn .AknColumn').width();
+            const mainColumn = $('.AknDefault-contentWithColumn .AknColumn');
+            const mainColumnWidth = 0 !== mainColumn.length ? mainColumn.width() : 0;
 
             return headerWidth + mainColumnWidth;
         },
@@ -502,6 +503,5 @@ define(
         _getLeftEndPosition() {
             return this._getOffsetWidth();
         }
-
     });
 });

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/filter/filter-column.html
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/filter/filter-column.html
@@ -1,0 +1,15 @@
+<button type="button" class="AknFilterBox-addFilterButton" aria-haspopup="true" style="width: 280px" data-toggle>
+    <div><%- filtersLabel %></div>
+</button>
+<div class="filter-selector">
+    <div>
+        <div class="ui-multiselect-menu ui-widget ui-widget-content ui-corner-all AknFilterBox-addFilterButton AknFilterBox-column filter-list select-filter-widget pimmultiselect">
+            <div class="ui-multiselect-filter"><input placeholder="" type="search"></div>
+            <div class="AknLoadingMask loading-mask filter-loading" style="top: 50px"></div>
+            <div class="filters-column"></div>
+            <div class="AknColumn-bottomButtonContainer AknColumn-bottomButtonContainer--sticky">
+                <div class="AknButton AknButton--apply close"><%- doneLabel %></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/filter/filter-group.html
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/filter/filter-group.html
@@ -1,0 +1,20 @@
+<ul class="ui-multiselect-checkboxes ui-helper-reset full">
+    <li class="ui-multiselect-optgroup-label">
+        <a><%- groupName %></a>
+    </li>
+    <% filters.forEach(filter => { %>
+    <li>
+        <label for="<%- filter.name %>" title="" class="ui-corner-all ui-state-hover">
+            <input
+                    id="<%- filter.name %>"
+                    name="multiselect_add-filter-select"
+                    type="checkbox" value="<%- filter.name %>"
+                    title="<%- filter.label %>"
+            <%- filter.enabled ? 'checked="checked"' : ''  %>
+            <%- true === ignoredFilters.includes(filter.name) ? 'disabled="true"' : ''  %>
+            aria-selected="true">
+            <span><%- filter.label %></span>
+        </label>
+    </li>
+    <% }) %>
+</ul>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Needed for EE PR.

Two modules are used to display filters panel. One was dedicated to products and another one is used in all other grids. The product panel is more customizable and according to Pierre, the fact that we have two modules comes from a merge into master error. We should only have the product module because even if it was specific, it is customizable, paginable and runs with a query which does not hydrate all attributes.
That's why I decided to make it more generic and reuse it in proposal grid (CE PR). Next step is to remove the second module and replace it everywhere with the generic one.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
