### PR TITLE
fix: $storageFsAlias passed to FileStorerInterface must be into camel…

### DIFF
--- a/src/Akeneo/Tool/Bundle/FileStorageBundle/Command/StoreFileCommand.php
+++ b/src/Akeneo/Tool/Bundle/FileStorageBundle/Command/StoreFileCommand.php
@@ -51,6 +51,7 @@ class StoreFileCommand extends ContainerAwareCommand
 
         $rawFile = new \SplFileInfo($filePath);
         $storer = $this->getFileStorer();
+        $storageFsAlias = $this->toCamelCase($storageFsAlias);
         $file = $storer->store($rawFile, $storageFsAlias);
 
         $output->writeln(
@@ -87,5 +88,26 @@ class StoreFileCommand extends ContainerAwareCommand
         }
 
         return true;
+    }
+
+    /**
+     * @param $storageFsAlias
+     *
+     * @return string
+     */
+    protected function toCamelCase($storageFsAlias)
+    {
+        return lcfirst(
+            join(
+                explode(
+                    '_',
+                    ucwords(
+                        $storageFsAlias,
+                        '_'
+                    )
+                ),
+                ''
+            )
+        );
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

File systems are indexed by camel-cazed name (like catalogStorage) in the mountManager. The alias parameter being is snake-case (like catalog_storage), it must be transformed into camel-case to pass it to the FileStorerInterface.

I have wrote a protected method who convert the snake-case parameter into camel-caze.
I call this method on $storageFsAlias before the FileStorerInterface::store call to correspond with indexes in MountManager.

References to #9819 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
