### PR TITLE
PIM-8252: fix acl for profiles grid buttons

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,7 +4,7 @@
 
 - PIM-8258: Fix missing translation for "copy none"
 - PXD-98: Fix panel content size for filters selector column
-- PIM-8252: Add ACL on the edit import/export profile button
+- PIM-8252: Add ACL on the edit import/export profile button and grid buttons
 
 # 3.0.10 (2019-03-28)
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/export_profile.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/export_profile.yml
@@ -12,6 +12,29 @@ datagrid:
                 route: pim_enrich_job_instance_rest_export_delete
             show_link:
                 route: pim_importexport_export_profile_show
+        actions:
+            view:
+                acl_resource: pim_importexport_export_profile_content_show
+                launcherOptions:
+                    className: AknIconButton AknIconButton--small AknIconButton--view
+                type:      navigate
+                label:     pim_datagrid.action.show.title
+                link:      show_link
+                rowAction: true
+            edit:
+                acl_resource:  pim_importexport_export_profile_edit
+                launcherOptions:
+                    className: AknIconButton AknIconButton--small AknIconButton--edit
+                type:  navigate
+                label: pim_common.edit
+                link:  edit_link
+            delete:
+                acl_resource:  pim_importexport_export_profile_remove
+                launcherOptions:
+                    className: AknIconButton AknIconButton--small AknIconButton--trash
+                type:  delete
+                label: pim_common.delete
+                link:  delete_link
         filters:
             columns:
                 job_name:

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/export_profile.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/export_profile.yml
@@ -14,7 +14,7 @@ datagrid:
                 route: pim_importexport_export_profile_show
         actions:
             view:
-                acl_resource: pim_importexport_export_profile_content_show
+                acl_resource: pim_importexport_export_profile_show
                 launcherOptions:
                     className: AknIconButton AknIconButton--small AknIconButton--view
                 type:      navigate

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/import_profile.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/import_profile.yml
@@ -14,7 +14,7 @@ datagrid:
                 route: pim_importexport_import_profile_show
         actions:
             view:
-                acl_resource: pim_importexport_import_profile_content_show
+                acl_resource: pim_importexport_import_profile_show
                 launcherOptions:
                     className: AknIconButton AknIconButton--small AknIconButton--view
                 type:      navigate

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/import_profile.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/import_profile.yml
@@ -12,6 +12,29 @@ datagrid:
                 route: pim_enrich_job_instance_rest_import_delete
             show_link:
                 route: pim_importexport_import_profile_show
+        actions:
+            view:
+                acl_resource: pim_importexport_import_profile_content_show
+                launcherOptions:
+                    className: AknIconButton AknIconButton--small AknIconButton--view
+                type:      navigate
+                label:     pim_datagrid.action.show.title
+                link:      show_link
+                rowAction: true
+            edit:
+                acl_resource:  pim_importexport_import_profile_edit
+                launcherOptions:
+                    className: AknIconButton AknIconButton--small AknIconButton--edit
+                type:  navigate
+                label: pim_common.edit
+                link:  edit_link
+            delete:
+                acl_resource:  pim_importexport_import_profile_remove
+                launcherOptions:
+                    className: AknIconButton AknIconButton--small AknIconButton--trash
+                type:  delete
+                label: pim_common.delete
+                link:  delete_link
         filters:
             columns:
                 job_name:

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/job_profile.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/job_profile.yml
@@ -31,27 +31,6 @@ datagrid:
                 type: url
                 params:
                     - code
-        actions:
-            view:
-                launcherOptions:
-                    className: AknIconButton AknIconButton--small AknIconButton--view
-                type:      navigate
-                label:     pim_datagrid.action.show.title
-                link:      show_link
-                rowAction: true
-            edit:
-                launcherOptions:
-                    className: AknIconButton AknIconButton--small AknIconButton--edit
-                type:  navigate
-                label: pim_common.edit
-                link:  edit_link
-            delete:
-                acl_resource:  pim_importexport_export_profile_remove
-                launcherOptions:
-                    className: AknIconButton AknIconButton--small AknIconButton--trash
-                type:  delete
-                label: pim_common.delete
-                link:  delete_link
         sorters:
             columns:
                 label:


### PR DESCRIPTION
ACLs were not applied on jobs profile grid, import and export.
To do his and be able of settings diffeent ACLs, i had to deport the configuration from the upper `job_profile` grid to its children because it's not possible to override partially in Oro ActionExtension.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
