### PR TITLE
PIM-8271: Fix import/export delete translation

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,7 @@
 - PIM-8258: Fix missing translation for "copy none"
 - PXD-98: Fix panel content size for filters selector column
 - PIM-8252: Add ACL on the edit import/export profile button and grid buttons
+- PIM-8271: Fix import/export delete translation
 
 # 3.0.10 (2019-03-28)
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -142,7 +142,6 @@ confirmation:
         export_profile: Are you sure you want to delete this export profile?
         job_instance: Are you sure you want to delete this job instance?
 
-
 pim_enrich:
     entity:
         import_profile:

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -142,6 +142,18 @@ confirmation:
         export_profile: Are you sure you want to delete this export profile?
         job_instance: Are you sure you want to delete this job instance?
 
+
+pim_enrich:
+    entity:
+        import_profile:
+            module:
+                delete:
+                    confirm: Are you sure you want to delete this import profile?
+        export_profile:
+            module:
+                delete:
+                    confirm: Are you sure you want to delete this export profile?
+
 pim_title:
     pim_importexport_export_profile_index:   Export profiles management
     pim_importexport_export_profile_edit:    Export profile {{ job.label }} | Edit

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.fr_FR.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.fr_FR.yml
@@ -134,6 +134,18 @@ confirmation:
     import_profile: Êtes-vous sûr(e) de que vouloir supprimer ce profil d'import ?
     export_profile: Êtes-vous sûr(e) de que vouloir supprimer ce profil d'export ?
     job_instance: Êtes-vous sûr(e) de vouloir supprimer cette opération ?
+
+pim_enrich:
+  entity:
+    import_profile:
+      module:
+        delete:
+          confirm: Êtes-vous sûr(e) de que vouloir supprimer ce profil d'import ?
+    export_profile:
+      module:
+        delete:
+          confirm: Êtes-vous sûr(e) de que vouloir supprimer ce profil d'export ?
+
 pim_title:
   pim_importexport_export_profile_index: Gestion des profils d'export
   pim_importexport_export_profile_edit: Profil d'export {{ job.label }} | Édition


### PR DESCRIPTION
For the record, the translation is not free because of this line: https://github.com/akeneo/pim-community-dev/blob/3.0/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/delete-confirm.ts#L25

So i have to add the exact translation key

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
