### PR TITLE
PIM-8262: Make Doctrine remove completeness orphans

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.orm.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/model/doctrine/Product.orm.yml
@@ -80,6 +80,7 @@ Pim\Component\Catalog\Model\Product:
                 - detach
         completenesses:
             targetEntity: Pim\Component\Catalog\Model\CompletenessInterface
+            orphanRemoval: true
             mappedBy: product
             cascade:
                 - remove


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The problem is that if you try to save a product which had a completeness on a non-actived locale, the completeness won't be removed.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | TODO
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
