### PR TITLE
PIM-8233: extract attribute normalization in dedicated classes

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,6 +4,10 @@
 
 - PIM-8239: Set latest doctrine migration during fresh install to be consistent with database state
 
+## Enhancements
+
+- PIM-8233: Extract attribute normalization in dedicated classes
+
 # 3.0.11 (2019-04-02)
 
 # Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/AkeneoPimEnrichmentBundle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle;
 
+use Akeneo\Pim\Enrichment\Bundle\DependencyInjection\Compiler\ConfigureAxisValueLabelsNormalizerPass;
 use Akeneo\Pim\Enrichment\Bundle\DependencyInjection\Compiler\Localization\RegisterLocalizersPass;
 use Akeneo\Pim\Enrichment\Bundle\DependencyInjection\Compiler\Localization\RegisterPresentersPass;
 use Akeneo\Pim\Enrichment\Bundle\DependencyInjection\Compiler\RegisterAttributeConstraintGuessersPass;
@@ -61,6 +62,7 @@ class AkeneoPimEnrichmentBundle extends Bundle
             ->addCompilerPass(new RegisterRendererPass())
             ->addCompilerPass(new RegisterCategoryItemCounterPass())
             ->addCompilerPass(new RegisterProductQueryFilterPass('product_and_product_model'))
+            ->addCompilerPass(new ConfigureAxisValueLabelsNormalizerPass())
         ;
 
         $mappings = [

--- a/src/Akeneo/Pim/Enrichment/Bundle/DependencyInjection/Compiler/ConfigureAxisValueLabelsNormalizerPass.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/DependencyInjection/Compiler/ConfigureAxisValueLabelsNormalizerPass.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2019 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Pim\Enrichment\Bundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Julian Prud'homme <julian.prudhomme@akeneo.com>
+ */
+class ConfigureAxisValueLabelsNormalizerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $normalizer = $container->getDefinition('pim_enrich.normalizer.entity_with_family_variant');
+
+        $simpleSelectLabelNormalizer = $container->getDefinition('pim_enrich.normalizer.entity_with_family_variant.simple_select.label.normalizer');
+        $normalizer->addArgument($simpleSelectLabelNormalizer);
+
+        $metricLabelNormalizer = $container->getDefinition('pim_enrich.normalizer.entity_with_family_variant.metric.label.normalizer');
+        $normalizer->addArgument($metricLabelNormalizer);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -59,6 +59,14 @@ services:
             - '@pim_catalog.context.catalog'
             - '@pim_catalog.repository.cached_attribute_option'
 
+    pim_enrich.normalizer.entity_with_family_variant.simple_select.label.normalizer:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer\SimpleSelectOptionNormalizer'
+        arguments:
+            - '@pim_catalog.repository.attribute_option'
+
+    pim_enrich.normalizer.entity_with_family_variant.metric.label.normalizer:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer\MetricNormalizer'
+
     pim_enrich.normalizer.completeness:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\CompletenessNormalizer'
         tags:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/AxisValueLabelsNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/AxisValueLabelsNormalizer.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+
+/**
+ * @author Julian Prud'homme <julian.prudhomme@akeneo.com>
+ */
+interface AxisValueLabelsNormalizer
+{
+    public function normalize(ValueInterface $value, string $locale): string;
+
+    public function supports(string $attributeType): bool;
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+
+/**
+ * @author Julian Prud'homme <julian.prudhomme@akeneo.com>
+ */
+class MetricNormalizer implements AxisValueLabelsNormalizer
+{
+    /**
+     * @param ValueInterface $value
+     * @param string         $locale
+     *
+     * @return string
+     */
+    public function normalize(ValueInterface $value, string $locale): string
+    {
+        return sprintf('%s %s', $value->getAmount(), $value->getUnit());
+    }
+
+    public function supports(string $attributeType): bool
+    {
+        return AttributeTypes::METRIC === $attributeType;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/SimpleSelectOptionNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/SimpleSelectOptionNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+
+/**
+ * @author Julian Prud'homme <julian.prudhomme@akeneo.com>
+ */
+class SimpleSelectOptionNormalizer implements AxisValueLabelsNormalizer
+{
+    /** @var IdentifiableObjectRepositoryInterface */
+    private $attributeOptionRepository;
+
+    public function __construct(IdentifiableObjectRepositoryInterface $attributeOptionRepository)
+    {
+        $this->attributeOptionRepository = $attributeOptionRepository;
+    }
+
+    /**
+     * @param ValueInterface $value
+     * @param string         $locale
+     *
+     * @return string
+     */
+    public function normalize(ValueInterface $value, string $locale): string
+    {
+        $optionCode = $value->getData();
+        $option = $this->attributeOptionRepository->findOneByIdentifier($value->getAttributeCode().'.'.$optionCode);
+        $option->setLocale($locale);
+        $label = $option->getTranslation()->getLabel();
+
+        return empty($label) ? '[' . $option->getCode() . ']' : $label;
+    }
+
+    public function supports(string $attributeType): bool
+    {
+        return AttributeTypes::OPTION_SIMPLE_SELECT === $attributeType;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
@@ -12,9 +12,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyVariantInterfa
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer\AxisValueLabelsNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\ImageAsLabel;
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\VariantProductRatioInterface;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -59,6 +61,9 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
     /** @var IdentifiableObjectRepositoryInterface */
     private $attributeOptionRepository;
 
+    /** @var AxisValueLabelsNormalizer[] */
+    private $normalizers;
+
     /** @var CatalogContext */
     private $catalogContext;
 
@@ -71,7 +76,8 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
         VariantProductRatioInterface $variantProductRatioQuery,
         ImageAsLabel $imageAsLabel,
         CatalogContext $catalogContext,
-        IdentifiableObjectRepositoryInterface $attributeOptionRepository
+        IdentifiableObjectRepositoryInterface $attributeOptionRepository,
+        AxisValueLabelsNormalizer ...$normalizers
     ) {
         $this->imageNormalizer                  = $imageNormalizer;
         $this->localeRepository                 = $localeRepository;
@@ -82,6 +88,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
         $this->imageAsLabel                     = $imageAsLabel;
         $this->catalogContext                   = $catalogContext;
         $this->attributeOptionRepository        = $attributeOptionRepository;
+        $this->normalizers = $normalizers;
     }
 
     /**
@@ -170,34 +177,31 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
             foreach ($this->attributesProvider->getAxes($entity) as $axisAttribute) {
                 $value = $entity->getValue($axisAttribute->getCode());
 
-                switch ($axisAttribute->getType()) {
-                    case AttributeTypes::OPTION_SIMPLE_SELECT:
-                        $optionCode = $value->getData();
-                        $option = $this->attributeOptionRepository->findOneByIdentifier($value->getAttributeCode().'.'.$optionCode);
-                        $option->setLocale($localeCode);
-                        $label = $option->getTranslation()->getLabel();
-                        $valuesForLocale[] = empty($label) ? '[' . $option->getCode() . ']' : $label;
+                $normalizedValue = (string) $value;
 
-                        break;
-                    case AttributeTypes::METRIC:
-                        $valuesForLocale[] = sprintf(
-                            '%s %s',
-                            $value->getAmount(),
-                            $value->getUnit()
-                        );
-
-                        break;
-                    default:
-                        $valuesForLocale[] = (string) $value;
-
-                        break;
+                $attributeNormalizer = $this->getAttributeLabelsNormalizer($axisAttribute);
+                if ($attributeNormalizer instanceof AxisValueLabelsNormalizer) {
+                    $normalizedValue = $attributeNormalizer->normalize($value, $localeCode);
                 }
+
+                $valuesForLocale[] = $normalizedValue;
             }
 
             $axesValuesLabels[$localeCode] = implode(', ', $valuesForLocale);
         }
 
         return $axesValuesLabels;
+    }
+
+    private function getAttributeLabelsNormalizer(AttributeInterface $attribute): ?AxisValueLabelsNormalizer
+    {
+        foreach ($this->normalizers as $normalizer) {
+            if ($normalizer->supports($attribute->getType())) {
+                return $normalizer;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizerSpec.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer;
+
+use Akeneo\Pim\Enrichment\Component\Product\Value\MetricValue;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use PhpSpec\ObjectBehavior;
+
+class MetricNormalizerSpec extends ObjectBehavior
+{
+    function it_normalizes_a_metric_product_value(MetricValue $value)
+    {
+        $value->getAmount()->willReturn(10);
+        $value->getUnit()->willReturn('KILOGRAM');
+        $this->normalize($value, 'en_US')->shouldReturn('10 KILOGRAM');
+    }
+
+    function it_supports_only_metric_attributes()
+    {
+        $this->supports(AttributeTypes::METRIC)->shouldReturn(true);
+        $this->supports(AttributeTypes::TEXT)->shouldReturn(false);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/SimpleSelectOptionNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/SimpleSelectOptionNormalizerSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeOptionValueInterface;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+
+class SimpleSelectOptionNormalizerSpec extends ObjectBehavior
+{
+    function let(IdentifiableObjectRepositoryInterface $attributeOptionRepository)
+    {
+        $this->beConstructedWith($attributeOptionRepository);
+    }
+
+    function it_normalizes_an_option_value_with_a_label(
+        ValueInterface $value,
+        $attributeOptionRepository,
+        AttributeOptionInterface $option,
+        AttributeOptionValueInterface $optionValue
+    ) {
+        $value->getData()->willReturn('thisrt_color');
+        $value->getAttributeCode()->willReturn('color');
+
+        $attributeOptionRepository->findOneByIdentifier('color.thisrt_color')->willReturn($option);
+        $option->setLocale('en_US')->shouldBeCalled();
+        $option->getTranslation()->willReturn($optionValue);
+        $optionValue->getLabel()->willReturn('White');
+
+        $this->normalize($value, 'en_US')->shouldReturn('White');
+    }
+
+    function it_normalizes_an_option_value_without_a_label(
+        ValueInterface $value,
+        $attributeOptionRepository,
+        AttributeOptionInterface $option,
+        AttributeOptionValueInterface $optionValue
+    ) {
+        $value->getData()->willReturn('thisrt_color');
+        $value->getAttributeCode()->willReturn('color');
+
+        $attributeOptionRepository->findOneByIdentifier('color.thisrt_color')->willReturn($option);
+        $option->setLocale('en_US')->shouldBeCalled();
+        $option->getTranslation()->willReturn($optionValue);
+
+        $optionValue->getLabel()->willReturn('');
+        $option->getCode()->willReturn('white');
+        $this->normalize($value, 'en_US')->shouldReturn('[white]');
+    }
+
+    function it_supports_only_simple_select_option()
+    {
+        $this->supports(AttributeTypes::OPTION_SIMPLE_SELECT)->shouldReturn(true);
+        $this->supports(AttributeTypes::TEXT)->shouldReturn(false);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This PR extract the label normalization for EntityWithFamilyVariantNormalizer in dedicated classes and allows to inject more normalizers, for example to normalize EE specific attribute type labels.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
