### PR TITLE
PIM-8272: Product grid filter search on label

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+# Bug fixes
+
+- PIM-8272: Fix "My account" product grid filter search on label
+
 # 3.0.11 (2019-04-02)
 
 # Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductGridFilterController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductGridFilterController.php
@@ -74,6 +74,7 @@ class ProductGridFilterController
             ['limit' => SearchableRepositoryInterface::FETCH_LIMIT, 'locale' => null, 'page' => 1]
         );
 
+        $options['locale'] = $options['catalogLocale'];
         unset($options['catalogLocale']);
 
         if ($request->get('identifiers', null) !== null) {


### PR DESCRIPTION
The "Product grid filters" field available under your user account profile, does not allow search on attribute labels only codes. By passing the catalog locale in search options, search is enabled on attribute code AND attribute labels.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
