### PR TITLE
PIM-8259: remove the white-space:nowrap statement for all grid cells

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -86,10 +86,6 @@
 
   &-bodyCell {
     cursor: pointer;
-    white-space: nowrap;
-    max-width: 15vw;
-    overflow: hidden;
-    text-overflow: ellipsis;
 
     &--flex {
       display: flex;
@@ -123,6 +119,9 @@
       font-style: italic;
       font-size: @AknFontSizeBig;
       white-space: nowrap;
+      max-width: 15vw;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     &--big {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
