### PR TITLE
PIM-8255: Fix version entity detached during the purge

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -2,6 +2,10 @@
 
 # 1.7.41 (2019-04-04)
 
+## Bug fixes
+
+- PIM-8255: Fix version entity detached when trying to remove it during the purge
+
 # 1.7.40 (2019-03-19)
 
 ## Bug fixes


### PR DESCRIPTION
The CHANGELOG was not edited while fixing this bug.