### PR TITLE
PIM-8274: Fix misplaced button on imports/exports

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 # Bug fixes
 
 - PIM-8239: Set latest doctrine migration during fresh install to be consistent with database state
+- PIM-8274: Fix misplaced button on imports/exports
 
 # 3.0.11 (2019-04-02)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
@@ -67,6 +67,7 @@ extensions:
     pim-job-instance-xlsx-product-import-show-upload:
         module: pim/job/common/edit/upload
         parent: pim-job-instance-xlsx-product-import-show-upload-switcher-item
+        position: 50
         config:
             type: xlsx
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
@@ -67,6 +67,7 @@ extensions:
     pim-job-instance-xlsx-product-model-import-show-upload:
         module: pim/job/common/edit/upload
         parent: pim-job-instance-xlsx-product-model-import-show-upload-switcher-item
+        position: 50
 
     pim-job-instance-xlsx-product-model-import-show-upload-button:
         module: pim/job/common/edit/upload-launch

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FormContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FormContainer.less
@@ -20,6 +20,10 @@
     margin: 20px 0 10px;
   }
 
+  &--withPadding:not(:empty)&--centered {
+    margin-bottom: 20px;
+  }
+
   &--withSmallPadding:not(:empty) {
     padding: 0 20px;
   }


### PR DESCRIPTION
On some imports, the "Download and import" button is not well placed, it's above the drag and drop zone, it should be always below the drag and drop zone.

This PR fixes it by setting some missing positions in the form extensions.

**Before**
![image-20190401-210843](https://user-images.githubusercontent.com/1516770/55591320-36f42880-5703-11e9-9b3b-b6b3e4e1860d.png)

**After**
![Screenshot from 2019-04-04 17-56-51](https://user-images.githubusercontent.com/1516770/55591311-32c80b00-5703-11e9-9fca-534633588cd9.png)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
