### PR TITLE
PIM-8269: Do not display empty values from deleted attributes from fa…

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8269: Do not create empty product values if it relies on an attribute which has been removed from family 
+
 # 2.3.36 (2019-04-02)
 
 ## Bug fixes

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -908,7 +908,6 @@ JSON;
                     ['locale' => null, 'scope' => null, 'data' => 'localizable'],
                 ],
                 'a_localizable_image' => [
-                    ['locale' => 'en_US', 'scope' => null, 'data' => null],
                     ['locale' => 'fr_FR', 'scope' => null, 'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt'],
                 ]
             ],

--- a/src/Pim/Component/Catalog/Factory/ValueCollectionFactory.php
+++ b/src/Pim/Component/Catalog/Factory/ValueCollectionFactory.php
@@ -48,7 +48,7 @@ class ValueCollectionFactory implements ValueCollectionFactoryInterface
     /**
      * {@inheritdoc}
      *
-     * Raw values that correspond to an non existing attribute (that was deleted
+     * Raw values that correspond to a non existing attribute (that was deleted
      * for instance) are NOT loaded.
      *
      * @see \Pim\Component\Catalog\Normalizer\Storage\Product\ProductValuesNormalizer.php
@@ -76,7 +76,17 @@ class ValueCollectionFactory implements ValueCollectionFactoryInterface
                         }
 
                         try {
-                            $values[] = $this->valueFactory->create($attribute, $channelCode, $localeCode, $data, true);
+                            $value = $this->valueFactory->create($attribute, $channelCode, $localeCode, $data, true);
+                            $productData = $value->getData();
+                            $isEmpty = (
+                                null === $productData ||
+                                (is_string($productData) && '' === trim($productData))  ||
+                                (is_array($productData) && 0 === count($productData))
+                            );
+
+                            if (!$isEmpty) {
+                                $values[] = $value;
+                            }
                         } catch (InvalidOptionException $e) {
                             $this->logger->warning(
                                 sprintf(

--- a/src/Pim/Component/Catalog/spec/Factory/ValueCollectionFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/ValueCollectionFactorySpec.php
@@ -50,15 +50,19 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         $value1->getLocale()->willReturn(null);
         $value1->getScope()->willReturn(null);
         $value1->getAttribute()->willReturn($sku);
+        $value1->getData()->willReturn('1234');
         $value2->getScope()->willReturn('ecommerce');
         $value2->getLocale()->willReturn('en_US');
         $value2->getAttribute()->willReturn($description);
+        $value2->getData()->willReturn('a description');
         $value3->getScope()->willReturn('tablet');
         $value3->getLocale()->willReturn('en_US');
         $value3->getAttribute()->willReturn($description);
+        $value3->getData()->willReturn('a tablet description');
         $value4->getScope()->willReturn('tablet');
         $value4->getLocale()->willReturn('fr_FR');
         $value4->getAttribute()->willReturn($description);
+        $value4->getData()->willReturn('une description');
 
         $attributeRepository->findOneByIdentifier('sku')->willReturn($sku);
         $attributeRepository->findOneByIdentifier('description')->willReturn($description);
@@ -87,7 +91,6 @@ class ValueCollectionFactorySpec extends ObjectBehavior
                 'tablet' => [
                     'en_US' => 'a text area for tablets in English',
                     'fr_FR' => 'une zone de texte pour les tablettes en français',
-
                 ],
             ],
         ]);
@@ -99,7 +102,6 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         $actualIterator->shouldHaveKeyWithValue('sku-<all_channels>-<all_locales>', $value1);
         $actualIterator->shouldHaveKeyWithValue('description-ecommerce-en_US', $value2);
         $actualIterator->shouldHaveKeyWithValue('description-tablet-en_US', $value3);
-        $actualIterator->shouldHaveKeyWithValue('description-tablet-fr_FR', $value4);
     }
 
     function it_skips_unknown_attributes_when_creating_a_values_collection_from_the_storage_format(
@@ -259,6 +261,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         $value1->getLocale()->willReturn(null);
         $value1->getScope()->willReturn(null);
         $value1->getAttribute()->willReturn($image);
+        $value1->getData()->willReturn('my_image');
 
         $attributeRepository->findOneByIdentifier('image')->willReturn($referenceData);
         $valueFactory->create($referenceData, null, null, 'my_image', true)->willThrow(
@@ -280,5 +283,37 @@ class ValueCollectionFactorySpec extends ObjectBehavior
 
         $actualValues->shouldReturnAnInstanceOf(ValueCollection::class);
         $actualValues->shouldHaveCount(1);
+    }
+
+    function it_does_not_return_empty_values(
+        $valueFactory,
+        $attributeRepository,
+        AttributeInterface $description,
+        ValueInterface $value1
+    ) {
+        $description->getCode()->willReturn('description');
+        $description->isUnique()->willReturn(false);
+        $attributeRepository->findOneByIdentifier('description')->willReturn($description);
+
+        $value1->getAttribute()->willReturn($description);
+        $value1->getData()->willReturn('');
+
+        $valueFactory
+            ->create($description, 'ecommerce', 'en_US', '', true)
+            ->willReturn($value1);
+
+        $actualValues = $this->createFromStorageFormat([
+            'description' => [
+                'ecommerce' => [
+                    'en_US' => '',
+                ],
+            ],
+        ]);
+
+        $actualValues->shouldBeAnInstanceOf(ValueCollection::class);
+        $actualValues->shouldHaveCount(0);
+
+        $actualIterator = $actualValues->getIterator();
+        $actualIterator->shouldNotHaveKeyWithValue('description-ecommerce-en_US', $value1);
     }
 }

--- a/src/Pim/Component/Catalog/spec/Factory/ValueCollectionFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/ValueCollectionFactorySpec.php
@@ -6,6 +6,8 @@ use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Repository\CachedObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Entity\Attribute;
+use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Exception\InvalidAttributeException;
 use Pim\Component\Catalog\Exception\InvalidOptionException;
 use Pim\Component\Catalog\Exception\InvalidOptionsException;
@@ -14,6 +16,8 @@ use Pim\Component\Catalog\Factory\ValueFactory;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\ValueCollection;
 use Pim\Component\Catalog\Model\ValueInterface;
+use Pim\Component\Catalog\Value\OptionsValue;
+use Pim\Component\Catalog\Value\ScalarValue;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 
@@ -285,35 +289,125 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         $actualValues->shouldHaveCount(1);
     }
 
-    function it_does_not_return_empty_values(
+    function it_does_not_return_null_or_empty_string_values(
         $valueFactory,
-        $attributeRepository,
-        AttributeInterface $description,
-        ValueInterface $value1
+        $attributeRepository
     ) {
-        $description->getCode()->willReturn('description');
-        $description->isUnique()->willReturn(false);
+        $description = new Attribute();
+        $description->setCode('description');
+        $description->setUnique(false);
+        $description->setScopable(true);
+        $description->setLocalizable(true);
         $attributeRepository->findOneByIdentifier('description')->willReturn($description);
-
-        $value1->getAttribute()->willReturn($description);
-        $value1->getData()->willReturn('');
 
         $valueFactory
             ->create($description, 'ecommerce', 'en_US', '', true)
-            ->willReturn($value1);
+            ->willReturn(new ScalarValue($description, 'ecommerce', 'en_US', ''));
+        $valueFactory
+            ->create($description, 'ecommerce', 'fr_FR', null, true)
+            ->willReturn(new ScalarValue($description, 'ecommerce', 'fr_FR', null));
 
         $actualValues = $this->createFromStorageFormat([
             'description' => [
                 'ecommerce' => [
                     'en_US' => '',
+                    'fr_FR' => null,
                 ],
             ],
         ]);
 
         $actualValues->shouldBeAnInstanceOf(ValueCollection::class);
         $actualValues->shouldHaveCount(0);
+    }
 
-        $actualIterator = $actualValues->getIterator();
-        $actualIterator->shouldNotHaveKeyWithValue('description-ecommerce-en_US', $value1);
+    function it_does_not_return_empty_array_values(
+        $valueFactory,
+        $attributeRepository
+    ) {
+        $colors = new Attribute();
+        $colors->setCode('colors');
+        $colors->setUnique(false);
+        $colors->setScopable(false);
+        $colors->setLocalizable(false);
+        $attributeRepository->findOneByIdentifier('colors')->willReturn($colors);
+
+        $valueFactory
+            ->create($colors, null, null, [], true)
+            ->willReturn(new OptionsValue($colors, null, null, []));
+
+        $actualValues = $this->createFromStorageFormat(
+            [
+                'colors' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => [],
+                    ],
+                ],
+            ]
+        );
+
+        $actualValues->shouldBeAnInstanceOf(ValueCollection::class);
+        $actualValues->shouldHaveCount(0);
+    }
+
+    function it_does_not_filter_falsy_values(
+        $valueFactory,
+        $attributeRepository
+    ) {
+        $number = new Attribute();
+        $number->setCode('number');
+        $number->setUnique(false);
+        $number->setScopable(false);
+        $number->setLocalizable(false);
+        $attributeRepository->findOneByIdentifier('number')->willReturn($number);
+
+        $text = new Attribute();
+        $text->setCode('text');
+        $text->setUnique(false);
+        $text->setScopable(false);
+        $text->setLocalizable(false);
+        $attributeRepository->findOneByIdentifier('text')->willReturn($text);
+
+        $yesNo = new Attribute();
+        $yesNo->setCode('yes_no');
+        $yesNo->setUnique(false);
+        $yesNo->setScopable(false);
+        $yesNo->setLocalizable(false);
+        $attributeRepository->findOneByIdentifier('yes_no')->willReturn($yesNo);
+
+        $valueFactory
+            ->create($number, null, null, 0.0, true)
+            ->willReturn(new ScalarValue($number, null, null, 0.0));
+        $valueFactory
+            ->create($text, null, null, '0', true)
+            ->willReturn(new ScalarValue($text, null, null, '0'));
+        $valueFactory
+            ->create($yesNo, null, null, false, true)
+            ->willReturn(new ScalarValue($yesNo, null, null, false));
+
+        $actualValues = $this->createFromStorageFormat(
+            [
+                'number' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => 0.0,
+                    ],
+                ],
+                'text' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => '0',
+                    ],
+                ],
+                'yes_no' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => false,
+                    ],
+                ],
+            ]
+        );
+
+        $actualValues->shouldBeAnInstanceOf(ValueCollection::class);
+        $actualValues->shouldHaveCount(3);
+        $actualValues->getIterator()->shouldHaveKey('number-<all_channels>-<all_locales>');
+        $actualValues->getIterator()->shouldHaveKey('text-<all_channels>-<all_locales>');
+        $actualValues->getIterator()->shouldHaveKey('yes_no-<all_channels>-<all_locales>');
     }
 }

--- a/tests/legacy/features/Pim/Behat/Decorator/TabElement/ComparisonPanelDecorator.php
+++ b/tests/legacy/features/Pim/Behat/Decorator/TabElement/ComparisonPanelDecorator.php
@@ -38,7 +38,7 @@ class ComparisonPanelDecorator extends ElementDecorator
             }
             $selector->click();
 
-            return true;
+            return 0 !== $this->selectedItemsCount();
         }, sprintf('Can not select "%s" elements', $mode));
     }
 
@@ -76,19 +76,18 @@ class ComparisonPanelDecorator extends ElementDecorator
             return $dropdown;
         }, 'Copy source dropdown was not found');
 
-        $this->spin(function () use ($dropdown) {
+        $toggle = $this->spin(function () use ($dropdown) {
             $toggle = $dropdown->find('css', '.AknActionButton');
             if (null === $toggle) {
                 return false;
             }
 
-            $toggle->click();
-
-            return true;
+            return $toggle;
         }, 'Dropdown action menu was not found');
 
 
-        $this->spin(function () use ($source, $dropdown) {
+        $this->spin(function () use ($source, $dropdown, $toggle) {
+            $toggle->click();
             $option = $dropdown->find('css', sprintf('.AknDropdown-menuLink[data-source="%s"]', $source));
             if (null === $option) {
                 return false;

--- a/tests/legacy/features/import/product/import_products_with_optional_values.feature
+++ b/tests/legacy/features/import/product/import_products_with_optional_values.feature
@@ -28,8 +28,11 @@ Feature: Import product information with optional values
     Then there should be 4 products
     And attribute opt_att_global of "caterpillar-pam" should be "Pam"
     And the tablet scopable value opt_att_scope of "caterpillar-pam" should be "PamTablet"
-    And attribute opt_att_global of "caterpillar-poum" should be ""
     And attribute opt_att_global of "caterpillar-pum" should be "PimPamPoum"
+    And the product "caterpillar-poum" should not have the following values:
+      | opt_att_global       |
+      | opt_att_local-en_US  |
+      | opt_att_scope-tablet |
     And the product "caterpillar-pim" should not have the following values:
       | opt_att_global |
 

--- a/tests/legacy/features/mass-action/validate/validate_editing_common_date_attributes.feature
+++ b/tests/legacy/features/mass-action/validate/validate_editing_common_date_attributes.feature
@@ -57,9 +57,12 @@ Feature: Validate editing common date attributes of multiple products
     And I display the Date attribute
     And I confirm mass edit
     And I wait for the "edit_common_attributes" job to finish
-    Then attribute Date of "boots" should be ""
-    And attribute Date of "sandals" should be ""
-    And attribute Date of "sneakers" should be ""
+    And the product "boots" should not have the following values:
+      | Date |
+    And the product "sandals" should not have the following values:
+      | Date |
+    And the product "sneakers" should not have the following values:
+      | Date |
     When I am on the products grid
     And I select rows boots, sandals and sneakers
     And I press the "Bulk actions" button
@@ -68,6 +71,9 @@ Feature: Validate editing common date attributes of multiple products
     And I change the Date to "01/01/2013"
     And I move on to the next step
     Then I should see validation tooltip "This date should be 2014-01-01 or after."
-    And attribute Date of "boots" should be ""
-    And attribute Date of "sandals" should be ""
-    And attribute Date of "sneakers" should be ""
+    And the product "boots" should not have the following values:
+      | Date |
+    And the product "sandals" should not have the following values:
+      | Date |
+    And the product "sneakers" should not have the following values:
+      | Date |

--- a/tests/legacy/features/mass-action/validate/validate_editing_common_file_attributes.feature
+++ b/tests/legacy/features/mass-action/validate/validate_editing_common_file_attributes.feature
@@ -56,7 +56,12 @@ Feature: Validate editing common file attributes of multiple products
     And I display the File attribute
     And I confirm mass edit
     And I wait for the "edit_common_attributes" job to finish
-    Then the file "file" of products boots, sandals and sneakers should be ""
+    And the product "boots" should not have the following values:
+      | file |
+    And the product "sandals" should not have the following values:
+      | file |
+    And the product "sneakers" should not have the following values:
+      | file |
     When I am on the products grid
     And I select rows boots, sandals and sneakers
     And I press the "Bulk actions" button
@@ -65,4 +70,9 @@ Feature: Validate editing common file attributes of multiple products
     And I attach file "bic-core-148.gif" to "File"
     And I move on to the next step
     Then I should see validation tooltip "The file extension is not allowed (allowed extensions: txt)."
-    And the file "file" of products boots, sandals and sneakers should be ""
+    And the product "boots" should not have the following values:
+      | file |
+    And the product "sandals" should not have the following values:
+      | file |
+    And the product "sneakers" should not have the following values:
+      | file |

--- a/tests/legacy/features/mass-action/validate/validate_editing_common_image_attributes.feature
+++ b/tests/legacy/features/mass-action/validate/validate_editing_common_image_attributes.feature
@@ -56,7 +56,12 @@ Feature: Validate editing common image attributes of multiple products
     And I display the Side view attribute
     And I confirm mass edit
     And I wait for the "edit_common_attributes" job to finish
-    Then the file "side_view" of products boots, sandals and sneakers should be ""
+    And the product "boots" should not have the following values:
+      | side_view |
+    And the product "sandals" should not have the following values:
+      | side_view |
+    And the product "sneakers" should not have the following values:
+      | side_view |
     When I am on the products grid
     And I select rows boots, sandals and sneakers
     And I press the "Bulk actions" button
@@ -65,4 +70,9 @@ Feature: Validate editing common image attributes of multiple products
     And I attach file "akeneo.txt" to "Side view"
     And I move on to the next step
     Then I should see validation tooltip "The file extension is not allowed (allowed extensions: gif, png, jpeg, jpg)."
-    And the file "side_view" of products boots, sandals and sneakers should be ""
+    And the product "boots" should not have the following values:
+      | side_view |
+    And the product "sandals" should not have the following values:
+      | side_view |
+    And the product "sneakers" should not have the following values:
+      | side_view |

--- a/tests/legacy/features/mass-action/validate/validate_editing_common_numeric_attributes.feature
+++ b/tests/legacy/features/mass-action/validate/validate_editing_common_numeric_attributes.feature
@@ -84,9 +84,12 @@ Feature: Validate editing common numeric attributes of multiple products
     And I display the Number in stock attribute
     And I confirm mass edit
     And I wait for the "edit_common_attributes" job to finish
-    Then attribute number_in_stock of "boots" should be ""
-    And attribute number_in_stock of "sandals" should be ""
-    And attribute number_in_stock of "sneakers" should be ""
+    And the product "boots" should not have the following values:
+      | number_in_stock |
+    And the product "sandals" should not have the following values:
+      | number_in_stock |
+    And the product "sneakers" should not have the following values:
+      | number_in_stock |
     When I am on the products grid
     And I select rows boots, sandals and sneakers
     And I press the "Bulk actions" button
@@ -95,9 +98,12 @@ Feature: Validate editing common numeric attributes of multiple products
     And I change the "Number in stock" to "-10"
     And I move on to the next step
     Then I should see validation tooltip "This value should be 0 or more."
-    And attribute number_in_stock of "boots" should be ""
-    And attribute number_in_stock of "sandals" should be ""
-    And attribute number_in_stock of "sneakers" should be ""
+    And the product "boots" should not have the following values:
+      | number_in_stock |
+    And the product "sandals" should not have the following values:
+      | number_in_stock |
+    And the product "sneakers" should not have the following values:
+      | number_in_stock |
 
   Scenario: Successfully mass edit a price attribute
     Given I select rows boots and sneakers

--- a/tests/legacy/features/mass-action/validate/validate_editing_common_select_attributes.feature
+++ b/tests/legacy/features/mass-action/validate/validate_editing_common_select_attributes.feature
@@ -59,9 +59,12 @@ Feature: Validate editing common select attributes of multiple products
     And I display the Weather conditions attribute
     And I confirm mass edit
     And I wait for the "edit_common_attributes" job to finish
-    Then the options "weather_conditions" of products boots and sneakers should be:
-      | value |
-      |       |
+    And the product "boots" should not have the following values:
+      | weather_conditions |
+    And the product "sandals" should not have the following values:
+      | weather_conditions |
+    And the product "sneakers" should not have the following values:
+      | weather_conditions |
 
   Scenario: Successfully mass edit a simple select attribute
     Given I select rows boots and sneakers
@@ -79,4 +82,9 @@ Feature: Validate editing common select attributes of multiple products
     And I display the Manufacturer attribute
     And I confirm mass edit
     And I wait for the "edit_common_attributes" job to finish
-    Then the option "manufacturer" of products boots, sandals and sneakers should be ""
+    And the product "boots" should not have the following values:
+      | Manufacturer |
+    And the product "sandals" should not have the following values:
+      | Manufacturer |
+    And the product "sneakers" should not have the following values:
+      | Manufacturer |

--- a/tests/legacy/features/mass-action/validate/validate_editing_common_text_attributes.feature
+++ b/tests/legacy/features/mass-action/validate/validate_editing_common_text_attributes.feature
@@ -57,9 +57,12 @@ Feature: Validate editing common text attributes of multiple products
     And I display the Info attribute
     And I confirm mass edit
     And I wait for the "edit_common_attributes" job to finish
-    Then attribute Info of "boots" should be ""
-    And attribute Info of "sandals" should be ""
-    And attribute Info of "sneakers" should be ""
+    And the product "boots" should not have the following values:
+      | Info |
+    And the product "sandals" should not have the following values:
+      | Info |
+    And the product "sneakers" should not have the following values:
+      | Info |
     When I am on the products grid
     And I select rows boots, sandals and sneakers
     And I press the "Bulk actions" button
@@ -68,9 +71,12 @@ Feature: Validate editing common text attributes of multiple products
     And I change the "Info" to "Extremely useful information"
     And I move on to the next step
     Then I should see validation tooltip "This value is too long. It should have 25 characters or less."
-    And attribute Info of "boots" should be ""
-    And attribute Info of "sandals" should be ""
-    And attribute Info of "sneakers" should be ""
+    And the product "boots" should not have the following values:
+      | Info |
+    And the product "sandals" should not have the following values:
+      | Info |
+    And the product "sneakers" should not have the following values:
+      | Info |
 
   Scenario: Successfully mass edit a text attribute
     Given I select rows boots and sneakers
@@ -89,9 +95,12 @@ Feature: Validate editing common text attributes of multiple products
     And I display the Comment attribute
     And I confirm mass edit
     And I wait for the "edit_common_attributes" job to finish
-    Then attribute Comment of "boots" should be ""
-    And attribute Comment of "sandals" should be ""
-    And attribute Comment of "sneakers" should be ""
+    And the product "boots" should not have the following values:
+      | Comment |
+    And the product "sandals" should not have the following values:
+      | Comment |
+    And the product "sneakers" should not have the following values:
+      | Comment |
     When I am on the products grid
     And I select rows boots, sandals and sneakers
     And I press the "Bulk actions" button
@@ -100,6 +109,9 @@ Feature: Validate editing common text attributes of multiple products
     And I change the Comment to an invalid value
     And I move on to the next step
     Then I should see validation tooltip "This value is too long. It should have 255 characters or less."
-    And attribute Comment of "boots" should be ""
-    And attribute Comment of "sandals" should be ""
-    And attribute Comment of "sneakers" should be ""
+    And the product "boots" should not have the following values:
+      | Comment |
+    And the product "sandals" should not have the following values:
+      | Comment |
+    And the product "sneakers" should not have the following values:
+      | Comment |

--- a/tests/legacy/features/product/join_a_document_to_a_product.feature
+++ b/tests/legacy/features/product/join_a_document_to_a_product.feature
@@ -9,8 +9,12 @@ Feature: Join a document to a product
     And the following attribute:
       | label-en_US | type             | allowed_extensions | group | code        |
       | Description | pim_catalog_file | txt                | other | description |
-    And a "Car" product
-    And the "Car" product has the "Description" attribute
+    And the following family:
+      | code     | attributes      |
+      | vehicles | sku,description |
+    And the following product:
+      | sku | family   |
+      | Car | vehicles |
     And I am logged in as "Julia"
     And I am on the "Car" product page
 

--- a/tests/legacy/features/product/join_an_image_to_a_product.feature
+++ b/tests/legacy/features/product/join_an_image_to_a_product.feature
@@ -6,11 +6,15 @@ Feature: Join an image to a product
 
   Background:
     Given the "default" catalog configuration
-    And a "Car" product
     And the following attribute:
       | label-en_US | type              | allowed_extensions | group | code   |
       | Visual      | pim_catalog_image | jpg,gif            | other | visual |
-    And the "Car" product has the "visual" attribute
+    And the following family:
+      | code     | attributes |
+      | vehicles | sku,visual |
+    And the following product:
+      | sku | family   |
+      | Car | vehicles |
     And I am logged in as "Mary"
     And I am on the "Car" product page
 
@@ -61,16 +65,17 @@ Feature: Join an image to a product
     And I remove the "Visual" file
     And I save the product
     Then I should not see the text "akeneo.jpg"
-    When I remove the "Visual" attribute
-    And I confirm the deletion
-    And I save the product
-    Then The file with original filename "akeneo.jpg" should exists in database
+    When I change the family of the product to ""
+    Then I should not see the text "Visual"
+    But The file with original filename "akeneo.jpg" should exists in database
 
   @jira https://akeneo.atlassian.net/browse/PIM-5712
   Scenario: Successfully remove an image field containing an image and keep a reference to the file in database
     When I attach file "akeneo.jpg" to "Visual"
     And I save the product
+    And I change the family of the product to ""
     And I remove the "Visual" attribute
     And I confirm the deletion
     And I save the product
-    Then The file with original filename "akeneo.jpg" should exists in database
+    Then I should not see the text "Visual"
+    But The file with original filename "akeneo.jpg" should exists in database

--- a/tests/legacy/features/product/remove_attributes_from_product.feature
+++ b/tests/legacy/features/product/remove_attributes_from_product.feature
@@ -6,12 +6,12 @@ Feature: Remove an attribute from a product
 
   Background:
     Given a "footwear" catalog configuration
-    And the following product:
-      | sku  | family  |
-      | nike | sandals |
     And I am logged in as "Sandra"
 
   Scenario: Fail to remove an attribute belonging to the family of the product
+    Given the following product:
+      | sku  | family  |
+      | nike | sandals |
     Given I am on the "nike" product page
     Then I should not see a remove link next to the "Manufacturer" field
 
@@ -19,8 +19,11 @@ Feature: Remove an attribute from a product
     Given the following attribute:
       | code            | label-en_US     | scopable | group | type             |
       | scopable_length | Scopable length | 1        | sizes | pim_catalog_text |
-    And the "nike" product has the "scopable_length" attribute
+    And the following product:
+      | sku  | scopable_length-mobile |
+      | nike | test                   |
     And I am on the "nike" product page
+    And I change the family of the product to "Sandals"
     When I visit the "Sizes" group
     And I remove the "Scopable length" attribute
     Then I confirm the deletion


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The problem is that when an attribute is removed from a family and the value is empty from all channels and all locales we should hide them on the PEF. Indeed, we cannot have empty optionnal attributes.

The best thing we can do is to remove all empty values on the database but in a fix it cant be done, it is a huge subject!

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
