### PR TITLE
PIM-8291: Use the UI locale in Completeness dashboard widget

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+# Bug fixes
+
+- PIM-8291: Use the UI locale in Completeness dashboard widget
+
 # 3.0.13 (2019-04-15)
 
 # Bug fixes
@@ -28,7 +32,7 @@
 - PIM-8267: Fix user's group delete translation
 - PIM-8271: Fix import/export delete translation
 - PIM-8264: Fix multiselect style
-- PIM-8265: Fix blinking display selector on products page 
+- PIM-8265: Fix blinking display selector on products page
 - PIM-8259: add a max width and a title attribute to the label field in the product grid
 
 # 3.0.10 (2019-03-28)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Widget/CompletenessWidget.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Widget/CompletenessWidget.php
@@ -63,7 +63,7 @@ class CompletenessWidget implements WidgetInterface
      */
     public function getData(): array
     {
-        $translationLocaleCode = $this->userContext->getCurrentLocaleCode();
+        $translationLocaleCode = $this->userContext->getUiLocaleCode();
         $result = $this->completenessWidgetQuery->fetch($translationLocaleCode);
 
         return $result->toArray();

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Widget/CompletenessWidgetSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Widget/CompletenessWidgetSpec.php
@@ -39,7 +39,7 @@ class CompletenessWidgetSpec extends ObjectBehavior
 
     function it_exposes_the_completeness_data($completenessWidgetQuery, $userContext)
     {
-        $userContext->getCurrentLocaleCode()->willReturn('en_US');
+        $userContext->getUiLocaleCode()->willReturn('en_US');
         $mobileCompleteness = new ChannelCompleteness('Mobile', 10, 40, [
             'English (United States)' => new LocaleCompleteness('English (United States)', 10),
             'French (France)' => new LocaleCompleteness('French (France)', 0)


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
