### PR TITLE
PIM-8288: keep locale-specific but non-localizable attribute values in the flat normalization to make them appear in the product changeset

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-8288: keep locale-specific but non-localizable attribute values in the flat normalization to make them appear in the product changeset
 - PIM-8269: Do not create empty product values if it relies on an attribute which has been removed from family 
 
 # 2.3.36 (2019-04-02)

--- a/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/ValueNormalizer.php
+++ b/src/Pim/Bundle/VersioningBundle/Normalizer/Flat/ValueNormalizer.php
@@ -152,7 +152,7 @@ class ValueNormalizer implements NormalizerInterface, SerializerAwareInterface
     protected function filterLocaleSpecific(ValueInterface $value)
     {
         $attribute = $value->getAttribute();
-        if ($attribute->isLocaleSpecific()) {
+        if ($attribute->isLocaleSpecific() && $attribute->isLocalizable()) {
             $currentLocale = $value->getLocale();
             $availableLocales = $attribute->getLocaleSpecificCodes();
             if (!in_array($currentLocale, $availableLocales)) {

--- a/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/ValueNormalizerSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/ValueNormalizerSpec.php
@@ -266,4 +266,19 @@ class ValueNormalizerSpec extends ObjectBehavior
         $this->normalize($value, 'flat', [])->shouldReturn(['simple-fr_FR-mobile' => '12']);
     }
 
+    function it_keeps_non_localizable_and_locale_specific_values(ValueInterface $value, AttributeInterface $simpleAttribute)
+    {
+        $simpleAttribute->getType()->willReturn(AttributeTypes::TEXT);
+
+        $value->getData()->willReturn('12');
+        $value->getAttribute()->willReturn($simpleAttribute);
+        $value->getLocale()->willReturn(null);
+        $value->getScope()->willReturn(null);
+        $simpleAttribute->isLocaleSpecific()->willReturn(true);
+        $simpleAttribute->getBackendType()->willReturn('text');
+        $simpleAttribute->isLocalizable()->willReturn(false);
+        $simpleAttribute->isScopable()->willReturn(false);
+
+        $this->normalize($value, 'flat', [])->shouldReturn(['simple' => '12']);
+    }
 }


### PR DESCRIPTION
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -
