### PR TITLE
PIM-8290: Fix flat to standard conversion of metrics, with unit filled and empty amount

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8290: Fix flat to standard conversion of metrics, with unit filled and empty amount 
+
 # 2.3.37 (2019-04-15)
 
 ## Bug fixes

--- a/src/Pim/Component/Catalog/Model/AbstractMetric.php
+++ b/src/Pim/Component/Catalog/Model/AbstractMetric.php
@@ -95,6 +95,9 @@ abstract class AbstractMetric implements MetricInterface
      */
     public function __toString()
     {
-        return ($this->data !== null) ? sprintf('%.4F %s', $this->data, $this->unit) : '';
+        return join(' ', array_filter([
+            $this->data !== null ? sprintf('%.4F', $this->data) : null,
+            $this->unit
+        ]));
     }
 }

--- a/src/Pim/Component/Catalog/spec/Factory/MetricFactorySpec.php
+++ b/src/Pim/Component/Catalog/spec/Factory/MetricFactorySpec.php
@@ -46,7 +46,7 @@ class MetricFactorySpec extends ObjectBehavior
         $metric = $this->createMetric('Weight', 'GRAM', null);
 
         $metric->shouldReturnAnInstanceOf(self::METRIC_CLASS);
-        $metric->__toString()->shouldBeEqualTo('');
+        $metric->__toString()->shouldBeEqualTo('GRAM');
         $metric->getFamily()->shouldBeEqualTo('Weight');
         $metric->getUnit()->shouldBeEqualTo('GRAM');
         $metric->getData()->shouldBeNull();

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/ValueConverter/MetricConverter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/ValueConverter/MetricConverter.php
@@ -38,7 +38,7 @@ class MetricConverter extends AbstractValueConverter
             if (1 === count($tokens)) {
                 /* PIM-8290: If there is only one word in the value field, this can be the unit either the amount.
                  * There can be 3 cases:
-                 * 1) this is a valid unit (e.g. 12 or 12.3456)
+                 * 1) this is a valid amount (e.g. 12 or 12.3456)
                  * 2) this is a valid metric (e.g. 'GRAM')
                  * 3) this is an invalid string (e.g. 'foo')
                  *

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/ValueConverter/MetricConverter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/ValueConverter/MetricConverter.php
@@ -42,7 +42,7 @@ class MetricConverter extends AbstractValueConverter
                  * 2) this is a valid metric (e.g. 'GRAM')
                  * 3) this is an invalid string (e.g. 'foo')
                  *
-                 * The case 1 is valid and will not be catch by this next regexp, and update a metric without unit.
+                 * The case 1 is valid and won't be caught by this next regexp, and update a metric without unit.
                  * The case 2 is valid but will not imply a value update as there is no amount
                  * The case 3 will raise an invalid unit value from ValidMetric validator.
                  */

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/ValueConverter/MetricConverter.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/Product/ValueConverter/MetricConverter.php
@@ -32,9 +32,31 @@ class MetricConverter extends AbstractValueConverter
         if ('' === $value) {
             $value = null;
         } else {
+            $data = null;
+            $unit = null;
             $tokens = $this->fieldSplitter->splitUnitValue($value);
-            $data = isset($tokens[0]) ? $tokens[0] : null;
-            $unit = isset($tokens[1]) ? $tokens[1] : null;
+            if (1 === count($tokens)) {
+                /* PIM-8290: If there is only one word in the value field, this can be the unit either the amount.
+                 * There can be 3 cases:
+                 * 1) this is a valid unit (e.g. 12 or 12.3456)
+                 * 2) this is a valid metric (e.g. 'GRAM')
+                 * 3) this is an invalid string (e.g. 'foo')
+                 *
+                 * The case 1 is valid and will not be catch by this next regexp, and update a metric without unit.
+                 * The case 2 is valid but will not imply a value update as there is no amount
+                 * The case 3 will raise an invalid unit value from ValidMetric validator.
+                 */
+                if (preg_match('/^[A-Za-z_]+$/', $tokens[0])) {
+                    $data = null;
+                    $unit = $tokens[0];
+                } else {
+                    $data = $tokens[0];
+                    $unit = null;
+                }
+            } else {
+                $data = $tokens[0];
+                $unit = $tokens[1];
+            }
 
             if (null !== $data) {
                 $data = !$attributeFieldInfo['attribute']->isDecimalsAllowed() && preg_match('|^\d+$|', $data) ?

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/ValueConverter/MetricConverterSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/Product/ValueConverter/MetricConverterSpec.php
@@ -85,6 +85,25 @@ class MetricConverterSpec extends ObjectBehavior
         $this->convert($fieldNameInfo, $value)->shouldReturn($expectedResult);
     }
 
+    function it_returns_no_amount_if_only_unit_provided($fieldSplitter, AttributeInterface $attribute)
+    {
+        $attribute->getCode()->willReturn('attribute_code');
+        $attribute->isDecimalsAllowed()->willReturn(true);
+        $fieldNameInfo = ['attribute' => $attribute, 'locale_code' => 'en_US', 'scope_code' => 'mobile'];
+
+        $value = 'GRAM';
+
+        $fieldSplitter->splitUnitValue($value)->willReturn(['GRAM']);
+
+        $expectedResult = ['attribute_code' => [[
+            'locale' => 'en_US',
+            'scope'  => 'mobile',
+            'data'   => ['amount' => null, 'unit' => 'GRAM'],
+        ]]];
+
+        $this->convert($fieldNameInfo, $value)->shouldReturn($expectedResult);
+    }
+
     function it_converts_integer_value($fieldSplitter, AttributeInterface $attribute)
     {
         $attribute->getCode()->willReturn('attribute_code');

--- a/tests/legacy/features/import/product/import_products_with_invalid_data.feature
+++ b/tests/legacy/features/import/product/import_products_with_invalid_data.feature
@@ -362,11 +362,13 @@ Feature: Execute a job
     When I am on the "csv_footwear_product_import" import job page
     And I launch the import job
     And I wait for the "csv_footwear_product_import" job to finish
-    Then I should see the text "skipped 2"
-    And there should be 2 product
+    Then I should see the text "skipped 1"
+    And there should be 3 product
     And the product "renault-kangoo" should have the following value:
       | length | 2500.0000 CENTIMETER |
     And the product "fiat-500" should have the following value:
+      | length |  |
+    And the product "fiat-panda" should have the following value:
       | length |  |
 
   Scenario: Skip new products with invalid price during an import


### PR DESCRIPTION
Before:
When importing a product file like this:

```
sku;weight;weight-unit
111;;GRAM
```

The converter will create a Metric `{amount: 'GRAM', unit: null}` instead of `{amount: null, unit: 'GRAM'}`.
This Metric will raise a validation because `"GRAM"` is not a valid amount, instead of simply skip this metric.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -