### PR TITLE
[BUGFIX] Solved 'Method Not Allowed' exception when using Bulk Action

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/routing/mass_edit/rest.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/routing/mass_edit/rest.yml
@@ -1,7 +1,7 @@
 pim_enrich_mass_edit_rest_get_filter:
     path: '/get-filter'
     defaults: { _controller: pim_enrich.controller.rest.mass_edit:getFilterAction }
-    methods: [POST]
+    methods: [POST,GET]
 
 pim_enrich_mass_edit_rest_launch:
     path: '/'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->
When you trigger the Bulk Action through the product overview the error 'Method Not Allowed' is thrown.

The Bulk Action triggers a GET call for the rest/mass_action controller but this route is only configured for POST which is changed in https://github.com/akeneo/pim-community-dev/commit/e62afad15b63fdb7dfc294ca4340360638f60d67#diff-c1afe1f5da13f6dfe68caf325bdab91a

See the screen shot below for more information:
![image](https://user-images.githubusercontent.com/6040343/56287738-76683f00-611d-11e9-8686-80f8b62f0e8b.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
