### PR TITLE
InMemoryRoleRepository must implement RoleRepositoryInterface

### DIFF
--- a/tests/back/Acceptance/User/InMemoryRoleRepository.php
+++ b/tests/back/Acceptance/User/InMemoryRoleRepository.php
@@ -32,7 +32,6 @@ class InMemoryRoleRepository implements RoleRepositoryInterface, SaverInterface,
             throw new \InvalidArgumentException('Only user role objects are supported.');
         }
         $index = $role->getRole();
-        $index = strtolower(str_replace('ROLE_', '', $index));
         $this->roles->set($index, $role);
     }
 

--- a/tests/back/Acceptance/User/InMemoryRoleRepository.php
+++ b/tests/back/Acceptance/User/InMemoryRoleRepository.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Akeneo\Test\Acceptance\User;
 
 use Akeneo\Test\Acceptance\Common\NotImplementedException;
-use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\UserManagement\Component\Model\RoleInterface;
+use Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ObjectRepository;
 
@@ -16,7 +16,7 @@ use Doctrine\Common\Persistence\ObjectRepository;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class InMemoryRoleRepository implements IdentifiableObjectRepositoryInterface, SaverInterface, ObjectRepository
+class InMemoryRoleRepository implements RoleRepositoryInterface, SaverInterface, ObjectRepository
 {
     /** @var RoleInterface[] */
     private $roles;

--- a/tests/back/Acceptance/spec/User/InMemoryRoleRepositorySpec.php
+++ b/tests/back/Acceptance/spec/User/InMemoryRoleRepositorySpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Akeneo\Test\Acceptance\User;
 
-use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Test\Acceptance\User\InMemoryRoleRepository;
 use PhpSpec\ObjectBehavior;
 use Akeneo\UserManagement\Component\Model\Role;
+use Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface;
 use Prophecy\Argument;
 
 class InMemoryRoleRepositorySpec extends ObjectBehavior
@@ -16,9 +16,9 @@ class InMemoryRoleRepositorySpec extends ObjectBehavior
         $this->shouldHaveType(InMemoryRoleRepository::class);
     }
 
-    function it_is_a_identifiable_object_repository()
+    function it_is_a_role_repository()
     {
-        $this->shouldImplement(IdentifiableObjectRepositoryInterface::class);
+        $this->shouldImplement(RoleRepositoryInterface::class);
     }
 
     function it_is_a_saver()

--- a/tests/back/Acceptance/spec/User/InMemoryRoleRepositorySpec.php
+++ b/tests/back/Acceptance/spec/User/InMemoryRoleRepositorySpec.php
@@ -42,7 +42,7 @@ class InMemoryRoleRepositorySpec extends ObjectBehavior
         $role = new Role();
         $role->setRole('role');
         $this->save($role);
-        $this->findOneByIdentifier('role')->shouldReturn($role);
+        $this->findOneByIdentifier('ROLE_ROLE')->shouldReturn($role);
     }
 
     function it_returns_null_if_the_role_does_not_exist()


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The InMemoryRoleRepository must implement the RoleRepositoryInterface which is used as type for the https://github.com/akeneo/pim-community-dev/blob/3.0/src/Akeneo/UserManagement/Component/Factory/UserFactory.php#L62

EDIT: we also removed the `strtolower(str_replace('ROLE_', '', $index))` in the `InMemoryRoleRepository::save` that is not compatible with the real behavior done in https://github.com/akeneo/pim-community-dev/blob/3.0/src/Akeneo/UserManagement/Component/Model/Role.php#L74

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
