### PR TITLE
PIM-8285: force the presence of column.code if not provided by the backend

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 # Bug fixes
 
 - PIM-8291: Use the UI locale in Completeness dashboard widget
+- PIM-8285: allow reordering of some datagrid columns by forcing the presence of column.code if not provided by the backend
 
 # 3.0.13 (2019-04-15)
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/column-selector.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/column-selector.ts
@@ -235,7 +235,7 @@ class ColumnSelector extends BaseView {
     _.each(Object.assign(columns, metadataColumns), (column: Column) => {
       const columnNames = metadataColumns.map((column: Column) => column.name);
       const label = column.name || column.code;
-      const data = {selected: columnNames.includes(label), sortOrder: columnNames.indexOf(label), removable: true};
+      const data = {code: label, selected: columnNames.includes(label), sortOrder: columnNames.indexOf(label), removable: true};
       datagridColumns[label] = Object.assign(column, data);
     });
 


### PR DESCRIPTION

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | ok
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

