### PR TITLE
TIP-1092 Hide import now button from the import profile export

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
@@ -38,6 +38,7 @@ extensions:
         position: 40
         config:
             label: pim_import_export.form.job_instance.button.import.launch
+            hideForCloudEdition: true
 
     pim-job-instance-csv-product-import-show-file-path:
         module: pim/job/common/file-path
@@ -64,6 +65,7 @@ extensions:
         position: 50
         config:
             label: pim_import_export.form.job_instance.button.import.upload_file
+            hideForCloudEdition: false
 
     pim-job-instance-csv-product-import-show-upload:
         module: pim/job/common/edit/upload

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher-item.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher-item.js
@@ -37,7 +37,8 @@ define(
 
                 this.getRoot().trigger('switcher:register', {
                     label: __(this.config.label),
-                    code: this.code
+                    code: this.code,
+                    hideForCloudEdition: this.config.hideForCloudEdition
                 });
 
                 return BaseForm.prototype.configure.apply(this, arguments);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher.js
@@ -11,11 +11,13 @@ define(
     [
         'underscore',
         'pim/form',
+        'pim/edition',
         'pim/template/import/switcher'
     ],
     function (
         _,
         BaseForm,
+        pimEdition,
         template
     ) {
         return BaseForm.extend({
@@ -50,10 +52,13 @@ define(
                     this.setCurrentActionCode(_.first(this.actions).code);
                 }
 
-                this.$el.empty().append(this.template({
-                    actions: this.actions,
-                    current: this.currentActionCode
-                }));
+
+                if (this.actions.length > 1) {
+                    this.$el.empty().append(this.template({
+                        actions: this.actions,
+                        current: this.currentActionCode
+                    }));
+                }
 
                 return BaseForm.prototype.render.apply(this, arguments);
             },
@@ -66,6 +71,10 @@ define(
              * @param {String} action.code  The extension code to display on click
              */
             registerAction: function (action) {
+                if (pimEdition.isCloudEdition() && action.hideForCloudEdition) {
+                    return;
+                }
+
                 this.actions.push(action);
                 this.render();
             },


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We must not display the `Import now` switcher item (import profile) in the SAAS edition because this is not SAAS compliant. More information are available [here](https://akeneo.atlassian.net/secure/RapidBoard.jspa?rapidView=67&projectKey=TIP&view=planning&selectedIssue=TIP-1092&epics=visible&selectedEpic=TIP-1087).

Before:
![before](https://user-images.githubusercontent.com/3585922/56414823-1d6ae900-628c-11e9-9612-7a35e25b36ad.png)

After:
![after](https://user-images.githubusercontent.com/3585922/56414748-ded52e80-628b-11e9-8230-5a447b97fcfa.png)


To hide this, an new env var named EDITION is given to webpack:

```bash
$ yarn requirements && NODE_PATH=node_modules EDITION=cloud  webpack --config $npm_package_config_source/webpack.config.js
```
Webpack make this var global and make it accessible via `process.env.EDITION` in the application (example [here](https://github.com/akeneo/pim-community-dev/pull/9885/files#diff-0baa3075248b34fc2e17c4730dc78852R3)). 

The edition is not mandatory, you still can run webpack without specifying it:

```bash
$ yarn requirements && NODE_PATH=node_modules webpack --config $npm_package_config_source/webpack.config.js
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
