### PR TITLE
PIM-8287: Fix horizontal scroll on history panel

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+# Bug fixes
+
+- PIM-8287: Fix horizontal scroll on history panel
+
 # 3.0.14 (2019-04-19)
 
 # Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/history.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/history.js
@@ -37,7 +37,7 @@ define(
     ) {
         return BaseForm.extend({
             template: _.template(template),
-            className: 'AknDefault-horizontalScroller panel-pane history-panel',
+            className: 'panel-pane history-panel',
             loading: false,
             expandedVersions: [],
             actions: {},

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/history.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/history.js
@@ -37,7 +37,7 @@ define(
     ) {
         return BaseForm.extend({
             template: _.template(template),
-            className: 'panel-pane history-panel',
+            className: 'AknDefault-horizontalScroller panel-pane history-panel',
             loading: false,
             expandedVersions: [],
             actions: {},

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -262,6 +262,11 @@
     overflow: hidden;
   }
 
+  &-multiline {
+    width: 100%;
+    word-break: break-word;
+  }
+
   &-expandable {
     width: 100px;
   }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/history.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/history.html
@@ -19,7 +19,7 @@
                     <td class="AknGrid-bodyCell version" data-column="version"><span class="AknButton AknButton--grey AknButton--round"><%- version.version %></span></td>
                     <td class="AknGrid-bodyCell AknGrid-bodyCell--noWrap AknGrid-bodyCell--highlight author" data-column="author"><%- version.author %><%- version.context ? ' (' + version.context + ')' : '' %></td>
                     <td class="AknGrid-bodyCell AknGrid-bodyCell--noWrap loggedAt" data-column="loggedAt"><%- version.logged_at %></td>
-                    <td class="AknGrid-bodyCell AknGrid-bodyCell--truncatable changes" data-column="changes"><div class="AknGrid-truncatable" title="<%- _.keys(version.changeset).join(', ') %>"><%- _.keys(version.changeset).join(', ') %></div></td>
+                    <td class="AknGrid-bodyCell AknGrid-bodyCell--truncatable changes" data-column="changes"><div class="AknGrid-multiline" title="<%- _.keys(version.changeset).join(', ') %>"><%- _.keys(version.changeset).join(', ') %></div></td>
                     <% if (hasAction) { %><td class="AknGrid-bodyCell actions"></td><% } %>
                 </tr>
                 <tr data-version="<%- version.version %>" class="AknGrid-bodyRow AknGrid-bodyRow--withoutTopBorder changeset <%- expandedVersions.find(item => item == version.version) ? '' : 'hide' %>">


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR adds a class to the history panel to allow it to be scrolled horizontally. This fixes an issue where the restore button wasn't visible unless the user fully expanded their browser window. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
