### PR TITLE
Fix exclude folders to make them relative

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -183,7 +183,12 @@ const webpackConfig = {
           },
         ],
         include: /(web\/bundles)/,
-        exclude: /lib|node_modules|vendor|tests|src|packages/,
+        exclude: [
+          path.resolve(rootDir, 'node_modules'),
+          path.resolve(rootDir, 'vendor'),
+          path.resolve(rootDir, 'tests'),
+          path.resolve(rootDir, 'src')
+        ],
       },
     ],
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -187,6 +187,7 @@ const webpackConfig = {
           path.resolve(rootDir, 'node_modules'),
           path.resolve(rootDir, 'vendor'),
           path.resolve(rootDir, 'tests'),
+          path.resolve(__dirname, 'tests'),
           path.resolve(rootDir, 'src')
         ],
       },


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

We have a bug in the configuration of `ts-loader` in the webpack config. Since we tell ts-loader to exclude certain files from the build, e.g. a file with a path matching any of these terms: `/lib|node_modules|vendor|tests|src|packages/` it also excluded project folders like `/src/code/my-pim-project`, causing the build to break. This PR fixes this issue by making the excluded files relative to the project directory. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
