### PR TITLE
DAPI-224: accept dots in paths

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/property.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/property.js
@@ -20,15 +20,16 @@ define([], function () {
          */
         accessProperty: function (data, path, defaultValue) {
             defaultValue = defaultValue || null;
-            var pathPart = path.split('.');
+            const pathPart = path.split('.');
 
-            if (undefined === data[pathPart[0]]) {
+            const part = pathPart[0].replace(/__DOT__/g, '.');
+            if (undefined === data[part]) {
                 return defaultValue;
             }
 
             return 1 === pathPart.length ?
-                data[pathPart[0]] :
-                this.accessProperty(data[pathPart[0]], pathPart.slice(1).join('.'), defaultValue);
+                data[part] :
+                this.accessProperty(data[part], pathPart.slice(1).join('.'), defaultValue);
         },
 
         /**
@@ -43,11 +44,23 @@ define([], function () {
         updateProperty: function (data, path, value) {
             var pathPart = path.split('.');
 
-            data[pathPart[0]] = 1 === pathPart.length ?
+            const part = pathPart[0].replace(/__DOT__/g, '.');
+            data[part] = 1 === pathPart.length ?
                 value :
-                this.updateProperty(data[pathPart[0]], pathPart.slice(1).join('.'), value);
+                this.updateProperty(data[part], pathPart.slice(1).join('.'), value);
 
             return data;
+        },
+
+        /**
+         * Create a safe path by concatenating escaped path segments to avoid dots of being incorrectly interpreted
+         *
+         * @param Array path
+         *
+         * @returns String
+         */
+        propertyPath: function(path) {
+            return path.map(e => e.replace(/\./g, '__DOT__')).join('.');
         }
     };
 });


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The property accessor component uses dots to split the property path to access data. This works well when all properties in the path doesn't contains any dots.

Unfortunately, in askFrankly bounded context, some properties contains dots in their names.

So this PR adds a way to properly escape dots in property names and then is able to put them back in the property name during the update phase.

This modification will not impact any other code and will not change existing behaviour

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
