### PR TITLE
Allow empty form extension .ymls to be ignored during the build

### DIFF
--- a/frontend/build/update-extensions.js
+++ b/frontend/build/update-extensions.js
@@ -71,7 +71,9 @@ function getExtensionsFromRequiredBundles() {
  * @param {string} paths
  */
 function mergeExtensions(paths) {
-    const config = paths.map(path => getFileContents(path))
+    const config = paths.map(path => {
+        return getFileContents(path) || {}
+    })
     const merged = deepmerge.all(config)
     const mergedExtensions = Object.entries(merged.extensions).map(([code, extension]) => {
         return extensionConfig = {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a bug where the `update-extensions` script that collects and merges the form extensions would break if there was an empty .yml file.  

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
