### PR TITLE
PIM-8289: Fix search on label or identifier for product variants ancestors

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,13 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8289: Fix search products on label or identifier for product variants ancestors
+
+## Elasticsearch
+
+- Please re-index the products and product models by launching the commands `console akeneo:elasticsearch:reset-indexes -e prod`, `pim:product:index --all -e prod` and `bin/console pim:product-model:index --all`.
+
 ## Improvement
 
 - PIM-8318: Bump Symfony version to 3.4.26 to fix Intl issues.

--- a/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/elasticsearch/index_configuration.yml
@@ -35,6 +35,7 @@ mappings:
                 normalizer: 'identifier_normalizer'
             ancestors.codes:
                 type: 'keyword'
+                normalizer: 'identifier_normalizer'
             ancestors.ids:
                 type: 'keyword'
         dynamic_templates:
@@ -47,6 +48,13 @@ mappings:
             -
                 label:
                     path_match: 'label.*'
+                    mapping:
+                        type: 'keyword'
+                        normalizer: 'text_normalizer'
+            -
+                ancestor_label:
+                    path_match: 'ancestors.labels.*'
+                    match_mapping_type: 'string'
                     mapping:
                         type: 'keyword'
                         normalizer: 'text_normalizer'


### PR DESCRIPTION
In the ES product indexes the fields `ancestors.codes` and `ancestors.labels` are not correctly mapped. They don't have any normalizer defined so the textual search is case sensitive.

It's a problem to count the products impacted by a mass edit action. All the product variants must be counted so these two fields are used to search on the product models parents.