### PR TITLE
Launch yarn run less during yarn run webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -205,7 +205,7 @@ const webpackConfig = {
 
   plugins: [
     new WebpackShellPlugin({
-      onBuildStart: ['yarn update-extensions'],
+      onBuildStart: ['yarn run less', 'yarn update-extensions'],
       dev: false
     }),
 


### PR DESCRIPTION
We tagged a 3.1.0, but we have a deployment problem. We are not able to deploy properly on `demo.akeneo.com` for instance with the current ansible scripts. In the current ansible scripts, there is no `yarn run less` command that is launched. Which means the PIM is deployed without any CSS.

Benoit doesn't want us to change the ansible scripts. That would mean we introduce a BC break in the build process in a minor version. 

This PR is a transparent way to solve the problem. Thanks to @tamarasaurus for the solution.

```bash
jjanvier:pcd$ docker-compose run --rm node yarn run webpack                                            
WARNING: The ES_JAVA_OPTS variable is not set. Defaulting to a blank string.
yarn run v1.13.0
$ yarn requirements && webpack --config webpack.config.js --env=prod
$ node frontend/build/check-requirements.js
Checking PIM frontend requirements
Starting webpack from /srv/pim in prod mode
Executing pre-build scripts
(node:49) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
$ node ./frontend/build/compile-less.js
$ node frontend/build/update-extensions.js
Updating form extensions.json

Starting LESS compilation                                                                                                      

‣ src/Oro/Bundle/PimDataGridBundle/Resources/public/less/index.less
‣ src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/index.less


✓ Saved CSS to web/css/pim.css
Version: webpack 4.29.6
Time: 11927ms
Built at: 04/30/2019 12:35:03 PM
        Asset      Size  Chunks                    Chunk Names
  main.min.js  1.33 MiB       0  [emitted]  [big]  main
vendor.min.js   327 KiB       1  [emitted]  [big]  vendor
Entrypoint main [big] = vendor.min.js main.min.js

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  main.min.js (1.33 MiB)
  vendor.min.js (327 KiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (1.65 MiB)
      vendor.min.js
      main.min.js


WARNING in webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/
Done in 13.45s.
```