### PR TITLE
DAPI-242: Improve Job execution queue filtering by job instance codes

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,5 +3,6 @@
 ## Bug fixes
 
 ## Technical improvement
+DAPI-242: Improve queue to consume specific jobs
 
 ## BC breaks

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobQueueConsumerCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobQueueConsumerCommand.php
@@ -49,7 +49,9 @@ class JobQueueConsumerCommand extends ContainerAwareCommand
         $this
             ->setName(self::COMMAND_NAME)
             ->setDescription('Launch a daemon that will consume job execution messages and launch the associated job execution in backgrounds')
-            ->addOption('run-once', null, InputOption::VALUE_NONE, 'Launch only one job execution and stop the daemon once the job execution is finished');
+            ->addOption('run-once', null, InputOption::VALUE_NONE, 'Launch only one job execution and stop the daemon once the job execution is finished')
+            ->addOption('job', 'j', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Job instance codes that should be consumed')
+        ;
     }
 
     /**
@@ -57,6 +59,8 @@ class JobQueueConsumerCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $jobInstanceCodes = $input->getOption('job');
+
         $errOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
 
         $consumerName = Uuid::uuid4();
@@ -67,7 +71,7 @@ class JobQueueConsumerCommand extends ContainerAwareCommand
 
         do {
             try {
-                $jobExecutionMessage = $this->getQueue()->consume($consumerName->toString());
+                $jobExecutionMessage = $this->getQueue()->consume($consumerName->toString(), $jobInstanceCodes);
 
                 $arguments = array_merge([$pathFinder->find(), $console, 'akeneo:batch:job' ], $this->getArguments($jobExecutionMessage));
                 $process = new Process($arguments);

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Queue/DatabaseJobExecutionQueue.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Queue/DatabaseJobExecutionQueue.php
@@ -44,12 +44,16 @@ class DatabaseJobExecutionQueue implements JobExecutionQueueInterface
     /**
      * {@inheritdoc}
      */
-    public function consume(string $consumer): JobExecutionMessage
+    public function consume(string $consumer, array $jobInstanceCodes = []): JobExecutionMessage
     {
         $hasBeenUpdated = false;
 
         do {
-            $jobExecutionMessage = $this->jobExecutionMessageRepository->getAvailableJobExecutionMessage();
+            if (empty($jobInstanceCodes)) {
+                $jobExecutionMessage = $this->jobExecutionMessageRepository->getAvailableJobExecutionMessage();
+            } else {
+                $jobExecutionMessage = $this->jobExecutionMessageRepository->getAvailableJobExecutionMessageFilteredByCodes($jobInstanceCodes);
+            }
 
             if (null !== $jobExecutionMessage) {
                 $jobExecutionMessage->consumedBy($consumer);

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Queue/DatabaseJobExecutionQueueSpec.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Queue/DatabaseJobExecutionQueueSpec.php
@@ -6,6 +6,7 @@ use Akeneo\Tool\Bundle\BatchQueueBundle\Queue\DatabaseJobExecutionQueue;
 use Akeneo\Tool\Bundle\BatchQueueBundle\Queue\JobExecutionMessageRepository;
 use Akeneo\Tool\Component\BatchQueue\Queue\JobExecutionMessage;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 class DatabaseJobExecutionQueueSpec extends ObjectBehavior
 {
@@ -33,10 +34,24 @@ class DatabaseJobExecutionQueueSpec extends ObjectBehavior
         JobExecutionMessage $jobExecutionMessage
     ) {
         $jobExecutionMessageRepository->getAvailableJobExecutionMessage()->willReturn($jobExecutionMessage);
+        $jobExecutionMessageRepository->getAvailableJobExecutionMessageFilteredByCodes(Argument::any())->shouldNotBeCalled();
         $jobExecutionMessageRepository->updateJobExecutionMessage($jobExecutionMessage)->willReturn(true);
 
         $jobExecutionMessage->consumedBy('consumer_name')->shouldBeCalled();
 
         $this->consume('consumer_name')->shouldReturn($jobExecutionMessage);
+    }
+
+    function it_filters_the_job_execution_to_consume(
+        $jobExecutionMessageRepository,
+        JobExecutionMessage $jobExecutionMessage
+    ) {
+        $jobExecutionMessageRepository->getAvailableJobExecutionMessage()->shouldNotBeCalled();
+        $jobExecutionMessageRepository->getAvailableJobExecutionMessageFilteredByCodes(['csv_export_product'])->willReturn($jobExecutionMessage);
+        $jobExecutionMessageRepository->updateJobExecutionMessage($jobExecutionMessage)->willReturn(true);
+
+        $jobExecutionMessage->consumedBy('consumer_name')->shouldBeCalled();
+
+        $this->consume('consumer_name', ['csv_export_product'])->shouldReturn($jobExecutionMessage);
     }
 }

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Command/JobQueueConsumerCommandIntegration.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Command/JobQueueConsumerCommandIntegration.php
@@ -40,12 +40,7 @@ class JobQueueConsumerCommandIntegration extends TestCase
 
     public function testLaunchAJobExecution()
     {
-        $jobExecution = $this->createJobExecution('csv_product_export', 'mary');
-
-        $options = ['email' => 'ziggy@akeneo.com', 'env' => $this->getParameter('kernel.environment')];
-        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
-
-        $this->getQueue()->publish($jobExecutionMessage);
+        $jobExecution = $this->createJobExecutionInQueue('csv_product_export');
 
         $output = $this->jobLauncher->launchConsumerOnce();
 
@@ -72,14 +67,36 @@ class JobQueueConsumerCommandIntegration extends TestCase
         $this->assertNotEmpty($row['consumer']);
     }
 
+    public function testLaunchFilteredJobExecution()
+    {
+        $jobExecution = $this->createJobExecutionInQueue('csv_product_export');
+
+        $output = $this->jobLauncher->launchConsumerOnce(['-j' => ['csv_product_export']]);
+        $standardOutput = $output->fetch();
+        $this->assertStringContainsString(sprintf('Job execution "%s" is finished.', $jobExecution->getId()), $standardOutput);
+
+        $row = $this->getJobExecutionDatabaseRow($jobExecution);
+
+        $this->assertEquals(BatchStatus::COMPLETED, $row['status']);
+        $this->assertEquals(ExitStatus::COMPLETED, $row['exit_code']);
+        $this->assertNotNull($row['health_check_time']);
+
+        $jobExecution = $this->get('pim_enrich.repository.job_execution')->findBy(['id' => $jobExecution->getId()]);
+        $jobExecution = $this->getJobExecutionManager()->resolveJobExecutionStatus($jobExecution[0]);
+
+        $this->assertEquals(BatchStatus::COMPLETED, $jobExecution->getStatus()->getValue());
+        $this->assertEquals(ExitStatus::COMPLETED, $jobExecution->getExitStatus()->getExitCode());
+
+        $stmt = $this->getConnection()->prepare('SELECT consumer from akeneo_batch_job_execution_queue');
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        $this->assertNotEmpty($row['consumer']);
+    }
+
     public function testStatusOfACrashedJobExecution()
     {
-        $jobExecution = $this->createJobExecution('infinite_loop_job', 'mary');
-
-        $options = ['email' => 'ziggy@akeneo.com', 'env' => $this->getParameter('kernel.environment')];
-        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
-
-        $this->getQueue()->publish($jobExecutionMessage);
+        $jobExecution = $this->createJobExecutionInQueue('infinite_loop_job');
 
         $daemonProcess = $this->jobLauncher->launchConsumerOnceInBackground();
 
@@ -107,12 +124,7 @@ class JobQueueConsumerCommandIntegration extends TestCase
 
     public function testJobExecutionStatusResolverWhenDaemonAndJobExecutionCrash()
     {
-        $jobExecution = $this->createJobExecution('infinite_loop_job', 'mary');
-
-        $options = ['email' => 'ziggy@akeneo.com', 'env' => $this->getParameter('kernel.environment')];
-        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
-
-        $this->getQueue()->publish($jobExecutionMessage);
+        $jobExecution = $this->createJobExecutionInQueue('infinite_loop_job');
 
         $daemonProcess = $this->jobLauncher->launchConsumerOnceInBackground();
 
@@ -141,6 +153,16 @@ class JobQueueConsumerCommandIntegration extends TestCase
 
         $this->assertEquals(BatchStatus::FAILED, $jobExecution->getStatus()->getValue());
         $this->assertEquals(ExitStatus::FAILED, $jobExecution->getExitStatus()->getExitCode());
+    }
+
+    private function createJobExecutionInQueue(string $jobInstanceCode): JobExecution
+    {
+        $jobExecution = $this->createJobExecution($jobInstanceCode, 'mary');
+        $options = ['email' => 'ziggy@akeneo.com', 'env' => $this->getParameter('kernel.environment')];
+        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
+        $this->getQueue()->publish($jobExecutionMessage);
+
+        return $jobExecution;
     }
 
     /**

--- a/src/Akeneo/Tool/Component/BatchQueue/Queue/JobExecutionQueueInterface.php
+++ b/src/Akeneo/Tool/Component/BatchQueue/Queue/JobExecutionQueueInterface.php
@@ -27,8 +27,9 @@ interface JobExecutionQueueInterface
      * This method loops until there is a message to consume into the queue.
      *
      * @param string $consumer name of the consumer
+     * @param string[] $jobInstanceCodes name of the job instances
      *
      * @return JobExecutionMessage
      */
-    public function consume(string $consumer): JobExecutionMessage;
+    public function consume(string $consumer, array $jobInstanceCodes = []): JobExecutionMessage;
 }

--- a/tests/back/Integration/IntegrationTestsBundle/Launcher/JobLauncher.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Launcher/JobLauncher.php
@@ -286,15 +286,18 @@ class JobLauncher
      *
      * @return BufferedOutput
      */
-    public function launchConsumerOnce(): BufferedOutput
+    public function launchConsumerOnce(array $options = []): BufferedOutput
     {
         $application = new Application($this->kernel);
         $application->setAutoExit(false);
 
-        $arrayInput = [
-            'command'  => JobQueueConsumerCommand::COMMAND_NAME,
-            '--run-once' => true,
-        ];
+        $arrayInput = array_merge(
+            $options,
+            [
+                'command'  => JobQueueConsumerCommand::COMMAND_NAME,
+                '--run-once' => true,
+            ]
+        );
 
         $input = new ArrayInput($arrayInput);
         $output = new BufferedOutput();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR allows launching a consumer for dedicated jobs using their job instance codes as a parameter.
For instance, for some mass edit jobs, we can launch something like this:

`romain@dandelion:~/workspace/pim/pim-ee$ bin/console --env=prod akeneo:batch:job-queue-consumer-daemon -j update_product_value -p add_product_value -p remove_product_value`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
