### PR TITLE
PIM-8323: Fix issue on attribute option removing

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8323: Fix issue on attribute option removing
+
 # 2.3.41 (2019-05-02)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
@@ -187,6 +187,12 @@ class AttributeOptionController
         $attributeOption = $this->findAttributeOptionOr404($attributeOptionId);
 
         try {
+            /*
+             * Removing the option is not enough in some cases.
+             * As the option can be loaded from the attribute, we have to delete it from the collection of the attribute too.
+             * Otherwise, the option could be considered as a new one when flushing, as the option is still in the collection of the attribute.
+             */
+            $attributeOption->getAttribute()->removeOption($attributeOption);
             $this->optionRemover->remove($attributeOption);
         } catch (\Exception $e) {
             return new JsonResponse(['message' => $e->getMessage()], Response::HTTP_BAD_REQUEST);


### PR DESCRIPTION
The bug is that under certain conditions, an attribute option is re-created after being deleted. It has been triggered by a custom code of a client, but the real cause is in the PIM. 

When an attribute option is removed, a version of the attribute is created, and its "updated at" date is updated. It occurs in a event suscriber, after that the attribute option has been removed from the Doctrine UOW and deleted in the database. (remove + flush)

The problem is that if the attribute is fully hydrated with its options collection before that the attribute option is removed, this attribute option is still in the collection but with `null` as id (the entity has been removed from the Doctrine UOW). So when the attribute is saved to persist the date of the udpate, the UOW considers that there's a new attribute option in the collection and it creates it in the database with a new id. The bug has not triggered before, because of the lazy loading of the attribute options.

The solution in this PR is not ideal, because it's the versioning system itself that should be questioned, but it would need too much works for a SLA. I added the fix in the controller because the "remover" is generic, and I think that it's not worth it do it in a specific "remover", especially as the "attribute option remover" is only used in this controller.

Don't hesitate to ask me a better explication IRL.