### PR TITLE
GITHUB-9927: fix narrow breakable space in the test since new version  of PHP

### DIFF
--- a/tests/legacy/features/localization/attribute/display_localized_attribute_history.feature
+++ b/tests/legacy/features/localization/attribute/display_localized_attribute_history.feature
@@ -17,4 +17,4 @@ Feature: Display the attribute history localized values
     Then there should be 2 update
     And I should see history:
       | version | author                              | property   | value      |
-      | 2       | Julien Février - Julien@example.com | number_max | 12 456,789 |
+      | 2       | Julien Février - Julien@example.com | number_max | 12 456,789 |


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

On recent version patch version of PHP, the behavior of INTL to format number is different for the french format.
I detected that by removing all docker images in local to pull up new version. The problem can be reproduced on version of PHP 7.1 (2.0) and 7.2 (3.0).

Note: I didn't see anything in PHP changelog about it :disappointed: 

**Unstability explanation**
It explains why on the CI it's the scenario fails: it's very probably due to the cache of the docker image.
It's different between the circle CI container. Older version of the FPM image are running this test as success, most recent one as failing.

**Before:**
It formats "12 456,789" with a non breakable space for french locale (unicode character: `\u00a0`) . Then, in the browser, this non breakable is transformed in a space. The test is successful.

**After:**
It formats "12 456,789" with a NARROW non breakable space for french locale  (unicode character: `\u202f`). Then, in the browser, this non breakable is **not** transformed in a space. The test is failing.


I just changed the test because:
- we know the cause and we are not changing it blindly
- it's non critical at all
- it doesn't break anything for the user



Note: we will have to purge the docker image cache


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
