### PR TITLE
PIM-8319: add loading mask on upload clic

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-8319: Prevent users from clicking several times on Import button during file upload.
 - PIM-8323: Fix issue on attribute option removing
 
 # 2.3.41 (2019-05-02)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/upload-launch.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/job/common/edit/upload-launch.js
@@ -13,16 +13,10 @@ define(
         'oro/translator',
         'pim/job/common/edit/launch',
         'pim/router',
-        'oro/messenger'
+        'oro/messenger',
+        'oro/loading-mask'
     ],
-    function (
-        $,
-        _,
-        __,
-        BaseLaunch,
-        router,
-        messenger
-    ) {
+    function ($, _, __, BaseLaunch, router, messenger, LoadingMask) {
         return BaseLaunch.extend({
             /**
              * {@inherit}
@@ -37,11 +31,12 @@ define(
              * {@inherit}
              */
             launch: function () {
+                var loadingMask = new LoadingMask();
+                loadingMask.render().$el.appendTo(this.getRoot().$el).show();
+
                 if (this.getFormData().file) {
                     var formData = new FormData();
                     formData.append('file', this.getFormData().file);
-
-                    router.showLoadingMask();
 
                     $.ajax({
                         url: this.getUrl(),
@@ -57,7 +52,11 @@ define(
                     .fail(() => {
                         messenger.notify('error', __('pim_enrich.form.job_instance.fail.launch'));
                     })
-                    .always(router.hideLoadingMask());
+                    .always(() => {
+                        loadingMask.hide().$el.remove();
+                    });
+                } else {
+                    loadingMask.hide().$el.remove();
                 }
             },
 

--- a/tests/legacy/features/product/edit_product.feature
+++ b/tests/legacy/features/product/edit_product.feature
@@ -97,7 +97,8 @@ Feature: Edit a product
       | Currencies              | EUR               |
       | Locales                 | French            |
     And I press the "Save" button
-    Then I should be redirected to the "channel_code" channel page
+    Then I should not see the text "There are unsaved changes."
+    And I should be redirected to the "channel_code" channel page
     And I am on the "sandal" product page
     Then I switch the scope to "channel_code"
     And I should see the text "The channel label"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Cherry pick of this commit https://github.com/akeneo/pim-community-dev/pull/8495 to add a loading mask to prevent the user to click several time on "Upload and Import" when the import takes time.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
