### PR TITLE
PIM-8283: Command akeneo:batch:purge-job-execution now works with option --days=0.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+# Bug fixes
+
+- PIM-8283: Command `akeneo:batch:purge-job-execution` now works with option `--days=0`.
+
 # 3.0.16 (2019-05-06)
 
 # Bug fixes

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Command/PurgeJobExecutionCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Command/PurgeJobExecutionCommand.php
@@ -32,7 +32,8 @@ class PurgeJobExecutionCommand extends ContainerAwareCommand
             'days',
             'd',
             InputOption::VALUE_OPTIONAL,
-            'How many days of jobs execution you want to keep'
+            'How many days of jobs execution you want to keep',
+            self::DEFAULT_NUMBER_OF_DAYS
         );
     }
 
@@ -41,7 +42,14 @@ class PurgeJobExecutionCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $days = $this->getNumberOfDaysOption($input);
+        $days = $input->getOption('days');
+        if (!is_numeric($days)) {
+            $output->writeln(
+                sprintf('<error>Option --days must be a number, "%s" given.</error>', $input->getOption('days'))
+            );
+
+            return;
+        }
 
         $jobsExecutions = $this->getJobExecutionRepository()->findPurgeables($days);
 
@@ -50,20 +58,6 @@ class PurgeJobExecutionCommand extends ContainerAwareCommand
             $this->getJobExecutionRepository()->remove($jobsExecutions);
             $output->write(sprintf("%s jobs execution deleted ...\n", count($jobsExecutions)));
         }
-    }
-
-    /**
-     * @param InputInterface $input
-     *
-     * @return int
-     */
-    protected function getNumberOfDaysOption(InputInterface $input)
-    {
-        if ($input->getOption('days') && (int) $input->getOption('days')) {
-            return (int) $input->getOption('days');
-        }
-
-        return self::DEFAULT_NUMBER_OF_DAYS;
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When the command was launched with the option `--days=0` condition we wrote was wrong and had behaved as we passed nothing.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
