### PR TITLE
PIM-8254: Avoid showing 403 error on entities edit pages and disable remove action when not granted

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,8 @@
 # Bug fixes
 
 - PIM-8329: Add Serbian flag for CS region
+- PIM-8254: Attributes, attribute groups, groups, group types and channels edit page are not accessible anymore
+    and remove action is disabled from grid if they are not granted.
 
 # 3.0.16 (2019-05-06)
 

--- a/src/Akeneo/Channel/Bundle/Resources/config/datagrid/channel.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/datagrid/channel.yml
@@ -34,12 +34,14 @@ datagrid:
                 label:     pim_common.edit
                 link:      edit_link
                 rowAction: true
+                acl_resource: pim_enrich_channel_edit
             delete:
                 launcherOptions:
                     className: AknIconButton AknIconButton--small AknIconButton--trash
                 type:  delete
                 label: pim_common.delete
                 link:  delete_link
+                acl_resource: pim_enrich_channel_remove
         sorters:
             columns:
                 label:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/group.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/group.yml
@@ -32,12 +32,14 @@ datagrid:
                 label:     pim_common.edit
                 link:      edit_link
                 rowAction: true
+                acl_resource: pim_enrich_group_edit
             delete:
                 launcherOptions:
                     className: AknIconButton AknIconButton--small AknIconButton--trash
                 type:  delete
                 label: pim_common.delete
                 link:  delete_link
+                acl_resource: pim_enrich_group_remove
         sorters:
             columns:
                 label:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
@@ -31,12 +31,14 @@ datagrid:
                 label:     pim_common.edit
                 link:      edit_link
                 rowAction: true
+                acl_resource: pim_enrich_associationtype_edit
             delete:
                 launcherOptions:
                     className: AknIconButton AknIconButton--small AknIconButton--trash
                 type:  delete
                 label: pim_common.delete
                 link:  delete_link
+                acl_resource: pim_enrich_associationtype_remove
         sorters:
             columns:
                 label:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/attribute.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/attribute.yml
@@ -43,12 +43,14 @@ datagrid:
                 label:     pim_common.edit
                 link:      edit_link
                 rowAction: true
+                acl_resource: pim_enrich_attribute_edit
             delete:
                 launcherOptions:
                     className: AknIconButton AknIconButton--small AknIconButton--trash
                 type:  delete
                 label: pim_common.delete
                 link:  delete_link
+                acl_resource: pim_enrich_attribute_remove
         sorters:
             columns:
                 scopable:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/group_type.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/group_type.yml
@@ -31,12 +31,14 @@ datagrid:
                 label:     pim_common.edit
                 link:      edit_link
                 rowAction: true
+                acl_resource: pim_enrich_grouptype_edit
             delete:
                 launcherOptions:
                     className: AknIconButton AknIconButton--small AknIconButton--trash
                 type:  delete
                 label: pim_common.delete
                 link:  delete_link
+                acl_resource: pim_enrich_grouptype_remove
         sorters:
             columns:
                 label:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/list.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/list.js
@@ -18,6 +18,7 @@ define([
     'pim/router',
     'pim/user-context',
     'pim/i18n',
+    'pim/security-context',
     'pim/template/form/attribute-group/list'
 ],
     function (
@@ -31,6 +32,7 @@ define([
         router,
         UserContext,
         i18n,
+        securityContext,
         template
     ) {
         return BaseForm.extend({
@@ -114,10 +116,12 @@ define([
              * @param {event} event
              */
             redirectToGroup: function (event) {
-                router.redirectToRoute(
-                    'pim_enrich_attributegroup_edit',
-                    {identifier: event.target.dataset.attributeGroupCode}
-                )
+                if (securityContext.isGranted('pim_enrich_attributegroup_edit')) {
+                    router.redirectToRoute(
+                        'pim_enrich_attributegroup_edit',
+                        {identifier: event.target.dataset.attributeGroupCode}
+                    )
+                }
             }
         });
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Avoid showing 403 error on entities edit pages by preventing click on the line and hiding the edit button when edit resource is not granted.
Hide remove action from the grid when the resource is not granted.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
