### PR TITLE
AOB-472: Fix broken style modals

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+# Improvements
+
+- AOB-472: Add missing check template bootstrap modal
+
 # Bug fixes
 
 - PIM-8329: Add Serbian flag for CS region

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,7 +2,7 @@
 
 # Improvements
 
-- AOB-472: Add missing check template bootstrap modal
+- AOB-472: Fix modal display when using illustration class
 
 # Bug fixes
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap-modal/bootstrap-modal.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap-modal/bootstrap-modal.js
@@ -15,7 +15,7 @@
 (function($, _, Backbone) {
   var template = _.template('\
     <div class="AknFullPage">\
-      <div class="AknFullPage-content<% if (typeof picture !== \'undefined\') { %>AknFullPage-content--withIllustration<% } %>">\
+      <div class="AknFullPage-content<% if (typeof picture !== \'undefined\' || typeof illustrationClass !== \'undefined\') { %> AknFullPage-content--withIllustration<% } %>">\
         <div>\
           <% if (typeof picture !== \'undefined\') { %>\
             <img src="bundles/pimui/images/<%- picture %>" alt="<%- picture %>"/>\


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR adds a simple check on the `illustrationClass` variable before adding the `AknFullPage-content--withIllustration` class. On the `onboarder` & `pim-onboarder` adding this class for a modal without picture/illustration broke it (titles were display on the left instead of being centered).

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
