### PR TITLE
PIM-8276: Label or identifier search input is now limited to 255 characters.

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8329: Add Serbian Flag for CS Region
+- PIM-8276: Label or identifier search input is now limited to 255 characters.
 
 # 2.3.42 (2019-05-06)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/search-filter.html
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/templates/filter/search-filter.html
@@ -1,1 +1,1 @@
-<input class="AknFilterBox-search" autocomplete="off" type="text" name="value" value="" placeholder="<%- label %>">
+<input class="AknFilterBox-search" maxlength="255" autocomplete="off" type="text" name="value" value="" placeholder="<%- label %>">


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

255 character has been choose because identifier are limited to 255 characters.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
