### PR TITLE
PIM-8334: Handles error during translator choice

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-8329: Add Serbian Flag for CS Region
 - PIM-8276: Label or identifier search input is now limited to 255 characters.
+- PIM-8334: When a translation choice is not correct, it does not break the page anymore.
 
 # 2.3.42 (2019-05-06)
 

--- a/src/Pim/Bundle/LocalizationBundle/DependencyInjection/PimLocalizationExtension.php
+++ b/src/Pim/Bundle/LocalizationBundle/DependencyInjection/PimLocalizationExtension.php
@@ -27,6 +27,7 @@ class PimLocalizationExtension extends Extension
         $loader->load('controllers.yml');
         $loader->load('forms.yml');
         $loader->load('providers.yml');
+        $loader->load('translator.yml');
         $loader->load('twig.yml');
         $loader->load('updaters.yml');
     }

--- a/src/Pim/Bundle/LocalizationBundle/Resources/config/translator.yml
+++ b/src/Pim/Bundle/LocalizationBundle/Resources/config/translator.yml
@@ -1,0 +1,7 @@
+services:
+    pim_localization.translator:
+        class: Pim\Bundle\LocalizationBundle\Translator\TranslatorDecorator
+        decorates: translator
+        decoration_inner_name: base_translator
+        arguments:
+            - '@base_translator'

--- a/src/Pim/Bundle/LocalizationBundle/Translator/TranslatorDecorator.php
+++ b/src/Pim/Bundle/LocalizationBundle/Translator/TranslatorDecorator.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Bundle\LocalizationBundle\Translator;
+
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Decorates the symfony translator to be able to returns translation key instead of error during transchoice.
+ * @see PIM-8334
+ *
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TranslatorDecorator implements TranslatorInterface
+{
+    /** @var TranslatorInterface */
+    private $symfonyTranslator;
+
+    public function __construct(TranslatorInterface $symfonyTranslator)
+    {
+        $this->symfonyTranslator = $symfonyTranslator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    {
+        return $this->symfonyTranslator->trans($id, $parameters, $domain, $locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
+    {
+        try {
+            return $this->symfonyTranslator->transChoice($id, $number, $parameters, $domain, $locale);
+        } catch (\Exception $exception) {
+            return (string) $id . ': ' . (string) $number;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLocale($locale)
+    {
+        $this->symfonyTranslator->setLocale($locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocale()
+    {
+        return $this->symfonyTranslator->getLocale();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslations(array $domains = [], $locale = null)
+    {
+        return $this->symfonyTranslator->getTranslations($domains, $locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFallbackLocales()
+    {
+        return $this->symfonyTranslator->getFallbackLocales();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCatalogue($locale = null)
+    {
+        return $this->symfonyTranslator->getCatalogue($locale);
+    }
+}

--- a/src/Pim/Bundle/LocalizationBundle/spec/Translator/TranslatorDecoratorSpec.php
+++ b/src/Pim/Bundle/LocalizationBundle/spec/Translator/TranslatorDecoratorSpec.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace spec\Pim\Bundle\LocalizationBundle\Translator;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class TranslatorDecoratorSpec extends ObjectBehavior
+{
+    function let(TranslatorInterface $translator)
+    {
+        $this->beConstructedWith($translator);
+    }
+
+    function it_translates($translator)
+    {
+        $translator->trans('to_translate', [], null, null)->willReturn('It is translated.');
+
+        $this->trans('to_translate')->shouldReturn('It is translated.');
+    }
+
+    function it_translates_choice($translator)
+    {
+        $key = 'something_to_translate';
+        $translator
+            ->transChoice($key, 2, [], null, null)
+            ->willReturn('2 affected products');
+
+        $this
+            ->transChoice($key, 2)
+            ->shouldReturn('2 affected products');
+    }
+
+    /**
+     * @see PIM-8334
+     *
+     * @param $translator
+     */
+    function it_returns_the_translation_key_and_the_number_if_it_can_not_translate_the_choice($translator)
+    {
+        $brokenKey = 'something_to_translate';
+        $translator
+            ->transChoice($brokenKey, 2, [], null, null)
+            ->willThrow(new \Exception('Can not translate because the key is broken.'));
+
+        $this
+            ->transChoice($brokenKey, 2)
+            ->shouldReturn('something_to_translate: 2');
+    }
+
+    function it_sets_locale($translator)
+    {
+        $translator->setLocale('en_US')->shouldBeCalled();
+
+        $this->setLocale('en_US');
+    }
+
+    function it_gets_locale($translator)
+    {
+        $translator->getLocale()->willReturn('en_US');
+
+        $this->getLocale()->shouldReturn('en_US');
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When you have an error in your translation file, it breaks the page.
For exemple, remove the coma between 1 and Inf in `'{0} Complete|{1} 1 missing value|]1,Inf] %count% missing values'`.

The fix works well for php classes AND the default twig extension `transchoice()`.
 
**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
