### PR TITLE
 AOB-479: Change relative resource paths in less files to absolute paths

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -7,6 +7,10 @@
 - PIM-8254: Attributes, attribute groups, groups, group types and channels edit page are not accessible anymore
     and remove action is disabled from grid if they are not granted.
 
+# Improvements
+
+- AOB-479: Resource paths in less files are now absolute and are checked when executing the "oro:assetic:dump" command to avoid wrong path resolution by Assetic.
+
 # 3.0.16 (2019-05-06)
 
 # Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/base/general.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/base/general.less
@@ -131,7 +131,7 @@ input[type=checkbox] {
   &:checked:before {
     border-color: @AknBlue;
     background-color: @AknBlue;
-    background-image: url("../../images/icon-checkwhite.svg");
+    background-image: url("/bundles/pimui/images/icon-checkwhite.svg");
     background-repeat: no-repeat;
     background-position: 0 0;
     background-size: @AknCheckboxSize - 1px;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/CatalogVolume.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/CatalogVolume.less
@@ -14,11 +14,7 @@
 
     &--count-products,
     &--average-max-records-per-reference-entity {
-      background-image: url("../../images/icon-product.svg");
-    }
-
-    &--count-channels {
-      background-image: url("../../images/icon-channel.svg");
+      background-image: url("/bundles/pimui/images/icon-product.svg");
     }
 
     &--average-max-attributes-per-family,
@@ -27,53 +23,53 @@
     &--count-localizable-attributes,
     &--count-attributes,
     &--average-max-attributes-per-reference-entity {
-      background-image: url("../../images/icon-tag.svg");
+      background-image: url("/bundles/pimui/images/icon-tag.svg");
     }
 
     &--average-max-options-per-attribute {
-      background-image: url("../../images/icon-add-attribute.svg");
+      background-image: url("/bundles/pimui/images/icon-add-attribute.svg");
     }
 
     &--count-locales {
-      background-image: url("../../images/icon-locale.svg");
+      background-image: url("/bundles/pimui/images/icon-locale.svg");
     }
 
     &--count-families {
-      background-image: url("../../images/bulk/icon-template.svg");
+      background-image: url("/bundles/pimui/images/bulk/icon-template.svg");
     }
 
     &--count-category-trees,
     &--count-asset-category-trees {
-      background-image: url("../../images/bulk/icon-folders.svg");
+      background-image: url("/bundles/pimui/images/bulk/icon-folders.svg");
     }
 
     &--count-asset-categories,
     &--count-categories {
-      background-image: url("../../images/icon-folder.svg");
+      background-image: url("/bundles/pimui/images/icon-folder.svg");
     }
 
     &--count-assets {
-      background-image: url("../../images/icon-asset.svg");
+      background-image: url("/bundles/pimui/images/icon-asset.svg");
     }
 
     &--count-product-models {
-      background-image: url("../../images/bulk/icon-model.svg");
+      background-image: url("/bundles/pimui/images/bulk/icon-model.svg");
     }
 
     &--count-variant-products {
-      background-image: url("../../images/bulk/icon-variant.svg");
+      background-image: url("/bundles/pimui/images/bulk/icon-variant.svg");
     }
 
     &--count-channels {
-      background-image: url("../../images/icon-shop.svg");
+      background-image: url("/bundles/pimui/images/icon-shop.svg");
     }
 
     &--count-reference-entity {
-      background-image: url("../../images/icon-reference-entity.svg");
+      background-image: url("/bundles/pimui/images/icon-reference-entity.svg");
     }
 
     &--header {
-      background-image: url('../../images/illustrations/Product-categories.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Product-categories.svg");
       background-size: 80%;
       background-position: 50%;
       width: 95px;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Column.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Column.less
@@ -94,7 +94,7 @@
   }
 
   &-blockDown {
-    background: url("../../images/icon-down.svg") no-repeat center;
+    background: url("/bundles/pimui/images/icon-down.svg") no-repeat center;
     display: inline-block;
     height: 8px;
     width: 18px;
@@ -189,7 +189,7 @@
   &-collapseButton {
     height: @AknBottomPanelHeight;
     width: @AknSecondColumnWidth;
-    background: url("../../images/icon-panelClose.svg") no-repeat 20px center;
+    background: url("/bundles/pimui/images/icon-panelClose.svg") no-repeat 20px center;
     background-size: @iconSize;
     background-color: @AknLightGray;
     cursor: pointer;
@@ -230,7 +230,7 @@
   &--collapsed &-collapseButton {
     width: @littleWidth;
     background-position: ((@littleWidth - @iconSize) / 2) center;
-    background-image: url("../../images/icon-panelOpen.svg");
+    background-image: url("/bundles/pimui/images/icon-panelOpen.svg");
   }
 
   &-bottomButtonContainer {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
@@ -49,7 +49,7 @@
   &-searchInput {
     font-size: @AknFontSizeBig;
     padding-left: 32px;
-    background: url("../../images/icon-search-purple.svg") no-repeat 0 9px;
+    background: url("/bundles/pimui/images/icon-search-purple.svg") no-repeat 0 9px;
     background-size: 20px;
     border: none;
     color: @AknLightPurple;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Dropdown.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Dropdown.less
@@ -149,7 +149,7 @@
     font-style: italic;
 
     &--arrow {
-      background: url("../../images/red_arrow.svg") no-repeat 0 40%;
+      background: url("/bundles/pimui/images/red_arrow.svg") no-repeat 0 40%;
       padding-left: 15px;
     }
   }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/FamilyVariant.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/FamilyVariant.less
@@ -90,7 +90,7 @@
             content: '';
             width: 60px;
             height: 32px;
-            background-image: url("../../images/connector-start.svg");
+            background-image: url("/bundles/pimui/images/connector-start.svg");
             display: inline-block;
         }
 
@@ -98,7 +98,7 @@
             content: '';
             width: 60px;
             height: 60px;
-            background-image: url("../../images/connector-end.svg");
+            background-image: url("/bundles/pimui/images/connector-end.svg");
             display: inline-block;
         }
     }
@@ -114,7 +114,7 @@
 
     &-attribute, &-columTitle {
         &--movable {
-            background: url("../../images/icon-dragcolumns.svg") no-repeat 0 center;
+            background: url("/bundles/pimui/images/icon-dragcolumns.svg") no-repeat 0 center;
             background-size: 13px;
             padding-left: 20px;
             cursor: move;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Header.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Header.less
@@ -84,75 +84,75 @@
 
   &-menuItemImage {
     &--iconCard {
-      background-image: url("../../images/icon-card-purple.svg");
+      background-image: url("/bundles/pimui/images/icon-card-purple.svg");
 
       &:first-child {
-        background-image: url("../../images/icon-card.svg");
+        background-image: url("/bundles/pimui/images/icon-card.svg");
       }
     }
 
     &--iconUpload {
-      background-image: url("../../images/icon-upload-purple.svg");
+      background-image: url("/bundles/pimui/images/icon-upload-purple.svg");
 
       &:first-child {
-        background-image: url("../../images/icon-upload.svg");
+        background-image: url("/bundles/pimui/images/icon-upload.svg");
       }
     }
 
     &--iconProduct {
-      background-image: url("../../images/icon-product-purple.svg");
+      background-image: url("/bundles/pimui/images/icon-product-purple.svg");
 
       &:first-child {
-        background-image: url("../../images/icon-product.svg");
+        background-image: url("/bundles/pimui/images/icon-product.svg");
       }
     }
 
     &--iconDownload {
-      background-image: url("../../images/icon-download-purple.svg");
+      background-image: url("/bundles/pimui/images/icon-download-purple.svg");
 
       &:first-child {
-        background-image: url("../../images/icon-download.svg");
+        background-image: url("/bundles/pimui/images/icon-download.svg");
       }
     }
 
     &--iconSettings {
-      background-image: url("../../images/icon-settings-purple.svg");
+      background-image: url("/bundles/pimui/images/icon-settings-purple.svg");
 
       &:first-child {
-        background-image: url("../../images/icon-settings.svg");
+        background-image: url("/bundles/pimui/images/icon-settings.svg");
       }
     }
 
     &--iconSystem {
-      background-image: url("../../images/icon-system-purple.svg");
+      background-image: url("/bundles/pimui/images/icon-system-purple.svg");
 
       &:first-child {
-        background-image: url("../../images/icon-system.svg");
+        background-image: url("/bundles/pimui/images/icon-system.svg");
       }
     }
 
     &--iconAsset {
-      background-image: url("../../images/icon-asset-purple.svg");
+      background-image: url("/bundles/pimui/images/icon-asset-purple.svg");
 
       &:first-child {
-        background-image: url("../../images/icon-asset.svg");
+        background-image: url("/bundles/pimui/images/icon-asset.svg");
       }
     }
 
     &--iconReferenceEntity {
-      background-image: url("../../images/icon-reference-entity-purple.svg");
+      background-image: url("/bundles/pimui/images/icon-reference-entity-purple.svg");
 
       &:first-child {
-        background-image: url("../../images/icon-reference-entity.svg");
+        background-image: url("/bundles/pimui/images/icon-reference-entity.svg");
       }
     }
 
     &--iconHelp {
-      background-image: url("../../images/icon-help-purple.svg");
+      background-image: url("/bundles/pimui/images/icon-help-purple.svg");
       background-size: 100%;
 
       &:first-child {
-        background-image: url("../../images/icon-help.svg");
+        background-image: url("/bundles/pimui/images/icon-help.svg");
         background-size: 100%;
       }
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/LoadingMask.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/LoadingMask.less
@@ -26,7 +26,7 @@
 }
 
 .AknLoadingMask {
-  background: rgba(255,255,255,0.8) url("../../images/loader-V2.svg") no-repeat center;
+  background: rgba(255,255,255,0.8) url("/bundles/pimui/images/loader-V2.svg") no-repeat center;
   position: absolute;
   top: 0;
   left: 0;
@@ -44,7 +44,7 @@
 }
 
 .AknLoadingIndicator {
-  background: url("../../images/loader-V2.svg") no-repeat center;
+  background: url("/bundles/pimui/images/loader-V2.svg") no-repeat center;
   background-size: 50px;
   width: 50px;
   transition: opacity .2s ease-in-out;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/MessageBox.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/MessageBox.less
@@ -53,7 +53,7 @@
   }
 
   &--withIcon {
-    background-image: url("../../images/icon-danger-darkred.svg");
+    background-image: url("/bundles/pimui/images/icon-danger-darkred.svg");
     background-repeat: no-repeat;
     background-position: 8px 50%;
     padding-left: 40px;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Notification.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Notification.less
@@ -39,15 +39,15 @@
     position: relative;
 
     &--import, &--massUpload {
-      background-image: url("../../images/icon-import.svg");
+      background-image: url("/bundles/pimui/images/icon-import.svg");
     }
 
     &--export, &--quickExport {
-      background-image: url("../../images/icon-export.svg");
+      background-image: url("/bundles/pimui/images/icon-export.svg");
     }
 
     &--massEdit {
-      background-image: url("../../images/icon-edit.svg");
+      background-image: url("/bundles/pimui/images/icon-edit.svg");
     }
 
     &--pimeeWorkflowProductDraftNotificationNewProposal,
@@ -57,35 +57,35 @@
     &--pimeeWorkflowProductDraftNotificationApprove,
     &--pimeeWorkflowProductDraftNotificationRefuse,
     &--pimeeWorkflowProductDraftNotificationRemove {
-      background-image: url("../../images/icon-proposal.svg");
+      background-image: url("/bundles/pimui/images/icon-proposal.svg");
     }
 
     &--pimeeWorkflowImportNotificationNewProposals {
-      background-image: url("../../images/icon-import-proposals.svg");
+      background-image: url("/bundles/pimui/images/icon-import-proposals.svg");
     }
 
     &--rule {
-      background-image: url("../../images/icon-rules.svg");
+      background-image: url("/bundles/pimui/images/icon-rules.svg");
     }
 
     &--settings {
-      background-image: url("../../images/icon-rules.svg");
+      background-image: url("/bundles/pimui/images/icon-rules.svg");
     }
 
     &--projectCalculation {
-      background-image: url("../../images/icon-tasks.svg");
+      background-image: url("/bundles/pimui/images/icon-tasks.svg");
     }
 
     &--projectCreated {
-      background-image: url("../../images/icon-tasks.svg");
+      background-image: url("/bundles/pimui/images/icon-tasks.svg");
     }
 
     &--projectFinished {
-      background-image: url("../../images/icon-tasks-done.svg");
+      background-image: url("/bundles/pimui/images/icon-tasks-done.svg");
     }
 
     &--robot {
-      background-image: url("../../images/icon-robot.svg");
+      background-image: url("/bundles/pimui/images/icon-robot.svg");
     }
   }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/NotificationMenu.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/NotificationMenu.less
@@ -8,7 +8,7 @@
     width: @AknDefaultButtonSize;
     border: 1px solid @AknBorderColor;
     border-radius: 100px;
-    background: url("../../images/icon-notification.svg") no-repeat 50% 50%;
+    background: url("/bundles/pimui/images/icon-notification.svg") no-repeat 50% 50%;
     background-size: @AknDefaultButtonSize / 2;
     cursor: pointer;
   }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Search.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Search.less
@@ -15,7 +15,7 @@
     font-size: 12px;
     line-height: @AknLittleButtonSize;
     border: none;
-    background: url("../../images/icon-search.svg") no-repeat 0 center;
+    background: url("/bundles/pimui/images/icon-search.svg") no-repeat 0 center;
     padding-left: 30px;
     flex-grow: 1;
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/SequentialEdit.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/SequentialEdit.less
@@ -32,13 +32,13 @@
 
   &-previous:before {
     margin-right: 10px;
-    background: url("../../images/icon-down.svg") no-repeat;
+    background: url("/bundles/pimui/images/icon-down.svg") no-repeat;
     transform: rotate(90deg);
   }
 
   &-next:after {
     margin-left: 10px;
-    background: url("../../images/icon-down.svg") no-repeat;
+    background: url("/bundles/pimui/images/icon-down.svg") no-repeat;
     transform: rotate(-90deg);
   }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/State.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/State.less
@@ -1,7 +1,7 @@
 @import '../base/variables';
 
 .AknState {
-  background: url("../../images/icon-plain-danger-orange.svg") no-repeat left center;
+  background: url("/bundles/pimui/images/icon-plain-danger-orange.svg") no-repeat left center;
   background-size: 18px;
   color: @AknDarkBlue;
   padding-left: 20px;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Steps.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Steps.less
@@ -42,7 +42,7 @@
 
   &-step--checked &-stepCircle {
     border-color: @AknGreen;
-    background: @AknGreen url("../../images/icon-checkwhite.svg") no-repeat 50%;
+    background: @AknGreen url("/bundles/pimui/images/icon-checkwhite.svg") no-repeat 50%;
   }
 
   &-step + &-step {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Subsection.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Subsection.less
@@ -104,6 +104,6 @@
     min-width: 65px;
     min-height: 65px;
     margin-right: 16px;
-    background-image: url("../../images/icon-info.svg");
+    background-image: url("/bundles/pimui/images/icon-info.svg");
   }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
@@ -44,7 +44,7 @@
 
   &-imageContainer--dropping {
     &:after {
-      background: RGBa(255, 255, 255, 0.8) url("../../images/icon-upload.svg") no-repeat 50% 50%;
+      background: RGBa(255, 255, 255, 0.8) url("/bundles/pimui/images/icon-upload.svg") no-repeat 50% 50%;
       background-size: 50%;
       opacity: 1;
     }
@@ -56,7 +56,7 @@
 
   &-imageContainer--removing {
     &:after {
-      background: RGBa(255, 255, 255, 0.8) url("../../images/icon-delete-slategrey.svg") no-repeat 50% 50%;
+      background: RGBa(255, 255, 255, 0.8) url("/bundles/pimui/images/icon-delete-slategrey.svg") no-repeat 50% 50%;
       background-size: 50%;
       opacity: 1;
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/VerticalList.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/VerticalList.less
@@ -26,7 +26,7 @@
 
     &--movable {
       cursor: move;
-      background: url("../../images/icon-dragcolumns.svg") no-repeat 0 center;
+      background: url("/bundles/pimui/images/icon-dragcolumns.svg") no-repeat 0 center;
       background-size: 13px;
       padding-left: 20px;
     }
@@ -51,7 +51,7 @@
   }
 
   &-delete {
-    background: url("../../images/icon-delete-slategrey.svg") no-repeat center;
+    background: url("/bundles/pimui/images/icon-delete-slategrey.svg") no-repeat center;
     background-size: 24px;
     width: 24px;
     height: 24px;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/ActionButton.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/ActionButton.less
@@ -23,7 +23,7 @@
     display: inline-block;
     width: 12px;
     height: 6px;
-    background: url("../../../images/jstree/icon-down.svg") no-repeat 0 center;
+    background: url("/bundles/pimui/images/jstree/icon-down.svg") no-repeat 0 center;
     background-size: 12px;
     margin-left: 3px;
   }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/Button.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/Button.less
@@ -250,7 +250,7 @@
   }
 
   &--dropdown {
-    background-image: url("../../../images/icon-down-white.svg");
+    background-image: url("/bundles/pimui/images/icon-down-white.svg");
     background-repeat: no-repeat;
     background-position: 92% center;
     background-size: 20px;
@@ -271,75 +271,75 @@
     }
 
     &--id {
-      background-image: url("../../../images/attribute/icon-id.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-id.svg");
     }
 
     &--text {
-      background-image: url("../../../images/attribute/icon-text.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-text.svg");
     }
 
     &--textarea {
-      background-image: url("../../../images/attribute/icon-textarea.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-textarea.svg");
     }
 
     &--number {
-      background-image: url("../../../images/attribute/icon-number.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-number.svg");
     }
 
     &--price {
-      background-image: url("../../../images/attribute/icon-price.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-price.svg");
     }
 
     &--multiselect {
-      background-image: url("../../../images/attribute/icon-multiselect.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-multiselect.svg");
     }
 
     &--select {
-      background-image: url("../../../images/attribute/icon-select.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-select.svg");
     }
 
     &--file {
-      background-image: url("../../../images/attribute/icon-file.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-file.svg");
     }
 
     &--asset {
-      background-image: url("../../../images/attribute/icon-asset.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-asset.svg");
     }
 
     &--switch {
-      background-image: url("../../../images/attribute/icon-switch.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-switch.svg");
     }
 
     &--date {
-      background-image: url("../../../images/attribute/icon-date.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-date.svg");
     }
 
     &--metric {
-      background-image: url("../../../images/attribute/icon-metric.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-metric.svg");
     }
 
     &--assetCollection {
-      background-image: url("../../../images/attribute/icon-assetCollection.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-assetCollection.svg");
     }
 
     &--reference-entity {
-      background-image: url("../../../images/attribute/icon-reference-entity.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-reference-entity.svg");
     }
 
     &--reference-entity-multiple {
-      background-image: url("../../../images/attribute/icon-reference-entity-multiple.svg");
+      background-image: url("/bundles/pimui/images/attribute/icon-reference-entity-multiple.svg");
     }
 
     &--delete {
-      background-image: url("../../../images/icon-delete-white.svg")
+      background-image: url("/bundles/pimui/images/icon-delete-white.svg")
     }
 
     &--dismiss {
-      background-image: url("../../../images/icon-delete-slategrey.svg")
+      background-image: url("/bundles/pimui/images/icon-delete-slategrey.svg")
     }
 
     &--validate {
-      background-image: url("../../../images/icon-check-green.svg")
+      background-image: url("/bundles/pimui/images/icon-check-green.svg")
     }
   }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/IconButton.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/IconButton.less
@@ -125,67 +125,67 @@
 
 
   &--ok {
-    .imageIcon("../../../images/icon-checkwhite.svg");
+    .imageIcon("/bundles/pimui/images/icon-checkwhite.svg");
   }
 
   &--editWhite {
-    .imageIcon("../../../images/icon-edit-white.svg");
+    .imageIcon("/bundles/pimui/images/icon-edit-white.svg");
   }
 
   &--remove {
-    .imageIcon("../../../images/icon-delete-slategrey.svg");
+    .imageIcon("/bundles/pimui/images/icon-delete-slategrey.svg");
   }
 
   &--removeWhite {
-    .imageIcon("../../../images/icon-delete-white.svg");
+    .imageIcon("/bundles/pimui/images/icon-delete-white.svg");
   }
 
   &--plus {
-    .imageIcon("../../../images/icon-plus.svg");
+    .imageIcon("/bundles/pimui/images/icon-plus.svg");
   }
 
   &--edit {
-    .imageIcon("../../../images/icon-edit.svg");
+    .imageIcon("/bundles/pimui/images/icon-edit.svg");
   }
 
   &--folder {
-    .imageIcon("../../../images/icon-folder.svg");
+    .imageIcon("/bundles/pimui/images/icon-folder.svg");
   }
 
   &--trash {
-    .imageIcon("../../../images/icon-trash.svg");
+    .imageIcon("/bundles/pimui/images/icon-trash.svg");
   }
 
   &--delete {
-    .imageIcon("../../../images/icon-delete-slategrey.svg");
+    .imageIcon("/bundles/pimui/images/icon-delete-slategrey.svg");
   }
 
   &--switch {
-    .imageIcon("../../../images/icon-switch.svg");
+    .imageIcon("/bundles/pimui/images/icon-switch.svg");
   }
 
   &--view {
-    .imageIcon("../../../images/icon-view.svg");
+    .imageIcon("/bundles/pimui/images/icon-view.svg");
   }
 
   &--unpublish {
-    .imageIcon("../../../images/icon-unpublish.svg");
+    .imageIcon("/bundles/pimui/images/icon-unpublish.svg");
   }
 
   &--play {
-    .imageIcon("../../../images/icon-play.svg");
+    .imageIcon("/bundles/pimui/images/icon-play.svg");
   }
 
   &--value {
-    .imageIcon("../../../images/icon-value.svg");
+    .imageIcon("/bundles/pimui/images/icon-value.svg");
   }
 
   &--link {
-    .imageIcon("../../../images/icon-link.svg");
+    .imageIcon("/bundles/pimui/images/icon-link.svg");
   }
 
   &--info {
-    .imageIcon("../../../images/icon-info.svg");
+    .imageIcon("/bundles/pimui/images/icon-info.svg");
   }
 
   &--topLeft {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/SecondaryActions.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/SecondaryActions.less
@@ -8,7 +8,7 @@
     cursor: pointer;
     opacity: 0.5;
     transition: opacity 0.1s ease-in;
-    background: url("../../../images/icon-more.svg") no-repeat center center;
+    background: url("/bundles/pimui/images/icon-more.svg") no-repeat center center;
 
     &--rotated {
       transform: rotate(90deg);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/SelectButton.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/SelectButton.less
@@ -13,7 +13,7 @@
   &--selected {
     border-color: @AknBlue;
     background-color: @AknBlue;
-    background-image: url("../../../images/icon-checkwhite.svg");
+    background-image: url("/bundles/pimui/images/icon-checkwhite.svg");
     background-repeat: no-repeat;
     background-position: 0 0;
     background-size: @AknCheckboxSize - 1px;
@@ -22,7 +22,7 @@
   &--partial {
     border-color: @AknBlue;
     background-color: @AknBlue;
-    background-image: url("../../../images/icon-checkpartialwhite.svg");
+    background-image: url("/bundles/pimui/images/icon-checkpartialwhite.svg");
     background-repeat: no-repeat;
     background-position: center;
     background-size: @AknCheckboxSize @AknCheckboxSize - 1px;
@@ -32,7 +32,7 @@
     cursor: not-allowed;
     border-color: lighten(@AknSlateGrey, 10%);
     background-color: lighten(@AknSlateGrey, 10%);
-    background-image: url("../../../images/icon-checkwhite.svg");
+    background-image: url("/bundles/pimui/images/icon-checkwhite.svg");
     background-repeat: no-repeat;
     background-position: 0 0;
     background-size: @AknCheckboxSize - 1px;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -5,7 +5,7 @@
   background-color: white;
 
   &-addFilterButton {
-    background: url("../../../images/icon-plus.svg") no-repeat right center;
+    background: url("/bundles/pimui/images/icon-plus.svg") no-repeat right center;
     background-size: 19px;
     width: ~"calc(100% + 10px)" !important; // Width is set by multiselect
     padding: 0 !important; // Padding is set by multiselect
@@ -53,7 +53,7 @@
     color: @AknDefaultFontColor;
     font-size: @AknDefaultFontSize;
     border: none;
-    background: url("../../../images/icon-search.svg") no-repeat 0 center;
+    background: url("/bundles/pimui/images/icon-search.svg") no-repeat 0 center;
     padding-left: 30px;
     flex-grow: 1;
     margin-top: 20px;
@@ -166,7 +166,7 @@
     display: inline-block;
     width: 12px;
     height: @searchHeight;
-    background: url("../../../images/jstree/icon-down.svg") no-repeat 0 center;
+    background: url("/bundles/pimui/images/jstree/icon-down.svg") no-repeat 0 center;
     background-size: 12px;
     margin-left: 3px;
   }
@@ -206,7 +206,7 @@
     order: -1;
     width: auto !important; // The width is updated by JS method.
     background-color: white;
-    background: url("../../../images/icon-filters.svg") no-repeat left 50%;
+    background: url("/bundles/pimui/images/icon-filters.svg") no-repeat left 50%;
     flex-grow: 1;
     padding-left: 35px !important; // The padding is updated by JS method.
     margin-left: 10px;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -274,7 +274,7 @@
   &-expand {
     width: 32px;
     height: 32px;
-    background: url("../../../images/icon-right.svg") no-repeat 50%;
+    background: url("/bundles/pimui/images/icon-right.svg") no-repeat 50%;
     transition: transform 0.2s ease-in;
 
     &--expanded {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/GridContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/GridContainer.less
@@ -24,7 +24,7 @@
   }
 
   &-noDataImage {
-    background-image: url("../../../images/illustrations/Attribute.svg");
+    background-image: url("/bundles/pimui/images/illustrations/Attribute.svg");
     background-repeat: no-repeat;
     background-position: center center;
     height: 200px;
@@ -33,15 +33,15 @@
     background-size: 100% auto;
 
     &--associations {
-      background-image: url("../../../images/illustrations/Association-types.svg");
+      background-image: url("/bundles/pimui/images/illustrations/Association-types.svg");
     }
 
     &--reference-entity {
-      background-image: url("../../../images/illustrations/NoResult.svg");
+      background-image: url("/bundles/pimui/images/illustrations/NoResult.svg");
     }
 
     &--user-group {
-      background-image: url("../../../images/illustrations/User-groups.svg");
+      background-image: url("/bundles/pimui/images/illustrations/User-groups.svg");
     }
   }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/MassActions.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/MassActions.less
@@ -2,7 +2,7 @@
 
 .AknMassActions {
   &-dropdown {
-    background: url("../../../images/icon-down.svg") no-repeat center;
+    background: url("/bundles/pimui/images/icon-down.svg") no-repeat center;
     background-size: 18px;
     margin: 6px 0px 0 6px;
     display: inline-block;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
@@ -85,7 +85,7 @@
      &--disabled {
        background-color: @AknDisabledInputColor;
        cursor: not-allowed;
-       background-image: url("../../../images/icon-lock.svg");
+       background-image: url("/bundles/pimui/images/icon-lock.svg");
        background-repeat: no-repeat;
        background-position: ~"calc(100% - 12px)" center;
        padding-right: @AknFormHeight - 4px;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetPreview.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetPreview.less
@@ -27,13 +27,13 @@
     max-width: ~"calc(100vw - 80px)";
     min-width: 40px;
     min-height: 40px;
-    background: url("../../../images/loader-V2.svg") no-repeat center;
+    background: url("/bundles/pimui/images/loader-V2.svg") no-repeat center;
   }
 
   &-left, &-right {
     flex-basis: @arrowWidth * 2 ;
     height: ~"calc(100vh - 290px)";
-    background-image: url("../../../images/icon-right.svg");
+    background-image: url("/bundles/pimui/images/icon-right.svg");
     background-size: @arrowWidth;
     background-repeat: no-repeat;
     background-position: center left;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
@@ -68,11 +68,11 @@
     padding-left: 30px;
 
     &--full {
-      background-image: url("../../../images/icon-robot-green.svg");
+      background-image: url("/bundles/pimui/images/icon-robot-green.svg");
     }
 
     &--pending {
-      background-image: url("../../../images/icon-robot-yellow.svg");
+      background-image: url("/bundles/pimui/images/icon-robot-yellow.svg");
     }
   }
 
@@ -145,7 +145,7 @@
     align-items: baseline;
     margin-top: 3px;
     color: @AknRed;
-    background: url("../../../images/icon-danger.svg") no-repeat left center;
+    background: url("/bundles/pimui/images/icon-danger.svg") no-repeat left center;
     padding-left: 26px;
   }
 
@@ -154,7 +154,7 @@
     align-items: baseline;
     margin-top: 3px;
     color: @AknDarkBlue;
-    background: url("../../../images/icon-danger-orange.svg") no-repeat left center;
+    background: url("/bundles/pimui/images/icon-danger-orange.svg") no-repeat left center;
     padding-left: 26px;
   }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/HorizontalNavtab.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/HorizontalNavtab.less
@@ -34,7 +34,7 @@
   &-item--forbidden &-link {
     opacity: 0.7;
     cursor: not-allowed;
-    background: url("../../../images/icon-lock2.svg") no-repeat right;
+    background: url("/bundles/pimui/images/icon-lock2.svg") no-repeat right;
     background-size: 21px;
   }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/MediaField.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/MediaField.less
@@ -14,7 +14,7 @@
 
   &--disabled {
     background: @AknDisabledInputColor;
-    background-image: url("../../../images/icon-lock.svg");
+    background-image: url("/bundles/pimui/images/icon-lock.svg");
     background-repeat: no-repeat;
     background-position: ~"calc(100% - 12px) center";
   }
@@ -36,7 +36,7 @@
 
       & + .AknMediaField-emptyContainer {
         background: @AknDisabledInputColor;
-        background-image: url("../../../images/icon-lock.svg");
+        background-image: url("/bundles/pimui/images/icon-lock.svg");
         background-repeat: no-repeat;
         background-position: ~"calc(100% - 12px)" center;
         padding-right: @AknFormHeight - 4px;
@@ -76,7 +76,7 @@
     margin-top: 3px;
     margin-left: 5px;
     cursor: pointer;
-    background-image: url("../../../images/icon-delete-slategrey.svg");
+    background-image: url("/bundles/pimui/images/icon-delete-slategrey.svg");
     background-size: 100%;
     display: block;
     background-repeat: no-repeat;
@@ -116,7 +116,7 @@
     display: block;
     margin-top: 2px;
     background-size: 100%;
-    background-image: url("../../../images/illustrations/Import.svg");
+    background-image: url("/bundles/pimui/images/illustrations/Import.svg");
   }
 
   &-trashIcon {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
@@ -92,7 +92,7 @@
   &[readonly]:not(.AknTextField--light),
   &[disabled]:not(.AknTextField--light) {
     background: @AknDisabledInputColor;
-    background-image: url("../../../images/icon-lock.svg");
+    background-image: url("/bundles/pimui/images/icon-lock.svg");
     background-repeat: no-repeat;
     background-position: ~"calc(100% - 12px)" center;
     padding-right: @AknFormHeight - 4px;
@@ -117,7 +117,7 @@
 
     &.AknTextField--disabled {
       border-bottom: 1px dotted @AknMediumGrey;
-      background-image: url("../../../images/icon-lock2.svg");
+      background-image: url("/bundles/pimui/images/icon-lock2.svg");
       background-repeat: no-repeat;
       background-size: 16px;
       background-position: ~"calc(100% - 12px)" center;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/bootstrap.dropdown.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/bootstrap.dropdown.less
@@ -26,6 +26,6 @@
 }
 
 .AknDropdown.open .AknIconButton--value {
-  background-image: url("../../images/icon-value-purple.svg");
+  background-image: url("/bundles/pimui/images/icon-value-purple.svg");
   opacity: 1;
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/flags.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/flags.less
@@ -9,7 +9,7 @@
   width: @flagWidth;
   height: @flagHeight;
   display: inline-block;
-  background: url('../../images/flags.png') no-repeat;
+  background: url("/bundles/pimui/images/flags.png") no-repeat;
   vertical-align: baseline;
   &.flag-ad {.flagPos(1, 0);}
   &.flag-ae {.flagPos(2, 0);}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/font-awesome.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/font-awesome.less
@@ -25,9 +25,9 @@
 }
 
 .icon-category {
-  background-image: url("../images/small-icon-category.png");
+  background-image: url("/bundles/pimui/images/small-icon-category.png");
 }
 
 .icon-product {
-  background-image: url("../images/small-icon-product.png");
+  background-image: url("/bundles/pimui/images/small-icon-product.png");
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
@@ -58,7 +58,7 @@
     li.jstree-checked {
       & > a > .jstree-checkbox {
         background-color: @AknBlue;
-        background-image: url("../../images/icon-checkwhite.svg");
+        background-image: url("/bundles/pimui/images/icon-checkwhite.svg");
         background-position: 0 0;
         background-size: @AknCheckboxSize @AknCheckboxSize;
         background-repeat: no-repeat;
@@ -87,18 +87,18 @@
     }
 
     li.jstree-closed > .jstree-icon {
-      .jstree-icon("../../images/jstree/icon-right.svg");
+      .jstree-icon("/bundles/pimui/images/jstree/icon-right.svg");
       background-size: 20px;
     }
 
     li.jstree-open > .jstree-icon {
-      .jstree-icon("../../images/jstree/icon-down.svg");
+      .jstree-icon("/bundles/pimui/images/jstree/icon-down.svg");
       background-size: 20px;
     }
 
     li.jstree-leaf.jstree-checked > a:not(.jstree-loading):not(.jstree-clicked) .jstree-icon,
     li.jstree-leaf:not(.jstree-checked) > a:not(.jstree-loading):not(.jstree-clicked) .jstree-icon {
-      .jstree-icon("../../images/jstree/icon-folder.svg")
+      .jstree-icon("/bundles/pimui/images/jstree/icon-folder.svg")
     }
 
     li.jstree-leaf.jstree-checked > input ~ a:not(.jstree-loading):not(.jstree-clicked),
@@ -113,19 +113,19 @@
     li.jstree-leaf.jstree-checked > input ~ a:not(.jstree-loading).jstree-clicked .jstree-icon,
     li.jstree-leaf.jstree-checked > a:not(.jstree-loading).jstree-clicked .jstree-icon,
     li.jstree-leaf:not(.jstree-checked) > a:not(.jstree-loading).jstree-clicked .jstree-icon {
-      .jstree-icon("../../images/jstree/icon-folderfull.svg")
+      .jstree-icon("/bundles/pimui/images/jstree/icon-folderfull.svg")
     }
 
     li:not(.jstree-leaf):not(.jstree-checked) > a:not(.jstree-loading):not(.jstree-clicked) .jstree-icon,
     li:not(.jstree-leaf).jstree-checked > a:not(.jstree-loading):not(.jstree-clicked) .jstree-icon {
-      .jstree-icon("../../images/jstree/icon-folders.svg")
+      .jstree-icon("/bundles/pimui/images/jstree/icon-folders.svg")
     }
 
     li:not(.jstree-leaf).jstree-checked > input ~ a:not(.jstree-loading):not(.jstree-clicked) .jstree-icon,
     li:not(.jstree-leaf).jstree-checked > a:not(.jstree-loading).jstree-clicked .jstree-icon,
     li:not(.jstree-leaf).jstree-checked > input ~ a:not(.jstree-loading).jstree-clicked .jstree-icon,
     li:not(.jstree-leaf):not(.jstree-checked) > a:not(.jstree-loading).jstree-clicked .jstree-icon {
-      .jstree-icon("../../images/jstree/icon-foldersfull.svg")
+      .jstree-icon("/bundles/pimui/images/jstree/icon-foldersfull.svg")
     }
 
     li:not(.jstree-leaf).jstree-checked > input ~ a:not(.jstree-clicked),
@@ -151,7 +151,7 @@
 
         .select2-arrow {
           border-left: none;
-          background: url("../../images/icon-down.svg") no-repeat 100% center;
+          background: url("/bundles/pimui/images/icon-down.svg") no-repeat 100% center;
           background-size: 20px;
 
           b {
@@ -197,7 +197,7 @@
   }
 
   .jstree-lockedicon {
-    background: url("../../images/jstree/icon-folderfull.svg") no-repeat center 0;
+    background: url("/bundles/pimui/images/jstree/icon-folderfull.svg") no-repeat center 0;
     display: inline-block;
     width: 20px;
     height: 20px;
@@ -214,7 +214,7 @@
   }
 
   > .jstree-icon {
-    .jstree-icon("../../images/jstree/icon-folders.svg")
+    .jstree-icon("/bundles/pimui/images/jstree/icon-folders.svg")
   }
 }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.multiselect.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.multiselect.less
@@ -188,7 +188,7 @@
     display: inline-block;
     border-left: 1px solid @AknBorderColor;
     background-size: 96px 48px;
-    background-image: url('../../css/images/select2x2.png');
+    background-image: url("/bundles/pimui/css/images/select2x2.png");
     background-position: 3px 2px;
     margin-left: 10px;
   }
@@ -209,7 +209,7 @@
       color: @AknDefaultFontColor;
       height: 30px;
       line-height: 30px;
-      background: url("../../images/icon-search.svg") no-repeat 0 5px;
+      background: url("/bundles/pimui/images/icon-search.svg") no-repeat 0 5px;
       background-size: 20px;
       padding-left: 25px;
 
@@ -279,7 +279,7 @@
         width: ~"calc(100% - 25px)" !important;
         color: @AknLightPurple;
         font-size: @AknFontSizeBig;
-        background: url("../../images/icon-search.svg") no-repeat 0 9px;
+        background: url("/bundles/pimui/images/icon-search.svg") no-repeat 0 9px;
         background-size: 20px;
         padding: 0 0 0 25px;
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -24,7 +24,7 @@
 
     .select2-arrow {
       width: 25px;
-      background: url("../../images/icon-down.svg") no-repeat 10px 10px;
+      background: url("/bundles/pimui/images/icon-down.svg") no-repeat 10px 10px;
       background-color: inherit;
       background-size: 18px;
       border-left: none;
@@ -41,7 +41,7 @@
     color: @AknLightFontColor;
     border-color: @AknBorderColor;
     cursor: not-allowed;
-    background-image: url("../../images/icon-lock.svg");
+    background-image: url("/bundles/pimui/images/icon-lock.svg");
     background-repeat: no-repeat;
     background-position: ~"calc(100% - 10px)" 10px;
     padding-right: @AknFormHeight - 4px;
@@ -75,7 +75,7 @@
     .select2-input {
       height: 30px;
       line-height: 30px;
-      background: url("../../images/icon-search.svg") no-repeat 0 5px;
+      background: url("/bundles/pimui/images/icon-search.svg") no-repeat 0 5px;
       background-size: 20px;
       border: none;
       padding-left: 25px;
@@ -164,7 +164,7 @@
 
     b {
       background-size: 96px 48px;
-      background-image: url('../../css/images/select2x2.png');
+      background-image: url("/bundles/pimui/css/images/select2x2.png");
       background-position: 6px 5px;
     }
   }
@@ -194,7 +194,7 @@
 .select2-container-multi .select2-choices .select2-search-choice,
 .select2-container.select2-allowclear .select2-choice {
   .select2-search-choice-close {
-    background-image: url("../../images/icon-remove.svg") !important;
+    background-image: url("/bundles/pimui/images/icon-remove.svg") !important;
     background-repeat: no-repeat;
     background-position: center;
     background-size: 10px;
@@ -242,7 +242,7 @@
 
     .select2-search-field {
       height: @AknFormHeight -7px;
-      background: url("../../images/icon-plus.svg") no-repeat;
+      background: url("/bundles/pimui/images/icon-plus.svg") no-repeat;
       background-size: 16px;
       background-position: right 20px center;
 
@@ -303,18 +303,18 @@
 
 .select2--withIcon.select2-drop {
   .select2-result-label-attribute {
-    background-image: url("../../images/icon-robot.svg");
+    background-image: url("/bundles/pimui/images/icon-robot.svg");
     background-repeat: no-repeat;
     background-position: 100% 50%;
     background-size: 25px;
     width: 100%;
 
     &.select2-result-label-attribute--full {
-      background-image: url("../../images/icon-robot-green.svg");
+      background-image: url("/bundles/pimui/images/icon-robot-green.svg");
     }
 
     &.select2-result-label-attribute--pending {
-      background-image: url("../../images/icon-robot-yellow.svg");
+      background-image: url("/bundles/pimui/images/icon-robot-yellow.svg");
     }
   }
 }
@@ -347,7 +347,7 @@
 
       .select2-arrow {
         width: 25px;
-        background: url("../../images/icon-down.svg") no-repeat 0 12px;
+        background: url("/bundles/pimui/images/icon-down.svg") no-repeat 0 12px;
         background-color: inherit;
         background-size: 12px;
         border-left: none;
@@ -452,7 +452,7 @@
         background-size: 12px;
 
         b {
-          background: url("../../images/jstree/icon-down.svg") no-repeat center center;
+          background: url("/bundles/pimui/images/jstree/icon-down.svg") no-repeat center center;
           background-size: 12px;
         }
       }
@@ -580,7 +580,7 @@
       }
 
       .select2-arrow {
-        background: url("../../images/icon-down-white.svg") no-repeat 3px center;
+        background: url("/bundles/pimui/images/icon-down-white.svg") no-repeat 3px center;
         background-size: 50%;
         border: none;
 
@@ -597,7 +597,7 @@
   .select2-search-choice-close,
   .select2.select2-container .select2-choice abbr,
   .select2.select2-container .select2-choice .select2-arrow b {
-    background-image: url("../../images/icon-remove.svg");
+    background-image: url("/bundles/pimui/images/icon-remove.svg");
     background-repeat: no-repeat;
     background-position: center;
     background-size: 100% !important;
@@ -607,7 +607,7 @@
     background-attachment: scroll;
     background-clip: border-box;
     background-color: rgba(0, 0, 0, 0);
-    background-image: url("../../images/icon-search.svg") !important;
+    background-image: url("/bundles/pimui/images/icon-search.svg") !important;
     background-origin: padding-box;
     background-position: 0 5px !important;
     background-size: 20px !important;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/pages/FullPage.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/pages/FullPage.less
@@ -72,7 +72,7 @@
     left: @AknFullPagePadding;
     width: 32px;
     height: 32px;
-    background: url("../../images/icon-delete-slategrey.svg") no-repeat 50% 50%;
+    background: url("/bundles/pimui/images/icon-delete-slategrey.svg") no-repeat 50% 50%;
     cursor: pointer;
     border: none;
     z-index: 1050;
@@ -146,99 +146,99 @@
   }
 
   &-illustration {
-    background-image: url('../../images/illustrations/Attribute.svg');
+    background-image: url("/bundles/pimui/images/illustrations/Attribute.svg");
     background-size: 210px 210px;
     height: 210px;
     background-position: right;
     background-repeat: no-repeat;
 
     &--api-connections {
-      background-image: url('../../images/illustrations/Api.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Api.svg");
     }
 
     &--association-types {
-      background-image: url('../../images/illustrations/Association-types.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Association-types.svg");
     }
 
     &--attributes {
-      background-image: url('../../images/illustrations/Attribute.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Attribute.svg");
     }
 
     &--robot {
-      background-image: url('../../images/illustrations/Robot.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Robot.svg");
     }
 
     &--attribute-groups {
-      background-image: url('../../images/illustrations/Attribute-groups.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Attribute-groups.svg");
     }
 
     &--projects {
-      background-image: url('../../images/illustrations/Project.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Project.svg");
     }
 
     &--products {
-      background-image: url('../../images/illustrations/Product.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Product.svg");
     }
 
     &--product-models {
-      background-image: url('../../images/illustrations/Product-model.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Product-model.svg");
     }
 
     &--product-model {
-      background-image: url('../../images/illustrations/Product-model.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Product-model.svg");
     }
 
     &--delete {
-      background-image: url('../../images/illustrations/Delete.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Delete.svg");
     }
 
     &--assets, &--asset {
-      background-image: url('../../images/illustrations/Asset.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Asset.svg");
     }
 
     &--export-profiles {
-      background-image: url('../../images/illustrations/Export.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Export.svg");
     }
 
     &--import-profiles {
-      background-image: url('../../images/illustrations/Import.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Import.svg");
     }
 
     &--categories {
-      background-image: url('../../images/illustrations/Product-categories.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Product-categories.svg");
     }
 
     &--families {
-      background-image: url('../../images/illustrations/Family.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Family.svg");
     }
 
     &--group,
     &--groups {
-      background-image: url('../../images/illustrations/Groups.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Groups.svg");
     }
 
     &--association {
-      background-image: url('../../images/illustrations/Association-types.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Association-types.svg");
     }
 
     &--channels {
-      background-image: url('../../images/illustrations/Channel.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Channel.svg");
     }
 
     &--api {
-      background-image: url('../../images/illustrations/Api.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Api.svg");
     }
 
     &--users {
-      background-image: url('../../images/illustrations/User.svg');
+      background-image: url("/bundles/pimui/images/illustrations/User.svg");
     }
 
     &--roles {
-      background-image: url('../../images/illustrations/User-roles.svg');
+      background-image: url("/bundles/pimui/images/illustrations/User-roles.svg");
     }
 
     &--proposal {
-      background-image: url('../../images/illustrations/Product.svg');
+      background-image: url("/bundles/pimui/images/illustrations/Product.svg");
     }
   }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/font-awesome/css/font-awesome.css
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/font-awesome/css/font-awesome.css
@@ -27,8 +27,8 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../font/fontawesome-webfont.eot?v=3.2.1');
-  src: url('../font/fontawesome-webfont.eot?#iefix&v=3.2.1') format('embedded-opentype'), url('../font/fontawesome-webfont.woff?v=3.2.1') format('woff'), url('../font/fontawesome-webfont.ttf?v=3.2.1') format('truetype'), url('../font/fontawesome-webfont.svg#fontawesomeregular?v=3.2.1') format('svg');
+  src: url('/bundles/pimui/lib/font-awesome/font/fontawesome-webfont.eot?v=3.2.1');
+  src: url('/bundles/pimui/lib/font-awesome/font/fontawesome-webfont.eot?#iefix&v=3.2.1') format('embedded-opentype'), url('/bundles/pimui/lib/font-awesome/font/fontawesome-webfont.woff?v=3.2.1') format('woff'), url('/bundles/pimui/lib/font-awesome/font/fontawesome-webfont.ttf?v=3.2.1') format('truetype'), url('/bundles/pimui/lib/font-awesome/font/fontawesome-webfont.svg#fontawesomeregular?v=3.2.1') format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/select2/select2.css
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/select2/select2.css
@@ -102,7 +102,7 @@ Version: 3.4.1 Timestamp: Thu Jun 27 18:02:10 PDT 2013
     text-decoration: none;
 
     border: 0;
-    background: url('select2.png') right top no-repeat;
+    background: url('/bundles/pimui/lib/select2/select2.png') right top no-repeat;
     cursor: pointer;
     outline: 0;
 }
@@ -226,7 +226,7 @@ Version: 3.4.1 Timestamp: Thu Jun 27 18:02:10 PDT 2013
     display: block;
     width: 100%;
     height: 100%;
-    background: url('select2.png') no-repeat 0 1px;
+    background: url('/bundles/pimui/lib/select2/select2.png') no-repeat 0 1px;
 }
 
 .select2-search {
@@ -262,13 +262,13 @@ Version: 3.4.1 Timestamp: Thu Jun 27 18:02:10 PDT 2013
        -moz-box-shadow: none;
             box-shadow: none;
 
-    background: #fff url('select2.png') no-repeat 100% -22px;
-    background: url('select2.png') no-repeat 100% -22px, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, white), color-stop(0.99, #eeeeee));
-    background: url('select2.png') no-repeat 100% -22px, -webkit-linear-gradient(center bottom, white 85%, #eeeeee 99%);
-    background: url('select2.png') no-repeat 100% -22px, -moz-linear-gradient(center bottom, white 85%, #eeeeee 99%);
-    background: url('select2.png') no-repeat 100% -22px, -o-linear-gradient(bottom, white 85%, #eeeeee 99%);
-    background: url('select2.png') no-repeat 100% -22px, -ms-linear-gradient(top, #ffffff 85%, #eeeeee 99%);
-    background: url('select2.png') no-repeat 100% -22px, linear-gradient(top, #ffffff 85%, #eeeeee 99%);
+    background: #fff url('/bundles/pimui/lib/select2/select2.png') no-repeat 100% -22px;
+    background: url('/bundles/pimui/lib/select2/select2.png') no-repeat 100% -22px, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, white), color-stop(0.99, #eeeeee));
+    background: url('/bundles/pimui/lib/select2/select2.png') no-repeat 100% -22px, -webkit-linear-gradient(center bottom, white 85%, #eeeeee 99%);
+    background: url('/bundles/pimui/lib/select2/select2.png') no-repeat 100% -22px, -moz-linear-gradient(center bottom, white 85%, #eeeeee 99%);
+    background: url('/bundles/pimui/lib/select2/select2.png') no-repeat 100% -22px, -o-linear-gradient(bottom, white 85%, #eeeeee 99%);
+    background: url('/bundles/pimui/lib/select2/select2.png') no-repeat 100% -22px, -ms-linear-gradient(top, #ffffff 85%, #eeeeee 99%);
+    background: url('/bundles/pimui/lib/select2/select2.png') no-repeat 100% -22px, linear-gradient(top, #ffffff 85%, #eeeeee 99%);
 }
 
 .select2-drop.select2-drop-above .select2-search input {
@@ -276,13 +276,13 @@ Version: 3.4.1 Timestamp: Thu Jun 27 18:02:10 PDT 2013
 }
 
 .select2-search input.select2-active {
-    background: #fff url('select2-spinner.gif') no-repeat 100%;
-    background: url('select2-spinner.gif') no-repeat 100%, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, white), color-stop(0.99, #eeeeee));
-    background: url('select2-spinner.gif') no-repeat 100%, -webkit-linear-gradient(center bottom, white 85%, #eeeeee 99%);
-    background: url('select2-spinner.gif') no-repeat 100%, -moz-linear-gradient(center bottom, white 85%, #eeeeee 99%);
-    background: url('select2-spinner.gif') no-repeat 100%, -o-linear-gradient(bottom, white 85%, #eeeeee 99%);
-    background: url('select2-spinner.gif') no-repeat 100%, -ms-linear-gradient(top, #ffffff 85%, #eeeeee 99%);
-    background: url('select2-spinner.gif') no-repeat 100%, linear-gradient(top, #ffffff 85%, #eeeeee 99%);
+    background: #fff url('/bundles/pimui/lib/select2/select2-spinner.gif') no-repeat 100%;
+    background: url('/bundles/pimui/lib/select2/select2-spinner.gif') no-repeat 100%, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, white), color-stop(0.99, #eeeeee));
+    background: url('/bundles/pimui/lib/select2/select2-spinner.gif') no-repeat 100%, -webkit-linear-gradient(center bottom, white 85%, #eeeeee 99%);
+    background: url('/bundles/pimui/lib/select2/select2-spinner.gif') no-repeat 100%, -moz-linear-gradient(center bottom, white 85%, #eeeeee 99%);
+    background: url('/bundles/pimui/lib/select2/select2-spinner.gif') no-repeat 100%, -o-linear-gradient(bottom, white 85%, #eeeeee 99%);
+    background: url('/bundles/pimui/lib/select2/select2-spinner.gif') no-repeat 100%, -ms-linear-gradient(top, #ffffff 85%, #eeeeee 99%);
+    background: url('/bundles/pimui/lib/select2/select2-spinner.gif') no-repeat 100%, linear-gradient(top, #ffffff 85%, #eeeeee 99%);
 }
 
 .select2-container-active .select2-choice,
@@ -438,7 +438,7 @@ disabled look for disabled choices in the results dropdown
 }
 
 .select2-more-results.select2-active {
-    background: #f4f4f4 url('select2-spinner.gif') no-repeat 100%;
+    background: #f4f4f4 url('/bundles/pimui/lib/select2/select2-spinner.gif') no-repeat 100%;
 }
 
 .select2-more-results {
@@ -521,7 +521,7 @@ disabled look for disabled choices in the results dropdown
 }
 
 .select2-container-multi .select2-choices .select2-search-field input.select2-active {
-    background: #fff url('select2-spinner.gif') no-repeat 100% !important;
+    background: #fff url('/bundles/pimui/lib/select2/select2-spinner.gif') no-repeat 100% !important;
 }
 
 .select2-default {
@@ -563,7 +563,7 @@ disabled look for disabled choices in the results dropdown
 
     font-size: 1px;
     outline: none;
-    background: url('select2.png') right top no-repeat;
+    background: url('/bundles/pimui/lib/select2/select2.png') right top no-repeat;
 }
 
 .select2-container-multi .select2-search-choice-close {
@@ -632,7 +632,7 @@ disabled look for disabled choices in the results dropdown
 
 @media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 144dpi)  {
   .select2-search input, .select2-search-choice-close, .select2-container .select2-choice abbr, .select2-container .select2-choice .select2-arrow b {
-      background-image: url('select2x2.png') !important;
+      background-image: url("/bundles/pimui/lib/select2/select2x2.png") !important;
       background-repeat: no-repeat !important;
       background-size: 60px 40px !important;
   }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/slimbox2/slimbox2.css
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/slimbox2/slimbox2.css
@@ -17,7 +17,7 @@
 }
 
 .lbLoading {
-	background: #fff url(loading.gif) no-repeat center;
+	background: #fff url("/bundles/pimui/lib/slimbox2/loading.gif") no-repeat center;
 }
 
 #lbImage {
@@ -42,7 +42,7 @@
 }
 
 #lbPrevLink:hover {
-	background: transparent url(prevlabel.gif) no-repeat 0 15%;
+	background: transparent url("/bundles/pimui/lib/slimbox2/prevlabel.gif") no-repeat 0 15%;
 }
 
 #lbNextLink {
@@ -50,7 +50,7 @@
 }
 
 #lbNextLink:hover {
-	background: transparent url(nextlabel.gif) no-repeat 100% 15%;
+	background: transparent url("/bundles/pimui/lib/slimbox2/nextlabel.gif") no-repeat 100% 15%;
 }
 
 #lbBottom {
@@ -67,7 +67,7 @@
 	float: right;
 	width: 66px;
 	height: 22px;
-	background: transparent url(closelabel.gif) no-repeat center;
+	background: transparent url("/bundles/pimui/lib/slimbox2/closelabel.gif") no-repeat center;
 	margin: 5px 0;
 	outline: none;
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**The problem**
As almost all resource paths in `url(...)` are relative in the PIM, when you `@import` PIM less files in another bundle (to override stuff for example), Assetic resolves paths wrongly.
We never saw the issue in the PIM because all the less is in UIBundle, but we had many issues in the Onboarder because of this.
This issue surely happened in customers projects too.

For example, a path declared as `url("../../images/jambon.png")` in the PIM could be resolved as `bundles/images/jambon.png` when compiled in a less importing the original file from the PIM, which doesn't exist at all.

**The fix**
- Always use absolute resource paths.
- Improve the `oro:assetic:dump` command to check if resource paths are absolute and if each path points to an existing file. It won't break the compilation because it could cause BC breaks, it will just display warnings.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
