### PR TITLE
PIM-8013: Fix 401 redirection on non-authorized page

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+# Bug fixes
+
+- PIM-8013: Fix 401 redirection on non authorized page
+
 # 3.0.17 (2019-05-10)
 
 # Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Http/FormAuthenticationEntryPoint.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Http/FormAuthenticationEntryPoint.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Platform\Bundle\UIBundle\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\HttpUtils;
+
+/**
+ * FormAuthenticationEntryPoint starts an authentication via a login form.
+ * This class extends that Symfony\Component\Security\Http\EntryPoint\FormAuthenticationEntryPoint to handle redirect to login properly in our SPA
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Anael Chardan <anael.chardan@akeneo.com>
+ */
+class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
+{
+    private $loginPath;
+    private $useForward;
+    private $httpKernel;
+    private $httpUtils;
+
+    /**
+     * @param HttpKernelInterface $kernel
+     * @param HttpUtils           $httpUtils  An HttpUtils instance
+     * @param string              $loginPath  The path to the login form
+     * @param bool                $useForward Whether to forward or redirect to the login form
+     */
+    public function __construct(HttpKernelInterface $kernel, HttpUtils $httpUtils, $loginPath, $useForward = false)
+    {
+        $this->httpKernel = $kernel;
+        $this->httpUtils = $httpUtils;
+        $this->loginPath = $loginPath;
+        $this->useForward = (bool) $useForward;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        if ($this->useForward) {
+            //This is the added code
+            if ($request->getRequestUri() === "/") {
+                return $this->httpUtils->createRedirectResponse($request, $this->loginPath);
+            }
+
+            $subRequest = $this->httpUtils->createRequest($request, $this->loginPath);
+
+            $response = $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+            if (200 === $response->getStatusCode()) {
+                $response->setStatusCode(401);
+            }
+
+            return $response;
+        }
+
+        return $this->httpUtils->createRedirectResponse($request, $this->loginPath);
+    }
+}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
@@ -48,3 +48,9 @@ services:
             - '@pim_user.context.user'
         tags:
             - { name: kernel.event_subscriber }
+
+    security.authentication.form_entry_point:
+        abstract: true
+        class: 'Akeneo\Platform\Bundle\UIBundle\Http\FormAuthenticationEntryPoint'
+        arguments:
+            - '@http_kernel'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The current problem is that we currently have problems like that: 

```
benoit@tec:/tmp$ wget http://pim-ce-master.local/-2019-01-23 18:35:19- http://pim-ce-master.local/Resolving pim-ce-master.local (pim-ce-master.local)... 127.0.0.1Connecting to pim-ce-master.local (pim-ce-master.local)|127.0.0.1|:80... connected.HTTP request sent, awaiting response... 401 Unauthorized
```

That what we get now:

```
wget http://localhost:8081
--2019-05-10 17:07:17--  http://localhost:8081/
Resolving localhost (localhost)... ::1, 127.0.0.1
Connecting to localhost (localhost)|::1|:8081... connected.
HTTP request sent, awaiting response... 302 Found
Location: http://localhost:8081/user/login [following]
--2019-05-10 17:07:24--  http://localhost:8081/user/login
Reusing existing connection to [localhost]:8081.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [text/html]
Saving to: ‘index.html.2’

index.html.2                                    [ <=>                                                                                      ]   3.47K  --.-KB/s    in 0s

2019-05-10 17:07:24 (386 MB/s) - ‘index.html.2’ saved [3558]
```

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
