### PR TITLE
PIM-8282: fix error message when removing category tree linked to a channel

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,6 +4,10 @@
 
 - PIM-8013: Fix 401 redirection on non authorized page
 
+# Improvements
+
+- PIM-8232: fix error message when removing category tree linked to a channel
+
 # 3.0.17 (2019-05-10)
 
 # Bug fixes

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -6,7 +6,7 @@
 
 # Improvements
 
-- PIM-8232: fix error message when removing category tree linked to a channel
+- PIM-8282: fix error message when removing category tree linked to a channel
 
 # 3.0.17 (2019-05-10)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/messages.en_US.yml
@@ -92,3 +92,5 @@ category:
   overview: Categories
 tree:
   edit: Edit tree
+  remove:
+      error_linked: This category tree cannot be deleted, it is linked to a channel

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/form.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/form.html.twig
@@ -54,7 +54,9 @@
                                   ~ 'info.category.keep products'|trans,
                               (form.vars.value.parent ? 'flash.category.removed' : 'flash.tree.removed')|trans,
                               '',
-                              'AknDropdown-menuLink delete'
+                              'AknDropdown-menuLink delete',
+                              '',
+                              'tree.remove.error_linked'
                           ) }}
                       {% endif %}
                   </div>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
@@ -37,6 +37,7 @@ Most Viewed: Most Viewed
 "Yes": "Yes"
 "No": "No"
 required: (required)
+The element could not be deleted: The element could not be deleted
 
 pim_ui.system_config:
     form:
@@ -284,9 +285,7 @@ Unique value:                        Unique value
 Attribute group:                     Attribute group
 Other:                               Other
 Variants behavior when edited:       Variants behavior when edited
-Edit:                                Edit
 Remove:                              Remove
-Delete:                              Delete
 Parameters:                          Parameters
 System:                              System
 Values:                              Values
@@ -310,7 +309,6 @@ Locale specific:                     Locale specific
 default:                             Default
 Axis:                                Axis
 Add attributes:                      Add attributes
-Translate from:                      Translate from
 switch_on:                           "Yes"
 switch_off:                          "No"
 Close:                               Close
@@ -330,7 +328,6 @@ Create:               Create
 Choose a family:      Choose a family
 Choose a unit:        Choose a unit
 No matches found:     No matches found
-Create:               Create
 
 Category tree: Category tree
 Completeness: Completeness
@@ -546,5 +543,3 @@ job_tracker:
         title: Process tracker
     filter:
         started_at: Started at
-
-

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Default/page_elements.html.twig
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Default/page_elements.html.twig
@@ -57,14 +57,14 @@
     {% set message = message|default('pim_enrich.entity.fallback.module.delete.item') %}
     {% set title = title|default('confirmation.delete'|trans) %}
     {% set successMessage = successMessage|default('flash.entity.removed'|trans) %}
-    {% set errorMessage = errorMessage|default('The element could not be deleted'|trans) %}
+    {% set errorMessage = errorMessage|default('The element could not be deleted')|trans %}
     href="javascript:void(0);" data-dialog="delete" data-title="{{ title }}" data-subtitle="{{ subTitle }}" data-message="{{ message }}" data-url="{{ url }}" data-redirect-url="{{ redirectUrl }}" data-method="DELETE" data-error-message="{{ errorMessage }}" data-success-message="{{ successMessage }}"
 {% endspaceless %}{% endmacro %}
 
 {% macro deleteLink(url, acl, redirectUrl, message, successMessage, title, class = '', subTitle = '', errorMessage = '') %}{% spaceless %}
     {% if acl is null or resource_granted(acl) %}
         {% import _self as elements %}
-        <a class="{{ class }}" title="{{ 'pim_common.delete'|trans|capitalize }}" {{elements.deleteLinkAttributes(url, redirectUrl, message, successMessage, title, subTitle)}} >
+        <a class="{{ class }}" title="{{ 'pim_common.delete'|trans|capitalize }}" {{elements.deleteLinkAttributes(url, redirectUrl, message, successMessage, title, subTitle, errorMessage)}} >
             {{ 'pim_common.delete'|trans|capitalize }}
         </a>
     {% endif %}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Default/page_elements.html.twig
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Default/page_elements.html.twig
@@ -53,14 +53,15 @@
 {% endspaceless %}
 {% endmacro %}
 
-{% macro deleteLinkAttributes(url, redirectUrl, message, successMessage, title, subTitle) %}{% spaceless %}
+{% macro deleteLinkAttributes(url, redirectUrl, message, successMessage, title, subTitle, errorMessage) %}{% spaceless %}
     {% set message = message|default('pim_enrich.entity.fallback.module.delete.item') %}
     {% set title = title|default('confirmation.delete'|trans) %}
     {% set successMessage = successMessage|default('flash.entity.removed'|trans) %}
-    href="javascript:void(0);" data-dialog="delete" data-title="{{ title }}" data-subtitle="{{ subTitle }}" data-message="{{ message }}" data-url="{{ url }}" data-redirect-url="{{ redirectUrl }}" data-method="DELETE" data-error-message="{% trans %}The element could not be deleted{% endtrans %}" data-success-message="{{ successMessage }}"
+    {% set errorMessage = errorMessage|default('The element could not be deleted'|trans) %}
+    href="javascript:void(0);" data-dialog="delete" data-title="{{ title }}" data-subtitle="{{ subTitle }}" data-message="{{ message }}" data-url="{{ url }}" data-redirect-url="{{ redirectUrl }}" data-method="DELETE" data-error-message="{{ errorMessage }}" data-success-message="{{ successMessage }}"
 {% endspaceless %}{% endmacro %}
 
-{% macro deleteLink(url, acl, redirectUrl, message, successMessage, title, class = '', subTitle = '') %}{% spaceless %}
+{% macro deleteLink(url, acl, redirectUrl, message, successMessage, title, class = '', subTitle = '', errorMessage = '') %}{% spaceless %}
     {% if acl is null or resource_granted(acl) %}
         {% import _self as elements %}
         <a class="{{ class }}" title="{{ 'pim_common.delete'|trans|capitalize }}" {{elements.deleteLinkAttributes(url, redirectUrl, message, successMessage, title, subTitle)}} >


### PR DESCRIPTION
All is in the PR title, i need a clear message when trying to remove category.

To do that, I have to add the error message as a parameter to a Twig macro (aw yeah) to be able to customize it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
