### PR TITLE
PIM-8275: Set default attribute group filter to "All" when selecting …

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -6,7 +6,7 @@
 - PIM-8276: Label or identifier search input is now limited to 255 characters.
 - PIM-8322: Add a command to update elasticsearch mapping without having the need to reindex everything.
 - PIM-8334: When a translation choice is not correct, it does not break the page anymore.
-- PIM-8275:Set default attribute group filter to "All" when selecting attributes on product mass actions
+- PIM-8275: Set default attribute group filter to "All" when selecting attributes on product mass actions
 
 # 2.3.42 (2019-05-06)
 

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -6,6 +6,7 @@
 - PIM-8276: Label or identifier search input is now limited to 255 characters.
 - PIM-8322: Add a command to update elasticsearch mapping without having the need to reindex everything.
 - PIM-8334: When a translation choice is not correct, it does not break the page anymore.
+- PIM-8275:Set default attribute group filter to "All" when selecting attributes on product mass actions
 
 # 2.3.42 (2019-05-06)
 
@@ -37,14 +38,14 @@
 
 ## Bug fixes
 
-- PIM-8290: Fix flat to standard conversion of metrics, with unit filled and empty amount 
+- PIM-8290: Fix flat to standard conversion of metrics, with unit filled and empty amount
 - PIM-8288: keep locale-specific but non-localizable attribute values in the flat normalization to make them appear in the product changeset
 
 # 2.3.37 (2019-04-15)
 
 ## Bug fixes
 
-- PIM-8269: Do not create empty product values if it relies on an attribute which has been removed from family 
+- PIM-8269: Do not create empty product values if it relies on an attribute which has been removed from family
 
 # 2.3.36 (2019-04-02)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/mass-edit/attributes.js
@@ -94,10 +94,6 @@ define(
                         }
                     });
 
-                    this.getExtension('attribute-group-selector').setCurrent(
-                        _.first(attributes).group
-                    );
-
                     this.setData(formData);
 
                     this.getRoot().trigger('pim_enrich:form:add-attribute:after');


### PR DESCRIPTION
…attributes on product mass actions

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

In the `Edit attribute values` and `Add attribute values` product mass actions, when the user added attributes to edit, the attribute group filter used to be set to the attribute group of the first selected attribute, which could be confusing because all selected attributes were not displayed.
With this PR the previous filter (default to "All") is kept when adding attributes.

Fixes #9455 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
