### PR TITLE
Fix sequential edit ui

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/SequentialEdit.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/SequentialEdit.less
@@ -28,6 +28,7 @@
     height: 25px;
     display: block;
     content: "";
+    cursor: default;
   }
 
   &-previous:before {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap-modal/bootstrap-modal.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap-modal/bootstrap-modal.js
@@ -100,6 +100,7 @@
      * @param {Boolean} [options.escape]      Whether the 'esc' key can dismiss the modal. Default: true, but false if options.cancellable is true
      * @param {Boolean} [options.animate]     Whether to animate in/out. Default: false
      * @param {Function} [options.template]   Compiled underscore template to override the default one
+     * @param {string} [options.picture]      Image filename to load for a custom illustration.
      */
     initialize: function(options) {
       this.options = _.extend({
@@ -112,7 +113,8 @@
         escape: true,
         animate: false,
         buttons: true,
-        template: template
+        template: template,
+        picture: undefined
       }, options);
     },
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Mini fix for the UI (seen with Camille):

1. Remove the `cursor: pointer` from a non-clickable element:
Before
![1](https://user-images.githubusercontent.com/1671213/57699057-50b85200-7657-11e9-88aa-f9f7ae6c0f67.gif)
After
![2](https://user-images.githubusercontent.com/1671213/57699060-52821580-7657-11e9-9dbc-dd2e3351b6f8.gif)

2. Fix the default option `picture` for the bootstrap modal. It is broken on the EE approval comment popup where a global picture object exists in the scope and the path is replaced by `[Object]` because there is no default value for the options.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
