### PR TITLE
PIM-8242: Fix search render of product grid filters

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 # Bug fixes
 
 - PIM-8013: Fix 401 redirection on non authorized page
+- PIM-8242: Fix the search result rendering of the product grid filters when a filter is unselected
 
 # Improvements
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
@@ -28,6 +28,7 @@ class FiltersColumn extends BaseView {
   public page: number = 1;
   public timer: any;
   public searchSelector: string;
+  private searchedFilters?: GridFilter[];
 
   readonly config: FiltersConfig;
   readonly template: string = `
@@ -196,15 +197,17 @@ class FiltersColumn extends BaseView {
       .val();
 
     if (searchValue.length === 0) {
+      this.searchedFilters = undefined;
+      
       return this.renderFilters();
     }
 
     return this.fetchFilters(searchValue, 1).then((loadedFilters: GridFilter[]) => {
       const defaultFilters: GridFilter[] = this.mergeAddedFilters(this.defaultFilters, loadedFilters)
       this.loadedFilters = this.mergeAddedFilters(this.loadedFilters, defaultFilters);
-      const searchedFilters = this.filterBySearchTerm(defaultFilters, searchValue);
+      this.searchedFilters = this.filterBySearchTerm(defaultFilters, searchValue);
 
-      return this.renderFilters(searchedFilters);
+      return this.renderFilters();
     });
   }
 
@@ -228,7 +231,7 @@ class FiltersColumn extends BaseView {
     $(this.filterList).off('scroll');
   }
 
-  renderFilters(filters = this.loadedFilters): void {
+  renderFilters(filters = this.searchedFilters || this.loadedFilters): void {
     const groupedFilters: {[name: string]: GridFilter[]} = this.groupFilters(filters);
     const list = document.createDocumentFragment();
     const filterColumn = $(this.filterList).find('.filters-column');


### PR DESCRIPTION

**Description (for Contributor and Core Developer)**

When searching in the filter list of the product grid, if you select then unselect a filter the current search result is discarded (it shouldn't):

Before
![1](https://user-images.githubusercontent.com/1671213/57707515-0ee3d780-7668-11e9-9bf5-65df974b6929.gif)

After
![2](https://user-images.githubusercontent.com/1671213/57707523-11dec800-7668-11e9-88f2-1fe8c5f18e3f.gif)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
