### PR TITLE
PIM-8343: Use BaseRemover instead of ObjectManager to delete a user

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+# Bug fixes
+
+- PIM-8343: Use BaseRemover instead of ObjectManager to delete a user
+
 # 3.0.18 (2019-05-15)
 
 # Bug fixes

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
@@ -18,7 +18,8 @@ services:
             - '@security.password_encoder'
             - '@event_dispatcher'
             - '@session'
-            - '@doctrine.orm.entity_manager'
+            - '@doctrine.orm.entity_manager' # todo merge 3.2: remove this line
+            - '@pim_user.remover.user'
 
     pim_user.controller.security_rest:
         class: '%pim_user.controller.security_rest.class%'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

This is basically a port of #9378 on the new UserController, it allows to trigger Akeneo storage events when deleting a user

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
