### PR TITLE
Fix #9833 add priority to event subscriber ConfigureMappingsSubscriber

### DIFF
--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Resources/config/doctrine.yml
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Resources/config/doctrine.yml
@@ -33,4 +33,4 @@ services:
             - '@akeneo_storage_utils.doctrine.orm_mappings_override_configurator'
             - '%akeneo_storage_utils.mapping_overrides%'
         tags:
-            - { name: doctrine.event_subscriber }
+            - { name: doctrine.event_subscriber, priority: 200 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Fix for  #9833 
The execution order of listeneres for the Event loadClassMetadata is changed, which is causing errors like "The target entity 'XXXInterface' specified on XXX  is unknown or not an entity". This error is thrown as the listener  Doctrine\ORM\Tools\ResolveTargetEntityListener is called after Akeneo\Bundle\StorageUtilsBundle\EventSubscriber\ConfigureMappingsSubscriber, which is responsible for merging the metadata of overridden entities to the new one. This results in an error that is thrown in the SchemaValidator which is caused by missing conversion of the interfaces to entities within the associations of the new entity.
Adding a higher priority to ConfigureMappingsSubscriber fixes this issue

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
