### PR TITLE
PIM-8346: Fix product grid price filters

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-8341: Use user locale for job execution normalization
 - PIM-8347: Fix variant navigation display in case of long attribute labels
+- PIM-8346: Hide the currency selector on the product grid price filters 'empty' and 'not empty'
 
 ## Improvement
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
@@ -85,6 +85,12 @@ define(
                     })
                 );
 
+                if (true === _.contains(['empty', 'not empty'], this._getDisplayValue().type)) {
+                    this._disableInput();
+                } else {
+                    this._enableInput();
+                }
+
                 return this;
             },
 
@@ -117,8 +123,8 @@ define(
              */
             _getCriteriaHint: function () {
                 var value = this._getDisplayValue();
-                if (_.contains(['empty', 'not empty'], value.type) && value.currency) {
-                    return this._getChoiceOption(value.type).label + ': ' + value.currency;
+                if (_.contains(['empty', 'not empty'], value.type)) {
+                    return this._getChoiceOption(value.type).label;
                 }
                 if (!value.value) {
                     return this.placeholder;
@@ -143,12 +149,6 @@ define(
              */
             _onValueUpdated: function(newValue, oldValue) {
                 this._highlightDropdown(newValue.currency, '.currency');
-                if (_.contains(['empty', 'not empty'], newValue.type)) {
-                    this._disableInput();
-                } else {
-                    this._enableInput();
-                }
-
                 this._triggerUpdate(newValue, oldValue);
                 this._updateCriteriaHint();
             },
@@ -166,20 +166,6 @@ define(
                 }
 
                 return this;
-            },
-
-            /**
-             * @inheritDoc
-             */
-            _onClickChoiceValue: function(e) {
-                NumberFilter.prototype._onClickChoiceValue.apply(this, arguments);
-                if ($(e.currentTarget).attr('data-input-toggle')) {
-                    if (_.contains(['empty', 'not empty'], $(e.currentTarget).attr('data-value'))) {
-                        this._disableInput();
-                    } else {
-                        this._enableInput();
-                    }
-                }
             },
 
             /**
@@ -209,18 +195,14 @@ define(
              * {@inheritdoc}
              */
             _disableInput() {
-                this.$el.find(this.criteriaValueSelectors.value).hide();
-                this.$el.find('.AknFilterChoice-currency')
-                    .addClass('AknFilterChoice-currency--centered');
+                this.$el.find('.AknFilterChoice-inputContainer').hide();
             },
 
             /**
              * {@inheritdoc}
              */
             _enableInput() {
-                this.$el.find(this.criteriaValueSelectors.value).show();
-                this.$el.find('.AknFilterChoice-currency')
-                    .removeClass('AknFilterChoice-currency--centered');
+                this.$el.find('.AknFilterChoice-inputContainer').show();
             }
         });
     }

--- a/src/Pim/Bundle/FilterBundle/Filter/ProductValue/PriceFilter.php
+++ b/src/Pim/Bundle/FilterBundle/Filter/ProductValue/PriceFilter.php
@@ -106,7 +106,7 @@ class PriceFilter extends OroNumberFilter
         ];
 
         if (!isset($operatorTypes[$type])) {
-            throw new InvalidArgumentException(sprintf('Operator "%s" is undefined', $type));
+            throw new \InvalidArgumentException(sprintf('Operator "%s" is undefined', $type));
         }
 
         return $operatorTypes[$type];

--- a/tests/legacy/features/product/filtering/filter_products_per_price.feature
+++ b/tests/legacy/features/product/filtering/filter_products_per_price.feature
@@ -41,7 +41,7 @@ Feature: Filter products per price
       | price  | <=       | 23 EUR   | postit and book |
       | price  | >        | 40.5 EUR |                 |
     When I show the filter "price"
-    And I filter by "price" with operator "is empty" and value " EUR"
+    And I filter by "price" with operator "is empty" and value ""
     And I should see product mug
-    And I filter by "price" with operator "is not empty" and value " EUR"
+    And I filter by "price" with operator "is not empty" and value ""
     And I should see product postit


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Hide the currency selector on the product grid price filters **empty** and **not empty**.
The goal is to not confuse the user and make them believe the price will be filtered on the selected currency (which is not the case).

Before:
![3](https://user-images.githubusercontent.com/1671213/58004198-f9950000-7ae2-11e9-807d-74c31ec21eda.png)

After:
![1](https://user-images.githubusercontent.com/1671213/58004203-fdc11d80-7ae2-11e9-9e5b-a67614aa0333.png)

Also, fix a bug where if you reload the page with a price filter **empty** or **not empty** the form will display an input type text:
![2](https://user-images.githubusercontent.com/1671213/58004325-4973c700-7ae3-11e9-8043-462f008092fe.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | Todo
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
