### PR TITLE
PIM-8336: Fix product grid's locale switcher cache

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/grid/locale-switcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/grid/locale-switcher.js
@@ -53,7 +53,15 @@ define(
             */
             configure() {
                 return $.when(
-                    this.fetchLocales().then(locales => this.locales = locales),
+                    this.fetchLocales().then(locales => {
+                        this.locales = locales;
+                        const currentLocaleCode = UserContext.get('catalogLocale');
+                        let currentLocale = _.find(this.locales, {code: currentLocaleCode});
+                        if (undefined === currentLocale) {
+                            currentLocale = _.first(this.locales);
+                            UserContext.set('catalogLocale', currentLocale.code);
+                        }
+                    }),
                     BaseForm.prototype.configure.apply(this, arguments)
                 );
             },
@@ -64,9 +72,6 @@ define(
             render() {
                 const currentLocaleCode = UserContext.get('catalogLocale');
                 let currentLocale = _.find(this.locales, { code: currentLocaleCode });
-                if (undefined === currentLocale) {
-                    currentLocale = _.first(this.locales);
-                }
 
                 this.$el.empty().append(this.template({
                     localeLabel: __('pim_enrich.entity.locale.uppercase_label'),


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

This PR does 2 things:
- the locale fetcher now caches active locales based on the `filter_locales` param in searchOptions argument (prior to this, it always returned the same result, regardless of the search options)
- in the product grid's locale switcher, if the current locale (in the UserContext) is not available (e.g because of permissions issues), it fallbacks to the first available locale and updates the UserContext accordingly. This check is done in `configure()` rather than `render()`, so the other components are aware of this change sooner

see https://akeneo.atlassian.net/browse/PIM-8336 for more info


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
