### PR TITLE
EE contribution - Attribute option form errors and validator

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -243,6 +243,8 @@ services:
 
     pim_catalog.validator.constraint.attribute_type_for_option:
         class: '%pim_catalog.validator.constraint.attribute_type_for_option.class%'
+        arguments:
+            - ['pim_catalog_simpleselect', 'pim_catalog_multiselect']
         tags:
             - { name: validator.constraint_validator, alias: pim_attribute_type_for_option_validator }
 

--- a/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/AttributeOptionController.php
@@ -257,11 +257,15 @@ class AttributeOptionController
      *
      * @param FormInterface $form
      *
-     * @return object
+     * @return array
      */
     protected function getFormErrors($form)
     {
         $errors = [];
+
+        foreach ($form->getErrors() as $error) {
+            $errors[$form->getName()] = $error->getMessage();
+        }
 
         foreach ($form as $child) {
             foreach ($child->getErrors(true) as $error) {

--- a/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOptionValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOptionValidator.php
@@ -16,18 +16,29 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class AttributeTypeForOptionValidator extends ConstraintValidator
 {
+    /** @var array */
+    protected $supportedAttributeTypes;
+
     /**
-     * @param object     $attributeOption
-     * @param Constraint $constraint
+     * AttributeTypeForOptionValidator constructor.
+     * @param array $supportedAttributeTypes
+     */
+    public function __construct(array $supportedAttributeTypes)
+    {
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+    }
+
+    /**
+     * @param object                            $attributeOption
+     * @param AttributeTypeForOption|Constraint $constraint
      */
     public function validate($attributeOption, Constraint $constraint)
     {
         /** @var AttributeOptionInterface */
         if ($attributeOption instanceof AttributeOptionInterface) {
             $attribute = $attributeOption->getAttribute();
-            $authorizedTypes = [AttributeTypes::OPTION_SIMPLE_SELECT, AttributeTypes::OPTION_MULTI_SELECT];
-            if (null !== $attribute && !in_array($attribute->getType(), $authorizedTypes)) {
-                $this->addInvalidAttributeViolation($constraint, $attributeOption, $authorizedTypes);
+            if (null !== $attribute && !in_array($attribute->getType(), $this->supportedAttributeTypes)) {
+                $this->addInvalidAttributeViolation($constraint, $attributeOption, $this->supportedAttributeTypes);
             }
         }
     }

--- a/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOptionValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOptionValidator.php
@@ -23,7 +23,7 @@ class AttributeTypeForOptionValidator extends ConstraintValidator
      * AttributeTypeForOptionValidator constructor.
      * @param array $supportedAttributeTypes
      *
-     * TODO on merge 3.2, remove = null
+     * TODO on merge 3.2, remove = null and add BC BREAK in changelog
      */
     public function __construct(array $supportedAttributeTypes = [])
     {

--- a/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOptionValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/AttributeTypeForOptionValidator.php
@@ -22,8 +22,10 @@ class AttributeTypeForOptionValidator extends ConstraintValidator
     /**
      * AttributeTypeForOptionValidator constructor.
      * @param array $supportedAttributeTypes
+     *
+     * TODO on merge 3.2, remove = null
      */
-    public function __construct(array $supportedAttributeTypes)
+    public function __construct(array $supportedAttributeTypes = [])
     {
         $this->supportedAttributeTypes = $supportedAttributeTypes;
     }
@@ -34,11 +36,18 @@ class AttributeTypeForOptionValidator extends ConstraintValidator
      */
     public function validate($attributeOption, Constraint $constraint)
     {
+        /* TODO on merge 3.2, remove condition - replace $authorizedTypes by $this->supportedAttributeTypes */
+        if (!empty($this->supportedAttributeTypes)) {
+            $authorizedTypes = $this->supportedAttributeTypes;
+        } else {
+            $authorizedTypes = [AttributeTypes::OPTION_SIMPLE_SELECT, AttributeTypes::OPTION_MULTI_SELECT];
+        }
+
         /** @var AttributeOptionInterface */
         if ($attributeOption instanceof AttributeOptionInterface) {
             $attribute = $attributeOption->getAttribute();
-            if (null !== $attribute && !in_array($attribute->getType(), $this->supportedAttributeTypes)) {
-                $this->addInvalidAttributeViolation($constraint, $attributeOption, $this->supportedAttributeTypes);
+            if (null !== $attribute && !in_array($attribute->getType(), $authorizedTypes)) {
+                $this->addInvalidAttributeViolation($constraint, $attributeOption, $authorizedTypes);
             }
         }
     }


### PR DESCRIPTION
I created a custom attribute in order to override default simple select attribute type.

When I submitted my first option the controller returned a 400 without any messages. The problem was due to the fact that the method getFormErrors only return errors for child forms so I overrided it to also return global form errors.

I also used parameter in the AttributeTypeForOptionValidator class to handle supported attribute types like a lot of your services because otherwise, we have to override your class instead of just the parameter of your service.

(cf https://github.com/akeneo/pim-community-dev/pull/9780)

