### PR TITLE
PIM-8347: Fix variant navigation display in case of long attribute labels

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8341: Use user locale for job execution normalization
+- PIM-8347: Fix variant navigation display in case of long attribute labels
 
 ## Improvement
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family-variant/attribute-set.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/family-variant/attribute-set.html
@@ -2,7 +2,7 @@
 <div class="AknFamilyVariant family-variant-levels">
     <div class="AknFamilyVariant-level">
         <div class="common-attribute AknFamilyVariant-column AknFamilyVariant-column--common">
-            <div class="AknFamilyVariant-axes AknVerticalList-item">
+            <div class="AknFamilyVariant-axes AknVerticalList-item" title="<%- __('pim_enrich.entity.family.variant.common.title') %>">
                 <%- __('pim_enrich.entity.family.variant.common.title') %>
             </div>
             <div data-level="0" id="attribute-groups-column-level-0" class="attribute-list connected-group-sortable">
@@ -28,7 +28,11 @@
             <span class="AknFamilyVariant-levelPathLabel"><%- __('pim_enrich.entity.family.variant.level_' + level.level + '.label') %></span>
         </div>
         <div class="family-variant-level AknFamilyVariant-column AknFamilyVariant-column--level<%- level.level %>" data-level="<%- level.level %>">
-            <div class="AknFamilyVariant-axes AknVerticalList-item">
+            <div class="AknFamilyVariant-axes AknVerticalList-item" title="
+                <%- level.axes.map(function (axis) {
+                    return i18n.getLabel(getAttribute(axis).labels, UserContext.get('catalogLocale'), getAttribute(axis).code);
+                }).join(', ') %>
+                (<%- __('pim_enrich.entity.family.variant.axis.label') %>)">
                 <%- level.axes.map(function (axis) {
                     return i18n.getLabel(getAttribute(axis).labels, UserContext.get('catalogLocale'), getAttribute(axis).code);
                 }).join(', ') %>

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/navigation.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/product/form/variant-navigation/navigation.html
@@ -4,7 +4,7 @@
     <span class="AknVariantNavigation-item <% if (navigation[level].selected && navigation[level].selected.id === entity.meta.id) { %>AknVariantNavigation-item--highlight<% } %>">
         <% if (level > 0) { %>
             <span class="AknVariantNavigation-itemLabel" data-action="navigateToLevel" data-level="<%- level %>">
-                <span class="AknVariantNavigation-axisName <%- navigation[level].selected ? 'AknVariantNavigation-axisName--selected' : '' %>" data-level="<%- level %>"><%- navigation[level].axes[currentLocale] %></span>
+                <span class="AknVariantNavigation-axisName <%- navigation[level].selected ? 'AknVariantNavigation-axisName--selected' : '' %>" data-level="<%- level %>" title="<%- navigation[level].axes[currentLocale] %>"><%- navigation[level].axes[currentLocale] %></span>
 
                 <% if (navigation[level].selected) { %>
                     <span class="AknVariantNavigation-axisValue" data-level="<%- level %>">

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/FamilyVariant.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/FamilyVariant.less
@@ -76,6 +76,11 @@
         color: @AknLightPurple;
         background-color: @AknLightGray;
         font-size: @AknFontSizeBig;
+        white-space: nowrap;
+        max-width: 28vw;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: inline-block;
     }
 
     &-column--level2 {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
@@ -5,9 +5,10 @@
   border-radius: 3px;
   height: 34px;
   margin-top: 20px;
+  display: flex;
 
   &-item {
-    display: inline-block;
+    display: inline-flex;
     padding: 0 20px;
     height: 32px;
     line-height: 32px;
@@ -51,18 +52,28 @@
         border-radius: 2px;
       }
     }
+
+    & + & {
+      margin-left: 10px;
+    }
   }
 
   &-itemLabel {
     cursor: pointer;
+    display: flex;
   }
 
   &-axisName {
     text-transform: uppercase;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: ~"calc(100vw / 5)";
+    display: inline-block;
+    overflow: hidden;
+  }
 
-    &--selected:after {
-      content:":";
-    }
+  &-axisName&-axisName--selected + &-axisValue:before {
+    content:":";
   }
 
   &-listItem {

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -371,6 +371,7 @@
     margin-left: 5px;
     margin-right: -15px;
     z-index: 5;
+    margin-top: 6px;
 
     .select2-choice {
       line-height: inherit;


### PR DESCRIPTION
Before

![Screenshot 2019-05-16 at 09 55 30](https://user-images.githubusercontent.com/1590933/58010086-0409c680-7af0-11e9-8210-39d04c60ff2c.png)

![same issue on the Family variant](https://user-images.githubusercontent.com/1590933/58010092-079d4d80-7af0-11e9-81ce-ff7034affaf1.png)


After

![Selection_085](https://user-images.githubusercontent.com/1590933/58010111-1126b580-7af0-11e9-9995-5fc78498cc6a.png)

![Selection_086](https://user-images.githubusercontent.com/1590933/58010115-13890f80-7af0-11e9-8bc0-9fb0e6fc5c88.png)




| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
