### PR TITLE
PIM-8351: Fix entity overriding priority

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8351: Fix entity overriding priority
+
 # 2.3.44 (2019-05-20)
 
 ## Bug fixes

--- a/src/Akeneo/Bundle/StorageUtilsBundle/Resources/config/doctrine.yml
+++ b/src/Akeneo/Bundle/StorageUtilsBundle/Resources/config/doctrine.yml
@@ -33,4 +33,4 @@ services:
             - '@akeneo_storage_utils.doctrine.orm_mappings_override_configurator'
             - '%akeneo_storage_utils.mapping_overrides%'
         tags:
-            - { name: doctrine.event_subscriber }
+            - { name: doctrine.event_subscriber, priority: 100 }

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/QueryBuilderUtility.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/QueryBuilderUtility.php
@@ -33,7 +33,7 @@ class QueryBuilderUtility
     }
 
     /**
-     * @todo Merge master: Dead code, to be removed.
+     * @deprecated Will be removed in 4.0
      *
      * Replaces name of tables in DBAL queries
      *

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/QueryBuilderUtility.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/QueryBuilderUtility.php
@@ -33,6 +33,8 @@ class QueryBuilderUtility
     }
 
     /**
+     * @todo Merge master: Dead code, to be removed.
+     *
      * Replaces name of tables in DBAL queries
      *
      * @param EntityManager $em
@@ -70,6 +72,8 @@ class QueryBuilderUtility
     }
 
     /**
+     * @todo Merge master: Dead code, to be removed.
+     *
      * Get metadata of product value table
      *
      * @param EntityManager $em

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/QueryBuilderUtility.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/QueryBuilderUtility.php
@@ -72,7 +72,7 @@ class QueryBuilderUtility
     }
 
     /**
-     * @todo Merge master: Dead code, to be removed.
+     * @deprecated Will be removed in 4.0
      *
      * Get metadata of product value table
      *


### PR DESCRIPTION
* What was the issue

Today, you can override basic entities by using ConfigureMappingsSubscriber and
- defining a new class
- defining a `mapping_override`
- defining a new ORM mapping.

An entity can have mapping (many to one, one to many, etc) to Interfaces, as we have a compiler pass to get real classes instead of these Interfaces (ResolveTargetEntityListener)

The issue is that the compilation to transform Interfaces to real classes was done before the override of entity. This implies an error during hydratation because Interfaces entities were not found.

* What causes the issue 

This issue exists since we upgraded Symfony from 3.4.4 to 3.4.26. We didn't find anything in the Symfony Changelog related to this issue.

* What is the solution

The solution is to change the priority of the ConfigureMappingsSubscriber to be executed before all the other subscribers.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added legacy Behats               | n
| Added acceptance tests            | n
| Added integration tests           | n
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
