### PR TITLE
TIP-1157: Fix query when there is no association type in the catalog

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProducts.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProducts.php
@@ -137,7 +137,7 @@ class SqlGetConnectorProducts implements Query\GetConnectorProducts
                 $row['category_codes'],
                 $row['group_codes'],
                 $row['product_model_code'],
-                $row['associations'],
+                $row['associations'] ?? [],
                 [],
                 $this->valueCollectionFactory->createFromStorageFormat($rawValues)
             );

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsIntegration.php
@@ -13,7 +13,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductPrice;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetConnectorProducts;
-use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\PriceCollectionValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
@@ -21,9 +20,6 @@ use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
 
-/**
- * @group ce
- */
 class SqlGetConnectorProductsIntegration extends TestCase
 {
     protected function setUp(): void
@@ -107,6 +103,9 @@ class SqlGetConnectorProductsIntegration extends TestCase
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
     }
 
+    /**
+     * @group ce
+     */
     public function test_get_product_from_the_PQB()
     {
         $query = $this->getQuery();
@@ -214,6 +213,9 @@ class SqlGetConnectorProductsIntegration extends TestCase
         Assert::assertEquals($expectedProducts, $product);
     }
 
+    /**
+     * @group ce
+     */
     public function test_get_product_from_the_PQB_by_filtering_on_values()
     {
         $query = $this->getQuery();
@@ -319,6 +321,9 @@ class SqlGetConnectorProductsIntegration extends TestCase
         Assert::assertEquals($expectedProducts, $product);
     }
 
+    /**
+     * @group ce
+     */
     public function test_get_product_from_an_identifier()
     {
         $userId = $this
@@ -386,6 +391,21 @@ class SqlGetConnectorProductsIntegration extends TestCase
 
         $query = $this->getQuery();
         $query->fromProductIdentifier('foo', (int) $userId);
+    }
+
+    public function test_it_returns_empty_associations_if_there_is_no_association_type()
+    {
+        $this->get('database_connection')->executeQuery('DELETE FROM pim_catalog_association_type_translation');
+        $this->get('database_connection')->executeQuery('DELETE FROM pim_catalog_association_type');
+
+        $userId = $this
+            ->get('database_connection')
+            ->fetchColumn('SELECT id FROM oro_user WHERE username = "admin"', [], 0);
+
+        $query = $this->getQuery();
+        $product = $query->fromProductIdentifier('apollon_B_false', (int)$userId);
+
+        Assert::assertSame([], $product->associations());
     }
 
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Fixes #10066 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
