### PR TITLE
PIM-8364: Fix bootstrap modal having illustration

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8257: Fix user grid filter set when creating a new user
+- PIM-8364: Fix bootstrap modal having illustration
 
 # 3.0.19 (2019-05-21)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap-modal/bootstrap-modal.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap-modal/bootstrap-modal.js
@@ -15,7 +15,7 @@
 (function($, _, Backbone) {
   var template = _.template('\
     <div class="AknFullPage">\
-      <div class="AknFullPage-content<% if (typeof picture !== \'undefined\' || typeof illustrationClass !== \'undefined\') { %> AknFullPage-content--withIllustration<% } %>">\
+      <div class="AknFullPage-content<% if (typeof picture !== \'undefined\') { %> AknFullPage-content--withIllustration<% } %>">\
         <div>\
           <% if (typeof picture !== \'undefined\') { %>\
             <img src="bundles/pimui/images/<%- picture %>" alt="<%- picture %>"/>\


### PR DESCRIPTION
This will fix the modal of the proposals screen in EE. The class "AknFullPage-content--withIllustration" must be added every time there will be a "AknFullPage-illustration" child.

It reports what has been done on 3.1, particularly this : https://github.com/akeneo/pim-community-dev/commit/c845eb9694eb979045f37ca27b67dfe8eec409bd#diff-d9e6bfe307e86d918a0bb77e6f941ca6

