### PR TITLE
[CE contribution] - Ignore some tables, which are not managed by doctrine

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -9,6 +9,10 @@ web_profiler:
     toolbar: true
     intercept_redirects: false
 
+doctrine:
+    dbal:
+        schema_filter: ~^(?!akeneo_structure_version_last_update|pim_aggregated_volume|pim_configuration|pim_session)~
+
 monolog:
     handlers:
         main:


### PR DESCRIPTION
Fixes #9796

Exclude the following tables from doctrine:
- akeneo_structure_version_last_update
- pim_aggregated_volume
- pim_configuration
- pim_session

Now Doctrine Diff command is not dropping these necessary tables anymore.