### PR TITLE
TIP-1117: Improve command to create new users

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -7,6 +7,7 @@
 ## Technical improvement
 
 - DAPI-242: Improve queue to consume specific jobs
+- TIP-1117: For security reasons, "admin" user is no longer part of the minimal catalog
 
 ## BC breaks
 

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -8,6 +8,7 @@
 
 - DAPI-242: Improve queue to consume specific jobs
 - TIP-1117: For security reasons, "admin" user is no longer part of the minimal catalog
+- TIP-1117: `pim:user:create` command now has a non interactive mode
 
 ## BC breaks
 

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal/users.csv
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal/users.csv
@@ -1,2 +1,1 @@
 username;first_name;last_name;email;password;catalog_default_locale;user_default_locale;catalog_default_scope;default_category_tree;roles;groups;enabled
-admin;John;Doe;admin@example.com;admin;en_US;en_US;ecommerce;master;ROLE_ADMINISTRATOR;IT support;1

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -315,6 +315,11 @@ abstract class ApiTestCase extends WebTestCase
             $user->removeRole($userRole);
         }
 
+        $group = $this->get('pim_user.repository.group')->findOneByIdentifier('IT support');
+        if (null !== $group) {
+            $user->addGroup($group);
+        }
+
         $this->get('validator')->validate($user);
         $this->get('pim_user.saver.user')->save($user);
 

--- a/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
+++ b/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
@@ -21,6 +21,33 @@ use Symfony\Component\Console\Question\Question;
 class CreateUserCommand extends ContainerAwareCommand
 {
     public const COMMAND_NAME = 'pim:user:create';
+    
+    /** @var string */
+    private $password;
+
+    /** @var string */
+    private $username;
+
+    /** @var string */
+    private $firstName;
+
+    /** @var string */
+    private $lastName;
+
+    /** @var string */
+    private $email;
+
+    /** @var string */
+    private $userDefaultLocaleCode;
+
+    /** @var string */
+    private $catalogDefaultLocaleCode;
+
+    /** @var string */
+    private $catalogDefaultScopeCode;
+
+    /** @var string */
+    private $defaultTreeCode;
 
     /**
      * {@inheritdoc}
@@ -37,32 +64,19 @@ class CreateUserCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
-        $output->writeln("Please enter the user's information below.");
-
-        $username = $this->askForUsername($input, $output);
-        $password = $this->askForPassword($input, $output);
-        $this->confirmPassword($input, $output, $password);
-        $firstName = $this->askForFirstName($input, $output);
-        $lastName = $this->askForLastName($input, $output);
-        $email = $this->askForEmail($input, $output);
-        $userDefaultLocaleCode = $this->askForUserDefaultLocaleCode($input, $output);
-        $catalogDefaultLocaleCode = $this->askForCatalogDefaultLocaleCode($input, $output);
-        $catalogDefaultScopeCode = $this->askForCatalogDefaultScopeCode($input, $output);
-        $defaultTreeCode = $this->askForDefaultTreeCode($input, $output);
-
         $user = $this->getContainer()->get('pim_user.factory.user')->create();
         $this->getContainer()->get('pim_user.updater.user')->update(
             $user,
             [
-                'username' => $username,
-                'password' => $password,
-                'first_name' => $firstName,
-                'last_name' => $lastName,
-                'email' => $email,
-                'user_default_locale' => $userDefaultLocaleCode,
-                'catalog_default_locale' => $catalogDefaultLocaleCode,
-                'catalog_default_scope' => $catalogDefaultScopeCode,
-                'default_category_tree' => $defaultTreeCode,
+                'username' => $this->username,
+                'password' => $this->password,
+                'first_name' => $this->firstName,
+                'last_name' => $this->lastName,
+                'email' => $this->email,
+                'user_default_locale' => $this->userDefaultLocaleCode,
+                'catalog_default_locale' => $this->catalogDefaultLocaleCode,
+                'catalog_default_scope' => $this->catalogDefaultScopeCode,
+                'default_category_tree' => $this->defaultTreeCode,
             ]
         );
 
@@ -81,7 +95,23 @@ class CreateUserCommand extends ContainerAwareCommand
 
         $this->getContainer()->get('pim_user.saver.user')->save($user);
 
-        $output->writeln(sprintf("<info>User %s has been created.</info>", $username));
+        $output->writeln(sprintf("<info>User %s has been created.</info>", $this->username));
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln("Please enter the user's information below.");
+
+        $this->username = $this->askForUsername($input, $output);
+        $this->password = $this->askForPassword($input, $output);
+        $this->confirmPassword($input, $output, $this->password);
+        $this->firstName = $this->askForFirstName($input, $output);
+        $this->lastName = $this->askForLastName($input, $output);
+        $this->email = $this->askForEmail($input, $output);
+        $this->userDefaultLocaleCode = $this->askForUserDefaultLocaleCode($input, $output);
+        $this->catalogDefaultLocaleCode = $this->askForCatalogDefaultLocaleCode($input, $output);
+        $this->catalogDefaultScopeCode = $this->askForCatalogDefaultScopeCode($input, $output);
+        $this->defaultTreeCode = $this->askForDefaultTreeCode($input, $output);
     }
 
     private function askForUsername(InputInterface $input, OutputInterface $output): string
@@ -260,5 +290,10 @@ class CreateUserCommand extends ContainerAwareCommand
         }
 
         $user->addRole($role);
+    }
+
+    private function isInteractive(): bool
+    {
+        return true;
     }
 }

--- a/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
+++ b/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
@@ -62,6 +62,7 @@ class CreateUserCommand extends ContainerAwareCommand
             ->addArgument('email')
             ->addArgument('firstName')
             ->addArgument('lastName')
+            ->addArgument('locale', null, 'A locale in the form "en_US"')
         ;
     }
 
@@ -304,20 +305,32 @@ class CreateUserCommand extends ContainerAwareCommand
 
     private function gatherArgumentsForNonInteractiveMode(InputInterface $input): void
     {
-        if (null !== $input->getArgument('username')) {
-            $this->username = $input->getArgument('username');
+        if (null === $input->getArgument('username')) {
+            throw new \InvalidArgumentException("The username is mandatory.");
         }
-        if (null !== $input->getArgument('password')) {
-            $this->password = $input->getArgument('password');
+        if (null === $input->getArgument('password')) {
+            throw new \InvalidArgumentException("The password is mandatory.");
         }
-        if (null !== $input->getArgument('email')) {
-            $this->email = $input->getArgument('email');
+        if (null === $input->getArgument('email')) {
+            throw new \InvalidArgumentException("The email is mandatory.");
         }
-        if (null !== $input->getArgument('firstName')) {
-            $this->firstName = $input->getArgument('firstName');
+        if (null === $input->getArgument('firstName')) {
+            throw new \InvalidArgumentException("The first name is mandatory.");
         }
-        if (null !== $input->getArgument('lastName')) {
-            $this->lastName = $input->getArgument('lastName');
+        if (null === $input->getArgument('lastName')) {
+            throw new \InvalidArgumentException("The last name is mandatory.");
         }
+        if (null === $input->getArgument('locale')) {
+            throw new \InvalidArgumentException("The locale is mandatory.");
+        }
+
+        $this->username = $input->getArgument('username');
+        $this->password = $input->getArgument('password');
+        $this->email = $input->getArgument('email');
+        $this->firstName = $input->getArgument('firstName');
+        $this->lastName = $input->getArgument('lastName');
+        $this->userDefaultLocaleCode = $input->getArgument('locale');
+        // we can't use $input->getArgument('locale') for catalog locale as maybe it's not activated
+        $this->catalogDefaultLocaleCode = 'en_US';
     }
 }

--- a/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
+++ b/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Question\Question;
 class CreateUserCommand extends ContainerAwareCommand
 {
     public const COMMAND_NAME = 'pim:user:create';
-    
+
     /** @var string */
     private $password;
 
@@ -56,7 +56,13 @@ class CreateUserCommand extends ContainerAwareCommand
     {
         $this
             ->setName(static::COMMAND_NAME)
-            ->setDescription('Creates a PIM user.');
+            ->setDescription('Creates a PIM user. This command can be launched interactively or non interactively (with the "-n" option). When launched non interactively you have to provide arguments to the command. When launched interactively, command arguments will be ignored.')
+            ->addArgument('username')
+            ->addArgument('password')
+            ->addArgument('email')
+            ->addArgument('firstName')
+            ->addArgument('lastName')
+        ;
     }
 
     /**
@@ -64,6 +70,10 @@ class CreateUserCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
+        if (!$input->isInteractive()) {
+            $this->gatherArgumentsForNonInteractiveMode($input);
+        }
+
         $user = $this->getContainer()->get('pim_user.factory.user')->create();
         $this->getContainer()->get('pim_user.updater.user')->update(
             $user,
@@ -292,8 +302,22 @@ class CreateUserCommand extends ContainerAwareCommand
         $user->addRole($role);
     }
 
-    private function isInteractive(): bool
+    private function gatherArgumentsForNonInteractiveMode(InputInterface $input): void
     {
-        return true;
+        if (null !== $input->getArgument('username')) {
+            $this->username = $input->getArgument('username');
+        }
+        if (null !== $input->getArgument('password')) {
+            $this->password = $input->getArgument('password');
+        }
+        if (null !== $input->getArgument('email')) {
+            $this->email = $input->getArgument('email');
+        }
+        if (null !== $input->getArgument('firstName')) {
+            $this->firstName = $input->getArgument('firstName');
+        }
+        if (null !== $input->getArgument('lastName')) {
+            $this->lastName = $input->getArgument('lastName');
+        }
     }
 }

--- a/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
+++ b/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
@@ -60,7 +60,15 @@ class CreateUserCommand extends ContainerAwareCommand
     {
         $this
             ->setName(static::COMMAND_NAME)
-            ->setDescription('Creates a PIM user. This command can be launched interactively or non interactively (with the "-n" option). When launched non interactively you have to provide arguments to the command. When launched interactively, command arguments will be ignored.')
+            ->setDescription(<<<DESC
+Creates a PIM user. This command can be launched interactively or non interactively (with the "-n" option). 
+When launched non interactively you have to provide arguments to the command. For instance:
+
+    pim:user:create kbeck secretp@ssw0rd kbeck@example.com Kent Beck en_US --admin -n
+
+When launched interactively, command arguments will be ignored.'
+DESC
+            )
             ->addArgument('username')
             ->addArgument('password')
             ->addArgument('email')

--- a/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
+++ b/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
@@ -359,8 +359,17 @@ DESC
         $this->firstName = $input->getArgument('firstName');
         $this->lastName = $input->getArgument('lastName');
         $this->userDefaultLocaleCode = $input->getArgument('locale');
-        // we can't use $input->getArgument('locale') for catalog locale as maybe it's not activated
-        $this->catalogDefaultLocaleCode = 'en_US';
+
+        $activatedLocaleCodes = $this->getContainer()->get('pim_catalog.repository.locale')->getActivatedLocaleCodes();
+        if (empty($activatedLocaleCodes)) {
+            throw new \InvalidArgumentException("There is no activated locale. The catalog default locale of the user must be an activated locale.");
+        }
+
+        if (in_array($input->getArgument('locale'), $activatedLocaleCodes)) {
+            $this->catalogDefaultLocaleCode = $input->getArgument('locale');
+        } else {
+            $this->catalogDefaultLocaleCode = $activatedLocaleCodes[0];
+        }
 
         $this->isAdmin = $input->getOption('admin');
     }

--- a/tests/back/Integration/TestCase.php
+++ b/tests/back/Integration/TestCase.php
@@ -9,6 +9,8 @@ use Akeneo\Pim\Enrichment\Component\FileStorage;
 use Akeneo\Test\IntegrationTestsBundle\Configuration\CatalogInterface;
 use Akeneo\Test\IntegrationTestsBundle\Security\SystemUserAuthenticator;
 use Akeneo\Tool\Component\FileStorage\FileInfoFactory;
+use Akeneo\UserManagement\Component\Model\User;
+use Akeneo\UserManagement\Component\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -155,5 +157,33 @@ abstract class TestCase extends KernelTestCase
         $this->get('pim_catalog.saver.category')->save($category);
 
         return $category;
+    }
+
+    protected function createAdminUser(): UserInterface
+    {
+        $user = $this->get('pim_user.factory.user')->create();
+        $user->setUsername('admin');
+        $user->setPlainPassword('admin');
+        $user->setEmail('admin@example.com');
+        $user->setSalt('E1F53135E559C253');
+        $user->setFirstName('John');
+        $user->setLastName('Doe');
+
+        $this->get('pim_user.manager')->updatePassword($user);
+
+        $adminRole = $this->get('pim_user.repository.role')->findOneByIdentifier('ROLE_ADMINISTRATOR');
+        if (null !== $adminRole) {
+            $user->addRole($adminRole);
+        }
+
+        $userRole = $this->get('pim_user.repository.role')->findOneByIdentifier(User::ROLE_DEFAULT);
+        if (null !== $userRole) {
+            $user->removeRole($userRole);
+        }
+
+        $this->get('validator')->validate($user);
+        $this->get('pim_user.saver.user')->save($user);
+
+        return $user;
     }
 }

--- a/tests/back/Integration/TestCase.php
+++ b/tests/back/Integration/TestCase.php
@@ -181,6 +181,11 @@ abstract class TestCase extends KernelTestCase
             $user->removeRole($userRole);
         }
 
+        $group = $this->get('pim_user.repository.group')->findOneByIdentifier('IT support');
+        if (null !== $group) {
+            $user->addGroup($group);
+        }
+
         $this->get('validator')->validate($user);
         $this->get('pim_user.saver.user')->save($user);
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
@@ -19,6 +19,7 @@ class DeleteProductEndToEnd extends AbstractProductTestCase
 
     public function testDeleteAProduct()
     {
+        $this->createAdminUser();
         $client = $this->createAuthenticatedClient();
 
         $this->assertCount(7, $this->getFromTestContainer('pim_catalog.repository.product')->findAll());
@@ -36,6 +37,7 @@ class DeleteProductEndToEnd extends AbstractProductTestCase
 
     public function testNotFoundAProduct()
     {
+        $this->createAdminUser();
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', 'api/rest/v1/products/not_found');

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/CategoryTree/ListChildrenCategoriesWithCountIncludingSubCategoriesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/CategoryTree/ListChildrenCategoriesWithCountIncludingSubCategoriesIntegration.php
@@ -17,6 +17,7 @@ class ListChildrenCategoriesWithCountIncludingSubCategoriesIntegration extends T
     protected function setUp(): void
     {
         parent::setUp();
+        $this->createAdminUser();
 
         $fixturesLoader = new CategoryTreeFixturesLoader($this->testKernel->getContainer());
         $fixturesLoader->givenTheCategoryTrees([

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/CategoryTree/ListChildrenCategoriesWithCountNotIncludingSubCategoriesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/CategoryTree/ListChildrenCategoriesWithCountNotIncludingSubCategoriesIntegration.php
@@ -17,6 +17,7 @@ class ListChildrenCategoriesWithCountNotIncludingSubCategoriesIntegration extend
     protected function setUp(): void
     {
         parent::setUp();
+        $this->createAdminUser();
 
         $fixturesLoader = new CategoryTreeFixturesLoader($this->testKernel->getContainer());
         $fixturesLoader->givenTheCategoryTrees([

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/CategoryTree/ListRootCategoriesWithCountIncludingSubCategoriesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/CategoryTree/ListRootCategoriesWithCountIncludingSubCategoriesIntegration.php
@@ -17,6 +17,7 @@ class ListRootCategoriesWithCountIncludingSubCategoriesIntegration extends TestC
     protected function setUp(): void
     {
         parent::setUp();
+        $this->createAdminUser();
 
         $fixturesLoader = new CategoryTreeFixturesLoader($this->testKernel->getContainer());
         $fixturesLoader->givenTheCategoryTrees([

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/CategoryTree/ListRootCategoriesWithCountNotIncludingSubCategoriesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/CategoryTree/ListRootCategoriesWithCountNotIncludingSubCategoriesIntegration.php
@@ -17,6 +17,7 @@ class ListRootCategoriesWithCountNotIncludingSubCategoriesIntegration extends Te
     protected function setUp(): void
     {
         parent::setUp();
+        $this->createAdminUser();
 
         $fixturesLoader = new CategoryTreeFixturesLoader($this->testKernel->getContainer());
         $fixturesLoader->givenTheCategoryTrees([

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountUsersIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountUsersIntegration.php
@@ -17,8 +17,7 @@ class CountUsersIntegration extends QueryTestCase
 
         $volume = $query->fetch();
 
-        // one user exist in the minimal catalog
-        Assert::assertEquals(9, $volume->getVolume());
+        Assert::assertEquals(8, $volume->getVolume());
         Assert::assertEquals('count_users', $volume->getVolumeName());
         Assert::assertEquals(false, $volume->hasWarning());
     }

--- a/tests/back/UserManagement/Integration/Bundle/RemoveRoleIntegration.php
+++ b/tests/back/UserManagement/Integration/Bundle/RemoveRoleIntegration.php
@@ -7,6 +7,12 @@ use Akeneo\UserManagement\Component\Exception\ForbiddenToRemoveRoleException;
 
 class RemoveRoleIntegration extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createAdminUser();
+    }
+
     public function testUnableToRemoveARoleIfUsersWillNoLongerHaveRole()
     {
         $this->expectException(ForbiddenToRemoveRoleException::class);


### PR DESCRIPTION
This PR improves the command to create a new user.
It allows the command to be launched non interactively (very useful for ops) like:

`pim:user:create kbeck secretp@ssw0rd kbeck@example.com Kent Beck en_US --admin -n`

The command can still be launched interactively, which is great for devs.

The command can now also add the admin role to the user with the `--admin` option.

Also, the admin user has been removed from the minimal catalog as it forces the ops to hack the PIM for a new SAAS instance. Also, it was kind of a security issue.
