### PR TITLE
PIM-8236: Fix search issue after navigation between tabs

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8351: Fix entity overriding priority
+- PIM-8236: Fix search issue after navigation between tabs 
 
 # 2.3.44 (2019-05-20)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/search-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/search-filter.js
@@ -45,6 +45,8 @@ define(
                         label: __('Search', {label: this.label})
                     })
                 );
+
+                this._writeDOMValue(this.value);
             },
 
             /**

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-list.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filters-list.js
@@ -119,6 +119,7 @@ define(['underscore', 'pim/form', 'oro/mediator', 'oro/tools'],
                             this.$el.append(filter.$el.get(0));
                         }
                     }
+                    filter.delegateEvents();
                 }, this);
 
                 BaseForm.prototype.render.apply(this, arguments);

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/family-variant.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/family-variant.js
@@ -76,12 +76,13 @@ define(
                             localeCode: UserContext.get('uiLocale')
                         }
                     );
+                    this.variantGrid.render();
                 }
 
                 this.$el.html(this.template());
 
                 this.renderExtensions();
-                this.getZone('grid').appendChild(this.variantGrid.render().el);
+                this.getZone('grid').appendChild(this.variantGrid.el);
             }
         });
     }


### PR DESCRIPTION
# The issue

- Go to a family with variant edit
- Go to family variant tab
- Search with the quick search filter ; it works
- Go to another tab
- Go back to the family variant tab
- The quick search filter does not work anymore

# The fix

There is 2 fixes:

- The first one is to add a delegateEvent on the filters because it was missing and the user typing events are not triggered
- The second one is to not re-render the grid if it was already rendered, to keep all the events of the current grid.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
