### PR TITLE
PIM-8352: Add comment about trusted proxy and HTTPS

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -11,7 +11,8 @@ $request = Request::createFromGlobals();
 
 /* In case your app is running behind a reverse-proxy/load-balancer set an environment variable TRUSTED_PROXY_IPS
    defining IPs or IP ranges as a comma list (example : TRUSTED_PROXY_IPS="10.0.0.0/8")
-   to allow usage of X-Forwarded-* headers */
+   to allow usage of X-Forwarded-* headers.
+   This also allows keeping the HTTPS protocol for any URL generated in the PIM */
 $loadBalancerTrustedIPs = getenv('TRUSTED_PROXY_IPS');
 if (!empty($loadBalancerTrustedIPs)) {
     $ipsArray = explode(',', $loadBalancerTrustedIPs);


### PR DESCRIPTION
Add comments for those who use HTTPS from a reverse proxy. By setting the environment variable `TRUSTED_PROXY_IPS` the PIM will generate absolute URL (per instance in the API) with the protocol HTTPS event if the server is on HTTP.