### PR TITLE
Respect the mysql port in dsn

### DIFF
--- a/app/PimRequirements.php
+++ b/app/PimRequirements.php
@@ -241,12 +241,15 @@ class PimRequirements extends SymfonyRequirements
      */
     protected function getConnection(array $parameters)
     {
+        $dsn = 'mysql:';
+        $dsnParams[] = 'host=' . $parameters['parameters']['database_host'];
+        if(isset($parameters['parameters']['database_port'])) {
+            $dsnParams[] = 'port=' . $parameters['parameters']['database_port'];
+        }
+        $dsn .= implode(";", $dsnParams);
+
         return new PDO(
-            sprintf(
-                'mysql:port=%s;host=%s',
-                $parameters['parameters']['database_port'],
-                $parameters['parameters']['database_host']
-            ),
+            $dsn,
             $parameters['parameters']['database_user'],
             $parameters['parameters']['database_password']
         );


### PR DESCRIPTION
Use the mysql port optionally specified in app/config/parameters.yml when constructing the dsn for PDO

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

If a mysql port is specified in the parameters.yml file then it is used in the DSN when constructing the PDO object. This is needed in the install phase when checking mysql version as may connect to wrong mysql service if port not used.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
