### PR TITLE
PIM-8374: Fix timeout when launching the completeness purge command

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,6 +4,7 @@
 
 - PIM-8257: Fix user grid filter set when creating a new user
 - PIM-8366: Translate the placeholder in the quick search input
+- PIM-8374: Fix timeout when launching the completeness purge command
 
 # 3.0.19 (2019-05-21)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/PurgeCompletenessCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/PurgeCompletenessCommand.php
@@ -119,6 +119,7 @@ class PurgeCompletenessCommand extends ContainerAwareCommand
     private function launchPurgeTask(array $productIds, string $env, string $rootDir)
     {
         $process = new Process([sprintf('%s/../bin/console', $rootDir), 'pim:completeness:purge-products', sprintf('--env=%s', $env), implode(',', $productIds)]);
+        $process->setTimeout(null);
         $process->run();
     }
 }


### PR DESCRIPTION
The command `pim:completeness:purge` launches several sub commands `pim:completeness:purge-products`, and they can be be very slow for some clients. One of them has a "timeout" error during the process.

As workaround, we have to launch each `pim:completeness:purge-products` process withtout timeout. The performance problems can be solved in a second time.