### PR TITLE
PIM-8375: Fix counter on grids when user selects all results then select all visible results

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8308: Fix missing translation for import and export profiles
+- PIM-8375: Fix counter on grids when user selects all results then select all visible results
 
 # 3.0.20 (2019-05-24)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/mass-actions.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/mass-actions.js
@@ -110,6 +110,9 @@ define(
              * Updates the count after clicking in "Select all visible" button
              */
             selectVisible() {
+                if (this.count === this.collection.state.totalRecords) {
+                    this.count = 0;
+                }
                 this.collection.trigger('backgrid:selectAllVisible');
 
                 this.updateView();


### PR DESCRIPTION
Before:

- You select All : it selects 1000 products
- You select All visible: it keeps the 1000 products

Now:

- You select All: it selects 1000 products
- You select All visible: it selects 25 products.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -