### PR TITLE
PIM-7942: Fix tooltip minimal width

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-8308: Fix broken translation keys for import and export profiles
 - PIM-8374: Fix timeout when launching the completeness purge command
 - PIM-7596: Fix margins on datagrids under tabs
+- PIM-7942: Fix tooltip minimal width
 
 # 2.3.45 (2019-05-23)
 

--- a/src/Pim/Bundle/UIBundle/Resources/config/assets.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/config/assets.yml
@@ -11,6 +11,7 @@ css:
     lib_customization:
         - bundles/pimui/less/lib/bootstrap.switch.less
         - bundles/pimui/less/lib/bootstrap.dropdown.less
+        - bundles/pimui/less/lib/bootstrap.tooltip.less
         - bundles/pimui/less/lib/dialog.less
         - bundles/pimui/less/lib/dropdown.less
         - bundles/pimui/less/lib/flags.less

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/bootstrap.tooltip.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/bootstrap.tooltip.less
@@ -1,0 +1,3 @@
+.tooltip-inner {
+  min-width: 150px;
+}


### PR DESCRIPTION
The default tooltip was too short and was unreadable.
We added a minimal width to prevent this.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

