### PR TITLE
PIM-6829: Fix mass edit enabled steps

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-8308: Fix broken translation keys for import and export profiles
 - PIM-8374: Fix timeout when launching the completeness purge command
 - PIM-7596: Fix margins on datagrids under tabs
+- PIM-6829: Fix mass edit enabled steps
 
 # 2.3.45 (2019-05-23)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/mass-edit/form.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/mass-edit/form.html
@@ -65,7 +65,7 @@
 
     <div class="AknFullPage-bottom">
         <div class="AknSteps">
-            <div class="AknSteps-step<% if (currentStepNumber > 0) { %> AknSteps-step--checked<% } %>">
+            <div class="AknSteps-step AknSteps-step--checked">
                 <div class="AknSteps-stepCircle"></div>
                 Select action
             </div>
@@ -77,11 +77,11 @@
                 <div class="AknSteps-stepCircle"></div>
             </div>
             <% } else { %>
-            <div class="AknSteps-step<% if (currentStepNumber > 1) { %> AknSteps-step--checked<% } %>">
+            <div class="AknSteps-step<% if (currentStepNumber >= 1) { %> AknSteps-step--checked<% } %>">
                 <div class="AknSteps-stepCircle"></div>
                 <%- label %>
             </div>
-            <div class="AknSteps-step<% if (currentStepNumber > 2) { %> AknSteps-step--checked<% } %>">
+            <div class="AknSteps-step<% if (currentStepNumber >= 2) { %> AknSteps-step--checked<% } %>">
                 <div class="AknSteps-stepCircle"></div>
                 <%- confirmLabel %>
             </div>


### PR DESCRIPTION
When you mass edit, the current and validated steps are annoted as green in the bottom of the page.
They were delayed, as they were 1 step late.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
