### PR TITLE
PIM-7657: Fix count on mass edit product selection

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7657: Fix count on mass edit product selection
+
 # 2.3.46 (2019-05-27)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/mass-actions.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/grid/mass-actions.js
@@ -110,6 +110,7 @@ define(
              * Updates the count after clicking in "Select all visible" button
              */
             selectVisible() {
+                this.selectNone();
                 this.collection.trigger('backgrid:selectAllVisible');
 
                 this.updateView();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes an issue on the product grid where the selected count is not updated when the user first clicks 'selects all', then 'select all visible'. 

The count for 'select all visible' is originally calculated by manually selecting each product in the grid. This doesn't trigger when the products are already selected so the count doesn't update. 

This fix deselects all the products before selecting them again. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
