### PR TITLE
PIM-8378: fix DI for EntityWithFamilyVariantNormalizer injection

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-8378: dix DI for EntityWithFamilyVariantNormalizer injection
+- PIM-8378: Fix DI for EntityWithFamilyVariantNormalizer injection
 
 # 2.3.46 (2019-05-27)
 

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8378: dix DI for EntityWithFamilyVariantNormalizer injection
+
 # 2.3.46 (2019-05-27)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/ProductModelController.php
@@ -9,7 +9,6 @@ use Akeneo\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Pim\Bundle\CatalogBundle\Filter\ObjectFilterInterface;
-use Pim\Bundle\EnrichBundle\Normalizer\EntityWithFamilyVariantNormalizer;
 use Pim\Bundle\UserBundle\Context\UserContext;
 use Pim\Component\Catalog\Comparator\Filter\EntityWithValuesFilter;
 use Pim\Component\Catalog\Localization\Localizer\AttributeConverterInterface;
@@ -73,7 +72,7 @@ class ProductModelController
     /** @var NormalizerInterface */
     private $constraintViolationNormalizer;
 
-    /** @var EntityWithFamilyVariantNormalizer */
+    /** @var NormalizerInterface */
     private $entityWithFamilyVariantNormalizer;
 
     /** @var SimpleFactoryInterface */
@@ -103,7 +102,7 @@ class ProductModelController
      * @param ValidatorInterface                $validator
      * @param SaverInterface                    $productModelSaver
      * @param NormalizerInterface               $constraintViolationNormalizer
-     * @param EntityWithFamilyVariantNormalizer $entityWithFamilyVariantNormalizer
+     * @param NormalizerInterface               $entityWithFamilyVariantNormalizer
      * @param SimpleFactoryInterface            $productModelFactory
      * @param NormalizerInterface               $violationNormalizer
      * @param FamilyVariantRepositoryInterface  $familyVariantRepository
@@ -122,7 +121,7 @@ class ProductModelController
         ValidatorInterface $validator,
         SaverInterface $productModelSaver,
         NormalizerInterface $constraintViolationNormalizer,
-        EntityWithFamilyVariantNormalizer $entityWithFamilyVariantNormalizer,
+        NormalizerInterface $entityWithFamilyVariantNormalizer,
         SimpleFactoryInterface $productModelFactory,
         NormalizerInterface $violationNormalizer,
         FamilyVariantRepositoryInterface $familyVariantRepository,

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/VariantNavigationNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/VariantNavigationNormalizer.php
@@ -23,16 +23,16 @@ class VariantNavigationNormalizer implements NormalizerInterface
     /** @var LocaleRepositoryInterface */
     private $localeRepository;
 
-    /** @var EntityWithFamilyVariantNormalizer */
+    /** @var NormalizerInterface */
     private $entityWithFamilyVariantNormalizer;
 
     /**
-     * @param LocaleRepositoryInterface         $localeRepository
-     * @param EntityWithFamilyVariantNormalizer $entityWithFamilyVariantNormalizer
+     * @param LocaleRepositoryInterface $localeRepository
+     * @param NormalizerInterface       $entityWithFamilyVariantNormalizer
      */
     public function __construct(
         LocaleRepositoryInterface $localeRepository,
-        EntityWithFamilyVariantNormalizer $entityWithFamilyVariantNormalizer
+        NormalizerInterface $entityWithFamilyVariantNormalizer
     ) {
         $this->localeRepository = $localeRepository;
         $this->entityWithFamilyVariantNormalizer = $entityWithFamilyVariantNormalizer;

--- a/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VariantNavigationNormalizerSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/Normalizer/VariantNavigationNormalizerSpec.php
@@ -4,19 +4,19 @@ namespace spec\Pim\Bundle\EnrichBundle\Normalizer;
 
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
-use Pim\Bundle\EnrichBundle\Normalizer\EntityWithFamilyVariantNormalizer;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
 use Pim\Component\Catalog\Model\VariantAttributeSetInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class VariantNavigationNormalizerSpec extends ObjectBehavior
 {
     function let(
         LocaleRepositoryInterface $localeRepository,
-        EntityWithFamilyVariantNormalizer $entityWithFamilyVariantNormalizer
+        NormalizerInterface $entityWithFamilyVariantNormalizer
     ) {
         $localeRepository->getActivatedLocaleCodes()->willReturn(['en_US', 'fr_FR']);
 


### PR DESCRIPTION
Type hint constructor with interface instead of concrete class to facilitate extension points.

Fixes #8429 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
