### PR TITLE
PIM-8386: Fix price filter default currency

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
@@ -80,7 +80,7 @@ define(
                         updateLabel: __('pim_common.update'),
                         currencies: this.currencies,
                         currencyLabel: __('pim_datagrid.filters.price_filter.label'),
-                        selectedCurrency: this._getDisplayValue().currency,
+                        selectedCurrency: this._getDisplayValue().currency || this._firstCurrency(),
                         value: this._getDisplayValue().value
                     })
                 );
@@ -189,6 +189,13 @@ define(
                 this._highlightDropdown(value, '.currency');
 
                 e.preventDefault();
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            _firstCurrency() {
+                return _.first(_.keys(this.currencies));
             },
 
             /**

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
@@ -52,7 +52,7 @@ define(
                 NumberFilter.prototype.initialize.apply(this, arguments);
 
                 this.emptyValue = {
-                    currency: _.first(_.keys(this.currencies)),
+                    currency: this._firstCurrency(),
                     type: _.findWhere(this.choices, { label: '=' }).data,
                     value: ''
                 };


### PR DESCRIPTION
Price filter default was not currently initialized.
When we render the criteria for the first time, we must use the first currency available.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
