### PR TITLE
TIP-1177: do not refresh structure version table when Product or Product model are saved

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/StructureVersion/EventListener/StructureVersionUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/StructureVersion/EventListener/StructureVersionUpdater.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\StructureVersion\EventListener;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Doctrine\Common\Util\ClassUtils;
 use Symfony\Bridge\Doctrine\RegistryInterface;
@@ -38,11 +40,13 @@ class StructureVersionUpdater implements EventSubscriberInterface
         ];
     }
 
-    /**
-     * Add the csv format
-     */
+
     public function onPostDBCreate(GenericEvent $event)
     {
+        if ($event->getSubject() instanceof ProductInterface || $event->getSubject() instanceof ProductModelInterface) {
+            return;
+        }
+
         $sql = <<<'SQL'
 REPLACE INTO akeneo_structure_version_last_update SET resource_name = :resource_name, last_update = :last_update;
 SQL;

--- a/tests/back/Pim/Enrichment/Specification/Bundle/StructureVersion/EventListener/StructureVersionUpdaterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/StructureVersion/EventListener/StructureVersionUpdaterSpec.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Bundle\StructureVersion\EventListener;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Doctrine\DBAL\Connection;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class StructureVersionUpdaterSpec extends ObjectBehavior
+{
+    function let(RegistryInterface $registry, Connection $connection)
+    {
+        $registry->getConnection()->willReturn($connection);
+        $this->beConstructedWith($registry);
+    }
+
+    function it_does_not_insert_into_the_structure_version_table_any_information_about_product_to_avoid_costly_requests(Connection $connection)
+    {
+        $event = new GenericEvent(new Product());
+
+        $connection->executeUpdate(Argument::cetera())->shouldNotBeCalled();
+        $this->onPostDBCreate($event);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- Before:
Install icecat CE: 4 sec  in this query (~install 100 sec)

- After:
Install icecat CE: 1 sec in this query (~install 97 sec)

3% improvement for 3 lines of code (on small catalog, in CE, but it's free).

It was not speced neither covered by integration test, just a behat that seems to be removed in 3.0.


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
