### PR TITLE
PIM-8385: Fix timeout when launching the clean attributes command

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8385: Fix timeout when launching the clean attributes command
+
 # 2.3.46 (2019-05-27)
 
 ## Bug fixes

--- a/src/Pim/Bundle/CatalogBundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
+++ b/src/Pim/Bundle/CatalogBundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
@@ -139,6 +139,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends ContainerA
     private function launchCleanTask(array $productIds, string $env, string $rootDir)
     {
         $process = new Process([sprintf('%s/../bin/console', $rootDir), 'pim:product:refresh', sprintf('--env=%s', $env), implode(',', $productIds)]);
+        $process->setTimeout(null);
         $process->run();
     }
 }


### PR DESCRIPTION
**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
