### PR TITLE
PIM-8317: Fix decimal separator in user context & mock

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
@@ -397,7 +397,7 @@ class UserController
 
     private function additionalProperties($user): array
     {
-        $decimalSeparator['ui-locale-decimal-separator'] = $this->numberFactory
+        $decimalSeparator['ui_locale_decimal_separator'] = $this->numberFactory
             ->create(['locale' => $user['user_default_locale']])
             ->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
 

--- a/tests/front/common/builder/user.js
+++ b/tests/front/common/builder/user.js
@@ -26,7 +26,8 @@ class UserBuilder {
       },
       meta: {
           id: 1
-      }
+      },
+      ui_locale_decimal_separator: '.'
     }
   }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- The key was wrong
- I updated the user context mock for the front-end tests with a decimal separator

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
