### PR TITLE
PIM-8381: do not expose disabled locales in attribute options export

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-8378: Fix DI for EntityWithFamilyVariantNormalizer injection
 - PIM-8385: Fix timeout when launching the clean attributes command
+- PIM-8381: Do not expose disabled locales in attribute options export
 
 # 2.3.46 (2019-05-27)
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_standard.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/serializers_standard.yml
@@ -115,6 +115,8 @@ services:
 
     pim_catalog.normalizer.standard.attribute_option:
         class: '%pim_catalog.normalizer.standard.attribute_option.class%'
+        arguments:
+            - '@pim_catalog.repository.cached_locale'
         tags:
             - { name: pim_serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/VersioningBundle/Resources/config/serializer/flat.yml
+++ b/src/Pim/Bundle/VersioningBundle/Resources/config/serializer/flat.yml
@@ -120,6 +120,8 @@ services:
 
     pim_versioning.serializer.normalizer.flat.option:
         class: '%pim_serializer.normalizer.flat.option.class%'
+        arguments:
+            - '@pim_catalog.repository.cached_locale'
         tags:
             - { name: pim_versioning.serializer.normalizer, priority: 90 }
 

--- a/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/AttributeOptionNormalizerSpec.php
+++ b/src/Pim/Bundle/VersioningBundle/spec/Normalizer/Flat/AttributeOptionNormalizerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Bundle\VersioningBundle\Normalizer\Flat;
 
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
@@ -9,6 +10,11 @@ use Pim\Component\Catalog\Model\AttributeOptionValueInterface;
 
 class AttributeOptionNormalizerSpec extends ObjectBehavior
 {
+    function let(IdentifiableObjectRepositoryInterface $localeRepository)
+    {
+        $this->beConstructedWith($localeRepository);
+    }
+
     function it_is_a_normalizer()
     {
         $this->shouldBeAnInstanceOf('Symfony\Component\Serializer\Normalizer\NormalizerInterface');

--- a/src/Pim/Component/Catalog/Normalizer/Standard/AttributeOptionNormalizer.php
+++ b/src/Pim/Component/Catalog/Normalizer/Standard/AttributeOptionNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Normalizer\Standard;
 
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -12,6 +13,14 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class AttributeOptionNormalizer implements NormalizerInterface
 {
+    /** @var IdentifiableObjectRepositoryInterface */
+    private $localeRepository;
+
+    public function __construct(IdentifiableObjectRepositoryInterface $localeRepository = null)
+    {
+        $this->localeRepository = $localeRepository;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -49,6 +58,14 @@ class AttributeOptionNormalizer implements NormalizerInterface
 
         foreach ($attributeOption->getOptionValues() as $translation) {
             if (empty($locales) || in_array($translation->getLocale(), $locales)) {
+                // TODO merge: remove null in master
+                if (null !== $this->localeRepository) {
+                    $locale = $this->localeRepository->findOneByIdentifier($translation->getLocale());
+                    if (null === $locale || !$locale->isActivated()) {
+                        continue;
+                    }
+                }
+
                 $labels[$translation->getLocale()] = $translation->getValue();
             }
         }

--- a/src/Pim/Component/Catalog/spec/Normalizer/Standard/AttributeOptionNormalizerSpec.php
+++ b/src/Pim/Component/Catalog/spec/Normalizer/Standard/AttributeOptionNormalizerSpec.php
@@ -2,13 +2,20 @@
 
 namespace spec\Pim\Component\Catalog\Normalizer\Standard;
 
+use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Model\AttributeInterface;
 use Pim\Component\Catalog\Model\AttributeOptionInterface;
 use Pim\Component\Catalog\Model\AttributeOptionValueInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
 
 class AttributeOptionNormalizerSpec extends ObjectBehavior
 {
+    function let(IdentifiableObjectRepositoryInterface $localeRepository)
+    {
+        $this->beConstructedWith($localeRepository);
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType('Pim\Component\Catalog\Normalizer\Standard\AttributeOptionNormalizer');
@@ -49,7 +56,10 @@ class AttributeOptionNormalizerSpec extends ObjectBehavior
         AttributeOptionInterface $attributeOption,
         AttributeInterface $attribute,
         AttributeOptionValueInterface $valueEn,
-        AttributeOptionValueInterface $valueFr
+        AttributeOptionValueInterface $valueFr,
+        LocaleInterface $enLocale,
+        LocaleInterface $frLocale,
+        $localeRepository
     ) {
         $attributeOption->getAttribute()->willReturn($attribute);
         $attribute->getCode()->willReturn('color');
@@ -64,6 +74,11 @@ class AttributeOptionNormalizerSpec extends ObjectBehavior
         $valueFr->getLocale()->willReturn('fr_FR');
         $valueFr->getValue()->willReturn('Rouge');
 
+        $localeRepository->findOneByIdentifier('en_US')->willReturn($enLocale);
+        $enLocale->isActivated()->willReturn(true);
+        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($frLocale);
+        $frLocale->isActivated()->willReturn(true);
+
         $this->normalize($attributeOption, 'standard', ['locales' => ['en_US', 'fr_FR', 'de_DE']])->shouldReturn([
             'code' => 'red',
             'attribute' => 'color',
@@ -72,6 +87,45 @@ class AttributeOptionNormalizerSpec extends ObjectBehavior
                 'en_US' => 'Red',
                 'fr_FR' => 'Rouge',
                 'de_DE' => null
+            ]
+        ]);
+    }
+
+    function it_normalizes_an_attribute_option_without_exposing_disabled_locales(
+        AttributeOptionInterface $attributeOption,
+        AttributeInterface $attribute,
+        AttributeOptionValueInterface $valueEn,
+        AttributeOptionValueInterface $valueFr,
+        LocaleInterface $enLocale,
+        LocaleInterface $frLocale,
+        $localeRepository
+    ) {
+        $attributeOption->getAttribute()->willReturn($attribute);
+        $attribute->getCode()->willReturn('color');
+        $attributeOption->getCode()->willReturn('red');
+        $attributeOption->getOptionValues()->willReturn([
+            'en_US' => $valueEn,
+            'fr_FR' => $valueFr,
+        ]);
+        $attributeOption->getSortOrder()->willReturn(1);
+        $valueEn->getLocale()->willReturn('en_US');
+        $valueEn->getValue()->willReturn('Red');
+        $valueFr->getLocale()->willReturn('fr_FR');
+        $valueFr->getValue()->willReturn('Rouge');
+
+        $localeRepository->findOneByIdentifier('en_US')->willReturn($enLocale);
+        $enLocale->isActivated()->willReturn(true);
+        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($frLocale);
+        $frLocale->isActivated()->willReturn(false);
+
+        $this->normalize($attributeOption, 'standard', ['locales' => ['en_US', 'fr_FR', 'de_DE']])->shouldReturn([
+            'code' => 'red',
+            'attribute' => 'color',
+            'sort_order' => 1,
+            'labels' => [
+                'en_US' => 'Red',
+                'fr_FR' => null,
+                'de_DE' => null,
             ]
         ]);
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Same fix as https://github.com/akeneo/pim-community-dev/pull/8877 : we don't expose disabled locales in attribute options standard format.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
