### PR TITLE
PIM-7583: Prevent js error for locales without country

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-8378: Fix DI for EntityWithFamilyVariantNormalizer injection
 - PIM-8385: Fix timeout when launching the clean attributes command
+- PIM-7583: Prevent js error for locales without country
 
 # 2.3.46 (2019-05-27)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/i18n.ts
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/i18n.ts
@@ -7,7 +7,7 @@ const flagTemplate = (country: string, language: string, displayLanguage: boolea
 };
 
 export const getFlag = (locale: string, displayLanguage: boolean = true): string => {
-  if (!locale) {
+  if (!locale || false === locale.includes('_')) {
     return '';
   }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR updates the i18n script to prevent `getFlag` from throwing an error for a badly formatted locale - e.g. 'test'. Like with an empty locale, it will return no flag; 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
