### PR TITLE
Revert "PIM-7583: Prevent js error for locales without country"

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,7 +4,6 @@
 
 - PIM-8378: Fix DI for EntityWithFamilyVariantNormalizer injection
 - PIM-8385: Fix timeout when launching the clean attributes command
-- PIM-7583: Prevent js error for locales without country
 
 # 2.3.46 (2019-05-27)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/i18n.ts
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/i18n.ts
@@ -7,7 +7,7 @@ const flagTemplate = (country: string, language: string, displayLanguage: boolea
 };
 
 export const getFlag = (locale: string, displayLanguage: boolean = true): string => {
-  if (!locale || false === locale.includes('_')) {
+  if (!locale) {
     return '';
   }
 


### PR DESCRIPTION
Reverts akeneo/pim-community-dev#10130

This PR is to revert the fix and wait for a better solution e.g. validating the format of locales 