### PR TITLE
PIM-8384: Improve Job execution queue filtering by job instance codes

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Technical improvement
+
+- PIM-8384: Improve queue to consume specific jobs
+
 ## Bug fixes
 
 - PIM-8378: Fix DI for EntityWithFamilyVariantNormalizer injection

--- a/src/Akeneo/Bundle/BatchQueueBundle/Command/JobQueueConsumerCommand.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Command/JobQueueConsumerCommand.php
@@ -49,7 +49,9 @@ class JobQueueConsumerCommand extends ContainerAwareCommand
         $this
             ->setName(self::COMMAND_NAME)
             ->setDescription('Launch a daemon that will consume job execution messages and launch the associated job execution in backgrounds')
-            ->addOption('run-once', null, InputOption::VALUE_NONE, 'Launch only one job execution and stop the daemon once the job execution is finished');
+            ->addOption('run-once', null, InputOption::VALUE_NONE, 'Launch only one job execution and stop the daemon once the job execution is finished')
+            ->addOption('job', 'j', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Job instance codes that should be consumed')
+        ;
     }
 
     /**
@@ -57,6 +59,8 @@ class JobQueueConsumerCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $jobInstanceCodes = $input->getOption('job');
+
         $errOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
 
         $consumerName = Uuid::uuid4();
@@ -67,7 +71,7 @@ class JobQueueConsumerCommand extends ContainerAwareCommand
 
         do {
             try {
-                $jobExecutionMessage = $this->getQueue()->consume($consumerName->toString());
+                $jobExecutionMessage = $this->getQueue()->consume($consumerName->toString(), $jobInstanceCodes);
 
                 $arguments = array_merge([$pathFinder->find(), $console, 'akeneo:batch:job' ], $this->getArguments($jobExecutionMessage));
                 $process = new Process($arguments);

--- a/src/Akeneo/Bundle/BatchQueueBundle/Queue/DatabaseJobExecutionQueue.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Queue/DatabaseJobExecutionQueue.php
@@ -49,12 +49,16 @@ class DatabaseJobExecutionQueue implements JobExecutionQueueInterface
     /**
      * {@inheritdoc}
      */
-    public function consume(string $consumer): JobExecutionMessage
+    public function consume(string $consumer, array $jobInstanceCodes = []): JobExecutionMessage
     {
         $hasBeenUpdated = false;
 
         do {
-            $jobExecutionMessage = $this->jobExecutionMessageRepository->getAvailableJobExecutionMessage();
+            if (empty($jobInstanceCodes)) {
+                $jobExecutionMessage = $this->jobExecutionMessageRepository->getAvailableJobExecutionMessage();
+            } else {
+                $jobExecutionMessage = $this->jobExecutionMessageRepository->getAvailableJobExecutionMessageFilteredByCodes($jobInstanceCodes);
+            }
 
             if (null !== $jobExecutionMessage) {
                 $jobExecutionMessage->consumedBy($consumer);

--- a/src/Akeneo/Bundle/BatchQueueBundle/Queue/JobExecutionMessageRepository.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Queue/JobExecutionMessageRepository.php
@@ -123,6 +123,39 @@ SQL;
     }
 
     /**
+     * Gets a job execution message that has not been consumed yet.
+     * If there is no job execution available, it returns null.
+     *
+     * @param string[] $jobInstanceCodes
+     *
+     * @return JobExecutionMessage|null
+     */
+    public function getAvailableJobExecutionMessageFilteredByCodes(array $jobInstanceCodes): ?JobExecutionMessage
+    {
+        $sql = <<<SQL
+SELECT 
+    q.id, q.job_execution_id, q.create_time, q.updated_time, q.options, q.consumer
+FROM
+    akeneo_batch_job_execution_queue q
+INNER JOIN akeneo_batch_job_execution je ON je.id = q.job_execution_id
+INNER JOIN akeneo_batch_job_instance ji ON ji.id = je.job_instance_id
+WHERE
+    q.consumer IS NULL
+AND ji.code IN (:job_instance_codes)
+ORDER BY
+    q.create_time, id
+LIMIT 1;
+SQL;
+        $stmt = $this->entityManager->getConnection()->executeQuery(
+            $sql,
+            ['job_instance_codes' => $jobInstanceCodes],
+            ['job_instance_codes' => Connection::PARAM_STR_ARRAY]
+        );
+        $row = $stmt->fetch();
+        return false !== $row ? $this->jobExecutionHydrator->hydrate($row) : null;
+    }
+
+    /**
      * Gets the job instance code associated to a job execution message.
      *
      * @param JobExecutionMessage $jobExecutionMessage

--- a/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Command/JobQueueConsumerCommandIntegration.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Command/JobQueueConsumerCommandIntegration.php
@@ -12,7 +12,6 @@ use Akeneo\Component\Batch\Model\JobExecution;
 use Akeneo\Component\Batch\Model\JobInstance;
 use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
 use Akeneo\Component\BatchQueue\Queue\JobExecutionQueueInterface;
-use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
 use Doctrine\DBAL\Driver\Connection;
@@ -40,12 +39,7 @@ class JobQueueConsumerCommandIntegration extends TestCase
 
     public function testLaunchAJobExecution()
     {
-        $jobExecution = $this->createJobExecution('csv_product_export', 'mary');
-
-        $options = ['email' => 'ziggy@akeneo.com', 'env' => $this->getParameter('kernel.environment')];
-        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
-
-        $this->getQueue()->publish($jobExecutionMessage);
+        $jobExecution = $this->createJobExecutionInQueue('csv_product_export');
 
         $output = $this->jobLauncher->launchConsumerOnce();
 
@@ -72,9 +66,36 @@ class JobQueueConsumerCommandIntegration extends TestCase
         $this->assertNotEmpty($row['consumer']);
     }
 
+    public function testLaunchFilteredJobExecution()
+    {
+        $jobExecution = $this->createJobExecutionInQueue('csv_product_export');
+
+        $output = $this->jobLauncher->launchConsumerOnce(['-j' => ['csv_product_export']]);
+        $standardOutput = $output->fetch();
+        $this->assertContains(sprintf('Job execution "%s" is finished.', $jobExecution->getId()), $standardOutput);
+
+        $row = $this->getJobExecutionDatabaseRow($jobExecution);
+
+        $this->assertEquals(BatchStatus::COMPLETED, $row['status']);
+        $this->assertEquals(ExitStatus::COMPLETED, $row['exit_code']);
+        $this->assertNotNull($row['health_check_time']);
+
+        $jobExecution = $this->get('pim_enrich.repository.job_execution')->findBy(['id' => $jobExecution->getId()]);
+        $jobExecution = $this->getJobExecutionManager()->resolveJobExecutionStatus($jobExecution[0]);
+
+        $this->assertEquals(BatchStatus::COMPLETED, $jobExecution->getStatus()->getValue());
+        $this->assertEquals(ExitStatus::COMPLETED, $jobExecution->getExitStatus()->getExitCode());
+
+        $stmt = $this->getConnection()->prepare('SELECT consumer from akeneo_batch_job_execution_queue');
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        $this->assertNotEmpty($row['consumer']);
+    }
+
     public function testStatusOfACrashedJobExecution()
     {
-        $jobExecution = $this->createJobExecution('infinite_loop_job', 'mary');
+        $jobExecution = $this->createJobExecutionInQueue('infinite_loop_job');
 
         $options = ['email' => 'ziggy@akeneo.com', 'env' => $this->getParameter('kernel.environment')];
         $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
@@ -107,12 +128,7 @@ class JobQueueConsumerCommandIntegration extends TestCase
 
     public function testJobExecutionStatusResolverWhenDaemonAndJobExecutionCrash()
     {
-        $jobExecution = $this->createJobExecution('infinite_loop_job', 'mary');
-
-        $options = ['email' => 'ziggy@akeneo.com', 'env' => $this->getParameter('kernel.environment')];
-        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
-
-        $this->getQueue()->publish($jobExecutionMessage);
+        $jobExecution = $this->createJobExecutionInQueue('infinite_loop_job');
 
         $daemonProcess = $this->jobLauncher->launchConsumerOnceInBackground();
 
@@ -175,6 +191,16 @@ class JobQueueConsumerCommandIntegration extends TestCase
         $jobExecution = $this->get('akeneo_batch.job_repository')->createJobExecution($jobInstance, $jobParameters);
         $jobExecution->setUser($user);
         $this->get('akeneo_batch.job_repository')->updateJobExecution($jobExecution);
+
+        return $jobExecution;
+    }
+
+    private function createJobExecutionInQueue(string $jobInstanceCode): JobExecution
+    {
+        $jobExecution = $this->createJobExecution($jobInstanceCode, 'mary');
+        $options = ['email' => 'ziggy@akeneo.com', 'env' => $this->getParameter('kernel.environment')];
+        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
+        $this->getQueue()->publish($jobExecutionMessage);
 
         return $jobExecution;
     }

--- a/src/Akeneo/Component/BatchQueue/Queue/JobExecutionQueueInterface.php
+++ b/src/Akeneo/Component/BatchQueue/Queue/JobExecutionQueueInterface.php
@@ -25,8 +25,9 @@ interface JobExecutionQueueInterface
      * This method loops until there is a message to consume into the queue.
      *
      * @param string $consumer name of the consumer
+     * @param string[] $jobInstanceCodes name of the job instances
      *
      * @return JobExecutionMessage
      */
-    public function consume(string $consumer): JobExecutionMessage;
+    public function consume(string $consumer, array $jobInstanceCodes = []): JobExecutionMessage;
 }

--- a/tests/back/Integration/IntegrationTestsBundle/Launcher/JobLauncher.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Launcher/JobLauncher.php
@@ -284,17 +284,22 @@ class JobLauncher
     /**
      * Launch the daemon command to consume and launch one job execution.
      *
+     * @param array $options
+     *
      * @return BufferedOutput
      */
-    public function launchConsumerOnce(): BufferedOutput
+    public function launchConsumerOnce(array $options = []): BufferedOutput
     {
         $application = new Application($this->kernel);
         $application->setAutoExit(false);
 
-        $arrayInput = [
-            'command'  => JobQueueConsumerCommand::COMMAND_NAME,
-            '--run-once' => true,
-        ];
+        $arrayInput = array_merge(
+            $options,
+            [
+                'command'  => JobQueueConsumerCommand::COMMAND_NAME,
+                '--run-once' => true,
+            ]
+        );
 
         $input = new ArrayInput($arrayInput);
         $output = new BufferedOutput();


### PR DESCRIPTION
Backport from master into 2.3 of PR #9988

Works exactly the same. There is one difference in the code though, assertStringContainsString() method is not available in the PhpUnit version of the 2.3, so I had to use something else.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
