### PR TITLE
PIM-8315: Fix undefined attribute groups in family mass edit

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8315: Fix undefined attribute groups in family mass edit
+
 # 3.0.21 (2019-05-27)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/mass-edit/toolbar/add-select/attribute/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/mass-edit/toolbar/add-select/attribute/select.js
@@ -24,9 +24,10 @@ define(
             fetchAttributeGroups(attributes) {
                 const groupCodes = _.unique(_.pluck(attributes, 'group'));
 
-                return FetcherRegistry.getFetcher('attribute-group').fetchByIdentifiers(groupCodes).then((attributeGroups) => {
-                    return this.populateGroupProperties(attributes, attributeGroups);
-                });
+                return FetcherRegistry.getFetcher('attribute-group')
+                    .fetchByIdentifiers(groupCodes).then((attributeGroups) => {
+                        return this.populateGroupProperties(attributes, attributeGroups);
+                    });
             },
 
             /**
@@ -37,9 +38,10 @@ define(
                     .then((identifiersToExclude) => {
                         searchParameters.options.excluded_identifiers = identifiersToExclude;
 
-                        return FetcherRegistry.getFetcher(this.mainFetcher).search(searchParameters).then(attributes => {
-                            return this.fetchAttributeGroups(attributes)
-                        });
+                        return FetcherRegistry.getFetcher(this.mainFetcher)
+                            .search(searchParameters).then(attributes => {
+                                return this.fetchAttributeGroups(attributes)
+                            });
                     });
             },
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/mass-edit/toolbar/add-select/attribute/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/mass-edit/toolbar/add-select/attribute/select.js
@@ -24,9 +24,9 @@ define(
             fetchAttributeGroups(attributes) {
                 const groupCodes = _.unique(_.pluck(attributes, 'group'));
 
-                return FetcherRegistry.getFetcher('attribute-group').fetchByIdentifiers(groupCodes).then(function (attributeGroups) {
+                return FetcherRegistry.getFetcher('attribute-group').fetchByIdentifiers(groupCodes).then((attributeGroups) => {
                     return this.populateGroupProperties(attributes, attributeGroups);
-                }.bind(this));
+                });
             },
 
             /**
@@ -34,13 +34,13 @@ define(
              */
             fetchItems: function (searchParameters) {
                 return this.getItemsToExclude()
-                    .then(function (identifiersToExclude) {
+                    .then((identifiersToExclude) => {
                         searchParameters.options.excluded_identifiers = identifiersToExclude;
 
                         return FetcherRegistry.getFetcher(this.mainFetcher).search(searchParameters).then(attributes => {
                             return this.fetchAttributeGroups(attributes)
                         });
-                    }.bind(this));
+                    });
             },
 
             /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/mass-edit/toolbar/add-select/attribute/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/mass-edit/toolbar/add-select/attribute/select.js
@@ -21,6 +21,14 @@ define(
         FamilyAddAttributeSelect
     ) {
         return FamilyAddAttributeSelect.extend({
+            fetchAttributeGroups(attributes) {
+                const groupCodes = _.unique(_.pluck(attributes, 'group'));
+
+                return FetcherRegistry.getFetcher('attribute-group').fetchByIdentifiers(groupCodes).then(function (attributeGroups) {
+                    return this.populateGroupProperties(attributes, attributeGroups);
+                }.bind(this));
+            },
+
             /**
              * {@inheritdoc}
              */
@@ -29,7 +37,9 @@ define(
                     .then(function (identifiersToExclude) {
                         searchParameters.options.excluded_identifiers = identifiersToExclude;
 
-                        return FetcherRegistry.getFetcher(this.mainFetcher).search(searchParameters);
+                        return FetcherRegistry.getFetcher(this.mainFetcher).search(searchParameters).then(attributes => {
+                            return this.fetchAttributeGroups(attributes)
+                        });
                     }.bind(this));
             },
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes an issue in the mass edit family screen where the attribute groups inside the attribute selector were not being loaded. In this PR, the select2 component has been updated to fetch the attribute groups and populate them in the results. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
