### PR TITLE
PIM-8410: Remove unused controller class parameter

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8315: Fix undefined attribute groups in family mass edit
+- PIM-8410: Remove unused controller class parameter `pim_enrich.controller.category_tree.class`
 
 # 3.0.21 (2019-05-27)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -1,5 +1,4 @@
 parameters:
-    pim_enrich.controller.category_tree.class: Akeneo\Pim\Enrichment\Bundle\Controller\Ui\CategoryTreeController
     pim_api.controller.media_file.class: Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi\MediaFileController
 
 services:


### PR DESCRIPTION
`pim_enrich.controller.category_tree.class` is not used anymore.
The best practice is to use FQDN in DI and override the whole service if needed.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
