### PR TITLE
TIP-1180: migrate local files to object storage

### DIFF
--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/JobExecutionController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/JobExecutionController.php
@@ -7,6 +7,7 @@ use Akeneo\Platform\Bundle\ImportExportBundle\Repository\InternalApi\JobExecutio
 use Akeneo\Tool\Bundle\BatchBundle\Manager\JobExecutionManager;
 use Akeneo\Tool\Bundle\BatchBundle\Monolog\Handler\BatchLogHandler;
 use Akeneo\Tool\Bundle\ConnectorBundle\EventListener\JobExecutionArchivist;
+use Akeneo\Tool\Component\Connector\LogKey;
 use Akeneo\Tool\Component\FileStorage\StreamedFileResponse;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\FilesystemInterface;
@@ -106,7 +107,7 @@ class JobExecutionController
 
         $this->eventDispatcher->dispatch(JobExecutionEvents::PRE_DOWNLOAD_LOG, new GenericEvent($jobExecution));
 
-        $logFileContent = $this->logFileSystem->read($jobExecution->getLogFile());
+        $logFileContent = $this->logFileSystem->read(new LogKey($jobExecution));
 
         $response = new Response($logFileContent);
         $disposition = $response->headers->makeDisposition(

--- a/src/Akeneo/Tool/Component/Connector/LogArchiver.php
+++ b/src/Akeneo/Tool/Component/Connector/LogArchiver.php
@@ -11,6 +11,13 @@ use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use League\Flysystem\Filesystem;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * Archives logs of the import/export in the "archivist" filesystem.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 class LogArchiver implements EventSubscriberInterface
 {
     /** @var Filesystem */
@@ -32,7 +39,7 @@ class LogArchiver implements EventSubscriberInterface
 
         if (is_file($logPath)) {
             $log = fopen($logPath, 'r');
-            $this->filesystem->writeStream($logPath, $log);
+            $this->filesystem->writeStream(new LogKey($jobExecution), $log);
             if (is_resource($log)) {
                 fclose($log);
             }

--- a/src/Akeneo/Tool/Component/Connector/LogKey.php
+++ b/src/Akeneo/Tool/Component/Connector/LogKey.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Akeneo\Tool\Component\Connector;
+
+use Akeneo\Tool\Component\Batch\Model\JobExecution;
+
+/**
+ * Key of a log file stored in the "archivist" filesystem.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class LogKey
+{
+    /** @var JobExecution */
+    private $jobExecution;
+
+    public function __construct(JobExecution $jobExecution)
+    {
+        $this->jobExecution = $jobExecution;
+
+        if (empty($jobExecution->getLogFile())) {
+            throw new \InvalidArgumentException('The log file should not be empty');
+        }
+
+        if (!is_file($jobExecution->getLogFile())) {
+            throw new \InvalidArgumentException('The log should exists.');
+        }
+    }
+
+    public function __toString(): string
+    {
+        $jobInstance = $this->jobExecution->getJobInstance();
+
+        return
+            $jobInstance->getType() . DIRECTORY_SEPARATOR .
+            $jobInstance->getJobName() . DIRECTORY_SEPARATOR .
+            $this->jobExecution->getId() . DIRECTORY_SEPARATOR .
+            'log' . DIRECTORY_SEPARATOR .
+            basename($this->jobExecution->getLogFile())
+        ;
+    }
+}

--- a/src/Akeneo/Tool/Component/Connector/spec/LogArchiverSpec.php
+++ b/src/Akeneo/Tool/Component/Connector/spec/LogArchiverSpec.php
@@ -5,6 +5,7 @@ namespace spec\Akeneo\Tool\Component\Connector;
 use Akeneo\Tool\Component\Batch\Event\JobExecutionEvent;
 use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
+use Akeneo\Tool\Component\Connector\LogKey;
 use League\Flysystem\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -18,14 +19,14 @@ class LogArchiverSpec extends ObjectBehavior
 
     function it_sends_log_to_flysystem($filesystem)
     {
-        $importInstance = new JobInstance(null, JobInstance::TYPE_IMPORT);
+        $importInstance = new JobInstance(null, JobInstance::TYPE_IMPORT, 'csv_import');
         $importExecution = (new JobExecution())
             ->setJobInstance($importInstance)
             ->setLogFile(__FILE__)
         ;
 
         $event = new JobExecutionEvent($importExecution);
-        $filesystem->writeStream(__FILE__, Argument::cetera())->shouldBeCalled();
+        $filesystem->writeStream(Argument::cetera())->shouldBeCalled();
 
         $this->archive($event);
     }

--- a/src/Akeneo/Tool/Component/Connector/spec/LogKeySpec.php
+++ b/src/Akeneo/Tool/Component/Connector/spec/LogKeySpec.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace spec\Akeneo\Tool\Component\Connector;
+
+use Akeneo\Tool\Component\Batch\Model\JobExecution;
+use Akeneo\Tool\Component\Batch\Model\JobInstance;
+use InvalidArgumentException;
+use PhpSpec\ObjectBehavior;
+
+class LogKeySpec extends ObjectBehavior
+{
+    function it_fails_when_log_file_is_empty()
+    {
+        $this->beConstructedWith(new JobExecution());
+        $this->shouldThrow(InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    function it_fails_when_log_file_does_not_exist()
+    {
+        $this->beConstructedWith((new JobExecution())->setLogFile('/does/not/exist'));
+        $this->shouldThrow(InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    function it_is_a_key_built_from_a_job_execution()
+    {
+        $importInstance = new JobInstance(null, JobInstance::TYPE_IMPORT, 'csv_import');
+        $importExecution = (new JobExecution())
+            ->setJobInstance($importInstance)
+            ->setLogFile(__FILE__)
+        ;
+
+        $this->beConstructedWith($importExecution);
+
+        // normally we should have something like 'import/csv_import/ID/log/LogKeySpec.php'
+        // but the ID is created by the ORM, we have no control on ID, no way to set it
+        $this->__toString()->shouldBe('import/csv_import//log/LogKeySpec.php');
+    }
+}

--- a/upgrades/schema/LocalLogToObjectStorage.php
+++ b/upgrades/schema/LocalLogToObjectStorage.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Connection;
+use League\Flysystem\Filesystem;
+
+/**
+ * Relocates import/export logs from a local filesystem to an object storage.
+ *
+ * The log files are listed from the akeneo_batch_job_execution table. Then, each existing and readable local file is
+ * stored in the object storage.
+ */
+class LocalLogToObjectStorage
+{
+    /** @var Filesystem */
+    private $objectStorage;
+
+    /** @var Connection */
+    private $database;
+
+    /** @var array */
+    private $errors = [];
+
+    public function __construct(
+        Filesystem $filesystem,
+        Connection $database
+    ) {
+        $this->objectStorage = $filesystem;
+        $this->database = $database;
+    }
+
+    public function countFiles(): int
+    {
+        return $this->database->executeQuery(
+            'SELECT COUNT(*) FROM akeneo_batch_job_execution je INNER JOIN akeneo_batch_job_instance ji ON je.job_instance_id = ji.id WHERE ji.type IN (\'export\', \'import\')'
+        )->fetchColumn();
+    }
+
+    public function relocateFiles(): array
+    {
+        $stmt = $this->database->executeQuery(
+            'SELECT ji.type, ji.job_name, je.id, je.log_file FROM akeneo_batch_job_execution je INNER JOIN akeneo_batch_job_instance ji ON je.job_instance_id = ji.id WHERE ji.type IN (\'export\', \'import\')'
+        );
+
+        while (false !== ($logInfo = $stmt->fetch())) {
+            try {
+                $this->relocate($logInfo);
+            } catch (RelocateException $e) {
+                $this->errors[] = $e->getMessage();
+            }
+        }
+
+        return $this->errors;
+    }
+
+    private function relocate(array $logInfo): void
+    {
+        $file = $this->open($logInfo);
+
+        $stored = $this->objectStorage->putStream($this->logKey($logInfo), $file);
+        if (!$stored) {
+            if (is_resource($file)) {
+                fclose($file);
+            }
+
+            throw new StoreException($logInfo['file_key']);
+        }
+
+        if (is_resource($file)) {
+            fclose($file);
+        }
+    }
+
+    private function open(array $logInfo)
+    {
+        $filePath = $logInfo['log_file'];
+        $file = @fopen($filePath, 'r');
+        if (false === $file) {
+            throw new OpenFileException($filePath);
+        }
+
+        return $file;
+    }
+
+    /**
+     * Build the log key the same way that in LogKey {@see \Akeneo\Tool\Component\Connector\LogKey}
+     */
+    private function logKey(array $logInfo): string
+    {
+        return
+            $logInfo['type'] . DIRECTORY_SEPARATOR .
+            $logInfo['job_name'] . DIRECTORY_SEPARATOR .
+            $logInfo['id'] . DIRECTORY_SEPARATOR .
+            'log' . DIRECTORY_SEPARATOR .
+            basename($logInfo['log_file'])
+        ;
+    }
+}

--- a/upgrades/schema/LocaleArchivesToObjectStorage.php
+++ b/upgrades/schema/LocaleArchivesToObjectStorage.php
@@ -1,0 +1,107 @@
+<?php
+
+
+namespace Pim\Upgrade\Schema;
+
+use League\Flysystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Relocates import/export archives from a local filesystem to an object storage.
+ *
+ * The archives files are listed from the "%archive_dir%/import" and "%archive_dir%/export". Then, each existing and readable local file is
+ * stored in the object storage.
+ */
+class LocaleArchivesToObjectStorage
+{
+    /** @var Finder */
+    private $archiveFileSystem;
+
+    /** @var Filesystem */
+    private $objectStorage;
+
+    /** @var string */
+    private $archiveDirectory;
+
+    /** @var array */
+    private $errors = [];
+
+    public function __construct(
+        Filesystem $filesystem,
+        string $archiveDirectory
+    ) {
+        $this->objectStorage = $filesystem;
+        $this->archiveFileSystem = $this->buildFinder($archiveDirectory);
+        $this->archiveDirectory = $archiveDirectory;
+    }
+
+    public function countFiles(): int
+    {
+        return $this->archiveFileSystem->count();
+    }
+
+    public function relocateFiles(): array
+    {
+        foreach ($this->archiveFileSystem as $file) {
+            try {
+                $this->relocate($file);
+            } catch (RelocateException $e) {
+                $this->errors[] = $e->getMessage();
+            }
+        }
+        
+        return $this->errors;
+    }
+
+    private function relocate(\SplFileInfo $fileInfo): void
+    {
+        $file = $this->open($fileInfo);
+
+        $stored = $this->objectStorage->putStream($this->archiveKey($fileInfo), $file);
+        if (!$stored) {
+            if (is_resource($file)) {
+                fclose($file);
+            }
+
+            throw new StoreException($this->archiveKey($fileInfo));
+        }
+
+        if (is_resource($file)) {
+            fclose($file);
+        }
+    }
+
+    /**
+     * @return resource
+     */
+    private function open(\SplFileInfo $fileInfo)
+    {
+        $file = @fopen($fileInfo->getPathname(), 'r');
+        if (false === $file) {
+            throw new OpenFileException($fileInfo->getPathname());
+        }
+
+        return $file;
+    }
+
+    private function buildFinder(string $localStorageDirectory): Finder
+    {
+        $finder = new Finder();
+        $dirs = [];
+        if (is_dir($localStorageDirectory . DIRECTORY_SEPARATOR . 'import')) {
+            $dirs[] = $localStorageDirectory . DIRECTORY_SEPARATOR . 'import';
+        }
+        if (is_dir($localStorageDirectory . DIRECTORY_SEPARATOR . 'export')) {
+            $dirs[] = $localStorageDirectory . DIRECTORY_SEPARATOR . 'export';
+        }
+        
+        $finder->files()->in($dirs);
+
+        return $finder;
+    }
+
+    private function archiveKey(\SplFileInfo $fileInfo): string
+    {
+        return str_replace($this->archiveDirectory . DIRECTORY_SEPARATOR, '', $fileInfo->getPathname());
+    }
+}

--- a/upgrades/schema/RelocateException.php
+++ b/upgrades/schema/RelocateException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Pim\Upgrade\Schema;
+
+abstract class RelocateException extends \LogicException
+{
+}
+
+class OpenFileException extends RelocateException
+{
+    public function __construct($filePath)
+    {
+        parent::__construct("Unable to open the file $filePath.");
+    }
+}
+
+class StoreException extends RelocateException
+{
+    public function __construct($fileKey)
+    {
+        parent::__construct("Unable to store the file $fileKey in the object storage.");
+    }
+}
+

--- a/upgrades/schema/archived_files_local_filesystem_to_object_storage.php
+++ b/upgrades/schema/archived_files_local_filesystem_to_object_storage.php
@@ -1,0 +1,48 @@
+<?php
+
+// This script is used to relocate import/export archives from a local filesystem to an object storage.
+//
+// The archives files are listed from the "%archive_dir%/import" and "%archive_dir%/export".
+// Then, each existing and readable local file is stored in the object storage "oneup_flysystem.archivist_filesystem".
+//
+// Please note that this script does NOT delete source files.
+
+if (!file_exists(__DIR__ . '/../../app/AppKernel.php')) {
+    die("Please run this command from your Symfony application root.");
+}
+
+require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/../../app/AppKernel.php';
+require __DIR__ . '/LocaleArchivesToObjectStorage.php';
+require __DIR__ . '/RelocateException.php';
+
+$envFile = __DIR__ . '/../.env';
+if (file_exists($envFile)) {
+    (new Symfony\Component\Dotenv\Dotenv())->load($envFile);
+}
+
+$kernel = new AppKernel('prod', false);
+$kernel->boot();
+$container = $kernel->getContainer();
+
+$storage = new \Pim\Upgrade\Schema\LocaleArchivesToObjectStorage(
+    $container->get('oneup_flysystem.archivist_filesystem'),
+    $container->getParameter('archive_dir')
+);
+
+echo "Relocating {$storage->countFiles()} local archive files to the object storage...\n";
+
+$errors = $storage->relocateFiles();
+
+if (!empty($errors)) {
+    echo "The following files have NOT been relocated:\n";
+    foreach ($errors as $error) {
+        echo "- $error\n";
+    }
+}
+
+echo "Done!\n";
+
+if (!empty($errors)) {
+    exit(-1);
+}

--- a/upgrades/schema/archived_logs_local_filesystem_to_object_storage.php
+++ b/upgrades/schema/archived_logs_local_filesystem_to_object_storage.php
@@ -1,0 +1,48 @@
+<?php
+
+// This script is used to relocate import/export logs from a local filesystem to an object storage.
+//
+// The log files are listed from the "akeneo_batch_job_execution" table.
+// Then, each existing and readable local file is stored in the object storage "oneup_flysystem.archivist_filesystem".
+//
+// Please note that this script does NOT delete source files.
+
+if (!file_exists(__DIR__ . '/../../app/AppKernel.php')) {
+    die("Please run this command from your Symfony application root.");
+}
+
+require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/../../app/AppKernel.php';
+require __DIR__ . '/LocalLogToObjectStorage.php';
+require __DIR__ . '/RelocateException.php';
+
+$envFile = __DIR__ . '/../.env';
+if (file_exists($envFile)) {
+    (new Symfony\Component\Dotenv\Dotenv())->load($envFile);
+}
+
+$kernel = new AppKernel('prod', false);
+$kernel->boot();
+$container = $kernel->getContainer();
+
+$storage = new \Pim\Upgrade\Schema\LocalLogToObjectStorage(
+    $container->get('oneup_flysystem.archivist_filesystem'),
+    $container->get('doctrine.dbal.default_connection')
+);
+
+echo "Relocating {$storage->countFiles()} local import/export logs to the object storage...\n";
+
+$errors = $storage->relocateFiles();
+
+if (!empty($errors)) {
+    echo "The following files have NOT been relocated:\n";
+    foreach ($errors as $error) {
+        echo "- $error\n";
+    }
+}
+
+echo "Done!\n";
+
+if (!empty($errors)) {
+    exit(-1);
+}


### PR DESCRIPTION
Migration scripts for our SAAS NFS PIM towards non NFS. To achieve that we now store some files (import/export logs, import/export archives, product medias) in object storage instead of locally. 

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

