### PR TITLE
PIM-8412: Fix wrong display of too long attribute group labels when filtering in the datagrid

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8412: Fix wrong display of too long attribute group labels when filtering in the datagrid
+
 # 3.0.22 (2019-06-04)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.multiselect.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.multiselect.less
@@ -317,3 +317,11 @@
     }
   }
 }
+
+.filters-column {
+  .ui-multiselect-optgroup-label a {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
@@ -46,7 +46,7 @@ class FiltersColumn extends BaseView {
   readonly filterGroupTemplate: string = `
     <ul class="ui-multiselect-checkboxes ui-helper-reset full">
         <li class="ui-multiselect-optgroup-label">
-            <a><%- groupName %></a>
+            <a title="<%- groupName %>"><%- groupName %></a>
         </li>
         <% filters.forEach(filter => { %>
           <li>
@@ -198,7 +198,7 @@ class FiltersColumn extends BaseView {
 
     if (searchValue.length === 0) {
       this.searchedFilters = undefined;
-      
+
       return this.renderFilters();
     }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
GTM by Stéphane for the UI.
Credits for the fix: @pierallard 

Before:
![Screenshot from 2019-06-06 13-45-10](https://user-images.githubusercontent.com/1942439/59030475-650bfb00-8861-11e9-931d-fc0107c5d7ce.png)

After:

![Screenshot from 2019-06-06 13-45-36](https://user-images.githubusercontent.com/1942439/59030480-689f8200-8861-11e9-8932-15bd0d34e6c2.png)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
