### PR TITLE
DAPI-137: Do not aggregate results in the PQB when there is a filter on id

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -8,7 +8,7 @@
 
 
 
-
+ - DAPI-137: Fix the PQB to not aggregate results when there is a filter on id
 
 
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -96,7 +96,7 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
             $this->addFilter('parent', Operators::IS_EMPTY, null);
         }
 
-        if (!$this->hasRawFilter('field', 'parent')) {
+        if (!$this->hasRawFilter('field', 'parent') && !$this->hasRawFilter('field', 'id')) {
             $this->searchAggregator->aggregateResults($this->getQueryBuilder(), $this->getRawFilters());
         }
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
@@ -270,7 +270,7 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
         $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
         $pqb->execute()->willReturn($cursor);
         $pqb->getQueryBuilder()->willReturn($sqb);
-        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldNotBeCalled();
 
         $this->execute()->shouldReturn($cursor);
     }
@@ -453,6 +453,38 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
                 'context'  => [],
                 'type'     => 'field'
             ]
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
+
+        $sqb->addFilter(Argument::cetera())->shouldNotBeCalled();
+
+        $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldNotBeCalled();
+        $this->execute()->shouldReturn($cursor);
+    }
+
+    function it_does_not_aggregate_when_there_is_a_filter_on_id(
+        $pqb,
+        $searchAggregator,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb
+    ) {
+        $rawFilters = [
+            [
+                'field'    => 'id',
+                'operator' => 'IN',
+                'value'    => ['product_41', 'product_42'],
+                'context'  => [],
+                'type'     => 'field'
+            ],
+            [
+                'field'    => 'foo',
+                'operator' => 'CONTAINS',
+                'value'    => '42',
+                'context'  => [],
+                'type'     => 'attribute'
+            ],
         ];
         $pqb->getRawFilters()->willReturn($rawFilters);
 


### PR DESCRIPTION
The original need is to add a filter on the draft status in the product grid (see https://github.com/akeneo/pim-enterprise-dev/pull/5949). To do so, the solution is to filter by the Ids of the products and product models that have a draft on the chosen status. 

The problem is that when this is combined with a filter on a category, the product variants that match the draft status filter are not displayed. It's because the ES query is modified by `ProductAndProductModelSearchAggregator` to aggregate the product variants in their product model. It adds a `must not` clause to exclude products whose parents match the category.

The simplest solution is to not add the aggregation clauses in the ES query if there is a filter on the Id. It makes sense for the operators `IN` and `=` but it's debatable for the operators `NOT IN` and `!=`. It has been accepted by the PM for the filter by draft status, but it may impact future features.

I searched where the filter by Id is used with the PQB, and it only occurs in the product associations. But I didn't find any impact of this change (especially because a product variant cannot be associated)