### PR TITLE
Add admin user to groups

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
+++ b/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
@@ -119,6 +119,7 @@ DESC
 
         if ($this->isAdmin) {
             $this->addAdminRoleTo($user);
+            $this->addEveryGroupTo($user);
         }
 
         $this->getContainer()->get('pim_user.saver.user')->save($user);
@@ -329,6 +330,15 @@ DESC
 
         if (null !== $role) {
             $user->addRole($role);
+        }
+    }
+
+    private function addEveryGroupTo(UserInterface $user): void
+    {
+        $groups = $this->getContainer()->get('pim_user.repository.group')->findAll();
+
+        foreach ($groups as $group) {
+            $user->addGroup($group);
         }
     }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR updates the create user command to add an admin user into every group. Currently, after creating an admin user using this command, the admin user is only in the default 'All' group, which doesn't have permission to edit the product identifier. This problem causes the akeneo-data-generator to fail when inserting products. 


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
