### PR TITLE
PIM-8417: Disable HTML prettify for WYSIWYG field

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7942: Fix tooltip minimal width
+- PIM-8417: Fix inconsistent behavior in WYSIWYG editor by disabling HTML prettify
 
 # 2.3.47 (2019-06-03)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -49,7 +49,7 @@ define(
                         ['insert', ['link']],
                         ['view', ['codeview']]
                     ],
-                    callbacks: {}
+                    prettifyHtml: false
                 })
                 .on('summernote.blur', this.updateModel.bind(this))
                 .on('summernote.keyup', this.removeEmptyTags.bind(this));

--- a/src/Pim/Bundle/UIBundle/Resources/public/js/pim-wysiwyg.js
+++ b/src/Pim/Bundle/UIBundle/Resources/public/js/pim-wysiwyg.js
@@ -22,7 +22,8 @@ define(
                 ['para', ['ul', 'ol']],
                 ['insert', ['link']],
                 ['view', ['codeview']]
-            ]
+            ],
+            prettifyHtml: false
         };
 
         Backbone.Router.prototype.on('route', function () {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
