### PR TITLE
PIM-8383: Do not take in account product without family when filtering IS_EMPTY + fix count on bulk actions

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8383: Do not take products without family into account when filtering on empty values
+
 # 3.0.25 (2019-06-18)
 
 # 3.0.24 (2019-06-17)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Query/CountImpactedProducts.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Query/CountImpactedProducts.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\ProductAndProductModelSearchAggregator;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/DateFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/DateFilter.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterHelper;
@@ -22,18 +23,18 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
 {
     const DATETIME_FORMAT = 'Y-m-d';
     const HUMAN_DATETIME_FORMAT = "yyyy-mm-dd";
-
-    /**
-     * @param AttributeValidatorHelper $attrValidatorHelper
-     * @param array $supportedAttributeTypes
-     * @param array $supportedOperators
-     */
+    
+    /** @var FamilyFilter */
+    private $familyFilter;
+    
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
+        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -134,6 +135,8 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
                 ];
 
                 $this->searchQueryBuilder->addMustNot($existsClause);
+                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
+                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
 
                 break;
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/DateFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/DateFilter.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterHelper;
@@ -23,18 +22,18 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
 {
     const DATETIME_FORMAT = 'Y-m-d';
     const HUMAN_DATETIME_FORMAT = "yyyy-mm-dd";
-    
-    /** @var FamilyFilter */
-    private $familyFilter;
-    
+
+    /**
+     * @param AttributeValidatorHelper $attrValidatorHelper
+     * @param array $supportedAttributeTypes
+     * @param array $supportedOperators
+     */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
-        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
-        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -133,10 +132,12 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
                 $existsClause = [
                     'exists' => ['field' => $attributePath]
                 ];
-
                 $this->searchQueryBuilder->addMustNot($existsClause);
-                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
-                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
+
+                $familyExistsClause = [
+                    'exists' => ['field' => 'family.code']
+                ];
+                $this->searchQueryBuilder->addFilter($familyExistsClause);
 
                 break;
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MediaFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MediaFilter.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterHelper;
@@ -20,18 +21,18 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
 {
     const PATH_SUFFIX = 'original_filename';
 
-    /**
-     * @param AttributeValidatorHelper $attrValidatorHelper
-     * @param array                    $supportedAttributeTypes
-     * @param array                    $supportedOperators
-     */
+    /** @var FamilyFilter */
+    private $familyFilter;
+
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
+        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->familyFilter = $familyFilter;
         $this->supportedOperators = $supportedOperators;
     }
 
@@ -127,6 +128,9 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
                     ],
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
+
+                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
+                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MediaFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MediaFilter.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterHelper;
@@ -21,18 +20,18 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
 {
     const PATH_SUFFIX = 'original_filename';
 
-    /** @var FamilyFilter */
-    private $familyFilter;
-
+    /**
+     * @param AttributeValidatorHelper $attrValidatorHelper
+     * @param array                    $supportedAttributeTypes
+     * @param array                    $supportedOperators
+     */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
-        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
-        $this->familyFilter = $familyFilter;
         $this->supportedOperators = $supportedOperators;
     }
 
@@ -129,8 +128,10 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
-                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
+                $familyExistsClause = [
+                    'exists' => ['field' => 'family.code'],
+                ];
+                $this->searchQueryBuilder->addFilter($familyExistsClause);
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MetricFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MetricFilter.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -29,23 +30,21 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
     /** @var MeasureConverter */
     protected $measureConverter;
 
-    /**
-     * @param AttributeValidatorHelper $attrValidatorHelper
-     * @param MeasureManager           $measureManager
-     * @param MeasureConverter         $measureConverter
-     * @param array                    $supportedAttributeTypes
-     * @param array                    $supportedOperators
-     */
+    /** @var FamilyFilter */
+    private $familyFilter;
+
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
         MeasureManager $measureManager,
         MeasureConverter $measureConverter,
+        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->measureManager = $measureManager;
         $this->measureConverter = $measureConverter;
+        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -142,6 +141,9 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
                     ]
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
+
+                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
+                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MetricFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MetricFilter.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -30,21 +29,23 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
     /** @var MeasureConverter */
     protected $measureConverter;
 
-    /** @var FamilyFilter */
-    private $familyFilter;
-
+    /**
+     * @param AttributeValidatorHelper $attrValidatorHelper
+     * @param MeasureManager           $measureManager
+     * @param MeasureConverter         $measureConverter
+     * @param array                    $supportedAttributeTypes
+     * @param array                    $supportedOperators
+     */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
         MeasureManager $measureManager,
         MeasureConverter $measureConverter,
-        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->measureManager = $measureManager;
         $this->measureConverter = $measureConverter;
-        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -142,8 +143,10 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
-                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
+                $familyExistsClause = [
+                    'exists' => ['field' => 'family.code']
+                ];
+                $this->searchQueryBuilder->addFilter($familyExistsClause);
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/NumberFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/NumberFilter.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -20,18 +21,18 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
  */
 class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInterface
 {
-    /**
-     * @param AttributeValidatorHelper $attrValidatorHelper
-     * @param array $supportedAttributeTypes
-     * @param array $supportedOperators
-     */
+    /** @var FamilyFilter */
+    private $familyFilter;
+
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
+        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->familyFilter = $familyFilter;
         $this->supportedOperators = $supportedOperators;
     }
 
@@ -120,6 +121,9 @@ class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInt
                     ]
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
+
+                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
+                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
                 break;
             case Operators::IS_NOT_EMPTY:
                 $clause = [

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/NumberFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/NumberFilter.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -21,18 +20,18 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
  */
 class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInterface
 {
-    /** @var FamilyFilter */
-    private $familyFilter;
-
+    /**
+     * @param AttributeValidatorHelper $attrValidatorHelper
+     * @param array $supportedAttributeTypes
+     * @param array $supportedOperators
+     */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
-        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
-        $this->familyFilter = $familyFilter;
         $this->supportedOperators = $supportedOperators;
     }
 
@@ -122,8 +121,10 @@ class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInt
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
-                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
+                $familyExistsClause = [
+                    'exists' => ['field' => 'family.code']
+                ];
+                $this->searchQueryBuilder->addFilter($familyExistsClause);
                 break;
             case Operators::IS_NOT_EMPTY:
                 $clause = [

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
@@ -24,20 +25,19 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
     /** @var AttributeOptionRepositoryInterface */
     protected $attributeOptionRepository;
 
-    /**
-     * @param AttributeValidatorHelper  $attrValidatorHelper
-     * @param AttributeOptionRepository $attributeOptionRepository
-     * @param array                     $supportedAttributeTypes
-     * @param array                     $supportedOperators
-     */
+    /** @var FamilyFilter */
+    private $familyFilter;
+
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
         AttributeOptionRepositoryInterface $attributeOptionRepository,
+        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->attributeOptionRepository = $attributeOptionRepository;
+        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -82,6 +82,9 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
                     ],
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
+
+                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
+                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
@@ -25,19 +24,20 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
     /** @var AttributeOptionRepositoryInterface */
     protected $attributeOptionRepository;
 
-    /** @var FamilyFilter */
-    private $familyFilter;
-
+    /**
+     * @param AttributeValidatorHelper  $attrValidatorHelper
+     * @param AttributeOptionRepository $attributeOptionRepository
+     * @param array                     $supportedAttributeTypes
+     * @param array                     $supportedOperators
+     */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
         AttributeOptionRepositoryInterface $attributeOptionRepository,
-        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->attributeOptionRepository = $attributeOptionRepository;
-        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -83,8 +83,10 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
-                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
+                $familyExistsClause = [
+                    'exists' => ['field' => 'family.code']
+                ];
+                $this->searchQueryBuilder->addFilter($familyExistsClause);
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/PriceFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/PriceFilter.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
 use Akeneo\Channel\Component\Repository\CurrencyRepositoryInterface;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -44,20 +45,19 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
     /** @var CurrencyRepositoryInterface */
     protected $currencyRepository;
 
-    /**
-     * @param AttributeValidatorHelper    $attrValidatorHelper
-     * @param CurrencyRepositoryInterface $currencyRepository
-     * @param array                       $supportedAttributeTypes
-     * @param array                       $supportedOperators
-     */
+    /** @var FamilyFilter */
+    private $familyFilter;
+
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
         CurrencyRepositoryInterface $currencyRepository,
+        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->currencyRepository = $currencyRepository;
+        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -169,6 +169,9 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
                     ],
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
+
+                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
+                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
                 break;
 
             case Operators::IS_EMPTY_FOR_CURRENCY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/PriceFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/PriceFilter.php
@@ -3,7 +3,6 @@
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
 use Akeneo\Channel\Component\Repository\CurrencyRepositoryInterface;
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -45,19 +44,20 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
     /** @var CurrencyRepositoryInterface */
     protected $currencyRepository;
 
-    /** @var FamilyFilter */
-    private $familyFilter;
-
+    /**
+     * @param AttributeValidatorHelper    $attrValidatorHelper
+     * @param CurrencyRepositoryInterface $currencyRepository
+     * @param array                       $supportedAttributeTypes
+     * @param array                       $supportedOperators
+     */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
         CurrencyRepositoryInterface $currencyRepository,
-        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->currencyRepository = $currencyRepository;
-        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -170,8 +170,10 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
-                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
+            $familyExistsClause = [
+                'exists' => ['field' => 'family.code']
+            ];
+            $this->searchQueryBuilder->addFilter($familyExistsClause);
                 break;
 
             case Operators::IS_EMPTY_FOR_CURRENCY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilter.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
 use Akeneo\Pim\Enrichment\Bundle\Doctrine\ReferenceDataRepositoryResolver;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterHelper;
@@ -27,23 +28,21 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
     /** @var ConfigurationRegistryInterface */
     protected $registry;
 
-    /**
-     * @param AttributeValidatorHelper         $attrValidatorHelper
-     * @param ReferenceDataRepositoryResolver  $referenceDataRepositoryResolver
-     * @param ConfigurationRegistryInterface   $registry
-     * @param array                            $supportedAttributeTypes
-     * @param array                            $supportedOperators
-     */
+    /** @var FamilyFilter */
+    private $familyFilter;
+
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
         ReferenceDataRepositoryResolver $referenceDataRepositoryResolver,
         ConfigurationRegistryInterface $registry,
+        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->referenceDataRepositoryResolver = $referenceDataRepositoryResolver;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->familyFilter = $familyFilter;
         $this->supportedOperators = $supportedOperators;
         $this->registry = $registry;
     }
@@ -88,6 +87,9 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
                     ],
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
+
+                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
+                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilter.php
@@ -3,7 +3,6 @@
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
 use Akeneo\Pim\Enrichment\Bundle\Doctrine\ReferenceDataRepositoryResolver;
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterHelper;
@@ -28,21 +27,23 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
     /** @var ConfigurationRegistryInterface */
     protected $registry;
 
-    /** @var FamilyFilter */
-    private $familyFilter;
-
+    /**
+     * @param AttributeValidatorHelper         $attrValidatorHelper
+     * @param ReferenceDataRepositoryResolver  $referenceDataRepositoryResolver
+     * @param ConfigurationRegistryInterface   $registry
+     * @param array                            $supportedAttributeTypes
+     * @param array                            $supportedOperators
+     */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
         ReferenceDataRepositoryResolver $referenceDataRepositoryResolver,
         ConfigurationRegistryInterface $registry,
-        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
         $this->referenceDataRepositoryResolver = $referenceDataRepositoryResolver;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
-        $this->familyFilter = $familyFilter;
         $this->supportedOperators = $supportedOperators;
         $this->registry = $registry;
     }
@@ -88,8 +89,10 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
-                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
+                $familyExistsClause = [
+                    'exists' => ['field' => 'family.code']
+                ];
+                $this->searchQueryBuilder->addFilter($familyExistsClause);
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -19,17 +20,17 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
  */
 class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterInterface
 {
-    /**
-     * @param AttributeValidatorHelper $attrValidatorHelper
-     * @param array                    $supportedAttributeTypes
-     * @param array                    $supportedOperators
-     */
+    /** @var FamilyFilter */
+    private $familyFilter;
+
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
+        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -130,6 +131,9 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
                     ],
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
+
+                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
+                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -20,17 +19,17 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
  */
 class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterInterface
 {
-    /** @var FamilyFilter */
-    private $familyFilter;
-
+    /**
+     * @param AttributeValidatorHelper $attrValidatorHelper
+     * @param array                    $supportedAttributeTypes
+     * @param array                    $supportedOperators
+     */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
-        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
-        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -132,8 +131,10 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
-                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
+                $familyExistsClause = [
+                    'exists' => ['field' => 'family.code']
+                ];
+                $this->searchQueryBuilder->addFilter($familyExistsClause);
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextFilter.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -19,17 +20,17 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
  */
 class TextFilter extends AbstractAttributeFilter implements AttributeFilterInterface
 {
-    /**
-     * @param AttributeValidatorHelper $attrValidatorHelper
-     * @param array                    $supportedAttributeTypes
-     * @param array                    $supportedOperators
-     */
+    /** @var FamilyFilter */
+    private $familyFilter;
+
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
+        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -126,6 +127,9 @@ class TextFilter extends AbstractAttributeFilter implements AttributeFilterInter
                     ],
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
+
+                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
+                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextFilter.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -20,17 +19,17 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
  */
 class TextFilter extends AbstractAttributeFilter implements AttributeFilterInterface
 {
-    /** @var FamilyFilter */
-    private $familyFilter;
-
+    /**
+     * @param AttributeValidatorHelper $attrValidatorHelper
+     * @param array                    $supportedAttributeTypes
+     * @param array                    $supportedOperators
+     */
     public function __construct(
         AttributeValidatorHelper $attrValidatorHelper,
-        FamilyFilter $familyFilter,
         array $supportedAttributeTypes = [],
         array $supportedOperators = []
     ) {
         $this->attrValidatorHelper = $attrValidatorHelper;
-        $this->familyFilter = $familyFilter;
         $this->supportedAttributeTypes = $supportedAttributeTypes;
         $this->supportedOperators = $supportedOperators;
     }
@@ -128,8 +127,10 @@ class TextFilter extends AbstractAttributeFilter implements AttributeFilterInter
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $this->familyFilter->setQueryBuilder($this->searchQueryBuilder);
-                $this->familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value');
+                $familyExistsClause = [
+                    'exists' => ['field' => 'family.code']
+                ];
+                $this->searchQueryBuilder->addFilter($familyExistsClause);
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -425,6 +425,7 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.number.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'
+            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_number']
             - ['<', '<=', '=', '!=', '>=', '>', 'EMPTY', 'NOT EMPTY']
         tags:
@@ -436,6 +437,7 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.date.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'
+            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_date']
             - ['=', '<', '>', 'BETWEEN', 'NOT BETWEEN', 'EMPTY', 'NOT EMPTY', '!=']
         tags:
@@ -447,6 +449,7 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.text.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'
+            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_text']
             - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY', 'NOT EMPTY', '!=']
         tags:
@@ -458,6 +461,7 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.text_area.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'
+            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_textarea']
             - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY', 'NOT EMPTY', '!=']
         tags:
@@ -470,6 +474,7 @@ services:
         arguments:
             - '@pim_catalog.validator.helper.attribute'
             - '@pim_catalog.repository.attribute_option'
+            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_simpleselect', 'pim_catalog_multiselect']
             - ['IN', 'EMPTY', 'NOT EMPTY', 'NOT IN']
         tags:
@@ -482,6 +487,7 @@ services:
         arguments:
             - '@pim_catalog.validator.helper.attribute'
             - '@pim_catalog.repository.currency'
+            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_price_collection']
             - ['<', '<=', '=', '!=', '>=', '>', 'EMPTY', 'EMPTY FOR CURRENCY', 'EMPTY ON ALL CURRENCIES', 'NOT EMPTY', 'NOT EMPTY ON AT LEAST ONE CURRENCY', 'NOT EMPTY FOR CURRENCY']
         tags:
@@ -495,6 +501,7 @@ services:
             - '@pim_catalog.validator.helper.attribute'
             - '@akeneo_measure.manager'
             - '@akeneo_measure.measure_converter'
+            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_metric']
             - ['<', '<=', '=', '!=', '>=', '>', 'EMPTY', 'EMPTY FOR CURRENCY', 'EMPTY ON ALL CURRENCIES', 'NOT EMPTY', 'NOT EMPTY ON AT LEAST ONE CURRENCY', 'NOT EMPTY FOR CURRENCY']
         tags:
@@ -506,6 +513,7 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.media.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'
+            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_file', 'pim_catalog_image']
             - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'EMPTY', 'NOT EMPTY']
         tags:
@@ -621,6 +629,7 @@ services:
             - '@pim_catalog.validator.helper.attribute'
             - '@pim_reference_data.repository_resolver'
             - '@pim_reference_data.registry'
+            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_reference_data_simpleselect', 'pim_reference_data_multiselect']
             - ['IN', 'EMPTY', 'NOT EMPTY', 'NOT IN']
         tags:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -425,7 +425,6 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.number.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'
-            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_number']
             - ['<', '<=', '=', '!=', '>=', '>', 'EMPTY', 'NOT EMPTY']
         tags:
@@ -437,7 +436,6 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.date.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'
-            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_date']
             - ['=', '<', '>', 'BETWEEN', 'NOT BETWEEN', 'EMPTY', 'NOT EMPTY', '!=']
         tags:
@@ -449,7 +447,6 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.text.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'
-            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_text']
             - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY', 'NOT EMPTY', '!=']
         tags:
@@ -461,7 +458,6 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.text_area.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'
-            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_textarea']
             - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'EMPTY', 'NOT EMPTY', '!=']
         tags:
@@ -474,7 +470,6 @@ services:
         arguments:
             - '@pim_catalog.validator.helper.attribute'
             - '@pim_catalog.repository.attribute_option'
-            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_simpleselect', 'pim_catalog_multiselect']
             - ['IN', 'EMPTY', 'NOT EMPTY', 'NOT IN']
         tags:
@@ -487,7 +482,6 @@ services:
         arguments:
             - '@pim_catalog.validator.helper.attribute'
             - '@pim_catalog.repository.currency'
-            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_price_collection']
             - ['<', '<=', '=', '!=', '>=', '>', 'EMPTY', 'EMPTY FOR CURRENCY', 'EMPTY ON ALL CURRENCIES', 'NOT EMPTY', 'NOT EMPTY ON AT LEAST ONE CURRENCY', 'NOT EMPTY FOR CURRENCY']
         tags:
@@ -501,7 +495,6 @@ services:
             - '@pim_catalog.validator.helper.attribute'
             - '@akeneo_measure.manager'
             - '@akeneo_measure.measure_converter'
-            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_metric']
             - ['<', '<=', '=', '!=', '>=', '>', 'EMPTY', 'EMPTY FOR CURRENCY', 'EMPTY ON ALL CURRENCIES', 'NOT EMPTY', 'NOT EMPTY ON AT LEAST ONE CURRENCY', 'NOT EMPTY FOR CURRENCY']
         tags:
@@ -513,7 +506,6 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.media.class%'
         arguments:
             - '@pim_catalog.validator.helper.attribute'
-            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_catalog_file', 'pim_catalog_image']
             - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'EMPTY', 'NOT EMPTY']
         tags:
@@ -629,7 +621,6 @@ services:
             - '@pim_catalog.validator.helper.attribute'
             - '@pim_reference_data.repository_resolver'
             - '@pim_reference_data.registry'
-            - '@pim_catalog.query.elasticsearch.filter.family'
             - ['pim_reference_data_simpleselect', 'pim_reference_data_multiselect']
             - ['IN', 'EMPTY', 'NOT EMPTY', 'NOT IN']
         tags:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/ProductQueryBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/ProductQueryBuilder.php
@@ -7,6 +7,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterfac
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterHelper;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FilterRegistryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\AttributeSorterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\FieldSorterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\SorterRegistryInterface;
@@ -239,6 +240,14 @@ class ProductQueryBuilder implements ProductQueryBuilderInterface
 
         $filter->setQueryBuilder($this->getQueryBuilder());
         $filter->addAttributeFilter($attribute, $operator, $value, $locale, $scope, $context);
+
+        // The products without family should not be returned when filtering on an empty value,
+        // as empty optional values are considered inexistant
+        if (Operators::IS_EMPTY === $operator
+            || Operators::IS_EMPTY_FOR_CURRENCY === $operator
+            || Operators::IS_EMPTY_ON_ALL_CURRENCIES === $operator) {
+            $this->addFilter('family', Operators::IS_NOT_EMPTY, null);
+        }
 
         return $this;
     }

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Query/CountImpactedProductsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Query/CountImpactedProductsIntegration.php
@@ -72,6 +72,22 @@ class CountImpactedProductsIntegration extends TestCase
         $this->assertProductsCountInSelection($pqbFilters, 242);
     }
 
+    public function testUserSelectedAllEntitiesWithEmptyAttributeFilter()
+    {
+        // top_composition only belongs of the 'Shoes' family, so the query should only return shoes products
+        $pqbFilters = [
+            [
+                'field' => 'top_composition',
+                'operator' => 'EMPTY',
+                'value' => null,
+                'context' => ['locale' => 'en_US', 'scope' => 'ecommerce'],
+            ],
+        ];
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+
+        $this->assertProductsCountInSelection($pqbFilters, 65);
+    }
+
     public function testUserSelectedAllEntitiesAndFilteredByLabel()
     {
         $pqbFilters = [

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/DateFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/DateFilterIntegration.php
@@ -19,7 +19,13 @@ class DateFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_date']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_date' => [
                     ['data' => '2017-02-06', 'locale' => null, 'scope' => null]
@@ -28,6 +34,7 @@ class DateFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_date' => [
                     ['data' => '2017-02-27', 'locale' => null, 'scope' => null]
@@ -35,7 +42,7 @@ class DateFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/LocalizableFilterIntegration.php
@@ -27,7 +27,13 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'scopable'            => false
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_date']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_date' => [
                     ['data' => '2016-04-23', 'locale' => 'en_US', 'scope' => null],
@@ -37,6 +43,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_date' => [
                     ['data' => '2016-09-23', 'locale' => 'en_US', 'scope' => null],
@@ -45,7 +52,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/LocalizableScopableFilterIntegration.php
@@ -27,7 +27,13 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             'scopable'            => true
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_scopable_date']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_date' => [
                     ['data' => '2016-04-23', 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -39,6 +45,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_date' => [
                     ['data' => '2016-09-23', 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -48,7 +55,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/ScopableFilterIntegration.php
@@ -27,7 +27,13 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'scopable'            => true
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_scopable_date']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_date' => [
                     ['data' => '2016-04-23', 'scope' => 'ecommerce', 'locale' => null],
@@ -37,6 +43,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_date' => [
                     ['data' => '2016-09-23', 'scope' => 'ecommerce', 'locale' => null],
@@ -44,7 +51,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableFilterIntegration.php
@@ -27,7 +27,13 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'scopable'            => false
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_media']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_image' => [
                     ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'en_US', 'scope' => null],
@@ -37,6 +43,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_image' => [
                     ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'en_US', 'scope' => null],
@@ -45,7 +52,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableScopableFilterIntegration.php
@@ -19,7 +19,13 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
     {
         parent::setUp();
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_scopable_image']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_image' => [
                     ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -31,6 +37,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_image' => [
                     ['data' => $this->getFixturePath('ziggy.png'), 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -40,7 +47,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/MediaFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/MediaFilterIntegration.php
@@ -19,7 +19,13 @@ class MediaFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'an_image']
+        ]);
+
         $this->createProduct('akeneo', [
+            'family' => 'a_family',
             'values' => [
                 'an_image' => [
                     ['data' => $this->getFixturePath('akeneo.jpg'), 'locale' => null, 'scope' => null]
@@ -28,6 +34,7 @@ class MediaFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('ziggy', [
+            'family' => 'a_family',
             'values' => [
                 'an_image' => [
                     ['data' => $this->getFixturePath('ziggy.png'), 'locale' => null, 'scope' => null]
@@ -35,7 +42,7 @@ class MediaFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/ScopableFilterIntegration.php
@@ -27,7 +27,13 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'scopable'            => true
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_media']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_image' => [
                     ['data' => $this->getFixturePath('akeneo.jpg'), 'scope' => 'ecommerce', 'locale' => null],
@@ -37,6 +43,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_image' => [
                     ['data' => $this->getFixturePath('ziggy.png'), 'scope' => 'ecommerce', 'locale' => null],
@@ -45,7 +52,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableFilterIntegration.php
@@ -30,7 +30,13 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'default_metric_unit' => 'METER',
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_metric']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_metric' => [
                     ['data' => ['amount' => 20, 'unit' => 'METER'], 'locale' => 'en_US', 'scope' => null],
@@ -40,6 +46,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_metric' => [
                     ['data' => ['amount' => 10, 'unit' => 'METER'], 'locale' => 'en_US', 'scope' => null],
@@ -48,7 +55,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableScopableFilterIntegration.php
@@ -31,7 +31,13 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             'default_metric_unit' => 'KILOWATT'
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_scopable_localizable_metric']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_localizable_metric' => [
                     ['data' => ['amount' => '-5.00', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -42,6 +48,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_localizable_metric' => [
                     ['data' => ['amount' => '-5.00', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -52,7 +59,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/MetricFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/MetricFilterIntegration.php
@@ -19,7 +19,13 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_metric']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_metric' => [
                     ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
@@ -28,6 +34,7 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_metric' => [
                     ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
@@ -35,7 +42,7 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/ScopableFilterIntegration.php
@@ -31,7 +31,13 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'default_metric_unit' => 'METER'
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_scopable_metric']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_metric' => [
                     ['data' => ['amount' => '10.55', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'ecommerce'],
@@ -41,6 +47,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_metric' => [
                     ['data' => ['amount' => '2', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'ecommerce'],
@@ -49,7 +56,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableFilterIntegration.php
@@ -29,7 +29,13 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'decimals_allowed'    => true,
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_number']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_number' => [
                     ['data' => -15, 'locale' => 'en_US', 'scope' => null],
@@ -39,6 +45,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_number' => [
                     ['data' => 19, 'locale' => 'en_US', 'scope' => null]
@@ -46,7 +53,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableScopableFilterIntegration.php
@@ -29,7 +29,13 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             'decimals_allowed'    => true,
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_scopable_number']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_number' => [
                     ['data' => -15, 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -40,6 +46,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_number' => [
                     ['data' => 19, 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -50,7 +57,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/NumberFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/NumberFilterIntegration.php
@@ -19,7 +19,13 @@ class NumberFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_number_float_negative']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_number_float_negative' => [
                     ['data' => -15.5, 'locale' => null, 'scope' => null]
@@ -28,6 +34,7 @@ class NumberFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_number_float_negative' => [
                     ['data' => 19.0, 'locale' => null, 'scope' => null]
@@ -35,7 +42,7 @@ class NumberFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/ScopableFilterIntegration.php
@@ -29,7 +29,13 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'decimals_allowed'    => true,
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_scopable_number']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_number' => [
                     ['data' => -15, 'locale' => null, 'scope' => 'ecommerce'],
@@ -39,6 +45,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_number' => [
                     ['data' => 19, 'locale' => null, 'scope' => 'tablet']
@@ -46,7 +53,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableFilterIntegration.php
@@ -37,7 +37,13 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'code'      => 'black'
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_simple_select']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_simple_select' => [
                     ['data' => 'orange', 'locale' => 'en_US', 'scope' => null],
@@ -47,6 +53,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_simple_select' => [
                     ['data' => 'black', 'locale' => 'en_US', 'scope' => null],
@@ -55,7 +62,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableScopableFilterIntegration.php
@@ -37,7 +37,13 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             'code'      => 'black'
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_scopable_simple_select']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_simple_select' => [
                     ['data' => 'orange', 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -49,6 +55,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_simple_select' => [
                     ['data' => 'black', 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -59,7 +66,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/OptionFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/OptionFilterIntegration.php
@@ -29,7 +29,13 @@ class OptionFilterIntegration extends AbstractProductQueryBuilderTestCase
             'code'      => 'black'
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_simple_select']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_simple_select' => [
                     ['data' => 'orange', 'locale' => null, 'scope' => null]
@@ -38,6 +44,7 @@ class OptionFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_simple_select' => [
                     ['data' => 'black', 'locale' => null, 'scope' => null]
@@ -45,7 +52,7 @@ class OptionFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/ScopableFilterIntegration.php
@@ -37,7 +37,13 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'code'      => 'black'
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_select_scopable_simple_select']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_select_scopable_simple_select' => [
                     ['data' => 'orange', 'locale' => null, 'scope' => 'ecommerce']
@@ -46,6 +52,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_select_scopable_simple_select' => [
                     ['data' => 'black', 'locale' => null, 'scope' => 'ecommerce'],
@@ -54,7 +61,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableFilterIntegration.php
@@ -42,7 +42,13 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'code'      => 'purple'
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_multi_select']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_multi_select' => [
                     ['data' => ['orange'], 'locale' => 'en_US', 'scope' => null],
@@ -52,6 +58,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_multi_select' => [
                     ['data' => ['black', 'orange'], 'locale' => 'en_US', 'scope' => null],
@@ -60,7 +67,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableScopableFilterIntegration.php
@@ -42,7 +42,13 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             'code'      => 'purple'
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_scopable_multi_select']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_multi_select' => [
                     ['data' => ['orange'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -54,6 +60,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_multi_select' => [
                     ['data' => ['black', 'purple'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -64,7 +71,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/OptionsFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/OptionsFilterIntegration.php
@@ -34,7 +34,13 @@ class OptionsFilterIntegration extends AbstractProductQueryBuilderTestCase
             'code'      => 'purple'
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_multi_select']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_multi_select' => [
                     ['data' => ['orange'], 'locale' => null, 'scope' => null]
@@ -43,6 +49,7 @@ class OptionsFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_multi_select' => [
                     ['data' => ['black', 'purple'], 'locale' => null, 'scope' => null]
@@ -50,7 +57,7 @@ class OptionsFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/ScopableFilterIntegration.php
@@ -42,7 +42,13 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'code'      => 'purple'
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_scopable_multi_select']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_multi_select' => [
                     ['data' => ['orange'], 'locale' => null, 'scope' => 'ecommerce']
@@ -51,6 +57,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_multi_select' => [
                     ['data' => ['black', 'purple'], 'locale' => null, 'scope' => 'ecommerce'],
@@ -59,7 +66,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableFilterIntegration.php
@@ -28,7 +28,13 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'decimals_allowed' => false,
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_price']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_price' => [
                     ['data' => [['amount' => 20, 'currency' => 'EUR']], 'locale' => 'en_US', 'scope' => null],
@@ -38,6 +44,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_price' => [
                     ['data' => [['amount' => 10, 'currency' => 'EUR']], 'locale' => 'en_US', 'scope' => null],
@@ -46,7 +53,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ],
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableScopableFilterIntegration.php
@@ -28,7 +28,13 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             'decimals_allowed' => true,
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_scopable_localizable_price']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_localizable_price' => [
                     [
@@ -47,6 +53,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_localizable_price' => [
                     [
@@ -65,7 +72,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             ],
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/PriceFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/PriceFilterIntegration.php
@@ -19,7 +19,13 @@ class PriceFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_price']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_price' => [
                     ['data' => [
@@ -31,6 +37,7 @@ class PriceFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_price' => [
                     ['data' => [['amount' => '15', 'currency' => 'EUR']], 'locale' => null, 'scope' => null]
@@ -38,7 +45,7 @@ class PriceFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/ScopableFilterIntegration.php
@@ -19,7 +19,13 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_scopable_price']
+        ]);
+
         $this->createProduct('product_one', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_price' => [
                     [
@@ -33,6 +39,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_two', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_price' => [
                     [
@@ -48,7 +55,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ],
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataMultiSelectFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataMultiSelectFilterIntegration.php
@@ -19,9 +19,15 @@ class ReferenceDataMultiSelectFilterIntegration extends AbstractProductQueryBuil
     {
         parent::setUp();
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_ref_data_multi_select']
+        ]);
+
         $this->createProduct(
             'product_one',
             [
+                'family' => 'a_family',
                 'values' => [
                     'a_ref_data_multi_select' => [
                         [
@@ -40,6 +46,7 @@ class ReferenceDataMultiSelectFilterIntegration extends AbstractProductQueryBuil
         $this->createProduct(
             'product_two',
             [
+                'family' => 'a_family',
                 'values' => [
                     'a_ref_data_multi_select' => [
                         [
@@ -58,6 +65,7 @@ class ReferenceDataMultiSelectFilterIntegration extends AbstractProductQueryBuil
         $this->createProduct(
             'product_three',
             [
+                'family' => 'a_family',
                 'values' => [
                     'a_ref_data_multi_select' => [
                         [
@@ -73,7 +81,7 @@ class ReferenceDataMultiSelectFilterIntegration extends AbstractProductQueryBuil
             ]
         );
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
@@ -19,9 +19,15 @@ class ReferenceDataSimpleSelectFilterIntegration extends AbstractProductQueryBui
     {
         parent::setUp();
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_ref_data_multi_select']
+        ]);
+
         $this->createProduct(
             'product_one',
             [
+                'family' => 'a_family',
                 'values' => [
                     'a_ref_data_simple_select' => [
                         ['data' => 'acid-green', 'scope' => null, 'locale' => null],
@@ -33,6 +39,7 @@ class ReferenceDataSimpleSelectFilterIntegration extends AbstractProductQueryBui
         $this->createProduct(
             'product_two',
             [
+                'family' => 'a_family',
                 'values' => [
                     'a_ref_data_simple_select' => [
                         ['data' => 'aero-blue', 'scope' => null, 'locale' => null],
@@ -41,7 +48,7 @@ class ReferenceDataSimpleSelectFilterIntegration extends AbstractProductQueryBui
             ]
         );
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableFilterIntegration.php
@@ -27,7 +27,13 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'scopable'            => false,
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_text']
+        ]);
+
         $this->createProduct('cat', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_text' => [
                     ['data' => 'black cat', 'locale' => 'en_US', 'scope' => null],
@@ -37,6 +43,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cattle', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_text' => [
                     ['data' => 'cattle', 'locale' => 'en_US', 'scope' => null],
@@ -46,6 +53,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('dog', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_text' => [
                     ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => null],
@@ -54,7 +62,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableScopableFilterIntegration.php
@@ -27,7 +27,13 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             'scopable'            => true,
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_scopable_text']
+        ]);
+
         $this->createProduct('cat', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_text' => [
                     ['data' => 'black cat', 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -39,6 +45,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('cattle', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_text' => [
                     ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -50,6 +57,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('dog', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_text' => [
                     ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -60,7 +68,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/ScopableFilterIntegration.php
@@ -27,7 +27,13 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'scopable'            => true,
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_scopable_text']
+        ]);
+
         $this->createProduct('cat', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_text' => [
                     ['data' => 'black cat', 'locale' => null, 'scope' => 'ecommerce'],
@@ -37,6 +43,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cattle', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_text' => [
                     ['data' => 'cattle', 'locale' => null, 'scope' => 'ecommerce'],
@@ -46,6 +53,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('dog', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_text' => [
                     ['data' => 'just a dog...', 'locale' => null, 'scope' => 'ecommerce'],
@@ -54,7 +62,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/TextFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/TextFilterIntegration.php
@@ -19,25 +19,34 @@ class TextFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_text']
+        ]);
+
         $this->createProduct('cat', [
+            'family' => 'a_family',
             'values' => [
                 'a_text' => [['data' => 'cat', 'locale' => null, 'scope' => null]],
             ],
         ]);
 
         $this->createProduct('cattle', [
+            'family' => 'a_family',
             'values' => [
                 'a_text' => [['data' => 'cattle', 'locale' => null, 'scope' => null]],
             ],
         ]);
 
         $this->createProduct('dog', [
+            'family' => 'a_family',
             'values' => [
                 'a_text' => [['data' => 'dog', 'locale' => null, 'scope' => null]],
             ],
         ]);
 
         $this->createProduct('best_dog', [
+            'family' => 'a_family',
             'values' => [
                 'a_text' => [['data' => 'my dog is the most beautiful', 'locale' => null, 'scope' => null]],
             ],
@@ -46,6 +55,7 @@ class TextFilterIntegration extends AbstractProductQueryBuilderTestCase
         // There is no html tags in TEXT attributes usually set in the PIM.
         // This tests shows that if it's the case they are stored as is and not stripped.
         $this->createProduct('best_cat', [
+            'family' => 'a_family',
             'values' => [
                 'a_text' => [
                     [
@@ -57,7 +67,7 @@ class TextFilterIntegration extends AbstractProductQueryBuilderTestCase
             ],
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableFilterIntegration.php
@@ -27,7 +27,13 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'scopable'            => false,
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_text_area']
+        ]);
+
         $this->createProduct('cat', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_text_area' => [
                     ['data' => 'black cat', 'locale' => 'en_US', 'scope' => null],
@@ -37,6 +43,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cattle', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_text_area' => [
                     ['data' => 'cattle', 'locale' => 'en_US', 'scope' => null],
@@ -46,6 +53,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('dog', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_text_area' => [
                     ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => null],
@@ -54,7 +62,7 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableScopableFilterIntegration.php
@@ -27,7 +27,13 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             'scopable'            => true,
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_localizable_scopable_text_area']
+        ]);
+
         $this->createProduct('cat', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_text_area' => [
                     ['data' => 'black cat', 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -39,6 +45,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('cattle', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_text_area' => [
                     ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -50,6 +57,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('dog', [
+            'family' => 'a_family',
             'values' => [
                 'a_localizable_scopable_text_area' => [
                     ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => 'ecommerce'],
@@ -60,7 +68,7 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/ScopableFilterIntegration.php
@@ -27,7 +27,13 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             'scopable'            => true,
         ]);
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_scopable_text_area']
+        ]);
+
         $this->createProduct('cat', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_text_area' => [
                     ['data' => 'black cat', 'locale' => null, 'scope' => 'ecommerce'],
@@ -37,6 +43,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cattle', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_text_area' => [
                     ['data' => 'cattle', 'locale' => null, 'scope' => 'ecommerce'],
@@ -46,6 +53,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('dog', [
+            'family' => 'a_family',
             'values' => [
                 'a_scopable_text_area' => [
                     ['data' => 'just a dog...', 'locale' => null, 'scope' => 'ecommerce'],
@@ -54,7 +62,7 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/TextAreaFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/TextAreaFilterIntegration.php
@@ -23,31 +23,41 @@ class TextAreaFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_text_area']
+        ]);
+
         $this->createProduct('cat', [
+            'family' => 'a_family',
             'values' => [
                 'a_text_area' => [['data' => 'cat', 'locale' => null, 'scope' => null]]
             ]
         ]);
 
         $this->createProduct('cattle', [
+            'family' => 'a_family',
             'values' => [
                 'a_text_area' => [['data' => 'cattle', 'locale' => null, 'scope' => null]]
             ]
         ]);
 
         $this->createProduct('dog', [
+            'family' => 'a_family',
             'values' => [
                 'a_text_area' => [['data' => 'dog', 'locale' => null, 'scope' => null]]
             ]
         ]);
 
         $this->createProduct('best_dog', [
+            'family' => 'a_family',
             'values' => [
                 'a_text_area' => [['data' => 'my dog is the most beautiful', 'locale' => null, 'scope' => null]]
             ]
         ]);
 
         $this->createProduct('best_cat', [
+            'family' => 'a_family',
             'values' => [
                 'a_text_area' => [
                     [
@@ -60,6 +70,7 @@ class TextAreaFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('best_rabbit', [
+            'family' => 'a_family',
             'values' => [
                 'a_text_area' => [
                     [
@@ -71,7 +82,7 @@ class TextAreaFilterIntegration extends AbstractProductQueryBuilderTestCase
             ]
         ]);
 
-        $this->createProduct('empty_product', []);
+        $this->createProduct('empty_product', ['family' => 'a_family']);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByMultiSelectIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByMultiSelectIntegration.php
@@ -11,7 +11,13 @@ class ExportProductsByMultiSelectIntegration extends AbstractExportTestCase
      */
     protected function loadFixtures() : void
     {
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_multi_select']
+        ]);
+
         $this->createProduct('product_option_A', [
+            'family' => 'a_family',
             'values'     => [
                 'a_multi_select' => [
                     ['data' => ['optionA'], 'locale' => null, 'scope' => null]
@@ -20,6 +26,7 @@ class ExportProductsByMultiSelectIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_option_B', [
+            'family' => 'a_family',
             'values'     => [
                 'a_multi_select' => [
                     ['data' => ['optionB'], 'locale' => null, 'scope' => null]
@@ -28,6 +35,7 @@ class ExportProductsByMultiSelectIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_option_A_B', [
+            'family' => 'a_family',
             'values'     => [
                 'a_multi_select' => [
                     ['data' => ['optionA', 'optionB'], 'locale' => null, 'scope' => null]
@@ -36,6 +44,7 @@ class ExportProductsByMultiSelectIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_without_option', [
+            'family' => 'a_family',
             'values'     => [
                 'a_multi_select' => [
                     ['data' => [], 'locale' => null, 'scope' => null]
@@ -43,7 +52,7 @@ class ExportProductsByMultiSelectIntegration extends AbstractExportTestCase
             ]
         ]);
 
-        $this->createProduct('product_without_option_attribute');
+        $this->createProduct('product_without_option_attribute', ['family' => 'a_family']);
 
     }
 
@@ -51,8 +60,8 @@ class ExportProductsByMultiSelectIntegration extends AbstractExportTestCase
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_multi_select
-product_option_A;;1;;;optionA
-product_option_A_B;;1;;;optionA,optionB
+product_option_A;;1;a_family;;optionA
+product_option_A_B;;1;a_family;;optionA,optionB
 
 CSV;
 
@@ -79,9 +88,9 @@ CSV;
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_multi_select
-product_option_A;;1;;;optionA
-product_option_B;;1;;;optionB
-product_option_A_B;;1;;;optionA,optionB
+product_option_A;;1;a_family;;optionA
+product_option_B;;1;a_family;;optionB
+product_option_A_B;;1;a_family;;optionA,optionB
 
 CSV;
 
@@ -107,9 +116,9 @@ CSV;
     public function testProductExportByFilteringWithEmpty()
     {
         $expectedCsv = <<<CSV
-sku;categories;enabled;family;groups
-product_without_option;;1;;
-product_without_option_attribute;;1;;
+sku;categories;enabled;family;groups;a_multi_select
+product_without_option;;1;a_family;;
+product_without_option_attribute;;1;a_family;;
 
 CSV;
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByMultiSelectReferenceDataIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByMultiSelectReferenceDataIntegration.php
@@ -11,7 +11,13 @@ class ExportProductsByMultiSelectReferenceDataIntegration extends AbstractExport
      */
     protected function loadFixtures() : void
     {
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_ref_data_multi_select']
+        ]);
+
         $this->createProduct('product_airguard', [
+            'family' => 'a_family',
             'values'     => [
                 'a_ref_data_multi_select' => [
                     ['data' => ['airguard'], 'locale' => null, 'scope' => null]
@@ -20,6 +26,7 @@ class ExportProductsByMultiSelectReferenceDataIntegration extends AbstractExport
         ]);
 
         $this->createProduct('product_braid', [
+            'family' => 'a_family',
             'values'     => [
                 'a_ref_data_multi_select' => [
                     ['data' => ['braid'], 'locale' => null, 'scope' => null]
@@ -28,6 +35,7 @@ class ExportProductsByMultiSelectReferenceDataIntegration extends AbstractExport
         ]);
 
         $this->createProduct('product_airguard_braid', [
+            'family' => 'a_family',
             'values'     => [
                 'a_ref_data_multi_select' => [
                     ['data' => ['airguard', 'braid'], 'locale' => null, 'scope' => null]
@@ -36,6 +44,7 @@ class ExportProductsByMultiSelectReferenceDataIntegration extends AbstractExport
         ]);
 
         $this->createProduct('product_without_option', [
+            'family' => 'a_family',
             'values'     => [
                 'a_ref_data_multi_select' => [
                     ['data' => [], 'locale' => null, 'scope' => null]
@@ -43,16 +52,15 @@ class ExportProductsByMultiSelectReferenceDataIntegration extends AbstractExport
             ]
         ]);
 
-        $this->createProduct('product_without_option_attribute');
-
+        $this->createProduct('product_without_option_attribute', ['family' => 'a_family']);
     }
 
     public function testProductExportByFilteringOnOneOption()
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_ref_data_multi_select
-product_airguard;;1;;;airguard
-product_airguard_braid;;1;;;airguard,braid
+product_airguard;;1;a_family;;airguard
+product_airguard_braid;;1;a_family;;airguard,braid
 
 CSV;
 
@@ -79,9 +87,9 @@ CSV;
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_ref_data_multi_select
-product_airguard;;1;;;airguard
-product_braid;;1;;;braid
-product_airguard_braid;;1;;;airguard,braid
+product_airguard;;1;a_family;;airguard
+product_braid;;1;a_family;;braid
+product_airguard_braid;;1;a_family;;airguard,braid
 
 CSV;
 
@@ -107,9 +115,9 @@ CSV;
     public function testProductExportByFilteringWithEmpty()
     {
         $expectedCsv = <<<CSV
-sku;categories;enabled;family;groups
-product_without_option;;1;;
-product_without_option_attribute;;1;;
+sku;categories;enabled;family;groups;a_ref_data_multi_select
+product_without_option;;1;a_family;;
+product_without_option_attribute;;1;a_family;;
 
 CSV;
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsBySimpleSelectIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsBySimpleSelectIntegration.php
@@ -11,7 +11,13 @@ class ExportProductsBySimpleSelectIntegration extends AbstractExportTestCase
      */
     protected function loadFixtures() : void
     {
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_simple_select']
+        ]);
+
         $this->createProduct('product_option_A', [
+            'family' => 'a_family',
             'values'     => [
                 'a_simple_select' => [
                     ['data' => 'optionA', 'locale' => null, 'scope' => null]
@@ -20,6 +26,7 @@ class ExportProductsBySimpleSelectIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_option_B', [
+            'family' => 'a_family',
             'values'     => [
                 'a_simple_select' => [
                     ['data' => 'optionB', 'locale' => null, 'scope' => null]
@@ -28,6 +35,7 @@ class ExportProductsBySimpleSelectIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_without_option', [
+            'family' => 'a_family',
             'values'     => [
                 'a_simple_select' => [
                     ['data' => null, 'locale' => null, 'scope' => null]
@@ -35,7 +43,7 @@ class ExportProductsBySimpleSelectIntegration extends AbstractExportTestCase
             ]
         ]);
 
-        $this->createProduct('product_without_option_attribute');
+        $this->createProduct('product_without_option_attribute', ['family' => 'a_family']);
 
     }
 
@@ -43,7 +51,7 @@ class ExportProductsBySimpleSelectIntegration extends AbstractExportTestCase
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_simple_select
-product_option_A;;1;;;optionA
+product_option_A;;1;a_family;;optionA
 
 CSV;
 
@@ -70,8 +78,8 @@ CSV;
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_simple_select
-product_option_A;;1;;;optionA
-product_option_B;;1;;;optionB
+product_option_A;;1;a_family;;optionA
+product_option_B;;1;a_family;;optionB
 
 CSV;
 
@@ -97,9 +105,9 @@ CSV;
     public function testProductExportByFilteringWithEmpty()
     {
         $expectedCsv = <<<CSV
-sku;categories;enabled;family;groups
-product_without_option;;1;;
-product_without_option_attribute;;1;;
+sku;categories;enabled;family;groups;a_simple_select
+product_without_option;;1;a_family;;
+product_without_option_attribute;;1;a_family;;
 
 CSV;
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsBySimpleSelectReferenceDataIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsBySimpleSelectReferenceDataIntegration.php
@@ -11,7 +11,13 @@ class ExportProductsBySimpleSelectReferenceDataIntegration extends AbstractExpor
      */
     protected function loadFixtures() : void
     {
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_ref_data_simple_select']
+        ]);
+
         $this->createProduct('product_option_baby_blue', [
+            'family' => 'a_family',
             'values'     => [
                 'a_ref_data_simple_select' => [
                     ['data' => 'baby-blue', 'locale' => null, 'scope' => null]
@@ -20,6 +26,7 @@ class ExportProductsBySimpleSelectReferenceDataIntegration extends AbstractExpor
         ]);
 
         $this->createProduct('product_option_champagne', [
+            'family' => 'a_family',
             'values'     => [
                 'a_ref_data_simple_select' => [
                     ['data' => 'champagne', 'locale' => null, 'scope' => null]
@@ -28,6 +35,7 @@ class ExportProductsBySimpleSelectReferenceDataIntegration extends AbstractExpor
         ]);
 
         $this->createProduct('product_without_option', [
+            'family' => 'a_family',
             'values'     => [
                 'a_ref_data_simple_select' => [
                     ['data' => null, 'locale' => null, 'scope' => null]
@@ -35,7 +43,7 @@ class ExportProductsBySimpleSelectReferenceDataIntegration extends AbstractExpor
             ]
         ]);
 
-        $this->createProduct('product_without_option_attribute');
+        $this->createProduct('product_without_option_attribute',['family' => 'a_family']);
 
     }
 
@@ -43,7 +51,7 @@ class ExportProductsBySimpleSelectReferenceDataIntegration extends AbstractExpor
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_ref_data_simple_select
-product_option_baby_blue;;1;;;baby-blue
+product_option_baby_blue;;1;a_family;;baby-blue
 
 CSV;
 
@@ -70,8 +78,8 @@ CSV;
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_ref_data_simple_select
-product_option_baby_blue;;1;;;baby-blue
-product_option_champagne;;1;;;champagne
+product_option_baby_blue;;1;a_family;;baby-blue
+product_option_champagne;;1;a_family;;champagne
 
 CSV;
 
@@ -97,9 +105,9 @@ CSV;
     public function testProductExportByFilteringWithEmpty()
     {
         $expectedCsv = <<<CSV
-sku;categories;enabled;family;groups
-product_without_option;;1;;
-product_without_option_attribute;;1;;
+sku;categories;enabled;family;groups;a_ref_data_simple_select
+product_without_option;;1;a_family;;
+product_without_option_attribute;;1;a_family;;
 
 CSV;
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByTextAreaIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByTextAreaIntegration.php
@@ -11,7 +11,13 @@ class ExportProductsByTextAreaIntegration extends AbstractExportTestCase
      */
     protected function loadFixtures() : void
     {
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_text_area']
+        ]);
+
         $this->createProduct('product_1', [
+            'family' => 'a_family',
             'values'     => [
                 'a_text_area' => [
                     ['data' => 'Awesome', 'locale' => null, 'scope' => null]
@@ -20,6 +26,7 @@ class ExportProductsByTextAreaIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_2', [
+            'family' => 'a_family',
             'values'     => [
                 'a_text_area' => [
                     ['data' => 'Awesome product', 'locale' => null, 'scope' => null]
@@ -28,6 +35,7 @@ class ExportProductsByTextAreaIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_3', [
+            'family' => 'a_family',
             'values'     => [
                 'a_text_area' => [
                     ['data' => 'This is nice', 'locale' => null, 'scope' => null]
@@ -35,14 +43,14 @@ class ExportProductsByTextAreaIntegration extends AbstractExportTestCase
             ]
         ]);
 
-        $this->createProduct('product_4');
+        $this->createProduct('product_4', ['family' => 'a_family']);
     }
 
     public function testProductExportByFilteringWithEqualsOperatorOnTextArea()
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_text_area
-product_1;;1;;;Awesome
+product_1;;1;a_family;;Awesome
 
 CSV;
 
@@ -69,8 +77,8 @@ CSV;
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_text_area
-product_1;;1;;;Awesome
-product_2;;1;;;"Awesome product"
+product_1;;1;a_family;;Awesome
+product_2;;1;a_family;;"Awesome product"
 
 CSV;
 
@@ -97,8 +105,8 @@ CSV;
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_text_area
-product_1;;1;;;Awesome
-product_2;;1;;;"Awesome product"
+product_1;;1;a_family;;Awesome
+product_2;;1;a_family;;"Awesome product"
 
 CSV;
 
@@ -124,8 +132,8 @@ CSV;
     public function testProductExportByFilteringWithIsEmptyOperatorOnTextArea()
     {
         $expectedCsv = <<<CSV
-sku;categories;enabled;family;groups
-product_4;;1;;
+sku;categories;enabled;family;groups;a_text_area
+product_4;;1;a_family;;
 
 CSV;
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByTextIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByTextIntegration.php
@@ -11,7 +11,13 @@ class ExportProductsByTextIntegration extends AbstractExportTestCase
      */
     protected function loadFixtures() : void
     {
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_text']
+        ]);
+
         $this->createProduct('product_1', [
+            'family' => 'a_family',
             'values'     => [
                 'a_text' => [
                     ['data' => 'Awesome', 'locale' => null, 'scope' => null]
@@ -20,6 +26,7 @@ class ExportProductsByTextIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_2', [
+            'family' => 'a_family',
             'values'     => [
                 'a_text' => [
                     ['data' => 'Awesome product', 'locale' => null, 'scope' => null]
@@ -28,6 +35,7 @@ class ExportProductsByTextIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_3', [
+            'family' => 'a_family',
             'values'     => [
                 'a_text' => [
                     ['data' => 'This is nice', 'locale' => null, 'scope' => null]
@@ -35,14 +43,14 @@ class ExportProductsByTextIntegration extends AbstractExportTestCase
             ]
         ]);
 
-        $this->createProduct('product_4');
+        $this->createProduct('product_4', ['family' => 'a_family']);
     }
 
     public function testProductExportByFilteringWithEqualsOperatorOnText()
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_text
-product_1;;1;;;Awesome
+product_1;;1;a_family;;Awesome
 
 CSV;
 
@@ -69,8 +77,8 @@ CSV;
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_text
-product_1;;1;;;Awesome
-product_2;;1;;;"Awesome product"
+product_1;;1;a_family;;Awesome
+product_2;;1;a_family;;"Awesome product"
 
 CSV;
 
@@ -97,8 +105,8 @@ CSV;
     {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;groups;a_text
-product_1;;1;;;Awesome
-product_2;;1;;;"Awesome product"
+product_1;;1;a_family;;Awesome
+product_2;;1;a_family;;"Awesome product"
 
 CSV;
 
@@ -124,8 +132,8 @@ CSV;
     public function testProductExportByFilteringWithIsEmptyOperatorOnText()
     {
         $expectedCsv = <<<CSV
-sku;categories;enabled;family;groups
-product_4;;1;;
+sku;categories;enabled;family;groups;a_text
+product_4;;1;a_family;;
 
 CSV;
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/ORM/Query/CountImpactedProductsSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/ORM/Query/CountImpactedProductsSpec.php
@@ -2,15 +2,14 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
-use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
-use Behat\Testwork\Argument\Exception\ArgumentException;
-use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\CountImpactedProducts;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
+use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
+use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class CountImpactedProductsSpec extends ObjectBehavior
@@ -460,7 +459,7 @@ class CountImpactedProductsSpec extends ObjectBehavior
         $this->count($pqbFilters)->shouldReturn(12);
     }
 
-    public function it_adds_a_filter_on_attributes_level_when_we_use_is_empty(
+    public function it_adds_a_filter_on_attributes_level_when_there_are_empty_attribute_filters(
         $productAndProductModelQueryBuilderFactory,
         SearchQueryBuilder $sqb,
         ProductQueryBuilderInterface $pqb,

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/DateFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/DateFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -25,13 +26,15 @@ class DateFilterSpec extends ObjectBehavior
     protected $timezone;
 
     function let(
-        AttributeValidatorHelper $attributeValidatorHelper
+        AttributeValidatorHelper $attributeValidatorHelper,
+        FamilyFilter $familyFilter
     ) {
         $this->timezone = ini_get('date.timezone');
         ini_set('date.timezone', 'UTC');
 
         $this->beConstructedWith(
             $attributeValidatorHelper,
+            $familyFilter,
             ['pim_catalog_date'],
             [
                 '=',
@@ -279,6 +282,7 @@ class DateFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_is_empty(
         $attributeValidatorHelper,
+        FamilyFilter $familyFilter,
         AttributeInterface $publishedOn,
         SearchQueryBuilder $sqb
     ) {
@@ -289,6 +293,9 @@ class DateFilterSpec extends ObjectBehavior
         $attributeValidatorHelper->validateScope($publishedOn, 'ecommerce')->shouldBeCalled();
 
         $sqb->addMustNot(['exists' => ['field' => 'values.publishedOn-date.ecommerce.en_US']])->shouldBeCalled();
+
+        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
+        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter(

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/DateFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/DateFilterSpec.php
@@ -2,7 +2,6 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -26,15 +25,13 @@ class DateFilterSpec extends ObjectBehavior
     protected $timezone;
 
     function let(
-        AttributeValidatorHelper $attributeValidatorHelper,
-        FamilyFilter $familyFilter
+        AttributeValidatorHelper $attributeValidatorHelper
     ) {
         $this->timezone = ini_get('date.timezone');
         ini_set('date.timezone', 'UTC');
 
         $this->beConstructedWith(
             $attributeValidatorHelper,
-            $familyFilter,
             ['pim_catalog_date'],
             [
                 '=',
@@ -282,7 +279,6 @@ class DateFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_is_empty(
         $attributeValidatorHelper,
-        FamilyFilter $familyFilter,
         AttributeInterface $publishedOn,
         SearchQueryBuilder $sqb
     ) {
@@ -293,9 +289,7 @@ class DateFilterSpec extends ObjectBehavior
         $attributeValidatorHelper->validateScope($publishedOn, 'ecommerce')->shouldBeCalled();
 
         $sqb->addMustNot(['exists' => ['field' => 'values.publishedOn-date.ecommerce.en_US']])->shouldBeCalled();
-
-        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
-        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
+        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter(

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MediaFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MediaFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -15,10 +16,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
 
 class MediaFilterSpec extends ObjectBehavior
 {
-    function let(AttributeValidatorHelper $attributeValidatorHelper)
+    function let(AttributeValidatorHelper $attributeValidatorHelper, FamilyFilter $familyFilter)
     {
         $this->beConstructedWith(
             $attributeValidatorHelper,
+            $familyFilter,
             ['pim_catalog_file', 'pim_catalog_image'],
             ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'EMPTY', 'NOT EMPTY']
         );
@@ -183,6 +185,7 @@ class MediaFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_empty(
         $attributeValidatorHelper,
+        FamilyFilter $familyFilter,
         AttributeInterface $name,
         SearchQueryBuilder $sqb
     ) {
@@ -199,6 +202,9 @@ class MediaFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
+
+        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
+        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($name, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MediaFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MediaFilterSpec.php
@@ -2,7 +2,6 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -16,11 +15,10 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
 
 class MediaFilterSpec extends ObjectBehavior
 {
-    function let(AttributeValidatorHelper $attributeValidatorHelper, FamilyFilter $familyFilter)
+    function let(AttributeValidatorHelper $attributeValidatorHelper)
     {
         $this->beConstructedWith(
             $attributeValidatorHelper,
-            $familyFilter,
             ['pim_catalog_file', 'pim_catalog_image'],
             ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'EMPTY', 'NOT EMPTY']
         );
@@ -185,7 +183,6 @@ class MediaFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_empty(
         $attributeValidatorHelper,
-        FamilyFilter $familyFilter,
         AttributeInterface $name,
         SearchQueryBuilder $sqb
     ) {
@@ -202,9 +199,7 @@ class MediaFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-
-        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
-        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
+        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($name, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MetricFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MetricFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Bundle\MeasureBundle\Convert\MeasureConverter;
 use Akeneo\Tool\Bundle\MeasureBundle\Manager\MeasureManager;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -20,12 +21,14 @@ class MetricFilterSpec extends ObjectBehavior
     function let(
         AttributeValidatorHelper $attributeValidatorHelper,
         MeasureManager $measureManager,
-        MeasureConverter $measureConverter
+        MeasureConverter $measureConverter,
+        FamilyFilter $familyFilter
     ) {
         $this->beConstructedWith(
             $attributeValidatorHelper,
             $measureManager,
             $measureConverter,
+            $familyFilter,
             ['pim_catalog_metric'],
             ['<', '<=', '=', '>=', '>', 'EMPTY', 'NOT EMPTY', '!=']
         );
@@ -311,6 +314,7 @@ class MetricFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_empty(
         $attributeValidatorHelper,
+        FamilyFilter $familyFilter,
         AttributeInterface $metric,
         SearchQueryBuilder $sqb
     ) {
@@ -327,6 +331,9 @@ class MetricFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
+
+        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
+        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($metric, Operators::IS_EMPTY, [], 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MetricFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MetricFilterSpec.php
@@ -2,7 +2,6 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Bundle\MeasureBundle\Convert\MeasureConverter;
 use Akeneo\Tool\Bundle\MeasureBundle\Manager\MeasureManager;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -21,14 +20,12 @@ class MetricFilterSpec extends ObjectBehavior
     function let(
         AttributeValidatorHelper $attributeValidatorHelper,
         MeasureManager $measureManager,
-        MeasureConverter $measureConverter,
-        FamilyFilter $familyFilter
+        MeasureConverter $measureConverter
     ) {
         $this->beConstructedWith(
             $attributeValidatorHelper,
             $measureManager,
             $measureConverter,
-            $familyFilter,
             ['pim_catalog_metric'],
             ['<', '<=', '=', '>=', '>', 'EMPTY', 'NOT EMPTY', '!=']
         );
@@ -314,7 +311,6 @@ class MetricFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_empty(
         $attributeValidatorHelper,
-        FamilyFilter $familyFilter,
         AttributeInterface $metric,
         SearchQueryBuilder $sqb
     ) {
@@ -331,9 +327,7 @@ class MetricFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-
-        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
-        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
+        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($metric, Operators::IS_EMPTY, [], 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/NumberFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/NumberFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -15,10 +16,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
 
 class NumberFilterSpec extends ObjectBehavior
 {
-    function let(AttributeValidatorHelper $attributeValidatorHelper)
+    function let(AttributeValidatorHelper $attributeValidatorHelper, FamilyFilter $familyFilter)
     {
         $this->beConstructedWith(
             $attributeValidatorHelper,
+            $familyFilter,
             ['pim_catalog_number'],
             ['<', '<=', '=', '>=', '>', 'EMPTY', 'NOT EMPTY', '!=']
         );
@@ -215,6 +217,7 @@ class NumberFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_is_empty(
         $attributeValidatorHelper,
+        FamilyFilter $familyFilter,
         AttributeInterface $size,
         SearchQueryBuilder $sqb
     ) {
@@ -231,6 +234,9 @@ class NumberFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
+
+        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
+        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($size, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/NumberFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/NumberFilterSpec.php
@@ -2,7 +2,6 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -16,11 +15,10 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
 
 class NumberFilterSpec extends ObjectBehavior
 {
-    function let(AttributeValidatorHelper $attributeValidatorHelper, FamilyFilter $familyFilter)
+    function let(AttributeValidatorHelper $attributeValidatorHelper)
     {
         $this->beConstructedWith(
             $attributeValidatorHelper,
-            $familyFilter,
             ['pim_catalog_number'],
             ['<', '<=', '=', '>=', '>', 'EMPTY', 'NOT EMPTY', '!=']
         );
@@ -217,7 +215,6 @@ class NumberFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_is_empty(
         $attributeValidatorHelper,
-        FamilyFilter $familyFilter,
         AttributeInterface $size,
         SearchQueryBuilder $sqb
     ) {
@@ -234,9 +231,7 @@ class NumberFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-
-        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
-        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
+        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($size, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/OptionFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/OptionFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -19,12 +20,14 @@ class OptionFilterSpec extends ObjectBehavior
 {
     function let(
         AttributeValidatorHelper $attributeValidatorHelper,
-        AttributeOptionRepository $attributeOptionRepository
+        AttributeOptionRepository $attributeOptionRepository,
+        FamilyFilter $familyFilter
     ) {
         $operators = ['IN', 'EMPTY', 'NOT_EMPTY', 'NOT IN'];
         $this->beConstructedWith(
             $attributeValidatorHelper,
             $attributeOptionRepository,
+            $familyFilter,
             ['pim_catalog_simpleselect', 'pim_catalog_multiselect'],
             $operators
         );
@@ -71,6 +74,7 @@ class OptionFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_empty(
         $attributeValidatorHelper,
+        FamilyFilter $familyFilter,
         AttributeInterface $color,
         SearchQueryBuilder $sqb
     ) {
@@ -87,6 +91,9 @@ class OptionFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
+
+        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
+        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($color, Operators::IS_EMPTY, ['black'], 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/OptionFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/OptionFilterSpec.php
@@ -2,7 +2,6 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -20,14 +19,12 @@ class OptionFilterSpec extends ObjectBehavior
 {
     function let(
         AttributeValidatorHelper $attributeValidatorHelper,
-        AttributeOptionRepository $attributeOptionRepository,
-        FamilyFilter $familyFilter
+        AttributeOptionRepository $attributeOptionRepository
     ) {
         $operators = ['IN', 'EMPTY', 'NOT_EMPTY', 'NOT IN'];
         $this->beConstructedWith(
             $attributeValidatorHelper,
             $attributeOptionRepository,
-            $familyFilter,
             ['pim_catalog_simpleselect', 'pim_catalog_multiselect'],
             $operators
         );
@@ -74,7 +71,6 @@ class OptionFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_empty(
         $attributeValidatorHelper,
-        FamilyFilter $familyFilter,
         AttributeInterface $color,
         SearchQueryBuilder $sqb
     ) {
@@ -91,9 +87,7 @@ class OptionFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-
-        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
-        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
+        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($color, Operators::IS_EMPTY, ['black'], 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/PriceFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/PriceFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -16,11 +17,12 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
 
 class PriceFilterSpec extends ObjectBehavior
 {
-    function let(AttributeValidatorHelper $attributeValidatorHelper, CurrencyRepositoryInterface $currencyRepository)
+    function let(AttributeValidatorHelper $attributeValidatorHelper, CurrencyRepositoryInterface $currencyRepository, FamilyFilter $familyFilter)
     {
         $this->beConstructedWith(
             $attributeValidatorHelper,
             $currencyRepository,
+            $familyFilter,
             ['pim_catalog_price_collection'],
             ['<', '<=', '=', '>=', '>', 'EMPTY', 'NOT EMPTY', '!=']
         );
@@ -271,6 +273,7 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_is_empty_on_all_currencies(
         $attributeValidatorHelper,
+        FamilyFilter $familyFilter,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
@@ -287,6 +290,9 @@ class PriceFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
+
+        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
+        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($price, Operators::IS_EMPTY, [], 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/PriceFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/PriceFilterSpec.php
@@ -2,7 +2,6 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -17,12 +16,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
 
 class PriceFilterSpec extends ObjectBehavior
 {
-    function let(AttributeValidatorHelper $attributeValidatorHelper, CurrencyRepositoryInterface $currencyRepository, FamilyFilter $familyFilter)
+    function let(AttributeValidatorHelper $attributeValidatorHelper, CurrencyRepositoryInterface $currencyRepository)
     {
         $this->beConstructedWith(
             $attributeValidatorHelper,
             $currencyRepository,
-            $familyFilter,
             ['pim_catalog_price_collection'],
             ['<', '<=', '=', '>=', '>', 'EMPTY', 'NOT EMPTY', '!=']
         );
@@ -273,7 +271,6 @@ class PriceFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_is_empty_on_all_currencies(
         $attributeValidatorHelper,
-        FamilyFilter $familyFilter,
         AttributeInterface $price,
         SearchQueryBuilder $sqb
     ) {
@@ -290,9 +287,7 @@ class PriceFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-
-        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
-        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
+        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($price, Operators::IS_EMPTY, [], 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -23,12 +24,14 @@ class ReferenceDataFilterSpec extends ObjectBehavior
     function let(
         AttributeValidatorHelper $attributeValidatorHelper,
         ReferenceDataRepositoryResolver $referenceDataRepositoryResolver,
-        ConfigurationRegistryInterface $registry
+        ConfigurationRegistryInterface $registry,
+        FamilyFilter $familyFilter
     ) {
         $this->beConstructedWith(
             $attributeValidatorHelper,
             $referenceDataRepositoryResolver,
             $registry,
+            $familyFilter,
             ['pim_reference_data_simpleselect', 'pim_reference_data_multiselect'],
             ['IN', 'EMPTY', 'NOT_EMPTY', 'NOT IN']
         );
@@ -80,6 +83,7 @@ class ReferenceDataFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_on_reference_data_with_operator_empty(
         $attributeValidatorHelper,
+        FamilyFilter $familyFilter,
         AttributeInterface $color,
         SearchQueryBuilder $sqb
     ) {
@@ -96,6 +100,9 @@ class ReferenceDataFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
+
+        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
+        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($color, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilterSpec.php
@@ -2,7 +2,6 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -24,14 +23,12 @@ class ReferenceDataFilterSpec extends ObjectBehavior
     function let(
         AttributeValidatorHelper $attributeValidatorHelper,
         ReferenceDataRepositoryResolver $referenceDataRepositoryResolver,
-        ConfigurationRegistryInterface $registry,
-        FamilyFilter $familyFilter
+        ConfigurationRegistryInterface $registry
     ) {
         $this->beConstructedWith(
             $attributeValidatorHelper,
             $referenceDataRepositoryResolver,
             $registry,
-            $familyFilter,
             ['pim_reference_data_simpleselect', 'pim_reference_data_multiselect'],
             ['IN', 'EMPTY', 'NOT_EMPTY', 'NOT IN']
         );
@@ -83,7 +80,6 @@ class ReferenceDataFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_on_reference_data_with_operator_empty(
         $attributeValidatorHelper,
-        FamilyFilter $familyFilter,
         AttributeInterface $color,
         SearchQueryBuilder $sqb
     ) {
@@ -100,9 +96,7 @@ class ReferenceDataFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-
-        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
-        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
+        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($color, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -15,10 +16,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
 
 class TextAreaFilterSpec extends ObjectBehavior
 {
-    function let(AttributeValidatorHelper $attributeValidatorHelper)
+    function let(AttributeValidatorHelper $attributeValidatorHelper, FamilyFilter $familyFilter)
     {
         $this->beConstructedWith(
             $attributeValidatorHelper,
+            $familyFilter,
             ['pim_catalog_textarea'],
             ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'IN', 'EMPTY', 'NOT EMPTY', '!=']
         );
@@ -106,6 +108,7 @@ class TextAreaFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_empty(
         $attributeValidatorHelper,
+        FamilyFilter $familyFilter,
         AttributeInterface $description,
         SearchQueryBuilder $sqb
     ) {
@@ -122,6 +125,9 @@ class TextAreaFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
+
+        $familyFilter->setQueryBuilder($sqb->getWrappedObject())->shouldBeCalled();
+        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($description, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilterSpec.php
@@ -2,7 +2,6 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -16,11 +15,10 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
 
 class TextAreaFilterSpec extends ObjectBehavior
 {
-    function let(AttributeValidatorHelper $attributeValidatorHelper, FamilyFilter $familyFilter)
+    function let(AttributeValidatorHelper $attributeValidatorHelper)
     {
         $this->beConstructedWith(
             $attributeValidatorHelper,
-            $familyFilter,
             ['pim_catalog_textarea'],
             ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'IN', 'EMPTY', 'NOT EMPTY', '!=']
         );
@@ -108,7 +106,6 @@ class TextAreaFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_empty(
         $attributeValidatorHelper,
-        FamilyFilter $familyFilter,
         AttributeInterface $description,
         SearchQueryBuilder $sqb
     ) {
@@ -125,9 +122,7 @@ class TextAreaFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-
-        $familyFilter->setQueryBuilder($sqb->getWrappedObject())->shouldBeCalled();
-        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
+        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($description, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -16,10 +17,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
 
 class TextFilterSpec extends ObjectBehavior
 {
-    function let(AttributeValidatorHelper $attributeValidatorHelper)
+    function let(AttributeValidatorHelper $attributeValidatorHelper, FamilyFilter $familyFilter)
     {
         $this->beConstructedWith(
             $attributeValidatorHelper,
+            $familyFilter,
             ['pim_catalog_text'],
             ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'IN', 'EMPTY', 'NOT EMPTY', '!=']
         );
@@ -103,6 +105,7 @@ class TextFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_empty(
         $attributeValidatorHelper,
+        FamilyFilter $familyFilter,
         AttributeInterface $name,
         SearchQueryBuilder $sqb
     ) {
@@ -118,6 +121,9 @@ class TextFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
+
+        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
+        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($name, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextFilterSpec.php
@@ -2,7 +2,6 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\FamilyFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
@@ -17,11 +16,10 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
 
 class TextFilterSpec extends ObjectBehavior
 {
-    function let(AttributeValidatorHelper $attributeValidatorHelper, FamilyFilter $familyFilter)
+    function let(AttributeValidatorHelper $attributeValidatorHelper)
     {
         $this->beConstructedWith(
             $attributeValidatorHelper,
-            $familyFilter,
             ['pim_catalog_text'],
             ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', 'IN', 'EMPTY', 'NOT EMPTY', '!=']
         );
@@ -105,7 +103,6 @@ class TextFilterSpec extends ObjectBehavior
 
     function it_adds_a_filter_with_operator_empty(
         $attributeValidatorHelper,
-        FamilyFilter $familyFilter,
         AttributeInterface $name,
         SearchQueryBuilder $sqb
     ) {
@@ -121,9 +118,7 @@ class TextFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-
-        $familyFilter->setQueryBuilder($sqb)->shouldBeCalled();
-        $familyFilter->addFieldFilter('family', Operators::IS_NOT_EMPTY, 'not_used_value')->shouldBeCalled();
+        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($name, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_date_fields.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_date_fields.feature
@@ -9,31 +9,33 @@ Feature: Filter products by date field
     And the following attributes:
       | label-en_US | code    | type             | localizable | scopable | useable_as_grid_filter | group |
       | release     | release | pim_catalog_date | 0           | 0        | 1                      | other |
+    And the following families:
+      | code     | label-en_US | attributes  |
+      | a_family | Family      | sku,release |
     And I am logged in as "Mary"
 
   Scenario: Successfully filter products by empty value for date attribute
     Given the following products:
-      | sku    | release    |
-      | postit | 2014-05-01 |
-      | book   |            |
-      | mug    |            |
-    And the "book" product has the "release" attribute
+      | sku    | family   |release    |
+      | postit | a_family |2014-05-01 |
+      | book   | a_family |           |
+      | mug    | a_family |           |
     And I am on the products grid
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
     And I should be able to use the following filters:
-      | filter  | operator     | value | result |
-      | release | is empty     |       | book   |
-      | release | is not empty |       | postit |
+      | filter  | operator     | value | result         |
+      | release | is empty     |       | book and mug   |
+      | release | is not empty |       | postit         |
 
   Scenario: Successfully filter products by date attributes
     Given the following products:
-      | sku    | release    |
-      | postit | 2014-05-01 |
-      | book   | 2014-05-02 |
-      | mug    | 2014-05-03 |
-      | tshirt | 2014-05-03 |
-      | pen    | 2014-05-06 |
+      | sku    | family   | release    |
+      | postit | a_family |2014-05-01 |
+      | book   | a_family |2014-05-02 |
+      | mug    | a_family |2014-05-03 |
+      | tshirt | a_family |2014-05-03 |
+      | pen    | a_family |2014-05-06 |
     When I am on the products grid
     Then the grid should contain 5 elements
     And I should see products postit, book, mug, tshirt and pen
@@ -46,9 +48,9 @@ Feature: Filter products by date field
 
   Scenario: Filter products by date attributes and keep the appropriate default filter values
     Given the following products:
-      | sku  | release    |
-      | book | 2014-05-02 |
-      | pen  | 2014-05-06 |
+      | sku  | family   | release    |
+      | book | a_family | 2014-05-02 |
+      | pen  | a_family | 2014-05-06 |
     And I am on the products grid
     And I show the filter "release"
     When I filter by "release" with operator "between" and value "05/01/2014 and 05/03/2014"

--- a/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_date_fields.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_date_fields.feature
@@ -24,9 +24,9 @@ Feature: Filter products by date field
     Then the grid should contain 3 elements
     And I should see products postit, book and mug
     And I should be able to use the following filters:
-      | filter  | operator     | value | result         |
-      | release | is empty     |       | book and mug   |
-      | release | is not empty |       | postit         |
+      | filter  | operator     | value | result       |
+      | release | is empty     |       | book and mug |
+      | release | is not empty |       | postit       |
 
   Scenario: Successfully filter products by date attributes
     Given the following products:

--- a/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_metric.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_metric.feature
@@ -35,5 +35,5 @@ Feature: Filter products per metric
       | weight | <=           | 120 Gram      | postit          |
       | weight | <=           | 0.25 Kilogram | postit and book |
       | weight | >            | 4 Kilogram    |                 |
-      | weight | is empty     |               | mug             |
+      | weight | is empty     |               |                 |
       | weight | is not empty |               | postit and book |

--- a/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_number_fields.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_number_fields.feature
@@ -25,7 +25,7 @@ Feature: Filter products by number field
     And I should see products postit, book and mug
     And I should be able to use the following filters:
       | filter | operator     | value | result |
-      | count  | is empty     |       | book   |
+      | count  | is empty     |       |        |
       | count  | is not empty |       | postit |
       | count  | >            | 200   |        |
       | count  | <            | 200   |        |
@@ -36,7 +36,7 @@ Feature: Filter products by number field
       | count  | =            | 200   | postit |
       | count  | =            | 0     |        |
       | count  | >            | 0     | postit |
-      | rate   | is empty     |       | mug    |
+      | rate   | is empty     |       |        |
       | rate   | is not empty |       | book   |
       | rate   | >            | 9.5   |        |
       | rate   | <=           | 9.5   | book   |

--- a/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_option_fields.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_option_fields.feature
@@ -26,7 +26,7 @@ Feature: Filter products per option
     Then I should be able to use the following filters:
       | filter | operator     | value | result |
       | size   | in list      | M     | Sweat  |
-      | size   | is empty     |       | Shirt  |
+      | size   | is empty     |       |        |
       | size   | is not empty |       | Sweat  |
 
   Scenario: Successfully filter products by a multi option
@@ -35,7 +35,7 @@ Feature: Filter products per option
     Then I should be able to use the following filters:
       | filter | operator     | value | result |
       | color  | in list      | Black | Shoes  |
-      | color  | is empty     |       | Shirt  |
+      | color  | is empty     |       |        |
       | color  | is not empty |       | Shoes  |
 
   @jira https://akeneo.atlassian.net/browse/PIM-5802

--- a/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_price.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_price.feature
@@ -28,20 +28,17 @@ Feature: Filter products per price
     And the grid should contain 4 elements
     And I should see products postit, book and mug
     And I should be able to use the following filters:
-      | filter | operator | value    | result          |
-      | price  | >=       | 20 EUR   | book            |
-      | price  | >        | 22.5 EUR |                 |
-      | price  | >=       | 22.5 EUR | book            |
-      | price  | >        | 12.5 EUR | book            |
-      | price  | >=       | 12.5 EUR | book, postit    |
-      | price  | =        | 12.5 EUR | postit          |
-      | price  | <        | 20 EUR   | postit          |
-      | price  | <        | 10.5 EUR |                 |
-      | price  | <=       | 13 EUR   | postit          |
-      | price  | <=       | 23 EUR   | postit and book |
-      | price  | >        | 40.5 EUR |                 |
-    When I show the filter "price"
-    And I filter by "price" with operator "is empty" and value ""
-    And I should see product mug
-    And I filter by "price" with operator "is not empty" and value ""
-    And I should see product postit
+      | filter | operator     | value    | result          |
+      | price  | >=           | 20 EUR   | book            |
+      | price  | >            | 22.5 EUR |                 |
+      | price  | >=           | 22.5 EUR | book            |
+      | price  | >            | 12.5 EUR | book            |
+      | price  | >=           | 12.5 EUR | book, postit    |
+      | price  | =            | 12.5 EUR | postit          |
+      | price  | <            | 20 EUR   | postit          |
+      | price  | <            | 10.5 EUR |                 |
+      | price  | <=           | 13 EUR   | postit          |
+      | price  | <=           | 23 EUR   | postit and book |
+      | price  | >            | 40.5 EUR |                 |
+      | price  | is empty     |          |                 |
+      | price  | is not empty |          | postit and book |

--- a/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_text_fields.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_text_fields.feature
@@ -54,9 +54,9 @@ Feature: Filter products by text field
     And I should see products postit, book and mug
     And I should be able to use the following filters:
       | filter      | operator     | value | result |
-      | name        | is empty     |       | book   |
+      | name        | is empty     |       |        |
       | name        | is not empty |       | postit |
-      | description | is empty     |       | postit |
+      | description | is empty     |       |        |
       | description | is not empty |       | mug    |
 
   Scenario: Successfully filter products by empty value for localizable text attribute
@@ -73,7 +73,7 @@ Feature: Filter products by text field
     And I should see products postit, book and mug
     And I should be able to use the following filters:
       | filter | operator     | value | result |
-      | name   | is empty     |       | book   |
+      | name   | is empty     |       |        |
       | name   | is not empty |       | postit |
 
   Scenario: Successfully filter products by empty value for scopable text attribute
@@ -90,7 +90,7 @@ Feature: Filter products by text field
     And I should see products postit, book and mug
     And I should be able to use the following filters:
       | filter | operator     | value | result |
-      | name   | is empty     |       | book   |
+      | name   | is empty     |       |        |
       | name   | is not empty |       | postit |
 
   Scenario: Successfully filter products by empty value for scopable and localizable text attribute
@@ -108,5 +108,5 @@ Feature: Filter products by text field
     And I should see products postit, book and mug
     And I should be able to use the following filters:
       | filter | operator     | value | result |
-      | name   | is empty     |       | book   |
+      | name   | is empty     |       |        |
       | name   | is not empty |       | postit |


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR makes that the products without family are not returned while we are filtering on IS_EMPTY;
It also fixes the bug on the counter for bulk actions.

Why there are so many files changed:
Because a lot of our tests are using products without family which is a use case we want to avoid now.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Y
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
