### PR TITLE
TIP-1173: fix value collection when attribute does not exist

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/ValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/ValueCollectionFactory.php
@@ -101,22 +101,18 @@ class ValueCollectionFactory
             return [];
         }
 
-        $attributesIndexedByCodes = [];
-
-        foreach ($attributes as $attribute) {
-            $attributesIndexedByCodes[$attribute->code()]['type'] = $attribute->type();
-            $attributesIndexedByCodes[$attribute->code()]['properties'] = $attribute->properties();
-        }
-
         $typesToValues = [];
 
         foreach ($rawValueCollections as $productIdentifier => $rawValues) {
             foreach ($rawValues as $attributeCode => $values) {
-                if (isset($attributesIndexedByCodes[$attributeCode])) {
-                    $typesToValues[$attributesIndexedByCodes[$attributeCode]['type']][$attributeCode][] = [
+                if (isset($attributes[$attributeCode])) {
+                    $type = $attributes[$attributeCode]->type();
+                    $properties = $attributes[$attributeCode]->properties();
+
+                    $typesToValues[$type][$attributeCode][] = [
                         'identifier' => $productIdentifier,
                         'values' => $values,
-                        'properties' => $attributesIndexedByCodes[$attributeCode]['properties']
+                        'properties' => $properties
                     ];
                 }
             }
@@ -129,16 +125,11 @@ class ValueCollectionFactory
     {
         $entities = [];
 
-        $attributesIndexedByCode = [];
-        foreach ($attributes as $attribute) {
-            $attributesIndexedByCode[$attribute->code()] = $attribute;
-        }
-
         foreach ($rawValueCollections as $productIdentifier => $valueCollection) {
             $values = [];
 
             foreach ($valueCollection as $attributeCode => $channelRawValue) {
-                $attribute = $attributesIndexedByCode[$attributeCode];
+                $attribute = $attributes[$attributeCode];
 
                 foreach ($channelRawValue as $channelCode => $localeRawValue) {
                     if ('<all_channels>' === $channelCode) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/WriteValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/WriteValueCollectionFactory.php
@@ -108,26 +108,18 @@ class WriteValueCollectionFactory
 
         $attributes = array_filter($this->getAttributeByCodes->forCodes(array_values(array_unique($attributeCodes))));
 
-        if (empty($attributes)) {
-            return [];
-        }
-
-        $attributesIndexedByCodes = [];
-
-        foreach ($attributes as $attribute) {
-            $attributesIndexedByCodes[$attribute->code()]['type'] = $attribute->type();
-            $attributesIndexedByCodes[$attribute->code()]['properties'] = $attribute->properties();
-        }
-
         $typesToValues = [];
 
         foreach ($rawValueCollections as $productIdentifier => $rawValues) {
             foreach ($rawValues as $attributeCode => $values) {
-                if (isset($attributesIndexedByCodes[$attributeCode])) {
-                    $typesToValues[$attributesIndexedByCodes[$attributeCode]['type']][$attributeCode][] = [
+                if (isset($attributes[$attributeCode])) {
+                    $type = $attributes[$attributeCode]->type();
+                    $properties = $attributes[$attributeCode]->properties();
+
+                    $typesToValues[$type][$attributeCode][] = [
                         'identifier' => $productIdentifier,
                         'values' => $values,
-                        'properties' => $attributesIndexedByCodes[$attributeCode]['properties']
+                        'properties' => $properties
                     ];
                 }
             }

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
@@ -55,7 +55,7 @@ SQL;
             );
         }
 
-        return array_merge(array_fill_keys($attributeCodes, null), $attributes);
+        return array_replace(array_fill_keys($attributeCodes, null), $attributes);
     }
 
     public function forCode(string $attributeCode): ?Attribute

--- a/src/Akeneo/Tool/Component/StorageUtils/Cache/LRUCache.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Cache/LRUCache.php
@@ -75,7 +75,7 @@ final class LRUCache
             $this->put((string) $key, $value);
         }
 
-        return array_merge($resultFromQuery, $fromCacheIndexedByKey);
+        return array_replace($resultFromQuery, $fromCacheIndexedByKey);
     }
 
     /**

--- a/src/Akeneo/Tool/Component/StorageUtils/spec/Cache/LRUCacheSpec.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/spec/Cache/LRUCacheSpec.php
@@ -132,6 +132,24 @@ final class LRUCacheSpec extends ObjectBehavior
             ]);
     }
 
+    function it_handles_string_keys_that_are_numeric(EntityObjectQuery $entityObjectQuery)
+    {
+        $entityObjectQuery->fromCode('123')->willReturn(new EntityObject('123'))->shouldBeCalledOnce();
+        $this->getForKey('123', $this->queryToFetchEntityFromCode($entityObjectQuery->getWrappedObject()));
+
+        $entityObjectQuery
+            ->fromCodes(['entity_code_2'])
+            ->willReturn(['entity_code_2' => new EntityObject('entity_code_2')])
+            ->shouldBeCalledOnce();
+
+        $this
+            ->getForKeys(['123', 'entity_code_2'], $this->queryToFetchEntitiesFromCodes($entityObjectQuery->getWrappedObject()))
+            ->shouldBeLike([
+                '123' => new EntityObject('123'),
+                'entity_code_2' => new EntityObject('entity_code_2'),
+            ]);
+    }
+
     private function queryToFetchEntityFromCode(EntityObjectQuery $entityObjectQuery)
     {
         return function(string $entityCode)  use ($entityObjectQuery) {

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/ValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/ValueCollectionFactorySpec.php
@@ -83,7 +83,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
             ],
         ];
 
-        $getAttributeByCodes->forCodes(['sku', 'description'])->willReturn([$sku, $description]);
+        $getAttributeByCodes->forCodes(['sku', 'description'])->willReturn(['sku' => $sku, 'description' => $description]);
 
         $valuesIndexedByType = [
             AttributeTypes::IDENTIFIER => [
@@ -146,7 +146,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
             ]
         ];
 
-        $getAttributeByCodes->forCodes(['attribute_that_does_not_exists'])->willReturn([]);
+        $getAttributeByCodes->forCodes(['attribute_that_does_not_exists'])->willReturn(['attribute_that_does_not_exists' => null]);
 
         $this->createFromStorageFormat($rawValues)->shouldBeLike(new ReadValueCollection([]));
     }
@@ -173,7 +173,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         ];
 
         $color = new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false);
-        $getAttributeByCodes->forCodes(['unknown_attribute', 'color'])->willReturn([$color,]);
+        $getAttributeByCodes->forCodes(['unknown_attribute', 'color'])->willReturn(['color' => $color, 'unknown_attribute' => null]);
 
         $typesToCode = [
             AttributeTypes::OPTION_SIMPLE_SELECT => [
@@ -215,7 +215,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         ];
 
         $getAttributeByCodes->forCodes(['color'])->willReturn([
-            new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false)
+            'color' => new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false)
         ]);
 
         $rawValueCollectionIndexedByType = [
@@ -283,7 +283,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         $number = new Attribute('number', AttributeTypes::NUMBER, [], false, false, null, false);
         $text = new Attribute('text', AttributeTypes::TEXTAREA, [], false, false, null, false);
         $yesNo = new Attribute('yes_no', AttributeTypes::BOOLEAN, [], false, false, null, false);
-        $getAttributeByCodes->forCodes(['number', 'text', 'yes_no'])->willReturn([$number, $text, $yesNo]);
+        $getAttributeByCodes->forCodes(['number', 'text', 'yes_no'])->willReturn(['number' => $number, 'text' => $text, 'yes_no' => $yesNo]);
 
         $typesToCode = [
             AttributeTypes::NUMBER => [

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/WriteValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/WriteValueCollectionFactorySpec.php
@@ -78,8 +78,8 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         ];
 
         $getAttributeByCodes->forCodes(['sku', 'description'])->willReturn([
-            new Attribute('sku', AttributeTypes::IDENTIFIER, [], false, false, null, false),
-            new Attribute('description', AttributeTypes::TEXTAREA, [], false, false, null, false)
+            'sku' => new Attribute('sku', AttributeTypes::IDENTIFIER, [], false, false, null, false),
+            'description' => new Attribute('description', AttributeTypes::TEXTAREA, [], false, false, null, false)
         ]);
 
         $valuesIndexedByType = [
@@ -177,7 +177,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
             ]
         ];
 
-        $getAttributeByCodes->forCodes(['attribute_that_does_not_exists'])->willReturn([]);
+        $getAttributeByCodes->forCodes(['attribute_that_does_not_exists'])->willReturn(['attribute_that_does_not_exists' => null]);
 
         $this->createFromStorageFormat($rawValues)->shouldBeLike(new WriteValueCollection([]));
     }
@@ -208,7 +208,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         ];
 
         $getAttributeByCodes->forCodes(['unknown_attribute', 'color'])->willReturn([
-            new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false),
+            'color' => new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false),
         ]);
 
         $typesToCode = [
@@ -257,7 +257,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         ];
 
         $getAttributeByCodes->forCodes(['color'])->willReturn([
-            new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false),
+            'color' => new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false),
         ]);
 
         $rawValueCollectionIndexedByType = [
@@ -317,7 +317,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         ];
 
         $getAttributeByCodes->forCodes(['color'])->willReturn([
-           new Attribute('color', AttributeTypes::OPTION_MULTI_SELECT, [], false, false, null, false),
+           'color' => new Attribute('color', AttributeTypes::OPTION_MULTI_SELECT, [], false, false, null, false),
         ]);
 
         $typesToCode = [
@@ -370,7 +370,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         ];
 
         $getAttributeByCodes->forCodes(['image'])->willReturn([
-            new Attribute('image', AttributeTypes::IMAGE, [], false, false, null, false),
+            'image' => new Attribute('image', AttributeTypes::IMAGE, [], false, false, null, false),
         ]);
 
         $typesToCode = [
@@ -427,7 +427,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         ];
 
         $getAttributeByCodes->forCodes(['image'])->willReturn([
-            new Attribute('image', AttributeTypes::IMAGE, [], false, false, null, false),
+            'image' => new Attribute('image', AttributeTypes::IMAGE, [], false, false, null, false),
         ]);
 
         $typesToCode = [
@@ -504,9 +504,9 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         ];
 
         $getAttributeByCodes->forCodes(['number', 'text', 'yes_no'])->willReturn([
-            new Attribute('number', AttributeTypes::NUMBER, [], false, false, null, false),
-            new Attribute('text', AttributeTypes::TEXTAREA, [], false, false, null, false),
-            new Attribute('yes_no', AttributeTypes::BOOLEAN, [], false, false, null, false),
+            'number' => new Attribute('number', AttributeTypes::NUMBER, [], false, false, null, false),
+            'text' => new Attribute('text', AttributeTypes::TEXTAREA, [], false, false, null, false),
+            'yes_no' => new Attribute('yes_no', AttributeTypes::BOOLEAN, [], false, false, null, false),
         ]);
 
         $typesToCode = [
@@ -653,9 +653,9 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
 
         $getAttributeByCodes->forCodes(['number', 'number2', 'number3'])->willReturn(
             [
-                new Attribute('number', AttributeTypes::NUMBER, [], false, false, null, false),
-                new Attribute('number2', AttributeTypes::NUMBER, [], false, false, null, false),
-                new Attribute('number3', AttributeTypes::NUMBER, [], false, false, null, false),
+                'number' => new Attribute('number', AttributeTypes::NUMBER, [], false, false, null, false),
+                'number2' => new Attribute('number2', AttributeTypes::NUMBER, [], false, false, null, false),
+                'number3' => new Attribute('number3', AttributeTypes::NUMBER, [], false, false, null, false),
             ]
         );
 

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributesIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributesIntegration.php
@@ -52,6 +52,13 @@ final class SqlGetAttributesIntegration extends TestCase
                 'scopable' => false,
                 'group' => 'other'
             ],
+            [
+                'code' => '123',
+                'type' => AttributeTypes::TEXT,
+                'localizable' => false,
+                'scopable' => false,
+                'group' => 'other'
+            ],
         ]);
     }
 
@@ -59,7 +66,7 @@ final class SqlGetAttributesIntegration extends TestCase
     {
         $expected = $this->getExpected();
         $query = $this->getQuery();
-        $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea']);
+        $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123']);
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
@@ -67,7 +74,7 @@ final class SqlGetAttributesIntegration extends TestCase
     {
         $expected = $this->getExpected();
         $query = $this->getCachedQuery();
-        $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea']);
+        $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123']);
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
@@ -77,6 +84,8 @@ final class SqlGetAttributesIntegration extends TestCase
             'a_text' => new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, false),
             'a_textarea' => new Attribute('a_textarea', AttributeTypes::TEXTAREA, [], false, false, null, false),
             'a_boolean' => new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, false),
+            'unknown_attribute_code' => null,
+            '123' => new Attribute('123', AttributeTypes::TEXT, [], false, false, null, false)
         ];
     }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
We modified the behavior of the interface GetATtributes to return `null` when an attribute does no exist.

`['my_attribute' => Attribute()...), 'unknown_attribute' => null'`

The check with isset is enough to know if the attribute exist.

Note: it makes failing the generator (I don't know why though, but it raised a bug)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
