### PR TITLE
PIM-8414: Fix the product variant breadcrumb size

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8414: Fix the product variant breadcrumb size
+
 # 3.0.23 (2019-06-11)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
@@ -6,19 +6,19 @@
   height: 34px;
   margin-top: 20px;
   display: flex;
+  overflow: hidden;
 
   &-item {
     display: inline-flex;
-    padding: 0 20px;
+    padding-left: 20px;
     height: 32px;
     line-height: 32px;
-    position: relative;
     z-index: 5;
-    flex-grow: 1;
+    min-width: 120px;
 
     &:after {
       content:"";
-      position: absolute;
+      position: relative;
       display: block;
       right:-13px;
       top:4px;
@@ -38,43 +38,38 @@
       z-index: 4;
 
       &:after {
-        content:"";
-        position: absolute;
-        display: block;
-        right:-13px;
-        top:4px;
-        width: 24px;
-        height: 24px;
         background: @AknLightGray;
-        transform: rotate(45deg);
-        box-sizing: border-box;
-        border: 1px solid @AknBorderColor;
-        border-width: 1px 1px 0 0;
-        border-radius: 2px;
       }
     }
 
     & + & {
-      margin-left: 10px;
+      padding-left: 30px;
     }
   }
 
   &-itemLabel {
     cursor: pointer;
     display: flex;
+    flex: 1;
+    overflow: hidden;
   }
 
   &-axisName {
     text-transform: uppercase;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: ~"calc(100vw / 5)";
-    display: inline-block;
+    overflow: hidden;
+    max-width: 240px;
+  }
+
+  &-axisValue {
+    text-overflow: ellipsis;
+    white-space: nowrap;
     overflow: hidden;
   }
 
   &-axisName&-axisName--selected + &-axisValue:before {
-    content:":";
+    content:": ";
   }
 
   &-listItem {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -425,6 +425,7 @@
   @circleSize: 18px;
 
   &.select2-container {
+    flex: 0;
     display: inline-block;
     width: auto;
     line-height: 10px;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Before
![image](https://user-images.githubusercontent.com/1671213/59358919-bf0f3380-8d2d-11e9-9c46-7482b0593fbf.png)

After
![image](https://user-images.githubusercontent.com/1671213/59358732-6344aa80-8d2d-11e9-98ac-b8894e6e99b6.png)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
