### PR TITLE
PIM-8447: Fix grids thumbnails display

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,7 +2,8 @@
 
 ## Bug fixes
 
-- PIM-8428 PIM displays pim_common.code on grids
+- PIM-8428: PIM displays pim_common.code on grids
+- PIM-8447: Fix grids thumbnails display
 
 # 3.1.6 (2019-06-11)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -318,6 +318,7 @@
     transition: border-color 0.2s ease-in;
     margin-top: 3px;
     margin-bottom: -3px;
+    object-fit: contain;
 
     &--withLayer {
       margin-top: 4px;


### PR DESCRIPTION
Small images were not well displayed in the grids.

Before:

![before 2019-06-17 16-49-44](https://user-images.githubusercontent.com/1516770/59613967-1d6a5680-9120-11e9-88eb-ffc68360f643.png)

After:

![after from 2019-06-17 16-50-52](https://user-images.githubusercontent.com/1516770/59613985-26f3be80-9120-11e9-94f9-e1df3ed645b2.png)


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
