### PR TITLE
SDS-11088: allow graceful shutdown for job consumer daemon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require": {
         "php": "7.1.*",
+        "ext-pcntl": "*",
         "ass/xmlsecurity": "1.1.1",
         "doctrine/annotations": "1.3.1",
         "doctrine/cache": "1.6.1",


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When deploying Akeneo (using tools like Capistrano, etc...), restarting the application may crash a running job. If there is a long queue, there's no way to stop it for a few minutes while deploying. It's especially blocking for continuous deployment.

This PR allow the use of the SIGQUIT posix signal to tell a daemon process to stop between jobs.

Usage example : 
```bash
$ ps faux | grep job-queue-consumer-daemon
vacla    29191  0.5  0.4 408540 66396 ?        S    17:53   0:00  |       \_ php bin/console --env=prod akeneo:batch:job-queue-consumer-daemon
vacla    30779  0.4  0.4 408540 66712 ?        S    17:53   0:00  |       \_ php bin/console --env=prod akeneo:batch:job-queue-consumer-daemon
vacla    31190  0.4  0.4 408540 66716 ?        S    17:53   0:00          \_ php bin/console --env=prod akeneo:batch:job-queue-consumer-daemon

$ kill -s SIGQUIT  29191 30779 31190
```

What's missing:
* proper handling from `\Akeneo\Bundle\BatchQueueBundle\Queue\DatabaseJobExecutionQueue::consume`
  - for now the waiting loop stays here and is only interrupted when `sleep !== 0` (which is not always the case when receiving a signal...)
    - I would propose some similar `stopConsuming` method on the interface
  - when it happens, an error occur due to the return type not matching method's signature : `Return value of Akeneo\Bundle\BatchQueueBundle\Queue\DatabaseJobExecutionQueue::consume() must be an instance of Akeneo\Component\BatchQueue\Queue\JobExecutionMessage, null returned`
    - note that this last error is only a verbosity problem and do not have an impact on jobs or functionnalities
* (for PaaS) allow to call something like `partners_supervisor graceful_shutdown` which would send the signal to each running daemon (or timeout ?), and do not restart

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
