### PR TITLE
DAPI-139: trigger an event at the end of the mass edit confirm action

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/form.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/form.js
@@ -208,6 +208,7 @@ define(
                                 operationView.setReadOnly(true);
                                 this.currentStep = 'confirm';
                                 this.render();
+                                this.getRoot().trigger('mass-edit:action:confirm');
                             }
                         })
                         .always(() => {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
