### PR TITLE
PIM-8450: Fix assets search with underscore in the code

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - GITHUB-9557: Fix yarn product dependencies requirements, cheers @AngelVazquezArroyo!
+- PIM-8450: Fix assets search with underscore in the code
 
 # 2.3.48 (2019-06-12)
 

--- a/src/Oro/Bundle/FilterBundle/Filter/SearchFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/SearchFilter.php
@@ -29,7 +29,7 @@ class SearchFilter extends AbstractFilter
                     true
                 )
             );
-            $ds->setParameter($parameterName, $word);
+            $ds->setParameter($parameterName, addcslashes($word, '_'));
         }
 
         return true;


### PR DESCRIPTION
Underscore '_' is a special character in MySQL like queries and we must escape them in the search terms.

Wilcards examples: https://www.guru99.com/wildcards.html

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
