### PR TITLE
Github Issue #10247 - Broken frontend build for projects within directory named "src"

### DIFF
--- a/frontend/build/compile-less.js
+++ b/frontend/build/compile-less.js
@@ -46,7 +46,7 @@ function collectBundleImports(bundlePaths) {
     // Make each path relative
     const indexFiles = bundlePaths.map(bundlePath => {
         return `${bundlePath}/${BUNDLE_LESS_INDEX_PATH}`
-                .replace(/(^.+)((?<=src).*[^vendor])(?=\/src|\/vendor)\//gm, '')
+                .replace(/(^.+)((?<=src).*[^vendor])(?=\/src)\//gm, '')
     })
 
     const bundleImports = []

--- a/frontend/build/compile-less.js
+++ b/frontend/build/compile-less.js
@@ -46,7 +46,7 @@ function collectBundleImports(bundlePaths) {
     // Make each path relative
     const indexFiles = bundlePaths.map(bundlePath => {
         return `${bundlePath}/${BUNDLE_LESS_INDEX_PATH}`
-                .replace(/(^.+)[^vendor](?=\/src|\/vendor)\//gm, '')
+                .replace(/(^.+)((?<=src).*[^vendor])(?=\/src|\/vendor)\//gm, '')
     })
 
     const bundleImports = []

--- a/frontend/build/update-extensions.js
+++ b/frontend/build/update-extensions.js
@@ -27,7 +27,7 @@ const EXTENSION_DEFAULTS = {
  * @param {string} path
  */
 function getRelativeBundlePath(path) {
-    return path.replace(/(^.+)[^vendor](?=\/src|\/vendor)\//gm, '')
+    return path.replace(/(^.+)((?<=src).*[^vendor])(?=\/src|\/vendor)\//gm, '')
 }
 
 /**

--- a/frontend/build/update-extensions.js
+++ b/frontend/build/update-extensions.js
@@ -27,7 +27,7 @@ const EXTENSION_DEFAULTS = {
  * @param {string} path
  */
 function getRelativeBundlePath(path) {
-    return path.replace(/(^.+)((?<=src).*[^vendor])(?=\/src|\/vendor)\//gm, '')
+    return path.replace(/(^.+)((?<=src).*[^vendor])(?=\/src)\//gm, '')
 }
 
 /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR aims to resolve the issue described in https://github.com/akeneo/pim-community-dev/issues/10247. If an installation of akeneo exists within a directory named "src", the `yarn run webpack` command will fail with the following error:

```java
$ yarn run webpack
yarn run v1.16.0
$ yarn requirements && NODE_PATH=node_modules webpack --config $npm_package_config_source/webpack.config.js
$ node $npm_package_config_source/frontend/build/check-requirements.js
Checking PIM frontend requirements
Starting webpack from /Users/liamtoohey/src/project-akeneo in dev mode
Executing pre-build scripts
(node:19219) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
$ node $npm_package_config_source/frontend/build/update-extensions.js
$ node $npm_package_config_styles
Updating form extensions.json
/Users/liamtoohey/src/project-akeneo/vendor/akeneo/pim-community-dev/frontend/build/update-extensions.js:76
    const mergedExtensions = Object.entries(merged.extensions).map(([code, extension]) => {
                                    ^

TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at mergeExtensions (/Users/liamtoohey/src/project-akeneo/vendor/akeneo/pim-community-dev/frontend/build/update-extensions.js:76:37)
    at Object.<anonymous> (/Users/liamtoohey/src/project-akeneo/vendor/akeneo/pim-community-dev/frontend/build/update-extensions.js:110:26)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:829:12)
    at startup (internal/bootstrap/node.js:283:19)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

/Users/liamtoohey/src/project-akeneo/node_modules/webpack-shell-plugin/lib/index.js:168
        throw e
```

As described in https://github.com/akeneo/pim-community-dev/issues/10247, this is due to a couple regex commands incorrectly removing part of the filepath strings when loading extensions.

This PR amends that regex command to only remove everything behind `src` **after** `vendor` pattern is found.

This solution has been tested for akeneo projects both within a `src` directory and outside. The regex command can be tested with filepaths here (with some examples):

- https://regex101.com/r/vdDaWy/5