### PR TITLE
PIM-8460: do not display Save button without permission on PM

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8383: Do not take products without family into account when filtering on empty values
+- PIM-8460: Do not display Save button if user does not have ACL edit permissions on product models.
 
 # 3.0.25 (2019-06-18)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -114,6 +114,7 @@ extensions:
         module: pim/product-model-edit-form/save
         parent: pim-product-model-edit-form
         targetZone: buttons
+        aclResourceId: pim_enrich_product_model_edit_attributes
         position: 0
 
     pim-product-model-edit-form-state:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/save-buttons.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/save-buttons.js
@@ -45,10 +45,12 @@ define(
              */
             render: function () {
                 var buttons = this.model.get('buttons');
-                this.$el.html(this.template({
-                    primaryButton: _.first(buttons),
-                    secondaryButtons: buttons.slice(1)
-                }));
+                if (buttons.length > 0) {
+                    this.$el.html(this.template({
+                        primaryButton: _.first(buttons),
+                        secondaryButtons: buttons.slice(1)
+                    }));
+                }
                 this.delegateEvents();
 
                 return this;


### PR DESCRIPTION
Apply 'edit atributes permissions' for the display of product model Save button 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
