### PR TITLE
PIM-8469 - Upgrade symfony version

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,10 @@
 
 - PIM-8464: Fix the product variant breadcrumb size
 
+## Improvement
+
+- PIM-8469: Bump Symfony version to 3.4.28 to fix Intl issues.
+
 # 2.3.49 (2019-06-19)
 
 ## Bug fixes

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "symfony/monolog-bundle": "3.1.0",
         "symfony/swiftmailer-bundle": "3.0.3",
         "symfony/security-acl": "3.0.0",
-        "symfony/symfony": "3.4.26",
+        "symfony/symfony": "3.4.28",
         "symfony/thanks": "^1.0",
         "symfony/polyfill-apcu": "1.4.0",
         "twig/extensions": "1.2.0",


### PR DESCRIPTION
EE: https://github.com/akeneo/pim-enterprise-dev/pull/6357

An integrator has an issue with Intl - (internal ref SDS-11138)
This is fixed by Symfony in the v3.4.28