### PR TITLE
PIM-8467: Fix warning counts in case of failed jobs in last operations widget

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,6 +4,7 @@
 
 - PIM-8428: PIM displays pim_common.code on grids
 - PIM-8447: Fix grids thumbnails display
+- PIM-8467: Fix warning counts in case of failed jobs in last operations widget
 
 # 3.1.6 (2019-06-11)
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/last-operations-widget.js
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/last-operations-widget.js
@@ -12,16 +12,6 @@ define(
         'use strict';
 
         return AbstractWidget.extend({
-            labelClasses: {
-                1: 'AknBadge--success',
-                3: '',
-                4: 'AknBadge--important',
-                5: 'AknBadge--important',
-                6: 'AknBadge--important',
-                7: 'AknBadge--important',
-                8: 'AknBadge--error'
-            },
-
             viewAllTitle: 'Show job tracker',
 
             options: {
@@ -112,10 +102,6 @@ define(
 
                 _.each(data, function (operation) {
                     const statusLabel = __(operation.statusLabel);
-
-                    operation.labelClass = this.labelClasses[operation.status] ?
-                        this.labelClasses[operation.status]
-                        : '';
 
                     operation.statusLabel = statusLabel.slice(0, 1).toUpperCase() +
                         statusLabel.slice(1).toLowerCase();

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/templates/last-operations-widget.html
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/templates/last-operations-widget.html
@@ -23,8 +23,8 @@
     <% _.each(data, function (operation) { %>
         <% var status = 'success'; %>
         <% status = (operation.warningCount !== null && parseInt(operation.warningCount) !== 0) ? 'warning' : status %>
-        <% status = (6 === operation.status) ? 'important' : status %>
-        <% var counter = (6 === operation.status) ? 1 : operation.warningCount %>
+        <% status = (6 === parseInt(operation.status)) ? 'important' : status %>
+        <% var counter = (6 === parseInt(operation.status)) ? 1 : operation.warningCount %>
 
         <tr class="AknGrid-bodyRow">
             <td class="AknGrid-bodyCell"> <%- operation.date %></td>


### PR DESCRIPTION
The bug was due to a js comparison of ```"6"===6``` which is false.
Now, ```6===6```.