### PR TITLE
TIP-1190: Disable the wait of the refresh of the index when indexin in ES, by default

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -68,7 +68,7 @@
 
 
 
-
+- TIP-1190: Refresh of the ES index is not at wait_for but disabled by default for performance reason
 
 
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
@@ -88,7 +88,7 @@ class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverI
             return;
         }
 
-        $indexRefresh = $options['index_refresh'] ?? Refresh::waitFor();
+        $indexRefresh = $options['index_refresh'] ?? Refresh::disable();
 
         $normalizedProducts = [];
         $normalizedProductModels = [];

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelIndexer.php
@@ -96,7 +96,7 @@ class ProductModelIndexer implements IndexerInterface, BulkIndexerInterface, Rem
             return;
         }
 
-        $indexRefresh = $options['index_refresh'] ?? Refresh::waitFor();
+        $indexRefresh = $options['index_refresh'] ?? Refresh::disable();
 
         $normalizedObjects = [];
         foreach ($objects as $object) {

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductGridFixturesLoader.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductGridFixturesLoader.php
@@ -67,6 +67,7 @@ final class ProductGridFixturesLoader
         Assert::assertCount(0, $errors);
 
         $this->container->get('pim_catalog.saver.product')->save($product);
+        $this->refreshEsIndex();
 
         return $rootProductModelWithoutSubProductModel;
     }
@@ -103,6 +104,7 @@ final class ProductGridFixturesLoader
         $errors = $this->container->get('pim_catalog.validator.product')->validate($subProductModel);
         Assert::assertCount(0, $errors);
         $this->container->get('pim_catalog.saver.product_model')->save($subProductModel);
+        $this->refreshEsIndex();
 
         return $subProductModel;
     }
@@ -138,16 +140,21 @@ final class ProductGridFixturesLoader
         $errors = $this->container->get('pim_catalog.validator.product')->validate($subProductModel);
         Assert::assertCount(0, $errors);
         $this->container->get('pim_catalog.saver.product_model')->save($subProductModel);
+        $this->refreshEsIndex();
 
         return $rootProductModelWithoutSubProductModel;
     }
 
     public function createProductAndProductModels()
     {
-        return [
+        $fixtures = [
             'product_models' => $this->createProductModels(),
             'products' => $this->createProducts()
         ];
+
+        $this->refreshEsIndex();
+
+        return $fixtures;
     }
 
     private function createProductModels() : array
@@ -312,5 +319,12 @@ final class ProductGridFixturesLoader
         $errors = $this->container->get('validator')->validate($familyVariant);
         Assert::assertCount(0, $errors);
         $this->container->get('pim_catalog.saver.family_variant')->save($familyVariant);
+    }
+
+    private function refreshEsIndex(): void
+    {
+        $this->container->get('akeneo_elasticsearch.client.product')->refreshIndex();
+        $this->container->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->container->get('akeneo_elasticsearch.client.product_model')->refreshIndex();
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
@@ -180,7 +180,7 @@ class ProductIndexerSpec extends ObjectBehavior
         $this->indexAll([$product1, $product2], ['index_refresh' => Refresh::waitFor()]);
     }
 
-    function it_indexes_products_and_disable_index_refresh_by_default(
+    function it_indexes_products_and_disables_index_refresh_by_default(
         ProductInterface $product1,
         ProductInterface $product2,
         $normalizer,

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
@@ -109,7 +109,7 @@ class ProductIndexerSpec extends ObjectBehavior
         $productIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
-        ], 'id', Refresh::waitFor())->shouldBeCalled();
+        ], 'id', Refresh::disable())->shouldBeCalled();
 
         $normalizer->normalize($product1, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(['id' => 'foo', 'a key' => 'a value']);
@@ -119,7 +119,7 @@ class ProductIndexerSpec extends ObjectBehavior
         $productModelIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
-        ], 'id', Refresh::waitFor())->shouldBeCalled();
+        ], 'id', Refresh::disable())->shouldBeCalled();
 
         $this->indexAll([$product1, $product2]);
     }
@@ -149,7 +149,7 @@ class ProductIndexerSpec extends ObjectBehavior
         $this->removeAll([40, 33])->shouldReturn(null);
     }
 
-    function it_indexes_products_and_wait_for_index_refresh_by_default(
+    function it_indexes_products_and_wait_for_index_refresh(
         ProductInterface $product1,
         ProductInterface $product2,
         $normalizer,
@@ -177,10 +177,10 @@ class ProductIndexerSpec extends ObjectBehavior
             ['id' => 'bar', 'a key' => 'another value'],
         ], 'id', Refresh::waitFor())->shouldBeCalled();
 
-        $this->indexAll([$product1, $product2]);
+        $this->indexAll([$product1, $product2], ['index_refresh' => Refresh::waitFor()]);
     }
 
-    function it_indexes_products_and_disable_index_refresh(
+    function it_indexes_products_and_disable_index_refresh_by_default(
         ProductInterface $product1,
         ProductInterface $product2,
         $normalizer,

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
@@ -149,7 +149,7 @@ class ProductIndexerSpec extends ObjectBehavior
         $this->removeAll([40, 33])->shouldReturn(null);
     }
 
-    function it_indexes_products_and_wait_for_index_refresh(
+    function it_indexes_products_and_waits_for_index_refresh(
         ProductInterface $product1,
         ProductInterface $product2,
         $normalizer,

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelIndexerSpec.php
@@ -108,7 +108,7 @@ class ProductModelIndexerSpec extends ObjectBehavior
         $productModelClient->bulkIndexes('an_index_type_for_test_purpose', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
-        ], 'id', Refresh::waitFor())->shouldBeCalled();
+        ], 'id', Refresh::disable())->shouldBeCalled();
 
         $normalizer->normalize($productModel1, ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(['id' => 'foo', 'a key' => 'a value']);
@@ -118,7 +118,7 @@ class ProductModelIndexerSpec extends ObjectBehavior
         $productAndProductModelClient->bulkIndexes('an_index_type_for_test_purpose', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
-        ], 'id', Refresh::waitFor())->shouldBeCalled();
+        ], 'id', Refresh::disable())->shouldBeCalled();
 
         $this->indexAll([$productModel1, $productModel2]);
     }
@@ -174,7 +174,7 @@ class ProductModelIndexerSpec extends ObjectBehavior
         $this->removeAll([40, 33])->shouldReturn(null);
     }
 
-    function it_indexes_product_models_and_wait_for_index_refresh_by_default(
+    function it_indexes_product_models_and_disable_refresh_of_the_index_by_default(
         $normalizer,
         $productModelClient,
         $productAndProductModelClient,
@@ -189,7 +189,7 @@ class ProductModelIndexerSpec extends ObjectBehavior
         $productModelClient->bulkIndexes('an_index_type_for_test_purpose', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
-        ], 'id', Refresh::waitFor())->shouldBeCalled();
+        ], 'id', Refresh::disable())->shouldBeCalled();
 
         $normalizer->normalize($productModel1, ProductAndProductModel\ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(['id' => 'foo', 'a key' => 'a value']);
@@ -199,7 +199,7 @@ class ProductModelIndexerSpec extends ObjectBehavior
         $productAndProductModelClient->bulkIndexes('an_index_type_for_test_purpose', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
-        ], 'id', Refresh::waitFor())->shouldBeCalled();
+        ], 'id', Refresh::disable())->shouldBeCalled();
 
         $this->indexAll([$productModel1, $productModel2]);
     }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelIndexerSpec.php
@@ -174,7 +174,7 @@ class ProductModelIndexerSpec extends ObjectBehavior
         $this->removeAll([40, 33])->shouldReturn(null);
     }
 
-    function it_indexes_product_models_and_disable_refresh_of_the_index_by_default(
+    function it_indexes_product_models_and_disables_refresh_of_the_index_by_default(
         $normalizer,
         $productModelClient,
         $productAndProductModelClient,


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

We should not `wait_for` index refresh when indexing products in ES.
It means it wait the next refresh from ES, which is every 1 sec by default. 

Most of the time, it is disabled but not everywhere. It is not a best practice to use it, as it impacts performance.
So by default, we should disable it (it's disable by default in ES if not provided explicitely).

On Icecat catalog, we have a performance gain of at least 10 seconds during the installation (1m45 => 1m35).
We have a gain of 1 minute during integration tests also, for free.

On association step during product import, as the batch size is at 1 during import for this step, we were waiting most of the time a refresh in ES on icecat catalog (several calls per product with refresh, 2 hours on this step, I don't know how it's used in production...).
  
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
