### PR TITLE
PIM-8475: Fix permission of sorting attribute groups

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # 3.1.x
 
+## Bug fixes
+
+- PIM-8475: Fix permission of sorting attribute groups
+
 # 3.1.7 (2019-06-26)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeGroupController.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeGroupController.php
@@ -319,6 +319,8 @@ class AttributeGroupController
      *
      * @param  Request $request
      *
+     * @AclAncestor("pim_enrich_attributegroup_sort")
+     *
      * @return Response
      */
     public function sortAction(Request $request)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/list.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/list.js
@@ -59,29 +59,33 @@ define([
              * {@inheritdoc}
              */
             render: function () {
+                const canSortAttributeGroup = securityContext.isGranted('pim_enrich_attributegroup_sort');
                 this.$el.html(this.template({
                     attributeGroups: _.sortBy(_.values(this.attributeGroups), function (attributeGroup) {
                         return attributeGroup.sort_order;
                     }),
                     i18n: i18n,
-                    uiLocale: UserContext.get('catalogLocale')
+                    uiLocale: UserContext.get('catalogLocale'),
+                    canSortAttributeGroup
                 }));
 
-                this.$('tbody').sortable({
-                    handle: '.handle',
-                    containment: 'parent',
-                    tolerance: 'pointer',
-                    update: this.updateAttributeOrders.bind(this),
-                    helper: function (e, tr) {
-                        var $originals = tr.children();
-                        var $helper = tr.clone();
-                        $helper.children().each(function (index) {
-                            $(this).width($originals.eq(index).width());
-                        });
+                if (canSortAttributeGroup) {
+                    this.$('tbody').sortable({
+                        handle: '.handle',
+                        containment: 'parent',
+                        tolerance: 'pointer',
+                        update: this.updateAttributeOrders.bind(this),
+                        helper: function (e, tr) {
+                            var $originals = tr.children();
+                            var $helper = tr.clone();
+                            $helper.children().each(function (index) {
+                                $(this).width($originals.eq(index).width());
+                            });
 
-                        return $helper;
-                    }
-                });
+                            return $helper;
+                        }
+                    });
+                }
 
                 this.renderExtensions();
             },

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-group/list.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-group/list.html
@@ -2,11 +2,13 @@
     <table class="AknGrid AknGrid--unclickable groups">
         <% _.each(attributeGroups, function (attributeGroup) { %>
         <tr class="AknGrid-bodyRow attribute-group" data-attribute-group-code="<%- attributeGroup.code %>">
+            <% if (canSortAttributeGroup) { %>
             <td class="AknGrid-bodyCell AknGrid-bodyCell--tight">
                 <span class="handle">
                     <i class="icon-reorder"></i>
                 </span>
             </td>
+            <% } %>
             <td class="AknGrid-bodyCell attribute-group-link" data-attribute-group-code="<%- attributeGroup.code %>"><%- i18n.getLabel(attributeGroup.labels, uiLocale, attributeGroup.code) %></td>
         </tr>
         <% }); %>


### PR DESCRIPTION
Before, there was no check of permission about the attribute group sort.

Now, if you unselect the role, it will
- check in the backend controller
- do not display handles
- do not allow sort

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added legacy Behats               | n
| Added acceptance tests            | n
| Added integration tests           | n
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -