### PR TITLE
PIM-8477: Fix rich text area link dialog

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8413: Fix modal of category selection in product and product model exports
+- PIM-8477: Fix rich text area link dialog
 
 # 3.0.26 (2019-06-21)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -122,10 +122,10 @@ define(
                     modal.find('.close').addClass('AknFullPage-cancel');
 
                     // Move Dialog to <body>
-                    const previousPosition = modal.parent();
+                    const oreviousParent = modal.parent();
                     modal.appendTo('body');
                     modal.one('hidden.bs.modal', function (e) {
-                        modal.appendTo(previousPosition);
+                        modal.appendTo(oreviousParent);
                     });
                 }
             }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -40,6 +40,7 @@ define(
              */
             postRender: function () {
                 this.$('textarea').summernote({
+                    onToolbarClick: this.setStyleForLinkModal,
                     disableResizeEditor: true,
                     height: 200,
                     iconPrefix: 'icon-',
@@ -94,6 +95,39 @@ define(
              */
             moveModalBackdrop: function () {
                 $('.modal-backdrop').prependTo('.AknFullPage');
+            },
+
+            /**
+             * Since 3.0, default pages includes a lot of .sticky and .fixed elements. It implies it's impossible to
+             * display elements on top of the page, without setting z-index in every element of the page.
+             * Here, summernote create a modal directly from the button, and this modal is hidden in the bottom of the
+             * page. We override the default behavior of the modal opening, to put it in the root of the <body>, then
+             * put it back once user selected its link.
+             *
+             * @param jqueryEvent
+             */
+            setStyleForLinkModal: function (jqueryEvent) {
+                const source = $(jqueryEvent.originalEvent.path[0]);
+
+                if (source.hasClass('icon-link') || source.hasClass('btn-sm')) {
+                    const modal = $('.note-link-dialog.modal');
+
+                    // Set PIM style
+                    modal.find('.note-link-text, .note-link-url').addClass('AknTextField');
+                    modal.find('label').addClass('AknFieldContainer-label');
+                    modal.find('.form-group.row').addClass('AknFieldContainer');
+                    modal.find('.modal-title').addClass('AknFullPage-subTitle');
+                    modal.find('.btn.btn-primary.note-link-btn').addClass('AknButton AknButton--apply');
+                    modal.find('.modal-footer').addClass('AknButtonList AknButtonList--single');
+                    modal.find('.close').addClass('AknFullPage-cancel');
+
+                    // Move Dialog to <body>
+                    const previousPosition = modal.parent();
+                    modal.appendTo('body');
+                    modal.one('hidden.bs.modal', function (e) {
+                        modal.appendTo(previousPosition);
+                    });
+                }
             }
         });
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/summernote.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/summernote.less
@@ -72,3 +72,15 @@
 .note-popover .popover .popover-content, .note-toolbar {
   padding: 0;
 }
+
+.note-link-dialog.modal.in {
+  @padding: 20px;
+  @modalWidth: @AknMaxFormWidth + 2 * @padding;
+  @modalHeight: 340px;
+  width: @modalWidth;
+  height: @modalHeight;
+  transform: translate(-@modalWidth/2, -@modalHeight/2);
+  left: 50%;
+  top: 50%;
+  padding: @padding;
+}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/pages/FullPage.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/pages/FullPage.less
@@ -76,6 +76,7 @@
     cursor: pointer;
     border: none;
     z-index: 1050;
+    font-size: 0;
   }
 
   &-previous {


### PR DESCRIPTION
Before (in fact, there was nothing at all before, but it's a screenshot from 2.3)
![Selection_096](https://user-images.githubusercontent.com/1590933/60274987-64fb9a00-98f9-11e9-801e-8ea984f9477c.png)

Now
![Selection_097](https://user-images.githubusercontent.com/1590933/60274985-64fb9a00-98f9-11e9-93cb-301d4d44011d.png)
