### PR TITLE
PIM-8463: display an explicit error message when an uploaded file is too big on import profiles

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -10,7 +10,7 @@
 
 - PIM-8413: Fix modal of category selection in product and product model exports
 - PIM-8477: Fix rich text area link dialog
-- PIM-8463: display an explicit error message when an uploaded file is too big on import profiles
+- PIM-8463: On import profiles, displays an explicit error message when file upload fails, for example when the file is too big
 
 # 3.0.26 (2019-06-21)
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8413: Fix modal of category selection in product and product model exports
+- PIM-8463: display an explicit error message when an uploaded file is too big on import profiles
 
 # 3.0.26 (2019-06-21)
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -20,6 +20,7 @@ use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -401,11 +402,10 @@ class JobInstanceController
             throw new AccessDeniedHttpException();
         }
 
+        /** @var UploadedFile|null $file */
         $file = $request->files->get('file');
-        if (null === $file) {
-            if ($this->isFileWasUploaded()) {
-                return new JsonResponse(['message' => 'pim_import_export.entity.import_profile.flash.upload.error_too_big'], 400);
-            }
+        if (null === $file && $this->isFileUpload()) {
+            return new JsonResponse(['message' => 'pim_import_export.entity.import_profile.flash.upload.error_too_big'], 400);
         }
 
         if (null !== $file) {
@@ -655,7 +655,7 @@ class JobInstanceController
      *
      * @return bool
      */
-    private function isFileWasUploaded(): bool
+    private function isFileUpload(): bool
     {
         return isset($_SERVER['CONTENT_LENGTH']) && $_SERVER['CONTENT_LENGTH'] > 0;
     }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -650,8 +650,10 @@ class JobInstanceController
     }
 
     /**
-     * This is the only way we found to test that a file too big was uploaded. If the file size exceeds the server limit,
-     * a warning is thrown on the apache container logs and the request does not contain any information that a file was uploaded on the FPM side.
+     * This is the only way we found to test that a file too big was uploaded.
+     * If the file size exceeds the server limit, a warning is thrown on the apache container logs
+     * and the request does not contain any information that a file was uploaded on the FPM side.
+     * Note: it happens only when the upload exceeds 'post_max_size'
      *
      * @return bool
      */

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -402,9 +402,8 @@ class JobInstanceController
             throw new AccessDeniedHttpException();
         }
 
-        /** @var UploadedFile|null $file */
         $file = $request->files->get('file');
-        if (null === $file && $this->isFileUpload()) {
+        if (null === $file && $this->isFileUpload($request)) {
             return new JsonResponse(['message' => 'pim_import_export.entity.import_profile.flash.upload.error_too_big'], 400);
         }
 
@@ -653,12 +652,13 @@ class JobInstanceController
      * This is the only way we found to test that a file too big was uploaded.
      * If the file size exceeds the server limit, a warning is thrown on the apache container logs
      * and the request does not contain any information that a file was uploaded on the FPM side.
-     * Note: it happens only when the upload exceeds 'post_max_size'
+     * This happens only when the upload exceeds 'post_max_size' and we can detect it by having a positive
+     * Content-Length header corresponding to the file length that was sent.
      *
      * @return bool
      */
-    private function isFileUpload(): bool
+    private function isFileUpload(Request $request): bool
     {
-        return isset($_SERVER['CONTENT_LENGTH']) && $_SERVER['CONTENT_LENGTH'] > 0;
+        return $request->server->get('CONTENT_LENGTH') > 0;
     }
 }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -404,12 +404,12 @@ class JobInstanceController
 
         $file = $request->files->get('file');
         if (null === $file && $this->isFileUpload($request)) {
-            return new JsonResponse(['message' => 'pim_import_export.entity.import_profile.flash.upload.error_too_big'], 400);
+            return new JsonResponse(['message' => 'pim_import_export.entity.import_profile.flash.upload.error'], 400);
         }
 
         if (null !== $file) {
-            if (UPLOAD_ERR_INI_SIZE === $file->getError()) {
-                return new JsonResponse(['message' => 'pim_import_export.entity.import_profile.flash.upload.error_too_big'], 400);
+            if (UPLOAD_ERR_OK !== $file->getError()) {
+                return new JsonResponse(['message' => 'pim_import_export.entity.import_profile.flash.upload.error'], 400);
             }
 
             $violations = $this->validator->validate($file);

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -654,8 +654,6 @@ class JobInstanceController
      * and the request does not contain any information that a file was uploaded on the FPM side.
      * This happens only when the upload exceeds 'post_max_size' and we can detect it by having a positive
      * Content-Length header corresponding to the file length that was sent.
-     *
-     * @return bool
      */
     private function isFileUpload(Request $request): bool
     {

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -32,7 +32,7 @@ pim_import_export:
                 create:
                     success: Import profile successfully created
                 upload:
-                    error: Unable to upload the file. Its size may exceed the configured upload max size on your PHP or HTTP server configuration?
+                    error: Unable to upload the file. Its size may exceed the configured maximum upload size on your PHP or HTTP server configuration
             page_title:
                 index: "]-Inf, 1] {{ count }} import profile|]1, Inf [{{ count }} import profiles"
             module:

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -32,7 +32,7 @@ pim_import_export:
                 create:
                     success: Import profile successfully created
                 upload:
-                    error_too_big: File size exceeds the server limit
+                    error: Unable to upload the file. Its size may exceed the configured upload max size on your PHP or HTTP server configuration?
             page_title:
                 index: "]-Inf, 1] {{ count }} import profile|]1, Inf [{{ count }} import profiles"
             module:

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -31,6 +31,8 @@ pim_import_export:
             flash:
                 create:
                     success: Import profile successfully created
+                upload:
+                    error_too_big: File size exceeds the server limit
             page_title:
                 index: "]-Inf, 1] {{ count }} import profile|]1, Inf [{{ count }} import profiles"
             module:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/upload-launch.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/upload-launch.js
@@ -49,8 +49,12 @@ define(
                     .then((response) => {
                         router.redirect(response.redirectUrl);
                     })
-                    .fail(() => {
-                        messenger.notify('error', __('pim_import_export.form.job_instance.fail.launch'));
+                    .fail((response) => {
+                        if (undefined !== response.responseJSON.message) {
+                            messenger.notify('error', __(response.responseJSON.message));
+                        } else {
+                            messenger.notify('error', __('pim_import_export.form.job_instance.fail.launch'));
+                        }
                     })
                     .always(() => {
                         loadingMask.hide().$el.remove();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
