### PR TITLE
PIM-7894: Fix metric and price filters design

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-7894: Fix metric and price filters design
+
 # 3.0.27 (2019-06-27)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -124,7 +124,7 @@ define(
                     // Move Dialog to <body>
                     const oreviousParent = modal.parent();
                     modal.appendTo('body');
-                    modal.one('hidden.bs.modal', function (e) {
+                    modal.one('hidden.bs.modal', function () {
                         modal.appendTo(oreviousParent);
                     });
                 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterChoice.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterChoice.less
@@ -41,17 +41,21 @@
     min-width: 100px;
   }
 
-  &-currency, &-unit {
-    right: 30px;
-    position: absolute;
-    top: 80px;
-
-    &--centered {
-      right: auto;
-    }
-  }
-
   &-inputContainer {
     height: 40px;
+    display: flex;
+  }
+
+  &-unit,
+  &-currency {
+    height: @AknFormHeight;
+    border: 1px solid @AknBorderColor;
+    border-left: none;
+    background: white;
+    margin-left: -1px;
+    z-index: 1;
+    padding: 7px;
+
+    &--centered {}
   }
 }

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/metric-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/metric-filter.js
@@ -241,6 +241,20 @@ define(
 
                 e.preventDefault();
             },
+
+            _enableInput: function() {
+                NumberFilter.prototype._enableInput.apply(this, arguments);
+                this.$('.AknFilterChoice-inputContainer').show();
+                this.$('.AknFilterChoice-unit').show();
+                this._updateCriteriaSelectorPosition();
+            },
+
+            _disableInput: function() {
+                NumberFilter.prototype._disableInput.apply(this, arguments);
+                this.$('.AknFilterChoice-inputContainer').hide();
+                this.$('.AknFilterChoice-unit').hide();
+                this._updateCriteriaSelectorPosition();
+            }
         });
     }
 );

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
@@ -196,6 +196,7 @@ define(
              */
             _disableInput() {
                 this.$el.find('.AknFilterChoice-inputContainer').hide();
+                this._updateCriteriaSelectorPosition();
             },
 
             /**
@@ -203,6 +204,7 @@ define(
              */
             _enableInput() {
                 this.$el.find('.AknFilterChoice-inputContainer').show();
+                this._updateCriteriaSelectorPosition();
             }
         });
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/filter/metric-filter.html
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/filter/metric-filter.html
@@ -16,7 +16,7 @@
             </div>
         </div>
     </div>
-    <div>
+    <div class="AknFilterChoice-inputContainer">
         <input type="text" name="value" class="AknTextField select-field" value="<%- value %>"/>
         <div class="AknFilterChoice-unit">
             <div class="AknDropdown unit">


### PR DESCRIPTION
Fixes a lot of issues on price and metric filters in the datagrid
- when number is too long, it was overriding the unit
- when operator was "empty", unit was still displayed
- sometimes, it was impossible to clic on validate because the popin was too down

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | n
| Added legacy Behats               | n
| Added acceptance tests            | n
| Added integration tests           | n
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -