### PR TITLE
TIP-1159: Save completeness from projection model

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/Completeness/SqlSaveProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/Completeness/SqlSaveProductCompletenesses.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\Completeness;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompletenessCollection;
+use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class SqlSaveProductCompletenesses implements SaveProductCompletenesses
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function save(ProductCompletenessCollection $completenesses): void
+    {
+        $this->connection->beginTransaction();
+
+        $productId = $completenesses->productId();
+        $this->connection->executeQuery($this->getDeleteQuery(), ['productId' => $productId]);
+
+        foreach ($completenesses as $completeness) {
+            $this->connection->executeUpdate(
+                $this->getInsertCompletenessQuery(),
+                [
+                    'productId' => $productId,
+                    'ratio' => $completeness->ratio(),
+                    'missingCount' => count($completeness->missingAttributeCodes()),
+                    'requiredCount' => $completeness->requiredCount(),
+                    'localeCode' => $completeness->localeCode(),
+                    'channelCode' => $completeness->channelCode(),
+                ]
+            );
+            $completenessId = $this->connection->lastInsertId();
+            $this->connection->executeUpdate(
+                $this->getInsertMissingAttributesQuery(),
+                [
+                    'completenessId' => $completenessId,
+                    'attributeCodes' => $completeness->missingAttributeCodes(),
+                ],
+                [
+                    'attributeCodes' => Connection::PARAM_STR_ARRAY,
+                ]
+            );
+        }
+
+        $this->connection->commit();
+    }
+
+    private function getDeleteQuery(): string
+    {
+        return <<<SQL
+DELETE FROM pim_catalog_completeness
+WHERE product_id = :productId
+SQL;
+    }
+
+    private function getInsertCompletenessQuery(): string
+    {
+        return <<<SQL
+INSERT INTO pim_catalog_completeness(locale_id, channel_id, product_id, ratio, missing_count, required_count)
+SELECT locale.id, channel.id, :productId, :ratio, :missingCount, :requiredCount  
+FROM pim_catalog_locale locale,
+     pim_catalog_channel channel
+WHERE locale.code = :localeCode
+  AND channel.code = :channelCode
+SQL;
+    }
+
+    private function getInsertMissingAttributesQuery(): string
+    {
+        return <<<SQL
+INSERT INTO pim_catalog_completeness_missing_attribute(completeness_id, missing_attribute_id)
+SELECT :completenessId, attribute.id
+FROM pim_catalog_attribute attribute
+WHERE attribute.code IN (:attributeCodes)
+SQL;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -136,6 +136,11 @@ services:
         arguments:
             - '@database_connection'
 
+    akeneo.pim.enrichment.product.query.save_product_completenesses:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\Completeness\SqlSaveProductCompletenesses'
+        arguments:
+            - '@database_connection'
+
     akeneo.pim.enrichment.product.query.category_codes_by_product_identifiers:
         class: 'Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\GetCategoryCodesByProductIdentifiers'
         arguments:
@@ -223,4 +228,3 @@ services:
         class: Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\CountVariantProducts
         arguments:
             - '@database_connection'
-

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/Projection/ProductCompletenessCollection.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/Projection/ProductCompletenessCollection.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Model\Projection;
+
+use IteratorAggregate;
+
+/**
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductCompletenessCollection implements IteratorAggregate
+{
+    /** @var int */
+    private $productId;
+
+    /** @var ProductCompleteness[] */
+    private $completenesses = [];
+
+    public function __construct(int $productId, array $completenesses)
+    {
+        $this->productId = $productId;
+        foreach ($completenesses as $completeness) {
+            $this->add($completeness);
+        }
+    }
+
+    public function productId(): int
+    {
+        return $this->productId;
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->completenesses);
+    }
+
+    private function add(ProductCompleteness $completeness): void
+    {
+        $key = sprintf('%s-%s', $completeness->channelCode(), $completeness->localeCode());
+        $this->completenesses[$key] = $completeness;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/SaveProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/SaveProductCompletenesses.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Query;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompletenessCollection;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface SaveProductCompletenesses
+{
+    public function save(ProductCompletenessCollection $completenesses): void;
+}

--- a/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/Completeness/SaveProductCompletenessesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/Completeness/SaveProductCompletenessesIntegration.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Product\Query\Sql\Completeness;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompleteness;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompletenessCollection;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SaveProductCompletenessesIntegration extends TestCase
+{
+    public function test_that_it_clears_existing_completenesses_and_missing_attributes_if_provided_completenesses_are_empty()
+    {
+        $productId = $this->createProduct('a_great_product');
+        Assert::assertNotEmpty($this->getCompletenessesFromDB($productId));
+        Assert::assertNotEmpty($this->getMissingAttributesFromDb($productId));
+
+        $this->executeSave(new ProductCompletenessCollection($productId, []));
+        Assert::assertEmpty($this->getCompletenessesFromDB($productId));
+        Assert::assertEmpty($this->getMissingAttributesFromDb($productId));
+    }
+
+    public function test_that_it_saves_completenesses_given_a_product_id()
+    {
+        $productId = $this->createProduct('a_great_product');
+        $collection = new ProductCompletenessCollection($productId, [
+            new ProductCompleteness('ecommerce', 'en_US', 5, [])
+        ]);
+        $this->executeSave($collection);
+
+        $dbCompletenesses = $this->getCompletenessesFromDB($productId);
+        Assert::assertCount(1, $dbCompletenesses);
+        Assert::assertEquals(
+            [
+                'channel_code' => 'ecommerce',
+                'locale_code' => 'en_US',
+                'ratio' => 100,
+                'missing_count' => 0,
+                'required_count' => 5,
+            ],
+            $dbCompletenesses['ecommerce-en_US']
+        );
+        Assert::assertEmpty($this->getMissingAttributesFromDb($productId));
+    }
+
+    public function test_that_it_saves_completenesses_and_missing_attributes()
+    {
+        $productId = $this->createProduct('a_great_product');
+
+        $collection = new ProductCompletenessCollection($productId, [
+            new ProductCompleteness('ecommerce', 'en_US', 5, ['a_text']),
+            new ProductCompleteness(
+                'tablet',
+                'fr_FR',
+                10,
+                [
+                    'a_localized_and_scopable_text_area',
+                    'a_yes_no',
+                    'a_multi_select',
+                    'a_file',
+                    'a_price',
+                    'a_number_float',
+                ]
+            ),
+        ]);
+
+        $this->executeSave($collection);
+
+        $dbCompletenesses = $this->getCompletenessesFromDB($productId);
+        Assert::assertCount(2, $dbCompletenesses);
+        Assert::assertEquals(
+            [
+                'channel_code' => 'ecommerce',
+                'locale_code' => 'en_US',
+                'ratio' => 80,
+                'missing_count' => 1,
+                'required_count' => 5,
+            ],
+            $dbCompletenesses['ecommerce-en_US']
+        );
+        Assert::assertEquals(
+            [
+                'channel_code' => 'tablet',
+                'locale_code' => 'fr_FR',
+                'ratio' => 40,
+                'missing_count' => 6,
+                'required_count' => 10,
+            ],
+            $dbCompletenesses['tablet-fr_FR']
+        );
+
+        $missingAttributeCodesFromDb = $this->getMissingAttributesFromDb($productId);
+        Assert:self::assertCount(2, $missingAttributeCodesFromDb);
+
+        Assert::assertEquals(['a_text'], $missingAttributeCodesFromDb['ecommerce-en_US']);
+        Assert::assertEqualsCanonicalizing(
+            [
+                'a_localized_and_scopable_text_area',
+                'a_yes_no',
+                'a_multi_select',
+                'a_file',
+                'a_price',
+                'a_number_float',
+            ],
+            $missingAttributeCodesFromDb['tablet-fr_FR']
+        );
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function executeSave(ProductCompletenessCollection $completenesses): void
+    {
+        $this->get('akeneo.pim.enrichment.product.query.save_product_completenesses')->save($completenesses);
+    }
+
+    private function createProduct(string $identifier): int
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier, 'familyA');
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        return $product->getId();
+    }
+
+    private function getCompletenessesFromDB(int $productId): array
+    {
+        $sql = <<<SQL
+SELECT channel.code as channel_code, locale.code as locale_code, completeness.ratio, completeness.missing_count, completeness.required_count
+FROM pim_catalog_completeness completeness
+    INNER JOIN pim_catalog_channel channel on channel.id = completeness.channel_id
+    INNER JOIN pim_catalog_locale locale on locale.id = completeness.locale_id
+WHERE product_id = :productId
+SQL;
+        $results = [];
+        $rows = $this->get('database_connection')->executeQuery($sql, ['productId' => $productId])->fetchAll();
+        foreach ($rows as $row) {
+            $key = sprintf('%s-%s', $row['channel_code'], $row['locale_code']);
+            $results[$key] = $row;
+        }
+
+        return $results;
+    }
+
+    private function getMissingAttributesFromDb(int $productId): array
+    {
+        $sql = <<<SQL
+SELECT channel.code as channel_code, locale.code as locale_code, attribute.code as missing_attribute_code
+FROM pim_catalog_completeness completeness
+    INNER JOIN pim_catalog_channel channel ON channel.id = completeness.channel_id
+    INNER JOIN pim_catalog_locale locale ON locale.id = completeness.locale_id
+    INNER JOIN pim_catalog_completeness_missing_attribute missing_attribute ON completeness.id = missing_attribute.completeness_id
+    INNER JOIN pim_catalog_attribute attribute on missing_attribute.missing_attribute_id = attribute.id
+WHERE completeness.product_id = :productId
+SQL;
+        $results = [];
+        $rows = $this->get('database_connection')->executeQuery($sql, ['productId' => $productId])->fetchAll();
+
+        foreach ($rows as $row) {
+            $key = sprintf('%s-%s', $row['channel_code'], $row['locale_code']);
+            $results[$key][] = $row['missing_attribute_code'];
+        }
+
+        return $results;
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/Projection/ProductCompletenessCollectionSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/Projection/ProductCompletenessCollectionSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Model\Projection;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompleteness;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompletenessCollection;
+use PhpSpec\ObjectBehavior;
+
+class ProductCompletenessCollectionSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(42, []);
+    }
+
+    function it_is_a_product_completeness_collection()
+    {
+        $this->shouldHaveType(ProductCompletenessCollection::class);
+    }
+
+    function it_is_an_iterator_aggregate()
+    {
+        $this->shouldImplement(\IteratorAggregate::class);
+    }
+
+    function it_can_only_store_product_completenesses()
+    {
+        $this->beConstructedWith(42, [new \stdClass()]);
+        $this->shouldThrow(\TypeError::class)->duringInstantiation();
+    }
+
+    function it_exposes_a_product_id()
+    {
+        $this->productId()->shouldReturn(42);
+    }
+
+    function it_can_store_product_completenesses()
+    {
+        $completeness = new ProductCompleteness('ecommerce', 'en_US', 4, []);
+        $otherCompleteness = new ProductCompleteness('ecommerce', 'fr_FR', 4, []);
+        $this->beConstructedWith(42, [$completeness, $otherCompleteness]);
+
+        $this->getIterator()->count()->shouldReturn(2);
+        $this->getIterator()->getArrayCopy()->shouldReturn([
+            'ecommerce-en_US' => $completeness,
+            'ecommerce-fr_FR' => $otherCompleteness,
+        ]);
+    }
+
+    function it_does_not_store_two_completenesses_with_the_same_channel_and_locale()
+    {
+        $completeness = new ProductCompleteness('ecommerce', 'en_US', 4, []);
+        $otherCompleteness = new ProductCompleteness('ecommerce', 'en_US', 5, ['description', 'price']);
+        $this->beConstructedWith(42, [$completeness, $otherCompleteness]);
+
+        $this->getIterator()->count()->shouldReturn(1);
+        $this->getIterator()->getArrayCopy()->shouldReturn(['ecommerce-en_US' => $otherCompleteness]);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Query to save completenesses projection model to database. Introduces a ProductCompletenessCollection object.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
