### PR TITLE
PIM-8480: Remove the job execution message orphans after a job execution purge

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes:
+
+- PIM-8480: Remove the job execution message orphans after a job execution purge.
+
 # 2.3.51 (2019-06-26)
 
 ## Improvement

--- a/src/Akeneo/Bundle/BatchBundle/Command/PurgeJobExecutionCommand.php
+++ b/src/Akeneo/Bundle/BatchBundle/Command/PurgeJobExecutionCommand.php
@@ -50,6 +50,9 @@ class PurgeJobExecutionCommand extends ContainerAwareCommand
             $this->getJobExecutionRepository()->remove($jobsExecutions);
             $output->write(sprintf("%s jobs execution deleted ...\n", count($jobsExecutions)));
         }
+
+        // Purge the message queue, even if there was no job executions to remove this time.
+        $this->deleteJobExecutionMessageOrphans();
     }
 
     /**
@@ -72,5 +75,10 @@ class PurgeJobExecutionCommand extends ContainerAwareCommand
     protected function getJobExecutionRepository()
     {
         return $this->getContainer()->get('akeneo_batch.job_repository');
+    }
+
+    private function deleteJobExecutionMessageOrphans(): void
+    {
+        $this->getContainer()->get('akeneo_batch_queue.query.delete_job_execution_message_orphans')->execute();
     }
 }

--- a/src/Akeneo/Bundle/BatchBundle/Command/PurgeJobExecutionCommand.php
+++ b/src/Akeneo/Bundle/BatchBundle/Command/PurgeJobExecutionCommand.php
@@ -51,7 +51,6 @@ class PurgeJobExecutionCommand extends ContainerAwareCommand
             $output->write(sprintf("%s jobs execution deleted ...\n", count($jobsExecutions)));
         }
 
-        // Purge the message queue, even if there was no job executions to remove this time.
         $this->deleteJobExecutionMessageOrphans();
     }
 

--- a/src/Akeneo/Bundle/BatchQueueBundle/Query/SqlDeleteJobExecutionMessageOrphansQuery.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Query/SqlDeleteJobExecutionMessageOrphansQuery.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\Query;
+
+use Akeneo\Component\BatchQueue\Query\DeleteJobExecutionMessageOrphansQueryInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SqlDeleteJobExecutionMessageOrphansQuery implements DeleteJobExecutionMessageOrphansQueryInterface
+{
+    /** @var Connection */
+    private $dbConnection;
+
+    public function __construct(Connection $dbConnection)
+    {
+        $this->dbConnection = $dbConnection;
+    }
+
+    public function execute(): void
+    {
+        $sql = <<<SQL
+DELETE FROM akeneo_batch_job_execution_queue
+    USING akeneo_batch_job_execution_queue
+    LEFT JOIN akeneo_batch_job_execution job_execution ON job_execution.id = akeneo_batch_job_execution_queue.job_execution_id
+    WHERE job_execution.id IS NULL;
+SQL;
+
+        $this->dbConnection->executeQuery($sql);
+    }
+}

--- a/src/Akeneo/Bundle/BatchQueueBundle/Resources/config/services.yml
+++ b/src/Akeneo/Bundle/BatchQueueBundle/Resources/config/services.yml
@@ -54,3 +54,8 @@ services:
             - '@akeneo_batch_queue.queue.database_job_execution_queue'
             - '@event_dispatcher'
             - '%kernel.environment%'
+
+    akeneo_batch_queue.query.delete_job_execution_message_orphans:
+        class: Akeneo\Bundle\BatchQueueBundle\Query\SqlDeleteJobExecutionMessageOrphansQuery
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Query/SqlDeleteJobExecutionMessageOrphansQueryIntegration.php
+++ b/src/Akeneo/Bundle/BatchQueueBundle/tests/integration/Query/SqlDeleteJobExecutionMessageOrphansQueryIntegration.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Bundle\BatchQueueBundle\tests\integration\Query;
+
+use Akeneo\Bundle\BatchBundle\Job\DoctrineJobRepository;
+use Akeneo\Bundle\BatchBundle\Job\JobInstanceRepository;
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\BatchQueue\Queue\JobExecutionMessage;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Driver\Connection;
+
+class SqlDeleteJobExecutionMessageOrphansQueryIntegration extends TestCase
+{
+    public function testItDeletesJobExecutionMessageOrphans(): void
+    {
+        $jobInstance = $this->getJobInstanceRepository()->findOneByIdentifier('edit_common_attributes');
+        $jobExecution = $this->getJobExecutionRepository()->createJobExecution($jobInstance, new JobParameters([]));
+
+        $this->createJobExecutionMessage($jobExecution->getId());
+        $this->createJobExecutionMessage(1234);
+        $this->createJobExecutionMessage(9876);
+
+        $this->get('akeneo_batch_queue.query.delete_job_execution_message_orphans')->execute();
+
+        $this->assertTrue($this->jobExecutionMessageExists($jobExecution->getId()));
+        $this->assertFalse($this->jobExecutionMessageExists(1234));
+        $this->assertFalse($this->jobExecutionMessageExists(9876));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    /**
+     * @return Connection
+     */
+    private function getDatabaseConnection(): Connection
+    {
+        return $this->get('doctrine.orm.entity_manager')->getConnection();
+    }
+
+    private function getJobExecutionRepository(): DoctrineJobRepository
+    {
+        return $this->get('akeneo_batch.job_repository');
+    }
+
+    private function getJobInstanceRepository(): JobInstanceRepository
+    {
+        return $this->get('akeneo_batch.job.job_instance_repository');
+    }
+
+    private function createJobExecutionMessage(int $jobExecutionId): void
+    {
+        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecutionId, []);
+
+        $this->get('akeneo_batch_queue.queue.job_execution_message_repository')->createJobExecutionMessage($jobExecutionMessage);
+    }
+
+    private function jobExecutionMessageExists(int $jobExecutionId): bool
+    {
+        $sql = <<<SQL
+SELECT 1
+FROM akeneo_pim.akeneo_batch_job_execution_queue
+WHERE job_execution_id = :jobExecutionId
+SQL;
+
+        $stmt = $this->getDatabaseConnection()->prepare($sql);
+        $stmt->bindValue('jobExecutionId', $jobExecutionId);
+        $stmt->execute();
+
+        return $stmt->rowCount() > 0;
+    }
+}

--- a/src/Akeneo/Component/BatchQueue/Query/DeleteJobExecutionMessageOrphansQueryInterface.php
+++ b/src/Akeneo/Component/BatchQueue/Query/DeleteJobExecutionMessageOrphansQueryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Component\BatchQueue\Query;
+
+/**
+ * Deletes the job execution messages whose job execution doesn't exist anymore.
+ *
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface DeleteJobExecutionMessageOrphansQueryInterface
+{
+    public function execute(): void;
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The old job executions can be deleted from the database with the command `akeneo:batch:purge-job-execution`. The problem is that it doesn't delete the messages related to these job executions in the queue.

To fix this problem I added a query function that deletes job execution message orphans, and I call it in the purge command. I think that it's better to keep the queue system decoupled instead of adding a foreign key with a "delete cascade" constraint.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | ok
| Changelog updated                 | ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
