### PR TITLE
PIM-8447: Fix deformed images in dropdowns

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,7 +3,7 @@
 ## Bug fixes
 
 - PIM-7894: Fix metric and price filters design
-- PIM-8447: Fix deformed images in dropdowns
+- PIM-8447: Fix deformed images in dropdowns and grids
 
 # 3.0.27 (2019-06-27)
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7894: Fix metric and price filters design
+- PIM-8447: Fix deformed images in dropdowns
 
 # 3.0.27 (2019-06-27)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -318,6 +318,7 @@
     transition: border-color 0.2s ease-in;
     margin-top: 3px;
     margin-bottom: -3px;
+    object-fit: contain;
 
     &--withLayer {
       margin-top: 4px;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -675,6 +675,7 @@
 
     img {
       margin-right: 10px;
+      object-fit: contain;
     }
 
     .select2-result-label-hint {


### PR DESCRIPTION
Some images are displayed deformed in the dropdowns. It's the case for the reference entity attributes in the PEF.

The solution is to add the CSS rule "object-fit: contain" as it has been done for the images in the grids : https://github.com/akeneo/pim-community-dev/blob/b1363e675e4d9795c20634ac73936c58f034c5e1/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Image.less#L165