### PR TITLE
PIM-8481: Fix space between long labels and buttons in simple selects

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # 3.1.x
 
+## Bug fixes
+
+- PIM-8481: Fix space between long labels and buttons in simple selects
+
 # 3.1.8 (2019-06-28)
 
 ## Bug fixes
@@ -64,7 +68,7 @@ Release of the 3.1.0
     Use `Akeneo\Platform\Bundle\ImportExportBundle\Widget\LastOperationsFetcher` instead.
 - `Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface` does not extend `Akeneo\Tool\Component\Localization\Model\LocalizableInterface` nor `Akeneo\Pim\Enrichment\Component\Product\Model\ScopableInterface` anymore
 - methods `getScope()`, `setScope()`, `getLocale()` and `setLocale()` were removed from `Akeneo\Pim\Enrichment\Component\Product\Model\AbstractProduct`
-- class `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\ScopableSubscriber` and its associated service definition `pim_catalog.event_subscriber.scopable` were removed 
+- class `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\ScopableSubscriber` and its associated service definition `pim_catalog.event_subscriber.scopable` were removed
 - Interface `Akeneo\Pim\Enrichment\Component\Product\Model\CompletenessInterface` added methods `setRatio()` , `setMissingCount()` and `setRequiredCount()`
 - Class `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\CompletenessRemover` `bulkDetacher` parameter is now mandatory.
 - Removed `objectDetacher` parameter from `Akeneo\Pim\Structure\Component\Model\FamilyInterface\SaveFamilyVariantOnFamilyUpdateSubscriber` constructor.

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/select2/select2.css
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/select2/select2.css
@@ -76,6 +76,7 @@ Version: 3.4.1 Timestamp: Thu Jun 27 18:02:10 PDT 2013
 
 .select2-container.select2-allowclear .select2-choice .select2-chosen {
     margin-right: 42px;
+    width: calc(100% - 60px);
 }
 
 .select2-container .select2-choice > .select2-chosen {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When there is a long label for a simple select option, the 'X' (remove) button is not clickable. This PR adds some space between the end of the label and the button. 

Before
![d8225256-3317-4396-8bd6-4b8aca5a2936](https://user-images.githubusercontent.com/1336344/60498252-8c19e900-9cb6-11e9-8062-141983f0ab8d.png)

After
![Screenshot (24)](https://user-images.githubusercontent.com/1336344/60498375-bb305a80-9cb6-11e9-97b8-3382747f6d46.png)



<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
