### PR TITLE
Fixed family locale on product mass edit

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/select2/family.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/select2/family.js
@@ -41,7 +41,7 @@ define(
                                 options: {
                                     limit: 20,
                                     page: page,
-                                    locale: UserContext.get('uiLocale')
+                                    locale: UserContext.get('catalogLocale')
                                 }
                             };
                         },
@@ -55,7 +55,7 @@ define(
                                     id: key,
                                     text: i18n.getLabel(
                                         value.labels,
-                                        UserContext.get('uiLocale'),
+                                        UserContext.get('catalogLocale'),
                                         value.code
                                     )
                                 });
@@ -73,7 +73,7 @@ define(
                                         id: family.code,
                                         text: i18n.getLabel(
                                             family.labels,
-                                            UserContext.get('uiLocale'),
+                                            UserContext.get('catalogLocale'),
                                             family.code
                                         )
                                     });
@@ -84,4 +84,4 @@ define(
                 }
             }
         }
-});
+    });


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
When we want to change the family of products in a bulk action you get a select field where the labels are filled from the uiLocale. But this locale is not always used. So with this fix the labels are filled with data from the selected catalogLocale.
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
