### PR TITLE
PIM-7888: Fix required boolean field when creating variant product

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7888: Fix required boolean field when creating variant product
+
 # 2.3.52 (2019-07-02)
 
 ## Bug fixes:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/add_child.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/add_child.yml
@@ -34,6 +34,7 @@ extensions:
         module: pim/form/common/fields/values/boolean
         config:
             required: true
+            defaultValue: false
 
     pim-product-model-add-child-field-simple-select-reference-data:
         module: pim/form/common/fields/values/simple-select-async


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

For boolean fields, we have some code that sets their default value when they render: 
```
            if (undefined === this.getModelValue() && _.has(this.config, 'defaultValue')) {
                this.updateModel(this.config.defaultValue);
            }
```
For the variant product creation, the defaultValue was not set, so it was ignored when saving the form which caused a validation error to be returned. This PR fixes the issue by adding the default value as false. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
