### PR TITLE
PIM-7935: Close variant select dropdowns on page navigation

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes:
+
+- PIM-7935: Close variant select dropdowns on page navigation
+
 # 2.3.52 (2019-07-02)
 
 ## Bug fixes:

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -51,7 +51,7 @@ define(
             templateProduct: _.template(templateProduct),
             templateProductModel: _.template(templateProductModel),
             templateAddChild: _.template(templateAddChild),
-            dropdowns: {},
+            dropdowns: [],
             queryTimer: null,
             events: {
                 'click [data-action="navigateToLevel"]': 'navigateToLevel'
@@ -64,6 +64,17 @@ define(
                 this.listenTo(UserContext, 'change:catalogLocale change:catalogScope', this.render);
 
                 return BaseForm.prototype.configure.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            shutdown: function () {
+                this.dropdowns.forEach(dropdown => {
+                    dropdown.close();
+                });
+
+                BaseForm.prototype.shutdown.apply(this, arguments);
             },
 
             /**
@@ -143,7 +154,7 @@ define(
                             this.addSelect2Footer(dropDown)
                         });
 
-                    this.dropdowns[index] = dropDown;
+                    this.dropdowns.push(dropDown.data('select2'));
                 });
             },
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -52,6 +52,7 @@ define(
             templateProductModel: _.template(templateProductModel),
             templateAddChild: _.template(templateAddChild),
             dropdowns: [],
+            formModal: null,
             queryTimer: null,
             events: {
                 'click [data-action="navigateToLevel"]': 'navigateToLevel'
@@ -73,6 +74,11 @@ define(
                 this.dropdowns.forEach(dropdown => {
                     dropdown.close();
                 });
+
+                if (this.formModal) {
+                    this.formModal.close();
+                    this.formModal.$el.remove();
+                }
 
                 BaseForm.prototype.shutdown.apply(this, arguments);
             },
@@ -264,6 +270,8 @@ define(
                         );
 
                         formModal.open();
+
+                        this.formModal = formModal;
                     });
             },
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a bug on the variant navigation where select2 dropdowns and form modals wouldn't close after clicking the back button. 


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
