### PR TITLE
PIM-8488: Fix wrapping of inline filters on records

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # 3.1.x
 
+## Bug fixes
+
+- PIM-8488: Fix wrapping of inline filters on records
+
 # 3.1.10 (2019-07-04)
 
 # 3.1.9 (2019-07-02)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -79,6 +79,7 @@
 
     &--inline {
       display: flex;
+      flex-wrap: wrap;
     }
   }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes the wrapping of filters for the inline filter box on reference entity records. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
