### PR TITLE
Fixed family locale on product mass edit

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8270: Update export jobs after a change on a channel category
+- GITHUB-10314: Fix family locale on mass edit product - cheers @gauquier!
 
 ## BC Breaks
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/select2/family.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/select2/family.js
@@ -41,7 +41,7 @@ define(
                                 options: {
                                     limit: 20,
                                     page: page,
-                                    locale: UserContext.get('uiLocale')
+                                    locale: UserContext.get('catalogLocale')
                                 }
                             };
                         },
@@ -55,7 +55,7 @@ define(
                                     id: key,
                                     text: i18n.getLabel(
                                         value.labels,
-                                        UserContext.get('uiLocale'),
+                                        UserContext.get('catalogLocale'),
                                         value.code
                                     )
                                 });
@@ -73,7 +73,7 @@ define(
                                         id: family.code,
                                         text: i18n.getLabel(
                                             family.labels,
-                                            UserContext.get('uiLocale'),
+                                            UserContext.get('catalogLocale'),
                                             family.code
                                         )
                                     });
@@ -84,4 +84,4 @@ define(
                 }
             }
         }
-});
+    });


### PR DESCRIPTION
When we want to change the family of products in a bulk action you get a select field where the labels are filled from the uiLocale. 
But this locale is not always used. 
So with this fix, the labels are filled with data from the selected catalogLocale.

Cf community PR : https://github.com/akeneo/pim-community-dev/pull/10314