### PR TITLE
PIM-8441: Fix badge positioning on PM dropdowns

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8441: Fix badge positioning on PM dropdowns
+
 # 3.0.29 (2019-07-04)
 
 # 3.0.28 (2019-07-02)
@@ -8,7 +12,7 @@
 
 - PIM-7894: Fix metric and price filters design
 - PIM-8447: Fix deformed images in dropdowns and grids
-- PIM-8477: Fix rich text area link dialog	
+- PIM-8477: Fix rich text area link dialog
 - PIM-8463: On import profiles, displays an explicit error message when file upload fails, for example when the file is too big
 
 # 3.0.27 (2019-06-27)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/VariantNavigation.less
@@ -77,6 +77,7 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    width: 100%;
   }
 
   &-listProductModelImage,


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes an issue on the product model variant dropdowns where the badges weren't positioned correctly. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
