### PR TITLE
PIM-8484: Show flash message instead of deprecated modal on deletion

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -12,6 +12,7 @@
 
 - PIM-7935: Close variant select dropdowns on page navigation
 - PIM-8476: Fix drag & drop on category trees
+- PIM-8484: Show flash message instead of deprecated error modal on deletion
 
 # 2.3.52 (2019-07-02)
 

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
@@ -68,7 +68,7 @@ define([
                             }
                         }
 
-                        this.getErrorDialog(message).open();
+                        this.showErrorFlashMessage(message)
                     }.bind(this),
                     success: function() {
                         var messageText = __('flash.' + this.getEntityCode() + '.removed');
@@ -103,7 +103,7 @@ define([
              *
              * @return {oro.Modal}
              */
-            getErrorDialog: function(response) {
+            showErrorFlashMessage: function(response) {
                 let message = '';
 
                 if (typeof response === 'string') {
@@ -116,12 +116,7 @@ define([
                     }
                 }
 
-                this.errorModal = new Modal({
-                    title: __('Delete Error'),
-                    content: '' === message ? __('error.removing.' + this.getEntityHint()) : message,
-                    cancelText: false
-                });
-                return this.errorModal;
+                messenger.notify('error', '' === message ? __('error.removing.' + this.getEntityHint()) : message);
             }
         });
     }

--- a/tests/legacy/features/family/delete_family.feature
+++ b/tests/legacy/features/family/delete_family.feature
@@ -23,10 +23,7 @@ Feature: Delete a family
     And I am on the families grid
     When I click on the "Delete" action of the row which contains "Boots"
     And I confirm the deletion
-    Then I should see a dialog with the following content:
-      | title        | content                                                                |
-      | Delete Error | Can not remove family "boots" because it is linked to family variants. |
-    When I press the "OK" button
+    Then I should see the flash message "Can not remove family "boots" because it is linked to family variants."
     Then I should be on the families page
     And I should see family Boots
 
@@ -45,5 +42,5 @@ Feature: Delete a family
     And I am on the families grid
     When I click on the "Delete" action of the row which contains "Sneakers"
     And I confirm the deletion
-    Then I should see the text "Delete error"
+    Then I should see the flash message "Family "sneakers" could not be removed as it still has products"
     And there should be a "Sneakers" family


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR updates the grids to show a flash message instead of an old style modal when there is a deletion error. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
