### PR TITLE
PIM-8534: Fix missing metric attributes on channel page

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8441: Fix badge positioning on PM dropdowns
+- PIM-8354: Fix missing metric attributes on channel page
 
 # 3.0.29 (2019-07-04)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/channel/form/properties/conversion-unit.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/channel/form/properties/conversion-unit.js
@@ -52,7 +52,10 @@ define([
                 }
 
                 $.when(
-                    FetcherRegistry.getFetcher('attribute').search({'types': 'pim_catalog_metric'}),
+                    FetcherRegistry.getFetcher('attribute').search({
+                        'types': 'pim_catalog_metric',
+                        'options': {'limit': 1000}
+                    }),
                     FetcherRegistry.getFetcher('measure').fetchAll()
                 ).then(function (attributes, measures) {
 


### PR DESCRIPTION
The number of metric attributes displayed in the channel edit page for the conversion is limited to 20 by default. 

Ideally the display of these attributes should be re-work to handle a large number of attributes, but it's not doable in a patch.

As workaround the limit is forced to 1000 for this page.