### PR TITLE
Extract push job to queue logic into a dedicated service

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
@@ -44,6 +44,20 @@ services:
             - '@akeneo_batch.logger.batch_log_handler'
             - '%kernel.environment%'
 
+    akeneo_batch_queue.queue.publish_job_to_queue:
+        class: Akeneo\Tool\Component\BatchQueue\Queue\PublishJobToQueue
+        arguments:
+            - '%akeneo_batch.entity.job_instance.class%'
+            - '%kernel.environment%'
+            - '@akeneo_batch.job_repository'
+            - '@validator'
+            - '@akeneo_batch.job.job_registry'
+            - '@akeneo_batch.job_parameters_factory'
+            - '@doctrine.orm.default_entity_manager'
+            - '@akeneo_batch.job.job_parameters_validator'
+            - '@akeneo_batch_queue.queue.database_job_execution_queue'
+            - '@event_dispatcher'
+
     # override of the original Akeneo Batch simple job launcher
     akeneo_batch.launcher.simple_job_launcher:
         class: '%akeneo_batch_queue.launcher.queue_job_launcher.class%'

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Command/PublishJobToQueueCommandSpec.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Command/PublishJobToQueueCommandSpec.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Tool\Bundle\BatchQueueBundle\Command;
+
+use Akeneo\Tool\Bundle\BatchBundle\Job\DoctrineJobRepository;
+use Akeneo\Tool\Bundle\BatchBundle\Job\JobInstanceRepository;
+use Akeneo\Tool\Component\Batch\Model\JobInstance;
+use Akeneo\Tool\Component\BatchQueue\Queue\PublishJobToQueue;
+use Doctrine\ORM\EntityManagerInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class PublishJobToQueueCommandSpec extends ObjectBehavior
+{
+    function let(
+        ContainerInterface $container,
+        PublishJobToQueue $publishJobToQueue,
+        DoctrineJobRepository $jobRepository,
+        EntityManagerInterface $entityManager,
+        JobInstanceRepository $jobInstanceRepository
+    ) {
+        $jobInstanceClass = 'Akeneo\Tool\Component\Batch\Model\JobInstance';
+        $container->get('akeneo_batch_queue.queue.publish_job_to_queue')->willReturn($publishJobToQueue);
+        $container->getParameter('akeneo_batch.entity.job_instance.class')->willReturn($jobInstanceClass);
+        $container->get('akeneo_batch.job_repository')->willReturn($jobRepository);
+
+        $jobRepository->getJobManager()->willReturn($entityManager);
+        $entityManager->getRepository($jobInstanceClass)->willReturn($jobInstanceRepository);
+    }
+
+    function it_has_a_name()
+    {
+        $this->getName()->shouldReturn('akeneo:batch:publish-job-to-queue');
+    }
+
+    function it_is_a_command()
+    {
+        $this->shouldBeAnInstanceOf(ContainerAwareCommand::class);
+    }
+
+    public function it_publishes_a_job_to_the_job_queue(
+        ContainerInterface $container,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition,
+        PublishJobToQueue $publishJobToQueue,
+        JobInstanceRepository $jobInstanceRepository,
+        JobInstance $jobInstance
+    ) {
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+
+        $inputCode = 'the_job_instance_code';
+        $inputConfig = '{"key": "data", "superkey": 50}';
+        $inputNoLog = null;
+        $inputUsername = 'admin';
+        $inputEmail = null;
+
+        $input->getArgument('code')->willReturn($inputCode);
+        $input->getOption('config')->willReturn($inputConfig);
+        $input->getOption('no-log')->willReturn($inputNoLog);
+        $input->getOption('username')->willReturn($inputUsername);
+        $input->getOption('email')->willReturn($inputEmail);
+
+        $publishJobToQueue->publish(
+            $inputCode,
+            json_decode($inputConfig, true),
+            false,
+            $inputUsername,
+            $inputEmail
+        )->shouldBeCalled();
+
+        $jobInstanceRepository->findOneBy(['code' => $inputCode])->willReturn($jobInstance);
+        $jobInstance->getType()->willReturn('jobType');
+        $jobInstance->getCode()->willReturn($inputCode);
+
+        $output->writeln('<info>JobType the_job_instance_code has been successfully pushed into the queue.</info>')->shouldBeCalled();
+
+        $this->run($input, $output);
+    }
+
+    public function it_throws_an_exception_if_the_config_string_is_malformed(
+        ContainerInterface $container,
+        InputInterface $input,
+        OutputInterface $output,
+        Application $application,
+        HelperSet $helperSet,
+        InputDefinition $definition
+    ) {
+        $definition->getOptions()->willReturn([]);
+        $definition->getArguments()->willReturn([]);
+
+        $application->getHelperSet()->willReturn($helperSet);
+        $application->getDefinition()->willReturn($definition);
+
+        $this->setApplication($application);
+        $this->setContainer($container);
+
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->shouldBeCalled();
+        $input->hasArgument(Argument::any())->shouldBeCalled();
+        $input->validate()->shouldBeCalled();
+
+        $inputCode = 'the_job_instance_code';
+        $inputConfig = '{{invalid_config}';
+        $inputNoLog = null;
+        $inputUsername = 'admin';
+        $inputEmail = null;
+
+        $input->getArgument('code')->willReturn($inputCode);
+        $input->getOption('config')->willReturn($inputConfig);
+        $input->getOption('no-log')->willReturn($inputNoLog);
+        $input->getOption('username')->willReturn($inputUsername);
+        $input->getOption('email')->willReturn($inputEmail);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during(
+            'run', [$input, $output]
+        );
+    }
+}

--- a/src/Akeneo/Tool/Component/BatchQueue/Queue/PublishJobToQueue.php
+++ b/src/Akeneo/Tool/Component/BatchQueue/Queue/PublishJobToQueue.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\BatchQueue\Queue;
+
+use Akeneo\Tool\Bundle\BatchBundle\Job\DoctrineJobRepository;
+use Akeneo\Tool\Component\Batch\Event\EventInterface;
+use Akeneo\Tool\Component\Batch\Event\JobExecutionEvent;
+use Akeneo\Tool\Component\Batch\Job\JobParameters;
+use Akeneo\Tool\Component\Batch\Job\JobParametersFactory;
+use Akeneo\Tool\Component\Batch\Job\JobParametersValidator;
+use Akeneo\Tool\Component\Batch\Job\JobRegistry;
+use Akeneo\Tool\Component\Batch\Model\JobExecution;
+use Akeneo\Tool\Component\Batch\Model\JobInstance;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Push a registered job instance to execute into the job execution queue.
+ *
+ * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
+ * @copyright 2019 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PublishJobToQueue
+{
+    /** @var string */
+    private $jobInstanceClass;
+
+    /** @var DoctrineJobRepository */
+    private $jobRepository;
+
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /** @var string */
+    private $kernelEnv;
+
+    /** @var JobRegistry */
+    private $jobRegistry;
+
+    /** @var JobParametersFactory */
+    private $jobParametersFactory;
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /** @var JobParametersValidator */
+    private $jobParametersValidator;
+
+    /** @var JobExecutionQueueInterface */
+    private $jobExecutionQueue;
+
+    /** @var EventDispatcherInterface */
+    private $eventDispatcher;
+
+    public function __construct(
+        string $jobInstanceClass,
+        string $kernelEnv,
+        DoctrineJobRepository $jobRepository,
+        ValidatorInterface $validator,
+        JobRegistry $jobRegistry,
+        JobParametersFactory $jobParametersFactory,
+        EntityManagerInterface $entityManager,
+        JobParametersValidator $jobParametersValidator,
+        JobExecutionQueueInterface $jobExecutionQueue,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->jobInstanceClass = $jobInstanceClass;
+        $this->jobRepository = $jobRepository;
+        $this->validator = $validator;
+        $this->kernelEnv = $kernelEnv;
+        $this->jobRegistry = $jobRegistry;
+        $this->jobParametersFactory = $jobParametersFactory;
+        $this->entityManager = $entityManager;
+        $this->jobParametersValidator = $jobParametersValidator;
+        $this->jobExecutionQueue = $jobExecutionQueue;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function publish(
+        string $jobInstanceCode,
+        array $config,
+        bool $noLog = false,
+        ?string $username = null,
+        ?string $email = null
+    ): void {
+        /** @var JobInstance $jobInstance */
+        $jobInstance = $this->jobRepository
+            ->getJobManager()
+            ->getRepository($this->jobInstanceClass)
+            ->findOneBy(['code' => $jobInstanceCode]);
+
+        if (null === $jobInstance) {
+            throw new \InvalidArgumentException(sprintf('Could not find job instance "%s".', $jobInstanceCode));
+        }
+
+        $options = ['env' => $this->kernelEnv];
+
+        if (null !== $email) {
+            $errors = $this->validator->validate($email, new Assert\Email());
+            if (count($errors) > 0) {
+                throw new \RuntimeException(
+                    sprintf('Email "%s" is invalid: %s', $email, $this->getErrorMessages($errors))
+                );
+            }
+            $options['email'] = $email;
+        }
+
+        if (true === $noLog) {
+            $options['no-log'] = true;
+        }
+
+        $jobParameters = $this->createJobParameters($jobInstance, $config);
+        $this->validateJobParameters($jobInstance, $jobParameters, $jobInstanceCode);
+        $jobExecution = $this->jobRepository->createJobExecution($jobInstance, $jobParameters);
+
+        if (null !== $username) {
+            $jobExecution->setUser($username);
+            $this->jobRepository->updateJobExecution($jobExecution);
+        }
+
+        $this->jobRepository->updateJobExecution($jobExecution);
+
+        $jobExecutionMessage = JobExecutionMessage::createJobExecutionMessage($jobExecution->getId(), $options);
+
+        $this->jobExecutionQueue->publish($jobExecutionMessage);
+
+        $this->dispatchJobExecutionEvent(EventInterface::JOB_EXECUTION_CREATED, $jobExecution);
+    }
+
+    private function createJobParameters(JobInstance $jobInstance, array $config): JobParameters
+    {
+        $job = $this->jobRegistry->get($jobInstance->getJobName());
+        $rawParameters = $jobInstance->getRawParameters();
+
+        $rawParameters = array_merge($rawParameters, $config);
+        $jobParameters = $this->jobParametersFactory->create($job, $rawParameters);
+
+        return $jobParameters;
+    }
+
+    private function validateJobParameters(JobInstance $jobInstance, JobParameters $jobParameters, string $code) : void
+    {
+        // We merge the JobInstance from the JobManager EntityManager to the DefaultEntityManager
+        // in order to be able to have a working UniqueEntity validation
+        $this->entityManager->merge($jobInstance);
+        $job = $this->jobRegistry->get($jobInstance->getJobName());
+        $errors = $this->jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution']);
+
+        if (count($errors) > 0) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Job instance "%s" running the job "%s" with parameters "%s" is invalid because of "%s"',
+                    $code,
+                    $job->getName(),
+                    print_r($jobParameters->all(), true),
+                    $this->getErrorMessages($errors)
+                )
+            );
+        }
+
+        $this->entityManager->clear(get_class($jobInstance));
+    }
+
+    private function getErrorMessages(ConstraintViolationListInterface $errors): string
+    {
+        $errorsStr = '';
+
+        foreach ($errors as $error) {
+            $errorsStr .= sprintf("\n  - %s", $error);
+        }
+
+        return $errorsStr;
+    }
+
+    private function dispatchJobExecutionEvent($eventName, JobExecution $jobExecution): void
+    {
+        $event = new JobExecutionEvent($jobExecution);
+        $this->eventDispatcher->dispatch($eventName, $event);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Currently to push a new job into the queue, we use the command `PublishJobToQueueCommand`. But if we need this logic somewhere else in the PIM without calling a command with a new php process etc.. we can't. 

So I've extracted the logic to push (publish) a job into the queue into a dedicated service.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -