### PR TITLE
 PIM-8556: remove single asset link attribute type 

### DIFF
--- a/src/Akeneo/Pim/Structure/Component/AttributeTypes.php
+++ b/src/Akeneo/Pim/Structure/Component/AttributeTypes.php
@@ -26,7 +26,6 @@ final class AttributeTypes
     const REFERENCE_DATA_MULTI_SELECT = 'pim_reference_data_multiselect';
     const REFERENCE_DATA_SIMPLE_SELECT = 'pim_reference_data_simpleselect';
     const REFERENCE_ENTITY_SIMPLE_SELECT = 'akeneo_reference_entity';
-    const ASSET_SINGLE_LINK = 'akeneo_asset_single_link';
     const ASSET_MULTIPLE_LINK = 'akeneo_asset_multiple_link';
 
     const BACKEND_TYPE_BOOLEAN = 'boolean';

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
@@ -288,7 +288,6 @@ class FamilyVariant implements FamilyVariantInterface
             AttributeTypes::BOOLEAN,
             AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT,
             AttributeTypes::REFERENCE_ENTITY_SIMPLE_SELECT,
-            AttributeTypes::ASSET_SINGLE_LINK
         ];
     }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes/create-button.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes/create-button.js
@@ -102,7 +102,6 @@ define(
                     .then(function (attributeTypes) {
                         // TODO: Remove the "delete" lines when we fully support the asset attribute types
                         delete attributeTypes.akeneo_asset_multiple_link;
-                        delete attributeTypes.akeneo_asset_single_link;
                         this.$el.html(this.template({
                             buttonTitle: __(this.config.buttonTitle)
                         }));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

From a functional point of view, it makes no sense to have a "single link asset" attribute type for product, so this PR removes it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -