### PR TITLE
PIM-8540: Display option label in product PDF

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # 3.1.x
 
+## Bug fixes
+
+- PIM-8540: Display option label in product PDF
+
 # 3.1.13 (2019-07-16)
 
 # 3.1.12 (2019-07-15)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/renderers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/renderers.yml
@@ -15,6 +15,7 @@ services:
             - 'AkeneoPimEnrichmentBundle:Product:renderPdf.html.twig'
             - '%upload_dir%'
             - '%pim_pdf_generator_font%'
+            - '@pim_catalog.repository.cached_attribute_option'
         tags:
             - { name: pim_pdf_generator.renderer, priority: 80 }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/Product/renderPdf.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/Product/renderPdf.html.twig
@@ -105,16 +105,17 @@
                                 {% set locale_attribute = attribute.isLocalizable or attribute.isLocaleSpecific ? locale : null %}
                                 {% set channel_attribute = attribute.isScopable ? scope : null %}
                                 {% set content = product.getValue(attribute.code, locale_attribute, channel_attribute) %}
+                                {% set manualHeight = true %}
 
                                 {% if 'pim_catalog_image' == attribute.type and content.media is not null %}
                                     {% set content = content.media.originalFilename %}
                                     {% set manualHeight = false %}
-                                {% else %}
-                                    {% if content != null %}
-                                        {% set manualHeight = attribute.label|length >(content.__toString()|length / 3) %}
-                                    {% else %}
-                                        {% set manualHeight = true %}
-                                    {% endif %}
+                                {% elseif ('pim_catalog_simpleselect' == attribute.type or 'pim_catalog_multiselect' == attribute.type) and attribute.code in optionLabels|keys %}
+                                    {% set content = optionLabels[attribute.code] %}
+                                {% endif %}
+
+                                {% if content != null and manualHeight == true %}
+                                    {% set manualHeight = attribute.label|length >(content.__toString()|length / 3) %}
                                 {% endif %}
 
                                 <div class="attributes"{% if manualHeight %} style="height: {{ (attribute.label|length / 30)|round(0, 'ceil') * 18 + 10 }}px"{% endif %}>

--- a/tests/back/Pim/Enrichment/Specification/Bundle/PdfGeneration/Renderer/ProductPdfRendererSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/PdfGeneration/Renderer/ProductPdfRendererSpec.php
@@ -79,6 +79,7 @@ class ProductPdfRendererSpec extends ObjectBehavior
             'groupedAttributes' => ['Design' => ['color' => $color]],
             'imagePaths'        => [],
             'customFont'        => null,
+            'optionLabels'      => [],
             'filter'            => 'pdf_thumbnail',
             'renderingDate'     => $renderingDate,
         ])->shouldBeCalled();
@@ -132,6 +133,7 @@ class ProductPdfRendererSpec extends ObjectBehavior
                 'groupedAttributes' => ['Media' => ['main_image' => $mainImage]],
                 'imagePaths'        => ['fookey'],
                 'customFont'        => null,
+                'optionLabels'      => [],
                 'filter'            => 'pdf_thumbnail',
                 'renderingDate'     => $renderingDate,
             ]


### PR DESCRIPTION
Before this fix, only the attribute code was displayed in the pdf for simple and multi select attributes.
We must display the selected and translated option labels in the PDF instead.


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
