### PR TITLE
PIM-8549: Fix filter caret being overwritten

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8540: Display option label in product PDF
+- PIM-8549: Fix filter caret invisible when option label is too long
 
 # 3.1.13 (2019-07-16)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -142,6 +142,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      max-width: inherit;
     }
   }
 


### PR DESCRIPTION
The filter caret can become invisible when the option label is very long. Ticket raised for reference entities, but i think it can be everywhere. The solution is to set the max width of the text inherit from the max width of its parent

**Before:**
![before](https://user-images.githubusercontent.com/1516770/61384851-b02e1a80-a8b1-11e9-8bcf-5153583e98d8.png)

**After:**
![after](https://user-images.githubusercontent.com/1516770/61384856-b45a3800-a8b1-11e9-9e5b-388003eb43ac.png)


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
