### PR TITLE
PIM-8555: Fix display of metric as variant axis in PEF

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8555: Fix display of metric as variant axis in PEF
+
 # 3.0.31 (2019-07-16)
 
 # 3.0.30 (2019-07-05)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -66,6 +66,9 @@ services:
 
     pim_enrich.normalizer.entity_with_family_variant.metric.label.normalizer:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer\MetricNormalizer'
+        arguments:
+            - '@pim_catalog.normalizer.standard.product.metric'
+            - '@pim_catalog.localization.localizer.metric'
 
     pim_enrich.normalizer.completeness:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\CompletenessNormalizer'

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizer.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer;
 
+use Akeneo\Pim\Enrichment\Component\Product\Localization\Localizer\MetricLocalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\MetricNormalizer as StandardMetricNormalizer;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 
 /**
@@ -12,6 +14,21 @@ use Akeneo\Pim\Structure\Component\AttributeTypes;
  */
 class MetricNormalizer implements AxisValueLabelsNormalizer
 {
+    /** @var StandardMetricNormalizer|null */
+    private $metricNormalizer;
+
+    /** @var MetricLocalizer|null */
+    private $metricLocalizer;
+
+    /**
+     * TODO: merge -> remove nullable and add BC break on UPGRADE
+     */
+    public function __construct(?StandardMetricNormalizer $metricNormalizer = null, ?MetricLocalizer $metricLocalizer = null)
+    {
+        $this->metricNormalizer = $metricNormalizer;
+        $this->metricLocalizer = $metricLocalizer;
+    }
+
     /**
      * @param ValueInterface $value
      * @param string         $locale
@@ -20,7 +37,22 @@ class MetricNormalizer implements AxisValueLabelsNormalizer
      */
     public function normalize(ValueInterface $value, string $locale): string
     {
-        return sprintf('%s %s', $value->getAmount(), $value->getUnit());
+        if ($this->metricLocalizer === null || $this->metricNormalizer === null) {
+            return sprintf('%s %s', $value->getData(), $value->getUnit());
+        }
+
+        $context = ['locale' => $locale];
+
+        $normalizedMetric = $this->metricNormalizer->normalize($value, 'standard', $context);
+
+        $metric = [
+            'amount' => $normalizedMetric['amount']->getData(),
+            'unit' => $value->getUnit()
+        ];
+
+        $localizedMetric = $this->metricLocalizer->localize($metric, $context);
+
+        return sprintf('%s %s', $localizedMetric['amount'], $localizedMetric['unit']);
     }
 
     public function supports(string $attributeType): bool

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizerSpec.php
@@ -2,14 +2,36 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\Metric;
 use Akeneo\Pim\Enrichment\Component\Product\Value\MetricValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use PhpSpec\ObjectBehavior;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\MetricNormalizer as StandardMetricNormalizer;
+use Akeneo\Pim\Enrichment\Component\Product\Localization\Localizer\MetricLocalizer;
+
 
 class MetricNormalizerSpec extends ObjectBehavior
 {
-    function it_normalizes_a_metric_product_value(MetricValue $value)
+    function let(StandardMetricNormalizer $metricNormalizer, MetricLocalizer $metricLocalizer)
     {
+        $this->beConstructedWith($metricNormalizer, $metricLocalizer);
+    }
+
+    function it_normalizes_a_metric_product_value(StandardMetricNormalizer $metricNormalizer, MetricLocalizer $metricLocalizer, MetricValue $value)
+    {
+        $metricNormalizer->normalize($value, 'standard', ['locale' => 'en_US'])->willReturn(
+            [
+                'amount' => new Metric('weight', 'KILOGRAM', 10, 'GRAM', 10)
+            ]
+        );
+
+        $metric = [
+            'amount' => 10,
+            'unit' => 'KILOGRAM'
+        ];
+
+        $metricLocalizer->localize($metric, ['locale' => 'en_US'])->willReturn($metric);
+
         $value->getAmount()->willReturn(10);
         $value->getUnit()->willReturn('KILOGRAM');
         $this->normalize($value, 'en_US')->shouldReturn('10 KILOGRAM');


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix display of metric as variant axis in PEF.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
