### PR TITLE
Tip 1159 simplify normalizer

### DIFF
--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -128,6 +128,7 @@ $rules = [
 
         // TIP-920: PIM/Enrichment should not be linked to Locale
         'Akeneo\Channel\Component\Model\LocaleInterface',
+        'Akeneo\Channel\Component\Model\Locale',
         'Akeneo\Channel\Component\Repository\LocaleRepositoryInterface',
 
         // TIP-921: PIM/Enrichment should not be linked to Channel

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -128,7 +128,6 @@ $rules = [
 
         // TIP-920: PIM/Enrichment should not be linked to Locale
         'Akeneo\Channel\Component\Model\LocaleInterface',
-        'Akeneo\Channel\Component\Model\Locale',
         'Akeneo\Channel\Component\Repository\LocaleRepositoryInterface',
 
         // TIP-921: PIM/Enrichment should not be linked to Channel

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetAttributeLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetAttributeLabels.php
@@ -33,7 +33,7 @@ final class SqlGetAttributeLabels implements GetAttributeLabelsInterface
         $this->connection = $connection;
     }
 
-    public function getLabels(array $attributeCodes): array
+    public function forAttributeCodes(array $attributeCodes): array
     {
         $sql = <<<SQL
 SELECT

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetAttributeLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetAttributeLabels.php
@@ -8,7 +8,16 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\GetAttributeLabelsInterface;
 use Doctrine\DBAL\Connection;
 
 /**
- * TODO DESC
+ * Executes SQL query to get the stored labels of a collection of attributes.
+ *
+ * Returns an array like:
+ * [
+ *      'name' => [
+ *          'en_US' => 'Name',
+ *          'fr_FR' => 'Nom',
+ *          'de_DE' => 'Name'
+ *      ], ...
+ * ]
  *
  * @author    Pierre Allard <pierre.allard@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetAttributeLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetAttributeLabels.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetAttributeLabelsInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * TODO DESC
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class SqlGetAttributeLabels implements GetAttributeLabelsInterface
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function getLabels(array $attributeCodes): array
+    {
+        $sql = <<<SQL
+SELECT
+   attribute.code AS code,
+   trans.label AS label,
+   trans.locale AS locale
+FROM pim_catalog_attribute attribute
+INNER JOIN pim_catalog_attribute_translation trans ON attribute.id=trans.foreign_key
+WHERE attribute.code IN (:attributeCodes)
+SQL;
+        $rows = $this->connection->executeQuery($sql, ['attributeCodes' => $attributeCodes])->fetchAll();
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['code']][$row['locale']] = $row['label'];
+        }
+
+        return $result;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetAttributeLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetAttributeLabels.php
@@ -44,7 +44,11 @@ FROM pim_catalog_attribute attribute
 INNER JOIN pim_catalog_attribute_translation trans ON attribute.id=trans.foreign_key
 WHERE attribute.code IN (:attributeCodes)
 SQL;
-        $rows = $this->connection->executeQuery($sql, ['attributeCodes' => $attributeCodes])->fetchAll();
+        $rows = $this->connection->executeQuery(
+            $sql,
+            ['attributeCodes' => $attributeCodes],
+            ['attributeCodes' => Connection::PARAM_STR_ARRAY]
+        )->fetchAll();
 
         $result = [];
         foreach ($rows as $row) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetChannelLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetChannelLabels.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetChannelLabelsInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Executes SQL query to get the stored labels of a collection of arrays.
+ *
+ * Returns an array like:
+ * [
+ *      'print' => [
+ *          'en_US' => 'Print',
+ *          'fr_FR' => 'Impression',
+ *          'de_DE' =>  'Drucken'
+ *      ], ...
+ * ]
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class SqlGetChannelLabels implements GetChannelLabelsInterface
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function getLabels(array $channelCodes): array
+    {
+        $sql = <<<SQL
+SELECT
+   channel.code AS code,
+   trans.label AS label,
+   trans.locale AS locale
+FROM pim_catalog_channel channel
+INNER JOIN pim_catalog_channel_translation trans ON channel.id=trans.foreign_key
+WHERE channel.code IN (:channelCodes)
+SQL;
+        $rows = $this->connection->executeQuery($sql, ['channelCodes' => $channelCodes])->fetchAll();
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['code']][$row['locale']] = $row['label'];
+        }
+
+        return $result;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetChannelLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetChannelLabels.php
@@ -44,7 +44,11 @@ FROM pim_catalog_channel channel
 INNER JOIN pim_catalog_channel_translation trans ON channel.id=trans.foreign_key
 WHERE channel.code IN (:channelCodes)
 SQL;
-        $rows = $this->connection->executeQuery($sql, ['channelCodes' => $channelCodes])->fetchAll();
+        $rows = $this->connection->executeQuery(
+            $sql,
+            ['channelCodes' => $channelCodes],
+            ['channelCodes' => Connection::PARAM_STR_ARRAY]
+        )->fetchAll();
 
         $result = [];
         foreach ($rows as $row) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetChannelLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetChannelLabels.php
@@ -33,7 +33,7 @@ final class SqlGetChannelLabels implements GetChannelLabelsInterface
         $this->connection = $connection;
     }
 
-    public function getLabels(array $channelCodes): array
+    public function forChannelCodes(array $channelCodes): array
     {
         $sql = <<<SQL
 SELECT

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetChannelLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/SqlGetChannelLabels.php
@@ -8,14 +8,14 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\GetChannelLabelsInterface;
 use Doctrine\DBAL\Connection;
 
 /**
- * Executes SQL query to get the stored labels of a collection of arrays.
+ * Executes SQL query to get the stored labels of a collection of channels.
  *
  * Returns an array like:
  * [
  *      'print' => [
  *          'en_US' => 'Print',
  *          'fr_FR' => 'Impression',
- *          'de_DE' =>  'Drucken'
+ *          'de_DE' => 'Drucken'
  *      ], ...
  * ]
  *

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -131,7 +131,7 @@ services:
         arguments:
             - '@pim_enrich.normalizer.product_completeness'
             - '@akeneo.pim.enrichment.channel.get_labels'
-            - '@pim_catalog.repository.cached_attribute'
+            - '@akeneo.pim.enrichment.attribute.get_labels'
 
     pim_enrich.normalizer.collection:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\CollectionNormalizer'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -130,7 +130,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\ProductCompletenessCollectionNormalizer'
         arguments:
             - '@pim_enrich.normalizer.product_completeness'
-            - '@pim_catalog.repository.channel'
+            - '@akeneo.pim.enrichment.channel.get_labels'
             - '@pim_catalog.repository.cached_attribute'
 
     pim_enrich.normalizer.collection:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -130,8 +130,8 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\ProductCompletenessCollectionNormalizer'
         arguments:
             - '@pim_enrich.normalizer.product_completeness'
-            - '@akeneo.pim.enrichment.channel.get_labels'
-            - '@akeneo.pim.enrichment.attribute.get_labels'
+            - '@akeneo.pim.enrichment.channel.query.get_labels'
+            - '@akeneo.pim.enrichment.attribute.query.get_labels'
 
     pim_enrich.normalizer.collection:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\CollectionNormalizer'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -132,7 +132,6 @@ services:
             - '@pim_enrich.normalizer.product_completeness'
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.repository.cached_attribute'
-            - '@pim_catalog.repository.cached_locale'
 
     pim_enrich.normalizer.collection:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\CollectionNormalizer'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -233,3 +233,8 @@ services:
         class: Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\SqlGetChannelLabels
         arguments:
             - '@database_connection'
+
+    akeneo.pim.enrichment.attribute.get_labels:
+        class: Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\SqlGetAttributeLabels
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -229,12 +229,12 @@ services:
         arguments:
             - '@database_connection'
 
-    akeneo.pim.enrichment.channel.get_labels:
+    akeneo.pim.enrichment.channel.query.get_labels:
         class: Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\SqlGetChannelLabels
         arguments:
             - '@database_connection'
 
-    akeneo.pim.enrichment.attribute.get_labels:
+    akeneo.pim.enrichment.attribute.query.get_labels:
         class: Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\SqlGetAttributeLabels
         arguments:
             - '@database_connection'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -228,3 +228,8 @@ services:
         class: Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\CountVariantProducts
         arguments:
             - '@database_connection'
+
+    akeneo.pim.enrichment.channel.get_labels:
+        class: Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\SqlGetChannelLabels
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
@@ -50,7 +50,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
     /** @var EntityWithFamilyVariantAttributesProvider */
     private $attributesProvider;
 
-    /** @var NormalizerInterface */
+    /** @var ProductCompletenessCollectionNormalizer */
     private $completenessCollectionNormalizer;
 
     /** @var CompletenessCalculatorInterface */
@@ -78,7 +78,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
         ImageNormalizer $imageNormalizer,
         LocaleRepositoryInterface $localeRepository,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
-        NormalizerInterface $completenessCollectionNormalizer,
+        ProductCompletenessCollectionNormalizer $completenessCollectionNormalizer,
         CompletenessCalculatorInterface $completenessCalculator,
         VariantProductRatioInterface $variantProductRatioQuery,
         ImageAsLabel $imageAsLabel,
@@ -246,7 +246,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
                 );
             }
 
-            return $this->completenessCollectionNormalizer->normalize($completenessCollection, 'internal_api');
+            return $this->completenessCollectionNormalizer->normalize($completenessCollection);
         }
 
         return [];

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductCompletenessCollectionNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductCompletenessCollectionNormalizer.php
@@ -13,6 +13,46 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 /**
  * Normalizes a ProductCompletenessCollection of a product (for the Product Edit Form)
  *
+ * [
+ *     [
+ *         'channel'  => 'ecommerce',
+ *         'labels'   => [
+ *             'en_US' => 'Ecommerce',
+ *             'fr_FR' => 'E-commerce',
+ *         ],
+ *         'stats'    => [
+ *             'total'    => 3,
+ *             'complete' => 0,
+ *         ],
+ *         'locales' => [
+ *             'de_DE' => [
+ *                 'completeness' => [
+ *                     'required' => 4,
+ *                     'missing' => 2,
+ *                     'ratio' => 50,
+ *                     'locale' => 'de_DE',
+ *                     'channel' => 'ecommerce'
+ *                 ],
+ *                 'missing' => [
+ *                     [
+ *                         'code' = 'description',
+ *                         'labels' = [
+ *                             'en_US' => 'Description',
+ *                             'fr_FR' => 'Description'
+ *                         ]
+ *                     ],
+ *                     ['...'],
+ *                 ],
+ *                 'label': 'German'
+ *             ],
+ *             'fr_FR'    => ['...'],
+ *             'en_US'     => ['...'],
+ *         ],
+ *     ],
+ *     ['...'],
+ *     ['...'],
+ * ]
+ *
  * @author    Pierre Allard <pierre.allard@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
@@ -39,52 +79,11 @@ class ProductCompletenessCollectionNormalizer
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @param ProductCompletenessCollection $completenesses
      *
-     * Normalized completeness collection that is returned looks like:
-     *
-     * [
-     *     [
-     *         'channel'  => 'ecommerce',
-     *         'labels'   => [
-     *             'en_US' => 'Ecommerce',
-     *             'fr_FR' => 'E-commerce',
-     *         ],
-     *         'stats'    => [
-     *             'total'    => 3,
-     *             'complete' => 0,
-     *         ],
-     *         'locales' => [
-     *             'de_DE' => [
-     *                 'completeness' => [
-     *                     'required' => 4,
-     *                     'missing' => 2,
-     *                     'ratio' => 50,
-     *                     'locale' => 'de_DE',
-     *                     'channel' => 'ecommerce'
-     *                 ],
-     *                 'missing' => [
-     *                     [
-     *                         'code' = 'description',
-     *                         'labels' = [
-     *                             'en_US' => 'Description',
-     *                             'fr_FR' => 'Description'
-     *                         ]
-     *                     ],
-     *                     ['...'],
-     *                 ],
-     *             ],
-     *             'fr_FR'    => ['...'],
-     *             'en_US'     => ['...'],
-     *         ],
-     *     ],
-     *     ['...'],
-     *     ['...'],
-     * ];
+     * @return array
      */
-    public function normalize($completenesses): array
+    public function normalize(ProductCompletenessCollection $completenesses): array
     {
         $channelCodes = $this->getChannelCodes($completenesses);
         $localeCodes = $this->getLocaleCodes($completenesses);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductCompletenessCollectionNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductCompletenessCollectionNormalizer.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi;
 
 use Akeneo\Channel\Component\Model\ChannelInterface;
+use Akeneo\Channel\Component\Model\Locale;
 use Akeneo\Channel\Component\Repository\ChannelRepositoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\CompletenessInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompleteness;
@@ -27,19 +28,14 @@ class ProductCompletenessCollectionNormalizer implements NormalizerInterface
     /** @var IdentifiableObjectRepositoryInterface */
     private $attributeRepository;
 
-    /** @var IdentifiableObjectRepositoryInterface */
-    private $localeRepository;
-
     public function __construct(
         NormalizerInterface $normalizer,
         ChannelRepositoryInterface $channelRepository,
-        IdentifiableObjectRepositoryInterface $attributeRepository,
-        IdentifiableObjectRepositoryInterface $localeRepository
+        IdentifiableObjectRepositoryInterface $attributeRepository
     ) {
         $this->normalizer = $normalizer;
         $this->channelRepository = $channelRepository;
         $this->attributeRepository = $attributeRepository;
-        $this->localeRepository = $localeRepository;
     }
 
     /**
@@ -202,7 +198,7 @@ class ProductCompletenessCollectionNormalizer implements NormalizerInterface
             $normalizedCompleteness = [];
             $normalizedCompleteness['completeness'] = $this->normalizer->normalize($completeness, $format, $context);
             $normalizedCompleteness['missing'] = [];
-            $normalizedCompleteness['label'] = $this->localeRepository->findOneByIdentifier($completeness->localeCode())->getName();
+            $normalizedCompleteness['label'] = $this->getLocaleName($completeness->localeCode());
 
             foreach ($completeness->missingAttributeCodes() as $attributeCode) {
                 $normalizedCompleteness['missing'][] = [
@@ -254,5 +250,18 @@ class ProductCompletenessCollectionNormalizer implements NormalizerInterface
 
             return $result;
         }, []);
+    }
+
+    /**
+     * @param string $localeCode
+     *
+     * @return string|null
+     */
+    private function getLocaleName(string $localeCode): ?string
+    {
+        $locale = new Locale();
+        $locale->setCode($localeCode);
+
+        return $locale->getName();
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductCompletenessCollectionNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductCompletenessCollectionNormalizer.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi;
 
-use Akeneo\Channel\Component\Model\Locale;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompleteness;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompletenessCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetAttributeLabelsInterface;
@@ -89,8 +88,8 @@ class ProductCompletenessCollectionNormalizer
         $missingAttributeCodes = $this->getMissingAttributeCodes($completenesses);
         $completenessesByChannel = $this->getCompletenessesByChannel($completenesses);
 
-        $channelLabels = $this->getChannelLabels->getLabels($channelCodes);
-        $attributeLabels = $this->getAttributeLabels->getLabels($missingAttributeCodes);
+        $channelLabels = $this->getChannelLabels->forChannelCodes($channelCodes);
+        $attributeLabels = $this->getAttributeLabels->forAttributeCodes($missingAttributeCodes);
 
         $normalizedCompletenessesPerChannel = [];
         foreach ($completenessesByChannel as $channelCode => $channelCompletenesses) {
@@ -307,13 +306,10 @@ class ProductCompletenessCollectionNormalizer
     /**
      * @param string $localeCode
      *
-     * @return string|null
+     * @return string
      */
-    private function getLocaleName(string $localeCode): ?string
+    private function getLocaleName(string $localeCode): string
     {
-        $locale = new Locale();
-        $locale->setCode($localeCode);
-
-        return $locale->getName();
+        return \Locale::getDisplayName($localeCode);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductNormalizer.php
@@ -79,7 +79,7 @@ class ProductNormalizer implements NormalizerInterface
     /** @var CollectionFilterInterface */
     protected $collectionFilter;
 
-    /** @var NormalizerInterface */
+    /** @var ProductCompletenessCollectionNormalizer */
     protected $completenessCollectionNormalizer;
 
     /** @var UserContext */
@@ -130,7 +130,7 @@ class ProductNormalizer implements NormalizerInterface
         CompletenessManager $completenessManager,
         ChannelRepositoryInterface $channelRepository,
         CollectionFilterInterface $collectionFilter,
-        NormalizerInterface $completenessCollectionNormalizer,
+        ProductCompletenessCollectionNormalizer $completenessCollectionNormalizer,
         UserContext $userContext,
         CompletenessCalculatorInterface $completenessCalculator,
         EntityWithFamilyValuesFillerInterface $productValuesFiller,
@@ -306,7 +306,7 @@ class ProductNormalizer implements NormalizerInterface
             );
         }
 
-        return $this->completenessCollectionNormalizer->normalize($completenessCollection, 'internal_api');
+        return $this->completenessCollectionNormalizer->normalize($completenessCollection);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetAttributeLabelsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetAttributeLabelsInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Query;
+
+/**
+ * TODO DESC
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetAttributeLabelsInterface
+{
+    public function getLabels(array $attributeCodes): array;
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetAttributeLabelsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetAttributeLabelsInterface.php
@@ -22,5 +22,5 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Query;
  */
 interface GetAttributeLabelsInterface
 {
-    public function getLabels(array $attributeCodes): array;
+    public function forAttributeCodes(array $attributeCodes): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetAttributeLabelsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetAttributeLabelsInterface.php
@@ -5,7 +5,16 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Component\Product\Query;
 
 /**
- * TODO DESC
+ * Executes query to get the stored labels of a collection of attributes.
+ *
+ * Returns an array like:
+ * [
+ *      'name' => [
+ *          'en_US' => 'Name',
+ *          'fr_FR' => 'Nom',
+ *          'de_DE' => 'Name'
+ *      ], ...
+ * ]
  *
  * @author    Pierre Allard <pierre.allard@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetChannelLabelsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetChannelLabelsInterface.php
@@ -12,7 +12,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Query;
  *      'print' => [
  *          'en_US' => 'Print',
  *          'fr_FR' => 'Impression',
- *          'de_DE' =>  'Drucken'
+ *          'de_DE' => 'Drucken'
  *      ], ...
  * ]
  *

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetChannelLabelsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetChannelLabelsInterface.php
@@ -22,5 +22,5 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Query;
  */
 interface GetChannelLabelsInterface
 {
-    public function getLabels(array $channelCodes): array;
+    public function forChannelCodes(array $channelCodes): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetChannelLabelsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetChannelLabelsInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Query;
+
+/**
+ * Executes query to get the stored labels of a collection of arrays.
+ *
+ * Returns an array like:
+ * [
+ *      'print' => [
+ *          'en_US' => 'Print',
+ *          'fr_FR' => 'Impression',
+ *          'de_DE' =>  'Drucken'
+ *      ], ...
+ * ]
+ *
+ * @author    Pierre Allard <pierre.allard@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetChannelLabelsInterface
+{
+    public function getLabels(array $channelCodes): array;
+}

--- a/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/Completeness/GetProductCompletenessesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/Completeness/GetProductCompletenessesIntegration.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Query\Sql\Completeness;
 
-use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompleteness;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompletenessCollection;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;

--- a/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/SqlGetAttributeLabelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/SqlGetAttributeLabelsIntegration.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Product\Query\Sql;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetAttributeLabelsInterface;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+class SqlGetAttributeLabelsIntegration extends TestCase
+{
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_that_it_returns_labels()
+    {
+        $result = $this->getAttributeLabels()->forAttributeCodes(['sku', 'nonexistingattribute']);
+        $expected = [
+            'sku' => [
+                'en_US' => 'SKU'
+            ]
+        ];
+        Assert::assertSame($result, $expected);
+    }
+
+    private function getAttributeLabels(): GetAttributeLabelsInterface
+    {
+        return $this->get('akeneo.pim.enrichment.attribute.query.get_labels');
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/SqlGetChannelLabelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/SqlGetChannelLabelsIntegration.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Product\Query\Sql;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetChannelLabelsInterface;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+class SqlGetChannelLabelsIntegration extends TestCase
+{
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_that_it_returns_labels()
+    {
+        $result = $this->getChannelLabels()->forChannelCodes(['ecommerce', 'nonexistingchannel']);
+        $expected = [
+            'ecommerce' => [
+                'en_US' => 'Default',
+                'de_DE' => 'Standard',
+                'fr_FR' => 'Défaut'
+            ]
+        ];
+        Assert::assertSame($result, $expected);
+    }
+
+    private function getChannelLabels(): GetChannelLabelsInterface
+    {
+        return $this->get('akeneo.pim.enrichment.channel.query.get_labels');
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizerSpec.php
@@ -7,11 +7,10 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\MetricInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompleteness;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompletenessCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer\AxisValueLabelsNormalizer;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\ProductCompletenessCollectionNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetProductCompletenesses;
 use Akeneo\Pim\Enrichment\Component\Product\Value\MetricValueInterface;
-use Akeneo\Test\Common\EntityWithValue\Builder\Product;
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Bundle\Context\CatalogContext;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\ImageNormalizer;
@@ -30,7 +29,6 @@ use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\CompleteVariantPr
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\VariantProductRatioInterface;
 use Akeneo\Channel\Component\Repository\LocaleRepositoryInterface;
 use Prophecy\Argument;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
 {
@@ -38,7 +36,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         ImageNormalizer $imageNormalizer,
         LocaleRepositoryInterface $localeRepository,
         EntityWithFamilyVariantAttributesProvider $attributesProvider,
-        NormalizerInterface $completenessCollectionNormalizer,
+        ProductCompletenessCollectionNormalizer $completenessCollectionNormalizer,
         CompletenessCalculatorInterface $completenessCalculator,
         VariantProductRatioInterface $variantProductRatioQuery,
         ImageAsLabel $imageAsLabel,
@@ -162,7 +160,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         $completenessCollectionNormalizer->normalize(new ProductCompletenessCollection(42, [
             new ProductCompleteness('ecommerce', 'fr_FR', 0, []),
             new ProductCompleteness('ecommerce', 'en_US', 0, [])
-        ]), 'internal_api')->willReturn(['NORMALIZED_COMPLETENESS']);
+        ]))->willReturn(['NORMALIZED_COMPLETENESS']);
 
         $simpleSelectOptionNormalizer->supports(Argument::any())->willReturn(false);
         $simpleSelectOptionNormalizer->supports('pim_catalog_simpleselect')->willReturn(true);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/ProductCompletenessCollectionNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/ProductCompletenessCollectionNormalizerSpec.php
@@ -49,7 +49,7 @@ class ProductCompletenessCollectionNormalizerSpec extends ObjectBehavior
             ]
         );
 
-        $getChannelLabels->getLabels(['mobile', 'print', '1234567890'])->willReturn([
+        $getChannelLabels->forChannelCodes(['mobile', 'print', '1234567890'])->willReturn([
             'mobile' => [
                 'en_US' => 'Mobile',
                 'fr_FR' => 'Mobile',
@@ -59,7 +59,7 @@ class ProductCompletenessCollectionNormalizerSpec extends ObjectBehavior
             ]
         ]);
 
-        $getAttributeLabels->getLabels(['name', 'sku', 'description'])->willReturn([
+        $getAttributeLabels->forAttributeCodes(['name', 'sku', 'description'])->willReturn([
             'sku' => [
                 'en_US' => 'SKU',
                 'fr_FR' => 'SKU',

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/ProductNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/ProductNormalizerSpec.php
@@ -20,6 +20,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Projection\ProductCompletenessCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\ImageNormalizer;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\ProductCompletenessCollectionNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\VariantNavigationNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetProductCompletenesses;
 use Akeneo\Pim\Enrichment\Component\Product\ValuesFiller\EntityWithFamilyValuesFillerInterface;
@@ -52,7 +53,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         CompletenessManager $completenessManager,
         ChannelRepositoryInterface $channelRepository,
         CollectionFilterInterface $collectionFilter,
-        NormalizerInterface $completenessCollectionNormalizer,
+        ProductCompletenessCollectionNormalizer $completenessCollectionNormalizer,
         UserContext $userContext,
         CompletenessCalculatorInterface $completenessCalculator,
         EntityWithFamilyValuesFillerInterface $productValuesFiller,
@@ -117,6 +118,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $missingAssociationAdder,
         $getProductCompletenesses,
         $completenessCalculator,
+        $completenessCollectionNormalizer,
         ProductInterface $mug,
         AssociationInterface $upsell,
         AssociationTypeInterface $groupType,
@@ -200,8 +202,10 @@ class ProductNormalizerSpec extends ObjectBehavior
         $groups->toArray()->willReturn([$group]);
         $group->getId()->willReturn(12);
 
-        $getProductCompletenesses->fromProductId(12)->willReturn(new ProductCompletenessCollection(12, []));
+        $productCompletenessCollection = new ProductCompletenessCollection(12, []);
+        $getProductCompletenesses->fromProductId(12)->willReturn($productCompletenessCollection);
         $completenessCalculator->calculate($mug)->willReturn([]);
+        $completenessCollectionNormalizer->normalize($productCompletenessCollection)->willReturn(['normalizedCompleteness']);
 
         $structureVersionProvider->getStructureVersion()->willReturn(12);
         $formProvider->getForm($mug)->willReturn('product-edit-form');
@@ -225,7 +229,7 @@ class ProductNormalizerSpec extends ObjectBehavior
                     'updated'           => 'normalized_update_version',
                     'model_type'        => 'product',
                     'structure_version' => 12,
-                    'completenesses'    => null,
+                    'completenesses'    => ['normalizedCompleteness'],
                     'required_missing_attributes' => 'INCOMPLETE VALUES',
                     'image'             => [
                         'filePath'         => '/p/i/m/4/all.png',
@@ -273,6 +277,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $missingAssociationAdder,
         $getProductCompletenesses,
         $completenessCalculator,
+        $completenessCollectionNormalizer,
         ProductInterface $mug,
         AssociationInterface $upsell,
         AssociationTypeInterface $groupType,
@@ -361,8 +366,10 @@ class ProductNormalizerSpec extends ObjectBehavior
         $groups->toArray()->willReturn([$group]);
         $group->getId()->willReturn(12);
 
-        $getProductCompletenesses->fromProductId(12)->willReturn(new ProductCompletenessCollection(12, []));
+        $productCompletenessCollection = new ProductCompletenessCollection(12, []);
+        $getProductCompletenesses->fromProductId(12)->willReturn($productCompletenessCollection);
         $completenessCalculator->calculate($mug)->willReturn([]);
+        $completenessCollectionNormalizer->normalize($productCompletenessCollection)->willReturn(['normalizedCompletenesses']);
 
         $structureVersionProvider->getStructureVersion()->willReturn(12);
         $formProvider->getForm($mug)->willReturn('product-edit-form');
@@ -408,7 +415,7 @@ class ProductNormalizerSpec extends ObjectBehavior
                     'updated'           => 'normalized_update_version',
                     'model_type'        => 'product',
                     'structure_version' => 12,
-                    'completenesses'    => null,
+                    'completenesses'    => ['normalizedCompletenesses'],
                     'required_missing_attributes' => 'INCOMPLETE VALUES',
                     'image'             => [
                         'filePath'         => '/p/i/m/4/all.png',


### PR DESCRIPTION
The internal ProductCompletenessCollection Normalizer was too complex because it loads a lot of useless things just for getting labels.
We extracted it into 2 queries to only channel and attribute labels.