### PR TITLE
PIM-8564: Wysiwyg - Add a link is broken when multiple rich textarea

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8542: Fix counter on categories when deleting a product on the grid
+- PIM-8564: fixes link dialog rendering for wysiwyg editors on product edition page
 
 # 3.1.14 (2019-07-18)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -110,7 +110,8 @@ define(
                 const source = $(jqueryEvent.originalEvent.path[0]);
 
                 if (source.hasClass('icon-link') || source.hasClass('btn-sm')) {
-                    const modal = $('.note-link-dialog.modal');
+                    const editor = source.closest('.note-editor');
+                    const modal = editor.find('.note-link-dialog.modal');
 
                     // Set PIM style
                     modal.find('.note-link-text, .note-link-url').addClass('AknTextField');

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -109,7 +109,10 @@ define(
             setStyleForLinkModal: function (jqueryEvent) {
                 const source = $(jqueryEvent.originalEvent.path[0]);
 
-                if (source.hasClass('icon-link') || source.hasClass('btn-sm')) {
+                if (
+                    source.hasClass('icon-link')
+                    || (source.hasClass('btn-sm') && ('showLinkDialog' === source.data('event')))
+                ) {
                     const editor = source.closest('.note-editor');
                     const modal = editor.find('.note-link-dialog.modal');
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

This pull request aims to fix the rendering issue of "Add link" modal dialogs when there are multiple Textarea attributes with "Rich Text editor" option enabled on the product edition page.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
