### PR TITLE
PIM-8349: import profile shows "undefined" instead of CSV or XLSX

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-8349: fixes missing variable passed to pim_enrich.job.upload translation
+- PIM-8349: Fixes missing variable passed to pim_enrich.job.upload translation
 
 # 2.3.54 (2019-07-19)
 

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8349: fixes missing variable passed to pim_enrich.job.upload translation
+
 # 2.3.54 (2019-07-19)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
@@ -69,6 +69,8 @@ extensions:
         module: pim/job/common/edit/upload
         parent: pim-job-instance-csv-product-model-import-show-upload-switcher-item
         position: 50
+        config:
+            type: csv
 
     pim-job-instance-csv-product-model-import-show-upload-button:
         module: pim/job/common/edit/upload-launch

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
@@ -67,6 +67,8 @@ extensions:
     pim-job-instance-xlsx-product-model-import-show-upload:
         module: pim/job/common/edit/upload
         parent: pim-job-instance-xlsx-product-model-import-show-upload-switcher-item
+        config:
+            type: xlsx
 
     pim-job-instance-xlsx-product-model-import-show-upload-button:
         module: pim/job/common/edit/upload-launch


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

The import profile shows "undefined" instead of CSV or XLSX

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
