### PR TITLE
Fix creation of index having uppercase character due to version BETA and preventing the PIM to be installed

### DIFF
--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
@@ -257,7 +257,7 @@ class Client
         $body['aliases'] = [$this->indexName => (object) []];
 
         $params = [
-            'index' => $this->indexName . '_' . str_replace('.', '_', CommunityVersion::VERSION) . '_' . Uuid::uuid4(),
+            'index' => strtolower($this->indexName . '_' . str_replace('.', '_', CommunityVersion::VERSION) . '_' . Uuid::uuid4()),
             'body' => $body,
         ];
 

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/UpdateIndexMapping.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/UpdateIndexMapping.php
@@ -28,7 +28,7 @@ final class UpdateIndexMapping
     public function updateIndexMapping(Client $client, string $indexNameOrAlias, Loader $indexConfiguration): void
     {
         // We don't care about the index name anymore as we use alias
-        $newIndexName = $indexNameOrAlias . '_' . str_replace('.', '_', CommunityVersion::VERSION) . '_' . Uuid::uuid4();
+        $newIndexName = strtolower($indexNameOrAlias . '_' . str_replace('.', '_', CommunityVersion::VERSION) . '_' . Uuid::uuid4());
 
         $this
             ->createIndexReadyForNewConfiguration($client->indices(), $newIndexName, $indexConfiguration)


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Index name does not accept lowercase characters.
Since the tag BETA, the index, which has the version in the naming, cannot be created.

Note: version name is useful in the index for the UX, when we will re-index data.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
