### PR TITLE
TIP-1180: do not fail when a file can not be relocated

### DIFF
--- a/upgrades/schema/LocalLogToObjectStorage.php
+++ b/upgrades/schema/LocalLogToObjectStorage.php
@@ -22,6 +22,9 @@ class LocalLogToObjectStorage
     /** @var array */
     private $errors = [];
 
+    /** @var int */
+    private $countRelocated = 0;
+
     public function __construct(
         Filesystem $filesystem,
         Connection $database
@@ -35,6 +38,11 @@ class LocalLogToObjectStorage
         return $this->database->executeQuery(
             'SELECT COUNT(*) FROM akeneo_batch_job_execution je INNER JOIN akeneo_batch_job_instance ji ON je.job_instance_id = ji.id WHERE ji.type IN (\'export\', \'import\')'
         )->fetchColumn();
+    }
+
+    public function countRelocated(): int
+    {
+        return $this->countRelocated;
     }
 
     public function relocateFiles(): array
@@ -70,6 +78,8 @@ class LocalLogToObjectStorage
         if (is_resource($file)) {
             fclose($file);
         }
+
+        $this->countRelocated++;
     }
 
     private function open(array $logInfo)

--- a/upgrades/schema/LocaleArchivesToObjectStorage.php
+++ b/upgrades/schema/LocaleArchivesToObjectStorage.php
@@ -26,6 +26,9 @@ class LocaleArchivesToObjectStorage
     /** @var array */
     private $errors = [];
 
+    /** @var int */
+    private $countRelocated = 0;
+
     public function __construct(
         Filesystem $filesystem,
         string $archiveDirectory
@@ -38,6 +41,11 @@ class LocaleArchivesToObjectStorage
     public function countFiles(): int
     {
         return $this->archiveFileSystem->count();
+    }
+
+    public function countRelocated(): int
+    {
+        return $this->countRelocated;
     }
 
     public function relocateFiles(): array
@@ -69,6 +77,8 @@ class LocaleArchivesToObjectStorage
         if (is_resource($file)) {
             fclose($file);
         }
+
+        $this->countRelocated++;
     }
 
     /**

--- a/upgrades/schema/archived_files_local_filesystem_to_object_storage.php
+++ b/upgrades/schema/archived_files_local_filesystem_to_object_storage.php
@@ -33,6 +33,12 @@ $storage = new \Pim\Upgrade\Schema\LocaleArchivesToObjectStorage(
 echo "Relocating {$storage->countFiles()} local archive files to the object storage...\n";
 
 $warnings = $storage->relocateFiles();
+$relocated = $storage->countRelocated();
+
+if (0 === $relocated) {
+    echo "No file have been relocated!\nDone!\n";
+    exit(-1);
+}
 
 if (!empty($warnings)) {
     echo "The following files have NOT been relocated:\n";

--- a/upgrades/schema/archived_files_local_filesystem_to_object_storage.php
+++ b/upgrades/schema/archived_files_local_filesystem_to_object_storage.php
@@ -32,17 +32,13 @@ $storage = new \Pim\Upgrade\Schema\LocaleArchivesToObjectStorage(
 
 echo "Relocating {$storage->countFiles()} local archive files to the object storage...\n";
 
-$errors = $storage->relocateFiles();
+$warnings = $storage->relocateFiles();
 
-if (!empty($errors)) {
+if (!empty($warnings)) {
     echo "The following files have NOT been relocated:\n";
-    foreach ($errors as $error) {
-        echo "- $error\n";
+    foreach ($warnings as $warning) {
+        echo "- $warning\n";
     }
 }
 
 echo "Done!\n";
-
-if (!empty($errors)) {
-    exit(-1);
-}

--- a/upgrades/schema/archived_logs_local_filesystem_to_object_storage.php
+++ b/upgrades/schema/archived_logs_local_filesystem_to_object_storage.php
@@ -33,6 +33,12 @@ $storage = new \Pim\Upgrade\Schema\LocalLogToObjectStorage(
 echo "Relocating {$storage->countFiles()} local import/export logs to the object storage...\n";
 
 $warnings = $storage->relocateFiles();
+$relocated = $storage->countRelocated();
+
+if (0 === $relocated) {
+    echo "No file have been relocated!\nDone!\n";
+    exit(-1);
+}
 
 if (!empty($warnings)) {
     echo "The following files have NOT been relocated:\n";

--- a/upgrades/schema/archived_logs_local_filesystem_to_object_storage.php
+++ b/upgrades/schema/archived_logs_local_filesystem_to_object_storage.php
@@ -32,17 +32,13 @@ $storage = new \Pim\Upgrade\Schema\LocalLogToObjectStorage(
 
 echo "Relocating {$storage->countFiles()} local import/export logs to the object storage...\n";
 
-$errors = $storage->relocateFiles();
+$warnings = $storage->relocateFiles();
 
-if (!empty($errors)) {
+if (!empty($warnings)) {
     echo "The following files have NOT been relocated:\n";
-    foreach ($errors as $error) {
-        echo "- $error\n";
+    foreach ($warnings as $warning) {
+        echo "- $warning\n";
     }
 }
 
 echo "Done!\n";
-
-if (!empty($errors)) {
-    exit(-1);
-}


### PR DESCRIPTION
The current behavior leads to problems during Serenity migrations. If a command exits with an error code (non 0), the other commands are not taken into account.

This is not what we want. It's a "normal" use case that some files can not be relocated. They probably have purged on the disk.

We now just exit -1 if no file at all have been relocated. It's probably the sign of something going wrong.