### PR TITLE
PIM-8577: Convert dates to user timezone in last operations widget

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # 3.1.x
 
+## Bug fixes
+
+- PIM-8577: Convert dates to user timezone in the dashboard's last operations widget
+
 # 3.1.16 (2019-07-22)
 
 ## Bug fixes:

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Widget/LastOperationsFetcher.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Widget/LastOperationsFetcher.php
@@ -55,12 +55,18 @@ class LastOperationsFetcher
                 'pim_import_export.batch_status.%d',
                 $operation['status']
             );
-            if ($operation['date'] instanceof \DateTime) {
-                $operation['date'] = $this->presenter->present($operation['date'], [
-                    'locale' => $locale,
-                    'timezone' => $timezone,
-                ]);
+
+            $date = $operation['date'] ?? null;
+            if (is_string($date)) {
+                $operation['date'] = $this->presenter->present(
+                    new \DateTime($date, new \DateTimeZone('UTC')),
+                    [
+                        'locale' => $locale,
+                        'timezone' => $timezone,
+                    ]
+                );
             }
+
             $operation['canSeeReport'] = !in_array($operation['type'], ['import', 'export']) ||
                 $this->securityFacade->isGranted(sprintf('pim_importexport_%s_execution_show', $operation['type']));
         }

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Widget/LastOperationsFetcherSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Widget/LastOperationsFetcherSpec.php
@@ -36,7 +36,7 @@ class LastOperationsFetcherSpec extends ObjectBehavior
         TokenInterface $token,
         LocaleInterface $locale
     ) {
-        $date = new \DateTime('2019-12-01');
+        $date = '2019-12-01 12:00:00';
         $operation = [
             'date'   => $date,
             'type'   => 'import',
@@ -52,10 +52,13 @@ class LastOperationsFetcherSpec extends ObjectBehavior
         $user->getUiLocale()->willReturn($locale);
         $user->getTimezone()->willReturn('Pacific/Kiritimati');
         $locale->getCode()->willReturn('fr_FR');
-        $presenter->present($date, ['locale' => 'fr_FR', 'timezone' => 'Pacific/Kiritimati'])->willReturn('01/12/2019');
+        $presenter->present(
+            new \DateTime($date, new \DateTimeZone('UTC')),
+            ['locale' => 'fr_FR', 'timezone' => 'Pacific/Kiritimati']
+        )->willReturn('02/12/2019 02:00:00');
 
         $operation['statusLabel'] = 'pim_import_export.batch_status.1';
-        $operation['date'] = '01/12/2019';
+        $operation['date'] = '02/12/2019 02:00:00';
         $operation['canSeeReport'] = false;
 
         $this->fetch()->shouldReturn([$operation]);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

The `Akeneo\Platform\Bundle\ImportExportBundle\Query\GetLastOperationsInterface` returns the date as a string, so it was never converted by the presenter

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
