### PR TITLE
PIM-8564: Wysiwyg - fix "add link" modal dialogs when multiple rich textarea

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8564: fixes link dialog rendering for wysiwyg editors on product edition page
+
 # 3.0.32 (2019-07-19)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -109,8 +109,12 @@ define(
             setStyleForLinkModal: function (jqueryEvent) {
                 const source = $(jqueryEvent.originalEvent.path[0]);
 
-                if (source.hasClass('icon-link') || source.hasClass('btn-sm')) {
-                    const modal = $('.note-link-dialog.modal');
+                if (
+                    source.hasClass('icon-link')
+                    || (source.hasClass('btn-sm') && ('showLinkDialog' === source.data('event')))
+                ) {
+                    const editor = source.closest('.note-editor');
+                    const modal = editor.find('.note-link-dialog.modal');
 
                     // Set PIM style
                     modal.find('.note-link-text, .note-link-url').addClass('AknTextField');


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This pull request aims to fix the rendering issue of "Add link" modal dialogs when there are multiple Textarea attributes with "Rich Text editor" option enabled on the product edition page.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
