### PR TITLE
TIP-1198 Don't need to check if web/bundle exist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,9 @@ jobs:
                 name: Start containers
                 command: docker-compose up -d fpm
           - run:
+                name: Generate production environment cache
+                command: docker-compose exec fpm bin/console cache:clear -e dev
+          - run:
                 name: PhpSpec
                 command: docker-compose exec -T fpm vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
           - run:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,10 @@
         "psr-4": {
             "Pim\\Upgrade\\": "upgrades/"
         },
-        "classmap": [ "app/AppKernel.php", "app/AppCache.php" ]
+        "classmap": [
+            "app/AppKernel.php",
+            "app/AppCache.php"
+        ]
     },
     "autoload-dev": {
         "psr-0": {
@@ -25,9 +28,7 @@
             "Pim\\Behat\\": "tests/legacy/features/Behat",
             "AkeneoTest\\": "tests/back",
             "Akeneo\\Test\\IntegrationTestsBundle\\": "tests/back/Integration/IntegrationTestsBundle/",
-            "Akeneo\\Test\\Integration\\": "tests/back/Integration/",
-            "Akeneo\\Test\\Acceptance\\": "tests/back/Acceptance/",
-            "Akeneo\\Test\\Common\\": "tests/back/Common/"
+            "Akeneo\\Test\\": "tests/back/"
         },
         "classmap": [ "tests/back/Integration/AppKernelTest.php" ]
     },
@@ -131,14 +132,7 @@
     },
     "scripts": {
         "symfony-scripts": [
-            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::removeSymfonyStandardFiles",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
-            "php bin/console --ansi fos:js-routing:dump --target=web/js/routes.js",
-            "php bin/console --ansi pim:installer:assets"
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
         ],
         "post-install-cmd": [
             "@symfony-scripts"

--- a/src/Akeneo/Platform/CommunityRequirements.php
+++ b/src/Akeneo/Platform/CommunityRequirements.php
@@ -109,17 +109,6 @@ class CommunityRequirements
             'Set the "<strong>memory_limit</strong>" setting in php.ini<a href="#phpini">*</a> to at least "512M".'
         );
 
-        $directories = array(
-            'web/bundles'
-        );
-        foreach ($directories as $directory) {
-            $requirements[] = new Requirement(
-                is_writable($this->baseDir.'/'.$directory),
-                $directory.' directory must be writable',
-                'Change the permissions of the "<strong>'.$directory.'</strong>" directory so that the web server can write into it.'
-            );
-        }
-
         $currentMySQLVersion = $this->getMySQLVersion();
         $requirements[] = new Requirement(
             version_compare($currentMySQLVersion, self::LOWEST_REQUIRED_MYSQL_VERSION, '>=')  &&


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR optimizes the class autoloading: we don't need to load classes in production if we only use them for test and there were some duplicated loading rules too.

Some post scripts are removed because we don't need them. Our install command do the same job, it is a pity to do two times the same job to install the PIM. We will save a little bit time to build our PIM :)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
