### PR TITLE
PIM-8582: Fix wysiwyg edit link not visible.

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8582: Fix wysiwyg edit link not visible
+
 # 3.0.33 (2019-07-24)
 
 ## Bug fixes

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-8582: Fix wysiwyg edit link not visible
+- PIM-8582: Fix wysiwyg edit link modal not visible
 
 # 3.0.33 (2019-07-24)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -25,7 +25,7 @@ define(
             fieldTemplate: _.template(fieldTemplate),
             events: {
                 'change .field-input:first textarea:first': 'updateModel',
-                'click .note-insert': 'moveModalBackdrop'
+                'click .note-insert': 'setStyleForLinkModal'
             },
 
             /**
@@ -40,7 +40,6 @@ define(
              */
             postRender: function () {
                 this.$('textarea').summernote({
-                    onToolbarClick: this.setStyleForLinkModal,
                     disableResizeEditor: true,
                     height: 200,
                     iconPrefix: 'icon-',
@@ -107,10 +106,13 @@ define(
              * @param jqueryEvent
              */
             setStyleForLinkModal: function (jqueryEvent) {
+                this.moveModalBackdrop();
+
                 const source = $(jqueryEvent.originalEvent.path[0]);
 
                 if (
                     source.hasClass('icon-link')
+                    || source.hasClass('icon-edit')
                     || (source.hasClass('btn-sm') && ('showLinkDialog' === source.data('event')))
                 ) {
                     const editor = source.closest('.note-editor');


### PR DESCRIPTION
Edit link was not visble because hidden under the backdrop mask.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
