### PR TITLE
PIM-7888: Fix creation of a product model / variant product with a boolean attribute as axis

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-7741: use the catalog locale when choosing a new parent product model
 - TIP-1200: Use SQL queries instead of repositories in UniqueVariantAxisValidator
+- PIM-7888: Fix creation of a product model / variant product with a boolean attribute as axis
 
 # 2.3.56 (2019-07-24)
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/CreateVariantProductIntegration.php
@@ -833,7 +833,7 @@ JSON;
             "a_yes_no": [{
                 "locale": null,
                 "scope": null,
-                "data": false
+                "data": true
             }],
             "a_localizable_scopable_image": [{
                 "locale": "en_US",
@@ -911,7 +911,7 @@ JSON;
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
                 'a_yes_no'                           => [
-                    ['locale' => null, 'scope' => null, 'data' => false],
+                    ['locale' => null, 'scope' => null, 'data' => true],
                 ],
                 'a_text_area'                           => [
                     ['locale' => null, 'scope' => null, 'data' => 'this is a very very very very very long  text'],
@@ -1044,7 +1044,7 @@ JSON;
                     [
                         'locale' => null,
                         'scope' => null,
-                        'data' => false,
+                        'data' => true,
                     ],
                 ],
             ],

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateVariantProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateVariantProductIntegration.php
@@ -93,7 +93,7 @@ class PartialUpdateVariantProductIntegration extends AbstractProductTestCase
             {
               "locale": null,
               "scope": null,
-              "data": false
+              "data": true
             }
           ]
         }
@@ -143,7 +143,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => false,
+                        "data"   => true,
                     ],
                 ],
             ],

--- a/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
+++ b/src/Pim/Bundle/EnrichBundle/Normalizer/EntityWithFamilyVariantNormalizer.php
@@ -191,6 +191,11 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
                         );
 
                         break;
+
+                    case AttributeTypes::BOOLEAN:
+                        $valuesForLocale[] = (true === $value->getData() ? '1' : '0');
+
+                        break;
                     default:
                         $valuesForLocale[] = (string) $value;
 
@@ -259,6 +264,8 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
                 $data = $value->getData();
                 $orderArray[] = $data->getUnit();
                 $orderArray[] = floatval($data->getData());
+            } elseif (AttributeTypes::BOOLEAN === $axisAttribute->getType()) {
+                $orderArray[] = (true === $value->getData() ? '1' : '0');
             } else {
                 $orderArray[] = (string) $value;
             }

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/add_child.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/add_child.yml
@@ -34,6 +34,7 @@ extensions:
         module: pim/form/common/fields/values/boolean
         config:
             required: true
+            defaultValue: false
 
     pim-product-model-add-child-field-simple-select-reference-data:
         module: pim/form/common/fields/values/simple-select-async

--- a/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxisValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/UniqueVariantAxisValidator.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Validator\Constraints;
 
+use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\EntityWithFamilyVariant\Query\GetValuesOfSiblings;
 use Pim\Component\Catalog\Exception\AlreadyExistingAxisValueCombinationException;
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
@@ -182,8 +183,11 @@ class UniqueVariantAxisValidator extends ConstraintValidator
 
         foreach ($axes as $axis) {
             $value = $values->getByCodes($axis->getCode());
-
-            $combination[] = (string)$value;
+            if (AttributeTypes::BOOLEAN === $axis->getType()) {
+                $combination[] = (true === $value->getData() ? '1' : '0');
+            } else {
+                $combination[] = (string)$value;
+            }
         }
 
         return implode(',', $combination);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

see #10318 

It also fixes the validation of variant axis uniqueness in case of a boolean variant axis and a `false` value, and the display of such values in the navigation ('0' is now displayed for false values instead of an empty string previously)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
