### PR TITLE
SDS-11392: Include less files in main stylesheet by default

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,10 @@
 
 - PIM-8349: Fixes missing variable passed to pim_enrich.job.upload translation
 
+## Improvement
+
+- GITHUB-10438: Include less files in the main stylesheet by default
+
 # 2.3.55 (2019-07-23)
 
 ## Bug fixes

--- a/src/Oro/Bundle/AsseticBundle/DependencyInjection/OroAsseticExtension.php
+++ b/src/Oro/Bundle/AsseticBundle/DependencyInjection/OroAsseticExtension.php
@@ -93,6 +93,14 @@ class OroAsseticExtension extends Extension
 
     protected function getAssetics(array $assets, array $debugGroups, bool $debugAll, array $stylesheets): array
     {
+        $allStylesheetGroups = array_reduce(
+            $stylesheets,
+            function ($previous, $stylesheetConf) {
+                return array_replace($previous, $stylesheetConf['groups']);
+            },
+            []
+        );
+
         $assetsGroupedByStylesheets = [];
 
         foreach ($stylesheets as $stylesheetName => $stylesheetConf) {
@@ -104,6 +112,15 @@ class OroAsseticExtension extends Extension
             }
 
             foreach ($assets as $groupName => $files) {
+                if (!in_array($groupName, $allStylesheetGroups)) {
+                    $assetsGroupedByStylesheets[self::DEFAULT_STYLESHEET_NAME]['compress'] = array_merge(
+                        $assetsGroupedByStylesheets[self::DEFAULT_STYLESHEET_NAME]['compress'],
+                        $files
+                    );
+
+                    continue;
+                }
+
                 if (!in_array($groupName, $stylesheetConf['groups'])) {
                     continue;
                 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

One case hasn't been expected in https://github.com/akeneo/pim-community-dev/pull/9696 : the PIM doesn't define stylesheet groups natively, but when an extension does (the Onboarder bundle for example) some less files from other extensions might be ignored.

With this PR, less file groups not included in any stylesheet are now included in the main stylesheet (pim.css) by default, so the behavior will be the same as before for integrators.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
