### PR TITLE
TIP-901: Remove duplicated keys in YAML files

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/association_group.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/association_group.yml
@@ -55,10 +55,6 @@ datagrid:
                     type:      string
                     label:     Code
                     data_name: g.code
-                label:
-                    type:      string
-                    label:     Label
-                    data_name: translation.label
                 type:
                     type:      choice
                     label:     Type

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/jsmessages.en_US.yml
@@ -148,7 +148,6 @@ pim_measure:
     GALLON: Gallon
     LITER: Liter
     MILLILITER: Milliliter
-    OUNCE: Ounce
     PINT: Pint
   # Weight
     DENIER: Denier

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/messages.en_US.yml
@@ -148,7 +148,6 @@ pim_measure:
     GALLON: Gallon
     LITER: Liter
     MILLILITER: Milliliter
-    OUNCE: Ounce
     PINT: Pint
   # Weight
     DENIER: Denier

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/event_subscribers.yml
@@ -37,15 +37,6 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
-    pim_locale.locale_subscriber:
-        class: '%pim_locale.locale_subscriber.class%'
-        arguments:
-            - '@request_stack'
-            - '@translator'
-            - '@doctrine.orm.entity_manager'
-        tags:
-            - { name: kernel.event_subscriber }
-
     pim_user.event_listener.create_user_system:
         class: '%pim_user.event_listener.create_user_system.class%'
         arguments:

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/User.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/User.orm.yml
@@ -83,7 +83,6 @@ Akeneo\UserManagement\Component\Model\User:
             gedmo:
                 timestampable:
                     on: update
-                    on: create
         productGridFilters:
             type: json_array
             nullable: true


### PR DESCRIPTION
Duplicated keys in YAML files trigger errors with Symfony4.