### PR TITLE
TIP-1185: Improve integration test for completeness dashboard calculation

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocale.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocale.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\FollowUp\Query\GetCompletenessPerChannelAndL
 use Akeneo\Pim\Enrichment\Component\FollowUp\ReadModel\ChannelCompleteness;
 use Akeneo\Pim\Enrichment\Component\FollowUp\ReadModel\CompletenessWidget;
 use Akeneo\Pim\Enrichment\Component\FollowUp\ReadModel\LocaleCompleteness;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Doctrine\DBAL\Connection;
 
@@ -153,15 +154,22 @@ SQL;
                                     [
                                         'terms' => [
                                             'categories' => $categoriesCodeAndLocalesByChannel['category_codes_in_channel']
-                                        ]
+                                        ],
                                     ],
                                     [
                                         'bool' => [
                                             'must' => [
-                                                'term' => ["enabled" => true]
+                                                [
+                                                    'term' => ["enabled" => true]
+                                                ],
+                                                [
+                                                    'term' => [
+                                                        'document_type' => ProductInterface::class,
+                                                    ]
+                                                ]
                                             ]
                                         ]
-                                    ]
+                                    ],
                                 ]
                             ]
                         ]
@@ -219,10 +227,17 @@ SQL;
                                         [
                                             'bool' => [
                                                 'should' => [
-                                                    ['term' => ["completeness." . $categoriesCodeAndLocalesByChannel['channel_code'] . "." . $locale => 100]]
+                                                    ['term' => ["completeness." . $categoriesCodeAndLocalesByChannel['channel_code'] . "." . $locale => 100]],
                                                 ],
                                                 'must' => [
-                                                    'term' => ["enabled" => true]
+                                                    [
+                                                        'term' => ["enabled" => true]
+                                                    ],
+                                                    [
+                                                        'term' => [
+                                                            'document_type' => ProductInterface::class,
+                                                        ]
+                                                    ]
                                                 ]
                                             ]
                                         ]

--- a/tests/back/Pim/Enrichment/Integration/PQB/AbstractProductQueryBuilderTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/AbstractProductQueryBuilderTestCase.php
@@ -105,9 +105,6 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
         $family_variant = $this->get('pim_catalog.factory.family_variant')->create();
         $this->get('pim_catalog.updater.family_variant')->update($family_variant, $data);
         $constraintList = $this->get('validator')->validate($family_variant);
-        foreach ($constraintList as $violation) {
-            echo $violation->getMessage().'<br>';
-        }
         $this->assertEquals(0, $constraintList->count());
         $this->get('pim_catalog.saver.family_variant')->save($family_variant);
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/AbstractProductQueryBuilderTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/AbstractProductQueryBuilderTestCase.php
@@ -105,6 +105,9 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
         $family_variant = $this->get('pim_catalog.factory.family_variant')->create();
         $this->get('pim_catalog.updater.family_variant')->update($family_variant, $data);
         $constraintList = $this->get('validator')->validate($family_variant);
+        foreach ($constraintList as $violation) {
+            echo $violation->getMessage().'<br>';
+        }
         $this->assertEquals(0, $constraintList->count());
         $this->get('pim_catalog.saver.family_variant')->save($family_variant);
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocaleIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocaleIntegration.php
@@ -140,7 +140,6 @@ class GetCompletenessPerChannelAndLocaleIntegration extends AbstractProductQuery
         $translationLocale = $this->get('pim_user.context.user')->getCurrentLocaleCode();
         $results = $this->get('akeneo.pim.enrichment.follow_up.completeness_widget_query')->fetch($translationLocale);
 
-        var_dump($results);
         $this->assertSame($completenessWidget->toArray(), $results->toArray());
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocaleIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocaleIntegration.php
@@ -78,7 +78,6 @@ class GetCompletenessPerChannelAndLocaleIntegration extends AbstractProductQuery
             'attribute_requirements' => [
                 'ecommerce' => ['sku', 'name'],
                 'mobile' => ['sku', 'name'],
-
             ]
         ]);
 
@@ -91,6 +90,35 @@ class GetCompletenessPerChannelAndLocaleIntegration extends AbstractProductQuery
             ]
         ]);
 
+        $this->createAttribute([
+            'code'              => 'size',
+            'type'              => AttributeTypes::BOOLEAN,
+            'localizable'       => false,
+            'scopable'          => false,
+        ]);
+
+        $this->createFamily([
+            'code'        => 'family_for_pm',
+            'attributes'  => ['sku', 'name', 'description', 'size'],
+            'attribute_requirements' => [
+                'ecommerce' => ['sku', 'name', 'description', 'size'],
+                'mobile' => ['sku', 'name', 'description', 'size']
+            ]
+        ]);
+
+        $this->createFamilyVariant([
+            'code'        => 'familyv',
+            'family'      => 'family_for_pm',
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['size'],
+                    'attributes' => ['size'],
+                ],
+            ]
+        ]);
+
+        $this->createProductModel();
         $this->createProducts(5, 5);
     }
 
@@ -112,6 +140,7 @@ class GetCompletenessPerChannelAndLocaleIntegration extends AbstractProductQuery
         $translationLocale = $this->get('pim_user.context.user')->getCurrentLocaleCode();
         $results = $this->get('akeneo.pim.enrichment.follow_up.completeness_widget_query')->fetch($translationLocale);
 
+        var_dump($results);
         $this->assertSame($completenessWidget->toArray(), $results->toArray());
     }
 
@@ -146,6 +175,24 @@ class GetCompletenessPerChannelAndLocaleIntegration extends AbstractProductQuery
                 ]
             ]);
         }
+    }
+
+    protected function createProductModel()
+    {
+        $data = [
+            'code' => 'product_model_incomplete',
+            'family_variant' => 'familyv',
+            'categories' => ['shoes'],
+            'values'  => [
+                'name'       => [
+                    ['data' => 'name_mobile_US_1', 'locale' => 'en_US', 'scope' => 'mobile']
+                ]
+            ]
+        ];
+
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
     }
 
     protected function createChannel(array $data = []): ChannelInterface


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR improves the ES queries and integration test for `Akeneo\Pim\Enrichment\Bundle\Storage\ElasticsearchAndSql\FollowUp\GetCompletenessPerChannelAndLocale` after the ES index merge done in https://github.com/akeneo/pim-community-dev/pull/10224. The queries now include filtering by `document_type` for products, and explicitly exclude product models. 


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
