### PR TITLE
PIM-8571: truncate the asset description on the PEF

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
@@ -45,6 +45,11 @@
         opacity: 0.6;
       }
     }
+
+    footer {
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
   }
 
   &-assetThumbnail {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
before: 
![before](https://user-images.githubusercontent.com/1978756/61880428-2e637000-aef5-11e9-8487-647b3156de92.png)

after :
![after](https://user-images.githubusercontent.com/1978756/61880446-34f1e780-aef5-11e9-86b4-aae263894e84.png)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
