### PR TITLE
PIM-7741: use the catalog locale when choosing a new parent product model

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7741: use the catalog locale when choosing a new parent product model
+
 # 2.3.56 (2019-07-24)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/product-model-field.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/mass-edit/form/product/product-model-field.js
@@ -101,7 +101,7 @@ define(
             convertBackendItem(item) {
                 return {
                     id: item.code,
-                    text: `${item.code} - ${item.meta.label[UserContext.get('uiLocale')]}`,
+                    text: `${item.code} - ${item.meta.label[UserContext.get('catalogLocale')]}`,
                     image: item.meta.image || null
                 };
             },


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
