### PR TITLE
PIM-8482: add ellipsis when label is too long on product edit form

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,6 +4,7 @@
 
 - PIM-8577: Convert dates to user timezone in the dashboard's last operations widget
 - PIM-8557: Remove empty headers when building the error reporting file
+- PIM-8482: Add ellipsis when label is too long on product edit form
 
 # 3.1.16 (2019-07-22)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
@@ -32,9 +32,13 @@
 
   &-label {
     color: @AknSlateGrey;
-    flex-grow: 1;
     font-size: @AknDefaultFontSize;
-    display: flex;
+    flex: 1;
+    min-width: 0;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    padding-right: 5px;
 
     &--grey {
       color: @AknGrey;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
before: 
![before](https://user-images.githubusercontent.com/1978756/61889265-6bcff980-af05-11e9-83f0-70729a573513.png)

After:
![after](https://user-images.githubusercontent.com/1978756/61889272-6ffc1700-af05-11e9-81a3-bccc165d4000.png)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
