### PR TITLE
Add logs to orphan archives removal

### DIFF
--- a/upgrades/schema/remove_orphan_archives.php
+++ b/upgrades/schema/remove_orphan_archives.php
@@ -146,10 +146,9 @@ function getLocalDirectoriesForJob(string $localStorageDirectory): Finder
 
 function removeDirectory(string $directory): void
 {
-    $fs = new Filesystem();
-
-    if ($fs->exists($directory)) {
-        $fs->remove($directory);
+    if ((new Filesystem())->exists($directory)) {
+        // using directly rm -rf instead of Filesytem::remove for NFS performance/stability problems
+        exec("rm -rf $directory");
         echo "  - Directory $directory removed.\n";
     }
 }


### PR DESCRIPTION
Log examples:

```
jjanvier:pcd$ docker-compose exec fpm php upgrades/schema/remove_orphan_archives.php                       
Removing orphan directories in the local archive storage /srv/pim/app/archive...

Removing orphan job execution directories...
  - Looking for job execution directories to remove in /srv/pim/app/archive/export/csv_attribute_export.
  - Looking for job execution directories to remove in /srv/pim/app/archive/export/csv_product_export.
  - Job execution directory /srv/pim/app/archive/export/csv_product_export/22 found.
  - Looking for job execution directories to remove in /srv/pim/app/archive/import/csv_attribute_import.
  - Job execution directory /srv/pim/app/archive/import/csv_attribute_import/32 found.
  - Directory /srv/pim/app/archive/import/csv_attribute_import/32 removed.
  - Job execution directory /srv/pim/app/archive/import/csv_attribute_import/30 found.

Removing orphan job directories...
  - Job directory /srv/pim/app/archive/export/csv_product_export found.
  - Job directory /srv/pim/app/archive/import/csv_attribute_import found.

Done!
```