### PR TITLE
TIP-901: make controllers public

### DIFF
--- a/src/Akeneo/Channel/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/controllers.yml
@@ -1,6 +1,7 @@
 services:
 
     pim_enrich.controller.rest.locale:
+        public: true
         class: 'Akeneo\Channel\Bundle\Controller\InternalApi\LocaleController'
         arguments:
             - '@pim_catalog.repository.locale'
@@ -8,6 +9,7 @@ services:
             - '@pim_catalog.filter.chained'
 
     pim_api.controller.locale:
+        public: true
         class: 'Akeneo\Channel\Bundle\Controller\ExternalApi\LocaleController'
         arguments:
             - '@pim_api.repository.locale'
@@ -18,6 +20,7 @@ services:
             - '%pim_api.configuration%'
 
     pim_api.controller.channel:
+        public: true
         class: 'Akeneo\Channel\Bundle\Controller\ExternalApi\ChannelController'
         arguments:
             - '@pim_api.repository.channel'
@@ -33,6 +36,7 @@ services:
             - '%pim_api.configuration%'
 
     pim_enrich.controller.rest.channel:
+        public: true
         class: 'Akeneo\Channel\Bundle\Controller\InternalApi\ChannelController'
         arguments:
             - '@pim_catalog.repository.channel'
@@ -44,6 +48,7 @@ services:
             - '@validator'
 
     pim_api.controller.currency:
+        public: true
         class: 'Akeneo\Channel\Bundle\Controller\ExternalApi\CurrencyController'
         arguments:
             - '@pim_api.repository.currency'
@@ -53,11 +58,13 @@ services:
             - '%pim_api.configuration%'
 
     pim_enrich.controller.rest.currency:
+        public: true
         class: 'Akeneo\Channel\Bundle\Controller\InternalApi\CurrencyController'
         arguments:
             - '@pim_catalog.repository.currency'
 
     pim_enrich.controller.currency:
+        public: true
         class: 'Akeneo\Channel\Bundle\Controller\UI\CurrencyController'
         arguments:
             - '@request_stack'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -4,12 +4,14 @@ parameters:
 
 services:
     pim_pdf_generator.controller.product:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ProductPdfController'
         arguments:
             - '@pim_catalog.repository.product'
             - '@pim_pdf_generator.renderer.registry'
 
     pim_comment.controller.comment:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\CommentController'
         arguments:
             - '@security.token_storage'
@@ -18,6 +20,7 @@ services:
             - '%pim_comment.entity.comment.class%'
 
     pim_localization.controller.format:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\FormatController'
         arguments:
             - '@pim_catalog.localization.factory.date'
@@ -30,6 +33,7 @@ services:
 
     ### External API
     pim_api.controller.product:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi\ProductController'
         arguments:
             - '@pim_external_api_serializer'
@@ -59,6 +63,7 @@ services:
             - '@akeneo.pim.enrichment.product.connector.get_product_from_identifiers'
 
     pim_api.controller.product_model:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi\ProductModelController'
         arguments:
             - '@pim_catalog.query.product_model_query_builder_factory'
@@ -84,6 +89,7 @@ services:
             - '%pim_api.configuration%'
 
     pim_api.controller.category:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi\CategoryController'
         arguments:
             - '@pim_api.repository.category'
@@ -99,6 +105,7 @@ services:
             - '%pim_api.configuration%'
 
     pim_enrich.controller.rest.category:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\CategoryController'
         arguments:
             - '@pim_catalog.repository.category'
@@ -107,6 +114,7 @@ services:
             - '@pim_catalog.filter.chained'
 
     pim_enrich.controller.rest.product_category:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ProductCategoryController'
         arguments:
             - '@pim_catalog.repository.product'
@@ -115,6 +123,7 @@ services:
 
 
     pim_enrich.controller.rest.product:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ProductController'
         arguments:
             - '@pim_catalog.repository.product'
@@ -137,6 +146,7 @@ services:
             - '@pim_enrich.filter.product_attribute_filter'
 
     pim_enrich.controller.rest.product_comment:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ProductCommentController'
         arguments:
             - '@security.token_storage'
@@ -151,6 +161,7 @@ services:
             - '@pim_enrich.resolver.locale'
 
     pim_enrich.controller.rest.product_model_category:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ProductModelCategoryController'
         arguments:
             - '@pim_catalog.repository.product_model'
@@ -159,6 +170,7 @@ services:
 
 
     pim_enrich.controller.rest.product_model:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ProductModelController'
         arguments:
             - '@pim_catalog.repository.product_model'
@@ -180,6 +192,7 @@ services:
             - '@pim_enrich.filter.product_model_attribute_filter'
 
     pim_enrich.controller.rest.group:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\GroupController'
         arguments:
             - '@pim_catalog.repository.group'
@@ -195,6 +208,7 @@ services:
             - '@pim_enrich.normalizer.violation'
 
     pim_enrich.controller.rest.sequential_edit:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\SequentialEditController'
         arguments:
             - '@oro_datagrid.mass_action.parameters_parser'
@@ -202,6 +216,7 @@ services:
             - '@pim_enrich.query.product_and_product_model_query_sequential_edit_builder_factory'
 
     pim_enrich.controller.rest.value:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ValuesController'
         arguments:
             - '@pim_catalog.builder.product'
@@ -214,6 +229,7 @@ services:
             - '@pim_enrich.normalizer.product_violation'
 
     pim_enrich.controller.rest.mass_edit:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\MassEditController'
         arguments:
             - '@oro_datagrid.mass_action.parameters_parser'
@@ -223,6 +239,7 @@ services:
             - '@pim_datagrid.adapter.items_counter'
 
     pim_enrich.controller.rest.media:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\MediaController'
         arguments:
             - '@validator'
@@ -231,6 +248,7 @@ services:
             - '@akeneo_file_storage.file_storage.file.file_storer'
 
     pim_enrich.controller.rest.versioning:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\VersioningController'
         arguments:
             - '@pim_versioning.repository.version'
@@ -239,6 +257,7 @@ services:
             - '@pim_user.context.user'
 
     pim_enrich.controller.category_tree.product:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\Ui\CategoryTreeController'
         arguments:
             - '@event_dispatcher'
@@ -253,6 +272,7 @@ services:
             - [ setContainer, [ '@service_container' ] ]
 
     pim_enrich.controller.file:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\Ui\FileController'
         arguments:
             - '@liip_imagine.controller'
@@ -263,6 +283,7 @@ services:
             - ['catalogStorage']
 
     pim_enrich.controller.product_model:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\Ui\ProductModelController'
         arguments:
             - '@pim_catalog.repository.product_model'
@@ -274,6 +295,7 @@ services:
             - '@@AkeneoPimEnrichment/ProductModel/listCategories.json.twig'
 
     pim_enrich.controller.product:
+        public: true
         class: 'Akeneo\Pim\Enrichment\Bundle\Controller\Ui\ProductController'
         arguments:
             - '@translator'
@@ -288,6 +310,7 @@ services:
             - '@@AkeneoPimEnrichment/Product/listCategories.json.twig'
 
     pim_api.controller.media_file:
+        public: true
         class: '%pim_api.controller.media_file.class%'
         arguments:
         - '@pim_api.repository.media_file'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
@@ -1,6 +1,7 @@
 services:
     ### External API
     pim_api.controller.attribute:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\ExternalApi\AttributeController'
         arguments:
             - '@pim_api.repository.attribute'
@@ -16,6 +17,7 @@ services:
             - '%pim_api.configuration%'
 
     pim_api.controller.attribute_group:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\ExternalApi\AttributeGroupController'
         arguments:
             - '@pim_api.repository.attribute_group'
@@ -31,6 +33,7 @@ services:
             - '%pim_api.configuration%'
 
     pim_api.controller.attribute_option:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\ExternalApi\AttributeOptionController'
         arguments:
             - '@pim_api.repository.attribute'
@@ -48,6 +51,7 @@ services:
             - ['pim_catalog_simpleselect', 'pim_catalog_multiselect']
 
     pim_api.controller.family:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\ExternalApi\FamilyController'
         arguments:
             - '@pim_api.repository.family'
@@ -63,6 +67,7 @@ services:
             - '%pim_api.configuration%'
 
     pim_api.controller.family_variant:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\ExternalApi\FamilyVariantController'
         arguments:
             - '@pim_api.repository.family'
@@ -79,6 +84,7 @@ services:
             - '%pim_api.configuration%'
 
     pim_api.controller.association_type:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\ExternalApi\AssociationTypeController'
         arguments:
             - '@pim_api.repository.association_type'
@@ -95,6 +101,7 @@ services:
 
     ### Internal Api
     pim_enrich.controller.rest.attribute:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\InternalApi\AttributeController'
         arguments:
             - '@pim_catalog.repository.attribute'
@@ -114,6 +121,7 @@ services:
             - '@pim_catalog.doctrine.query.attribute_is_an_family_variant_axis'
 
     pim_enrich.controller.rest.attribute_group:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\InternalApi\AttributeGroupController'
         arguments:
             - '@pim_catalog.repository.attribute_group'
@@ -133,6 +141,7 @@ services:
             - '@pim_catalog.filter.chained'
 
     pim_enrich.controller.rest.family:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\InternalApi\FamilyController'
         arguments:
             - '@pim_catalog.repository.family'
@@ -147,6 +156,7 @@ services:
             - '@pim_enrich.normalizer.violation'
 
     pim_enrich.controller.rest.family_variant:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\InternalApi\FamilyVariantController'
         arguments:
             - '@pim_catalog.repository.family_variant'
@@ -160,6 +170,7 @@ services:
             - '@pim_enrich.repository.family_variant.search'
 
     pim_enrich.controller.attribute_option:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\InternalApi\AttributeOptionController'
         arguments:
             - '@pim_internal_api_serializer'
@@ -176,11 +187,13 @@ services:
             - '@pim_enrich.normalizer.structured.attribute_option'
 
     pim_enrich.controller.rest.attribute_type:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\InternalApi\AttributeTypeController'
         arguments:
             - '@pim_catalog.registry.attribute_type'
 
     pim_enrich.controller.rest.association_type:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\InternalApi\AssociationTypeController'
         arguments:
             - '@pim_catalog.repository.association_type'
@@ -193,6 +206,7 @@ services:
             - '@pim_enrich.normalizer.violation'
 
     pim_enrich.controller.rest.group_type:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\InternalApi\GroupTypeController'
         arguments:
             - '@pim_catalog.repository.group_type'
@@ -206,6 +220,7 @@ services:
             - '@pim_enrich.normalizer.violation'
 
     pim_reference_data.controller.configuration_rest:
+        public: true
         class: 'Akeneo\Pim\Structure\Bundle\Controller\InternalApi\ReferenceDataConfigurationRestController'
         arguments:
             - '@pim_reference_data.registry'

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/config/controllers.yml
@@ -4,11 +4,13 @@ parameters:
 
 services:
     pim_analytics.controller.data:
+        public: true
         class: '%pim_analytics.controller.data.class%'
         arguments:
             - '@pim_analytics.data_collector.chained'
 
     pim_analytics.controller.system_info:
+        public: true
         class: '%pim_analytics.controller.system_info.class%'
         arguments:
             - '@templating'

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Resources/config/controllers.yml
@@ -3,6 +3,7 @@ parameters:
 
 services:
     pim_volume_monitoring.controller.volume_monitoring:
+        public: true
         class: '%pim_volume_monitoring.controller.volume_monitoring.class%'
         arguments:
             - '@pim_volume_monitoring.volume.normalizer.volumes'

--- a/src/Akeneo/Platform/Bundle/DashboardBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/DashboardBundle/Resources/config/controllers.yml
@@ -3,6 +3,7 @@ parameters:
 
 services:
     pim_dashboard.controller.widget:
+        public: true
         class: '%pim_dashboard.controller.widget.class%'
         arguments:
             - '@pim_dashboard.widget.registry'

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
@@ -6,6 +6,7 @@ parameters:
 
 services:
     pim_import_export.controller.export_profile:
+        public: true
         class: '%pim_import_export.controller.export_profile.class%'
         arguments:
             - '@templating'
@@ -19,6 +20,7 @@ services:
             - export
 
     pim_import_export.controller.import_profile:
+        public: true
         class: '%pim_import_export.controller.import_profile.class%'
         arguments:
             - '@templating'
@@ -32,6 +34,7 @@ services:
             - import
 
     pim_import_export.controller.export_execution:
+        public: true
         class: '%pim_import_export.controller.export_execution.class%'
         arguments:
             - '@templating'
@@ -45,6 +48,7 @@ services:
             - export
 
     pim_import_export.controller.import_execution:
+        public: true
         class: '%pim_import_export.controller.import_execution.class%'
         arguments:
             - '@templating'
@@ -58,6 +62,7 @@ services:
             - import
 
     pim_enrich.controller.rest.job_instance:
+        public: true
         class: 'Akeneo\Platform\Bundle\ImportExportBundle\Controller\InternalApi\JobInstanceController'
         arguments:
             - '@akeneo_batch.job.job_instance_repository'
@@ -81,6 +86,7 @@ services:
             - '@oneup_flysystem.jobs_storage_filesystem'
 
     pim_enrich.controller.rest.job_execution:
+        public: true
         class: 'Akeneo\Platform\Bundle\ImportExportBundle\Controller\InternalApi\JobExecutionController'
         arguments:
             - '@translator'
@@ -91,6 +97,7 @@ services:
 
 
     pim_enrich.controller.job_tracker:
+        public: true
         class: 'Akeneo\Platform\Bundle\ImportExportBundle\Controller\Ui\JobTrackerController'
         arguments:
             - '@templating'

--- a/src/Akeneo/Platform/Bundle/NotificationBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/Resources/config/controllers.yml
@@ -3,6 +3,7 @@ parameters:
 
 services:
     pim_notification.controller.notification:
+        public: true
         class: '%pim_notification.controller.notification.class%'
         arguments:
             - '@templating'

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/controllers.yml
@@ -3,12 +3,14 @@ parameters:
 
 services:
     pim_ui.controller.ajax_option:
+        public: true
         class: '%pim_ui.controller.ajax_option.class%'
         arguments:
             - '@doctrine'
             - '@pim_reference_data.registry'
 
     pim_localization.controller.locale:
+        public: true
         class: 'Akeneo\Platform\Bundle\UIBundle\Controller\LocaleController'
         arguments:
             - '@pim_localization.provider.ui_locale'

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Resources/config/controllers.yml
@@ -4,11 +4,13 @@ parameters:
 
 services:
     pim_api.controller.token:
+        public: true
         class: '%pim_api.controller.token.class%'
         arguments:
             - '@fos_oauth_server.server'
 
     pim_api.controller.root_endpoint:
+        public: true
         class: '%pim_api.controller.root_endpoint.class%'
         arguments:
             - '@router'

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
@@ -5,6 +5,7 @@ parameters:
 
 services:
     pim_user.controller.user_rest:
+        public: true
         class: '%pim_user.controller.user_rest.class%'
         arguments:
             - '@security.token_storage'
@@ -23,17 +24,20 @@ services:
             - '@translator'
 
     pim_user.controller.security_rest:
+        public: true
         class: '%pim_user.controller.security_rest.class%'
         arguments:
             - '@oro_security.security_facade'
             - '@oro_security.acl.annotation_provider'
 
     pim_user.controller.user_group_rest:
+        public: true
         class: '%pim_user.controller.user_group_rest.class%'
         arguments:
             - '@pim_user.repository.group'
 
     pim_enrich.controller.rest.api_client:
+        public: true
         class: 'Akeneo\UserManagement\Bundle\Controller\ApiClientController'
         arguments:
             - '@fos_oauth_server.client_manager.default'
@@ -41,6 +45,7 @@ services:
             - '@pim_internal_api_serializer'
 
     pim_user.controller.user_role_rest:
+        public: true
         class: 'Akeneo\UserManagement\Bundle\Controller\Rest\UserRoleController'
         arguments:
             - '@pim_user.repository.role'

--- a/src/Oro/Bundle/ConfigBundle/Resources/config/controllers.yml
+++ b/src/Oro/Bundle/ConfigBundle/Resources/config/controllers.yml
@@ -3,6 +3,7 @@ parameters:
 
 services:
     oro_config.controller.configuration:
+        public: true
         class: '%oro_config.controller.configuration.class%'
         arguments:
             - '@oro_config.global'

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/controllers.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/controllers.yml
@@ -7,12 +7,14 @@ parameters:
 
 services:
     pim_datagrid.controller.datagrid:
+        public: true
         class: '%pim_datagrid.controller.datagrid.class%'
         arguments:
             - '@templating'
             - '@oro_datagrid.datagrid.metadata_parser'
 
     pim_datagrid.controller.export:
+        public: true
         abstract: false
         class: '%pim_datagrid.controller.export.class%'
         arguments:
@@ -21,6 +23,7 @@ services:
             - '@pim_serializer'
 
     pim_datagrid.controller.product_export:
+        public: true
         class: '%pim_datagrid.controller.product_export.class%'
         arguments:
             - '@request_stack'
@@ -33,12 +36,14 @@ services:
             - '@oro_datagrid.mass_action.parameters_parser'
 
     pim_datagrid.controller.mass_action:
+        public: true
         class: '%pim_datagrid.controller.mass_action.class%'
         arguments:
             - '@pim_datagrid.extension.mass_action.dispatcher'
             - '@oro_datagrid.mass_action.parameters_parser'
 
     pim_datagrid.controller.rest.datagrid_view:
+        public: true
         class: '%pim_datagrid.controller.rest.datagrid_view.class%'
         arguments:
             - '@pim_internal_api_serializer'
@@ -54,6 +59,7 @@ services:
             - '@pim_datagrid.factory.datagrid_view'
 
     pim_datagrid.controller.productgrid:
+        public: true
         class: Oro\Bundle\PimDataGridBundle\Controller\ProductGridController
         arguments:
             - '@pim_datagrid.product_grid.query.list_attributes'


### PR DESCRIPTION
With Symfony4, all services are private by default. Including the controllers. Which means, if you update the PIM to Symfony4, you'll have this kind of error:

`[2019-07-25 19:21:36] request.CRITICAL: Uncaught PHP Exception InvalidArgumentException: "Controller "pim_user.controller.security_rest" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?" at /srv/pim/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Controller/ContainerControllerResolver.php line 71 {"exception":"[object] (InvalidArgumentException(code: 0): Controller \"pim_user.controller.security_rest\" cannot be fetched from the container because it is private. Did you forget to tag the service with \"controller.service_arguments\"? at /srv/pim/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Controller/ContainerControllerResolver.php:71, Error(code: 0): Class 'pim_user.controller.security_rest' not found at /srv/pim/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php:133)"} []`

We have to make controllers public in order to work with Symfony4.