### PR TITLE
TIP-1200: Use SQL queries in UniqueVariantAxisValidator

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7741: use the catalog locale when choosing a new parent product model
+- TIP-1200: Use SQL queries instead of repositories in UniqueVariantAxisValidator
 
 # 2.3.56 (2019-07-24)
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateListProductModelIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/ProductModel/PartialUpdateListProductModelIntegration.php
@@ -257,7 +257,7 @@ JSON;
         $this->assertSame($expectedContent, $response['content']);
     }
 
-    public function testCreateAndUpdateProductModelsWithUpdatedAxeValue()
+    public function testCreateAndUpdateProductModelsWithAlreadyExistingAxeValue()
     {
         $data =
 <<<JSON
@@ -269,6 +269,27 @@ JSON;
 <<<JSON
 {"line":1,"code":"sub_sweat_option_a","status_code":204}
 {"line":2,"code":"sub_sweat_option_b","status_code":422,"message":"Validation failed.","errors":[{"property":"attribute","message":"Cannot set value \"Option A\" for the attribute axis \"a_simple_select\" on product model \"sub_sweat_option_b\", as the product model \"sub_sweat_option_a\" already has this value"}]}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/product-models', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testCreateAndUpdateProductModelsWithUpdatedAxeValue()
+    {
+        $data =
+            <<<JSON
+    {"code": "sub_sweat_option_a", "parent": "sweat", "values": {"a_simple_select": [{"locale": null, "scope": null, "data": "optionB"}]}}
+    {"code": "sub_sweat_option_b", "parent": "sweat", "values": {"a_simple_select": [{"locale": null, "scope": null, "data": "optionB"}]}}
+JSON;
+
+        $expectedContent =
+            <<<JSON
+{"line":1,"code":"sub_sweat_option_a","status_code":422,"message":"Validation failed.","errors":[{"property":"attribute","message":"Variant axis \"a_simple_select\" cannot be modified, \"Option B\" given"}]}
+{"line":2,"code":"sub_sweat_option_b","status_code":201}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/product-models', [], [], [], $data);

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/SqlGetValuesOfSiblings.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/SqlGetValuesOfSiblings.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Query;
+
+use Doctrine\DBAL\Connection;
+use Pim\Component\Catalog\EntityWithFamilyVariant\Query\GetValuesOfSiblings;
+use Pim\Component\Catalog\Factory\ValueCollectionFactoryInterface;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class SqlGetValuesOfSiblings implements GetValuesOfSiblings
+{
+    /** @var Connection  */
+    private $connection;
+
+    /** @var ValueCollectionFactoryInterface */
+    private $valueCollectionFactory;
+
+    public function __construct(Connection $connection, ValueCollectionFactoryInterface $valueCollectionFactory)
+    {
+        $this->connection = $connection;
+        $this->valueCollectionFactory = $valueCollectionFactory;
+    }
+
+    public function for(EntityWithFamilyVariantInterface $entity): array
+    {
+        if (null === $entity->getParent()) {
+            return [];
+        }
+
+        if ($entity instanceof ProductModelInterface) {
+            $identifier = $entity->getCode();
+            $sql = <<<SQL
+SELECT code as identifier, raw_values
+FROM pim_catalog_product_model
+WHERE parent_id = :parentId
+AND code != :identifier;
+SQL;
+        } elseif ($entity instanceof ProductInterface) {
+            $identifier = $entity->getIdentifier();
+            $sql = <<<SQL
+SELECT identifier, raw_values
+FROM pim_catalog_product
+WHERE product_model_id = :parentId
+AND identifier != :identifier;
+SQL;
+        }
+
+        $valuesOfSiblings = [];
+        $rows = $this->connection->executeQuery(
+            $sql,
+            [
+                'parentId' => $entity->getParent()->getId(),
+                'identifier' => $identifier
+            ]
+        );
+        foreach ($rows as $row) {
+            $valuesOfSiblings[$row['identifier']] = $this->valueCollectionFactory->createFromStorageFormat(
+                json_decode($row['raw_values'], true)
+            );
+        }
+
+        return $valuesOfSiblings;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
@@ -83,3 +83,9 @@ services:
         class: Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\CountVariantProducts
         arguments:
             - '@database_connection'
+
+    pim_catalog.query.get_values_of_siblings:
+        class: Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\SqlGetValuesOfSiblings
+        arguments:
+            - '@database_connection'
+            - '@pim_catalog.factory.value_collection'

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -128,6 +128,7 @@ services:
             - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
             - '@pim_catalog.repository.entity_with_family_variant'
             - '@pim_catalog.validator.unique_axes_combination_set'
+            - '@pim_catalog.query.get_values_of_siblings'
         tags:
             - { name: validator.constraint_validator, alias: pim_unique_variant_axes_validator }
 

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/ORM/Query/SqlGetValuesOfSiblingsIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/ORM/Query/SqlGetValuesOfSiblingsIntegration.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Doctrine\ORM\Query;
+
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueInterface;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SqlGetValuesOfSiblingsIntegration extends TestCase
+{
+    public function test_that_it_gets_the_siblings_values_of_a_new_product_model()
+    {
+        $productModel = $this->createProductModel(
+            [
+                'code' => 'new_sub_pm',
+                'parent' => 'sweat',
+            ],
+            false
+        );
+
+        $valuesOfSiblings = $this->getValuesOfSiblings($productModel);
+        Assert::assertCount(2, $valuesOfSiblings);
+        Assert::assertArrayHasKey('sub_sweat_option_a', $valuesOfSiblings);
+        Assert::assertArrayHasKey('sub_sweat_option_b', $valuesOfSiblings);
+    }
+
+    public function test_that_it_gets_the_siblings_values_of_an_existing_product_model()
+    {
+        $subSweatA = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('sub_sweat_option_a');
+
+        $valuesOfSiblings = $this->getValuesOfSiblings($subSweatA);
+        Assert::assertCount(1, $valuesOfSiblings);
+        Assert::assertArrayHasKey('sub_sweat_option_b', $valuesOfSiblings);
+        Assert::assertNull($valuesOfSiblings['sub_sweat_option_b']->getByCodes('a_number_integer'));
+        Assert::assertInstanceOf(ValueInterface::class, $valuesOfSiblings['sub_sweat_option_b']->getByCodes('a_text'));
+    }
+
+    public function test_that_it_gets_the_siblings_values_of_a_new_variant_product()
+    {
+        $variantProduct = $this->createProduct(
+            'new_identifier',
+            [
+                'parent' => 'sub_sweat_option_a',
+            ],
+            false
+        );
+
+        $valuesOfSiblings = $this->getValuesOfSiblings($variantProduct);
+        Assert::assertCount(2, $valuesOfSiblings);
+        Assert::assertArrayHasKey('apollon_optiona_true', $valuesOfSiblings);
+        Assert::assertArrayHasKey('apollon_optiona_false', $valuesOfSiblings);
+    }
+
+    public function test_that_it_gets_the_siblings_values_of_an_existing_variant_product()
+    {
+        $apollonATrue = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_optiona_true');
+
+        $valuesOfSiblings = $this->getValuesOfSiblings($apollonATrue);
+        Assert::assertCount(1, $valuesOfSiblings);
+        Assert::assertArrayHasKey('apollon_optiona_false', $valuesOfSiblings);
+    }
+
+    // - sweat
+    //     - sub_sweat_option_a
+    //         - apollon_optiona_true
+    //         - apollon_optiona_false
+    //     - sub_sweat_option_b
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->createProductModel(
+            [
+                'code' => 'sweat',
+                'family_variant' => 'familyVariantA1',
+                'values' => [
+                    'a_number_integer' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => 42,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->createProductModel(
+            [
+                'code' => 'sub_sweat_option_a',
+                'parent' => 'sweat',
+                'family_variant' => 'familyVariantA1',
+                'values' => [
+                    'a_simple_select' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => 'optionA',
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->createProductModel(
+            [
+                'code' => 'sub_sweat_option_b',
+                'parent' => 'sweat',
+                'family_variant' => 'familyVariantA1',
+                'values' => [
+                    'a_simple_select' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => 'optionB',
+                        ],
+                    ],
+                    'a_text' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => 'Lorem ipsum',
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->createProduct(
+            'apollon_optiona_true',
+            [
+                'categories' => ['master'],
+                'parent' => 'sub_sweat_option_a',
+                'values' => [
+                    'a_yes_no' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => true,
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->createProduct(
+            'apollon_optiona_false',
+            [
+                'categories' => ['master'],
+                'parent' => 'sub_sweat_option_a',
+                'values' => [
+                    'a_yes_no' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => false,
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function createProduct($identifier, array $data = [], bool $save = true): ProductInterface
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+
+        if (true === $save) {
+            $errors = $this->get('pim_catalog.validator.product')->validate($product);
+            if (0 !== $errors->count()) {
+                throw new \Exception(
+                    sprintf(
+                        'Impossible to setup test in %s: %s',
+                        static::class,
+                        $errors->get(0)->getMessage()
+                    )
+                );
+            }
+
+            $this->get('pim_catalog.saver.product')->save($product);
+        }
+
+        return $product;
+    }
+
+    private function createProductModel(array $data = [], bool $save = true): ProductModelInterface
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+
+        if (true === $save) {
+            $errors = $this->get('pim_catalog.validator.product')->validate($productModel);
+            if (0 !== $errors->count()) {
+                throw new \Exception(
+                    sprintf(
+                        'Impossible to setup test in %s: %s',
+                        static::class,
+                        $errors->get(0)->getMessage()
+                    )
+                );
+            }
+            $this->get('pim_catalog.saver.product_model')->save($productModel);
+        }
+
+        return $productModel;
+    }
+
+    private function getValuesOfSiblings(EntityWithFamilyVariantInterface $entity): array
+    {
+        return $this->get('pim_catalog.query.get_values_of_siblings')->for($entity);
+    }
+}

--- a/src/Pim/Component/Catalog/EntityWithFamilyVariant/Query/GetValuesOfSiblings.php
+++ b/src/Pim/Component/Catalog/EntityWithFamilyVariant/Query/GetValuesOfSiblings.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace Pim\Component\Catalog\EntityWithFamilyVariant\Query;
 
 use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+use Pim\Component\Catalog\Model\ValueCollectionInterface;
 
 /**
- * @author    Mathias METAYER <mathias.metayer@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 interface GetValuesOfSiblings
 {
     /**
+     * Returns the values of the siblings of an EntityWithVariantInterface, indexed by identifier
+     *
      * @return ValueCollectionInterface[]
      */
     public function for(EntityWithFamilyVariantInterface $entity): array;

--- a/src/Pim/Component/Catalog/EntityWithFamilyVariant/Query/GetValuesOfSiblings.php
+++ b/src/Pim/Component/Catalog/EntityWithFamilyVariant/Query/GetValuesOfSiblings.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\EntityWithFamilyVariant\Query;
+
+use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetValuesOfSiblings
+{
+    /**
+     * @return ValueCollectionInterface[]
+     */
+    public function for(EntityWithFamilyVariantInterface $entity): array;
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
@@ -4,6 +4,7 @@ namespace spec\Pim\Component\Catalog\Validator\Constraints;
 
 use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Doctrine\ORM\Repository\EntityWithFamilyVariantRepository;
+use Pim\Component\Catalog\EntityWithFamilyVariant\Query\GetValuesOfSiblings;
 use Pim\Component\Catalog\Exception\AlreadyExistingAxisValueCombinationException;
 use Pim\Component\Catalog\FamilyVariant\EntityWithFamilyVariantAttributesProvider;
 use Pim\Component\Catalog\Model\AttributeInterface;
@@ -11,6 +12,7 @@ use Pim\Component\Catalog\Model\EntityWithFamilyVariantInterface;
 use Pim\Component\Catalog\Model\FamilyVariantInterface;
 use Pim\Component\Catalog\Model\ProductInterface;
 use Pim\Component\Catalog\Model\ProductModelInterface;
+use Pim\Component\Catalog\Model\ValueCollectionInterface;
 use Pim\Component\Catalog\Model\ValueInterface;
 use Pim\Component\Catalog\Validator\Constraints\UniqueVariantAxis;
 use Pim\Component\Catalog\Validator\UniqueAxesCombinationSet;
@@ -26,9 +28,10 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         EntityWithFamilyVariantAttributesProvider $axesProvider,
         EntityWithFamilyVariantRepository $repository,
         UniqueAxesCombinationSet $uniqueAxesCombinationSet,
+        GetValuesOfSiblings $getValuesOfSiblings,
         ExecutionContextInterface $context
     ) {
-        $this->beConstructedWith($axesProvider, $repository, $uniqueAxesCombinationSet);
+        $this->beConstructedWith($axesProvider, $repository, $uniqueAxesCombinationSet, $getValuesOfSiblings);
         $this->initialize($context);
     }
 
@@ -52,7 +55,7 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     }
 
     function it_raises_no_violation_if_the_entity_has_no_family_variant(
-        $context,
+        ExecutionContextInterface $context,
         EntityWithFamilyVariantInterface $entity,
         UniqueVariantAxis $constraint
     ) {
@@ -64,7 +67,7 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     }
 
     function it_raises_no_violation_if_the_entity_has_no_parent(
-        $context,
+        ExecutionContextInterface $context,
         FamilyVariantInterface $familyVariant,
         EntityWithFamilyVariantInterface $entity,
         UniqueVariantAxis $constraint
@@ -77,39 +80,36 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $this->validate($entity, $constraint);
     }
 
-    function it_raises_no_violation_if_the_entity_has_no_sibling(
-        $context,
-        $repository,
-        $axesProvider,
+    function it_raises_no_violation_if_the_entity_has_no_axis(
+        ExecutionContextInterface $context,
+        EntityWithFamilyVariantAttributesProvider $axesProvider,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent,
         EntityWithFamilyVariantInterface $entity,
         UniqueVariantAxis $constraint
     ) {
         $entity->getParent()->willReturn($parent);
-        $axesProvider->getAxes($entity)->willReturn([]);
         $entity->getFamilyVariant()->willReturn($familyVariant);
-        $repository->findSiblings($entity)->willReturn([]);
+        $axesProvider->getAxes($entity)->willReturn([]);
 
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
 
         $this->validate($entity, $constraint);
     }
 
-    function it_raises_no_violation_if_the_entity_has_no_axis(
-        $context,
-        $repository,
-        $axesProvider,
+    function it_raises_no_violation_if_the_entity_has_no_sibling(
+        ExecutionContextInterface $context,
+        EntityWithFamilyVariantAttributesProvider $axesProvider,
+        GetValuesOfSiblings $getValuesOfSiblings,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent,
         EntityWithFamilyVariantInterface $entity,
-        EntityWithFamilyVariantInterface $sibling,
         UniqueVariantAxis $constraint
     ) {
         $entity->getParent()->willReturn($parent);
-        $entity->getFamilyVariant()->willReturn($familyVariant);
         $axesProvider->getAxes($entity)->willReturn([]);
-        $repository->findSiblings($entity)->willReturn([$sibling]);
+        $entity->getFamilyVariant()->willReturn($familyVariant);
+        $getValuesOfSiblings->for($entity)->willReturn([]);
 
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
 
@@ -117,25 +117,23 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     }
 
     function it_raises_no_violation_if_axes_combination_is_empty(
-        $context,
-        $repository,
-        $axesProvider,
-        $uniqueAxesCombinationSet,
+        ExecutionContextInterface $context,
+        EntityWithFamilyVariantAttributesProvider $axesProvider,
+        UniqueAxesCombinationSet $uniqueAxesCombinationSet,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent,
         ProductModelInterface $entity,
-        ProductModelInterface $sibling1,
-        ProductModelInterface $sibling2,
         AttributeInterface $color,
+        ValueCollectionInterface $values,
         ValueInterface $emptyValue,
         UniqueVariantAxis $constraint
     ) {
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
+        $entity->getValuesForVariation()->willReturn($values);
+        $values->getByCodes('color')->willReturn($emptyValue);
         $axesProvider->getAxes($entity)->willReturn([$color]);
         $color->getCode()->willReturn('color');
-        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
-
         $entity->getValue('color')->willReturn($emptyValue);
         $emptyValue->__toString()->willReturn('');
         $uniqueAxesCombinationSet->addCombination(Argument::any())->shouldNotBeCalled();
@@ -146,16 +144,17 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     }
 
     function it_raises_no_violation_if_there_is_no_duplicate_in_any_sibling_product_model_from_database(
-        $context,
-        $repository,
-        $axesProvider,
-        $uniqueAxesCombinationSet,
+        ExecutionContextInterface $context,
+        EntityWithFamilyVariantAttributesProvider $axesProvider,
+        UniqueAxesCombinationSet $uniqueAxesCombinationSet,
+        GetValuesOfSiblings $getValuesOfSiblings,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent,
         ProductModelInterface $entity,
-        ProductModelInterface $sibling1,
-        ProductModelInterface $sibling2,
         AttributeInterface $color,
+        ValueCollectionInterface $values,
+        ValueCollectionInterface $valuesOfFirstSibling,
+        ValueCollectionInterface $valuesOfSecondSibling,
         ValueInterface $blue,
         ValueInterface $red,
         ValueInterface $yellow,
@@ -166,17 +165,20 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $axesProvider->getAxes($entity)->willReturn([$color]);
         $color->getCode()->willReturn('color');
 
-        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
-        $sibling1->getCode()->willReturn('sibling1');
-        $sibling2->getCode()->willReturn('sibling2');
-
-        $entity->getValue('color')->willReturn($blue);
-        $sibling1->getValue('color')->willReturn($red);
-        $sibling2->getValue('color')->willReturn($yellow);
+        $values->getByCodes('color')->willReturn($blue);
+        $entity->getValuesForVariation()->willReturn($values);
 
         $blue->__toString()->willReturn('[blue]');
         $red->__toString()->willReturn('[red]');
         $yellow->__toString()->willReturn('[yellow]');
+
+        $getValuesOfSiblings->for($entity)->willReturn([
+            'sibling1' => $valuesOfFirstSibling,
+            'sibling2' => $valuesOfSecondSibling,
+        ]);
+
+        $valuesOfFirstSibling->getByCodes('color')->willReturn($red);
+        $valuesOfSecondSibling->getByCodes('color')->willReturn($yellow);
 
         $uniqueAxesCombinationSet->addCombination($entity, '[blue]')->shouldBeCalled();
 
@@ -186,37 +188,36 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     }
 
     function it_raises_no_violation_if_there_is_no_duplicate_in_any_sibling_variant_product_from_database(
-        $context,
-        $repository,
-        $axesProvider,
-        $uniqueAxesCombinationSet,
+        ExecutionContextInterface $context,
+        EntityWithFamilyVariantAttributesProvider $axesProvider,
+        UniqueAxesCombinationSet $uniqueAxesCombinationSet,
+        GetValuesOfSiblings $getValuesOfSiblings,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent,
         ProductInterface $entity,
-        ProductInterface $sibling1,
-        ProductInterface $sibling2,
         AttributeInterface $color,
+        ValueCollectionInterface $values,
+        ValueCollectionInterface $valuesOfSibling,
         ValueInterface $blue,
         ValueInterface $red,
-        ValueInterface $yellow,
         UniqueVariantAxis $constraint
     ) {
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
+        $entity->getValuesForVariation()->willReturn($values);
+        $values->getByCodes('color')->willReturn($blue);
+
         $axesProvider->getAxes($entity)->willReturn([$color]);
         $color->getCode()->willReturn('color');
 
-        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
-        $sibling1->getIdentifier()->willReturn('sibling1');
-        $sibling2->getIdentifier()->willReturn('sibling2');
-
-        $entity->getValue('color')->willReturn($blue);
-        $sibling1->getValue('color')->willReturn($red);
-        $sibling2->getValue('color')->willReturn($yellow);
-
         $blue->__toString()->willReturn('[blue]');
         $red->__toString()->willReturn('[red]');
-        $yellow->__toString()->willReturn('[yellow]');
+
+        $getValuesOfSiblings->for($entity)->willReturn(
+            [
+                'sibbling_identifier' => $valuesOfSibling,
+            ]
+        );
 
         $uniqueAxesCombinationSet->addCombination($entity, '[blue]')->shouldBeCalled();
 
@@ -226,16 +227,17 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     }
 
     function it_raises_a_violation_if_there_is_a_duplicate_value_in_any_sibling_product_model(
-        $context,
-        $repository,
-        $axesProvider,
-        $uniqueAxesCombinationSet,
+        ExecutionContextInterface $context,
+        EntityWithFamilyVariantAttributesProvider $axesProvider,
+        UniqueAxesCombinationSet $uniqueAxesCombinationSet,
+        GetValuesOfSiblings $getValuesOfSiblings,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent,
         ProductModelInterface $entity,
-        ProductModelInterface $sibling1,
-        ProductModelInterface $sibling2,
         AttributeInterface $color,
+        ValueCollectionInterface $values,
+        ValueCollectionInterface $valuesOfFirstSibling,
+        ValueCollectionInterface $valuesOfSecondSibling,
         ValueInterface $blue,
         ValueInterface $yellow,
         UniqueVariantAxis $constraint,
@@ -244,16 +246,21 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $entity->getCode()->willReturn('entity_code');
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
+        $entity->getValuesForVariation()->willReturn($values);
         $axesProvider->getAxes($entity)->willReturn([$color]);
         $color->getCode()->willReturn('color');
 
-        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
-        $sibling1->getCode()->willReturn('sibling1');
-        $sibling2->getCode()->willReturn('sibling2');
+        $getValuesOfSiblings->for($entity)->willReturn(
+            [
+                'sibling1' => $valuesOfFirstSibling,
+                'sibling2' => $valuesOfSecondSibling,
+            ]
+        );
 
-        $entity->getValue('color')->willReturn($blue);
-        $sibling1->getValue('color')->willReturn($blue);
-        $sibling2->getValue('color')->willReturn($yellow);
+        $values->getByCodes('color')->willReturn($blue);
+
+        $valuesOfFirstSibling->getByCodes('color')->willReturn($yellow);
+        $valuesOfSecondSibling->getByCodes('color')->willReturn($blue);
 
         $blue->__toString()->willReturn('[blue]');
         $yellow->__toString()->willReturn('[yellow]');
@@ -267,7 +274,7 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
                     '%values%' => '[blue]',
                     '%attributes%' => 'color',
                     '%validated_entity%' => 'entity_code',
-                    '%sibling_with_same_value%' => 'sibling1',
+                    '%sibling_with_same_value%' => 'sibling2',
                 ]
             )
             ->willReturn($violation);
@@ -278,34 +285,40 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     }
 
     function it_raises_a_violation_if_there_is_a_duplicate_value_in_any_sibling_variant_product(
-        $context,
-        $repository,
-        $axesProvider,
-        $uniqueAxesCombinationSet,
+        ExecutionContextInterface $context,
+        EntityWithFamilyVariantAttributesProvider $axesProvider,
+        UniqueAxesCombinationSet $uniqueAxesCombinationSet,
+        GetValuesOfSiblings $getValuesOfSiblings,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent,
         ProductInterface $entity,
-        ProductInterface $sibling1,
-        ProductInterface $sibling2,
         AttributeInterface $color,
+        ValueCollectionInterface $values,
+        ValueCollectionInterface $valuesOfFirstSibling,
+        ValueCollectionInterface $valuesOfSecondSibling,
         ValueInterface $blue,
         ValueInterface $yellow,
         UniqueVariantAxis $constraint,
         ConstraintViolationBuilderInterface $violation
     ) {
-        $entity->getIdentifier()->willReturn('entity_identifier');
+        $entity->getIdentifier()->willReturn('my_identifier');
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
+        $entity->getValuesForVariation()->willReturn($values);
         $axesProvider->getAxes($entity)->willReturn([$color]);
         $color->getCode()->willReturn('color');
 
-        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
-        $sibling1->getIdentifier()->willReturn('sibling1');
-        $sibling2->getIdentifier()->willReturn('sibling2');
+        $getValuesOfSiblings->for($entity)->willReturn(
+            [
+                'sibling1' => $valuesOfFirstSibling,
+                'sibling2' => $valuesOfSecondSibling,
+            ]
+        );
 
-        $entity->getValue('color')->willReturn($blue);
-        $sibling1->getValue('color')->willReturn($blue);
-        $sibling2->getValue('color')->willReturn($yellow);
+        $values->getByCodes('color')->willReturn($blue);
+
+        $valuesOfFirstSibling->getByCodes('color')->willReturn($yellow);
+        $valuesOfSecondSibling->getByCodes('color')->willReturn($blue);
 
         $blue->__toString()->willReturn('[blue]');
         $yellow->__toString()->willReturn('[yellow]');
@@ -318,8 +331,8 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
                 [
                     '%values%' => '[blue]',
                     '%attributes%' => 'color',
-                    '%validated_entity%' => 'entity_identifier',
-                    '%sibling_with_same_value%' => 'sibling1',
+                    '%validated_entity%' => 'my_identifier',
+                    '%sibling_with_same_value%' => 'sibling2',
                 ]
             )
             ->willReturn($violation);
@@ -330,42 +343,48 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     }
 
     function it_raises_a_violation_if_there_is_a_duplicate_value_in_any_sibling_product_model_with_multiple_attributes_in_axis(
-        $context,
-        $repository,
-        $axesProvider,
-        $uniqueAxesCombinationSet,
+        ExecutionContextInterface $context,
+        EntityWithFamilyVariantAttributesProvider $axesProvider,
+        UniqueAxesCombinationSet $uniqueAxesCombinationSet,
+        GetValuesOfSiblings $getValuesOfSiblings,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent,
         ProductModelInterface $entity,
-        ProductModelInterface $sibling1,
-        ProductModelInterface $sibling2,
         AttributeInterface $color,
+        AttributeInterface $size,
+        ValueCollectionInterface $values,
+        ValueCollectionInterface $valuesOfFirstSibling,
+        ValueCollectionInterface $valuesOfSecondSibling,
         ValueInterface $blue,
         ValueInterface $yellow,
-        AttributeInterface $size,
-        ValueInterface $xl,
         UniqueVariantAxis $constraint,
-        ConstraintViolationBuilderInterface $violation
+        ConstraintViolationBuilderInterface $violation,
+        ValueInterface $xl
     ) {
         $entity->getCode()->willReturn('entity_code');
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
+        $entity->getValuesForVariation()->willReturn($values);
+
         $axesProvider->getAxes($entity)->willReturn([$color, $size]);
         $color->getCode()->willReturn('color');
         $size->getCode()->willReturn('size');
 
-        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
-        $sibling1->getCode()->willReturn('sibling1');
-        $sibling2->getCode()->willReturn('sibling2');
+        $values->getByCodes('color')->willReturn($blue);
+        $values->getByCodes('size')->willReturn($xl);
 
-        $entity->getValue('color')->willReturn($blue);
-        $entity->getValue('size')->willReturn($xl);
+        $valuesOfFirstSibling->getByCodes('color')->willReturn($yellow);
+        $valuesOfFirstSibling->getByCodes('size')->willReturn($xl);
 
-        $sibling1->getValue('color')->willReturn($blue);
-        $sibling1->getValue('size')->willReturn($xl);
+        $valuesOfSecondSibling->getByCodes('color')->willReturn($blue);
+        $valuesOfSecondSibling->getByCodes('size')->willReturn($xl);
 
-        $sibling2->getValue('color')->willReturn($yellow);
-        $sibling2->getValue('size')->willReturn($xl);
+        $getValuesOfSiblings->for($entity)->willReturn(
+            [
+                'sibling1' => $valuesOfFirstSibling,
+                'sibling2' => $valuesOfSecondSibling,
+            ]
+        );
 
         $blue->__toString()->willReturn('[blue]');
         $yellow->__toString()->willReturn('[yellow]');
@@ -380,7 +399,7 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
                     '%values%' => '[blue],[xl]',
                     '%attributes%' => 'color,size',
                     '%validated_entity%' => 'entity_code',
-                    '%sibling_with_same_value%' => 'sibling1',
+                    '%sibling_with_same_value%' => 'sibling2',
                 ]
             )
             ->willReturn($violation);
@@ -391,42 +410,48 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     }
 
     function it_raises_a_violation_if_there_is_a_duplicate_value_in_any_sibling_variant_product_with_multiple_attributes_in_axis(
-        $context,
-        $repository,
-        $axesProvider,
-        $uniqueAxesCombinationSet,
+        ExecutionContextInterface $context,
+        EntityWithFamilyVariantAttributesProvider $axesProvider,
+        UniqueAxesCombinationSet $uniqueAxesCombinationSet,
+        GetValuesOfSiblings $getValuesOfSiblings,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent,
         ProductInterface $entity,
-        ProductInterface $sibling1,
-        ProductInterface $sibling2,
         AttributeInterface $color,
+        AttributeInterface $size,
+        ValueCollectionInterface $values,
+        ValueCollectionInterface $valuesOfFirstSibling,
+        ValueCollectionInterface $valuesOfSecondSibling,
         ValueInterface $blue,
         ValueInterface $yellow,
-        AttributeInterface $size,
-        ValueInterface $xl,
         UniqueVariantAxis $constraint,
-        ConstraintViolationBuilderInterface $violation
+        ConstraintViolationBuilderInterface $violation,
+        ValueInterface $xl
     ) {
-        $entity->getIdentifier()->willReturn('entity_identifier');
+        $entity->getIdentifier()->willReturn('entity_code');
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
+        $entity->getValuesForVariation()->willReturn($values);
+
         $axesProvider->getAxes($entity)->willReturn([$color, $size]);
         $color->getCode()->willReturn('color');
         $size->getCode()->willReturn('size');
 
-        $repository->findSiblings($entity)->willReturn([$sibling1, $sibling2]);
-        $sibling1->getIdentifier()->willReturn('sibling1');
-        $sibling2->getIdentifier()->willReturn('sibling2');
+        $values->getByCodes('color')->willReturn($blue);
+        $values->getByCodes('size')->willReturn($xl);
 
-        $entity->getValue('color')->willReturn($blue);
-        $entity->getValue('size')->willReturn($xl);
+        $valuesOfFirstSibling->getByCodes('color')->willReturn($yellow);
+        $valuesOfFirstSibling->getByCodes('size')->willReturn($xl);
 
-        $sibling1->getValue('color')->willReturn($blue);
-        $sibling1->getValue('size')->willReturn($xl);
+        $valuesOfSecondSibling->getByCodes('color')->willReturn($blue);
+        $valuesOfSecondSibling->getByCodes('size')->willReturn($xl);
 
-        $sibling2->getValue('color')->willReturn($yellow);
-        $sibling2->getValue('size')->willReturn($xl);
+        $getValuesOfSiblings->for($entity)->willReturn(
+            [
+                'sibling1' => $valuesOfFirstSibling,
+                'sibling2' => $valuesOfSecondSibling,
+            ]
+        );
 
         $blue->__toString()->willReturn('[blue]');
         $yellow->__toString()->willReturn('[yellow]');
@@ -440,8 +465,8 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
                 [
                     '%values%' => '[blue],[xl]',
                     '%attributes%' => 'color,size',
-                    '%validated_entity%' => 'entity_identifier',
-                    '%sibling_with_same_value%' => 'sibling1',
+                    '%validated_entity%' => 'entity_code',
+                    '%sibling_with_same_value%' => 'sibling2',
                 ]
             )
             ->willReturn($violation);
@@ -452,15 +477,16 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     }
 
     function it_raises_a_violation_if_there_is_a_duplicated_product_model_in_the_batch(
-        $context,
-        $repository,
-        $axesProvider,
-        $uniqueAxesCombinationSet,
+        ExecutionContextInterface $context,
+        EntityWithFamilyVariantAttributesProvider $axesProvider,
+        UniqueAxesCombinationSet $uniqueAxesCombinationSet,
+        GetValuesOfSiblings $getValuesOfSiblings,
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $entity1,
         ProductModelInterface $entity2,
         ProductModelInterface $parent,
         AttributeInterface $color,
+        ValueCollectionInterface $values,
         ValueInterface $blue,
         AlreadyExistingAxisValueCombinationException $exception,
         UniqueVariantAxis $constraint,
@@ -468,18 +494,19 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     ) {
         $entity1->getParent()->willReturn($parent);
         $entity1->getFamilyVariant()->willReturn($familyVariant);
-        $repository->findSiblings($entity1)->willReturn([]);
         $axesProvider->getAxes($entity1)->willReturn([$color]);
         $color->getCode()->willReturn('color');
+        $getValuesOfSiblings->for($entity1)->willReturn([]);
 
         $entity2->getCode()->willReturn('entity_2');
         $entity2->getParent()->willReturn($parent);
         $entity2->getFamilyVariant()->willReturn($familyVariant);
-        $repository->findSiblings($entity2)->willReturn([]);
+        $getValuesOfSiblings->for($entity2)->willReturn([]);
         $axesProvider->getAxes($entity2)->willReturn([$color]);
 
-        $entity1->getValue('color')->willReturn($blue);
-        $entity2->getValue('color')->willReturn($blue);
+        $values->getByCodes('color')->willReturn($blue);
+        $entity1->getValuesForVariation()->willReturn($values);
+        $entity2->getValuesForVariation()->willReturn($values);
         $blue->__toString()->willReturn('[blue]');
 
         $uniqueAxesCombinationSet->addCombination($entity2, '[blue]')->willThrow($exception->getWrappedObject());
@@ -503,15 +530,16 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     }
 
     function it_raises_a_violation_if_there_is_a_duplicated_variant_product_in_the_batch(
-        $context,
-        $repository,
-        $axesProvider,
-        $uniqueAxesCombinationSet,
+        ExecutionContextInterface $context,
+        EntityWithFamilyVariantAttributesProvider $axesProvider,
+        UniqueAxesCombinationSet $uniqueAxesCombinationSet,
+        GetValuesOfSiblings $getValuesOfSiblings,
         FamilyVariantInterface $familyVariant,
         ProductInterface $entity1,
         ProductInterface $entity2,
         ProductModelInterface $parent,
         AttributeInterface $color,
+        ValueCollectionInterface $values,
         ValueInterface $blue,
         AlreadyExistingAxisValueCombinationException $exception,
         UniqueVariantAxis $constraint,
@@ -519,18 +547,19 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
     ) {
         $entity1->getParent()->willReturn($parent);
         $entity1->getFamilyVariant()->willReturn($familyVariant);
-        $repository->findSiblings($entity1)->willReturn([]);
         $axesProvider->getAxes($entity1)->willReturn([$color]);
         $color->getCode()->willReturn('color');
+        $getValuesOfSiblings->for($entity1)->willReturn([]);
 
         $entity2->getIdentifier()->willReturn('entity_2');
         $entity2->getParent()->willReturn($parent);
         $entity2->getFamilyVariant()->willReturn($familyVariant);
-        $repository->findSiblings($entity2)->willReturn([]);
+        $getValuesOfSiblings->for($entity2)->willReturn([]);
         $axesProvider->getAxes($entity2)->willReturn([$color]);
 
-        $entity1->getValue('color')->willReturn($blue);
-        $entity2->getValue('color')->willReturn($blue);
+        $values->getByCodes('color')->willReturn($blue);
+        $entity1->getValuesForVariation()->willReturn($values);
+        $entity2->getValuesForVariation()->willReturn($values);
         $blue->__toString()->willReturn('[blue]');
 
         $uniqueAxesCombinationSet->addCombination($entity2, '[blue]')->willThrow($exception->getWrappedObject());


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Use SQL queries instead of repos to get the values of siblings in UniqueVariantAxisValidator.
It avoids getting updated values if a sibling was previously updated but not persisted (hello Doctrine UOW) -> see [this test](https://github.com/akeneo/pim-community-dev/pull/10461/files#diff-49da1a039638d0f0b9294b0593520f98R281) for instance

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
