### PR TITLE
PIM-8589: Fix add attribute to attribute group

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8591: Fix product history author display
+- PIM-8589: Fix add attribute to attribute group when no permission on group "Other"
 
 # 3.0.34 (2019-07-24)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/attribute.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/attribute.js
@@ -64,7 +64,7 @@ define(
                 this.onExtensions('add-attribute:add', this.addAttributes.bind(this));
 
                 return FetcherRegistry.getFetcher('attribute')
-                    .search({attribute_groups: 'other'})
+                    .search({attribute_groups: 'other', rights: 0})
                     .then(function (attributes) {
                         this.otherAttributes = _.pluck(attributes, 'code');
                     }.bind(this)).then(function () {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/select.js
@@ -48,6 +48,7 @@ define(
             onGetQuery: function (options) {
                 return FetcherRegistry.getFetcher('attribute').search({
                         identifiers: this.getParent().getOtherAttributes().join(','),
+                        rights: 0,
                         search: options.term
                     }).then(this.prepareChoices)
                     .then(function (choices) {


### PR DESCRIPTION
Even if the user does not have the view rights on the attribute group "Other", he should be able to add attributes to other attribute group. This PR fix the calls by passing `rights: 0` to the fetcher to get all attributes without checking rights.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
