### PR TITLE
PIM-8597: Fix display of long attribute names in the filter menu

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -4,6 +4,7 @@
 
 - PIM-8577: Convert dates to user timezone in the dashboard's last operations widget
 - PIM-8557: Remove empty headers when building the error reporting file
+- PIM-8597: Fix display of long attribute names in the filter menu
 
 # 3.1.16 (2019-07-22)
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/filter/filter-group.html
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/filter/filter-group.html
@@ -4,7 +4,7 @@
     </li>
     <% filters.forEach(filter => { %>
     <li>
-        <label for="<%- filter.name %>" title="" class="ui-corner-all ui-state-hover">
+        <label for="<%- filter.name %>" title="<%- filter.label %>" class="ui-corner-all ui-state-hover">
             <input
                     id="<%- filter.name %>"
                     name="multiselect_add-filter-select"


### PR DESCRIPTION
In the product-grid filters menu, the labels of the attributes usable as a filter are not fully displayed (they are shortened with an "ellipsis"). The goal of this PR is to display the full label when the mouse is hovering it.