### PR TITLE
TIP-1196: only one run_phpunit.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,8 @@ jobs:
                 name: Start containers
                 command: docker-compose up -d fpm
           - run:
-                name: Generate dev environment cache (for symfony phpstan extension)
-                command: docker-compose exec fpm bin/console -e dev cache:clear
+                name: Generate dev cache for Symfony's Phpstan extension
+                command: docker-compose exec fpm bin/console --env=dev cache:clear
           - run:
                 name: PhpSpec
                 command: docker-compose exec -T fpm vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
                 name: PHPunit Integration
                 command: |
                     TESTFILES=$(docker-compose exec -T fpm .circleci/find_phpunit.sh PIM_Integration_Test | circleci tests split)
-                    .circleci/run_phpunit.sh $TESTFILES
+                    .circleci/run_phpunit.sh app $TESTFILES
           - store_test_results:
                 path: var/tests/phpunit
           - store_artifacts:
@@ -172,7 +172,7 @@ jobs:
                 name: PHPunit End to end
                 command: |
                     TESTFILES=$(docker-compose exec -T fpm .circleci/find_phpunit.sh End_to_End | circleci tests split)
-                    .circleci/run_phpunit.sh $TESTFILES
+                    .circleci/run_phpunit.sh app $TESTFILES
           - store_test_results:
                 path: var/tests/phpunit
           - store_artifacts:

--- a/.circleci/run_phpunit.sh
+++ b/.circleci/run_phpunit.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
 
-# We need the TESTFILES var in $1
+# Usage:
+#   run_phpunit.sh path/to/phpunit.xml test_file_1 test_file_2 test_file_3 test_file_4...
+
+CONFIGDIR=$1
+shift
 TESTFILES=$@
 
 fail=0
 for TESTFILE in $TESTFILES; do
     echo $TESTFILE
-    docker-compose exec -T fpm ./vendor/bin/phpunit -c app --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml --filter $TESTFILE
+    docker-compose exec -T fpm ./vendor/bin/phpunit -c $CONFIGDIR --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml --filter $TESTFILE
     fail=$(($fail + $?))
 done
 


### PR DESCRIPTION
Try to remove the useless run_phpunit.sh file that is present on EE