### PR TITLE
PIM-8409: Remove asset single link attribute from list

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes/create-button.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes/create-button.js
@@ -102,6 +102,7 @@ define(
                     .then(function (attributeTypes) {
                         // TODO: Remove the "delete" lines when we fully support the asset attribute types
                         delete attributeTypes.akeneo_asset_multiple_link;
+                        delete attributeTypes.akeneo_asset_single_link;
                         this.$el.html(this.template({
                             buttonTitle: __(this.config.buttonTitle)
                         }));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We didn't go far enough when removing the asset-single attribute. I've put back the removal of the button in the UI so that customers do not see it.

We need to rework this part :/


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
