### PR TITLE
TIP-1192 Make the symfony kernel compatible with SF4

### DIFF
--- a/app/bundles.php
+++ b/app/bundles.php
@@ -1,0 +1,67 @@
+<?php
+
+return [
+    // Symfony bundles
+    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle::class => ['all' => true],
+    Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
+    Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
+    Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],
+    Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
+
+    // ORO dependencies
+    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['all' => true],
+    FOS\JsRoutingBundle\FOSJsRoutingBundle::class => ['all' => true],
+    FOS\RestBundle\FOSRestBundle::class => ['all' => true],
+    Liip\ImagineBundle\LiipImagineBundle::class => ['all' => true],
+
+    // ORO bundle
+    Oro\Bundle\ConfigBundle\OroConfigBundle::class => ['all' => true],
+    Oro\Bundle\DataGridBundle\OroDataGridBundle::class => ['all' => true],
+    Oro\Bundle\FilterBundle\OroFilterBundle::class => ['all' => true],
+    Oro\Bundle\SecurityBundle\OroSecurityBundle::class => ['all' => true],
+    Oro\Bundle\TranslationBundle\OroTranslationBundle::class => ['all' => true],
+
+    // Pim dependencies
+    Akeneo\Tool\Bundle\ElasticsearchBundle\AkeneoElasticsearchBundle::class => ['all' => true],
+    Akeneo\Tool\Bundle\BatchBundle\AkeneoBatchBundle::class => ['all' => true],
+    Akeneo\Tool\Bundle\BatchQueueBundle\AkeneoBatchQueueBundle::class => ['all' => true],
+    Akeneo\Tool\Bundle\BufferBundle\AkeneoBufferBundle::class => ['all' => true],
+    Akeneo\Tool\Bundle\FileStorageBundle\AkeneoFileStorageBundle::class => ['all' => true],
+    Akeneo\Tool\Bundle\MeasureBundle\AkeneoMeasureBundle::class => ['all' => true],
+    Akeneo\Tool\Bundle\StorageUtilsBundle\AkeneoStorageUtilsBundle::class => ['all' => true],
+    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
+    FOS\OAuthServerBundle\FOSOAuthServerBundle::class => ['all' => true],
+    Oneup\FlysystemBundle\OneupFlysystemBundle::class => ['all' => true],
+
+    // PIM bundles
+    Oro\Bundle\PimFilterBundle\PimFilterBundle::class => ['all' => true],
+    Akeneo\UserManagement\Bundle\PimUserBundle::class => ['all' => true],
+    Akeneo\Channel\Bundle\AkeneoChannelBundle::class => ['all' => true],
+    Akeneo\Pim\Enrichment\Bundle\AkeneoPimEnrichmentBundle::class => ['all' => true],
+    Akeneo\Pim\Structure\Bundle\AkeneoPimStructureBundle::class => ['all' => true],
+    Akeneo\Tool\Bundle\ClassificationBundle\AkeneoClassificationBundle::class => ['all' => true],
+    Akeneo\Platform\Bundle\AnalyticsBundle\PimAnalyticsBundle::class => ['all' => true],
+    Akeneo\Tool\Bundle\ApiBundle\PimApiBundle::class => ['all' => true],
+    Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\PimCatalogVolumeMonitoringBundle::class => ['all' => true],
+    Akeneo\Tool\Bundle\ConnectorBundle\PimConnectorBundle::class => ['all' => true],
+    Akeneo\Platform\Bundle\DashboardBundle\PimDashboardBundle::class => ['all' => true],
+    Oro\Bundle\PimDataGridBundle\PimDataGridBundle::class => ['all' => true],
+    Akeneo\Platform\Bundle\ImportExportBundle\PimImportExportBundle::class => ['all' => true],
+    Akeneo\Platform\Bundle\InstallerBundle\PimInstallerBundle::class => ['all' => true],
+    Akeneo\Platform\Bundle\NotificationBundle\PimNotificationBundle::class => ['all' => true],
+    Akeneo\Platform\Bundle\UIBundle\PimUIBundle::class => ['all' => true],
+    Akeneo\Tool\Bundle\VersioningBundle\AkeneoVersioningBundle::class => ['all' => true],
+
+    // Dev related bundles
+    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true, 'behat' => true],
+    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true, 'behat' => true],
+    Symfony\Bundle\WebServerBundle\WebServerBundle::class => ['dev' => true, 'test' => true, 'behat' => true],
+
+    // Tests related bundles
+    Acme\Bundle\AppBundle\AcmeAppBundle::class => ['dev' => true, 'test' => true, 'behat' => true],
+    Akeneo\Test\IntegrationTestsBundle\AkeneoIntegrationTestsBundle::class => ['dev' => true, 'test' => true],
+    FriendsOfBehat\SymfonyExtension\Bundle\FriendsOfBehatSymfonyExtensionBundle::class => ['test_fake' => true],
+];

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -8,7 +8,6 @@ framework:
         fallback: en_US
     secret: '%env(APP_SECRET)%'
     router:
-        resource: '%kernel.root_dir%/config/routing.yml'
         strict_requirements: '%env(APP_DEBUG)%'
     form: true
     csrf_protection: true

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: config.yml }
 
 framework:
-    router:   { resource: "%kernel.root_dir%/config/routing_dev.yml" }
     profiler: { only_exceptions: false }
 
 web_profiler:

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -9,6 +9,3 @@ _profiler:
 _errors:
     resource: "@TwigBundle/Resources/config/routing/errors.xml"
     prefix:   /_error
-
-_main:
-    resource: routing.yml

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "friendsofsymfony/jsrouting-bundle": "2.1.1",
         "friendsofsymfony/oauth-server-bundle": "1.6.2",
         "friendsofsymfony/rest-bundle": "2.5.0",
-        "gedmo/doctrine-extensions":"v2.4.26",
+        "gedmo/doctrine-extensions":"v2.4.37",
         "league/flysystem": "1.0.40",
         "league/flysystem-ziparchive": "1.0.3",
         "liip/imagine-bundle": "2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57fb88c1abac29a5e2a575eb8a71101a",
+    "content-hash": "3da8d45e6c7792cda32db144b6ff32c7",
     "packages": [
         {
             "name": "ass/xmlsecurity",
@@ -1988,30 +1988,32 @@
         },
         {
             "name": "gedmo/doctrine-extensions",
-            "version": "v2.4.26",
+            "version": "v2.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Atlantic18/DoctrineExtensions.git",
-                "reference": "983dd85d6860f87fb7dffd0d9f7ad1462e20a09d"
+                "reference": "5dd471f656e46d815f063bf3f12c667649ec7ffb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Atlantic18/DoctrineExtensions/zipball/983dd85d6860f87fb7dffd0d9f7ad1462e20a09d",
-                "reference": "983dd85d6860f87fb7dffd0d9f7ad1462e20a09d",
+                "url": "https://api.github.com/repos/Atlantic18/DoctrineExtensions/zipball/5dd471f656e46d815f063bf3f12c667649ec7ffb",
+                "reference": "5dd471f656e46d815f063bf3f12c667649ec7ffb",
                 "shasum": ""
             },
             "require": {
-                "behat/transliterator": "~1.0",
+                "behat/transliterator": "~1.2",
                 "doctrine/common": "~2.4",
                 "php": ">=5.3.2"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.2"
             },
             "require-dev": {
                 "doctrine/common": ">=2.5.0",
                 "doctrine/mongodb-odm": ">=1.0.2",
                 "doctrine/orm": ">=2.5.0",
-                "phpunit/phpunit": "~4.4",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "symfony/yaml": "~2.6"
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.5",
+                "symfony/yaml": "~2.6|~3.0|~4.0"
             },
             "suggest": {
                 "doctrine/mongodb-odm": "to use the extensions with the MongoDB ODM",
@@ -2024,8 +2026,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Gedmo\\": "lib/"
+                "psr-4": {
+                    "Gedmo\\": "lib/Gedmo"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2063,7 +2065,7 @@
                 "tree",
                 "uploadable"
             ],
-            "time": "2016-12-21T13:46:54+00:00"
+            "time": "2019-03-17T18:16:12+00:00"
         },
         {
             "name": "guzzlehttp/ringphp",

--- a/tests/back/Integration/AppKernelTest.php
+++ b/tests/back/Integration/AppKernelTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Akeneo\Test\Common\Path;
-
 /**
  * App kernel for the integration tests.
  *
@@ -12,41 +10,14 @@ use Akeneo\Test\Common\Path;
 class AppKernelTest extends AppKernel
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
+     *
+     * Necessary to make gedmo extension tree work. Otherwise the path located in
+     * "vendor/akeneo/pim-community-dev/src/Akeneo/Platform/config/bundles/gedmo_doctrine_extensions.yml"
+     * is never the right one...
      */
-    protected function registerProjectBundles(): array
+    public function getRootDir(): string
     {
-        return [
-            new Acme\Bundle\AppBundle\AcmeAppBundle(),
-            new Akeneo\Test\IntegrationTestsBundle\AkeneoIntegrationTestsBundle()
-        ];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getCacheDir(): string
-    {
-        return new Path('var', 'cache', 'test_kernel');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getLogDir(): string
-    {
-        return new Path('var', 'logs');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName(): string
-    {
-        if (null === $this->name) {
-            $this->name =  parent::getName() . '_test';
-        }
-
-        return $this->name;
+        return $this->getProjectDir() . DIRECTORY_SEPARATOR . 'app';
     }
 }


### PR DESCRIPTION
For more information, please read http://fabien.potencier.org/symfony4-directory-structure.html and https://symfony.com/doc/current/bundles.html.

This is another step forward SF4 (and maybe Flex).

Next move is to remove those `AppKernelTest` classes :)