### PR TITLE
PIM-8601: Fix purge of the job execution according to the date of creation and not deletion

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-8601: Fix purge of the job execution according to the date of creation and not deletion
+
 # 3.2.2 (2019-08-01)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Command/PurgeJobExecutionCommand.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Command/PurgeJobExecutionCommand.php
@@ -26,7 +26,7 @@ class PurgeJobExecutionCommand extends ContainerAwareCommand
     {
         $this->setName('akeneo:batch:purge-job-execution');
         $this->setDescription(
-            'Purge jobs execution older than number of days you want except the last one, by default 90 days'
+            'Purge jobs execution older than number of days you want except the last one, by default 90 days, minimum is 1 day'
         );
         $this->addOption(
             'days',
@@ -43,9 +43,9 @@ class PurgeJobExecutionCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $days = $input->getOption('days');
-        if (!is_numeric($days)) {
+        if (!(is_numeric($days) && $days > 0)) {
             $output->writeln(
-                sprintf('<error>Option --days must be a number, "%s" given.</error>', $input->getOption('days'))
+                sprintf('<error>Option --days must be a number strictly superior to 0, "%s" given.</error>', $input->getOption('days'))
             );
 
             return;

--- a/tests/back/Tool/Integration/Batch/Persistence/Sql/DeleteJobExecutionIntegration.php
+++ b/tests/back/Tool/Integration/Batch/Persistence/Sql/DeleteJobExecutionIntegration.php
@@ -21,7 +21,7 @@ class DeleteJobExecutionIntegration extends TestCase
         $numberOfJobs = (int) $this->getConnection()->executeQuery('SELECT COUNT(*) as number_of_jobs FROM akeneo_batch_job_execution')->fetch()['number_of_jobs'];
         Assert::assertSame(2, $numberOfJobs);
 
-        $this->getConnection()->executeUpdate('UPDATE akeneo_batch_job_execution SET end_time = Date_ADD(end_time, INTERVAL -10 day)');
+        $this->getConnection()->executeUpdate('UPDATE akeneo_batch_job_execution SET create_time = Date_ADD(end_time, INTERVAL -10 day)');
 
         $deleteJobExecution = $this->getDeleteQuery();
         $deleteJobExecution->olderThanDays(1);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When you purge the job executions, some job execution are not purged because it failed.
The `end_time` is not set and the query does not delete jobs without `end_time`.

We could remove jobs without `end_time`, but it means that a job executed today that failed would be purged also, whatever the parameter of the command (older than X days).

The most simple thing is just to be based on the date of creation.

**Cons:**
As a job could be put in the queue and executed only some hours later, I forced to purge at a minimum of 1 day.
I don't think there is any usecase at allowing 0 day. 

It means also if a job last 24 hours you can have a problem if you execute the command with "older than 1 day".
But I don't think that's a good practice to purge jobs older than 1 days and also and if a job last 24 hours, we have bigger problem.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
