### PR TITLE
PIM-8600: Fix import filepath tooltip

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # 3.1.x
 
+## Bug fixes
+
+- PIM-8600: Fix import filepath tooltip
+
 # 3.1.17 (2019-07-30)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -95,6 +95,7 @@ pim_import_export:
                     file_path:
                         title: File path
                         help: Where to write the generated file on the file system
+                        help_import: The directory of the file to be used for the import
                     delimiter:
                         title: Delimiter
                         help: One character used to set the field delimiter

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.fr_FR.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.fr_FR.yml
@@ -87,6 +87,7 @@ pim_import_export:
           file_path:
             title: Chemin du fichier
             help: Emplacement du fichier généré sur le serveur
+            help_import: Emplacement du fichier utilisé par l'import sur le serveur
           delimiter:
             title: Délimiteur
             help: Caractère unique utilisé pour délimiter les valeurs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
@@ -95,7 +95,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_import_export.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help_import
 
     pim-job-instance-csv-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/allow-file-upload

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
@@ -94,7 +94,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_import_export.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help_import
 
     pim-job-instance-csv-product-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/allow-file-upload

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
@@ -94,7 +94,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_import_export.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help_import
 
     pim-job-instance-csv-product-model-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/allow-file-upload

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
@@ -95,7 +95,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_import_export.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help_import
 
     pim-job-instance-xlsx-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/allow-file-upload

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
@@ -95,7 +95,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_import_export.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help_import
 
     pim-job-instance-xlsx-product-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/allow-file-upload

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
@@ -95,7 +95,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_import_export.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help_import
 
     pim-job-instance-xlsx-product-model-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/allow-file-upload

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
@@ -95,7 +95,7 @@ extensions:
             fieldCode: configuration.filePath
             readOnly: false
             label: pim_import_export.form.job_instance.tab.properties.file_path.title
-            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help
+            tooltip: pim_import_export.form.job_instance.tab.properties.file_path.help_import
 
     pim-job-instance-yml-base-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/allow-file-upload


### PR DESCRIPTION
Add a different translation key for filepath in import profile because it's not the same use case than export profile.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
