### PR TITLE
PIM-8603: Sort attribute columns by code if no order is defined

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-8603: Sort attribute columns by code if no order is defined
+- PIM-8603: Sort attribute columns by label if no order is defined
 
 # 3.1.17 (2019-07-30)
 

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,5 +1,9 @@
 # 3.1.x
 
+## Bug fixes
+
+- PIM-8603: Sort attribute columns by code if no order is defined
+
 # 3.1.17 (2019-07-30)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumns.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumns.php
@@ -129,7 +129,7 @@ FROM pim_catalog_attribute AS att
 INNER JOIN pim_catalog_attribute_group AS g ON att.group_id = g.id
 LEFT JOIN pim_catalog_attribute_translation AS att_trans ON att.id = att_trans.foreign_key AND att_trans.locale = :locale
 WHERE att.useable_as_grid_filter = 1 AND att.code NOT IN (:attributesToExclude) $sqlSearch
-ORDER BY g.sort_order ASC, att.sort_order ASC, att.code ASC
+ORDER BY g.sort_order ASC, att.sort_order ASC, label ASC
 LIMIT $limit OFFSET $offset
 SQL;
 

--- a/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumns.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumns.php
@@ -129,7 +129,7 @@ FROM pim_catalog_attribute AS att
 INNER JOIN pim_catalog_attribute_group AS g ON att.group_id = g.id
 LEFT JOIN pim_catalog_attribute_translation AS att_trans ON att.id = att_trans.foreign_key AND att_trans.locale = :locale
 WHERE att.useable_as_grid_filter = 1 AND att.code NOT IN (:attributesToExclude) $sqlSearch
-ORDER BY g.sort_order ASC, att.sort_order ASC
+ORDER BY g.sort_order ASC, att.sort_order ASC, att.code ASC
 LIMIT $limit OFFSET $offset
 SQL;
 


### PR DESCRIPTION
Add a sort on attribute code to have a constant order even when all attributes order and attribute groups order are set to 0.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
