### PR TITLE
TIP-1193 Run behat on the right env using makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-        # The version of docker compose used by circle ci does not support -`e` option (`docker-composer exec -e ENV_VAR=value`) to set environment variables to containers
+        # The version of docker compose used by circle ci does not support `-e` option (`docker-composer exec -e ENV_VAR=value`) to set environment variables to containers.
         # To load .env.behat (app/bootstrap.php) we need to set APP_ENV=behat but it is not possible because of the version of docker-composer.
         # To avoid to upgrade it, we use this little trick
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
       - attach_workspace:
           at: ~/
         # The version of docker compose used by circle ci does not support `-e` option (`docker-composer exec -e ENV_VAR=value`) to set environment variables to containers.
-        # To load .env.behat (app/bootstrap.php) we need to set APP_ENV=behat but it is not possible because of the version of docker-composer.
+        # To load .env.behat (from app/bootstrap.php) we need to set APP_ENV=behat but it is not possible because of the version of docker-compose.
         # To avoid to upgrade it, we use this little trick
       - run:
             name: Copy env file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+        # The version of docker compose used by circle ci does not support -`e` option (`docker-composer exec -e ENV_VAR=value`) to set environment variables to containers
+        # To load .env.behat (app/bootstrap.php) we need to set APP_ENV=behat but it is not possible because of the version of docker-composer.
+        # To avoid to upgrade it, we use this little trick
       - run:
             name: Copy env file
             command: cp .env.behat .env

--- a/Makefile
+++ b/Makefile
@@ -162,5 +162,5 @@ phpunit: vendor
 
 .PHONY: behat-legacy
 behat-legacy: behat.yml vendor node_modules
-	${PHP_EXEC} vendor/bin/behat -p legacy ${F}
+	$(DOCKER_COMPOSE) exec -u docker -e APP_ENV=behat fpm php vendor/bin/behat -p legacy ${F}
 


### PR DESCRIPTION
This PR adds a comment to explain a little trick on the CI and it fixes makefile to run behat on the right env.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
