### PR TITLE
TIP-1193 Add default values to docker-composer.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,9 +62,9 @@ services:
     image: 'mysql:5.7'
     environment:
       MYSQL_ROOT_PASSWORD: 'root'
-      MYSQL_USER: '${APP_DATABASE_USER}'
-      MYSQL_DATABASE: '${APP_DATABASE_NAME}'
-      MYSQL_PASSWORD: '${APP_DATABASE_PASSWORD}'
+      MYSQL_USER: '${APP_DATABASE_USER:-akeneo_pim}'
+      MYSQL_DATABASE: '${APP_DATABASE_NAME:-akeneo_pim}'
+      MYSQL_PASSWORD: '${APP_DATABASE_PASSWORD:-akeneo_pim}'
     networks:
       - 'akeneo'
 
@@ -72,9 +72,9 @@ services:
     image: 'mysql:5.7'
     environment:
       MYSQL_ROOT_PASSWORD: 'root'
-      MYSQL_USER: '${APP_DATABASE_USER}'
-      MYSQL_DATABASE: '${APP_DATABASE_NAME}'
-      MYSQL_PASSWORD: '${APP_DATABASE_PASSWORD}'
+      MYSQL_USER: '${APP_DATABASE_USER:-akeneo_pim}'
+      MYSQL_DATABASE: '${APP_DATABASE_NAME:-akeneo_pim}'
+      MYSQL_PASSWORD: '${APP_DATABASE_PASSWORD:-akeneo_pim}'
     networks:
       - 'behat'
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

To avoid this kind of problem when you up your containers without a `.env` file, default env vars values have been added .

```
jjanvier:pcd$ docker-compose up -d                                                                       
WARNING: The APP_DATABASE_PASSWORD variable is not set. Defaulting to a blank string.
WARNING: The APP_DATABASE_USER variable is not set. Defaulting to a blank string.
WARNING: The APP_DATABASE_NAME variable is not set. Defaulting to a blank string.
Recreating pcd_mysql-behat_1 ... 
Recreating pcd_mysql_1 ... 
Starting pcd_node_1 ... 
pcd_fpm_1 is up-to-date
pcd_selenium_1 is up-to-date
pcd_object-storage_1 is up-to-date
pcd_elasticsearch_1 is up-to-date
Recreating pcd_httpd-behat_1 ... 
Recreating pcd_mysql_1 ... done
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
