### PR TITLE
PIM-8595: Fix missing translation (pim_common.code) in attributes lis…

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-8595: Fix missing translation (pim_common.code) in attributes list / family list
+
 # 3.2.1 (2019-07-31)
 
 # 3.2.0 (2019-07-24)

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/attribute.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/attribute.yml
@@ -67,7 +67,7 @@ datagrid:
             columns:
                 code:
                     type:      string
-                    label:     pim_common.code
+                    label:     Code
                     data_name: a.code
                 label:
                     type: search

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/family.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/family.yml
@@ -51,7 +51,7 @@ datagrid:
             columns:
                 code:
                     type: string
-                    label: pim_common.code
+                    label: Code
                     data_name: f.code
                 label:
                     type: search


### PR DESCRIPTION
Fix missing translation (pim_common.code) in attributes list / family list.
Fixed in 3.1 but it was not included in the pullups.