### PR TITLE
PIM-8611: Fix filters applied when a product model is excluded from a product-grid selection

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -6,6 +6,7 @@
 - PIM-8589: Fix add attribute to attribute group when no permission on group "Other"
 - PIM-8445: Fix variant axes settings CSS style
 - PIM-8614: Fix empty variant axes validation
+- PIM-8611: Fix filters applied when a product model is excluded from a product-grid selection
 
 # 3.0.34 (2019-07-24)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductMassActionRepository.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductMassActionRepository.php
@@ -42,6 +42,13 @@ class ProductMassActionRepository implements ProductMassActionRepositoryInterfac
         if (!empty($values)) {
             $condition = $inset ? Operators::IN_LIST : Operators::NOT_IN_LIST;
             $queryBuilder->addFilter('id', $condition, $values);
+
+            $productModelIds = array_values(array_filter($values, function ($id) {
+                return 0 === strpos($id, 'product_model_');
+            }));
+            if (false === $inset && !empty($productModelIds)) {
+                $queryBuilder->addFilter('ancestor.id', Operators::NOT_IN_LIST, $productModelIds);
+            }
         }
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/AncestorFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/AncestorFilter.php
@@ -86,13 +86,7 @@ class AncestorFilter extends AbstractFieldFilter
                         self::ANCESTOR_ID_ES_FIELD => $values,
                     ],
                 ];
-                $filterClause = [
-                    'exists' => [
-                        'field' => self::ANCESTOR_ID_ES_FIELD,
-                    ],
-                ];
                 $this->searchQueryBuilder->addMustNot($mustNotClause);
-                $this->searchQueryBuilder->addFilter($filterClause);
                 break;
         }
     }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/ORM/Repository/ProductMassActionRepositorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/ORM/Repository/ProductMassActionRepositorySpec.php
@@ -3,8 +3,11 @@
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Repository;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilder;
 use Doctrine\ORM\EntityManager;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 class ProductMassActionRepositorySpec extends ObjectBehavior
 {
@@ -17,5 +20,21 @@ class ProductMassActionRepositorySpec extends ObjectBehavior
     function it_throws_an_exception_when_trying_to_delete_without_product_ids()
     {
         $this->shouldThrow(new \LogicException('No products to remove'))->duringDeleteFromIds(array());
+    }
+
+    function it_applies_mass_action_parameters_with_product_models_to_exclude(ProductQueryBuilder $queryBuilder)
+    {
+        $queryBuilder->addFilter('id', Operators::NOT_IN_LIST, ['product_1', 'product_model_3'])->shouldBeCalled();
+        $queryBuilder->addFilter('ancestor.id', Operators::NOT_IN_LIST, ['product_model_3'])->shouldBeCalled();
+
+        $this->applyMassActionParameters($queryBuilder, false, ['product_1', 'product_model_3']);
+    }
+
+    function it_applies_mass_action_parameters_without_product_models_to_exclude(ProductQueryBuilder $queryBuilder)
+    {
+        $queryBuilder->addFilter('id', Operators::NOT_IN_LIST, ['product_1', 'product_3'])->shouldBeCalled();
+        $queryBuilder->addFilter('ancestor.id', Argument::cetera())->shouldNotBeCalled();
+
+        $this->applyMassActionParameters($queryBuilder, false, ['product_1', 'product_3']);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/AncestorFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/AncestorFilterSpec.php
@@ -88,14 +88,6 @@ class AncestorFilterSpec extends ObjectBehavior
             ]
         )->shouldBeCalled();
 
-        $sqb->addFilter(
-            [
-                'exists' => [
-                    'field' => 'ancestors.ids',
-                ],
-            ]
-        )->shouldBeCalled();
-
         $this->setQueryBuilder($sqb);
         $this->addFieldFilter(
             'ancestor.id',


### PR DESCRIPTION
There's a bug when a user selects all the products in a filtered product-grid to export them, but un-select manually one (or several) product-model (by clicking on the checkbox). 
The export will well exclude the product-model, but will add its variants.

It's because in this case, the ES query is built with the filters of the product-grid chosen by the user, and will add a filter to exclude the id of the products that have been unselected. In the case of a product-model, it results that the variants of the excluded product-model match the ES query, when they should be excluded.

To fix that I added a filter on the field "ancestor.id" to exclude the variants of the excluded product-models.
To do that I had to change the `AncestorFilter` application, to remove a clause on the existence of the field "ancestor" to not exclude the "simple" products when the operator `NOT IN` is used for this filter. I don't know why this clause was here, especially as it's not applied with the operator `IN`