### PR TITLE
PIM-8614: Fix empty variant axes validation

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,7 @@
 - PIM-8591: Fix product history author display
 - PIM-8589: Fix add attribute to attribute group when no permission on group "Other"
 - PIM-8445: Fix variant axes settings CSS style
+- PIM-8614: Fix empty variant axes validation
 
 # 3.0.34 (2019-07-24)
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/NotEmptyVariantAxesValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/NotEmptyVariantAxesValidator.php
@@ -63,7 +63,7 @@ class NotEmptyVariantAxesValidator extends ConstraintValidator
             $isEmptyMetricValue = (null !== $value && $value->getData() instanceof MetricInterface &&
                 null === $value->getData()->getData());
 
-            if ((null === $value || (empty($value->getData()) && !is_bool($value->getData()))) || $isEmptyMetricValue) {
+            if (null === $value || null === $value->getData() || '' === $value->getData() || $isEmptyMetricValue) {
                 $this->context->buildViolation(NotEmptyVariantAxes::EMPTY_AXIS_VALUE, [
                     '%attribute%' => $axis->getCode()
                 ])->atPath($constraint->propertyPath)->addViolation();

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/NotEmptyVariantAxesValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/NotEmptyVariantAxesValidatorSpec.php
@@ -93,6 +93,26 @@ class NotEmptyVariantAxesValidatorSpec extends ObjectBehavior
         $this->validate($entity, $constraint);
     }
 
+    function it_raises_no_violation_if_the_entity_has_zero_as_value_for_its_axis(
+        $axesProvider,
+        $context,
+        EntityWithFamilyVariantInterface $entity,
+        FamilyVariantInterface $familyVariant,
+        NotEmptyVariantAxes $constraint,
+        AttributeInterface $size,
+        ValueInterface $zero
+    ) {
+        $entity->getFamilyVariant()->willReturn($familyVariant);
+        $axesProvider->getAxes($entity)->willReturn([$size]);
+        $size->getCode()->willReturn('size');
+        $entity->getValue('size')->willReturn($zero);
+        $zero->getData()->willReturn('0');
+
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate($entity, $constraint);
+    }
+
     function it_raises_a_violation_if_the_entity_has_no_value_for_an_axis(
         $axesProvider,
         $context,


### PR DESCRIPTION
The PHP function `empty()` returns `true` for the value `'0'`, but it's a valid value for an option code, and so for an axis value.