### PR TITLE
PIM-8461: Do not display 'Compare/translate' if user has no permission to edit product attributes

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8461: Do not display 'Compare/translate' if user has no permission to edit product attributes
+
 # 2.3.57 (2019-07-31)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product/edit.yml
@@ -121,6 +121,7 @@ extensions:
         module: pim/product-edit-form/start-copy
         parent: pim-product-edit-form-secondary-actions
         targetZone: secondary-actions
+        aclResourceId: pim_enrich_product_edit_attributes
         position: 80
 
     pim-product-edit-form-save-buttons:

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -87,6 +87,7 @@ extensions:
         module: pim/product-edit-form/start-copy
         parent: pim-product-model-edit-form-secondary-actions
         targetZone: secondary-actions
+        aclResourceId: pim_enrich_product_model_edit_attributes
         position: 80
 
     pim-product-model-edit-form-delete:


### PR DESCRIPTION


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -