### PR TITLE
PIM-7583: Allow user to import custom locales without '_'

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7583: Allow user to import custom locales without '_'
+
 # 2.3.57 (2019-07-31)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/i18n.ts
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/i18n.ts
@@ -11,12 +11,17 @@ export const getFlag = (locale: string, displayLanguage: boolean = true): string
     return '';
   }
 
-  const info = locale.split('_');
-  let language = info[0];
-  let country = info[1];
+  var country = '';
+  var language = locale;
 
-  if (3 === info.length) {
+  if (locale.includes('_')) {
+    const info = locale.split('_');
+    language = info[0];
+    country = info[1];
+
+    if (3 === info.length) {
       country = info[2];
+    }
   }
 
   return flagTemplate(country.toLowerCase(), language, displayLanguage);


### PR DESCRIPTION
The split wasn't working and break the grid.

Now:
![Selection_110](https://user-images.githubusercontent.com/1590933/62462842-bdd81100-b788-11e9-99cd-876465ba47ea.png)



| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
