### PR TITLE
PIM-8387: Fix product export builder on simple/multi select attribute filters

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -6,6 +6,7 @@
 - PIM-8589: Fix add attribute to attribute group when no permission on group "Other"
 - PIM-8445: Fix variant axes settings CSS style
 - PIM-8614: Fix empty variant axes validation
+- PIM-8387: Fix product export builder on simple/multi select attribute filters
 
 # 3.0.34 (2019-07-24)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/filter/attribute/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/filter/attribute/select.js
@@ -135,6 +135,8 @@ define([
                 operator: operator,
                 value: cleanedValues
             });
+
+            this.render();
         },
 
         /**


### PR DESCRIPTION
The filter was not rendered after the status change, so the right input was not hidden/showed after change.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
