### PR TITLE
DAPI-26: Add the enrichment progress in the widget's project drop down

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ProjectWidget.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ProjectWidget.less
@@ -210,4 +210,9 @@
     left: 10px;
     right: auto !important;
   }
+
+  .select2-result-label, .select2-no-results {
+    display: flex;
+    padding-top: 0;
+  }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ProjectWidget.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ProjectWidget.less
@@ -200,14 +200,14 @@
     z-index: auto;
     height: 50px;
   }
+}
 
-  .teamwork-assistant-widget-project-dropdown,
-  .select2-drop--forProjectWidget {
-    max-width: 600px !important;
+.teamwork-assistant-widget-project-dropdown,
+.select2-drop--forProjectWidget {
+  max-width: 600px !important;
 
-    &:before {
-      left: 10px;
-      right: auto !important;
-    }
+  &:before {
+    left: 10px;
+    right: auto !important;
   }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ProjectWidget.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ProjectWidget.less
@@ -119,24 +119,63 @@
 
   &-mainSelectorLine,
   &-secondarySelectorLine {
-    display: flex;
-    justify-content: space-between;
     color: @AknGrey;
     overflow: hidden;
     width: 100%;
   }
 
+  &-secondarySelectorLine {
+    display: flex;
+    justify-content: space-between;
+  }
+
   &-mainSelectorLineTitle,
   &-secondarySelectorLineTitle {
     color: @AknDefaultFontColor;
+  }
+
+  &-secondarySelectorLineTitle {
     min-width: 33%;
     display: flex;
     flex-direction: column;
     justify-content: center;
   }
 
+  &-mainSelectorLine,
+  &-mainSelectorCurrent {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  &-mainSelectorLineTitle,
+  &-mainSelectorCurrentTitle {
+    flex: 3;
+    min-width: initial;
+  }
+
   &-mainSelectorLineTitle {
     margin-right: 10px;
+  }
+
+  &-mainSelectorLineProperties,
+  &-mainSelectorCurrentProperties {
+    flex: 6;
+    text-align: left;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  &-mainSelectorLineCompleteness,
+  &-mainSelectorCurrentCompleteness {
+    flex: 1;
+    margin-left: 10px;
+    text-align: right;
   }
 
   &-info {
@@ -160,5 +199,15 @@
     top: auto;
     z-index: auto;
     height: 50px;
+  }
+
+  .teamwork-assistant-widget-project-dropdown,
+  .select2-drop--forProjectWidget {
+    max-width: 600px !important;
+
+    &:before {
+      left: 10px;
+      right: auto !important;
+    }
   }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

DAPI-26: https://akeneo.atlassian.net/browse/DAPI-26

This pull request updates the css rules for redering the enrichment progress in the widget's project dropdown. This part is used by the Entreprise Edition only.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
