### PR TITLE
PIM-8623: Fix wysiwyg edit link modal on Firefox

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8623: Fix wysiwyg edit link modal on Firefox
+
 # 3.0.35 (2019-08-05)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -108,7 +108,9 @@ define(
             setStyleForLinkModal: function (jqueryEvent) {
                 this.moveModalBackdrop();
 
-                const source = $(jqueryEvent.originalEvent.path[0]);
+                const source = jqueryEvent.originalEvent.path ?
+                    $(jqueryEvent.originalEvent.path[0]) :
+                    $(jqueryEvent.originalEvent.originalTarget);
 
                 if (
                     source.hasClass('icon-link')


### PR DESCRIPTION
The originalEvent does not exist on Firefox but in Chrome.
This tricky allows to get the original Path in Firefox.