### PR TITLE
PIM-8624: Fix default product grid view selector in user profile when there is more than 20 views

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8623: Fix wysiwyg edit link modal on Firefox
+- PIM-8624: Fix default product grid view selector in user profile when there is more than 20 views
 
 # 3.0.35 (2019-08-05)
 

--- a/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/default-grid-views.ts
+++ b/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/default-grid-views.ts
@@ -42,9 +42,9 @@ class DefaultGridView extends BaseView {
           datagridAlias: datagridAlias,
           fieldName: 'default_' + datagridAlias.replace(/-/g, '_') + '_view',
           label: 'pim_user_management.entity.user.properties.default_' + datagridAlias.replace(/-/g, '_') + '_view',
-          allowClear: true,
-          isMultiple: false,
           readOnly: this.config.readOnly,
+          choiceUrl: 'pim_datagrid_view_rest_index',
+          placeholder: 'pim_datagrid.view_selector.default_view',
         }
       });
       datagridViewSelector.configure().then(() => {

--- a/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepository.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepository.php
@@ -51,6 +51,11 @@ class DatagridViewRepository extends EntityRepository implements DatagridViewRep
         $options += ['limit' => 20, 'page' => 1];
         $offset = (int) $options['limit'] * ((int) $options['page'] - 1);
 
+        $identifiers = null;
+        if (isset($options['identifiers'])) {
+            $identifiers = $options['identifiers'];
+        }
+
         $qb = $this->createQueryBuilder('v')
             ->where('v.type = :type')
                 ->setParameter('type', DatagridView::TYPE_PUBLIC)
@@ -60,6 +65,11 @@ class DatagridViewRepository extends EntityRepository implements DatagridViewRep
                 ->setParameter('term', sprintf('%%%s%%', $term))
             ->setMaxResults((int) $options['limit'])
             ->setFirstResult($offset);
+
+        if (null !== $identifiers) {
+            $qb->andWhere('v.id IN (:ids)');
+            $qb->setParameter('ids', $identifiers);
+        }
 
         return $qb->getQuery()->execute();
     }

--- a/tests/back/Oro/Integration/DatagridView/DatagridViewRepositoryIntegration.php
+++ b/tests/back/Oro/Integration/DatagridView/DatagridViewRepositoryIntegration.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Oro\Integration\DatagridView;
+
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\UserManagement\Component\Repository\UserRepositoryInterface;
+use Oro\Bundle\PimDataGridBundle\Entity\DatagridView;
+use Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * @author Pierre Allard <pierre.allard@akeneo.com>
+ */
+class DatagridViewRepositoryIntegration extends TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_that_it_returns_all_views(): void
+    {
+        $view1Id = $this->createDatagridView('view 1', 'product-grid')->getId();
+        $view2Id = $this->createDatagridView('view 2', 'product-grid')->getId();
+        $view3Id = $this->createDatagridView('view 3', 'product-grid')->getId();
+        $user = $this->getUserRepository()->findOneBy(['username' => 'admin']);
+        $result = $this->getDatagridViewRepository()->findDatagridViewBySearch($user, 'product-grid');
+        $expected = [$view1Id, $view2Id, $view3Id];
+        Assert::same(array_map(function ($view) {
+            return $view->getId();
+        }, $result), $expected);
+    }
+
+    public function test_that_it_filters_by_ids(): void
+    {
+        $view1Id = $this->createDatagridView('view 1', 'product-grid')->getId();
+        $view2Id = $this->createDatagridView('view 2', 'product-grid')->getId();
+        $this->createDatagridView('view 3', 'product-grid');
+        $user = $this->getUserRepository()->findOneBy(['username' => 'admin']);
+        $result = $this->getDatagridViewRepository()->findDatagridViewBySearch($user, 'product-grid', '', [
+            'identifiers' => [$view1Id, $view2Id]
+        ]);
+        $expected = [$view1Id, $view2Id];
+        Assert::same(array_map(function ($view) {
+            return $view->getId();
+        }, $result), $expected);
+    }
+
+    private function getDatagridViewRepository(): DatagridViewRepositoryInterface
+    {
+        return $this->get('pim_datagrid.repository.datagrid_view');
+    }
+
+    private function getUserRepository(): UserRepositoryInterface
+    {
+        return $this->get('pim_user.repository.user');
+    }
+
+    private function createDatagridView(string $label, string $alias): DatagridView
+    {
+        $view = new DatagridView();
+        $view->setLabel($label);
+        $view->setDatagridAlias($alias);
+        $view->setColumns(['created_at']);
+
+        static::assertCount(0, $this->get('validator')->validate($view));
+        $this->get('pim_datagrid.saver.datagrid_view')->save($view);
+
+        return $view;
+    }
+}

--- a/tests/legacy/features/Context/Page/Base/Form.php
+++ b/tests/legacy/features/Context/Page/Base/Form.php
@@ -714,8 +714,9 @@ class Form extends Base
 
         if ($label->hasAttribute('for')) {
             $for = $label->getAttribute('for');
+            $forElement = $this->getClosest($label, 'AknFieldContainer')->find('css', '#s2id_' . $for);
 
-            if (0 === strpos($for, 's2id_')) {
+            if (0 === strpos($for, 's2id_') || null !== $forElement) {
                 if ($this->getClosest($label, 'AknFieldContainer')->find('css', '.select2-container-multi')) {
                     return 'multiSelect2';
                 } elseif ($this->getClosest($label, 'AknFieldContainer')->find('css', '.select2-container')) {


### PR DESCRIPTION
The previous field was loading "all" the grid views before displaying it.
2 issues:
- it's not scalable (imagine 10000 views)
- the query automatically strip to the 20 firsts ones.

So I transformed it into an "ajax-way", to load them only when user click, and 20 by 20.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

