### PR TITLE
PIM-8628: Display label translations on configuration screens even you don't have 'Allowed to view information' permission on a locale

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8623: Fix wysiwyg edit link modal on Firefox
+- PIM-8628: Display label translations on configuration screens even you don't have "Allowed to view information" permission on a locale
 
 # 3.0.35 (2019-08-05)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/properties/translation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/properties/translation.js
@@ -62,7 +62,7 @@ define([
                 );
 
                 return $.when(
-                    this.getLocales(true)
+                    this.getLocales()
                         .then(function (locales) {
                             this.locales = locales;
                         }.bind(this)),
@@ -134,7 +134,7 @@ define([
              * Updates locales if were updated
              */
             onLocalesUpdated: function () {
-                this.getLocales(false)
+                this.getLocales()
                     .then(function (locales) {
                             this.locales = locales;
 
@@ -145,13 +145,10 @@ define([
             /**
              * Fetches and returns activated locales.
              *
-             * @param {Boolean} cached
-             *
              * @returns {Promise}
              */
-            getLocales: function (cached) {
-                return FetcherRegistry.getFetcher('locale')
-                    .search({activated: true, cached: cached});
+            getLocales: function () {
+                return FetcherRegistry.getFetcher('locale').fetchActivated({filter_locales: false});
             }
         });
     }


### PR DESCRIPTION
By default, the translation module was not loading the locales without the permission "pim.internal_api.locale.view".
The correct behavior is to even display the locales in the configuration screens.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
