### PR TITLE
PIM-8630: Fix revert action when it exists an association type with integer as code

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-8461: Do not display 'Compare/translate' if user has no permission to edit product attributes
 - PIM-7583: Allow user to import custom locales without '_'
+- PIM-8630: Fix revert action when it exists an association type with integer as code
 
 # 2.3.57 (2019-07-31)
 

--- a/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ConvertedField.php
+++ b/src/Pim/Component/Connector/ArrayConverter/FlatToStandard/ConvertedField.php
@@ -35,7 +35,7 @@ class ConvertedField
     public function appendTo($convertedField): array
     {
         if (array_key_exists($this->columnName, $convertedField)) {
-            $convertedField[$this->columnName] = array_merge_recursive($convertedField[$this->columnName], $this->value);
+            $convertedField[$this->columnName] = array_replace_recursive($convertedField[$this->columnName], $this->value);
         } else {
             $convertedField[$this->columnName] = $this->value;
         }

--- a/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ConvertedFieldSpec.php
+++ b/src/Pim/Component/Connector/spec/ArrayConverter/FlatToStandard/ConvertedFieldSpec.php
@@ -4,7 +4,6 @@ namespace spec\Pim\Component\Connector\ArrayConverter\FlatToStandard;
 
 use Pim\Component\Connector\ArrayConverter\FlatToStandard\ConvertedField;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class ConvertedFieldSpec extends ObjectBehavior
 {
@@ -25,6 +24,33 @@ class ConvertedFieldSpec extends ObjectBehavior
             'associations' => [
                 'UP_SELL' => ['groups' => ['value2', 'test2']],
                 'X_SELL' => ['groups' => ['value', 'test']],
+            ]
+        ]);
+    }
+
+    function it_appends_association_with_number_to_converted_item()
+    {
+        $this->beConstructedWith('associations', [1234 => ['groups' => ['value', 'test']]]);
+
+        $this->appendTo([
+            'associations' => ['UP_SELL' => ['groups' => ['value2', 'test2']]]
+        ])->shouldReturn([
+            'associations' => [
+                'UP_SELL' => ['groups' => ['value2', 'test2']],
+                1234 => ['groups' => ['value', 'test']],
+            ]
+        ]);
+    }
+
+    function it_appends_associations_with_numbers_to_converted_item()
+    {
+        $this->beConstructedWith('associations', [1234 => ['groups' => ['value', 'test']]]);
+
+        $this->appendTo([
+            'associations' => [1234 => ['products' => ['value2', 'test2']]]
+        ])->shouldReturn([
+            'associations' => [
+                1234 => ['products' => ['value2', 'test2'], 'groups' => ['value', 'test']],
             ]
         ]);
     }


### PR DESCRIPTION
The issue happened on the `array_merge_recursive` of `['X_SELL' => [...]]` and `[1234 => [ ... ]]`.
This returned `['X_SELL' => [...], 0 => [...]]`.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | y
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

