### PR TITLE
Fix unstable in the CI due to the grid loaded two times, which lead to non-deterministic behavior when clicking on rows

### DIFF
--- a/tests/legacy/features/pim/enrichment/product-model/navigate_product_and_product_model_edit_page.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/navigate_product_and_product_model_edit_page.feature
@@ -8,7 +8,7 @@ Feature: Navigate to product model and product edit pages
   Scenario: Successfully navigate to a product model and a product edit page
     Given a "catalog_modeling" catalog configuration
     And I am logged in as "Julia"
-    And I am on the products page
+    And I am on the products grid
     And I type "color" in the manage filter input
     And I show the filter "color"
     And I filter by "color" with operator "in list" and value "Crimson red"

--- a/tests/legacy/features/pim/enrichment/product-model/navigate_product_and_product_model_edit_page.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/navigate_product_and_product_model_edit_page.feature
@@ -14,6 +14,6 @@ Feature: Navigate to product model and product edit pages
     And I filter by "color" with operator "in list" and value "Crimson red"
     When I click on the "tshirt-unique-size-crimson-red" row
     Then I should see the title "Product tshirt-unique-size-crimson-red | Edit"
-    When I am on the products page
+    When I am on the products grid
     And I click on the "model-tshirt-divided-crimson-red" row
     Then I should see the title "Product model Divided crimson red | Edit"

--- a/tests/legacy/features/pim/enrichment/product/datagrid/datagrid_views.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/datagrid_views.feature
@@ -252,11 +252,11 @@ Feature: Datagrid views
 
   @ce
   Scenario: Don't display view type switcher if there is only one view type
-    Given I am on the products page
+    Given I am on the products grid
     Then I should not see the text "Views"
 
   Scenario: Successfully display filter values when refreshing a saved view
-    Given I am on the products page
+    Given I am on the products grid
     And I filter by "family" with operator "is empty" and value ""
     And I create the view:
       | new-view-label | Empty family |

--- a/tests/legacy/features/pim/enrichment/product/datagrid/datagrid_views.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/datagrid_views.feature
@@ -252,7 +252,7 @@ Feature: Datagrid views
 
   @ce
   Scenario: Don't display view type switcher if there is only one view type
-    Given I am on the products grid
+    Given I am on the products page
     Then I should not see the text "Views"
 
   Scenario: Successfully display filter values when refreshing a saved view

--- a/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_label_or_identifier.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_products_per_label_or_identifier.feature
@@ -27,7 +27,7 @@ Feature: Filter products by label or identifier field
       | 6589              | office | paper                | post          |            |
       | mug               | home   | Mug                  | 2412          |            |
       | 50_shades_of_grey | book   | 50 shades of grey    | 1212          | 2424       |
-    And I am on the products page
+    And I am on the products grid
     Then the grid should contain 4 elements
     And I should see products 125824, 6589, mug and 50_shades_of_grey
     And I should be able to use the following filters:

--- a/tests/legacy/features/pim/enrichment/product/datagrid/multiple_page_selection.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/multiple_page_selection.feature
@@ -11,7 +11,7 @@ Feature: Select items on several pages
   @jira https://akeneo.atlassian.net/browse/PIM-7214
   Scenario: Select multiple products on multiple pages
     Given 30 empty products
-    When I am on the products page
+    When I am on the products grid
     And I sort by "ID" value ascending
     And I select row product_1
     And I select all visible entities

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_grid_context.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_grid_context.feature
@@ -40,7 +40,7 @@ Feature: Quick export products according to the product grid context
   Scenario: Successfully quick export only current working locale from grid context as a CSV file
     Given I add the "french" locale to the "tablet" channel
     And I add the "french" locale to the "mobile" channel
-    And I am on the products page
+    And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
       | SKU    | blue-suede-shoes |
@@ -54,7 +54,7 @@ Feature: Quick export products according to the product grid context
       | [description] | Chaussures en suedine bleues |
     And I press the "Save" button
     And I should not see the text "There are unsaved changes."
-    And I am on the products page
+    And I am on the products grid
     And I switch the locale to "fr_FR"
     And I display the columns [sku], [description]
     And I select row blue-suede-shoes

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
@@ -7,7 +7,7 @@ Feature: Export products and product models
   Background:
     Given a "catalog_modeling" catalog configuration
     And I am logged in as "Julia"
-    And I am on the products page
+    And I am on the products grid
 
   Scenario: Successfully export products to multiple channels
     When I type "color" in the manage filter input

--- a/tests/legacy/features/pim/enrichment/product/mass-action/sequential-edit/sequential_edit_product_and_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/sequential-edit/sequential_edit_product_and_product_model.feature
@@ -7,7 +7,7 @@ Feature: Edit sequentially some products
   Background:
     Given a "catalog_modeling" catalog configuration
     And I am logged in as "Julia"
-    And I am on the products page
+    And I am on the products grid
 
   @ce
   Scenario: Successfully sequentially edit some products but not the product models 1/2

--- a/tests/legacy/features/pim/enrichment/product/mass-edit/edit-common-attribute/mass_edit_products_and_product_models.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-edit/edit-common-attribute/mass_edit_products_and_product_models.feature
@@ -24,7 +24,7 @@ Feature: Apply a mass action on products only (and not product models)
       | cult-of-luna-black-m | clothing    | long_sleeves,summer,supplier_zaro | black | m    |
       | another-watch        | accessories | supplier_zaro                     | black |      |
     And I am logged in as "Julia"
-    And I am on the products page
+    And I am on the products grid
 
   Scenario: Apply a mass action on products and product models
     Given I type "col" in the manage filter input

--- a/tests/legacy/features/pim/enrichment/product/mass-edit/mass_add_to_existing_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-edit/mass_add_to_existing_product_model.feature
@@ -51,7 +51,7 @@ Feature: Apply a add to products to existing product model
     And I fill in the following information:
       | Size | S |
     And I save the product
-    And I am on the products page
+    And I am on the products grid
     And I select rows 1111111171
     And I press the "Bulk actions" button
     And I choose the "Add to an existing product model" operation

--- a/tests/legacy/features/pim/enrichment/product/mass-edit/mass_add_to_existing_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-edit/mass_add_to_existing_product_model.feature
@@ -9,7 +9,7 @@ Feature: Apply a add to products to existing product model
     And I am logged in as "Julia"
 
   Scenario: It automatically selects family variant when there is only one
-    Given I am on the products page
+    Given I am on the products grid
     And I select rows 1111111171
     And I press the "Bulk actions" button
     And I choose the "Add to an existing product model" operation
@@ -18,7 +18,7 @@ Feature: Apply a add to products to existing product model
     Then I should see the text "Accessories by size"
 
   Scenario: Successfully display leaf product models
-    Given I am on the products page
+    Given I am on the products grid
     And I select rows 1111111171
     And I press the "Bulk actions" button
     And I choose the "Add to an existing product model" operation
@@ -31,7 +31,7 @@ Feature: Apply a add to products to existing product model
     And the fields Family should be disabled
 
   Scenario: Successfully show validation error on family issues
-    Given I am on the products page
+    Given I am on the products grid
     And I select rows 1111111171
     And I press the "Bulk actions" button
     And I choose the "Add to an existing product model" operation
@@ -65,7 +65,7 @@ Feature: Apply a add to products to existing product model
     And the parent of the product "1111111171" should be "model-braided-hat"
 
   Scenario: Fail to adds products to product model with null metric axis
-    Given I am on the products page
+    Given I am on the products grid
     And the following attributes:
       | code                  | label-en_US           | type                     | unique | group     | decimals_allowed | negative_allowed | metric_family | default_metric_unit | useable_as_grid_filter |
       | display_diagonal      | Display diagonal      | pim_catalog_metric       | 0      | other     | 0                | 0                | Length        | INCH                | 1                      |

--- a/tests/legacy/features/pim/enrichment/product/mass-edit/mass_edit_products_and_product_models.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-edit/mass_edit_products_and_product_models.feature
@@ -24,7 +24,7 @@ Feature: Apply a mass action on products only (and not product models)
       | cult-of-luna-black-m | clothing    | long_sleeves,summer,supplier_zaro | black | m    |
       | another-watch        | accessories | supplier_zaro                     | black |      |
     And I am logged in as "Julia"
-    And I am on the products page
+    And I am on the products grid
 
   Scenario: Mass edits family of only products within a selection of products and product models
     Given I type "col" in the manage filter input

--- a/tests/legacy/features/pim/enrichment/product/pef/edit_and_display_all_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/pef/edit_and_display_all_attributes.feature
@@ -7,7 +7,7 @@ Feature: Edit and see all attributes
   Background:
     Given the "footwear" catalog configuration
     And I am logged in as "Julia"
-    And I am on the products page
+    And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
       | SKU    | boots |

--- a/tests/legacy/features/pim/enrichment/product/pef/edit_boolean_value.feature
+++ b/tests/legacy/features/pim/enrichment/product/pef/edit_boolean_value.feature
@@ -7,7 +7,7 @@ Feature: Edit a boolean value
   Scenario: Successfully update a boolean value
     Given the "apparel" catalog configuration
     And I am logged in as "Mary"
-    And I am on the products page
+    And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
       | SKU    | gladiator |

--- a/tests/legacy/features/pim/enrichment/product/pef/edit_product_and_filter_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/pef/edit_product_and_filter_attributes.feature
@@ -7,7 +7,7 @@ Feature: Edit product and filter attributes
   Background:
     Given the "footwear" catalog configuration
     And I am logged in as "Mary"
-    And I am on the products page
+    And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
       | SKU    | boots |

--- a/tests/legacy/features/pim/enrichment/product/pef/edit_product_with_localized_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/pef/edit_product_with_localized_attributes.feature
@@ -64,6 +64,7 @@ Feature: Edit a product with localized attributes
     And I save the user
     And I should see the text "System Navigation"
     And I am on the "foo" product page
+    And I wait 3 seconds
     Then the field Date should contain "05/28/2015"
 
   Scenario: Successfully show datetimepicker in my UI locale

--- a/tests/legacy/features/pim/enrichment/reference-data/product/sorting/sort_products_per_reference_data.feature
+++ b/tests/legacy/features/pim/enrichment/reference-data/product/sorting/sort_products_per_reference_data.feature
@@ -19,7 +19,7 @@ Feature: Sort products
       | postit  | heel_color  | Pink              |
       | postit  | sole_fabric | Cashmerewool,Silk |
     And I am logged in as "Mary"
-    When I am on the products page
+    When I am on the products grid
     Then the grid should contain 2 elements
     When I display the columns SKU, Sole color, Heel color and Sole fabric
     Then I sort by "Sole color" value ascending

--- a/tests/legacy/features/pim/structure/attribute/option/sort_attribute_options.feature
+++ b/tests/legacy/features/pim/structure/attribute/option/sort_attribute_options.feature
@@ -49,7 +49,7 @@ Feature: Sort attribute options
       | pink   |
     And I save the attribute
     And I should not see the text "There are unsaved changes"
-    And I am on the products page
+    And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
       | SKU    | boots |


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When does it fail?

- We display the datagrid
- We click on a row
- The datagrid should be refreshed
- Row is uncheck
- We click on bulk action => no row selected, **error**

When does it work?

- We display the datagrid
- The datagrid is refreshed
- We click on a row
- We click on bulk action
- etc (it's working)

**Solution** 

Switch to the method "display datagrid" which is almost the same, but a little bit more robust.
I also added a wait for a test, because I think it will stabilize it (same problem of partial loading, but on the PEF)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
