### PR TITLE
PIM-8632: Fix empty column in the product datagrid when product model doest not have any shared value

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-8631: Fix column selector in the case of an attribute code as integer
+- PIM-8632: Fix empty column in the product datagrid when product model doest not have any shared value
 
 # 3.0.36 (2019-08-08)
 
@@ -14,7 +14,7 @@
 - PIM-8623: Fix wysiwyg edit link modal on Firefox
 - PIM-8628: Display label translations on configuration screens even you don't have "Allowed to view information" permission on a locale
 - PIM-8624: Fix default product grid view selector in user profile when there is more than 20 views
-- PIM-8632: Fix empty column in the product datagrid when product model doest not have any shared value
+- PIM-8631: Fix column selector in the case of an attribute code as integer
 
 # 3.0.35 (2019-08-05)
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -8,6 +8,7 @@
 - PIM-8623: Fix wysiwyg edit link modal on Firefox
 - PIM-8628: Display label translations on configuration screens even you don't have "Allowed to view information" permission on a locale
 - PIM-8624: Fix default product grid view selector in user profile when there is more than 20 views
+- PIM-8632: Fix empty column in the product datagrid when product model doest not have any shared value
 
 # 3.0.35 (2019-08-05)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/FetchProductRowsFromIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/FetchProductRowsFromIdentifiers.php
@@ -123,7 +123,11 @@ SQL;
                 p.identifier,
                 a_label.code attribute_as_label_code,
                 a_image.code attribute_as_image_code,
-                JSON_MERGE(COALESCE(pm1.raw_values, '{}'), COALESCE(pm2.raw_values, '{}'), p.raw_values) as raw_values
+                JSON_MERGE(
+                   CASE pm1.raw_values WHEN '[]' THEN '{}' ELSE COALESCE(pm1.raw_values, '{}') END,
+                   CASE pm2.raw_values WHEN '[]' THEN '{}' ELSE COALESCE(pm2.raw_values, '{}') END,
+                   p.raw_values
+                ) as raw_values
             FROM
                 pim_catalog_product p
                 LEFT JOIN pim_catalog_product_model pm1 ON pm1.id = p.product_model_id


### PR DESCRIPTION
In the case of
- a product model without any value
- a product variant of this PM with a value on it

The query will do a JSON_MERGE of `[]`, `{ sku: ... }`, which result in `[{}, { sku: ... }]`.

If I have to add a test, feel free to indicate what and where.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

