### PR TITLE
PIM-7675: Fix file input

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7675: Fix file input style
+
 # 2.3.58 (2019-08-08)
 
 ## Bug fixes

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/TextField.less
@@ -68,8 +68,10 @@
 
   &--file {
     color: transparent; // To remove the generated label near the text
-    height: 140px;
-    margin-top: -30px;
+
+    // TODO Merge - Revert this commit in 3.0!
+    border: none;
+    margin-left: -8px;
   }
 
   &--disabled,


### PR DESCRIPTION
The style was broken (and very crappy)
So we decided to put it back as the "browser way". No style.
This input is already nice in 3.0, so this commit will be reverted on merge.
![Selection_112](https://user-images.githubusercontent.com/1590933/62716437-79f04080-ba02-11e9-80f0-343ec3d19350.png)
