### PR TITLE
PIM-8633: Fix query to get product models when root product model does not have any shared value

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,7 +2,8 @@
 
 ## Bug fixes
 
-- PIM-8632: Fix empty column in the product datagrid when product model doest not have any shared value
+- PIM-8632: Fix empty column in the product datagrid when product model does not have any shared value
+- PIM-8633: Fix query to get product models when root product model does not have any shared value
 - PIM-8631: Fix column selector in the case of an attribute code as integer
 - PIM-8313: Do not display already added attributes in the family attributes selector dropdown
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodes.php
@@ -248,7 +248,10 @@ SQL;
             SELECT 
                 pm.code,
                 a_label.code attribute_as_label_code,
-                JSON_MERGE(COALESCE(parent.raw_values, '{}'), pm.raw_values) as raw_values
+                JSON_MERGE(
+                    CASE parent.raw_values WHEN '[]' THEN '{}' ELSE COALESCE(parent.raw_values, '{}') END,
+                    pm.raw_values
+                ) as raw_values
             FROM
                 pim_catalog_product_model pm
                 JOIN pim_catalog_family_variant fv ON fv.id = pm.family_variant_id

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodesIntegration.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\ProductGrid;
 
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductGrid\FetchProductModelRowsFromCodes;
 use Akeneo\Pim\Enrichment\Component\Product\Grid\ReadModel\Row;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Value\MediaValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use Webmozart\Assert\Assert;
 
 class FetchProductModelRowsFromCodesIntegration extends TestCase
 {
@@ -33,7 +35,7 @@ class FetchProductModelRowsFromCodesIntegration extends TestCase
         );
         [$rootProductModel, $subProductModel] = $fixturesLoader->createProductAndProductModels()['product_models'];
 
-        $query = $this->get('akeneo.pim.enrichment.product.grid.query.fetch_product_model_rows_from_codes');
+        $query = $this->getFetchProductRowsFromCodes();
         $rows = $query(['root_product_model', 'sub_product_model'], ['sku', 'an_image', 'a_text'], 'ecommerce', 'en_US', $userId);
 
         $akeneoImage = current($this
@@ -87,7 +89,7 @@ class FetchProductModelRowsFromCodesIntegration extends TestCase
         $rootProductModelWithLabelInSubProductModel = $fixturesLoader->createProductModelsWithLabelInSubProductModel();
         $subProductModelWithLabelInParent = $fixturesLoader->createProductModelsWithLabelInParentProductModel();
 
-        $query = $this->get('akeneo.pim.enrichment.product.grid.query.fetch_product_model_rows_from_codes');
+        $query = $this->getFetchProductRowsFromCodes();
         $rows = $query(['root_product_model_without_sub_product_model', 'root_product_model_with_image_in_sub_product_model', 'sub_product_model'], [], 'ecommerce', 'en_US', $userId);
 
         $akeneoImage = current($this
@@ -137,6 +139,111 @@ class FetchProductModelRowsFromCodesIntegration extends TestCase
         AssertRows::same($expectedRows, $rows);
     }
 
+    public function test_it_works_with_empty_product_model()
+    {
+        $this->createFamily('family', ['a_simple_select', 'a_yes_no']);
+        $this->createFamilyVariant('family', 'familyVariant', ['a_simple_select'], ['a_yes_no']);
+        $this->createProductModel('productModel', 'familyVariant');
+        $this->createProductModel('subProductModel', 'familyVariant', 'productModel');
+        $this->createVariantProduct('productVariant', 'subProductModel');
+
+        $query = $this->getFetchProductRowsFromCodes();
+        $result = $query(['subProductModel'], ['a_simple_select', 'a_yes_no'], 'ecommerce', 'en_US');
+
+        Assert::count($result, 1);
+        $row = $result[0];
+        $simpleSelectValue = $row->values()->getValues()[0];
+        Assert::same($simpleSelectValue->getAttributeCode(), 'a_simple_select');
+        Assert::same($simpleSelectValue->getData(), 'optionA');
+    }
+
+    private function createFamily(string $familyCode, array $attributeCodes): void
+    {
+        $familyData = [
+            'code' => $familyCode,
+            'attributes' => array_merge(['sku'], $attributeCodes),
+        ];
+
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $this->get('pim_catalog.updater.family')->update($family, $familyData);
+        $errors = $this->get('validator')->validate($family);
+        Assert::same(0, $errors->count());
+        $this->get('pim_catalog.saver.family')->save($family);
+    }
+
+    private function createFamilyVariant(string $familyCode, string $variantCode, array $attributeCodesLvl1, array $attributeCodesLvl2): void
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
+            'code' => $variantCode,
+            'family' => $familyCode,
+            'variant_attribute_sets' => [
+                [
+                    'axes' => $attributeCodesLvl1,
+                    'attributes' => $attributeCodesLvl1,
+                    'level' => 1,
+                ],
+                [
+                    'axes' => $attributeCodesLvl2,
+                    'attributes' => $attributeCodesLvl2,
+                    'level' => 2,
+                ]
+            ],
+        ]);
+
+        $errors = $this->get('validator')->validate($familyVariant);
+        Assert::same(0, $errors->count());
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+    }
+
+    private function createProductModel(
+        string $productModelCode,
+        string $familyVariantCode,
+        ?string $parentCode = null
+    ): void {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $data = [
+            'code' => $productModelCode,
+            'family_variant' => $familyVariantCode,
+            'values' => [],
+        ];
+        if (null !== $parentCode) {
+            $data['parent'] = $parentCode;
+            $data['values'] = [
+                'a_simple_select' => [
+                    ['data' => 'optionA', 'locale' => null, 'scope' => null],
+                ]
+            ];
+        }
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+
+        $errors = $this->get('validator')->validate($productModel);
+        Assert::same(0, $errors->count());
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+    }
+
+    private function createVariantProduct(string $identifier, string $parentCode): void
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+
+        $this->get('pim_catalog.updater.product')->update($product, [
+            'parent' => $parentCode,
+            'values' => [
+                'a_yes_no' => [
+                    ['data' => true, 'locale' => null, 'scope' => null],
+                ],
+            ]
+        ]);
+        $errors = $this->get('validator')->validate($product);
+        Assert::same(0, $errors->count());
+        $this->get('pim_catalog.saver.product')->save($product);
+    }
+
+    private function getFetchProductRowsFromCodes(): FetchProductModelRowsFromCodes
+    {
+        return $this->get('akeneo.pim.enrichment.product.grid.query.fetch_product_model_rows_from_codes');
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -145,4 +252,3 @@ class FetchProductModelRowsFromCodesIntegration extends TestCase
         return $this->catalog->useTechnicalCatalog();
     }
 }
-


### PR DESCRIPTION
Follow this fix:
https://github.com/akeneo/pim-community-dev/pull/10552

As @ahocquard said, there is another fail with this case with another query. Fixed!