### PR TITLE
PIM-7483: fix activity navigation dropdown menu when the menu is collapsed

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/common/menu.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/form_extensions/common/menu.yml
@@ -30,6 +30,7 @@ extensions:
             stateCode: pim-menu-activity
             tab: pim-menu-activity
             navigationTitle: pim_menu.navigation.activity
+            collapsedModifier: AknColumn--firstColumn
 
     pim-menu-activity-navigation-block:
         module: pim/menu/navigation-block

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/column.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/form/common/column.js
@@ -107,10 +107,14 @@ define(
             setCollapsed: function (value) {
                 sessionStorage.setItem(this.getSessionStorageKey(), value ? '1' : '0');
 
+                var collapseModifier = '';
+                if (this.config.collapsedModifier !== undefined) {
+                    collapseModifier = this.config.collapsedModifier;
+                }
                 if (value) {
-                    this.$el.addClass('AknColumn--collapsed');
+                    this.$el.addClass('AknColumn--collapsed ' + collapseModifier);
                 } else {
-                    this.$el.removeClass('AknColumn--collapsed');
+                    this.$el.removeClass('AknColumn--collapsed ' + collapseModifier);
                 }
             },
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/Column.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/Column.less
@@ -237,4 +237,8 @@
     padding: 20px;
     text-align: center;
   }
+
+  &--firstColumn {
+    z-index: 803;
+  }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
