### PR TITLE
PIM-8357: Fix styling of actions on history grid

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -8,6 +8,7 @@
 - PIM-8633: Fix query to get product models when root product model does not have any shared value
 - PIM-8631: Fix column selector in the case of an attribute code as integer
 - PIM-8313: Do not display already added attributes in the family attributes selector dropdown
+- PIM-8537: Fix styling of actions on history grid
 
 # 3.0.36 (2019-08-08)
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8357: Fix styling of actions on history grid
+
 # 3.0.37 (2019-08-13)
 
 ## Bug fixes
@@ -8,7 +12,6 @@
 - PIM-8633: Fix query to get product models when root product model does not have any shared value
 - PIM-8631: Fix column selector in the case of an attribute code as integer
 - PIM-8313: Do not display already added attributes in the family attributes selector dropdown
-- PIM-8537: Fix styling of actions on history grid
 
 # 3.0.36 (2019-08-08)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/ButtonList.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/ButtonList.less
@@ -25,6 +25,16 @@
     display: none;
   }
 
+  &--wrap {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  &--wrap :first-child {
+    margin-right: 10px;
+    margin-bottom: 10px;
+  }
+
   &--right {
     justify-content: flex-end;
     margin-right: 0;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/history.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/history.html
@@ -20,7 +20,7 @@
                     <td class="AknGrid-bodyCell AknGridHistory-bodyCell--highlight author" data-column="author"><%- version.author %><%- version.context ? ' (' + version.context + ')' : '' %></td>
                     <td class="AknGrid-bodyCell AknGrid-bodyCell--noWrap loggedAt" data-column="loggedAt"><%- version.logged_at %></td>
                     <td class="AknGrid-bodyCell AknGridHistory-bodyCell--changes changes" data-column="changes"><div class="AknGrid-multiline" title="<%- _.keys(version.changeset).join(', ') %>"><%- _.keys(version.changeset).join(', ') %></div></td>
-                    <% if (hasAction) { %><td class="AknGrid-bodyCell actions"></td><% } %>
+                    <% if (hasAction) { %><td class="AknGrid-bodyCell AknButtonList AknButtonList--wrap actions"></td><% } %>
                 </tr>
                 <tr data-version="<%- version.version %>" class="AknGrid-bodyRow AknGrid-bodyRow--withoutTopBorder changeset <%- expandedVersions.find(item => item == version.version) ? '' : 'hide' %>">
                     <td class="AknGrid-bodyCell"></td>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes spacing between actions on the history grid

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
