### PR TITLE
PIM-8442: Display flash messages instead of old popup when an error occurs in the attribute option edition

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/pim-attributeoptionview.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/pim-attributeoptionview.js
@@ -11,6 +11,7 @@ define(
         'pim/template/attribute-option/index',
         'pim/template/attribute-option/edit',
         'pim/template/attribute-option/show',
+        'oro/messenger',
         'jquery-ui'
     ],
     function (
@@ -24,7 +25,8 @@ define(
         Dialog,
         indexTemplate,
         editTemplate,
-        showTemplate
+        showTemplate,
+        messenger
     ) {
         'use strict';
 
@@ -176,10 +178,7 @@ define(
                         .tooltip('destroy')
                         .tooltip('show');
                 } else {
-                    Dialog.alert(
-                        __('alert.attribute_option.error_occurred_during_submission'),
-                        __('pim_enrich.entity.attribute_option.flash.update.fail')
-                    );
+                    messenger.notify('error', response.optionValues);
                 }
             },
             cancelSubmit: function (e) {
@@ -360,7 +359,7 @@ define(
             requestRowEdition: function (attributeOptionRow) {
                 if (this.currentlyEditedItemView) {
                     if (this.currentlyEditedItemView.dirty) {
-                        Dialog.alert(__('alert.attribute_option.save_before_edit_other'));
+                        messenger.notify('error', __('alert.attribute_option.save_before_edit_other'));
 
                         return false;
                     } else {
@@ -414,7 +413,7 @@ define(
                             message = response.responseText;
                         }
 
-                        Dialog.alert(message, __('pim_enrich.entity.attribute_option.flash.delete.fail'));
+                        messenger.notify('error', message);
                     }.bind(this)
                 });
             },

--- a/tests/legacy/features/pim/structure/attribute/option/delete_attribute_options.feature
+++ b/tests/legacy/features/pim/structure/attribute/option/delete_attribute_options.feature
@@ -43,7 +43,5 @@ Feature: Delete attribute options
     And I visit the "Options" tab
     When I remove the "white" option
     And I confirm the deletion
-    Then I should see the text "Error during deletion of the attribute option"
     And I should see the text "Attribute option \"white\" could not be removed as it is used as variant axis value."
-    When I press the "OK" button
     Then I should see the text "white"


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
