### PR TITLE
PIM-8438: display a flash message with the real error when attribute saving fails

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8357: Fix styling of actions on history grid
+- PIM-8438: Add an explicit error message when an attribute label is too long
 
 # 3.0.37 (2019-08-13)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/edit.yml
@@ -57,7 +57,7 @@ extensions:
         position: 110
 
     pim-attribute-edit-form-save:
-        module: pim/form/common/save-form
+        module: pim/attribute-edit-form/save-form
         parent: pim-attribute-edit-form
         targetZone: buttons
         position: 0

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
@@ -900,6 +900,7 @@ config:
     # Attribute
     pim/attribute-edit-form/tab/choices:                    pimui/js/attribute/form/choices
     pim/attribute-edit-form/choices/options-grid:           pimui/js/attribute/form/choices/options-grid
+    pim/attribute-edit-form/save-form:                      pimui/js/attribute/form/save
     pim/attribute-edit-form/delete:                         pimui/js/attribute/form/delete
     pim/attribute-edit-form/properties/available-locales:   pimui/js/attribute/form/properties/available-locales
     pim/attribute-edit-form/properties/default-metric-unit: pimui/js/attribute/form/properties/default-metric-unit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/save.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/save.js
@@ -1,0 +1,37 @@
+'use strict';
+
+define(
+    [
+        'pim/form/common/save-form',
+        'oro/messenger'
+    ],
+    function (BaseSave, messenger) {
+        return BaseSave.extend({
+            fail: function (response) {
+                let errorMessage = this.updateFailureMessage;
+
+                switch (response.status) {
+                case 400:
+                    this.getRoot().trigger(
+                        'pim_enrich:form:entity:bad_request',
+                        {'sentData': this.getFormData(), 'response': response.responseJSON}
+                    );
+                    errorMessage = response.responseJSON[0] !== undefined ?
+                        response.responseJSON[0].message :
+                        errorMessage;
+                    break;
+                case 500:
+                    const message = response.responseJSON ? response.responseJSON : response;
+                    this.getRoot().trigger('pim_enrich:form:entity:error:save', message);
+                    break;
+                default:
+                }
+
+                messenger.notify(
+                    'error',
+                    errorMessage
+                );
+            }
+        });
+    }
+);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
