### PR TITLE
PIM-8629: Allow import profile actions to be filtered by allowed property

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8357: Fix styling of actions on history grid
+- PIM-8629: Fix hiding of upload button on import profiles
 
 # 3.0.37 (2019-08-13)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
@@ -63,7 +63,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
-            permissionKey: uploadAllowed
+            allowedKey: uploadAllowed
             label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-csv-base-import-show-upload:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
@@ -63,6 +63,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
+            permissionKey: uploadAllowed
             label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-csv-base-import-show-upload:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
@@ -63,6 +63,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
+            allowedKey: uploadAllowed
             label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-csv-product-import-show-upload:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
@@ -63,6 +63,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
+            allowedKey: uploadAllowed
             label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-csv-product-model-import-show-upload:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
@@ -62,6 +62,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
+            allowedKey: uploadAllowed
             label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-xlsx-base-import-show-upload:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
@@ -62,6 +62,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
+            allowedKey: uploadAllowed
             label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-xlsx-product-import-show-upload:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
@@ -62,6 +62,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
+            allowedKey: uploadAllowed
             label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-xlsx-product-model-import-show-upload:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
@@ -63,6 +63,7 @@ extensions:
         aclResourceId: pim_importexport_import_profile_launch
         position: 50
         config:
+            allowedKey: uploadAllowed
             label: pim_import_export.form.job_instance.button.import.upload_file
 
     pim-job-instance-yml-base-import-show-upload:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher-item.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher-item.js
@@ -38,7 +38,7 @@ define(
                 this.getRoot().trigger('switcher:register', {
                     label: __(this.config.label),
                     code: this.code,
-                    permissionKey: this.config.permissionKey
+                    allowedKey: this.config.allowedKey
                 });
 
                 return BaseForm.prototype.configure.apply(this, arguments);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher-item.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher-item.js
@@ -37,7 +37,8 @@ define(
 
                 this.getRoot().trigger('switcher:register', {
                     label: __(this.config.label),
-                    code: this.code
+                    code: this.code,
+                    permissionKey: this.config.permissionKey
                 });
 
                 return BaseForm.prototype.configure.apply(this, arguments);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher.js
@@ -46,6 +46,10 @@ define(
                     return;
                 }
 
+                const { configuration } = this.getRoot().getFormData();
+
+                this.actions = this.filterByPermission(this.actions, configuration || {});
+
                 if (null === this.currentActionCode) {
                     this.setCurrentActionCode(_.first(this.actions).code);
                 }
@@ -56,6 +60,25 @@ define(
                 }));
 
                 return BaseForm.prototype.render.apply(this, arguments);
+            },
+
+            /**
+             * Filters allowed switcher-items by permission. The permission is defined by specifying a permissionKey
+             * in the configuration of a switcher-item. This permissionKey corresponds to a key on the import
+             * profile configuration.
+             *
+             * @param actions
+             * @param configuration
+             * @returns {*}
+             */
+            filterByPermission: function (actions, configuration) {
+                return actions.filter(({ permissionKey }) => {
+                    if (permissionKey === undefined || configuration[permissionKey] === undefined) {
+                        return true;
+                    }
+
+                    return configuration[permissionKey];
+                });
             },
 
             /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/import/switcher.js
@@ -63,21 +63,20 @@ define(
             },
 
             /**
-             * Filters allowed switcher-items by permission. The permission is defined by specifying a permissionKey
-             * in the configuration of a switcher-item. This permissionKey corresponds to a key on the import
-             * profile configuration.
+             * This function filters actions based on whether they are allowed to be shown. The allowedKey is defined
+             * on switcher-items and corresponds to a property in the import profile configuration.
              *
              * @param actions
              * @param configuration
              * @returns {*}
              */
             filterByPermission: function (actions, configuration) {
-                return actions.filter(({ permissionKey }) => {
-                    if (permissionKey === undefined || configuration[permissionKey] === undefined) {
+                return actions.filter(({ allowedKey }) => {
+                    if (allowedKey === undefined || configuration[allowedKey] === undefined) {
                         return true;
                     }
 
-                    return configuration[permissionKey];
+                    return configuration[allowedKey];
                 });
             },
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Currently, the upload button on import profiles remains even if uploads are disabled in the import profile settings. This PR fixes this issue by filtering the import profile actions by the `uploadAllowed` property on the import profile configuration. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
