### PR TITLE
TIP-901: database migration for native_json type removal

### DIFF
--- a/upgrades/schema/Version_4_0_20190801084247_remove_native_json_type.php
+++ b/upgrades/schema/Version_4_0_20190801084247_remove_native_json_type.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_4_0_20190801084247_remove_native_json_type extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql("ALTER TABLE pim_catalog_product MODIFY raw_values JSON NOT NULL COMMENT ''");
+        $this->addSql("ALTER TABLE pim_catalog_product_model MODIFY raw_values JSON NOT NULL COMMENT ''");
+        $this->addSql("ALTER TABLE pim_aggregated_volume MODIFY volume JSON NOT NULL COMMENT ''");
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
When migrating from 3.2 to master, we have the following error (introduced by https://github.com/akeneo/pim-community-dev/pull/10527 and https://github.com/akeneo/pim-enterprise-dev/pull/6659):

```
janvier:pcd$ docker-compose exec fpm bin/console doctrine:schema:update --env=prod                                                                              
10:33:50 ERROR     [console] Error thrown while running command "doctrine:schema:update --env=prod". Message: "Unknown column type "native_json" requested. Any Doctrine type that you use has to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database introspection then you might have forgotten to register all database types for a Doctrine Type. Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement Type#getMappedDatabaseTypes(). If the type name is empty you might have a problem with the cache or forgot some mapping information." ["exception" => Doctrine\DBAL\DBALException { …},"command" => "doctrine:schema:update --env=prod","message" => "Unknown column type "native_json" requested. Any Doctrine type that you use has to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database introspection then you might have forgotten to register all database types for a Doctrine Type. Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement Type#getMappedDatabaseTypes(). If the type name is empty you might have a problem with the cache or forgot some mapping information."]

In DBALException.php line 283:
                                                                               
  Unknown column type "native_json" requested. Any Doctrine type that you use  
   has to be registered with \Doctrine\DBAL\Types\Type::addType(). You can ge  
  t a list of all the known types with \Doctrine\DBAL\Types\Type::getTypesMap  
  (). If this error occurs during database introspection then you might have   
  forgotten to register all database types for a Doctrine Type. Use AbstractP  
  latform#registerDoctrineTypeMapping() or have your custom types implement T  
  ype#getMappedDatabaseTypes(). If the type name is empty you might have a pr  
  oblem with the cache or forgot some mapping information.                     
                                                                               
```

This migration fixes the problem.

FYI, if you want to see the comments of a column in a table:

`SELECT * FROM information_schema.columns WHERE table_name = 'pim_catalog_product'\G`