### PR TITLE
PIM-8661: Fix merging values from a variant product when one of its ancestors has empty values

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-8661: API: Fix getting values from a variant product when one of its ancestors has empty values
+
 # 3.2.4 (2019-08-14)
 
 # 3.2.3 (2019-08-13)


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Empty values are stored as an empty JSON array in `raw_values` column, which used to conflict with the JSON_MERGE MySQL function, and return an array instead of an object. 
ex:
`SELECT JSON_MERGE('[]', '{"foo": "bar"}', '{"bar": "baz"}');` 
will return
 `[{"foo": "bar"}, {"bar": "baz"}]`
whereas we expect 
`{"foo": "bar", "bar": "baz"}`

This PR ensures that we merge only objects in order to get the expected format for the results.

<!--- (What does this Pull Request do? reference the related issue?) --->



| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
