### PR TITLE
PIM-8667: Fix grid filters for numeric attribute codes

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,7 @@
 - PIM-8357: Fix styling of actions on history grid
 - PIM-8438: Add an explicit error message when an attribute label is too long
 - PIM-8629: Fix hiding of upload button on import profiles
+- PIM-8667: Fix grid filters for numeric attribute codes
 
 # 3.0.37 (2019-08-13)
 

--- a/src/Oro/Bundle/PimDataGridBundle/Datagrid/Configuration/Product/FiltersConfigurator.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datagrid/Configuration/Product/FiltersConfigurator.php
@@ -37,7 +37,8 @@ class FiltersConfigurator implements ConfiguratorInterface
         $attributes = ($attributes === null) ? [] : $attributes;
 
         $displayedFilters = [];
-        foreach ($attributes as $attributeCode => $attribute) {
+        foreach ($attributes as $attribute) {
+            $attributeCode = $attribute['code'];
             if (!$attribute['useableAsGridFilter']) {
                 continue;
             }

--- a/src/Oro/Bundle/PimDataGridBundle/Datagrid/Configuration/Product/SelectedAttributesConfigurator.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datagrid/Configuration/Product/SelectedAttributesConfigurator.php
@@ -72,7 +72,7 @@ class SelectedAttributesConfigurator implements ConfiguratorInterface
      */
     private function addAttributesConfig(DatagridConfiguration $configuration): void
     {
-        $filterValues = array_merge($this->requestParams->get('_filter', []), $this->requestStack->getCurrentRequest()->get('filters', []));
+        $filterValues = array_replace($this->requestParams->get('_filter', []), $this->requestStack->getCurrentRequest()->get('filters', []));
         unset($filterValues['scope']);
         unset($filterValues['category']);
         $attributesUsedAsFilter = array_keys($filterValues);

--- a/src/Oro/Bundle/PimDataGridBundle/Extension/Filter/FilterExtension.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/Filter/FilterExtension.php
@@ -194,7 +194,7 @@ class FilterExtension extends AbstractExtension
                     sprintf('[%s][%s][label]', FormatterConfiguration::COLUMNS_KEY, $column)
                 );
             }
-            $filters[] = $this->getFilterObject($column, $filter);
+            $filters[] = $this->getFilterObject((string)$column, $filter);
         }
 
         // TODO: Try to make filter without views, to remove this kind of stuff

--- a/src/Oro/Bundle/PimDataGridBundle/spec/Datagrid/Configuration/Product/FiltersConfiguratorSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/Datagrid/Configuration/Product/FiltersConfiguratorSpec.php
@@ -33,8 +33,8 @@ class FiltersConfiguratorSpec extends ObjectBehavior
                 'group'               => 'General',
                 'groupOrder'          => 1
             ],
-            'name' => [
-                'code'                => 'name',
+            123456 => [
+                'code'                => '123456',
                 'label'               => 'Name',
                 'useableAsGridFilter' => 1,
                 'type'                => 'pim_catalog_text',
@@ -61,9 +61,9 @@ class FiltersConfiguratorSpec extends ObjectBehavior
                 'group'      => 'General',
                 'groupOrder' => 1
             ],
-            'name' => [
+            '123456' => [
                 0            => 'text_config',
-                'data_name'  => 'name',
+                'data_name'  => '123456',
                 'label'      => 'Name',
                 'enabled'    => false,
                 'order'      => 2,


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Fixes searching and applying filters for attributes with numeric codes in the grid. The issue was mostly due to bad string/int casting

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
