### PR TITLE
PIM-8663: Fix category tree selector

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-8663: Fix category tree selector
 - PIM-8601: Fix purge of the job execution according to the date of creation and not deletion
 
 # 3.2.2 (2019-08-01)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/tree-manage.jstree.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/tree-manage.jstree.js
@@ -20,7 +20,7 @@ define(
             }
             var selectedNode       = $el.attr('data-node-id') || -1;
             var selectedTree       = $el.attr('data-tree-id') || -1;
-            var selectedNodeOrTree = selectedNode in [0, -1] ? selectedTree : selectedNode;
+            var selectedNodeOrTree = [0, -1].indexOf(selectedNode) !== -1 ? selectedTree : selectedNode;
             var preventFirst       = selectedNode > 0;
             var loadingMask        = new LoadingMask();
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix the category tree selector.

(A category with an ID of `1` was always ignored because of the js operator `in` that operate on array/object keys and not values.)
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
