### PR TITLE
PIM-8674: Check provided date validity when creating a DateValue

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,10 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-8663: Fix category tree selector
+- PIM-8674: Check date validity when creating a date value
+
 # 3.2.5 (2019-08-19)
 
 ## Bug fixes
@@ -12,7 +17,6 @@
 
 ## Bug fixes
 
-- PIM-8663: Fix category tree selector
 - PIM-8601: Fix purge of the job execution according to the date of creation and not deletion
 - PIM-8583: Add missing translations on role deletion
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
@@ -34,12 +34,22 @@ class DateValueFactory extends AbstractValueFactory
             );
         }
 
+        $matches = [];
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data, $matches)) {
+            throw $this->buildInvalidDateException($attribute, $data);
+        }
+
+        list($year, $month, $day) = explode('-', $matches[0]);
+        if (true !== checkdate($month, $day, $year)) {
+            throw InvalidPropertyException::validDateExpected(
+                $attribute->getCode(),
+                static::class,
+                $data
+            );
+        }
+
         try {
             $date = new \DateTime($data);
-
-            if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data)) {
-                throw $this->buildInvalidDateException($attribute, $data);
-            }
         } catch (\Exception $e) {
             throw $this->buildInvalidDateException($attribute, $data);
         }

--- a/src/Akeneo/Tool/Component/StorageUtils/Exception/InvalidPropertyException.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Exception/InvalidPropertyException.php
@@ -136,6 +136,28 @@ class InvalidPropertyException extends PropertyException
     }
 
     /**
+     * Build an exception when the provided date is invalid
+     *
+     * @param string $propertyName
+     * @param string $className
+     * @param string $propertyValue
+     *
+     * @return InvalidPropertyException
+     */
+    public static function validDateExpected($propertyName, $className, $propertyValue)
+    {
+        $message = 'Property "%s" expects a valid date as data, "%s" given.';
+
+        return new static(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName, $propertyValue),
+            self::DATE_EXPECTED_CODE
+        );
+    }
+
+    /**
      * Build an exception when the group type is invalid or is not allowed.
      *
      * @param string $propertyName

--- a/src/Akeneo/Tool/Component/StorageUtils/spec/Exception/InvalidPropertyExceptionSpec.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/spec/Exception/InvalidPropertyExceptionSpec.php
@@ -56,7 +56,7 @@ class InvalidPropertyExceptionSpec extends ObjectBehavior
         $this->getCode()->shouldReturn($exception->getCode());
     }
 
-    function it_creates_an_invalid_date_exception()
+    function it_creates_an_invalid_date_format_exception()
     {
         $exception = InvalidPropertyException::dateExpected(
             'created_date',
@@ -70,6 +70,30 @@ class InvalidPropertyExceptionSpec extends ObjectBehavior
             '2017/12/12',
             'Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\DateAttributeSetter',
             'Property "created_date" expects a string with the format "yyyy-mm-dd" as data, "2017/12/12" given.',
+            InvalidPropertyException::DATE_EXPECTED_CODE
+        );
+
+        $this->shouldBeAnInstanceOf(get_class($exception));
+        $this->getPropertyName()->shouldReturn($exception->getPropertyName());
+        $this->getPropertyValue()->shouldReturn($exception->getPropertyValue());
+        $this->getClassName()->shouldReturn($exception->getClassName());
+        $this->getMessage()->shouldReturn($exception->getMessage());
+        $this->getCode()->shouldReturn($exception->getCode());
+    }
+
+    function it_creates_an_invalid_date_exception()
+    {
+        $exception = InvalidPropertyException::validDateExpected(
+            'created_date',
+            'Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\DateAttributeSetter',
+            '2019-02-31'
+        );
+
+        $this->beConstructedWith(
+            'created_date',
+            '2019-02-31',
+            'Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\DateAttributeSetter',
+            'Property "created_date" expects a valid date as data, "2019-02-31" given.',
             InvalidPropertyException::DATE_EXPECTED_CODE
         );
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/DateValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/DateValueFactorySpec.php
@@ -2,12 +2,12 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Factory\Value;
 
+use Akeneo\Pim\Enrichment\Component\Product\Factory\Value\DateValueFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Value\DateValue;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
-use Akeneo\Pim\Enrichment\Component\Product\Factory\Value\DateValueFactory;
-use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Value\DateValue;
 
 class DateValueFactorySpec extends ObjectBehavior
 {
@@ -183,6 +183,26 @@ class DateValueFactorySpec extends ObjectBehavior
         $this
             ->shouldThrow($exception)
             ->during('create', [$attribute, 'ecommerce', 'en_US', '03-04-2013']);
+    }
+
+    function it_throws_an_exception_when_provided_date_is_invalid(AttributeInterface $attribute)
+    {
+        $attribute->isScopable()->willReturn(true);
+        $attribute->isLocalizable()->willReturn(true);
+        $attribute->getCode()->willReturn('date_attribute');
+        $attribute->getType()->willReturn('pim_catalog_date');
+        $attribute->getBackendType()->willReturn('date');
+        $attribute->isBackendTypeReferenceData()->willReturn(false);
+
+        $exception = InvalidPropertyException::validDateExpected(
+            'date_attribute',
+            DateValueFactory::class,
+            '0000-00-00'
+        );
+
+        $this
+            ->shouldThrow($exception)
+            ->during('create', [$attribute, 'ecommerce', 'en_US', '0000-00-00']);
     }
 
     public function getMatchers(): array


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

When creating a DateValue, the validity of the provided date was not checked, so one could create a date value with invalid dates (e.g '0000-00-00' or '2019-02-31')  from the API, which resulted in invalid data stroed in the DB.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
