### PR TITLE
PIM-6138: Fix display of remove button according to ACL

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -6,6 +6,7 @@
 - PIM-8438: Add an explicit error message when an attribute label is too long
 - PIM-8629: Fix hiding of upload button on import profiles
 - PIM-8667: Fix grid filters for numeric attribute codes
+- PIM-6138: Fix display of remove icons on family grid and category tree when user does not have permission
 
 # 3.0.37 (2019-08-13)
 
@@ -26,7 +27,6 @@
 - PIM-8623: Fix wysiwyg edit link modal on Firefox
 - PIM-8628: Display label translations on configuration screens even you don't have "Allowed to view information" permission on a locale
 - PIM-8624: Fix default product grid view selector in user profile when there is more than 20 views
-- PIM-6138: Fix display of remove icons on family grid and category tree when user does not have permission
 
 # 3.0.35 (2019-08-05)
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -26,6 +26,7 @@
 - PIM-8623: Fix wysiwyg edit link modal on Firefox
 - PIM-8628: Display label translations on configuration screens even you don't have "Allowed to view information" permission on a locale
 - PIM-8624: Fix default product grid view selector in user profile when there is more than 20 views
+- PIM-6138: Fix display of remove icons on family grid and category tree when user does not have permission
 
 # 3.0.35 (2019-08-05)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/form.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/form.html.twig
@@ -24,7 +24,7 @@
 }) }}
 
     {% set buttons %}
-        {% if form.vars.value.id %}
+        {% if form.vars.value.id and resource_granted(acl ~ '_category_remove') %}
             <div class="AknSecondaryActions AknDropdown AknButtonList-item secondary-actions">
               <div class="AknSecondaryActions-button dropdown-button" data-toggle="dropdown"></div>
               <div class="AknDropdown-menu AknDropdown-menu--right">

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/family.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/family.yml
@@ -39,6 +39,7 @@ datagrid:
                 type:  delete
                 label: pim_common.delete
                 link:  delete_link
+                acl_resource: pim_enrich_family_remove
         sorters:
             columns:
                 label:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Fix the display of the remove button in family grid and category tree when the user does not have the permissions

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
