### PR TITLE
PIM-8673: Add a fallback to get the mime-type of files loaded without metadata.

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -4,6 +4,7 @@
 
 - PIM-8663: Fix category tree selector
 - PIM-8674: Check date validity when creating a date value
+- PIM-8673: Add a fallback to get the mime-type of files loaded without metadata.
 
 # 3.2.5 (2019-08-19)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
@@ -7,6 +7,7 @@ services:
         arguments:
             - '@akeneo_file_storage.file_storage.filesystem_provider'
             - ['catalogStorage']
+            - '@akeneo_file_storage.repository.file_info'
         tags:
             - { name: liip_imagine.binary.loader, loader: flysystem_data_loader }
 

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileStorer.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileStorer.php
@@ -73,7 +73,12 @@ class FileStorer implements FileStorerInterface
             $options = [];
             $mimeType = $file->getMimeType();
             if (null !== $mimeType) {
-                $options['ContentType'] = $mimeType;
+                /*
+                 * AWS S3 (see PIM-5405) and Google Cloud Storage (see PIM-8673) require a Content-Type metadata to properly handle a file type.
+                 * But each Flysystem adapter use is own Config format.
+                 */
+                $options['ContentType'] = $mimeType; // AWS S3
+                $options['metadata']['contentType'] = $mimeType; // Google Cloud Storage
             }
             $isFileWritten = $filesystem->writeStream($file->getKey(), $resource, $options);
         } catch (FileExistsException $e) {

--- a/tests/back/Platform/Specification/Bundle/UIBundle/Imagine/FlysystemLoaderSpec.php
+++ b/tests/back/Platform/Specification/Bundle/UIBundle/Imagine/FlysystemLoaderSpec.php
@@ -4,16 +4,18 @@ namespace Specification\Akeneo\Platform\Bundle\UIBundle\Imagine;
 
 use Akeneo\Pim\Enrichment\Component\FileStorage;
 use Akeneo\Tool\Component\FileStorage\FilesystemProvider;
+use Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface;
+use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use League\Flysystem\FilesystemInterface;
 use PhpSpec\ObjectBehavior;
 
 class FlysystemLoaderSpec extends ObjectBehavior
 {
-    function let(FilesystemProvider $filesystemProvider, FilesystemInterface $filesystem)
+    function let(FilesystemProvider $filesystemProvider, FilesystemInterface $filesystem, FileInfoRepositoryInterface $fileInfoRepository)
     {
         $filesystemProvider->getFilesystem(FileStorage::CATALOG_STORAGE_ALIAS)->willReturn($filesystem);
 
-        $this->beConstructedWith($filesystemProvider, [FileStorage::CATALOG_STORAGE_ALIAS]);
+        $this->beConstructedWith($filesystemProvider, [FileStorage::CATALOG_STORAGE_ALIAS], $fileInfoRepository);
     }
 
     function it_is_a_loader()
@@ -28,6 +30,23 @@ class FlysystemLoaderSpec extends ObjectBehavior
         $filesystem->has($filepath)->willReturn(true);
         $filesystem->read($filepath)->willReturn('IMAGE CONTENT');
         $filesystem->getMimetype($filepath)->willReturn('image/png');
+
+        $binary = $this->find($filepath);
+
+        $binary->getContent()->shouldReturn('IMAGE CONTENT');
+        $binary->getMimeType()->shouldReturn('image/png');
+    }
+
+    function it_sets_the_mimetype_of_a_binary_file($filesystem, $fileInfoRepository, FileInfoInterface $fileInfo)
+    {
+        $filepath = '2/f/a/4/2fa4afe5465afe5655age_flower';
+
+        $filesystem->has($filepath)->willReturn(true);
+        $filesystem->read($filepath)->willReturn('IMAGE CONTENT');
+        $filesystem->getMimetype($filepath)->willReturn('application/octet-stream');
+
+        $fileInfo->getMimeType()->willReturn('image/png');
+        $fileInfoRepository->findOneByIdentifier($filepath)->willReturn($fileInfo);
 
         $binary = $this->find($filepath);
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When using a cloud storage solution (AWS S3, Google Cloud Storage). You need to send the `Content-Type` metadata along with your file or it will be stored as `application/octet-stream`.

The goal of this PR is to:
- Set the metadata option required by each Flysystem adapter (dirty fix, but a rewrite to handle properly each adapter configuration would probably be too much).
- Fallback to load the mime-type of a file from the FileInfo repository if we get a `Content-Type` `application/octet-stream` when loading a file from the storage.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
