### PR TITLE
PIM-8655: Fix page title of the categories settings

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-8655: Fix page title of the categories settings
+
 # 3.2.6 (2019-08-22)
 
 ## Bug fixes:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/edit.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/edit.html.twig
@@ -38,6 +38,9 @@
 
                 PageTitle.set({ 'category.label': '{{ form.vars.value.label }}' });
 
+                // On the initial page load the routing is completed before we set the PageTitle params so we need to trigger it manually (see PIM-8655).
+                PageTitle.render('pim_enrich_categorytree_edit', { 'category.label': '{{ form.vars.value.label }}' });
+
                 FetcherRegistry.initialize().done(function () {
                     FormBuilder.build('pim-menu-user-navigation').then(function (form) {
                         $('.user-menu').append(form.el);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The categories settings page display a title of `Category tree {{ category.label }} | Edit` on the initial page load (`category.label` is not defined). 

The problem is that the `PageTitle` service is triggered by a routing change, but the script in `CategoryTree/edit.html.twig` that set the  `PageTitle` params is executed after the event happen.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
