### PR TITLE
PIM-8678: Change the updated property value of the Family entity when the attribute requirements are updated

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8615: Fix issue issue with boolean attribute used as variant axis
+- PIM-8678: Fill the updated property on Family entity update
 
 # 3.0.38 (2019-08-20)
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -2,8 +2,11 @@
 
 ## Bug fixes
 
-- PIM-8615: Fix issue issue with boolean attribute used as variant axis
+- PIM-8615: Fix issue with boolean attribute used as variant axis
 - PIM-8678: Fill the updated property on Family entity update
+
+## BC Breaks
+- Change `Akeneo\Pim\Structure\Component\Mode\FamilyInterface` to extend `Akeneo\Tool\Component\Versioning\Model\TimestampableInterface`
 
 # 3.0.38 (2019-08-20)
 

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyInterface.php
@@ -4,6 +4,7 @@ namespace Akeneo\Pim\Structure\Component\Model;
 
 use Akeneo\Tool\Component\Localization\Model\TranslatableInterface;
 use Akeneo\Tool\Component\StorageUtils\Model\ReferableInterface;
+use Akeneo\Tool\Component\Versioning\Model\TimestampableInterface;
 use Akeneo\Tool\Component\Versioning\Model\VersionableInterface;
 use Doctrine\Common\Collections\Collection;
 
@@ -14,7 +15,11 @@ use Doctrine\Common\Collections\Collection;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-interface FamilyInterface extends TranslatableInterface, ReferableInterface, VersionableInterface
+interface FamilyInterface extends
+    TranslatableInterface,
+    ReferableInterface,
+    VersionableInterface,
+    TimestampableInterface
 {
     /**
      * Get id

--- a/tests/back/Pim/Structure/Specification/Component/Model/FamilySpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Model/FamilySpec.php
@@ -2,15 +2,23 @@
 
 namespace Specification\Akeneo\Pim\Structure\Component\Model;
 
-use PhpSpec\ObjectBehavior;
-use Akeneo\Pim\Structure\Component\Model\Family;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\Family;
+use Akeneo\Tool\Component\Localization\Model\TranslatableInterface;
+use Akeneo\Tool\Component\StorageUtils\Model\ReferableInterface;
+use Akeneo\Tool\Component\Versioning\Model\TimestampableInterface;
+use Akeneo\Tool\Component\Versioning\Model\VersionableInterface;
+use PhpSpec\ObjectBehavior;
 
 class FamilySpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
         $this->shouldHaveType(Family::class);
+        $this->shouldImplement(TimestampableInterface::class);
+        $this->shouldImplement(TranslatableInterface::class);
+        $this->shouldImplement(ReferableInterface::class);
+        $this->shouldImplement(VersionableInterface::class);
     }
 
     function it_contains_attributes(AttributeInterface $sku, AttributeInterface $name)


### PR DESCRIPTION
This pull request aims to change the value of the updated property from the Family entity when the user updates the attribute requirements (SETTINGS > FAMILIES > ${FAMILY} > Attributes)

This is done "automatically" if the family implement the Timestampable interface. Interface methods already are implemented in the Family model, but the the interface was not declared.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
