### PR TITLE
TIP-1220: ProductIndexer as Interface

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -125,7 +125,8 @@
 - Change constructor or `Akeneo\Pim\Enrichment\Bundle\Command\CalculateCompletenessCommand` to remove
     `Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface` and add
     `Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses` and
-    `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexer`
+    `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexerInterface` and
+    it does not extend `Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand` anymore
 - Update constructor of `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\CompleteFilter`, remove `Doctrine\ORM\EntityManagerInterface` and add `Doctrine\DBAL\Connection`
 - Remove methods `getCompletenesses` and `setCompletenesses` from `Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface`
 - Replace `Akeneo\Pim\Enrichment\Component\Product\Factory\Write` by `Akeneo\Pim\Enrichment\Component\Product\Factory\Read` with method `createByCheckingData`
@@ -141,6 +142,12 @@
     - `Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface`
     - `Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface`
     - `Akeneo\Tool\Component\StorageUtils\Remover\BulkRemoverInterface`
+- Class `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexer` now implements the single interface `Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface` instead of
+    `Akeneo\Tool\Component\StorageUtils\Indexer\IndexerInterface`, `Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface`, `Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface` and `Akeneo\Tool\Component\StorageUtils\Remover\BulkRemoverInterface`
+- Update constructor of `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\IndexProductsSubscriber` to remove
+    `Akeneo\Tool\Component\StorageUtils\Indexer\IndexerInterface`, `Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface` and `Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface`
+    and add `Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface`
+- Command `Akeneo\Pim\Enrichment\Bundle\Command\IndexProductCommand` does not extend `Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand` anymore
 
 ### CLI Commands
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -122,7 +122,7 @@
 - Remove class `Akeneo\Pim\Enrichment\Bundle\Command\PurgeProductsCompletenessCommand`
 - Remove class `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\CompletenessRemover`
 - Remove class `Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessRemoverInterface`
-- Change constructor or `Akeneo\Pim\Enrichment\Bundle\Command\CalculateCompletenessCommand` to remove
+- Change constructor of `Akeneo\Pim\Enrichment\Bundle\Command\CalculateCompletenessCommand` to remove
     `Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface` and add
     `Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses` and
     `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexerInterface` and

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -135,6 +135,11 @@
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ProductModelController` to make `Akeneo\Tool\Bundle\ElasticsearchBundle\Client` mandatory
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\PdfGeneration\Renderer\ProductPdfRenderer` to make `Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface` mandatory and `string $customFont` becomes the last argument
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueVariantAxisValidator` to make `Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\GetValuesOfSiblings` mandatory and remove `Akeneo\Pim\Enrichment\Component\Product\Repository\EntityWithFamilyVariantRepositoryInterface`
+- Replace methods and following interface from `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexer` by the single interface `Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface` and its new methods:
+    - `Akeneo\Tool\Component\StorageUtils\Indexer\IndexerInterface`
+    - `Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface`
+    - `Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface`
+    - `Akeneo\Tool\Component\StorageUtils\Remover\BulkRemoverInterface`
 
 ### CLI Commands
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -136,6 +136,7 @@
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\PdfGeneration\Renderer\ProductPdfRenderer` to make `Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface` mandatory and `string $customFont` becomes the last argument
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueVariantAxisValidator` to make `Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\GetValuesOfSiblings` mandatory and remove `Akeneo\Pim\Enrichment\Component\Product\Repository\EntityWithFamilyVariantRepositoryInterface`
 - Replace methods and following interface from `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexer` by the single interface `Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface` and its new methods:
+- Replace interfaces from `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexer` by the single interface `Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface` and change methods accordingly. Replaced interfaces are:
     - `Akeneo\Tool\Component\StorageUtils\Indexer\IndexerInterface`
     - `Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface`
     - `Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface`

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CalculateCompletenessCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CalculateCompletenessCommand.php
@@ -117,7 +117,7 @@ class CalculateCompletenessCommand extends Command
             }, $productsToSave);
 
             $this->computeAndPersistProductCompletenesses->fromProductIdentifiers($identifiers);
-            $this->productIndexer->indexFromProductIdentifiers($productsToSave);
+            $this->productIndexer->indexFromProductIdentifiers($identifiers);
         }
 
         $output->writeln("<info>Missing completenesses generated.</info>");

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CalculateCompletenessCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CalculateCompletenessCommand.php
@@ -2,15 +2,14 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Command;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexer;
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelIndexer;
 use Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class CalculateCompletenessCommand extends ContainerAwareCommand
+class CalculateCompletenessCommand extends Command
 {
     use LockableTrait;
 
@@ -37,7 +36,7 @@ class CalculateCompletenessCommand extends ContainerAwareCommand
     /** @var ComputeAndPersistProductCompletenesses */
     private $computeAndPersistProductCompletenesses;
 
-    /** @var ProductIndexer */
+    /** @var ProductIndexerInterface */
     private $productIndexer;
 
     /** @var EntityManagerClearerInterface */
@@ -50,7 +49,7 @@ class CalculateCompletenessCommand extends ContainerAwareCommand
         Client $productAndProductModelClient,
         ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
-        ProductIndexer $productIndexer,
+        ProductIndexerInterface $productIndexer,
         EntityManagerClearerInterface $cacheClearer,
         int $batchSize
     ) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CalculateCompletenessCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CalculateCompletenessCommand.php
@@ -101,24 +101,24 @@ class CalculateCompletenessCommand extends ContainerAwareCommand
             $productsToSave[] = $product;
 
             if (count($productsToSave) === $this->batchSize) {
-                $this->computeAndPersistProductCompletenesses->fromProductIdentifiers(
-                    array_map(function (ProductInterface $product) {
-                        return $product->getIdentifier();
-                    }, $productsToSave)
-                );
-                $this->productIndexer->indexAll($productsToSave);
+                $identifiers = array_map(function (ProductInterface $product) {
+                    return $product->getIdentifier();
+                }, $productsToSave);
+
+                $this->computeAndPersistProductCompletenesses->fromProductIdentifiers($identifiers);
+                $this->productIndexer->indexFromProductIdentifiers($identifiers);
                 $this->cacheClearer->clear();
                 $productsToSave = [];
             }
         }
 
         if (!empty($productsToSave)) {
-            $this->computeAndPersistProductCompletenesses->fromProductIdentifiers(
-                array_map(function (ProductInterface $product) {
-                    return $product->getIdentifier();
-                }, $productsToSave)
-            );
-            $this->productIndexer->indexAll($productsToSave);
+            $identifiers = array_map(function (ProductInterface $product) {
+                return $product->getIdentifier();
+            }, $productsToSave);
+
+            $this->computeAndPersistProductCompletenesses->fromProductIdentifiers($identifiers);
+            $this->productIndexer->indexFromProductIdentifiers($productsToSave);
         }
 
         $output->writeln("<info>Missing completenesses generated.</info>");

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductCommand.php
@@ -10,7 +10,7 @@ use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface;
 use Doctrine\Common\Persistence\ObjectManager;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class IndexProductCommand extends ContainerAwareCommand
+class IndexProductCommand extends Command
 {
     protected static $defaultName = 'pim:product:index';
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductCommand.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Command;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
-use Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface;
+use Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -33,8 +34,8 @@ class IndexProductCommand extends ContainerAwareCommand
     /** @var ProductRepositoryInterface */
     private $productRepository;
 
-    /** @var BulkIndexerInterface */
-    private $bulkProductIndexer;
+    /** @var ProductIndexerInterface */
+    private $productIndexer;
 
     /** @var ObjectManager */
     private $objectManager;
@@ -47,14 +48,14 @@ class IndexProductCommand extends ContainerAwareCommand
 
     public function __construct(
         ProductRepositoryInterface $productRepository,
-        BulkIndexerInterface $bulkProductIndexer,
+        ProductIndexerInterface $productIndexer,
         ObjectManager $objectManager,
         Client $productAndProductModelClient,
         string $productAndProductModelIndexName
     ) {
         parent::__construct();
         $this->productRepository = $productRepository;
-        $this->bulkProductIndexer = $bulkProductIndexer;
+        $this->productIndexer = $productIndexer;
         $this->objectManager = $objectManager;
         $this->productAndProductModelClient = $productAndProductModelClient;
         $this->productAndProductModelIndexName = $productAndProductModelIndexName;
@@ -124,7 +125,10 @@ class IndexProductCommand extends ContainerAwareCommand
 
         $progressBar->start();
         while (!empty($products = $this->productRepository->searchAfter($lastProduct, self::BULK_SIZE))) {
-            $this->bulkProductIndexer->indexAll($products, ['index_refresh' => Refresh::disable()]);
+            $identifiers = array_map(function (ProductInterface $product) {
+                return $product->getIdentifier();
+            }, $products);
+            $this->productIndexer->indexFromProductIdentifiers($identifiers, ['index_refresh' => Refresh::disable()]);
             $this->objectManager->clear();
 
             $lastProduct = end($products);
@@ -166,29 +170,39 @@ class IndexProductCommand extends ContainerAwareCommand
 
         $i = 0;
         $productBulk = [];
+        $identifiers = [];
         $totalProductsIndexed = 0;
         $progressBar = new ProgressBar($output, $totalProductsIndexed);
 
         $progressBar->start();
         foreach ($products as $product) {
             $productBulk[] = $product;
+            $identifiers[] = $product->getIdentifier();
 
             $i++;
 
             if (0 === $i % self::BULK_SIZE) {
-                $this->bulkProductIndexer->indexAll($productBulk, ['index_refresh' => Refresh::disable()]);
+                $this->productIndexer->indexFromProductIdentifiers(
+                    $identifiers,
+                    ['index_refresh' => Refresh::disable()]
+                );
+
                 $this->objectManager->clear();
 
                 $progressBar->advance(count($productBulk));
 
                 $productBulk = [];
+                $identifiers = [];
 
                 $totalProductsIndexed += self::BULK_SIZE;
             }
         }
 
         if (!empty($productBulk)) {
-            $this->bulkProductIndexer->indexAll($productBulk, ['index_refresh' => Refresh::disable()]);
+            $this->productIndexer->indexFromProductIdentifiers(
+                $identifiers,
+                ['index_refresh' => Refresh::disable()]
+            );
             $this->objectManager->clear();
 
             $progressBar->advance(count($productBulk));

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductCommand.php
@@ -169,14 +169,12 @@ class IndexProductCommand extends Command
         $output->writeln(sprintf('<info>%d products found for indexing</info>', $productsCount));
 
         $i = 0;
-        $productBulk = [];
         $identifiers = [];
         $totalProductsIndexed = 0;
-        $progressBar = new ProgressBar($output, $totalProductsIndexed);
+        $progressBar = new ProgressBar($output, $productsCount);
 
         $progressBar->start();
         foreach ($products as $product) {
-            $productBulk[] = $product;
             $identifiers[] = $product->getIdentifier();
 
             $i++;
@@ -189,25 +187,24 @@ class IndexProductCommand extends Command
 
                 $this->objectManager->clear();
 
-                $progressBar->advance(count($productBulk));
+                $progressBar->advance(count($identifiers));
 
-                $productBulk = [];
                 $identifiers = [];
 
                 $totalProductsIndexed += self::BULK_SIZE;
             }
         }
 
-        if (!empty($productBulk)) {
+        if (!empty($identifiers)) {
             $this->productIndexer->indexFromProductIdentifiers(
                 $identifiers,
                 ['index_refresh' => Refresh::disable()]
             );
             $this->objectManager->clear();
 
-            $progressBar->advance(count($productBulk));
+            $progressBar->advance(count($identifiers));
 
-            $totalProductsIndexed += count($productBulk);
+            $totalProductsIndexed += count($identifiers);
         }
         $progressBar->finish();
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
@@ -113,10 +113,7 @@ class ProductIndexer implements ProductIndexerInterface
      */
     public function removeFromProductId(string $productId, array $options = []): void
     {
-        $this->productAndProductModelClient->delete(
-            self::INDEX_TYPE,
-            self::PRODUCT_IDENTIFIER_PREFIX . (string) $productId
-        );
+        $this->productAndProductModelClient->delete(self::INDEX_TYPE, self::PRODUCT_IDENTIFIER_PREFIX . $productId);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
@@ -90,13 +90,7 @@ class ProductIndexer implements ProductIndexerInterface
             $normalizedProducts[] = $normalizedProduct;
         }
 
-        if (count($normalizedProducts) === 1) {
-            $this->productAndProductModelClient->index(
-                self::INDEX_TYPE,
-                $normalizedProducts[0]['id'],
-                $normalizedProducts[0]
-            );
-        } elseif (count($normalizedProducts) > 1) {
+        if (!empty($normalizedProducts)) {
             $this->productAndProductModelClient->bulkIndexes(
                 self::INDEX_TYPE,
                 $normalizedProducts,
@@ -121,7 +115,7 @@ class ProductIndexer implements ProductIndexerInterface
      *
      * {@inheritdoc}
      */
-    public function removeManyFromProductIds(array $productIds, array $options = []): void
+    public function removeFromProductIds(array $productIds, array $options = []): void
     {
         $this->productAndProductModelClient->bulkDelete(self::INDEX_TYPE, array_map(
             function ($productId) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Indexing\ProductAndProductModel\ProductModelNormalizer;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Akeneo\Tool\Component\StorageUtils\Indexer\IndexerInterface;
+use Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface;
 use Akeneo\Tool\Component\StorageUtils\Remover\BulkRemoverInterface;
 use Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -21,31 +24,131 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverInterface, BulkRemoverInterface
+class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverInterface, BulkRemoverInterface, ProductIndexerInterface
 {
     private const PRODUCT_IDENTIFIER_PREFIX = 'product_';
+
+    /**
+     * Index type is not used anymore in ES6 but is still needed by Client
+     */
+    private const INDEX_TYPE = '';
+
     /** @var NormalizerInterface */
     private $normalizer;
 
     /** @var Client */
     private $productAndProductModelClient;
 
-    /** @var string */
-    private $indexType;
+    /** @var ProductRepositoryInterface */
+    private $productRepository;
 
     /**
-     * @param NormalizerInterface $normalizer
-     * @param Client              $productAndProductModelClient
-     * @param string              $indexType
+     * @param NormalizerInterface        $normalizer
+     * @param Client                     $productAndProductModelClient
+     * @param ProductRepositoryInterface $productRepository
      */
     public function __construct(
         NormalizerInterface $normalizer,
         Client $productAndProductModelClient,
-        string $indexType
+        ProductRepositoryInterface $productRepository
     ) {
         $this->normalizer = $normalizer;
         $this->productAndProductModelClient = $productAndProductModelClient;
-        $this->indexType = $indexType;
+        $this->productRepository = $productRepository;
+    }
+
+    /**
+     * Indexes a product in both the product index and the product and product model index.
+     *
+     * {@inheritdoc}
+     */
+    public function indexFromProductIdentifier(string $productIdentifier, array $options = []): void
+    {
+        $object = $this->productRepository->findOneByIdentifier($productIdentifier);
+        if (!$object instanceof ProductInterface) {
+            return;
+        }
+
+        $normalizedObject = $this->normalizer->normalize(
+            $object,
+            ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+        );
+        $this->validateObjectNormalization($normalizedObject);
+        $this->productAndProductModelClient->index(self::INDEX_TYPE, $normalizedObject['id'], $normalizedObject);
+    }
+
+    /**
+     * Indexes a list of products in both the product index and the product and product model index.
+     *
+     * If the index_refresh is provided, it uses the refresh strategy defined.
+     * Otherwise the waitFor strategy is by default.
+     *
+     * {@inheritdoc}
+     */
+    public function indexFromProductIdentifiers(array $productIdentifiers, array $options = []): void
+    {
+        $indexRefresh = $options['index_refresh'] ?? Refresh::disable();
+
+        $normalizedProductModels = [];
+        foreach ($productIdentifiers as $productIdentifier) {
+            $object = $this->productRepository->findOneByIdentifier($productIdentifier);
+            if (!$object instanceof ProductInterface) {
+                continue;
+            }
+
+            $normalizedProductModel = $this->normalizer->normalize(
+                $object,
+                ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
+            );
+            $this->validateObjectNormalization($normalizedProductModel);
+            $normalizedProductModels[] = $normalizedProductModel;
+        }
+
+        if (empty($normalizedProductModels)) {
+            return;
+        }
+
+        $this->productAndProductModelClient->bulkIndexes(
+            self::INDEX_TYPE,
+            $normalizedProductModels,
+            'id',
+            $indexRefresh
+        );
+    }
+
+    /**
+     * Removes the products from both the product index and the product and product model index.
+     *
+     * {@inheritdoc}
+     */
+    public function removeFromProductIdentifier(string $productIdentifier, array $options = []): void
+    {
+        $this->productAndProductModelClient->delete(
+            self::INDEX_TYPE,
+            self::PRODUCT_IDENTIFIER_PREFIX . $productIdentifier
+        );
+    }
+
+    /**
+     * Removes the products from both the product index and the product and product model index.
+     *
+     * {@inheritdoc}
+     */
+    public function removeManyFromProductIdentifiers(array $productIdentifiers, array $options = []): void
+    {
+        if (empty($productIdentifiers)) {
+            return;
+        }
+
+        $this->productAndProductModelClient->bulkDelete(
+            self::INDEX_TYPE,
+            array_map(
+                function (string $productIdentifiers) {
+                    return self::PRODUCT_IDENTIFIER_PREFIX . $productIdentifiers;
+                },
+                $productIdentifiers
+            )
+        );
     }
 
     /**
@@ -60,7 +163,7 @@ class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverI
             ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX
         );
         $this->validateObjectNormalization($normalizedObject);
-        $this->productAndProductModelClient->index($this->indexType, $normalizedObject['id'], $normalizedObject);
+        $this->productAndProductModelClient->index(self::INDEX_TYPE, $normalizedObject['id'], $normalizedObject);
     }
 
     /**
@@ -90,7 +193,7 @@ class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverI
         }
 
         $this->productAndProductModelClient->bulkIndexes(
-            $this->indexType,
+            self::INDEX_TYPE,
             $normalizedProductModels,
             'id',
             $indexRefresh
@@ -105,7 +208,7 @@ class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverI
     public function remove($objectId, array $options = []) : void
     {
         $this->productAndProductModelClient->delete(
-            $this->indexType,
+            self::INDEX_TYPE,
             self::PRODUCT_IDENTIFIER_PREFIX . (string) $objectId
         );
     }
@@ -121,7 +224,7 @@ class ProductIndexer implements IndexerInterface, BulkIndexerInterface, RemoverI
         foreach ($objects as $objectId) {
             $objectIds[]  = self::PRODUCT_IDENTIFIER_PREFIX . (string) $objectId;
         }
-        $this->productAndProductModelClient->bulkDelete($this->indexType, $objectIds);
+        $this->productAndProductModelClient->bulkDelete(self::INDEX_TYPE, $objectIds);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
@@ -107,7 +107,7 @@ class ProductIndexer implements ProductIndexerInterface
     }
 
     /**
-     * Removes the products from both the product index and the product and product model index.
+     * Removes the product from the product index and the product model index.
      *
      * {@inheritdoc}
      */
@@ -125,7 +125,7 @@ class ProductIndexer implements ProductIndexerInterface
     }
 
     /**
-     * Removes the products from both the product index and the product and product model index.
+     * Removes the products from the product index and the product model index.
      *
      * {@inheritdoc}
      */

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
@@ -111,16 +111,11 @@ class ProductIndexer implements ProductIndexerInterface
      *
      * {@inheritdoc}
      */
-    public function removeFromProductIdentifier(string $productIdentifier, array $options = []): void
+    public function removeFromProductId(string $productId, array $options = []): void
     {
-        $object = $this->productRepository->findOneByIdentifier($productIdentifier);
-        if (!$object instanceof ProductInterface) {
-            return;
-        }
-
         $this->productAndProductModelClient->delete(
             self::INDEX_TYPE,
-            self::PRODUCT_IDENTIFIER_PREFIX . (string) $object->getId()
+            self::PRODUCT_IDENTIFIER_PREFIX . (string) $productId
         );
     }
 
@@ -129,21 +124,14 @@ class ProductIndexer implements ProductIndexerInterface
      *
      * {@inheritdoc}
      */
-    public function removeManyFromProductIdentifiers(array $productIdentifiers, array $options = []): void
+    public function removeManyFromProductIds(array $productIds, array $options = []): void
     {
-        $objectIds = [];
-        foreach ($productIdentifiers as $productIdentifier) {
-            $object = $this->productRepository->findOneByIdentifier($productIdentifier);
-            if ($object instanceof ProductInterface) {
-                $objectIds[] = self::PRODUCT_IDENTIFIER_PREFIX . (string) $object->getId();
-            }
-        }
-
-        if (empty($objectIds)) {
-            return;
-        }
-
-        $this->productAndProductModelClient->bulkDelete(self::INDEX_TYPE, $objectIds);
+        $this->productAndProductModelClient->bulkDelete(self::INDEX_TYPE, array_map(
+            function ($productId) {
+                return self::PRODUCT_IDENTIFIER_PREFIX . (string) $productId;
+            },
+            $productIds
+        ));
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexer.php
@@ -176,12 +176,12 @@ class ProductModelDescendantsIndexer implements
         }
 
         if ($productModelChildren->first() instanceof ProductInterface) {
-            $identifiers = [];
+            $productIds = [];
             foreach ($productModelChildren as $productModelChild) {
-                $identifiers[] = $productModelChild->getIdentifier();
+                $productIds[] = (string) $productModelChild->getId();
             }
 
-            $this->productIndexer->removeManyFromProductIdentifiers($identifiers);
+            $this->productIndexer->removeManyFromProductIds($productIds);
 
             return;
         }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexer.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Akeneo\Tool\Component\StorageUtils\Indexer\IndexerInterface;
+use Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface;
 use Akeneo\Tool\Component\StorageUtils\Remover\BulkRemoverInterface;
 use Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface;
 use Doctrine\Common\Collections\Collection;
@@ -27,11 +28,8 @@ class ProductModelDescendantsIndexer implements
     RemoverInterface,
     BulkRemoverInterface
 {
-    /** @var BulkIndexerInterface */
+    /** @var ProductIndexerInterface */
     private $productIndexer;
-
-    /** @var BulkRemoverInterface */
-    private $productRemover;
 
     /** @var BulkIndexerInterface */
     private $productModelIndexer;
@@ -40,19 +38,16 @@ class ProductModelDescendantsIndexer implements
     private $productModelRemover;
 
     /**
-     * @param BulkIndexerInterface $productIndexer
-     * @param BulkRemoverInterface $productRemover
-     * @param BulkIndexerInterface $productModelIndexer
-     * @param BulkRemoverInterface $productModelRemover
+     * @param ProductIndexerInterface $productIndexer
+     * @param BulkIndexerInterface    $productModelIndexer
+     * @param BulkRemoverInterface    $productModelRemover
      */
     public function __construct(
-        BulkIndexerInterface $productIndexer,
-        BulkRemoverInterface $productRemover,
+        ProductIndexerInterface $productIndexer,
         BulkIndexerInterface $productModelIndexer,
         BulkRemoverInterface $productModelRemover
     ) {
         $this->productIndexer = $productIndexer;
-        $this->productRemover = $productRemover;
         $this->productModelIndexer = $productModelIndexer;
         $this->productModelRemover = $productModelRemover;
     }
@@ -138,7 +133,7 @@ class ProductModelDescendantsIndexer implements
     }
 
     /**
-     * Recursive method that indexes the a list of product model children and their children
+     * Recursive method that indexes a list of product model children and their children
      * (products or product models).
      *
      * @param Collection $productModelChildren
@@ -151,7 +146,12 @@ class ProductModelDescendantsIndexer implements
         }
 
         if ($productModelChildren->first() instanceof ProductInterface) {
-            $this->productIndexer->indexAll($productModelChildren->toArray(), $options);
+            $identifiers = [];
+            foreach ($productModelChildren as $productModelChild) {
+                $identifiers[] = $productModelChild->getIdentifier();
+            }
+
+            $this->productIndexer->indexFromProductIdentifiers($identifiers, $options);
 
             return;
         }
@@ -176,7 +176,12 @@ class ProductModelDescendantsIndexer implements
         }
 
         if ($productModelChildren->first() instanceof ProductInterface) {
-            $this->productRemover->removeAll($productModelChildren->toArray());
+            $identifiers = [];
+            foreach ($productModelChildren as $productModelChild) {
+                $identifiers[] = $productModelChild->getIdentifier();
+            }
+
+            $this->productIndexer->removeManyFromProductIdentifiers($identifiers);
 
             return;
         }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexer.php
@@ -181,7 +181,7 @@ class ProductModelDescendantsIndexer implements
                 $productIds[] = (string) $productModelChild->getId();
             }
 
-            $this->productIndexer->removeManyFromProductIds($productIds);
+            $this->productIndexer->removeFromProductIds($productIds);
 
             return;
         }

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/IndexProductModelsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/IndexProductModelsSubscriber.php
@@ -54,7 +54,7 @@ class IndexProductModelsSubscriber implements EventSubscriberInterface
         return [
             StorageEvents::POST_SAVE     => 'indexProductModel',
             StorageEvents::POST_SAVE_ALL => 'bulkIndexProductModels',
-            StorageEvents::PRE_REMOVE    => 'deleteProductModel',
+            StorageEvents::POST_REMOVE   => 'deleteProductModel',
         ];
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/IndexProductModelsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/IndexProductModelsSubscriber.php
@@ -108,6 +108,6 @@ class IndexProductModelsSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->productModelIndexRemover->remove($event->getSubjectId());
+        $this->productModelIndexRemover->remove((string) $event->getSubjectId());
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/IndexProductsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/IndexProductsSubscriber.php
@@ -103,6 +103,6 @@ class IndexProductsSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->productIndexer->removeFromProductId((string) $product->getId());
+        $this->productIndexer->removeFromProductId((string) $event->getSubjectId());
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/IndexProductsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/IndexProductsSubscriber.php
@@ -42,7 +42,7 @@ class IndexProductsSubscriber implements EventSubscriberInterface
         return [
             StorageEvents::POST_SAVE     => ['indexProduct', 300],
             StorageEvents::POST_SAVE_ALL => ['bulkIndexProducts', 300],
-            StorageEvents::PRE_REMOVE    => ['deleteProduct', 300],
+            StorageEvents::POST_REMOVE   => ['deleteProduct', 300],
         ];
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/IndexProductsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/IndexProductsSubscriber.php
@@ -103,6 +103,6 @@ class IndexProductsSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->productIndexer->removeFromProductIdentifier($product->getIdentifier());
+        $this->productIndexer->removeFromProductId((string) $product->getId());
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
@@ -22,6 +22,5 @@ services:
         class: '%pim_catalog.elasticsearch.indexer.product_model_descendants_indexer.class%'
         arguments:
             - '@pim_catalog.elasticsearch.indexer.product'
-            - '@pim_catalog.elasticsearch.indexer.product'
             - '@pim_catalog.elasticsearch.indexer.product_model'
             - '@pim_catalog.elasticsearch.indexer.product_model'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
@@ -9,7 +9,7 @@ services:
         arguments:
             - '@pim_indexing_serializer'
             - '@akeneo_elasticsearch.client.product_and_product_model'
-            - 'pim_catalog_product'
+            - '@pim_catalog.repository.product'
 
     pim_catalog.elasticsearch.indexer.product_model:
         class: '%pim_catalog.elasticsearch.indexer.product_model_indexer.class%'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
@@ -77,8 +77,6 @@ services:
         class: '%pim_catalog.event_subscriber.index_products.class%'
         arguments:
               - '@pim_catalog.elasticsearch.indexer.product'
-              - '@pim_catalog.elasticsearch.indexer.product'
-              - '@pim_catalog.elasticsearch.indexer.product'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/Akeneo/Tool/Component/StorageUtils/Indexer/ProductIndexerInterface.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Indexer/ProductIndexerInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Akeneo\Tool\Component\StorageUtils\Indexer;
+
+/**
+ * Interface ProductIndexerInterface
+ *
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ProductIndexerInterface
+{
+    /**
+     * @param string $productIdentifier
+     * @param array  $options
+     */
+    public function indexFromProductIdentifier(string $productIdentifier, array $options = []);
+
+    /**
+     * @param array $productIdentifiers
+     * @param array $options
+     */
+    public function indexFromProductIdentifiers(array $productIdentifiers, array $options = []);
+
+    /**
+     * @param string $productIdentifier
+     * @param array  $options
+     */
+    public function removeFromProductIdentifier(string $productIdentifier, array $options = []);
+
+    /**
+     * @param array $productIdentifiers
+     * @param array $options
+     */
+    public function removeManyFromProductIdentifiers(array $productIdentifiers, array $options = []);
+}

--- a/src/Akeneo/Tool/Component/StorageUtils/Indexer/ProductIndexerInterface.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Indexer/ProductIndexerInterface.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Tool\Component\StorageUtils\Indexer;
 
 /**
- * Interface ProductIndexerInterface
- *
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
@@ -35,5 +33,5 @@ interface ProductIndexerInterface
      * @param string[] $productIdentifiers
      * @param array    $options
      */
-    public function removeManyFromProductIds(array $productIdentifiers, array $options = []): void;
+    public function removeFromProductIds(array $productIdentifiers, array $options = []): void;
 }

--- a/src/Akeneo/Tool/Component/StorageUtils/Indexer/ProductIndexerInterface.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Indexer/ProductIndexerInterface.php
@@ -18,8 +18,8 @@ interface ProductIndexerInterface
     public function indexFromProductIdentifier(string $productIdentifier, array $options = []);
 
     /**
-     * @param array $productIdentifiers
-     * @param array $options
+     * @param string[] $productIdentifiers
+     * @param array    $options
      */
     public function indexFromProductIdentifiers(array $productIdentifiers, array $options = []);
 
@@ -30,8 +30,8 @@ interface ProductIndexerInterface
     public function removeFromProductIdentifier(string $productIdentifier, array $options = []);
 
     /**
-     * @param array $productIdentifiers
-     * @param array $options
+     * @param string[] $productIdentifiers
+     * @param array    $options
      */
     public function removeManyFromProductIdentifiers(array $productIdentifiers, array $options = []);
 }

--- a/src/Akeneo/Tool/Component/StorageUtils/Indexer/ProductIndexerInterface.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Indexer/ProductIndexerInterface.php
@@ -26,14 +26,14 @@ interface ProductIndexerInterface
     public function indexFromProductIdentifiers(array $productIdentifiers, array $options = []): void;
 
     /**
-     * @param string $productIdentifier
+     * @param string $productId
      * @param array  $options
      */
-    public function removeFromProductIdentifier(string $productIdentifier, array $options = []): void;
+    public function removeFromProductId(string $productId, array $options = []): void;
 
     /**
      * @param string[] $productIdentifiers
      * @param array    $options
      */
-    public function removeManyFromProductIdentifiers(array $productIdentifiers, array $options = []): void;
+    public function removeManyFromProductIds(array $productIdentifiers, array $options = []): void;
 }

--- a/src/Akeneo/Tool/Component/StorageUtils/Indexer/ProductIndexerInterface.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Indexer/ProductIndexerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Tool\Component\StorageUtils\Indexer;
 
 /**
@@ -15,23 +17,23 @@ interface ProductIndexerInterface
      * @param string $productIdentifier
      * @param array  $options
      */
-    public function indexFromProductIdentifier(string $productIdentifier, array $options = []);
+    public function indexFromProductIdentifier(string $productIdentifier, array $options = []): void;
 
     /**
      * @param string[] $productIdentifiers
      * @param array    $options
      */
-    public function indexFromProductIdentifiers(array $productIdentifiers, array $options = []);
+    public function indexFromProductIdentifiers(array $productIdentifiers, array $options = []): void;
 
     /**
      * @param string $productIdentifier
      * @param array  $options
      */
-    public function removeFromProductIdentifier(string $productIdentifier, array $options = []);
+    public function removeFromProductIdentifier(string $productIdentifier, array $options = []): void;
 
     /**
      * @param string[] $productIdentifiers
      * @param array    $options
      */
-    public function removeManyFromProductIdentifiers(array $productIdentifiers, array $options = []);
+    public function removeManyFromProductIdentifiers(array $productIdentifiers, array $options = []): void;
 }

--- a/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Akeneo\Test\IntegrationTestsBundle\Loader;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\IntegrationTestsBundle\Security\SystemUserAuthenticator;
-use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Plugin\ListPaths;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -375,7 +375,14 @@ class FixturesLoader implements FixturesLoaderInterface
     protected function indexProducts(): void
     {
         $products = $this->container->get('pim_catalog.repository.product')->findAll();
-        $this->container->get('pim_catalog.elasticsearch.indexer.product')->indexAll($products);
+        $this->container->get('pim_catalog.elasticsearch.indexer.product')->indexFromProductIdentifiers(
+            array_map(
+                function (ProductInterface $product) {
+                    return $product->getIdentifier();
+                },
+                $products
+            )
+        );
     }
 
     /**

--- a/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
@@ -374,13 +374,12 @@ class FixturesLoader implements FixturesLoaderInterface
      */
     protected function indexProducts(): void
     {
-        $products = $this->container->get('pim_catalog.repository.product')->findAll();
         $this->container->get('pim_catalog.elasticsearch.indexer.product')->indexFromProductIdentifiers(
-            array_map(
-                function (ProductInterface $product) {
-                    return $product->getIdentifier();
-                },
-                $products
+            array_column(
+                $this->container->get('database_connection')->fetchAll(
+                    'SELECT p.identifier as identifier from pim_catalog_product p;'
+                ),
+                'identifier'
             )
         );
     }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
@@ -25,7 +25,9 @@ class DeleteProductEndToEnd extends AbstractProductTestCase
         $this->assertCount(7, $this->getFromTestContainer('pim_catalog.repository.product')->findAll());
 
         $fooProduct = $this->getFromTestContainer('pim_catalog.repository.product')->findOneByIdentifier('foo');
-        $this->getFromTestContainer('pim_catalog.elasticsearch.indexer.product')->index($fooProduct);
+        $this->getFromTestContainer('pim_catalog.elasticsearch.indexer.product')->indexFromProductIdentifier(
+            $fooProduct->getIdentitifer()
+        );
         $client->request('DELETE', 'api/rest/v1/products/foo');
 
         $response = $client->getResponse();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
@@ -24,10 +24,7 @@ class DeleteProductEndToEnd extends AbstractProductTestCase
 
         $this->assertCount(7, $this->getFromTestContainer('pim_catalog.repository.product')->findAll());
 
-        $fooProduct = $this->getFromTestContainer('pim_catalog.repository.product')->findOneByIdentifier('foo');
-        $this->getFromTestContainer('pim_catalog.elasticsearch.indexer.product')->indexFromProductIdentifier(
-            $fooProduct->getIdentitifer()
-        );
+        $this->getFromTestContainer('pim_catalog.elasticsearch.indexer.product')->indexFromProductIdentifier('foo');
         $client->request('DELETE', 'api/rest/v1/products/foo');
 
         $response = $client->getResponse();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/DeleteVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/DeleteVariantProductEndToEnd.php
@@ -17,7 +17,9 @@ class DeleteVariantProductEndToEnd extends AbstractProductTestCase
         $this->assertCount(242, $this->getFromTestContainer('pim_catalog.repository.product')->findAll());
 
         $bikerJacketLeatherXxs = $this->getFromTestContainer('pim_catalog.repository.product')->findOneByIdentifier('biker-jacket-leather-xxs');
-        $this->get('pim_catalog.elasticsearch.indexer.product')->index($bikerJacketLeatherXxs);
+        $this->get('pim_catalog.elasticsearch.indexer.product')->indexFromProductIdentifier(
+            $bikerJacketLeatherXxs->getIdentifier()
+        );
         $client->request('DELETE', 'api/rest/v1/products/biker-jacket-leather-xxs');
 
         $response = $client->getResponse();

--- a/tests/back/Pim/Enrichment/Integration/Completeness/CalculateCompletenessCommandIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/CalculateCompletenessCommandIntegration.php
@@ -64,6 +64,6 @@ class CalculateCompletenessCommandIntegration extends AbstractCompletenessTestCa
     {
         $this->get('database_connection')->executeQuery('DELETE FROM pim_catalog_completeness');
 
-        $this->get('pim_catalog.elasticsearch.indexer.product')->index($product);
+        $this->get('pim_catalog.elasticsearch.indexer.product')->indexFromProductIdentifier($product->getIdentifier());
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Command/IndexProductCommandSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Command/IndexProductCommandSpec.php
@@ -4,27 +4,24 @@ namespace Specification\Akeneo\Pim\Enrichment\Bundle\Command;
 
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
-use Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
 use Prophecy\Argument;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class IndexProductCommandSpec extends ObjectBehavior
 {
     function let(
-        ContainerInterface $container,
         ProductRepositoryInterface $productRepository,
         ProductIndexerInterface $productIndexer,
         ObjectManager $objectManager,
@@ -37,7 +34,6 @@ class IndexProductCommandSpec extends ObjectBehavior
             $productAndProductModelClient,
             'akeneo_pim_product_and_product_model'
         );
-        $this->setContainer($container);
 
         $productAndProductModelClient->hasIndex()->willReturn(true);
     }
@@ -49,7 +45,7 @@ class IndexProductCommandSpec extends ObjectBehavior
 
     function it_is_a_command()
     {
-        $this->shouldBeAnInstanceOf(ContainerAwareCommand::class);
+        $this->shouldBeAnInstanceOf(Command::class);
     }
 
     function it_indexes_all_products(

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/ProductModelDescendantsSaverSpec.php
@@ -7,6 +7,7 @@ use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Akeneo\Tool\Component\StorageUtils\Indexer\IndexerInterface;
+use Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Bundle\Doctrine\Common\Saver\ProductModelDescendantsSaver;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
@@ -22,7 +23,7 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
     function let(
         ProductModelRepositoryInterface $productModelRepository,
         ProductQueryBuilderFactoryInterface $pqbFactory,
-        BulkIndexerInterface $bulkProductIndexer,
+        ProductIndexerInterface $productIndexer,
         BulkIndexerInterface $bulkProductModelIndexer,
         IndexerInterface $productModelIndexer,
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses
@@ -30,7 +31,7 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $this->beConstructedWith(
             $productModelRepository,
             $pqbFactory,
-            $bulkProductIndexer,
+            $productIndexer,
             $bulkProductModelIndexer,
             $productModelIndexer,
             $computeAndPersistProductCompletenesses,
@@ -46,7 +47,7 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
     function it_computes_completeness_and_indexes_a_product_model_descendants_which_are_products_and_sub_product_models(
         $productModelRepository,
         $pqbFactory,
-        $bulkProductIndexer,
+        $productIndexer,
         $bulkProductModelIndexer,
         $productModelIndexer,
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
@@ -75,7 +76,7 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
         $variantProduct2->getIdentifier()->willReturn('product_2');
         $computeAndPersistProductCompletenesses->fromProductIdentifiers(['product_1', 'product_2'])->shouldBeCalled();
 
-        $bulkProductIndexer->indexAll([$variantProduct1, $variantProduct2], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
+        $productIndexer->indexFromProductIdentifiers(['product_1', 'product_2'], ['index_refresh' => Refresh::disable()])->shouldBeCalled();
 
         $productModelRepository->findChildrenProductModels($productModel)->willReturn([$productModelsChildren]);
         $bulkProductModelIndexer->indexAll([$productModelsChildren]);
@@ -88,7 +89,7 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
     function it_does_not_fail_when_product_model_has_no_child(
         $productModelRepository,
         $pqbFactory,
-        $bulkProductIndexer,
+        $productIndexer,
         $bulkProductModelIndexer,
         $productModelIndexer,
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
@@ -106,7 +107,7 @@ class ProductModelDescendantsSaverSpec extends ObjectBehavior
 
         $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::any())->shouldNotBeCalled();
 
-        $bulkProductIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();
+        $productIndexer->indexFromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
 
         $productModelRepository->findChildrenProductModels($productModel)->willReturn([]);
         $bulkProductModelIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
@@ -105,7 +105,7 @@ class ProductIndexerSpec extends ObjectBehavior
         $normalizer,
         $productAndProductModelIndexClient,
         $productRepository
-    )     {
+    ) {
         $productRepository->findOneByIdentifier(Argument::cetera())->shouldNotBeCalled();
         $normalizer->normalize(Argument::cetera())->shouldNotBeCalled();
         $productAndProductModelIndexClient->bulkIndexes(Argument::cetera())->shouldNotBeCalled();

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
@@ -113,34 +113,19 @@ class ProductIndexerSpec extends ObjectBehavior
         $this->indexFromProductIdentifiers([]);
     }
 
-    function it_deletes_products_from_elasticsearch_index(
-        $productAndProductModelIndexClient,
-        $productRepository,
-        ProductInterface $product
-    ) {
-        $productRepository->findOneByIdentifier('40')->willReturn($product);
-        $product->getId()->willReturn(40);
-
+    function it_deletes_products_from_elasticsearch_index($productAndProductModelIndexClient)
+    {
         $productAndProductModelIndexClient->delete(ProductIndexer::INDEX_TYPE, 'product_40')->shouldBeCalled();
 
-        $this->removeFromProductIdentifier(40)->shouldReturn(null);
+        $this->removeFromProductId(40)->shouldReturn(null);
     }
 
-    function it_bulk_deletes_products_from_elasticsearch_index(
-        $productAndProductModelIndexClient,
-        $productRepository,
-        ProductInterface $product1,
-        ProductInterface $product2
-    ) {
-        $productRepository->findOneByIdentifier('40')->willReturn($product1);
-        $product1->getId()->willReturn(40);
-        $productRepository->findOneByIdentifier('33')->willReturn($product2);
-        $product2->getId()->willReturn(33);
-
+    function it_bulk_deletes_products_from_elasticsearch_index($productAndProductModelIndexClient)
+    {
         $productAndProductModelIndexClient->bulkDelete(ProductIndexer::INDEX_TYPE, ['product_40', 'product_33'])
             ->shouldBeCalled();
 
-        $this->removeManyFromProductIdentifiers([40, 33])->shouldReturn(null);
+        $this->removeManyFromProductIds([40, 33])->shouldReturn(null);
     }
 
     function it_indexes_products_from_identifiers_and_waits_for_index_refresh(

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
@@ -2,10 +2,12 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
 use Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Akeneo\Tool\Component\StorageUtils\Indexer\IndexerInterface;
+use Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface;
 use Akeneo\Tool\Component\StorageUtils\Remover\BulkRemoverInterface;
 use Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface;
 use PhpSpec\ObjectBehavior;
@@ -17,9 +19,16 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class ProductIndexerSpec extends ObjectBehavior
 {
-    function let(NormalizerInterface $normalizer, Client $productAndProductModelIndexClient)
-    {
-        $this->beConstructedWith($normalizer, $productAndProductModelIndexClient, 'an_index_type_for_test_purpose');
+    function let(
+        NormalizerInterface $normalizer,
+        Client $productAndProductModelIndexClient,
+        ProductRepositoryInterface $productRepository
+    )     {
+        $this->beConstructedWith(
+            $normalizer,
+            $productAndProductModelIndexClient,
+            $productRepository
+        );
     }
 
     function it_is_initializable()
@@ -31,6 +40,7 @@ class ProductIndexerSpec extends ObjectBehavior
     {
         $this->shouldImplement(IndexerInterface::class);
         $this->shouldImplement(BulkIndexerInterface::class);
+        $this->shouldImplement(ProductIndexerInterface::class);
     }
 
     function it_is_a_index_remover()
@@ -70,10 +80,46 @@ class ProductIndexerSpec extends ObjectBehavior
     {
         $normalizer->normalize($product, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(['id' => 'foobar', 'a key' => 'a value']);
-        $productAndProductModelIndexClient->index('an_index_type_for_test_purpose', 'foobar', ['id' => 'foobar', 'a key' => 'a value'])
+        $productAndProductModelIndexClient->index('', 'foobar', ['id' => 'foobar', 'a key' => 'a value'])
             ->shouldBeCalled();
 
         $this->index($product);
+    }
+
+    function it_indexes_a_single_product_from_identifier(
+        $normalizer,
+        $productAndProductModelIndexClient,
+        $productRepository,
+        ProductInterface $product
+    ) {
+        $identifier = 'foobar';
+        $productRepository->findOneByIdentifier($identifier)->willReturn($product);
+        $normalizer
+            ->normalize($product, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => $identifier, 'a key' => 'a value']);
+        $productAndProductModelIndexClient
+            ->index('', $identifier, ['id' => $identifier, 'a key' => 'a value'])
+            ->shouldBeCalled();
+
+        $this->indexFromProductIdentifier($identifier);
+    }
+
+    function it_does_not_index_anything_if_identifier_is_unknown(
+        $normalizer,
+        $productAndProductModelIndexClient,
+        $productRepository,
+        ProductInterface $product
+    ) {
+        $identifier = 'foobar';
+        $productRepository->findOneByIdentifier($identifier)->willReturn(null);
+        $normalizer
+            ->normalize(null, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->shouldNotBeCalled();
+        $productAndProductModelIndexClient
+            ->index('', $identifier, ['id' => $identifier, 'a key' => 'a value'])
+            ->shouldNotBeCalled();
+
+        $this->indexFromProductIdentifier($identifier);
     }
 
     function it_bulk_indexes_products(
@@ -87,12 +133,40 @@ class ProductIndexerSpec extends ObjectBehavior
         $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(['id' => 'bar', 'a key' => 'another value']);
 
-        $productAndProductModelIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
+        $productAndProductModelIndexClient->bulkIndexes('', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
         ], 'id', Refresh::disable())->shouldBeCalled();
 
         $this->indexAll([$product1, $product2]);
+    }
+
+    function it_bulk_indexes_products_from_identifiers(
+        $normalizer,
+        $productAndProductModelIndexClient,
+        $productRepository,
+        ProductInterface $product1,
+        ProductInterface $product2
+    ) {
+        $identifiers = ['foo', 'bar', 'unknown'];
+
+        $productRepository->findOneByIdentifier($identifiers[0])->willReturn($product1);
+        $productRepository->findOneByIdentifier($identifiers[1])->willReturn($product2);
+        $productRepository->findOneByIdentifier($identifiers[2])->willReturn(null);
+
+        $normalizer->normalize($product1, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => $identifiers[0], 'a key' => 'a value']);
+        $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => $identifiers[1], 'a key' => 'another value']);
+        $normalizer->normalize(null, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->shouldNotBeCalled();
+
+        $productAndProductModelIndexClient->bulkIndexes('', [
+            ['id' => $identifiers[0], 'a key' => 'a value'],
+            ['id' => $identifiers[1], 'a key' => 'another value'],
+        ], 'id', Refresh::disable())->shouldBeCalled();
+
+        $this->indexFromProductIdentifiers($identifiers);
     }
 
     function it_does_not_bulk_index_empty_arrays_of_products($normalizer, $productAndProductModelIndexClient)
@@ -103,18 +177,30 @@ class ProductIndexerSpec extends ObjectBehavior
         $this->indexAll([]);
     }
 
+    function it_does_not_bulk_index_empty_arrays_of_identifiers(
+        $normalizer,
+        $productAndProductModelIndexClient,
+        $productRepository
+    )     {
+        $productRepository->findOneByIdentifier(Argument::cetera())->shouldNotBeCalled();
+        $normalizer->normalize(Argument::cetera())->shouldNotBeCalled();
+        $productAndProductModelIndexClient->bulkIndexes(Argument::cetera())->shouldNotBeCalled();
+
+        $this->indexFromProductIdentifiers([]);
+    }
+
     function it_deletes_products_from_elasticsearch_index($productAndProductModelIndexClient)
     {
-        $productAndProductModelIndexClient->delete('an_index_type_for_test_purpose', 'product_40')->shouldBeCalled();
+        $productAndProductModelIndexClient->delete('', 'product_40')->shouldBeCalled();
 
-        $this->remove(40)->shouldReturn(null);
+        $this->removeFromProductIdentifier(40)->shouldReturn(null);
     }
 
     function it_bulk_deletes_products_from_elasticsearch_index($productAndProductModelIndexClient)
     {
-        $productAndProductModelIndexClient->bulkDelete('an_index_type_for_test_purpose', ['product_40', 'product_33'])->shouldBeCalled();
+        $productAndProductModelIndexClient->bulkDelete('', ['product_40', 'product_33'])->shouldBeCalled();
 
-        $this->removeAll([40, 33])->shouldReturn(null);
+        $this->removeManyFromProductIdentifiers([40, 33])->shouldReturn(null);
     }
 
     function it_indexes_products_and_waits_for_index_refresh(
@@ -128,12 +214,40 @@ class ProductIndexerSpec extends ObjectBehavior
         $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(['id' => 'bar', 'a key' => 'another value']);
 
-        $productAndProductModelIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
+        $productAndProductModelIndexClient->bulkIndexes('', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
         ], 'id', Refresh::waitFor())->shouldBeCalled();
 
         $this->indexAll([$product1, $product2], ['index_refresh' => Refresh::waitFor()]);
+    }
+
+    function it_indexes_products_from_identifiers_and_waits_for_index_refresh(
+        $normalizer,
+        $productAndProductModelIndexClient,
+        $productRepository,
+        ProductInterface $product1,
+        ProductInterface $product2
+    ) {
+        $identifiers = ['foo', 'bar', 'unknown'];
+
+        $productRepository->findOneByIdentifier($identifiers[0])->willReturn($product1);
+        $productRepository->findOneByIdentifier($identifiers[1])->willReturn($product2);
+        $productRepository->findOneByIdentifier($identifiers[2])->willReturn(null);
+
+        $normalizer->normalize($product1, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => $identifiers[0], 'a key' => 'a value']);
+        $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => $identifiers[1], 'a key' => 'another value']);
+        $normalizer->normalize(null, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->shouldNotBeCalled();
+
+        $productAndProductModelIndexClient->bulkIndexes('', [
+            ['id' => $identifiers[0], 'a key' => 'a value'],
+            ['id' => $identifiers[1], 'a key' => 'another value'],
+        ], 'id', Refresh::waitFor())->shouldBeCalled();
+
+        $this->indexFromProductIdentifiers($identifiers, ['index_refresh' => Refresh::waitFor()]);
     }
 
     function it_indexes_products_and_disables_index_refresh_by_default(
@@ -148,12 +262,40 @@ class ProductIndexerSpec extends ObjectBehavior
         $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(['id' => 'bar', 'a key' => 'another value']);
 
-        $productAndProductModelIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
+        $productAndProductModelIndexClient->bulkIndexes('', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
         ], 'id', Refresh::disable())->shouldBeCalled();
 
         $this->indexAll([$product1, $product2], ['index_refresh' => Refresh::disable()]);
+    }
+
+    function it_indexes_products_from_identifiers_and_disables_index_refresh_by_default(
+        $normalizer,
+        $productAndProductModelIndexClient,
+        $productRepository,
+        ProductInterface $product1,
+        ProductInterface $product2
+    ) {
+        $identifiers = ['foo', 'bar', 'unknown'];
+
+        $productRepository->findOneByIdentifier($identifiers[0])->willReturn($product1);
+        $productRepository->findOneByIdentifier($identifiers[1])->willReturn($product2);
+        $productRepository->findOneByIdentifier($identifiers[2])->willReturn(null);
+
+        $normalizer->normalize($product1, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => $identifiers[0], 'a key' => 'a value']);
+        $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => $identifiers[1], 'a key' => 'another value']);
+        $normalizer->normalize(null, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->shouldNotBeCalled();
+
+        $productAndProductModelIndexClient->bulkIndexes('', [
+            ['id' => $identifiers[0], 'a key' => 'a value'],
+            ['id' => $identifiers[1], 'a key' => 'another value'],
+        ], 'id', Refresh::disable())->shouldBeCalled();
+
+        $this->indexFromProductIdentifiers($identifiers, ['index_refresh' => Refresh::disable()]);
     }
 
     function it_indexes_products_and_enable_index_refresh_without_waiting_for_it(
@@ -167,11 +309,39 @@ class ProductIndexerSpec extends ObjectBehavior
         $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(['id' => 'bar', 'a key' => 'another value']);
 
-        $productAndProductModelIndexClient->bulkIndexes('an_index_type_for_test_purpose', [
+        $productAndProductModelIndexClient->bulkIndexes('', [
             ['id' => 'foo', 'a key' => 'a value'],
             ['id' => 'bar', 'a key' => 'another value'],
         ], 'id', Refresh::enable())->shouldBeCalled();
 
         $this->indexAll([$product1, $product2], ['index_refresh' => Refresh::enable()]);
+    }
+
+    function it_indexes_products_from_identifiers_and_enable_index_refresh_without_waiting_for_it(
+        $normalizer,
+        $productAndProductModelIndexClient,
+        $productRepository,
+        ProductInterface $product1,
+        ProductInterface $product2
+    ) {
+        $identifiers = ['foo', 'bar', 'unknown'];
+
+        $productRepository->findOneByIdentifier($identifiers[0])->willReturn($product1);
+        $productRepository->findOneByIdentifier($identifiers[1])->willReturn($product2);
+        $productRepository->findOneByIdentifier($identifiers[2])->willReturn(null);
+
+        $normalizer->normalize($product1, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => $identifiers[0], 'a key' => 'a value']);
+        $normalizer->normalize($product2, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->willReturn(['id' => $identifiers[1], 'a key' => 'another value']);
+        $normalizer->normalize(null, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
+            ->shouldNotBeCalled();
+
+        $productAndProductModelIndexClient->bulkIndexes('', [
+            ['id' => $identifiers[0], 'a key' => 'a value'],
+            ['id' => $identifiers[1], 'a key' => 'another value'],
+        ], 'id', Refresh::enable())->shouldBeCalled();
+
+        $this->indexFromProductIdentifiers($identifiers, ['index_refresh' => Refresh::enable()]);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
@@ -19,7 +19,7 @@ class ProductIndexerSpec extends ObjectBehavior
         NormalizerInterface $normalizer,
         Client $productAndProductModelIndexClient,
         ProductRepositoryInterface $productRepository
-    )     {
+    ) {
         $this->beConstructedWith(
             $normalizer,
             $productAndProductModelIndexClient,
@@ -48,9 +48,12 @@ class ProductIndexerSpec extends ObjectBehavior
         $normalizer
             ->normalize($product, ProductModelNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
             ->willReturn(['id' => $identifier, 'a key' => 'a value']);
-        $productAndProductModelIndexClient
-            ->index(ProductIndexer::INDEX_TYPE, $identifier, ['id' => $identifier, 'a key' => 'a value'])
-            ->shouldBeCalled();
+        $productAndProductModelIndexClient->bulkIndexes(
+            ProductIndexer::INDEX_TYPE,
+            [['id' => $identifier, 'a key' => 'a value']],
+            'id',
+            Refresh::disable()
+        )->shouldBeCalled();
 
         $this->indexFromProductIdentifier($identifier);
     }
@@ -125,7 +128,7 @@ class ProductIndexerSpec extends ObjectBehavior
         $productAndProductModelIndexClient->bulkDelete(ProductIndexer::INDEX_TYPE, ['product_40', 'product_33'])
             ->shouldBeCalled();
 
-        $this->removeManyFromProductIds([40, 33])->shouldReturn(null);
+        $this->removeFromProductIds([40, 33])->shouldReturn(null);
     }
 
     function it_indexes_products_from_identifiers_and_waits_for_index_refresh(

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexerSpec.php
@@ -293,10 +293,10 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productChildrenIterator->current()->willReturn($childProduct1, $childProduct2);
         $productChildrenIterator->rewind()->shouldBeCalled();
         $productChildrenIterator->next()->shouldBeCalled();
-        $childProduct1->getIdentifier()->willReturn('foo');
-        $childProduct2->getIdentifier()->willReturn('bar');
+        $childProduct1->getId()->willReturn(30);
+        $childProduct2->getId()->willReturn(40);
 
-        $productIndexer->removeManyFromProductIdentifiers(['foo', 'bar'])->shouldBeCalled();
+        $productIndexer->removeManyFromProductIds(['30', '40'])->shouldBeCalled();
 
         $productModel->getProductModels()->willReturn($productModelChildren);
         $productModelChildren->isEmpty()->willReturn(true);
@@ -361,10 +361,10 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productVariantsChildrenIterator->current()->willReturn($childVariantProduct1, $childVariantProduct2);
         $productVariantsChildrenIterator->rewind()->shouldBeCalled();
         $productVariantsChildrenIterator->next()->shouldBeCalled();
-        $childVariantProduct1->getIdentifier()->willReturn('foo');
-        $childVariantProduct2->getIdentifier()->willReturn('bar');
+        $childVariantProduct1->getId()->willReturn(30);
+        $childVariantProduct2->getId()->willReturn(40);
 
-        $productIndexer->removeManyFromProductIdentifiers(['foo', 'bar'])->shouldBeCalled();
+        $productIndexer->removeManyFromProductIds(['30', '40'])->shouldBeCalled();
 
         $this->remove($rootProductModel);
     }
@@ -393,9 +393,9 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productChildrenIterator1->current()->willReturn($childProduct1, $childProduct2);
         $productChildrenIterator1->rewind()->shouldBeCalled();
         $productChildrenIterator1->next()->shouldBeCalled();
-        $childProduct1->getIdentifier()->willReturn('foo');
-        $childProduct2->getIdentifier()->willReturn('bar');
-        $productIndexer->removeManyFromProductIdentifiers(['foo', 'bar'])->shouldBeCalled();
+        $childProduct1->getId()->willReturn(10);
+        $childProduct2->getId()->willReturn(20);
+        $productIndexer->removeManyFromProductIds(['10', '20'])->shouldBeCalled();
 
         $productModel1->getProductModels()->willReturn($productModelChildren1);
         $productModelChildren1->isEmpty()->willReturn(true);
@@ -409,9 +409,9 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productChildrenIterator2->current()->willReturn($childProduct3, $childProduct4);
         $productChildrenIterator2->rewind()->shouldBeCalled();
         $productChildrenIterator2->next()->shouldBeCalled();
-        $childProduct3->getIdentifier()->willReturn('pika');
-        $childProduct4->getIdentifier()->willReturn('chu');
-        $productIndexer->removeManyFromProductIdentifiers(['pika', 'chu'])->shouldBeCalled();
+        $childProduct3->getId()->willReturn(30);
+        $childProduct4->getId()->willReturn(40);
+        $productIndexer->removeManyFromProductIds(['30', '40'])->shouldBeCalled();
 
         $productModel2->getProductModels()->willReturn($productModelChildren2);
         $productModelChildren2->isEmpty()->willReturn(true);
@@ -426,7 +426,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         \stdClass $aWrongObject1,
         \stdClass $aWrongObject2
     ) {
-        $productIndexer->removeManyFromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
+        $productIndexer->removeManyFromProductIds(Argument::cetera())->shouldNotBeCalled();
         $productModelRemover->removeAll(Argument::cetera())->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)
@@ -437,7 +437,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productIndexer,
         $productModelRemover
     ) {
-        $productIndexer->removeManyFromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
+        $productIndexer->removeManyFromProductIds(Argument::cetera())->shouldNotBeCalled();
         $productModelRemover->removeAll(Argument::cetera())->shouldNotBeCalled();
 
         $this->removeAll([]);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexerSpec.php
@@ -4,6 +4,7 @@ namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
 use Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface;
 use Akeneo\Tool\Component\StorageUtils\Indexer\IndexerInterface;
+use Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface;
 use Akeneo\Tool\Component\StorageUtils\Remover\BulkRemoverInterface;
 use Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -16,12 +17,11 @@ use Prophecy\Argument;
 class ProductModelDescendantsIndexerSpec extends ObjectBehavior
 {
     function let(
-        BulkIndexerInterface $productIndexer,
-        BulkRemoverInterface $productRemover,
+        ProductIndexerInterface $productIndexer,
         BulkIndexerInterface $productModelIndexer,
         BulkRemoverInterface $productModelRemover
     ) {
-        $this->beConstructedWith($productIndexer, $productRemover,$productModelIndexer, $productModelRemover);
+        $this->beConstructedWith($productIndexer, $productModelIndexer, $productModelRemover);
     }
 
     function it_is_initializable()
@@ -46,15 +46,25 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productModelIndexer,
         ProductModelInterface $productModel,
         ArrayCollection $productChildren,
+        \ArrayIterator $productChildrenIterator,
         ArrayCollection $productModelChildren,
         ProductInterface $childProduct1,
         ProductInterface $childProduct2
     ) {
+        $childProduct1->getIdentifier()->willReturn('foo');
+        $childProduct2->getIdentifier()->willReturn('bar');
+
         $productModel->getProducts()->willReturn($productChildren);
         $productChildren->isEmpty()->willReturn(false);
         $productChildren->first()->willReturn($childProduct1);
-        $productChildren->toArray()->willReturn([$childProduct1, $childProduct2]);
-        $productIndexer->indexAll([$childProduct1, $childProduct2], [])->shouldBeCalled();
+
+        $productChildren->getIterator()->willReturn($productChildrenIterator);
+        $productChildrenIterator->valid()->willReturn(true, true, false);
+        $productChildrenIterator->current()->willReturn($childProduct1, $childProduct2);
+        $productChildrenIterator->rewind()->shouldBeCalled();
+        $productChildrenIterator->next()->shouldBeCalled();
+
+        $productIndexer->indexFromProductIdentifiers(['foo', 'bar'], [])->shouldBeCalled();
 
         $productModel->getProductModels()->willReturn($productModelChildren);
         $productModelChildren->isEmpty()->willReturn(true);
@@ -74,7 +84,8 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         ArrayCollection $rootProductModelChildren,
         ArrayCollection $emptyChildProductModelChildren,
         ArrayCollection $productVariantsChildren,
-        \ArrayIterator $rootProductModelChildrenIterator
+        \ArrayIterator $rootProductModelChildrenIterator,
+        \ArrayIterator $productVariantsChildrenIterator
     ) {
         // Starting first recursion
         $rootProductModel->getProducts()->willReturn($emptyProductsChildren);
@@ -113,7 +124,15 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productVariantsChildren->first()->willReturn($childVariantProduct1);
         $productVariantsChildren->toArray()->willReturn([$childVariantProduct1, $childVariantProduct2]);
 
-        $productIndexer->indexAll([$childVariantProduct1, $childVariantProduct2], [])->shouldBeCalled();
+        $productVariantsChildren->getIterator()->willReturn($productVariantsChildrenIterator);
+        $productVariantsChildrenIterator->valid()->willReturn(true, true, false);
+        $productVariantsChildrenIterator->current()->willReturn($childVariantProduct1, $childVariantProduct2);
+        $productVariantsChildrenIterator->rewind()->shouldBeCalled();
+        $productVariantsChildrenIterator->next()->shouldBeCalled();
+
+        $childVariantProduct1->getIdentifier()->willReturn('foo');
+        $childVariantProduct2->getIdentifier()->willReturn('bar');
+        $productIndexer->indexFromProductIdentifiers(['foo', 'bar'], [])->shouldBeCalled();
 
         $this->index($rootProductModel);
     }
@@ -123,7 +142,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productModelIndexer,
         \stdClass $aWrongObject
     ) {
-        $productIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();
+        $productIndexer->indexFromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
         $productModelIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)->during('index', [$aWrongObject]);
@@ -141,13 +160,23 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         ArrayCollection $productChildren1,
         ArrayCollection $productModelChildren1,
         ArrayCollection $productChildren2,
-        ArrayCollection $productModelChildren2
+        ArrayCollection $productModelChildren2,
+        \ArrayIterator $productChildrenIterator1,
+        \ArrayIterator $productChildrenIterator2
     ) {
         $productModel1->getProducts()->willReturn($productChildren1);
         $productChildren1->isEmpty()->willReturn(false);
         $productChildren1->first()->willReturn($childProduct1);
         $productChildren1->toArray()->willReturn([$childProduct1, $childProduct2]);
-        $productIndexer->indexAll([$childProduct1, $childProduct2], [])->shouldBeCalled();
+        $childProduct1->getIdentifier()->willReturn('foo');
+        $childProduct2->getIdentifier()->willReturn('bar');
+
+        $productChildren1->getIterator()->willReturn($productChildrenIterator1);
+        $productChildrenIterator1->valid()->willReturn(true, true, false);
+        $productChildrenIterator1->current()->willReturn($childProduct1, $childProduct2);
+        $productChildrenIterator1->rewind()->shouldBeCalled();
+        $productChildrenIterator1->next()->shouldBeCalled();
+        $productIndexer->indexFromProductIdentifiers(['foo', 'bar'], [])->shouldBeCalled();
 
         $productModel1->getProductModels()->willReturn($productModelChildren1);
         $productModelChildren1->isEmpty()->willReturn(true);
@@ -157,7 +186,14 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productChildren2->isEmpty()->willReturn(false);
         $productChildren2->first()->willReturn($childProduct3);
         $productChildren2->toArray()->willReturn([$childProduct3, $childProduct4]);
-        $productIndexer->indexAll([$childProduct3, $childProduct4], [])->shouldBeCalled();
+        $childProduct3->getIdentifier()->willReturn('pika');
+        $childProduct4->getIdentifier()->willReturn('chu');
+        $productChildren2->getIterator()->willReturn($productChildrenIterator2);
+        $productChildrenIterator2->valid()->willReturn(true, true, false);
+        $productChildrenIterator2->current()->willReturn($childProduct3, $childProduct4);
+        $productChildrenIterator2->rewind()->shouldBeCalled();
+        $productChildrenIterator2->next()->shouldBeCalled();
+        $productIndexer->indexFromProductIdentifiers(['pika', 'chu'], [])->shouldBeCalled();
 
         $productModel2->getProductModels()->willReturn($productModelChildren2);
         $productModelChildren2->isEmpty()->willReturn(true);
@@ -177,11 +213,21 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $children->first()->willReturn($productChild);
         $children->toArray()->willReturn([$productChild]);
         $children->getIterator()->willReturn($childrenIterator);
+        $childrenIterator->valid()->willReturn(true, false);
+        $childrenIterator->current()->willReturn($productChild);
+        $childrenIterator->rewind()->shouldBeCalled();
+        $childrenIterator->next()->shouldBeCalled();
 
         $productModel->getProductModels()->willReturn(new ArrayCollection());
         $productModel->getProducts()->willReturn($children);
 
-        $productIndexer->indexAll([$productChild], ['my_option_key' => 'my_option_value', 'my_option_key2' => 'my_option_value2'])->shouldBeCalled();
+        $productChild->getIdentifier()->willReturn('foo');
+        $productIndexer
+            ->indexFromProductIdentifiers(
+                ['foo'],
+                ['my_option_key' => 'my_option_value', 'my_option_key2' => 'my_option_value2']
+            )
+            ->shouldBeCalled();
 
         $this->index($productModel, ['my_option_key' => 'my_option_value', 'my_option_key2' => 'my_option_value2']);
     }
@@ -212,7 +258,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         \stdClass $aWrongObject1,
         \stdClass $aWrongObject2
     ) {
-        $productIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();
+        $productIndexer->indexFromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
         $productModelIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)
@@ -223,26 +269,34 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productIndexer,
         $productModelIndexer
     ) {
-        $productIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();
+        $productIndexer->indexFromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
         $productModelIndexer->indexAll(Argument::cetera())->shouldNotBeCalled();
 
         $this->indexAll([]);
     }
 
     function it_removes_the_descendants_of_a_product_model_that_are_variant_products(
-        $productRemover,
+        $productIndexer,
         $productModelRemover,
         ProductModelInterface $productModel,
         ArrayCollection $productChildren,
         ArrayCollection $productModelChildren,
         ProductInterface $childProduct1,
-        ProductInterface $childProduct2
+        ProductInterface $childProduct2,
+        \ArrayIterator $productChildrenIterator
     ) {
         $productModel->getProducts()->willReturn($productChildren);
         $productChildren->isEmpty()->willReturn(false);
         $productChildren->first()->willReturn($childProduct1);
-        $productChildren->toArray()->willReturn([$childProduct1, $childProduct2]);
-        $productRemover->removeAll([$childProduct1, $childProduct2])->shouldBeCalled();
+        $productChildren->getIterator()->willReturn($productChildrenIterator);
+        $productChildrenIterator->valid()->willReturn(true, true, false);
+        $productChildrenIterator->current()->willReturn($childProduct1, $childProduct2);
+        $productChildrenIterator->rewind()->shouldBeCalled();
+        $productChildrenIterator->next()->shouldBeCalled();
+        $childProduct1->getIdentifier()->willReturn('foo');
+        $childProduct2->getIdentifier()->willReturn('bar');
+
+        $productIndexer->removeManyFromProductIdentifiers(['foo', 'bar'])->shouldBeCalled();
 
         $productModel->getProductModels()->willReturn($productModelChildren);
         $productModelChildren->isEmpty()->willReturn(true);
@@ -252,7 +306,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
     }
 
     function it_removes_a_product_model_descendants_that_are_product_models_and_variant_products(
-        $productRemover,
+        $productIndexer,
         $productModelRemover,
         ProductModelInterface $rootProductModel,
         ProductModelInterface $childProductModel,
@@ -262,7 +316,8 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         ArrayCollection $rootProductModelChildren,
         ArrayCollection $emptyChildProductModelChildren,
         ArrayCollection $productVariantsChildren,
-        \ArrayIterator $rootProductModelChildrenIterator
+        \ArrayIterator $rootProductModelChildrenIterator,
+        \ArrayIterator $productVariantsChildrenIterator
     ) {
         // Starting first recursion
         $rootProductModel->getProducts()->willReturn($emptyProductsChildren);
@@ -301,13 +356,21 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productVariantsChildren->first()->willReturn($childVariantProduct1);
         $productVariantsChildren->toArray()->willReturn([$childVariantProduct1, $childVariantProduct2]);
 
-        $productRemover->removeAll([$childVariantProduct1, $childVariantProduct2])->shouldBeCalled();
+        $productVariantsChildren->getIterator()->willReturn($productVariantsChildrenIterator);
+        $productVariantsChildrenIterator->valid()->willReturn(true, true, false);
+        $productVariantsChildrenIterator->current()->willReturn($childVariantProduct1, $childVariantProduct2);
+        $productVariantsChildrenIterator->rewind()->shouldBeCalled();
+        $productVariantsChildrenIterator->next()->shouldBeCalled();
+        $childVariantProduct1->getIdentifier()->willReturn('foo');
+        $childVariantProduct2->getIdentifier()->willReturn('bar');
+
+        $productIndexer->removeManyFromProductIdentifiers(['foo', 'bar'])->shouldBeCalled();
 
         $this->remove($rootProductModel);
     }
 
     function it_bulk_removes_the_descendants_of_a_list_of_product_models(
-        $productRemover,
+        $productIndexer,
         $productModelRemover,
         ProductModelInterface $productModel1,
         ProductModelInterface $productModel2,
@@ -318,13 +381,21 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         ArrayCollection $productChildren1,
         ArrayCollection $productModelChildren1,
         ArrayCollection $productChildren2,
-        ArrayCollection $productModelChildren2
+        ArrayCollection $productModelChildren2,
+        \ArrayIterator $productChildrenIterator1,
+        \ArrayIterator $productChildrenIterator2
     ) {
         $productModel1->getProducts()->willReturn($productChildren1);
         $productChildren1->isEmpty()->willReturn(false);
         $productChildren1->first()->willReturn($childProduct1);
-        $productChildren1->toArray()->willReturn([$childProduct1, $childProduct2]);
-        $productRemover->removeAll([$childProduct1, $childProduct2])->shouldBeCalled();
+        $productChildren1->getIterator()->willReturn($productChildrenIterator1);
+        $productChildrenIterator1->valid()->willReturn(true, true, false);
+        $productChildrenIterator1->current()->willReturn($childProduct1, $childProduct2);
+        $productChildrenIterator1->rewind()->shouldBeCalled();
+        $productChildrenIterator1->next()->shouldBeCalled();
+        $childProduct1->getIdentifier()->willReturn('foo');
+        $childProduct2->getIdentifier()->willReturn('bar');
+        $productIndexer->removeManyFromProductIdentifiers(['foo', 'bar'])->shouldBeCalled();
 
         $productModel1->getProductModels()->willReturn($productModelChildren1);
         $productModelChildren1->isEmpty()->willReturn(true);
@@ -333,8 +404,14 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productModel2->getProducts()->willReturn($productChildren2);
         $productChildren2->isEmpty()->willReturn(false);
         $productChildren2->first()->willReturn($childProduct3);
-        $productChildren2->toArray()->willReturn([$childProduct3, $childProduct4]);
-        $productRemover->removeAll([$childProduct3, $childProduct4])->shouldBeCalled();
+        $productChildren2->getIterator()->willReturn($productChildrenIterator2);
+        $productChildrenIterator2->valid()->willReturn(true, true, false);
+        $productChildrenIterator2->current()->willReturn($childProduct3, $childProduct4);
+        $productChildrenIterator2->rewind()->shouldBeCalled();
+        $productChildrenIterator2->next()->shouldBeCalled();
+        $childProduct3->getIdentifier()->willReturn('pika');
+        $childProduct4->getIdentifier()->willReturn('chu');
+        $productIndexer->removeManyFromProductIdentifiers(['pika', 'chu'])->shouldBeCalled();
 
         $productModel2->getProductModels()->willReturn($productModelChildren2);
         $productModelChildren2->isEmpty()->willReturn(true);
@@ -344,12 +421,12 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
     }
 
     function it_does_not_bulk_remove_non_product_model_objects(
-        $productRemover,
+        $productIndexer,
         $productModelRemover,
         \stdClass $aWrongObject1,
         \stdClass $aWrongObject2
     ) {
-        $productRemover->removeAll(Argument::cetera())->shouldNotBeCalled();
+        $productIndexer->removeManyFromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
         $productModelRemover->removeAll(Argument::cetera())->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)
@@ -357,10 +434,10 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
     }
 
     function it_does_not_bulk_remove_empty_arrays_of_product_models(
-        $productRemover,
+        $productIndexer,
         $productModelRemover
     ) {
-        $productRemover->removeAll(Argument::cetera())->shouldNotBeCalled();
+        $productIndexer->removeManyFromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
         $productModelRemover->removeAll(Argument::cetera())->shouldNotBeCalled();
 
         $this->removeAll([]);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelDescendantsIndexerSpec.php
@@ -296,7 +296,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $childProduct1->getId()->willReturn(30);
         $childProduct2->getId()->willReturn(40);
 
-        $productIndexer->removeManyFromProductIds(['30', '40'])->shouldBeCalled();
+        $productIndexer->removeFromProductIds(['30', '40'])->shouldBeCalled();
 
         $productModel->getProductModels()->willReturn($productModelChildren);
         $productModelChildren->isEmpty()->willReturn(true);
@@ -364,7 +364,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $childVariantProduct1->getId()->willReturn(30);
         $childVariantProduct2->getId()->willReturn(40);
 
-        $productIndexer->removeManyFromProductIds(['30', '40'])->shouldBeCalled();
+        $productIndexer->removeFromProductIds(['30', '40'])->shouldBeCalled();
 
         $this->remove($rootProductModel);
     }
@@ -395,7 +395,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productChildrenIterator1->next()->shouldBeCalled();
         $childProduct1->getId()->willReturn(10);
         $childProduct2->getId()->willReturn(20);
-        $productIndexer->removeManyFromProductIds(['10', '20'])->shouldBeCalled();
+        $productIndexer->removeFromProductIds(['10', '20'])->shouldBeCalled();
 
         $productModel1->getProductModels()->willReturn($productModelChildren1);
         $productModelChildren1->isEmpty()->willReturn(true);
@@ -411,7 +411,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productChildrenIterator2->next()->shouldBeCalled();
         $childProduct3->getId()->willReturn(30);
         $childProduct4->getId()->willReturn(40);
-        $productIndexer->removeManyFromProductIds(['30', '40'])->shouldBeCalled();
+        $productIndexer->removeFromProductIds(['30', '40'])->shouldBeCalled();
 
         $productModel2->getProductModels()->willReturn($productModelChildren2);
         $productModelChildren2->isEmpty()->willReturn(true);
@@ -426,7 +426,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         \stdClass $aWrongObject1,
         \stdClass $aWrongObject2
     ) {
-        $productIndexer->removeManyFromProductIds(Argument::cetera())->shouldNotBeCalled();
+        $productIndexer->removeFromProductIds(Argument::cetera())->shouldNotBeCalled();
         $productModelRemover->removeAll(Argument::cetera())->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)
@@ -437,7 +437,7 @@ class ProductModelDescendantsIndexerSpec extends ObjectBehavior
         $productIndexer,
         $productModelRemover
     ) {
-        $productIndexer->removeManyFromProductIds(Argument::cetera())->shouldNotBeCalled();
+        $productIndexer->removeFromProductIds(Argument::cetera())->shouldNotBeCalled();
         $productModelRemover->removeAll(Argument::cetera())->shouldNotBeCalled();
 
         $this->removeAll([]);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductModelsSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductModelsSubscriberSpec.php
@@ -30,7 +30,7 @@ class IndexProductModelsSubscriberSpec extends ObjectBehavior
         $this->getSubscribedEvents()->shouldReturn([
             StorageEvents::POST_SAVE => 'indexProductModel',
             StorageEvents::POST_SAVE_ALL => 'bulkIndexProductModels',
-            StorageEvents::PRE_REMOVE => 'deleteProductModel',
+            StorageEvents::POST_REMOVE => 'deleteProductModel',
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductsSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductsSubscriberSpec.php
@@ -3,9 +3,7 @@
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\EventSubscriber;
 
 use Akeneo\Tool\Component\StorageUtils\Event\RemoveEvent;
-use Akeneo\Tool\Component\StorageUtils\Indexer\BulkIndexerInterface;
-use Akeneo\Tool\Component\StorageUtils\Indexer\IndexerInterface;
-use Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface;
+use Akeneo\Tool\Component\StorageUtils\Indexer\ProductIndexerInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\IndexProductsSubscriber;
@@ -15,9 +13,9 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 
 class IndexProductsSubscriberSpec extends ObjectBehavior
 {
-    function let(IndexerInterface $indexer, BulkIndexerInterface $bulkIndexer, RemoverInterface $remover)
+    function let(ProductIndexerInterface $indexer)
     {
-        $this->beConstructedWith($indexer, $bulkIndexer, $remover);
+        $this->beConstructedWith($indexer);
     }
 
     function it_is_initializable()
@@ -42,13 +40,13 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
 
         $product->getIdentifier()->willReturn('identifier');
 
-        $indexer->index($product)->shouldBeCalled();
+        $indexer->indexFromProductIdentifier('identifier')->shouldBeCalled();
 
         $this->indexProduct($event);
     }
 
     function it_bulk_indexes_products(
-        $bulkIndexer,
+        $indexer,
         GenericEvent $event,
         ProductInterface $product1,
         ProductInterface $product2
@@ -58,17 +56,17 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
         $product1->getIdentifier()->willReturn('identifier1');
         $product2->getIdentifier()->willReturn('identifier2');
 
-        $bulkIndexer->indexAll([$product1, $product2])->shouldBeCalled();
+        $indexer->indexFromProductIdentifiers(['identifier1', 'identifier2'])->shouldBeCalled();
 
         $this->bulkIndexProducts($event);
     }
 
-    function it_delete_product_from_elasticsearch_index($remover, RemoveEvent $event, ProductInterface $product)
+    function it_delete_product_from_elasticsearch_index($indexer, RemoveEvent $event, ProductInterface $product)
     {
-        $event->getSubjectId()->willReturn(40);
         $event->getSubject()->willReturn($product);
+        $product->getIdentifier()->willReturn('40');
 
-        $remover->remove(40)->shouldBeCalled();
+        $indexer->removeFromProductIdentifier('40')->shouldBeCalled();
 
         $this->deleteProduct($event)->shouldReturn(null);
     }
@@ -82,7 +80,7 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
         $event->hasArgument('unitary')->willReturn(true);
         $event->getArgument('unitary')->willReturn(false);
 
-        $indexer->index(Argument::any())->shouldNotBeCalled();
+        $indexer->indexFromProductIdentifier(Argument::any())->shouldNotBeCalled();
 
         $this->indexProduct($event);
     }
@@ -95,7 +93,7 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
         $event->getSubject()->willReturn($product);
         $event->hasArgument('unitary')->willReturn(false);
 
-        $indexer->index(Argument::any())->shouldNotBeCalled();
+        $indexer->indexFromProductIdentifier(Argument::any())->shouldNotBeCalled();
 
         $this->indexProduct($event);
     }
@@ -103,37 +101,37 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
     function it_does_not_index_a_non_product_entity($indexer, GenericEvent $event, \stdClass $subject)
     {
         $event->getSubject()->willReturn($subject);
-        $indexer->index(Argument::cetera())->shouldNotBeCalled();
+        $indexer->indexFromProductIdentifier(Argument::cetera())->shouldNotBeCalled();
 
         $this->indexProduct($event);
     }
 
     function it_does_not_bulk_index_non_product_entities(
-        $bulkIndexer,
+        $indexer,
         GenericEvent $event,
         \stdClass $subject1
     ) {
         $event->getSubject()->willReturn([$subject1]);
 
-        $bulkIndexer->indexAll(Argument::any())->shouldNotBeCalled();
+        $indexer->indexFromProductIdentifiers(Argument::any())->shouldNotBeCalled();
 
         $this->bulkIndexProducts($event);
     }
 
-    function it_does_not_bulk_index_non_collections($bulkIndexer, GenericEvent $event, \stdClass $subject1)
+    function it_does_not_bulk_index_non_collections($indexer, GenericEvent $event, \stdClass $subject1)
     {
         $event->getSubject()->willReturn($subject1);
 
-        $bulkIndexer->indexAll(Argument::any())->shouldNotBeCalled();
+        $indexer->indexFromProductIdentifiers(Argument::any())->shouldNotBeCalled();
 
         $this->bulkIndexProducts($event);
     }
 
-    function it_does_not_delete_non_product_entity_from_elasticsearch($remover, RemoveEvent $event, \stdClass $subject)
+    function it_does_not_delete_non_product_entity_from_elasticsearch($indexer, RemoveEvent $event, \stdClass $subject)
     {
         $event->getSubject()->willReturn($subject);
 
-        $remover->remove(40)->shouldNotBeCalled();
+        $indexer->removeFromProductIdentifier(40)->shouldNotBeCalled();
 
         $this->deleteProduct($event)->shouldReturn(null);
     }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductsSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductsSubscriberSpec.php
@@ -64,9 +64,9 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
     function it_delete_product_from_elasticsearch_index($indexer, RemoveEvent $event, ProductInterface $product)
     {
         $event->getSubject()->willReturn($product);
-        $product->getIdentifier()->willReturn('40');
+        $product->getId()->willReturn(40);
 
-        $indexer->removeFromProductIdentifier('40')->shouldBeCalled();
+        $indexer->removeFromProductId('40')->shouldBeCalled();
 
         $this->deleteProduct($event)->shouldReturn(null);
     }
@@ -126,7 +126,7 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
 
     function it_does_not_delete_non_product_entity_from_elasticsearch($indexer)
     {
-        $indexer->removeFromProductIdentifier(40)->shouldNotBeCalled();
+        $indexer->removeFromProductId(Argument::any())->shouldNotBeCalled();
 
         $this->deleteProduct(new RemoveEvent(new \stdClass(), 40))->shouldReturn(null);
     }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductsSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductsSubscriberSpec.php
@@ -98,12 +98,11 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
         $this->indexProduct($event);
     }
 
-    function it_does_not_index_a_non_product_entity($indexer, GenericEvent $event, \stdClass $subject)
+    function it_does_not_index_a_non_product_entity($indexer)
     {
-        $event->getSubject()->willReturn($subject);
         $indexer->indexFromProductIdentifier(Argument::cetera())->shouldNotBeCalled();
 
-        $this->indexProduct($event);
+        $this->indexProduct(new GenericEvent(new \stdClass()));
     }
 
     function it_does_not_bulk_index_non_product_entities(
@@ -118,21 +117,17 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
         $this->bulkIndexProducts($event);
     }
 
-    function it_does_not_bulk_index_non_collections($indexer, GenericEvent $event, \stdClass $subject1)
+    function it_does_not_bulk_index_non_collections($indexer)
     {
-        $event->getSubject()->willReturn($subject1);
-
         $indexer->indexFromProductIdentifiers(Argument::any())->shouldNotBeCalled();
 
-        $this->bulkIndexProducts($event);
+        $this->bulkIndexProducts(new GenericEvent(new \stdClass()));
     }
 
-    function it_does_not_delete_non_product_entity_from_elasticsearch($indexer, RemoveEvent $event, \stdClass $subject)
+    function it_does_not_delete_non_product_entity_from_elasticsearch($indexer)
     {
-        $event->getSubject()->willReturn($subject);
-
         $indexer->removeFromProductIdentifier(40)->shouldNotBeCalled();
 
-        $this->deleteProduct($event)->shouldReturn(null);
+        $this->deleteProduct(new RemoveEvent(new \stdClass(), 40))->shouldReturn(null);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductsSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductsSubscriberSpec.php
@@ -64,7 +64,7 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
     function it_delete_product_from_elasticsearch_index($indexer, RemoveEvent $event, ProductInterface $product)
     {
         $event->getSubject()->willReturn($product);
-        $product->getId()->willReturn(40);
+        $event->getSubjectId()->willReturn('40');
 
         $indexer->removeFromProductId('40')->shouldBeCalled();
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductsSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/IndexProductsSubscriberSpec.php
@@ -28,7 +28,7 @@ class IndexProductsSubscriberSpec extends ObjectBehavior
         $this->getSubscribedEvents()->shouldReturn([
             StorageEvents::POST_SAVE     => ['indexProduct', 300],
             StorageEvents::POST_SAVE_ALL => ['bulkIndexProducts', 300],
-            StorageEvents::PRE_REMOVE    => ['deleteProduct', 300],
+            StorageEvents::POST_REMOVE   => ['deleteProduct', 300],
         ]);
     }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

https://akeneo.atlassian.net/browse/TIP-1220  

Remove old interfaces from `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexer` and replace them by a single one new interface `ProductIndexerInterface`.  Public methods modification:

| Old methods | New methods
| --------------------------------- | ---
| index($object, ..) | indexFromProductIdentifier(string $productIdentifier, ..)
| indexAll($objects, ..) | indexFromProductIdentifiers(array $productIdentifiers, ..)
| remove($objectId, ..) | removeFromProductId(string $productId, ..)
| removeAll($objects, ..) | removeFromProductIds(array $productIds, ..)

Change and adapt in entire application and tests.  
Inject the ProductRepository in order to fetch and normalize product. This is a temporary solution, it will be replaced by a specific model (TIP-1222).  
Remove the injection of `indexType` in `ProductIndexer` as it is not used anymore.  
Please note that `ProductModelIndexer` will have the same modification in another card/PR  
Remove ES index is now done in `POST_REMOVE` instead of `PRE_REMOVE`. We don't really know why it was in PRE, but it seems the good way to do it after the DB transaction.  


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
