### PR TITLE
Fix integer as codes for required attributes masks

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Family/Sql/SqlGetRequiredAttributesMasks.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Family/Sql/SqlGetRequiredAttributesMasks.php
@@ -98,15 +98,15 @@ SQL;
         $masksPerFamily = [];
         foreach ($rows as $masksPerChannelAndLocale) {
             $masksPerFamily[$masksPerChannelAndLocale['family_code']][] = new RequiredAttributesMaskForChannelAndLocale(
-                $masksPerChannelAndLocale['channel_code'],
-                $masksPerChannelAndLocale['locale_code'],
+                (string) $masksPerChannelAndLocale['channel_code'],
+                (string) $masksPerChannelAndLocale['locale_code'],
                 json_decode($masksPerChannelAndLocale['mask'], true)
             );
         }
 
         $result = [];
         foreach ($masksPerFamily as $familyCode => $masksPerChannelAndLocale) {
-            $result[$familyCode] = new RequiredAttributesMask($familyCode, $masksPerChannelAndLocale);
+            $result[$familyCode] = new RequiredAttributesMask((string) $familyCode, $masksPerChannelAndLocale);
         }
 
         return $result;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR fixes a problem where an integer couldn't be used as the code for `RequiredAttributesMaskForChannelAndLocale` and `RequiredAttributesMask`. This fixes the data generation step on the EE CI for performance tests. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
