### PR TITLE
PIM-6978: Do not refresh datagrid on firstload

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8978: Fix the double loading of the product grid after login
+
 # 3.0.39 (2019-08-28)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/product_scope-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/product_scope-filter.js
@@ -84,7 +84,7 @@ define(
                 var scope = DatagridState.get('product-grid', 'scope');
                 if (!scope) {
                     scope = this.catalogScope;
-                    this.setValue({value: scope});
+                    this.setValueSilent({value: scope});
                 }
 
                 UserContext.set('catalogScope', scope);
@@ -92,6 +92,17 @@ define(
                 this.selectWidget.multiselect('refresh');
 
                 this.render();
+            },
+
+            /**
+             * Updates the current scope without refreshing the datagrid
+             */
+            setValueSilent: function(value) {
+                if (this._isNewValueUpdated(value)) {
+                    this.value = app.deepClone(value);
+                    this._updateDOMValue();
+                }
+                return this;
             },
 
             /**

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/product_scope-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/product_scope-filter.js
@@ -18,6 +18,7 @@ define(
         'oro/datafilter/select-filter',
         'pim/user-context',
         'pim/datagrid/state',
+        'oro/app',
         'pim/template/datagrid/filter/scope-filter'
     ],
     function (
@@ -27,6 +28,7 @@ define(
         SelectFilter,
         UserContext,
         DatagridState,
+        app,
         template
     ) {
         'use strict';


### PR DESCRIPTION
On the first loading of the product grid, the grid is loaded 2 times. Why ?
- It loads the datagrid with the default parameters
- When the datagrid is loaded, every filter call "datagrid_filters:rendered".
- The scope filter check that its value is filled, and if not, set the user catalog scope, which is already the scope used in the first step, so changed nothing.

The chosen solution is to keep the current behavior but do not ask for a datagrid refresh (i.e. send an event "onValueUpdated").


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | y
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
