### PR TITLE
PIM-7127: Hide version from CSS call

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Improvement
+
+- PIM-7127: Hide version from CSS call
+
 # 2.3.59 (2019-08-12)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/VersionStrategy/CacheBusterVersionStrategy.php
+++ b/src/Pim/Bundle/EnrichBundle/VersionStrategy/CacheBusterVersionStrategy.php
@@ -31,10 +31,10 @@ class CacheBusterVersionStrategy implements VersionStrategyInterface
      */
     public function applyVersion($path)
     {
-        $versioned = sprintf('%s?%s', ltrim($path, DIRECTORY_SEPARATOR), $this->getVersion($path));
+        $versioned = sprintf('%s?%s', ltrim($path, DIRECTORY_SEPARATOR), md5($this->getVersion($path)));
 
         if ($path && DIRECTORY_SEPARATOR == $path[0]) {
-            return DIRECTORY_SEPARATOR.$versioned;
+            return DIRECTORY_SEPARATOR . $versioned;
         }
 
         return $versioned;

--- a/src/Pim/Bundle/EnrichBundle/spec/VersionStrategy/CacheBusterVersionStrategySpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/VersionStrategy/CacheBusterVersionStrategySpec.php
@@ -2,15 +2,13 @@
 
 namespace spec\Pim\Bundle\EnrichBundle\VersionStrategy;
 
-use Pim\Bundle\EnrichBundle\VersionStrategy\CacheBusterVersionStrategy;
-use Pim\Bundle\CatalogBundle\VersionProviderInterface;
-use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
+use Pim\Bundle\CatalogBundle\VersionProviderInterface;
 
 class CacheBusterVersionStrategySpec extends ObjectBehavior
 {
-    public function let(VersionProviderInterface $versionProvider) {
+    public function let(VersionProviderInterface $versionProvider)
+    {
         $this->beConstructedWith($versionProvider);
     }
 
@@ -29,14 +27,16 @@ class CacheBusterVersionStrategySpec extends ObjectBehavior
     public function it_returns_the_versioned_asset_path($versionProvider)
     {
         $versionProvider->getPatch()->willReturn('2.0.2');
+        $hash = md5('2.0.2');
 
-        $this->applyVersion('css/pim.css')->shouldReturn('css/pim.css?2.0.2');
+        $this->applyVersion('css/pim.css')->shouldReturn('css/pim.css?' . $hash);
     }
 
     public function it_returns_the_versioned_asset_path_with_leading_slash($versionProvider)
     {
         $versionProvider->getPatch()->willReturn('1.7.8');
+        $hash = md5('1.7.8');
 
-        $this->applyVersion('/js/main.dist.js')->shouldReturn('/js/main.dist.js?1.7.8');
+        $this->applyVersion('/js/main.dist.js')->shouldReturn('/js/main.dist.js?' . $hash);
     }
 }


### PR DESCRIPTION
Hide the PIM version from the dev console when requesting CSS files

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
