### PR TITLE
Display "product_link_rules" job into the Activity Tracker

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/EventListener/AddUsernameToGridListener.php
+++ b/src/Oro/Bundle/PimDataGridBundle/EventListener/AddUsernameToGridListener.php
@@ -34,6 +34,11 @@ class AddUsernameToGridListener
         $dataSource->setParameters($parameters);
 
         $qb = $dataSource->getQueryBuilder();
-        $qb->andWhere($qb->expr()->eq('e.user', ':user'));
+        $qb->andWhere(
+            $qb->expr()->orX(
+                $qb->expr()->eq('e.user', ':user'),
+                $qb->expr()->eq('e.jobInstance', '') // put the job instance related to link product rules
+            )
+        );
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This card aims to display the job "product_link_rules" into the Activity Tracker.

Note: 
- Only jobs owned by the current user are displayed cf `\Oro\Bundle\PimDataGridBundle\EventListener\AddUsernameToGridListener`
- Some config hardcoded jobs are excluded from the grid cf `\Oro\Bundle\PimDataGridBundle\EventListener\BlackListJobsFromGridListener`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
