### PR TITLE
PIM-8677: Purge all job executions

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes:
 
 - PIM-8719: Fix Mink Selenium dependency
+- PIM-8677: Purge all job executions
 
 # 3.2.7 (2019-08-27)
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Command/PurgeJobExecutionCommand.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Command/PurgeJobExecutionCommand.php
@@ -7,6 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * Purge Jobs Execution history
@@ -45,13 +46,22 @@ class PurgeJobExecutionCommand extends ContainerAwareCommand
         $days = $input->getOption('days');
         if (!(is_numeric($days) && $days >= 0)) {
             $output->writeln(
-                sprintf('<error>Option --days must be a number greater than or equal to 0, "%s" given.</error>', $input->getOption('days'))
+                sprintf(
+                    '<error>Option --days must be a number greater than or equal to 0, "%s" given.</error>',
+                    $input->getOption('days')
+                )
             );
 
             return;
         }
 
         if (0 === (int) $days) {
+            $helper = $this->getHelper('question');
+            $confirmation = new ConfirmationQuestion('This will delete ALL job executions. Do you confirm? ', false);
+            if (!$helper->ask($input, $output, $confirmation)) {
+                $output->write("Operation aborted\n");
+                return;
+            }
             $this->purgeJobExecution()->all();
             $output->write("All jobs execution deleted ...\n");
         } else {
@@ -62,6 +72,6 @@ class PurgeJobExecutionCommand extends ContainerAwareCommand
 
     private function purgeJobExecution(): PurgeJobExecution
     {
-        return  $this->getContainer()->get('akeneo.platform.import_export.purge_job_execution');
+        return $this->getContainer()->get('akeneo.platform.import_export.purge_job_execution');
     }
 }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Command/PurgeJobExecutionCommand.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Command/PurgeJobExecutionCommand.php
@@ -43,16 +43,21 @@ class PurgeJobExecutionCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $days = $input->getOption('days');
-        if (!(is_numeric($days) && $days > 0)) {
+        if (!(is_numeric($days) && $days >= 0)) {
             $output->writeln(
-                sprintf('<error>Option --days must be a number strictly superior to 0, "%s" given.</error>', $input->getOption('days'))
+                sprintf('<error>Option --days must be a number greater than or equal to 0, "%s" given.</error>', $input->getOption('days'))
             );
 
             return;
         }
 
-        $numberOfDeletedJobExecutions = $this->purgeJobExecution()->olderThanDays($days);
-        $output->write(sprintf("%s jobs execution deleted ...\n", $numberOfDeletedJobExecutions));
+        if (0 === (int) $days) {
+            $this->purgeJobExecution()->all();
+            $output->write("All jobs execution deleted ...\n");
+        } else {
+            $numberOfDeletedJobExecutions = $this->purgeJobExecution()->olderThanDays($days);
+            $output->write(sprintf("%s jobs execution deleted ...\n", $numberOfDeletedJobExecutions));
+        }
     }
 
     private function purgeJobExecution(): PurgeJobExecution

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Purge/PurgeJobExecution.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Purge/PurgeJobExecution.php
@@ -41,4 +41,11 @@ final class PurgeJobExecution
 
         return $numberOfDeletedJobExecutions;
     }
+
+    public function all(): void
+    {
+        $this->deleteJobExecution->all();
+        $this->deleteOrphanJobExecutionMessages->execute();
+        $this->deleteOrphansJobExecutionDirectories->execute();
+    }
 }

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Persistence/Sql/DeleteJobExecution.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Persistence/Sql/DeleteJobExecution.php
@@ -59,4 +59,10 @@ SQL;
 
         return $numberDeletedJobExecution;
     }
+
+    public function all(): void
+    {
+        $query = 'DELETE FROM akeneo_batch_job_execution';
+        $this->connection->executeUpdate($query);
+    }
 }

--- a/tests/back/Tool/Integration/Batch/Persistence/Sql/DeleteJobExecutionIntegration.php
+++ b/tests/back/Tool/Integration/Batch/Persistence/Sql/DeleteJobExecutionIntegration.php
@@ -31,6 +31,23 @@ class DeleteJobExecutionIntegration extends TestCase
 
     }
 
+    public function test_that_it_deletes_all_jobs()
+    {
+        $this->launchJob();
+        $this->launchJob();
+        $numberOfJobs = (int) $this->getConnection()->executeQuery('SELECT COUNT(*) as number_of_jobs FROM akeneo_batch_job_execution')->fetch()['number_of_jobs'];
+        Assert::assertSame(2, $numberOfJobs);
+
+        $this->getConnection()->executeUpdate('UPDATE akeneo_batch_job_execution SET create_time = Date_ADD(end_time, INTERVAL -10 day)');
+
+        $deleteJobExecution = $this->getDeleteQuery();
+        $deleteJobExecution->all();
+
+        $numberOfJobs = (int) $this->getConnection()->executeQuery('SELECT COUNT(*) as number_of_jobs FROM akeneo_batch_job_execution')->fetch()['number_of_jobs'];
+        Assert::assertSame(0, $numberOfJobs);
+
+    }
+
     private function getDeleteQuery(): DeleteJobExecution
     {
         return $this->get('akeneo_batch.delete_job_execution');


### PR DESCRIPTION
Re-enable the 0 day purge for job executions.

The purge command was modified in #10485 but there is a use case for a 0 days purge.
It's more about tooling than daily use because it is used to clean the tracker and boards after an installation with job fixtures.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
