### PR TITLE
PIM-8712: Fix folder prefix for temporary files

### DIFF
--- a/.circleci/local-object-storage-setup.sh
+++ b/.circleci/local-object-storage-setup.sh
@@ -34,6 +34,10 @@ oneup_flysystem:
             awss3v3:
                 client: acme.s3_client
                 bucket: archive
+        tmp_storage_adapter:
+            awss3v3:
+                client: acme.s3_client
+                bucket: tmpstorage
 
 OBJECT_STORAGE_CONF
 

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-8712: Fix folder prefix for temporary files
+
 # 3.2.7 (2019-08-27)
 
 ## Bug fixes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
 
   object-storage:
     image: 'minio/minio'
-    entrypoint: '/bin/sh -c "mkdir -p /data/archive /data/catalog/ /data/jobs && minio server /data"'
+    entrypoint: '/bin/sh -c "mkdir -p /data/archive /data/catalog /data/jobs /data/tmpstorage && minio server /data"'
     environment:
       MINIO_ACCESS_KEY: 'AKENEO_OBJECT_STORAGE_ACCESS_KEY'
       MINIO_SECRET_KEY: 'AKENEO_OBJECT_STORAGE_SECRET_KEY'

--- a/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/file_storage.yml
+++ b/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/file_storage.yml
@@ -19,6 +19,7 @@ services:
         class: '%akeneo_file_storage.file_storage.file.file_fetcher.class%'
         arguments:
             - '@oneup_flysystem.tmp_storage_filesystem'
+            - '%tmp_storage_dir%'
 
     akeneo_file_storage.file_storage.file.output_file_fetcher:
         class: '%akeneo_file_storage.file_storage.file.output_file_fetcher.class%'

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
@@ -41,7 +41,8 @@ class FileFetcher implements FileFetcherInterface
             );
         }
 
-        $prefix = $options['prefix'] ?? '/tmp/pim';
+        // Use the env variable 'tmp_storage_dir' instead
+        $prefix = $options['prefix'] ?? '/tmp/pim/file_storage';
         $localPathname = $prefix . $fileKey;
 
         if (!is_dir(dirname($localPathname))) {

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
@@ -41,19 +41,21 @@ class FileFetcher implements FileFetcherInterface
             );
         }
 
+        // Do we need this?
         if (!$this->tmpFilesystem->has(dirname($fileKey))) {
             $this->tmpFilesystem->createDir(dirname($fileKey));
         }
 
         // TODO: we should not get the path prefix like that
         // TODO: it should be injected in the constructor
-        $localPathname = $this->tmpFilesystem->getAdapter()->getPathPrefix() . $fileKey;
+        $prefix = $options['prefix'] ?? $this->tmpFilesystem->getAdapter()->getPathPrefix();
+        $localPathname = $prefix . $fileKey;
 
         if (!is_dir(dirname($localPathname))) {
             mkdir(dirname($localPathname), 0777, true);
         }
 
-        // Should tmpFilesystem putStream be used instead?
+        // Use putStream of tmpFileSystem? 
         if (false === file_put_contents($localPathname, $stream)) {
             throw new FileTransferException(
                 sprintf('Unable to put the file "%s" from the filesystem.', $localPathname)

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
@@ -19,9 +19,19 @@ class FileFetcher implements FileFetcherInterface
     /** @var Filesystem */
     protected $tmpFilesystem;
 
-    public function __construct(Filesystem $tmpFilesystem)
+    /** @var string */
+    private $tmpStorageDir;
+
+    /*
+     * TODO: remove null for $tmpStorageDir
+     */
+    public function __construct(Filesystem $tmpFilesystem, string $tmpStorageDir = null)
     {
         $this->tmpFilesystem = $tmpFilesystem;
+        $this->tmpStorageDir = $tmpStorageDir;
+        if (null === $tmpStorageDir) {
+            $this->tmpStorageDir = $this->tmpFilesystem->getAdapter()->getPathPrefix();
+        }
     }
 
     /**
@@ -39,8 +49,7 @@ class FileFetcher implements FileFetcherInterface
             );
         }
 
-        // Use the env variable 'tmp_storage_dir' instead
-        $prefix = $options['prefix'] ?? $this->tmpFilesystem->getAdapter()->getPathPrefix();
+        $prefix = $options['prefix'] ?? $this->tmpStorageDir;
         $localPathname = rtrim($prefix, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $fileKey;
 
         if (!is_dir(dirname($localPathname))) {

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
@@ -49,9 +49,9 @@ class FileFetcher implements FileFetcherInterface
         // TODO: it should be injected in the constructor
         $localPathname = $this->tmpFilesystem->getAdapter()->getPathPrefix() . $fileKey;
 
-        if (false === file_put_contents($localPathname, $stream)) {
+        if (false === $this->tmpFilesystem->putStream($localPathname, $stream)) {
             throw new FileTransferException(
-                sprintf('Unable to fetch the file "%s" from the filesystem.', $fileKey)
+                sprintf('Unable to put the file "%s" from the filesystem.', $fileKey)
             );
         }
 

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
@@ -55,7 +55,7 @@ class FileFetcher implements FileFetcherInterface
             mkdir(dirname($localPathname), 0777, true);
         }
 
-        // Use putStream of tmpFileSystem? 
+        // Use putStream of tmpFileSystem?
         if (false === file_put_contents($localPathname, $stream)) {
             throw new FileTransferException(
                 sprintf('Unable to put the file "%s" from the filesystem.', $localPathname)

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
@@ -41,21 +41,13 @@ class FileFetcher implements FileFetcherInterface
             );
         }
 
-        // Do we need this?
-        if (!$this->tmpFilesystem->has(dirname($fileKey))) {
-            $this->tmpFilesystem->createDir(dirname($fileKey));
-        }
-
-        // TODO: we should not get the path prefix like that
-        // TODO: it should be injected in the constructor
-        $prefix = $options['prefix'] ?? $this->tmpFilesystem->getAdapter()->getPathPrefix();
+        $prefix = $options['prefix'] ?? '/tmp/pim';
         $localPathname = $prefix . $fileKey;
 
         if (!is_dir(dirname($localPathname))) {
             mkdir(dirname($localPathname), 0777, true);
         }
 
-        // Use putStream of tmpFileSystem?
         if (false === file_put_contents($localPathname, $stream)) {
             throw new FileTransferException(
                 sprintf('Unable to put the file "%s" from the filesystem.', $localPathname)

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
@@ -43,8 +43,8 @@ class FileFetcher implements FileFetcherInterface
         $prefix = $options['prefix'] ?? $this->tmpFilesystem->getAdapter()->getPathPrefix();
         $localPathname = rtrim($prefix, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $fileKey;
 
-        if (!$this->tmpFilesystem->has(dirname($localPathname))) {
-            $this->tmpFilesystem->createDir(dirname($localPathname));
+        if (!is_dir(dirname($localPathname))) {
+            mkdir(dirname($localPathname), 0777, true);
         }
 
         if (false === file_put_contents($localPathname, $stream)) {

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
@@ -49,9 +49,14 @@ class FileFetcher implements FileFetcherInterface
         // TODO: it should be injected in the constructor
         $localPathname = $this->tmpFilesystem->getAdapter()->getPathPrefix() . $fileKey;
 
-        if (false === $this->tmpFilesystem->putStream($localPathname, $stream)) {
+        if (!is_dir(dirname($localPathname))) {
+            mkdir(dirname($localPathname), 0777, true);
+        }
+
+        // Should tmpFilesystem putStream be used instead?
+        if (false === file_put_contents($localPathname, $stream)) {
             throw new FileTransferException(
-                sprintf('Unable to put the file "%s" from the filesystem.', $fileKey)
+                sprintf('Unable to put the file "%s" from the filesystem.', $localPathname)
             );
         }
 

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileStorer.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileStorer.php
@@ -50,7 +50,7 @@ class FileStorer implements FileStorerInterface
     /**
      * {@inheritdoc}
      */
-    public function store(\SplFileInfo $localFile, $destFsAlias, $deleteRawFile = false)
+    public function store(\SplFileInfo $localFile, $destFsAlias, $deleteRawFile = false, string $prefix = '')
     {
         if (!is_file($localFile->getPathname())) {
             throw new InvalidFile(sprintf('The file "%s" does not exist.', $localFile->getPathname()));
@@ -80,7 +80,7 @@ class FileStorer implements FileStorerInterface
                 $options['ContentType'] = $mimeType; // AWS S3
                 $options['metadata']['contentType'] = $mimeType; // Google Cloud Storage
             }
-            $isFileWritten = $filesystem->writeStream($file->getKey(), $resource, $options);
+            $isFileWritten = $filesystem->writeStream(rtrim($prefix, '/').'/'.$file->getKey(), $resource, $options);
         } catch (FileExistsException $e) {
             throw new FileTransferException($error, $e->getCode(), $e);
         }

--- a/src/Akeneo/Tool/Component/FileStorage/spec/File/FileFetcherSpec.php
+++ b/src/Akeneo/Tool/Component/FileStorage/spec/File/FileFetcherSpec.php
@@ -10,12 +10,16 @@ use PhpSpec\ObjectBehavior;
 
 class FileFetcherSpec extends ObjectBehavior
 {
-    function let(Filesystem $tmpFilesystem)
+    function let(Filesystem $tmpFilesystem, Local $adapter)
     {
+        $tmpFilesystem->getAdapter()->willReturn($adapter);
+        $prefix = sys_get_temp_dir() . '/spec/';
+        $adapter->getPathPrefix()->willReturn($prefix);
+
         $this->beConstructedWith($tmpFilesystem);
     }
 
-    function it_fetches_a_file($tmpFilesystem, Local $adapter, FilesystemInterface $filesystem)
+    function it_fetches_a_file($tmpFilesystem, FilesystemInterface $filesystem)
     {
         if (!is_dir(sys_get_temp_dir() . '/spec/path/to')) {
             mkdir(sys_get_temp_dir() . '/spec/path/to', 0777, true);
@@ -23,10 +27,6 @@ class FileFetcherSpec extends ObjectBehavior
 
         $filesystem->has('path/to/file.txt')->willReturn(true);
         $filesystem->readStream('path/to/file.txt')->shouldBeCalled();
-
-        $prefix = sys_get_temp_dir() . '/spec/';
-        $tmpFilesystem->getAdapter()->willReturn($adapter);
-        $adapter->getPathPrefix()->willReturn($prefix);
 
         $rawFile = $this->fetch($filesystem, 'path/to/file.txt');
         $rawFile->shouldBeAnInstanceOf('\SplFileInfo');

--- a/src/Akeneo/Tool/Component/FileStorage/spec/File/FileFetcherSpec.php
+++ b/src/Akeneo/Tool/Component/FileStorage/spec/File/FileFetcherSpec.php
@@ -28,9 +28,6 @@ class FileFetcherSpec extends ObjectBehavior
         $tmpFilesystem->getAdapter()->willReturn($adapter);
         $adapter->getPathPrefix()->willReturn($prefix);
 
-        $tmpFilesystem->has($prefix . 'path/to')->willReturn(false);
-        $tmpFilesystem->createDir($prefix . 'path/to')->shouldBeCalled();
-
         $rawFile = $this->fetch($filesystem, 'path/to/file.txt');
         $rawFile->shouldBeAnInstanceOf('\SplFileInfo');
         $rawPathname = $rawFile->getWrappedObject()->getPathname();

--- a/src/Akeneo/Tool/Component/FileStorage/spec/File/FileFetcherSpec.php
+++ b/src/Akeneo/Tool/Component/FileStorage/spec/File/FileFetcherSpec.php
@@ -24,11 +24,12 @@ class FileFetcherSpec extends ObjectBehavior
         $filesystem->has('path/to/file.txt')->willReturn(true);
         $filesystem->readStream('path/to/file.txt')->shouldBeCalled();
 
+        $prefix = sys_get_temp_dir() . '/spec/';
         $tmpFilesystem->getAdapter()->willReturn($adapter);
-        $adapter->getPathPrefix()->willReturn(sys_get_temp_dir() . '/spec/');
+        $adapter->getPathPrefix()->willReturn($prefix);
 
-        $tmpFilesystem->has('path/to')->willReturn(false);
-        $tmpFilesystem->createDir('path/to')->shouldBeCalled();
+        $tmpFilesystem->has($prefix . 'path/to')->willReturn(false);
+        $tmpFilesystem->createDir($prefix . 'path/to')->shouldBeCalled();
 
         $rawFile = $this->fetch($filesystem, 'path/to/file.txt');
         $rawFile->shouldBeAnInstanceOf('\SplFileInfo');

--- a/tests/back/Pim/Enrichment/Integration/Updater/Copier/MediaAttributeCopierIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/Copier/MediaAttributeCopierIntegration.php
@@ -165,7 +165,6 @@ class MediaAttributeCopierIntegration extends AbstractCopierTestCase
 
         $standardProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 
-
         $result = $this->sanitizeMediaAttributeData($result);
         $standardValues = $this->sanitizeMediaAttributeData($standardProduct['values'][$fields['to']]);
 


### PR DESCRIPTION
This PR fixes the FileFetcher when using a remote filesystem to store files like Amazon S3.
It started with a fix for assets mass upload where we seen that there are issues with remote filesystem and local temporary storage dir. https://github.com/akeneo/pim-enterprise-dev/pull/6807
This PR introduces the use of a remote filesystem for dev and CI and uses the application config to know the correct temporary storage.

Files are stored on the remote fs and fetched into a local temporary directory per app configuration: https://github.com/akeneo/pim-community-dev/blob/3.2/app/config/pim_parameters.yml#L23

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
