### PR TITLE
PIM-8734: Change label for default channel in minimal catalog

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -4,6 +4,7 @@
 
 - PIM-8719: Fix Mink Selenium dependency
 - PIM-8677: Purge all job executions
+- PIM-8734: Change label to "Ecommerce" for default channel in minimal catalog
 
 # 3.2.7 (2019-08-27)
 

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal/channels.csv
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal/channels.csv
@@ -1,2 +1,2 @@
 code;label-en_US;label-de_DE;label-fr_FR;locales;currencies;tree
-ecommerce;Default;Standard;Défaut;en_US;USD;master
+ecommerce;Ecommerce;Ecommerce;Ecommerce;en_US;USD;master


### PR DESCRIPTION
When a new client opens for the first time its PIM, some entities are created by default (a category tree, a channel, a locale) 

The existing channel code is "ecommerce" but its label is "Default". 
It can be a bit confusing for the customer, especially if the Used change the channel locale and keep en_US for its UI language. The label Default is then displayed, and the user does not understand where does it come from. 

Expected: change the label "Default" for "Ecommerce" to be compliant with the channel's code.
 
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | OK
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
