### PR TITLE
PIM-8754: Fix completeness for locale specific attribute

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8754: Fix completeness for locale specific attribute
+
 # 3.0.41 (2019-09-05)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/IncompleteValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/IncompleteValueCollectionFactory.php
@@ -77,7 +77,7 @@ class IncompleteValueCollectionFactory
         // PIM-8754: for specific case of local specific non localizable attribute,
         // we must keep the locale in the required value key for the UI
         // but we must check the missing value without locale
-        if ($requiredValue->forAttribute()->isLocaleSpecific() && !$requiredValue->forAttribute()->isLocalizable()) {
+        if (!$requiredValue->forAttribute()->isLocalizable() && $requiredValue->forAttribute()->isLocaleSpecific()) {
             $actualValue = $entityWithValues->getValues()->getByCodes(
                 $requiredValue->attribute(),
                 $requiredValue->channel(),

--- a/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/IncompleteValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/IncompleteValueCollectionFactory.php
@@ -74,7 +74,10 @@ class IncompleteValueCollectionFactory
         LocaleInterface $locale,
         EntityWithValuesInterface $entityWithValues
     ) {
-        if (!$requiredValue->forAttribute()->isLocalizable() && $requiredValue->forAttribute()->isLocaleSpecific()) {
+        // PIM-8754: for specific case of local specific non localizable attribute,
+        // we must keep the locale in the required value key for the UI
+        // but we must check the missing value without locale
+        if ($requiredValue->forAttribute()->isLocaleSpecific() && !$requiredValue->forAttribute()->isLocalizable()) {
             $actualValue = $entityWithValues->getValues()->getByCodes(
                 $requiredValue->attribute(),
                 $requiredValue->channel(),

--- a/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/IncompleteValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/IncompleteValueCollectionFactory.php
@@ -74,11 +74,19 @@ class IncompleteValueCollectionFactory
         LocaleInterface $locale,
         EntityWithValuesInterface $entityWithValues
     ) {
-        $actualValue = $entityWithValues->getValues()->getByCodes(
-            $requiredValue->attribute(),
-            $requiredValue->channel(),
-            $requiredValue->locale()
-        );
+        if (!$requiredValue->forAttribute()->isLocalizable() && $requiredValue->forAttribute()->isLocaleSpecific()) {
+            $actualValue = $entityWithValues->getValues()->getByCodes(
+                $requiredValue->attribute(),
+                $requiredValue->channel(),
+                null
+            );
+        } else {
+            $actualValue = $entityWithValues->getValues()->getByCodes(
+                $requiredValue->attribute(),
+                $requiredValue->channel(),
+                $requiredValue->locale()
+            );
+        }
 
         if (null === $actualValue) {
             return true;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/RequiredValue.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/RequiredValue.php
@@ -116,6 +116,10 @@ class RequiredValue
      */
     public function locale(): ?string
     {
-        return $this->forAttribute->isLocalizable() ? $this->forLocale->getCode() : null;
+        if ($this->forAttribute->isLocalizable() || $this->forAttribute->isLocaleSpecific()) {
+            return $this->forLocale->getCode();
+        }
+
+        return null;
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/EntityWithFamily/IncompleteValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/EntityWithFamily/IncompleteValueCollectionFactorySpec.php
@@ -32,9 +32,11 @@ class IncompleteValueCollectionFactorySpec extends ObjectBehavior
         $price->getCode()->willReturn('price');
         $price->isScopable()->willReturn(true);
         $price->isLocalizable()->willReturn(false);
+        $price->isLocaleSpecific()->willReturn(false);
         $description->getCode()->willReturn('description');
         $description->isScopable()->willReturn(true);
         $description->isLocalizable()->willReturn(true);
+        $description->isLocaleSpecific()->willReturn(true);
         $name->getCode()->willReturn('name');
         $name->isScopable()->willReturn(false);
         $name->isLocalizable()->willReturn(true);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/EntityWithFamily/RequiredValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/EntityWithFamily/RequiredValueCollectionFactorySpec.php
@@ -94,7 +94,7 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
         $expectedRequiredValue5->forLocale()->willReturn($fr_FR);
         $expectedRequiredValue5->attribute()->willReturn('image');
         $expectedRequiredValue5->channel()->willReturn(null);
-        $expectedRequiredValue5->locale()->willReturn(null);
+        $expectedRequiredValue5->locale()->willReturn('fr_FR');
 
         $family->getAttributeRequirements()->willReturn([$requirement1, $requirement2, $requirement3, $requirement4, $requirement5, $requirement6]);
 
@@ -104,12 +104,15 @@ class RequiredValueCollectionFactorySpec extends ObjectBehavior
         $sku->isScopable()->willReturn(false);
         $sku->isLocalizable()->willReturn(false);
         $sku->isLocaleSpecific()->willReturn(false);
+
         $description->isScopable()->willReturn(true);
         $description->isLocalizable()->willReturn(true);
         $description->isLocaleSpecific()->willReturn(false);
+
         $price->isScopable()->willReturn(false);
         $price->isLocalizable()->willReturn(false);
         $price->isLocaleSpecific()->willReturn(false);
+
         $image->isScopable()->willReturn(false);
         $image->isLocalizable()->willReturn(false);
         $image->isLocaleSpecific()->willReturn(true);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/EntityWithFamily/RequiredValueSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/EntityWithFamily/RequiredValueSpec.php
@@ -30,14 +30,14 @@ class RequiredValueSpec extends ObjectBehavior
         $this->forChannel()->shouldReturn($channel);
     }
 
-    function it_returns_the_locale($locale)
+    function it_returns_the_locale(LocaleInterface $locale)
     {
         $this->forLocale()->shouldReturn($locale);
     }
 
     function it_helps_to_retrieve_the_value_when_the_attribute_is_non_scopable_non_localizable_non_locale_specific(
-        $attribute,
-        $locale
+        AttributeInterface $attribute,
+        LocaleInterface $locale
     ) {
         $attribute->isScopable()->willReturn(false);
         $attribute->isLocalizable()->willReturn(false);
@@ -48,9 +48,9 @@ class RequiredValueSpec extends ObjectBehavior
         $this->locale($locale)->shouldReturn(null);
     }
 
-    function it_helps_to_retrive_the_when_the_attribute_is_scopable_non_localizable_non_locale_specific(
-        $attribute,
-        $locale
+    function it_helps_to_retrive_the_value_when_the_attribute_is_scopable_non_localizable_non_locale_specific(
+        AttributeInterface $attribute,
+        LocaleInterface $locale
     ) {
         $attribute->getCode()->willReturn('attribute_code');
         $attribute->isScopable()->willReturn(true);
@@ -62,9 +62,9 @@ class RequiredValueSpec extends ObjectBehavior
         $this->locale($locale)->shouldReturn(null);
     }
 
-    function it_helps_to_retrive_the_when_the_attribute_is_localizable_non_scopable_non_locale_specific(
-        $attribute,
-        $locale
+    function it_helps_to_retrive_the_value_when_the_attribute_is_localizable_non_scopable_non_locale_specific(
+        AttributeInterface $attribute,
+        LocaleInterface $locale
     ) {
         $attribute->getCode()->willReturn('attribute_code');
         $attribute->isScopable()->willReturn(false);
@@ -76,9 +76,9 @@ class RequiredValueSpec extends ObjectBehavior
         $this->locale($locale)->shouldReturn('locale');
     }
 
-    function it_helps_to_retrive_the_when_the_locale_specific_non_scopable_non_localizable(
-        $attribute,
-        $locale,
+    function it_helps_to_retrive_the_value_when_the_locale_specific_non_scopable_non_localizable(
+        AttributeInterface $attribute,
+        LocaleInterface $locale,
         LocaleInterface $anotherLocale
     ) {
         $attribute->getCode()->willReturn('attribute_code');

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/EntityWithFamily/RequiredValueSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/EntityWithFamily/RequiredValueSpec.php
@@ -48,7 +48,7 @@ class RequiredValueSpec extends ObjectBehavior
         $this->locale($locale)->shouldReturn(null);
     }
 
-    function it_helps_to_retrive_the_value_when_the_attribute_is_scopable_non_localizable_non_locale_specific(
+    function it_helps_to_retrieve_the_value_when_the_attribute_is_scopable_non_localizable_non_locale_specific(
         AttributeInterface $attribute,
         LocaleInterface $locale
     ) {
@@ -62,7 +62,7 @@ class RequiredValueSpec extends ObjectBehavior
         $this->locale($locale)->shouldReturn(null);
     }
 
-    function it_helps_to_retrive_the_value_when_the_attribute_is_localizable_non_scopable_non_locale_specific(
+    function it_helps_to_retrieve_the_value_when_the_attribute_is_localizable_non_scopable_non_locale_specific(
         AttributeInterface $attribute,
         LocaleInterface $locale
     ) {
@@ -76,7 +76,7 @@ class RequiredValueSpec extends ObjectBehavior
         $this->locale($locale)->shouldReturn('locale');
     }
 
-    function it_helps_to_retrive_the_value_when_the_locale_specific_non_scopable_non_localizable(
+    function it_helps_to_retrieve_the_value_when_the_locale_specific_non_scopable_non_localizable(
         AttributeInterface $attribute,
         LocaleInterface $locale,
         LocaleInterface $anotherLocale
@@ -90,7 +90,6 @@ class RequiredValueSpec extends ObjectBehavior
 
         $this->attribute()->shouldReturn('attribute_code');
         $this->channel()->shouldReturn(null);
-        $this->locale($locale)->shouldReturn(null);
-        $this->locale($anotherLocale)->shouldReturn(null);
+        $this->locale($locale)->shouldReturn('locale');
     }
 }


### PR DESCRIPTION
Local specific attribute completeness is not correct because the RequiredValue didn't return the locale to compute the completeness on the locale.

It returned a required value key of `myattribute-<all_channels>-<all_locales>` when it should have return `myattribute-<all_channels>-en_US` for example. The completeness was then computed only on the last available locale.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Updated
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
