### PR TITLE
PIM-8753: Fix pim:versioning:purge command without parameter

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -5,6 +5,7 @@
 - PIM-8719: Fix Mink Selenium dependency
 - PIM-8677: Purge all job executions
 - PIM-8734: Change label to "Ecommerce" for default channel in minimal catalog
+- PIM-8753: Fix pim:versioning:purge command without parameter
 
 # 3.2.7 (2019-08-27)
 

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Command/PurgeCommand.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Command/PurgeCommand.php
@@ -71,10 +71,6 @@ class PurgeCommand extends ContainerAwareCommand
             );
         }
 
-        if (null === $input->getOption('more-than-days') && null === $input->getOption('less-than-days')) {
-            $input->setOption('more-than-days', self::DEFAULT_MORE_THAN_DAYS);
-        }
-
         $resourceFQCN = $input->hasArgument('entity') ? $input->getArgument('entity') : null;
         $isForced = $input->getOption('force');
 
@@ -130,6 +126,10 @@ class PurgeCommand extends ContainerAwareCommand
         $isForced = $input->getOption('force');
         $moreThanDays = null !== $input->getOption('more-than-days') ? (int) $input->getOption('more-than-days') : null;
         $lessThanDays = null !== $input->getOption('less-than-days') ? (int) $input->getOption('less-than-days') : null;
+
+        if (null === $moreThanDays && null === $lessThanDays) {
+            $moreThanDays = self::DEFAULT_MORE_THAN_DAYS;
+        }
 
         $resourceName = $input->hasArgument('entity') ? $input->getArgument('entity') : null;
         $resourceNameLabel = '';


### PR DESCRIPTION
When launching the command in `--no-interaction` mode, we didn't set the default value for the number. This PR just set the same default for every mode, interactive or not.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
