### PR TITLE
FIX Nightly: Fix press button step

### DIFF
--- a/tests/legacy/features/Context/WebUser.php
+++ b/tests/legacy/features/Context/WebUser.php
@@ -1694,6 +1694,8 @@ class WebUser extends PimContext
      */
     public function iPressTheButton($button, $modalWait = null)
     {
+        $this->getCurrentPage()->pressButton($button, true);
+
         $this->spin(function () use ($button, $modalWait) {
             if (null !== $modalWait) {
                 foreach ($this->getCurrentPage()->findAll('css', '.modal') as $modal) {
@@ -1702,8 +1704,6 @@ class WebUser extends PimContext
                     }
                 }
             }
-
-            $this->getCurrentPage()->pressButton($button, true);
 
             return null === $modalWait;
         }, sprintf("Can not find any '%s' button%s", $button, null !== $modalWait ? ' or no modal found' : ''));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix behat `vendor/akeneo/pim-community-dev/tests/legacy/features/pim/enrichment/product/mass-edit/mass_add_to_existing_product_model.feature` which was failing because the mass action modal wouldn't show up after pressing the button.

See EE build https://github.com/akeneo/pim-enterprise-dev/pull/6877

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
