### PR TITLE
PIM-8751: Fix simple and multi select attributes history when creating a new option

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8757: Use a stream to create export archive
+- PIM-8751: Fix simple and multi select attributes history when creating a new option
 
 # 2.3.61 (2019-09-10)
 

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/CreateAttributeOptionIntegration.php
@@ -55,7 +55,7 @@ JSON;
         $attributeOptionStandard = [
             'code'       => 'optionD',
             'attribute'  => 'a_multi_select',
-            'sort_order' => 1,
+            'sort_order' => 21,
             'labels'     => [],
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
@@ -119,7 +119,7 @@ JSON;
         $attributeOptionStandard = [
             'code'       => 'optionF',
             'attribute'  => 'a_multi_select',
-            'sort_order' => 1,
+            'sort_order' => 21,
             'labels'     => [],
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateAttributeOptionIntegration.php
@@ -55,7 +55,7 @@ JSON;
         );
     }
 
-    public function testStandardFormatWhenAnAttributeOptionIsCreatedButIncompleted()
+    public function testStandardFormatWhenAnAttributeOptionIsCreatedButIncomplete()
     {
         $client = $this->createAuthenticatedClient();
 
@@ -74,7 +74,7 @@ JSON;
         $attributeOptionStandard = [
             'code'       => 'newOption',
             'attribute'  => 'a_multi_select',
-            'sort_order' => 1,
+            'sort_order' => 21,
             'labels'     => [],
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
@@ -99,7 +99,7 @@ JSON;
         $attributeOptionStandard = [
             'code'       => 'newOption',
             'attribute'  => 'a_multi_select',
-            'sort_order' => 1,
+            'sort_order' => 21,
             'labels'     => [],
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
@@ -129,7 +129,7 @@ JSON;
         $attributeOptionStandard = [
             'code'       => 'newOption',
             'attribute'  => 'a_multi_select',
-            'sort_order' => 1,
+            'sort_order' => 21,
             'labels'     => [],
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');
@@ -159,7 +159,7 @@ JSON;
         $attributeOptionStandard = [
             'code'       => 'newOption',
             'attribute'  => 'a_multi_select',
-            'sort_order' => 1,
+            'sort_order' => 21,
             'labels'     => [],
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.attribute_option');

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateListAttributeOptionIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/AttributeOption/PartialUpdateListAttributeOptionIntegration.php
@@ -50,7 +50,7 @@ JSON;
             'optionC' => [
                 'code' => 'optionC',
                 'attribute' => 'a_multi_select',
-                'sort_order' => 1,
+                'sort_order' => 21,
                 'labels' => [
                     'en_US' => 'Option C',
                 ],

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/GetAttributeOptionsMaxSortOrder.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/GetAttributeOptionsMaxSortOrder.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Query;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetAttributeOptionsMaxSortOrder
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function forAttributeCodes(array $attributeCodes): array
+    {
+        $sql = <<<SQL
+SELECT a.code AS attribute_code, MAX(o.sort_order) as sort_order
+FROM pim_catalog_attribute_option o
+INNER JOIN pim_catalog_attribute a ON a.id = o.attribute_id
+WHERE a.code IN (:attributeCodes)
+GROUP BY attribute_code;
+SQL;
+
+        $sortOrders = [];
+        $rows = $this->connection->executeQuery(
+            $sql,
+            [
+                'attributeCodes' => $attributeCodes
+            ],
+            [
+                'attributeCodes' => Connection::PARAM_STR_ARRAY,
+            ]
+        )->fetchAll();
+
+        foreach ($rows as $row) {
+            $sortOrders[$row['attribute_code']] = (int) $row['sort_order'];
+        }
+
+        return $sortOrders;
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Entity/AttributeOption.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/AttributeOption.php
@@ -40,7 +40,7 @@ class AttributeOption implements AttributeOptionInterface
     protected $locale;
 
     /** @var int */
-    protected $sortOrder = 1;
+    protected $sortOrder;
 
     /**
      * Constructor

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/AttributeOption/SetAttributeOptionSortOrderSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/AttributeOption/SetAttributeOptionSortOrderSubscriber.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber\AttributeOption;
+
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\GetAttributeOptionsMaxSortOrder;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SetAttributeOptionSortOrderSubscriber implements EventSubscriberInterface
+{
+    /** @var GetAttributeOptionsMaxSortOrder */
+    private $getAttributeOptionsMaxSortOrder;
+
+    public function __construct(GetAttributeOptionsMaxSortOrder $getAttributeOptionsMaxSortOrder)
+    {
+        $this->getAttributeOptionsMaxSortOrder = $getAttributeOptionsMaxSortOrder;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            StorageEvents::PRE_SAVE => 'onPreSave',
+            StorageEvents::PRE_SAVE_ALL => 'onPreSaveAll',
+        ];
+    }
+
+    public function onPreSave(GenericEvent $event): void
+    {
+        if (!$event->hasArgument('unitary') || false === $event->getArgument('unitary')) {
+            return;
+        }
+
+        $subject = $event->getSubject();
+        if ($subject instanceof AttributeOptionInterface) {
+            $this->setSortOrders([$subject]);
+
+            return;
+        }
+        if ($subject instanceof AttributeInterface) {
+            $this->setSortOrders($subject->getOptions()->toArray());
+        }
+    }
+
+    public function onPreSaveAll(GenericEvent $event)
+    {
+        $subjects = $event->getSubject();
+        if (!is_array($subjects)) {
+            return;
+        }
+
+        if (current($subjects) instanceof AttributeOptionInterface) {
+            $this->setSortOrders($subjects);
+
+            return;
+        }
+
+        if (current($subjects) instanceof AttributeInterface) {
+            $options = [];
+            foreach ($subjects as $attribute) {
+                foreach ($attribute->getOptions() as $option) {
+                    $options[] = $option;
+                }
+            }
+            $this->setSortOrders($options);
+        }
+    }
+
+    /**
+     * @param AttributeOptionInterface[] $options
+     */
+    private function setSortOrders(array $options): void
+    {
+        $options = array_filter($options, function (AttributeoptionInterface $option) {
+            return null === $option->getSortOrder();
+        });
+        if (empty($options)) {
+            return;
+        }
+
+        $attributeCodes = array_unique(array_map(function (AttributeOptionInterface $option): string {
+            return $option->getAttribute()->getCode();
+        }, $options));
+
+        $currentMaxSortOrders = $this->getAttributeOptionsMaxSortOrder->forAttributeCodes(
+            array_values($attributeCodes)
+        );
+
+        foreach ($options as $option) {
+            $attributeCode = $option->getAttribute()->getCode();
+
+            if (!isset($currentMaxSortOrders[$attributeCode])) {
+                $sortOrder = $currentMaxSortOrders[$attributeCode] = 0;
+            } else {
+                $sortOrder = ++$currentMaxSortOrders[$attributeCode];
+            }
+            $option->setSortOrder($sortOrder);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -189,3 +189,10 @@ services:
             - '@akeneo_elasticsearch.client.product_and_product_model'
         tags:
             - { name: kernel.event_subscriber }
+
+    pim_catalog.event_subscriber.attribute_option_set_sort_order:
+        class: 'Pim\Bundle\CatalogBundle\EventSubscriber\AttributeOption\SetAttributeOptionSortOrderSubscriber'
+        arguments:
+            - '@pim_catalog.query.get_attribute_options_max_sort_order'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
@@ -89,3 +89,8 @@ services:
         arguments:
             - '@database_connection'
             - '@pim_catalog.factory.value_collection'
+
+    pim_catalog.query.get_attribute_options_max_sort_order:
+        class: 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\GetAttributeOptionsMaxSortOrder'
+        arguments:
+            - '@database_connection'

--- a/src/Pim/Bundle/CatalogBundle/spec/Entity/AttributeOptionSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/Entity/AttributeOptionSpec.php
@@ -6,7 +6,6 @@ use PhpSpec\ObjectBehavior;
 use Pim\Bundle\CatalogBundle\Entity\AttributeOption;
 use Pim\Bundle\CatalogBundle\Entity\AttributeOptionValue;
 use Pim\Component\Catalog\Model\AttributeOptionValueInterface;
-use Prophecy\Argument;
 
 class AttributeOptionSpec extends ObjectBehavior
 {
@@ -26,13 +25,15 @@ class AttributeOptionSpec extends ObjectBehavior
         $this->getCode()->shouldReturn('1234');
     }
 
-    function it_returns_the_expected_translation(AttributeOptionValueInterface $en, AttributeOptionValueInterface $fr)
-    {
+    function it_returns_the_expected_translation(
+        AttributeOptionValueInterface $en,
+        AttributeOptionValueInterface $fr
+    ) {
         $en->getLocale()->willReturn('en');
         $fr->getLocale()->willReturn('fr');
 
-        $en->setOption(Argument::any())->shouldBeCalled();
-        $fr->setOption(Argument::any())->shouldBeCalled();
+        $en->setOption($this)->shouldBeCalled();
+        $fr->setOption($this)->shouldBeCalled();
 
         $this->addOptionValue($en);
         $this->addOptionValue($fr);
@@ -41,15 +42,20 @@ class AttributeOptionSpec extends ObjectBehavior
         $this->getOptionValue()->shouldReturn($fr);
     }
 
-    function it_display_an_attribute_option()
+    function it_displays_an_attribute_option()
     {
         $value = new AttributeOptionValue();
-        $value->setLabel(100);
+        $value->setLabel('100');
         $value->setLocale('en_US');
 
         $this->setLocale('en_US');
         $this->addOptionValue($value);
 
         $this->__toString()->shouldReturn('100');
+    }
+
+    function it_has_no_default_sort_order()
+    {
+        $this->getSortOrder()->shouldBeNull();;
     }
 }

--- a/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/AttributeOption/SetAttributeOptionSortOrderSubscriberSpec.php
+++ b/src/Pim/Bundle/CatalogBundle/spec/EventSubscriber/AttributeOption/SetAttributeOptionSortOrderSubscriberSpec.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace spec\Pim\Bundle\CatalogBundle\EventSubscriber\AttributeOption;
+
+use Akeneo\Component\StorageUtils\StorageEvents;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\GetAttributeOptionsMaxSortOrder;
+use Pim\Bundle\CatalogBundle\Entity\Attribute;
+use Pim\Bundle\CatalogBundle\Entity\AttributeOption;
+use Pim\Bundle\CatalogBundle\EventSubscriber\AttributeOption\SetAttributeOptionSortOrderSubscriber;
+use Pim\Component\Catalog\Model\AttributeOptionInterface;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class SetAttributeOptionSortOrderSubscriberSpec extends ObjectBehavior
+{
+    function let(GetAttributeOptionsMaxSortOrder $getAttributeOptionsMaxSortOrder)
+    {
+        $this->beConstructedWith($getAttributeOptionsMaxSortOrder);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldImplement(EventSubscriberInterface::class);
+        $this->shouldHaveType(SetAttributeOptionSortOrderSubscriber::class);
+    }
+
+    function it_subscribes_to_pre_save_and_pre_save_all_events()
+    {
+        $subscribedEvents = $this::getSubscribedEvents();
+        $subscribedEvents->shouldHaveKey(StorageEvents::PRE_SAVE);
+        $subscribedEvents->shouldHaveKey(StorageEvents::PRE_SAVE_ALL);
+    }
+
+    function it_only_handles_attributes_and_options(GetAttributeOptionsMaxSortOrder $getAttributeOptionsMaxSortOrder)
+    {
+        $getAttributeOptionsMaxSortOrder->forAttributeCodes(Argument::any())->shouldNotBeCalled();
+        $this->onPreSave(new GenericEvent(new \stdClass(), ['unitary' => true]));
+        $this->onPreSaveAll(new GenericEvent([new \stdClass()]));
+    }
+
+    function it_does_nothing_on_pre_save_for_non_unitary_events(
+        GetAttributeOptionsMaxSortOrder $getAttributeOptionsMaxSortOrder
+    ) {
+        $getAttributeOptionsMaxSortOrder->forAttributeCodes(Argument::any())->shouldNotBeCalled();
+        $this->onPreSave(new GenericEvent(new AttributeOption(), ['unitary' => false]));
+    }
+
+    function it_does_nothing_if_option_has_a_non_null_sort_order(
+        GetAttributeOptionsMaxSortOrder $getAttributeOptionsMaxSortOrder,
+        AttributeOptionInterface $option
+    ) {
+        $option->getSortOrder()->willReturn(42);
+
+        $option->setSortOrder(Argument::any())->shouldNotBeCalled();
+        $getAttributeOptionsMaxSortOrder->forAttributeCodes(Argument::any())->shouldNotBeCalled();
+
+        $this->onPreSaveAll(new GenericEvent([$option->getWrappedObject()]));
+    }
+
+    function it_sets_sort_orders_for_options_with_a_null_sort_order(
+        GetAttributeOptionsMaxSortOrder $getAttributeOptionsMaxSortOrder,
+        AttributeOptionInterface $option1,
+        AttributeOptionInterface $option2,
+        AttributeOptionInterface $option3
+    ) {
+        $color = new Attribute();
+        $color->setCode('color');
+        $size = new Attribute();
+        $size->setCode('size');
+
+        $option1->getSortOrder()->willReturn(null);
+        $option1->getAttribute()->willReturn($color);
+        $option2->getSortOrder()->willReturn(null);
+        $option2->getAttribute()->willReturn($color);
+        $option3->getSortOrder()->willReturn(null);
+        $option3->getAttribute()->willReturn($size);
+
+        $getAttributeOptionsMaxSortOrder->forAttributeCodes(['color', 'size'])->willReturn(
+            [
+                'color' => 10,
+                'size' => 22,
+            ]
+        );
+        $option1->setSortOrder(11)->shouldBeCalled();
+        $option2->setSortOrder(12)->shouldBeCalled();
+        $option3->setSortOrder(23)->shouldBeCalled();
+
+        $this->onPreSaveAll(
+            new GenericEvent(
+                [
+                    $option1->getWrappedObject(),
+                    $option2->getWrappedObject(),
+                    $option3->getWrappedObject(),
+                ]
+            )
+        );
+    }
+
+    function it_sets_sort_order_to_zero_if_the_attribute_has_no_option_yet(
+        GetAttributeOptionsMaxSortOrder $getAttributeOptionsMaxSortOrder,
+        AttributeOptionInterface $option1,
+        AttributeOptionInterface $option2
+    ) {
+        $color = new Attribute();
+        $color->setCode('color');
+
+        $option1->getSortOrder()->willReturn(null);
+        $option1->getAttribute()->willReturn($color);
+        $option2->getSortOrder()->willReturn(null);
+        $option2->getAttribute()->willReturn($color);
+
+        $getAttributeOptionsMaxSortOrder->forAttributeCodes(['color'])->willReturn([]);
+        $option1->setSortOrder(0)->shouldBeCalled();
+        $option2->setSortOrder(1)->shouldBeCalled();
+
+        $this->onPreSaveAll(
+            new GenericEvent([$option1->getWrappedObject(), $option2->getWrappedObject()])
+        );
+    }
+
+    function it_sets_sort_orders_of_options_when_saving_an_attribute(
+        GetAttributeOptionsMaxSortOrder $getAttributeOptionsMaxSortOrder,
+        AttributeOptionInterface $blue,
+        AttributeOptionInterface $red
+    ) {
+        $color = new Attribute();
+        $color->setCode('color');
+        $color->addOption($blue->getWrappedObject());
+        $color->addOption($red->getWrappedObject());
+
+        $blue->getAttribute()->willReturn($color);
+        $blue->getSortOrder()->willReturn(null);
+        $red->getAttribute()->willReturn($color);
+        $red->getSortOrder()->willReturn(null);
+
+        $getAttributeOptionsMaxSortOrder->forAttributeCodes(['color'])->willReturn(['color' => 12]);
+
+        $blue->setSortOrder(13)->shouldBeCalled();
+        $red->setSortOrder(14)->shouldBeCalled();
+
+        $this->onPreSave(new GenericEvent($color, ['unitary' => true]));
+    }
+
+    function it_sets_sort_orders_of_options_when_saving_multiple_attributes(
+        GetAttributeOptionsMaxSortOrder $getAttributeOptionsMaxSortOrder,
+        AttributeOptionInterface $blue,
+        AttributeOptionInterface $red,
+        AttributeOptionInterface $xl,
+        AttributeOptionInterface $xxl
+    ) {
+        $color = new Attribute();
+        $color->setCode('color');
+        $color->addOption($blue->getWrappedObject());
+        $color->addOption($red->getWrappedObject());
+
+        $blue->getAttribute()->willReturn($color);
+        $blue->getSortOrder()->willReturn(null);
+        $red->getAttribute()->willReturn($color);
+        $red->getSortOrder()->willReturn(null);
+
+        $size = new Attribute();
+        $size->setCode('size');
+        $size->addOption($xl->getWrappedObject());
+        $size->addOption($xxl->getWrappedObject());
+
+        $xl->getAttribute()->willReturn($size);
+        $xl->getSortOrder()->willReturn(null);
+        $xxl->getAttribute()->willReturn($size);
+        $xxl->getSortOrder()->willReturn(10);
+
+        $name = new Attribute();
+        $name->setCode('name');
+
+        $getAttributeOptionsMaxSortOrder->forAttributeCodes(['color', 'size'])->willReturn(
+            ['color' => 12, 'size' => 41]
+        );
+
+        $blue->setSortOrder(13)->shouldBeCalled();
+        $red->setSortOrder(14)->shouldBeCalled();
+        $xl->setSortOrder(42)->shouldBeCalled();
+        $xxl->setSortOrder(Argument::any())->shouldNotBeCalled();
+
+        $this->onPreSaveAll(new GenericEvent([$color, $size, $name]));
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/ORM/Query/GetAttributeOptionsMaxSortOrderIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/ORM/Query/GetAttributeOptionsMaxSortOrderIntegration.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Doctrine\ORM\Query;
+
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Pim\Bundle\CatalogBundle\Entity\AttributeOption;
+use Pim\Component\Catalog\AttributeTypes;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetAttributeOptionsMaxSortOrderIntegration extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_gets_the_max_options_sort_order_indexed_by_attribute_code()
+    {
+        $this->createSimpleSelectAttribute('color', ['blue', 'red', 'green']);
+        $this->createSimpleSelectAttribute('size', ['xs', 's', 'm', 'l', 'xl']);
+        $this->createSimpleSelectAttribute(
+            'material',
+            [
+                12 => 'leather',
+                23 => 'cotton',
+                4 => 'metal',
+            ]
+        );
+
+        $expected = [
+            'color' => 2,
+            'size' => 4,
+            'material' => 23,
+        ];
+
+        $actual = $this->get('pim_catalog.query.get_attribute_options_max_sort_order')
+                       ->forAttributeCodes(['size', 'color', 'material']);
+
+        Assert::assertSameSize($expected, $actual);
+        foreach ($expected as $expectedKey => $expectedValue) {
+            Assert::assertArrayHasKey($expectedKey, $actual);
+            Assert::assertSame($expectedValue, $actual[$expectedKey]);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_return_a_value_for_an_attribute_without_options()
+    {
+        $this->createSimpleSelectAttribute('select_without_options', []);
+        Assert::assertSame([], $this->get('pim_catalog.query.get_attribute_options_max_sort_order')
+                                    ->forAttributeCodes(['select_without_options']));
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function createSimpleSelectAttribute(string $code, array $optionCodes): void
+    {
+        $attribute = $this->get('pim_catalog.factory.attribute')->create();
+        $attribute->setCode($code);
+        $attribute->setType(AttributeTypes::OPTION_SIMPLE_SELECT);
+        $attribute->setBackendType(AttributeTypes::BACKEND_TYPE_OPTION);
+
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        foreach ($optionCodes as $sortOrder => $optionCode) {
+            $option = new AttributeOption();
+            $option->setCode($optionCode);
+            $option->setAttribute($attribute);
+            $option->setSortOrder($sortOrder);
+            $this->get('pim_catalog.saver.attribute_option')->save($option);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/SetAttributeOptionSortOrderSubscriberIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/SetAttributeOptionSortOrderSubscriberIntegration.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\EventSubscriber;
+
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Pim\Bundle\CatalogBundle\Entity\AttributeOption;
+use Pim\Component\Catalog\AttributeTypes;
+use Pim\Component\Catalog\Model\AttributeInterface;
+
+/**
+ * @author    Mathias METAYER <mathias.metayer@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SetAttributeOptionSortOrderSubscriberIntegration extends TestCase
+{
+    public function test_that_sort_order_is_set_when_saving_an_attribute_option()
+    {
+        $color = $this->createSimpleSelectAttributeWithOptions('color', [0 => 'blue', 1 => 'red']);
+        $option = new AttributeOption();
+        $option->setCode('yellow');
+        $option->setAttribute($color);
+
+        $this->get('pim_catalog.saver.attribute_option')->save($option);
+
+        Assert::assertSame(2, $option->getSortOrder());
+    }
+
+    public function test_sort_orders_are_set_when_saving_multiple_attribute_options()
+    {
+        $color = $this->createSimpleSelectAttributeWithOptions('color', [20 => 'blue', 5 => 'red']);
+        $size = $this->createSimpleSelectAttributeWithOptions('size', []);
+
+        $option1 = new AttributeOption();
+        $option1->setCode('yellow');
+        $option1->setAttribute($color);
+
+        $option2 = new AttributeOption();
+        $option2->setCode('xs');
+        $option2->setAttribute($size);
+
+        $option3 = new AttributeOption();
+        $option3->setCode('xl');
+        $option3->setAttribute($size);
+
+        $this->get('pim_catalog.saver.attribute_option')->saveAll([$option1, $option2, $option3]);
+
+        Assert::assertSame(21, $option1->getSortOrder());
+        Assert::assertSame(0, $option2->getSortOrder());
+        Assert::assertSame(1, $option3->getSortOrder());
+    }
+
+    public function test_that_sort_orders_are_set_when_saving_an_attribute()
+    {
+        $material = $this->createSimpleSelectAttributeWithOptions('material', [
+            10 => 'leather',
+            12 => 'wool',
+        ]);
+
+        $cotton = new AttributeOption();
+        $cotton->setCode('cotton');
+        $material->addOption($cotton);
+        $polyester = new AttributeOption();
+        $polyester->setCode('polyester');
+        $material->addOption($polyester);
+
+        $this->get('pim_catalog.saver.attribute')->save($material);
+
+        Assert::assertSame(13, $cotton->getSortOrder());
+        Assert::assertSame(14, $polyester->getSortOrder());
+    }
+
+    public function test_that_sort_orders_are_set_when_saving_multiple_attributes()
+    {
+        $color = $this->createSimpleSelectAttributeWithOptions('color', [4 => 'blue', 5 => 'red']);
+        $yellow = new AttributeOption();
+        $yellow->setCode('yellow');
+        $color->addOption($yellow);
+
+        $size = $this->createSimpleSelectAttributeWithOptions('size', []);
+        $xs = new AttributeOption();
+        $xs->setCode('xs');
+        $size->addOption($xs);
+        $xl = new AttributeOption();
+        $xl->setCode('xl');
+        $size->addOption($xl);
+
+        $material = $this->get('pim_catalog.factory.attribute')->create();
+        $material->setCode('material');
+        $material->setType(AttributeTypes::OPTION_MULTI_SELECT);
+        $material->setBackendType(AttributeTypes::BACKEND_TYPE_OPTIONS);
+
+        $cotton = new AttributeOption();
+        $cotton->setCode('cotton');
+        $material->addOption($cotton);
+        $polyester = new AttributeOption();
+        $polyester->setCode('polyester');
+        $material->addOption($polyester);
+
+        $this->get('pim_catalog.saver.attribute')->saveAll([$color, $size, $material]);
+
+        Assert::assertSame(6, $yellow->getSortOrder());
+        Assert::assertSame(0, $xs->getSortOrder());
+        Assert::assertSame(1, $xl->getSortOrder());
+        Assert::assertSame(0, $cotton->getSortOrder());
+        Assert::assertSame(1, $polyester->getSortOrder());
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function createSimpleSelectAttributeWithOptions(string $code, array $optionCodes): AttributeInterface
+    {
+        $attribute = $this->get('pim_catalog.factory.attribute')->create();
+        $attribute->setCode($code);
+        $attribute->setType(AttributeTypes::OPTION_SIMPLE_SELECT);
+        $attribute->setBackendType(AttributeTypes::BACKEND_TYPE_OPTION);
+
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        foreach ($optionCodes as $sortOrder => $optionCode) {
+            $option = new AttributeOption();
+            $option->setCode($optionCode);
+            $option->setAttribute($attribute);
+            $option->setSortOrder($sortOrder);
+            $this->get('pim_catalog.saver.attribute_option')->save($option);
+        }
+
+        return $attribute;
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

When creating a new attribute option for a simple/multi select via the UI, the sort order was not set, so it defaulted to 1 (`Pim\Bundle\CatalogBundle\Entity\AttributeOption`'s default value for `$sortOrder` property), which caused inconsistencies in the 'History' tab (newly created option appeared in 2nd position in the options list, instead of last position).

This PR:
- removes the default value for `$sortOrder`
- adds a subscriber which computes and sets the sort order (if needed, i.e when it's `null`) when saving attribute options (or attributes with options)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
