### PR TITLE
PIM-8757: Use a stream to create export archive

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8757: Use a stream to create export archive
+
 # 2.3.61 (2019-09-10)
 
 # 2.3.60 (2019-09-05)

--- a/src/Pim/Component/Connector/Archiver/FileWriterArchiver.php
+++ b/src/Pim/Component/Connector/Archiver/FileWriterArchiver.php
@@ -121,7 +121,6 @@ class FileWriterArchiver extends AbstractFilesystemArchiver
                     '%filename%' => $fileName,
                 ]
             );
-            $this->filesystem->put($archivedFilePath, file_get_contents($filePath));
-        }
+            $this->filesystem->putStream($archivedFilePath, fopen($filePath, 'r'));        }
     }
 }

--- a/src/Pim/Component/Connector/Archiver/FileWriterArchiver.php
+++ b/src/Pim/Component/Connector/Archiver/FileWriterArchiver.php
@@ -121,6 +121,7 @@ class FileWriterArchiver extends AbstractFilesystemArchiver
                     '%filename%' => $fileName,
                 ]
             );
-            $this->filesystem->putStream($archivedFilePath, fopen($filePath, 'r'));        }
+            $this->filesystem->putStream($archivedFilePath, fopen($filePath, 'r'));
+        }
     }
 }

--- a/src/Pim/Component/Connector/spec/Archiver/FileWriterArchiverSpec.php
+++ b/src/Pim/Component/Connector/spec/Archiver/FileWriterArchiverSpec.php
@@ -29,7 +29,7 @@ class FileWriterArchiverSpec extends ObjectBehavior
     }
 
     function it_creates_a_file_when_writer_is_valid(
-        $filesystem,
+        Filesystem $filesystem,
         $jobRegistry,
         Writer $writer,
         JobExecution $jobExecution,
@@ -54,13 +54,13 @@ class FileWriterArchiverSpec extends ObjectBehavior
         $writer->getWrittenFiles()->willReturn([$pathname => $filename]);
         $writer->getPath()->willReturn($pathname);
 
-        $filesystem->put(
+        $filesystem->putStream(
             'type' . DIRECTORY_SEPARATOR .
             'my_job_name' . DIRECTORY_SEPARATOR .
             '12' . DIRECTORY_SEPARATOR .
             'output' . DIRECTORY_SEPARATOR .
             $filename,
-            ''
+            Argument::type('resource')
         )->shouldBeCalled();
 
         $this->archive($jobExecution);


### PR DESCRIPTION
When creating the archive for big export, we can crash the memory if we read the file at once. Using a stream fixes the memory consumption.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | updated
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
