### PR TITLE
PIM-8750: Fix wrong re-render on simple-select-async

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -6,6 +6,7 @@
 - PIM-8677: Purge all job executions
 - PIM-8734: Change label to "Ecommerce" for default channel in minimal catalog
 - PIM-8753: Fix pim:versioning:purge command without parameter
+- PIM-8750: Fix keyboard navigation with the family selector on the create product form
 
 # 3.2.7 (2019-08-27)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/simple-select-async.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/simple-select-async.js
@@ -28,13 +28,6 @@ function (
   Routing
 ) {
   return BaseField.extend({
-    events: {
-        'change input': function (event) {
-            this.errors = [];
-            this.updateModel(this.getFieldValue(event.target));
-            this.getRoot().render();
-        }
-    },
     template: _.template(template),
     choiceUrl: null,
     resultsPerPage: 20,
@@ -81,7 +74,17 @@ function (
      * {@inheritdoc}
      */
     postRender(templateContext) {
-      initSelect2.init(this.$('.select2'), this.getSelect2Options(templateContext));
+      const $select2 = this.$('.select2');
+
+      initSelect2.init($select2, this.getSelect2Options(templateContext));
+
+      const onChange = () => {
+        this.errors = [];
+        this.updateModel(this.getFieldValue($select2));
+        this.getRoot().render();
+      }
+
+      $select2.on('change', onChange);
     },
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

If you press tab on the identifier field to select the next field family (keyboard navigation) and you start typing to search for a family; then the select2 field misbehave and jump in the top-left corner of the screen:
![bug](https://user-images.githubusercontent.com/1671213/64964008-8043c900-d89a-11e9-87ca-243840072a77.gif)

Fix:
![fix](https://user-images.githubusercontent.com/1671213/64964014-83d75000-d89a-11e9-94cd-ff54ad7a8761.gif)

I fixed it by luck, as it seems to be a race condition between a re-render of the template and the select2 dynamic dropdown positioning.

Removing the re-render doesn't break/change everything on the behavior of the form/select2 on this page and it should not break anything elsewhere (but we never know).

(If someone with extensive knowledge of the frontend stack / select2 have a better explanation I'm interested)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
