### PR TITLE
TIP-1160: Add migration

### DIFF
--- a/tests/back/Pim/Enrichment/Upgrade/RemoveProductEmptyRawValuesIntegration.php
+++ b/tests/back/Pim/Enrichment/Upgrade/RemoveProductEmptyRawValuesIntegration.php
@@ -11,7 +11,7 @@ class RemoveProductEmptyRawValuesIntegration extends TestCase
 {
     protected function getConfiguration()
     {
-        $this->catalog->useTechnicalCatalog();
+        return $this->catalog->useTechnicalCatalog();
     }
 
     public function testItRemovesAllEmptyValues()
@@ -63,9 +63,9 @@ SQL;
     private function reExecuteMigration(string $migrationLabel)
     {
         $resultDown = $this->getCommandLauncher()->executeForeground(sprintf('doctrine:migrations:execute %s --down -n', $migrationLabel));
-        $this->assertEquals(0, $resultDown->getCommandStatus());
+        $this->assertEquals(0, $resultDown->getCommandStatus(), json_encode($resultDown->getCommandOutput()));
 
         $resultUp = $this->getCommandLauncher()->executeForeground(sprintf('doctrine:migrations:execute %s --up -n', $migrationLabel));
-        $this->assertEquals(0, $resultUp->getCommandStatus());
+        $this->assertEquals(0, $resultUp->getCommandStatus(), json_encode($resultUp->getCommandOutput()));
     }
 }

--- a/tests/back/Pim/Enrichment/Upgrade/RemoveProductEmptyRawValuesIntegration.php
+++ b/tests/back/Pim/Enrichment/Upgrade/RemoveProductEmptyRawValuesIntegration.php
@@ -1,0 +1,71 @@
+<?php
+
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\Console\CommandLauncher;
+use Doctrine\DBAL\Connection;
+
+/**
+ * This class will be removed after 4.0 version
+ */
+class RemoveProductEmptyRawValuesIntegration extends TestCase
+{
+    protected function getConfiguration()
+    {
+        $this->catalog->useTechnicalSqlCatalog();
+    }
+
+    public function testItRemovesAllEmptyValues()
+    {
+        $this->getConnection()->executeQuery('DELETE FROM pim_catalog_product');
+        $sql = <<<SQL
+INSERT INTO pim_catalog_product VALUES
+    (NULL, 18, NULL, NULL, 1, 'product1', '{"name": {"<all_channels>": {"<all_locales>": ""}}}', NOW(), NOW()),
+    (NULL, 18, NULL, NULL, 1, 'product2', '{"name": {"<all_channels>": {"<all_locales>": []}}}', NOW(), NOW()),
+    (NULL, 18, NULL, NULL, 1, 'product3', '{"name": {"<all_channels>": {"<all_locales>": [""]}}}', NOW(), NOW()),
+    (NULL, 18, NULL, NULL, 1, 'product4', '{"name": {"<all_channels>": {"<all_locales>": null}}}', NOW(), NOW()),
+    (NULL, 18, NULL, NULL, 1, 'product5', '{"name": {"<all_channels>": {"<all_locales>": ""}}, "foo": {"<all_channels>": {"<all_locales>": "bar"}}}', NOW(), NOW()),
+    (NULL, 18, NULL, NULL, 1, 'product6', '{"name": {"<all_channels>": {"fr_FR": "", "en_US": "bar"}}}', NOW(), NOW()),
+    (NULL, 18, NULL, NULL, 1, 'product7', '{"name": {"ecommerce": {"<all_locales>": ""}, "mobile": {"<all_locales>": "bar"}}}', NOW(), NOW())
+SQL;
+
+        $this->getConnection()->executeQuery($sql);
+
+        $this->reExecuteMigration('_4_0_20190916122239_remove_product_empty_raw_values');
+
+        $this->assertProductRawValuesEquals('product1', '{}');
+        $this->assertProductRawValuesEquals('product2', '{}');
+        $this->assertProductRawValuesEquals('product3', '{}');
+        $this->assertProductRawValuesEquals('product4', '{}');
+        $this->assertProductRawValuesEquals('product5', '{"foo": {"<all_channels>": {"<all_locales>": "bar"}}}');
+        $this->assertProductRawValuesEquals('product6', '{"name": {"<all_channels>": {"en_US": "bar"}}}');
+        $this->assertProductRawValuesEquals('product7', '{"name": {"mobile": {"<all_locales>": "bar"}}}');
+    }
+
+    private function getCommandLauncher(): CommandLauncher
+    {
+        return $this->get('pim_catalog.command_launcher');
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->get('database_connection');
+    }
+
+    private function assertProductRawValuesEquals(string $productIdentifier, string $expectedRawValues)
+    {
+        $result = $this->getConnection()->fetchArray(
+            'SELECT raw_values FROM pim_catalog_product WHERE identifier=:identifier',
+            ['identifier' => $productIdentifier]
+        );
+        $this->assertEquals($expectedRawValues, $result[0]);
+    }
+
+    private function reExecuteMigration(string $migrationLabel)
+    {
+        $resultDown = $this->getCommandLauncher()->executeForeground(sprintf('doctrine:migrations:execute %s --down -n', $migrationLabel));
+        $this->assertEquals(0, $resultDown->getCommandStatus());
+
+        $resultUp = $this->getCommandLauncher()->executeForeground(sprintf('doctrine:migrations:execute %s --up -n', $migrationLabel));
+        $this->assertEquals(0, $resultUp->getCommandStatus());
+    }
+}

--- a/tests/back/Pim/Enrichment/Upgrade/RemoveProductEmptyRawValuesIntegration.php
+++ b/tests/back/Pim/Enrichment/Upgrade/RemoveProductEmptyRawValuesIntegration.php
@@ -11,7 +11,7 @@ class RemoveProductEmptyRawValuesIntegration extends TestCase
 {
     protected function getConfiguration()
     {
-        $this->catalog->useTechnicalSqlCatalog();
+        $this->catalog->useTechnicalCatalog();
     }
 
     public function testItRemovesAllEmptyValues()
@@ -19,13 +19,13 @@ class RemoveProductEmptyRawValuesIntegration extends TestCase
         $this->getConnection()->executeQuery('DELETE FROM pim_catalog_product');
         $sql = <<<SQL
 INSERT INTO pim_catalog_product VALUES
-    (NULL, 18, NULL, NULL, 1, 'product1', '{"name": {"<all_channels>": {"<all_locales>": ""}}}', NOW(), NOW()),
-    (NULL, 18, NULL, NULL, 1, 'product2', '{"name": {"<all_channels>": {"<all_locales>": []}}}', NOW(), NOW()),
-    (NULL, 18, NULL, NULL, 1, 'product3', '{"name": {"<all_channels>": {"<all_locales>": [""]}}}', NOW(), NOW()),
-    (NULL, 18, NULL, NULL, 1, 'product4', '{"name": {"<all_channels>": {"<all_locales>": null}}}', NOW(), NOW()),
-    (NULL, 18, NULL, NULL, 1, 'product5', '{"name": {"<all_channels>": {"<all_locales>": ""}}, "foo": {"<all_channels>": {"<all_locales>": "bar"}}}', NOW(), NOW()),
-    (NULL, 18, NULL, NULL, 1, 'product6', '{"name": {"<all_channels>": {"fr_FR": "", "en_US": "bar"}}}', NOW(), NOW()),
-    (NULL, 18, NULL, NULL, 1, 'product7', '{"name": {"ecommerce": {"<all_locales>": ""}, "mobile": {"<all_locales>": "bar"}}}', NOW(), NOW())
+    (NULL, NULL, NULL, NULL, 1, 'product1', '{"name": {"<all_channels>": {"<all_locales>": ""}}}', NOW(), NOW()),
+    (NULL, NULL, NULL, NULL, 1, 'product2', '{"name": {"<all_channels>": {"<all_locales>": []}}}', NOW(), NOW()),
+    (NULL, NULL, NULL, NULL, 1, 'product3', '{"name": {"<all_channels>": {"<all_locales>": [""]}}}', NOW(), NOW()),
+    (NULL, NULL, NULL, NULL, 1, 'product4', '{"name": {"<all_channels>": {"<all_locales>": null}}}', NOW(), NOW()),
+    (NULL, NULL, NULL, NULL, 1, 'product5', '{"name": {"<all_channels>": {"<all_locales>": ""}}, "foo": {"<all_channels>": {"<all_locales>": "bar"}}}', NOW(), NOW()),
+    (NULL, NULL, NULL, NULL, 1, 'product6', '{"name": {"<all_channels>": {"fr_FR": "", "en_US": "bar"}}}', NOW(), NOW()),
+    (NULL, NULL, NULL, NULL, 1, 'product7', '{"name": {"ecommerce": {"<all_locales>": ""}, "mobile": {"<all_locales>": "bar"}}}', NOW(), NOW())
 SQL;
 
         $this->getConnection()->executeQuery($sql);

--- a/tests/back/Pim/Enrichment/Upgrade/RemoveProductModelEmptyRawValuesIntegration.php
+++ b/tests/back/Pim/Enrichment/Upgrade/RemoveProductModelEmptyRawValuesIntegration.php
@@ -1,5 +1,6 @@
 <?php
 
+use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Component\Console\CommandLauncher;
 use Doctrine\DBAL\Connection;
@@ -9,9 +10,9 @@ use Doctrine\DBAL\Connection;
  */
 class RemoveProductModelEmptyRawValuesIntegration extends TestCase
 {
-    protected function getConfiguration()
+    protected function getConfiguration(): Configuration
     {
-        $this->catalog->useTechnicalCatalog();
+        return $this->catalog->useTechnicalCatalog();
     }
 
     public function testItRemovesAllEmptyValues()
@@ -29,7 +30,6 @@ INSERT INTO pim_catalog_product_model VALUES
     (NULL, NULL, :familyId, 'pm6', '{"name": {"<all_channels>": {"fr_FR": "", "en_US": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0),
     (NULL, NULL, :familyId, 'pm7', '{"name": {"ecommerce": {"<all_locales>": ""}, "mobile": {"<all_locales>": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0)
 SQL;
-
         $this->getConnection()->executeQuery($sql, ['familyId' => $familyId]);
 
         $this->reExecuteMigration('_4_0_20190917080512_remove_product_model_empty_raw_values');

--- a/tests/back/Pim/Enrichment/Upgrade/RemoveProductModelEmptyRawValuesIntegration.php
+++ b/tests/back/Pim/Enrichment/Upgrade/RemoveProductModelEmptyRawValuesIntegration.php
@@ -1,0 +1,71 @@
+<?php
+
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\Console\CommandLauncher;
+use Doctrine\DBAL\Connection;
+
+/**
+ * This class will be removed after 4.0 version
+ */
+class RemoveProductModelEmptyRawValuesIntegration extends TestCase
+{
+    protected function getConfiguration()
+    {
+        $this->catalog->useTechnicalSqlCatalog();
+    }
+
+    public function testItRemovesAllEmptyValues()
+    {
+        $this->getConnection()->executeQuery('DELETE FROM pim_catalog_product_model');
+        $sql = <<<SQL
+INSERT INTO pim_catalog_product_model VALUES
+    (NULL, NULL, 10, 'pm1', '{"name": {"<all_channels>": {"<all_locales>": ""}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, 10, 'pm2', '{"name": {"<all_channels>": {"<all_locales>": []}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, 10, 'pm3', '{"name": {"<all_channels>": {"<all_locales>": [""]}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, 10, 'pm4', '{"name": {"<all_channels>": {"<all_locales>": null}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, 10, 'pm5', '{"name": {"<all_channels>": {"<all_locales>": ""}}, "foo": {"<all_channels>": {"<all_locales>": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, 10, 'pm6', '{"name": {"<all_channels>": {"fr_FR": "", "en_US": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, 10, 'pm7', '{"name": {"ecommerce": {"<all_locales>": ""}, "mobile": {"<all_locales>": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0)
+SQL;
+
+        $this->getConnection()->executeQuery($sql);
+
+        $this->reExecuteMigration('_4_0_20190917080512_remove_product_model_empty_raw_values');
+
+        $this->assertProductModelRawValuesEquals('pm1', '{}');
+        $this->assertProductModelRawValuesEquals('pm2', '{}');
+        $this->assertProductModelRawValuesEquals('pm3', '{}');
+        $this->assertProductModelRawValuesEquals('pm4', '{}');
+        $this->assertProductModelRawValuesEquals('pm5', '{"foo": {"<all_channels>": {"<all_locales>": "bar"}}}');
+        $this->assertProductModelRawValuesEquals('pm6', '{"name": {"<all_channels>": {"en_US": "bar"}}}');
+        $this->assertProductModelRawValuesEquals('pm7', '{"name": {"mobile": {"<all_locales>": "bar"}}}');
+    }
+
+    private function getCommandLauncher(): CommandLauncher
+    {
+        return $this->get('pim_catalog.command_launcher');
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->get('database_connection');
+    }
+
+    private function assertProductModelRawValuesEquals(string $productModelCode, string $expectedRawValues)
+    {
+        $result = $this->getConnection()->fetchArray(
+            'SELECT raw_values FROM pim_catalog_product_model WHERE code=:code',
+            ['code' => $productModelCode]
+        );
+        $this->assertEquals($expectedRawValues, $result[0]);
+    }
+
+    private function reExecuteMigration(string $migrationLabel)
+    {
+        $resultDown = $this->getCommandLauncher()->executeForeground(sprintf('doctrine:migrations:execute %s --down -n', $migrationLabel));
+        $this->assertEquals(0, $resultDown->getCommandStatus());
+
+        $resultUp = $this->getCommandLauncher()->executeForeground(sprintf('doctrine:migrations:execute %s --up -n', $migrationLabel));
+        $this->assertEquals(0, $resultUp->getCommandStatus());
+    }
+}

--- a/tests/back/Pim/Enrichment/Upgrade/RemoveProductModelEmptyRawValuesIntegration.php
+++ b/tests/back/Pim/Enrichment/Upgrade/RemoveProductModelEmptyRawValuesIntegration.php
@@ -65,9 +65,9 @@ SQL;
     private function reExecuteMigration(string $migrationLabel)
     {
         $resultDown = $this->getCommandLauncher()->executeForeground(sprintf('doctrine:migrations:execute %s --down -n', $migrationLabel));
-        $this->assertEquals(0, $resultDown->getCommandStatus());
+        $this->assertEquals(0, $resultDown->getCommandStatus(), json_encode($resultDown->getCommandOutput()));
 
         $resultUp = $this->getCommandLauncher()->executeForeground(sprintf('doctrine:migrations:execute %s --up -n', $migrationLabel));
-        $this->assertEquals(0, $resultUp->getCommandStatus());
+        $this->assertEquals(0, $resultUp->getCommandStatus(), json_encode($resultUp->getCommandOutput()));
     }
 }

--- a/tests/back/Pim/Enrichment/Upgrade/RemoveProductModelEmptyRawValuesIntegration.php
+++ b/tests/back/Pim/Enrichment/Upgrade/RemoveProductModelEmptyRawValuesIntegration.php
@@ -11,24 +11,26 @@ class RemoveProductModelEmptyRawValuesIntegration extends TestCase
 {
     protected function getConfiguration()
     {
-        $this->catalog->useTechnicalSqlCatalog();
+        $this->catalog->useTechnicalCatalog();
     }
 
     public function testItRemovesAllEmptyValues()
     {
         $this->getConnection()->executeQuery('DELETE FROM pim_catalog_product_model');
+        $familySearch = $this->getConnection()->fetchArray('SELECT id FROM pim_catalog_family_variant LIMIT 1');
+        $familyId = $familySearch[0];
         $sql = <<<SQL
 INSERT INTO pim_catalog_product_model VALUES
-    (NULL, NULL, 10, 'pm1', '{"name": {"<all_channels>": {"<all_locales>": ""}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, 10, 'pm2', '{"name": {"<all_channels>": {"<all_locales>": []}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, 10, 'pm3', '{"name": {"<all_channels>": {"<all_locales>": [""]}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, 10, 'pm4', '{"name": {"<all_channels>": {"<all_locales>": null}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, 10, 'pm5', '{"name": {"<all_channels>": {"<all_locales>": ""}}, "foo": {"<all_channels>": {"<all_locales>": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, 10, 'pm6', '{"name": {"<all_channels>": {"fr_FR": "", "en_US": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, 10, 'pm7', '{"name": {"ecommerce": {"<all_locales>": ""}, "mobile": {"<all_locales>": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0)
+    (NULL, NULL, :familyId, 'pm1', '{"name": {"<all_channels>": {"<all_locales>": ""}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, :familyId, 'pm2', '{"name": {"<all_channels>": {"<all_locales>": []}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, :familyId, 'pm3', '{"name": {"<all_channels>": {"<all_locales>": [""]}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, :familyId, 'pm4', '{"name": {"<all_channels>": {"<all_locales>": null}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, :familyId, 'pm5', '{"name": {"<all_channels>": {"<all_locales>": ""}}, "foo": {"<all_channels>": {"<all_locales>": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, :familyId, 'pm6', '{"name": {"<all_channels>": {"fr_FR": "", "en_US": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0),
+    (NULL, NULL, :familyId, 'pm7', '{"name": {"ecommerce": {"<all_locales>": ""}, "mobile": {"<all_locales>": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0)
 SQL;
 
-        $this->getConnection()->executeQuery($sql);
+        $this->getConnection()->executeQuery($sql, ['familyId' => $familyId]);
 
         $this->reExecuteMigration('_4_0_20190917080512_remove_product_model_empty_raw_values');
 

--- a/upgrades/schema/Version_4_0_20190916122239_remove_empty_raw_values.php
+++ b/upgrades/schema/Version_4_0_20190916122239_remove_empty_raw_values.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexer;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\EmptyValuesCleaner;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * TODO
+ */
+final class Version_4_0_20190916122239_remove_empty_raw_values extends AbstractMigration implements ContainerAwareInterface
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    const BATCH_SIZE = 100;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $productsToProcess = true;
+        $toReindex = [];
+        $page = 0;
+        while ($productsToProcess) {
+            $productsToProcess = false;
+            $sql = sprintf(
+                "SELECT identifier, raw_values FROM pim_catalog_product LIMIT %d, %s",
+                $page * self::BATCH_SIZE,
+                self::BATCH_SIZE
+            );
+            $rows = $this->connection->executeQuery($sql)->fetchAll();
+
+            foreach ($rows as $row) {
+                $productsToProcess = true;
+                $rawValues = json_decode($row['raw_values'], true);
+                $cleanRawValues = $this->getValueCleaner()->cleanAllValues(['ID' => $rawValues])['ID'];
+                if ($rawValues !== $cleanRawValues) {
+                    $this->connection->executeQuery(
+                        'UPDATE pim_catalog_product SET raw_values = :rawValues WHERE identifier = :identifier',
+                        [
+                            'rawValues' => json_encode($cleanRawValues),
+                            'identifier' => $row['identifier']
+                        ], [
+                            'rawValues' => Type::STRING,
+                            'identifier' => Type::STRING
+                        ]
+                    );
+                    $toReindex[] = $row['identifier'];
+                    if (count($toReindex) % self::BATCH_SIZE === 0) {
+                        $this->getProductIndexer()->indexFromProductIdentifiers($toReindex);
+                        $toReindex = [];
+                    }
+                }
+            }
+
+            $page++;
+        }
+
+        $this->getProductIndexer()->indexFromProductIdentifiers($toReindex);
+    }
+
+    public function down(Schema $schema) : void
+    {
+    }
+
+    private function getValueCleaner(): EmptyValuesCleaner
+    {
+        return $this->container->get('akeneo.pim.enrichment.factory.empty_values_cleaner');
+    }
+
+    private function getProductIndexer(): ProductIndexer
+    {
+        return $this->container->get('pim_catalog.elasticsearch.indexer.product');
+    }
+}

--- a/upgrades/schema/Version_4_0_20190916122239_remove_empty_raw_values.php
+++ b/upgrades/schema/Version_4_0_20190916122239_remove_empty_raw_values.php
@@ -3,6 +3,7 @@
 namespace Pim\Upgrade\Schema;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexer;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelIndexer;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\EmptyValuesCleaner;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
@@ -11,7 +12,8 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * TODO
+ * This migration will delete the empty values from raw values of product and product models.
+ * For example, the value {attr: {<all_channels>: {<all_locales: []}}} will be removed from the raw_values field.
  */
 final class Version_4_0_20190916122239_remove_empty_raw_values extends AbstractMigration implements ContainerAwareInterface
 {
@@ -30,8 +32,14 @@ final class Version_4_0_20190916122239_remove_empty_raw_values extends AbstractM
 
     public function up(Schema $schema) : void
     {
+        $this->cleanProducts();
+        $this->cleanProductModels();
+    }
+
+    private function cleanProducts()
+    {
         $productsToProcess = true;
-        $toReindex = [];
+        $productIdentifiersToIndex = [];
         $page = 0;
         while ($productsToProcess) {
             $productsToProcess = false;
@@ -57,10 +65,10 @@ final class Version_4_0_20190916122239_remove_empty_raw_values extends AbstractM
                             'identifier' => Type::STRING
                         ]
                     );
-                    $toReindex[] = $row['identifier'];
-                    if (count($toReindex) % self::BATCH_SIZE === 0) {
-                        $this->getProductIndexer()->indexFromProductIdentifiers($toReindex);
-                        $toReindex = [];
+                    $productIdentifiersToIndex[] = $row['identifier'];
+                    if (count($productIdentifiersToIndex) % self::BATCH_SIZE === 0) {
+                        $this->getProductIndexer()->indexFromProductIdentifiers($productIdentifiersToIndex);
+                        $productIdentifiersToIndex = [];
                     }
                 }
             }
@@ -68,7 +76,50 @@ final class Version_4_0_20190916122239_remove_empty_raw_values extends AbstractM
             $page++;
         }
 
-        $this->getProductIndexer()->indexFromProductIdentifiers($toReindex);
+        $this->getProductIndexer()->indexFromProductIdentifiers($productIdentifiersToIndex);
+    }
+
+    private function cleanProductModels()
+    {
+        $productModelsToProcess = true;
+        $productModelCodesToIndex = [];
+        $page = 0;
+        while ($productModelsToProcess) {
+            $productModelsToProcess = false;
+            $sql = sprintf(
+                "SELECT code, raw_values FROM pim_catalog_product_model LIMIT %d, %s",
+                $page * self::BATCH_SIZE,
+                self::BATCH_SIZE
+            );
+            $rows = $this->connection->executeQuery($sql)->fetchAll();
+
+            foreach ($rows as $row) {
+                $productModelsToProcess = true;
+                $rawValues = json_decode($row['raw_values'], true);
+                $cleanRawValues = $this->getValueCleaner()->cleanAllValues(['ID' => $rawValues])['ID'];
+                if ($rawValues !== $cleanRawValues) {
+                    $this->connection->executeQuery(
+                        'UPDATE pim_catalog_product_model SET raw_values = :rawValues WHERE code = :code',
+                        [
+                            'rawValues' => json_encode($cleanRawValues),
+                            'code' => $row['code']
+                        ], [
+                            'rawValues' => Type::STRING,
+                            'code' => Type::STRING
+                        ]
+                    );
+                    $productModelCodesToIndex[] = $row['code'];
+                    if (count($productModelCodesToIndex) % self::BATCH_SIZE === 0) {
+                        $this->getProductModelIndexer()->indexFromProductModelCodes($productModelCodesToIndex);
+                        $productModelCodesToIndex = [];
+                    }
+                }
+            }
+
+            $page++;
+        }
+
+        $this->getProductModelIndexer()->indexFromProductModelCodes($productModelCodesToIndex);
     }
 
     public function down(Schema $schema) : void
@@ -83,5 +134,10 @@ final class Version_4_0_20190916122239_remove_empty_raw_values extends AbstractM
     private function getProductIndexer(): ProductIndexer
     {
         return $this->container->get('pim_catalog.elasticsearch.indexer.product');
+    }
+
+    private function getProductModelIndexer(): ProductModelIndexer
+    {
+        return $this->container->get('pim_catalog.elasticsearch.indexer.product_model');
     }
 }

--- a/upgrades/schema/Version_4_0_20190916122239_remove_product_empty_raw_values.php
+++ b/upgrades/schema/Version_4_0_20190916122239_remove_product_empty_raw_values.php
@@ -53,7 +53,8 @@ final class Version_4_0_20190916122239_remove_product_empty_raw_values
             foreach ($rows as $row) {
                 $productsToProcess = true;
                 $rawValues = json_decode($row['raw_values'], true);
-                $cleanRawValues = $this->getValueCleaner()->cleanAllValues(['ID' => $rawValues])['ID'];
+                $cleanRawValues = $this->getValueCleaner()->cleanAllValues(['ID' => $rawValues]);
+                $cleanRawValues = isset($cleanRawValues['ID']) ? $cleanRawValues['ID'] : (object) [];
                 if ($rawValues !== $cleanRawValues) {
                     $this->connection->executeQuery(
                         'UPDATE pim_catalog_product SET raw_values = :rawValues WHERE identifier = :identifier',

--- a/upgrades/schema/Version_4_0_20190917080512_remove_product_model_empty_raw_values.php
+++ b/upgrades/schema/Version_4_0_20190917080512_remove_product_model_empty_raw_values.php
@@ -5,6 +5,7 @@ namespace Pim\Upgrade\Schema;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelIndexer;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\EmptyValuesCleaner;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\Migrations\AbstractMigration;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -47,7 +48,8 @@ final class Version_4_0_20190917080512_remove_product_model_empty_raw_values
             foreach ($rows as $row) {
                 $productModelsToProcess = true;
                 $rawValues = json_decode($row['raw_values'], true);
-                $cleanRawValues = $this->getValueCleaner()->cleanAllValues(['ID' => $rawValues])['ID'];
+                $cleanRawValues = $this->getValueCleaner()->cleanAllValues(['ID' => $rawValues]);
+                $cleanRawValues = isset($cleanRawValues['ID']) ? $cleanRawValues['ID'] : (object) [];
                 if ($rawValues !== $cleanRawValues) {
                     $this->connection->executeQuery(
                         'UPDATE pim_catalog_product_model SET raw_values = :rawValues WHERE code = :code',

--- a/upgrades/schema/Version_4_0_20190917080512_remove_product_model_empty_raw_values.php
+++ b/upgrades/schema/Version_4_0_20190917080512_remove_product_model_empty_raw_values.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Upgrade\Schema;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelDescendantsIndexer;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelIndexer;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\EmptyValuesCleaner;
 use Doctrine\DBAL\Schema\Schema;
@@ -64,6 +65,7 @@ final class Version_4_0_20190917080512_remove_product_model_empty_raw_values
                     $productModelCodesToIndex[] = $row['code'];
                     if (count($productModelCodesToIndex) % self::BATCH_SIZE === 0) {
                         $this->getProductModelIndexer()->indexFromProductModelCodes($productModelCodesToIndex);
+                        // @TODO Need to reindex children TIP-1257
                         $productModelCodesToIndex = [];
                     }
                 }
@@ -72,6 +74,7 @@ final class Version_4_0_20190917080512_remove_product_model_empty_raw_values
         }
 
         $this->getProductModelIndexer()->indexFromProductModelCodes($productModelCodesToIndex);
+        // @TODO Need to reindex children TIP-1257
     }
 
     public function down(Schema $schema) : void
@@ -86,5 +89,10 @@ final class Version_4_0_20190917080512_remove_product_model_empty_raw_values
     private function getProductModelIndexer(): ProductModelIndexer
     {
         return $this->container->get('pim_catalog.elasticsearch.indexer.product_model');
+    }
+
+    private function getProductModelDescendantsIndexer(): ProductModelDescendantsIndexer
+    {
+        return $this->container->get('pim_catalog.elasticsearch.indexer.product_model_descendance');
     }
 }

--- a/upgrades/schema/Version_4_0_20190917080512_remove_product_model_empty_raw_values.php
+++ b/upgrades/schema/Version_4_0_20190917080512_remove_product_model_empty_raw_values.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelIndexer;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\EmptyValuesCleaner;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * This migration will delete the empty values from raw values of product models.
+ * For example, the value {attr: {<all_channels>: {<all_locales: []}}} will be removed from the raw_values field.
+ */
+final class Version_4_0_20190917080512_remove_product_model_empty_raw_values extends AbstractMigration
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    private const BATCH_SIZE = 1000;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $productModelsToProcess = true;
+        $productModelCodesToIndex = [];
+        $page = 0;
+        while ($productModelsToProcess) {
+            $productModelsToProcess = false;
+            $sql = sprintf(
+                "SELECT code, raw_values FROM pim_catalog_product_model LIMIT %d, %s",
+                $page * self::BATCH_SIZE,
+                self::BATCH_SIZE
+            );
+            $rows = $this->connection->executeQuery($sql)->fetchAll();
+
+            foreach ($rows as $row) {
+                $productModelsToProcess = true;
+                $rawValues = json_decode($row['raw_values'], true);
+                $cleanRawValues = $this->getValueCleaner()->cleanAllValues(['ID' => $rawValues])['ID'];
+                if ($rawValues !== $cleanRawValues) {
+                    $this->connection->executeQuery(
+                        'UPDATE pim_catalog_product_model SET raw_values = :rawValues WHERE code = :code',
+                        [
+                            'rawValues' => json_encode($cleanRawValues),
+                            'code' => $row['code']
+                        ], [
+                            'rawValues' => Type::STRING,
+                            'code' => Type::STRING
+                        ]
+                    );
+                    $productModelCodesToIndex[] = $row['code'];
+                    if (count($productModelCodesToIndex) % self::BATCH_SIZE === 0) {
+                        $this->getProductModelIndexer()->indexFromProductModelCodes($productModelCodesToIndex);
+                        $productModelCodesToIndex = [];
+                    }
+                }
+            }
+
+            $page++;
+        }
+
+        $this->getProductModelIndexer()->indexFromProductModelCodes($productModelCodesToIndex);
+    }
+
+    public function down(Schema $schema) : void
+    {
+    }
+
+    private function getValueCleaner(): EmptyValuesCleaner
+    {
+        return $this->container->get('akeneo.pim.enrichment.factory.empty_values_cleaner');
+    }
+
+    private function getProductModelIndexer(): ProductModelIndexer
+    {
+        return $this->container->get('pim_catalog.elasticsearch.indexer.product_model');
+    }
+}


### PR DESCRIPTION
We forbid the use of null values in the domain, as it does not make sense (the value object should not accept null values anymore). It was the cause of multiple bug.

So, we should not have any null value anymore in the storage, which was not the case.
The gaol of this script is to clean the database.

The completeness is not impacted, no need to relaculate it.
We will have to re-index only the impacted product. Do note that the indexation will be with sql queries as we are currently reworking it.