### PR TITLE
TIP-1252 Removes deprecated docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   setup:
     machine:
       image: ubuntu-1604:201903-01
-      docker_layer_caching: true
     steps:
       - checkout
       - run:
@@ -76,7 +75,6 @@ jobs:
   back_static_and_acceptance:
       machine:
           image: ubuntu-1604:201903-01
-          docker_layer_caching: true
       steps:
           - attach_workspace:
                 at: ~/
@@ -125,7 +123,6 @@ jobs:
   back_phpunit:
       machine:
           image: ubuntu-1604:201903-01
-          docker_layer_caching: true
       parallelism: 10
       steps:
           - attach_workspace:
@@ -162,7 +159,6 @@ jobs:
   back_behat_legacy:
     machine:
       image: ubuntu-1604:201903-01
-      docker_layer_caching: true
     parallelism: 20
     steps:
       - attach_workspace:
@@ -218,7 +214,6 @@ jobs:
   front_static_acceptance_and_integration:
       machine:
           image: ubuntu-1604:201903-01
-          docker_layer_caching: true
       steps:
         - attach_workspace:
             at: ~/


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Docker layer caching will be removed for the container plan and very expensive for the Performance Plan.
So we remove it and will work on an alternative solution.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
