### PR TITLE
TIP-1252 Removes deprecated docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   setup:
     machine:
       enabled: true
-      docker_layer_caching: true
     steps:
       - checkout
       - run:
@@ -75,7 +74,6 @@ jobs:
   back_static_and_acceptance:
       machine:
           enabled: true
-          docker_layer_caching: true
       steps:
           - attach_workspace:
                 at: ~/
@@ -118,7 +116,6 @@ jobs:
   back_phpunit_integration:
       machine:
           enabled: true
-          docker_layer_caching: true
       parallelism: 10
       steps:
           - attach_workspace:
@@ -149,7 +146,6 @@ jobs:
   back_phpunit_end_to_end:
       machine:
           enabled: true
-          docker_layer_caching: true
       parallelism: 10
       steps:
           - attach_workspace:
@@ -180,7 +176,6 @@ jobs:
   back_behat_legacy:
     machine:
       enabled: true
-      docker_layer_caching: true
     parallelism: 20
     steps:
       - attach_workspace:
@@ -238,7 +233,6 @@ jobs:
   front_static_acceptance_and_integration:
       machine:
           enabled: true
-          docker_layer_caching: true
       steps:
         - attach_workspace:
             at: ~/


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Docker layer caching will be removed for the container plan and very expensive for the Performance Plan.
So we remove it and will work on an alternative solution.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
