### PR TITLE
TIP-1250: use the OSS image for ES

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - 'pim'
 
   elasticsearch:
-    image: 'docker.elastic.co/elasticsearch/elasticsearch:7.3.1'
+    image: 'docker.elastic.co/elasticsearch/elasticsearch-oss:7.3.1'
     environment:
       ES_JAVA_OPTS: '${ES_JAVA_OPTS:--Xms512m -Xmx512m}'
       discovery.type: 'single-node'


### PR DESCRIPTION
Because on the non OSS package, xpack plugin is installed. It works 2 weeks for free and then you have to pay for it.