### PR TITLE
PIM-7890: fix non removed category filter in job instances

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 ## Bug fixes
 
 - PIM-8738: Fix memory leak executing "akeneo:batch:purge-job-execution" command
+- PIM-8790: Fix non removed category filter in job instances
 
 # 2.3.62 (2019-09-13)
 

--- a/src/Pim/Bundle/EnrichBundle/EventListener/Storage/RemoveCategoryFilterInJobInstanceSubscriber.php
+++ b/src/Pim/Bundle/EnrichBundle/EventListener/Storage/RemoveCategoryFilterInJobInstanceSubscriber.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\EventListener\Storage;
+
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Doctrine\ORM\EntityRepository;
+use Pim\Component\Catalog\Model\CategoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RemoveCategoryFilterInJobInstanceSubscriber implements EventSubscriberInterface
+{
+    private const DEFAULT_CATEGORY_TREE_FILTER = ['master'];
+
+    /** @var EntityRepository */
+    private $repository;
+
+    /** @var BulkSaverInterface */
+    private $bulkSaver;
+
+    private $computedCodes = [];
+
+    public function __construct(EntityRepository $repository, BulkSaverInterface $bulkSaver)
+    {
+        $this->repository = $repository;
+        $this->bulkSaver = $bulkSaver;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            StorageEvents::PRE_REMOVE      => 'computeAndHoldCategoryTreeCodes',
+            StorageEvents::PRE_REMOVE_ALL  => 'computeAndHoldCategoryTreeCodes',
+            StorageEvents::POST_REMOVE     => 'removeCategoryFilter',
+            StorageEvents::POST_REMOVE_ALL => 'removeCategoryFilters',
+        ];
+    }
+
+    /**
+     * We can not get the child's codes of a category after delete. So when a category is going to be deleted,
+     * we get all the child's codes linked to it and keep them in $computedCodes property.
+     *
+     * @param GenericEvent $event
+     * @return RemoveCategoryFilterInJobInstanceSubscriber
+     */
+    public function computeAndHoldCategoryTreeCodes(GenericEvent $event): RemoveCategoryFilterInJobInstanceSubscriber
+    {
+        $subject = $event->getSubject();
+        if ($subject instanceof CategoryInterface) {
+            $this->computedCodes[$subject->getCode()] = $this->getCodeAndChildrenCodes($subject);
+        }
+
+        if (is_array($subject) && current($subject) instanceof CategoryInterface) {
+            foreach ($subject as $category) {
+                $this->computedCodes[$category->getCode()] = $this->getCodeAndChildrenCodes($category);
+            }
+        }
+
+        return $this;
+    }
+
+    public function removeCategoryFilter(GenericEvent $event): int
+    {
+        $subject = $event->getSubject();
+        if (!$subject instanceof CategoryInterface) {
+            return 0;
+        }
+
+        if (!$event->hasArgument('unitary') || false === $event->getArgument('unitary')) {
+            return 0;
+        }
+
+        $code = $subject->getCode();
+
+        return $this->removeCategoryCodesFilterInAllJobInstances($this->computedCodes[$code] ?? [$code]);
+    }
+
+    public function removeCategoryFilters(GenericEvent $event): int
+    {
+        $subject = $event->getSubject();
+        if (!is_array($subject) || !current($subject) instanceof CategoryInterface) {
+            return 0;
+        }
+
+        $codes = [];
+        foreach ($subject as $category) {
+            $code = $category->getCode();
+            $codes = array_merge($codes, $this->computedCodes[$code] ?? [$code]);
+        }
+
+        return $this->removeCategoryCodesFilterInAllJobInstances(array_unique($codes));
+    }
+
+    /**
+     * Get the code of the category and its children.
+     *
+     * @param CategoryInterface $category
+     * @return string[]
+     */
+    private function getCodeAndChildrenCodes(CategoryInterface $category): array
+    {
+        $codes = [$category->getCode()];
+        foreach ($category->getChildren() as $child) {
+            $codes = array_merge($codes, $this->getCodeAndChildrenCodes($child));
+        }
+
+        return $codes;
+    }
+
+    private function removeCategoryCodesFilterInAllJobInstances(array $categoryCodes): int
+    {
+        $jobsToUpdate = [];
+        foreach ($this->repository->findAll() as $jobInstance) {
+            if ($this->removeCategoryCodesFilterInJobInstance($jobInstance, $categoryCodes)) {
+                $jobsToUpdate[] = $jobInstance;
+            }
+        }
+
+        if (!empty($jobsToUpdate)) {
+            $this->bulkSaver->saveAll($jobsToUpdate);
+        }
+
+        return count($jobsToUpdate);
+    }
+
+    private function removeCategoryCodesFilterInJobInstance(JobInstance $jobInstance, array $categoryCodes): bool
+    {
+        $rawParameters = $jobInstance->getRawParameters();
+
+        if (is_array($rawParameters['filters']['data'] ?? null)) {
+            foreach ($rawParameters['filters']['data'] as $filterKey => $filter) {
+                if ('categories' !== $filter['field']) {
+                    continue;
+                }
+
+                $newValues = [];
+                foreach ($filter['value'] as $value) {
+                    if (!in_array($value, $categoryCodes)) {
+                        $newValues[] = $value;
+                    }
+                }
+
+                if (count($newValues) === 0) {
+                    $rawParameters['filters']['data'][$filterKey]['value'] = self::DEFAULT_CATEGORY_TREE_FILTER;
+                    $jobInstance->setRawParameters($rawParameters);
+
+                    return true;
+                }
+
+                if (count($newValues) !== count(($filter['value']))) {
+                    $rawParameters['filters']['data'][$filterKey]['value'] = $newValues;
+                    $jobInstance->setRawParameters($rawParameters);
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/event_listeners.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/event_listeners.yml
@@ -54,3 +54,11 @@ services:
         class: '%pim_enrich.event_listener.add_locale.class%'
         tags:
             - { name: doctrine.event_subscriber }
+
+    pim_enrich.event_listener.remove_category_filter_in_job_instance:
+        class: Pim\Bundle\EnrichBundle\EventListener\Storage\RemoveCategoryFilterInJobInstanceSubscriber
+        arguments:
+            - '@akeneo_batch.job.job_instance_repository'
+            - '@akeneo_batch.saver.job_instance'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/EnrichBundle/spec/EventListener/Storage/RemoveCategoryFilterInJobInstanceSubscriberSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/EventListener/Storage/RemoveCategoryFilterInJobInstanceSubscriberSpec.php
@@ -238,7 +238,7 @@ class RemoveCategoryFilterInJobInstanceSubscriberSpec extends ObjectBehavior
                 'data' => [
                     [
                         'field' => 'categories',
-                        'operator' => 'IN',
+                        'operator' => 'IN CHILDREN',
                         'value' => ['master'],
                     ],
                 ],
@@ -304,8 +304,8 @@ class RemoveCategoryFilterInJobInstanceSubscriberSpec extends ObjectBehavior
                 'data' => [
                     [
                         'field' => 'categories',
-                        'operator' => 'IN',
-                        'value' => ['master'],
+                        'operator' => 'IN CHILDREN',
+                        'value' => ['parent_code1', 'parent_code2'],
                     ],
                 ],
             ],

--- a/src/Pim/Bundle/EnrichBundle/spec/EventListener/Storage/RemoveCategoryFilterInJobInstanceSubscriberSpec.php
+++ b/src/Pim/Bundle/EnrichBundle/spec/EventListener/Storage/RemoveCategoryFilterInJobInstanceSubscriberSpec.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Pim\Bundle\EnrichBundle\EventListener\Storage;
+
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Doctrine\ORM\EntityRepository;
+use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Entity\Category;
+use Pim\Bundle\EnrichBundle\EventListener\Storage\RemoveCategoryFilterInJobInstanceSubscriber;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RemoveCategoryFilterInJobInstanceSubscriberSpec extends ObjectBehavior
+{
+    function let(EntityRepository $repository, BulkSaverInterface $bulkSaver)
+    {
+        $this->beConstructedWith($repository, $bulkSaver);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(RemoveCategoryFilterInJobInstanceSubscriber::class);
+    }
+
+   function it_implements_event_subscriber_interface()
+    {
+        $this->shouldImplement(EventSubscriberInterface::class);
+    }
+
+
+    function it_subscribes_to_storage_events()
+    {
+        $this->getSubscribedEvents()->shouldReturn([
+            StorageEvents::PRE_REMOVE      => 'computeAndHoldCategoryTreeCodes',
+            StorageEvents::PRE_REMOVE_ALL  => 'computeAndHoldCategoryTreeCodes',
+            StorageEvents::POST_REMOVE     => 'removeCategoryFilter',
+            StorageEvents::POST_REMOVE_ALL => 'removeCategoryFilters',
+        ]);
+    }
+
+    function it_removes_category_in_job_filter(
+        EntityRepository $repository,
+        BulkSaverInterface $bulkSaver,
+        JobInstance $jobInstance1,
+        JobInstance $jobInstance2
+    ) {
+        $category = $this->createCategory('code');
+        $event = new GenericEvent($category, ['unitary' => true]);
+
+        $repository->findAll()->willReturn([$jobInstance1, $jobInstance2]);
+        $jobInstance1->getRawParameters()->willReturn([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1', 'value2'],
+                    ],
+                ],
+            ],
+        ]);
+        $jobInstance2->getRawParameters()->willReturn([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1', 'code'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $jobInstance2->setRawParameters([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1'],
+                    ],
+                ],
+            ],
+        ])->shouldBeCalled();
+        $bulkSaver->saveAll([$jobInstance2])->shouldBeCalled();
+
+        $this->removeCategoryFilter($event)->shouldReturn(1);
+    }
+
+    function it_does_not_remove_unitary(
+        EntityRepository $repository,
+        BulkSaverInterface $bulkSaver,
+        JobInstance $jobInstance1,
+        JobInstance $jobInstance2
+    ) {
+        $category = $this->createCategory('code');
+        $event = new GenericEvent($category, ['unitary' => false]);
+
+        $repository->findAll()->willReturn([$jobInstance1, $jobInstance2]);
+        $jobInstance1->getRawParameters()->willReturn([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1', 'value2'],
+                    ],
+                ],
+            ],
+        ]);
+        $jobInstance2->getRawParameters()->willReturn([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1', 'code'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $jobInstance2->setRawParameters(Argument::cetera())->shouldNotBeCalled();
+        $bulkSaver->saveAll([$jobInstance2])->shouldNotBeCalled();
+
+        $this->removeCategoryFilter($event)->shouldReturn(0);
+    }
+
+    function it_removes_child_category_in_job_filter(
+        EntityRepository $repository,
+        BulkSaverInterface $bulkSaver,
+        JobInstance $jobInstance1,
+        JobInstance $jobInstance2
+    ) {
+        $category = $this->createCategory('code');
+        $parentCategory = $this->createCategory('parent_code', [$category]);
+
+        $event = new GenericEvent($parentCategory, ['unitary' => true]);
+
+        $repository->findAll()->willReturn([$jobInstance1, $jobInstance2]);
+        $jobInstance1->getRawParameters()->willReturn([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1', 'value2'],
+                    ],
+                ],
+            ],
+        ]);
+        $jobInstance2->getRawParameters()->willReturn([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1', 'code'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $jobInstance2->setRawParameters([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1'],
+                    ],
+                ],
+            ],
+        ])->shouldBeCalled();
+        $bulkSaver->saveAll([$jobInstance2])->shouldBeCalled();
+
+        $this->computeAndHoldCategoryTreeCodes($event);
+        $this->removeCategoryFilter($event)->shouldReturn(1);
+    }
+
+    function it_removes_categories_in_job_filter(
+        EntityRepository $repository,
+        BulkSaverInterface $bulkSaver,
+        JobInstance $jobInstance1,
+        JobInstance $jobInstance2
+    ) {
+        $category1 = $this->createCategory('code1');
+        $category2 = $this->createCategory('code2');
+        $event = new GenericEvent([$category1, $category2]);
+
+        $repository->findAll()->willReturn([$jobInstance1, $jobInstance2]);
+        $jobInstance1->getRawParameters()->willReturn([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1', 'code1', 'code2'],
+                    ],
+                ],
+            ],
+        ]);
+        $jobInstance2->getRawParameters()->willReturn([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['code2'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $jobInstance1->setRawParameters([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1'],
+                    ],
+                ],
+            ],
+        ])->shouldBeCalled();
+        $jobInstance2->setRawParameters([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['master'],
+                    ],
+                ],
+            ],
+        ])->shouldBeCalled();
+        $bulkSaver->saveAll([$jobInstance1, $jobInstance2])->shouldBeCalled();
+
+        $this->removeCategoryFilters($event)->shouldReturn(2);
+    }
+
+    function it_removes_child_categories_in_job_filter(
+        EntityRepository $repository,
+        BulkSaverInterface $bulkSaver,
+        JobInstance $jobInstance1,
+        JobInstance $jobInstance2
+    ) {
+        $category1 = $this->createCategory('code1');
+        $parentCategory1 = $this->createCategory('parent_code1', [$category1]);
+
+        $subCategory = $this->createCategory('sub_code');
+        $category2 = $this->createCategory('code2', [$subCategory]);
+        $parentCategory2 = $this->createCategory('parent_code2', [$category2]);
+
+        $event = new GenericEvent([$parentCategory1, $parentCategory2]);
+
+        $repository->findAll()->willReturn([$jobInstance1, $jobInstance2]);
+        $jobInstance1->getRawParameters()->willReturn([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1', 'code1', 'code2'],
+                    ],
+                ],
+            ],
+        ]);
+        $jobInstance2->getRawParameters()->willReturn([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['sub_code'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $jobInstance1->setRawParameters([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['value1'],
+                    ],
+                ],
+            ],
+        ])->shouldBeCalled();
+        $jobInstance2->setRawParameters([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => ['master'],
+                    ],
+                ],
+            ],
+        ])->shouldBeCalled();
+        $bulkSaver->saveAll([$jobInstance1, $jobInstance2])->shouldBeCalled();
+
+        $this->computeAndHoldCategoryTreeCodes($event);
+        $this->removeCategoryFilters($event)->shouldReturn(2);
+    }
+
+    private function createCategory(string $code, array $children = []): Category
+    {
+        $category = new Category();
+        $category->setCode($code);
+        foreach ($children as $child) {
+            $category->addChild($child);
+        }
+
+        return $category;
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/EventListener/RemoveCategoryFilterInJobInstanceSubscriberIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/EventListener/RemoveCategoryFilterInJobInstanceSubscriberIntegration.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\EnrichBundle\tests\integration\EventListener;
+
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\ORM\EntityManager;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RemoveCategoryFilterInJobInstanceSubscriberIntegration extends TestCase
+{
+    public function testValueFilterIsDeletedInJobInstance()
+    {
+        $category = $this->createCategory(['code' => 'foo']);
+        $category = $this->getFromTestContainer('pim_catalog.repository.category')->findOneByIdentifier(
+            $category->getCode()
+        );
+        $jobInstance = $this->createJobInstanceWithCategoryFilter(
+            'job1',
+            ['master_accessories_scarves', $category->getCode(), 'whatever']
+        );
+
+        $this->getFromTestContainer('pim_catalog.remover.category')->remove($this->getFromTestContainer('pim_catalog.repository.category')->findOneByIdentifier($category->getCode()));
+
+        $jobInstance = $this
+            ->getFromTestContainer('akeneo_batch.job.job_instance_repository')
+            ->findOneByIdentifier($jobInstance->getCode());
+        $rawParameters = $jobInstance->getRawParameters();
+        $filters = array_filter($rawParameters['filters']['data'] ?? [], function ($filter) {
+            return 'categories' === $filter['field'];
+        });
+        $this->assertCount(1, $filters);
+        $categoryFilter = current($filters);
+        $this->assertEquals(['master_accessories_scarves', 'whatever'], $categoryFilter['value']);
+    }
+
+    public function testEntireFilterIsDeletedInJobInstance()
+    {
+        $category = $this->createCategory(['code' => 'bar']);
+        $category = $this->getFromTestContainer('pim_catalog.repository.category')->findOneByIdentifier(
+            $category->getCode()
+        );
+        $jobInstance = $this->createJobInstanceWithCategoryFilter(
+            'job2',
+            [$category->getCode()]
+        );
+
+        $this->getFromTestContainer('pim_catalog.remover.category')->remove($this->getFromTestContainer('pim_catalog.repository.category')->findOneByIdentifier($category->getCode()));
+
+        $jobInstance = $this
+            ->getFromTestContainer('akeneo_batch.job.job_instance_repository')
+            ->findOneByIdentifier($jobInstance->getCode());
+        $rawParameters = $jobInstance->getRawParameters();
+        $filters = array_filter($rawParameters['filters']['data'] ?? [], function ($filter) {
+            return 'categories' === $filter['field'];
+        });
+        $this->assertCount(1, $filters);
+        $categoryFilter = current($filters);
+        $this->assertEquals(['master'], $categoryFilter['value']);
+    }
+
+    public function testValueFilterIsDeletedInJobInstanceWhenParentIsDeleted()
+    {
+        $parentCategory = $this->createCategory(['code' => 'parent']);
+        $category = $this->createCategory(['code' => 'foobar', 'parent' => 'parent']);
+        $jobInstance = $this->createJobInstanceWithCategoryFilter(
+            'job3',
+            [$category->getCode()]
+        );
+
+        $this->getFromTestContainer('pim_catalog.remover.category')->remove($this->getFromTestContainer('pim_catalog.repository.category')->findOneByIdentifier($parentCategory->getCode()));
+        $this->assertNull($this->getFromTestContainer('pim_catalog.repository.category')->findOneByIdentifier(
+            $category->getCode()
+        ));
+
+        $jobInstance = $this
+            ->getFromTestContainer('akeneo_batch.job.job_instance_repository')
+            ->findOneByIdentifier($jobInstance->getCode());
+        $rawParameters = $jobInstance->getRawParameters();
+        $filters = array_filter($rawParameters['filters']['data'] ?? [], function ($filter) {
+            return 'categories' === $filter['field'];
+        });
+        $this->assertCount(1, $filters);
+        $categoryFilter = current($filters);
+        $this->assertEquals(['master'], $categoryFilter['value']);
+    }
+
+    public function testValuesFilterAreDeletedInJobInstance()
+    {
+        $parentCategory = $this->createCategory(['code' => 'parent']);
+        $category1 = $this->createCategory(['code' => 'cat1', 'parent' => 'parent']);
+        $category2 = $this->createCategory(['code' => 'cat2', 'parent' => 'parent']);
+        $category3 = $this->createCategory(['code' => 'cat3']);
+        $jobInstance = $this->createJobInstanceWithCategoryFilter(
+            'job3',
+            ['master_accessories_scarves', $category1->getCode(), $category2->getCode(), $category3->getCode(), 'what']
+        );
+
+        $this->getFromTestContainer('pim_catalog.remover.category')->removeAll([
+            $this->getFromTestContainer('pim_catalog.repository.category')->findOneByIdentifier($parentCategory->getCode()),
+            $this->getFromTestContainer('pim_catalog.repository.category')->findOneByIdentifier($category3->getCode()),
+        ]);
+
+        $jobInstance = $this
+            ->getFromTestContainer('akeneo_batch.job.job_instance_repository')
+            ->findOneByIdentifier($jobInstance->getCode());
+        $rawParameters = $jobInstance->getRawParameters();
+        $filters = array_filter($rawParameters['filters']['data'] ?? [], function ($filter) {
+            return 'categories' === $filter['field'];
+        });
+        $this->assertCount(1, $filters);
+        $categoryFilter = current($filters);
+        $this->assertEquals(['master_accessories_scarves', 'what'], $categoryFilter['value']);
+    }
+
+    private function createJobInstanceWithCategoryFilter(string $code, array $values = []): JobInstance
+    {
+        /** @var EntityManager $entityManager */
+        $entityManager = $this->getFromTestContainer('doctrine.orm.default_entity_manager');
+
+        $jobInstance = new JobInstance('connector', 'type', 'job_name');
+        $jobInstance->setCode($code);
+        $jobInstance->setLabel($code);
+        $jobInstance->setRawParameters([
+            'filters' => [
+                'data' => [
+                    [
+                        'field' => 'enabled',
+                        'operator' => '=',
+                        'value' => true
+                    ],
+                    [
+                        'field' => 'categories',
+                        'operator' => 'IN',
+                        'value' => $values,
+                    ],
+                ],
+            ],
+        ]);
+        $entityManager->persist($jobInstance);
+        $entityManager->flush();
+
+        return $jobInstance;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}

--- a/src/Pim/Bundle/EnrichBundle/tests/integration/EventListener/RemoveCategoryFilterInJobInstanceSubscriberIntegration.php
+++ b/src/Pim/Bundle/EnrichBundle/tests/integration/EventListener/RemoveCategoryFilterInJobInstanceSubscriberIntegration.php
@@ -62,7 +62,7 @@ class RemoveCategoryFilterInJobInstanceSubscriberIntegration extends TestCase
         });
         $this->assertCount(1, $filters);
         $categoryFilter = current($filters);
-        $this->assertEquals(['master'], $categoryFilter['value']);
+        $this->assertEquals(['bar'], $categoryFilter['value']);
     }
 
     public function testValueFilterIsDeletedInJobInstanceWhenParentIsDeleted()
@@ -88,7 +88,7 @@ class RemoveCategoryFilterInJobInstanceSubscriberIntegration extends TestCase
         });
         $this->assertCount(1, $filters);
         $categoryFilter = current($filters);
-        $this->assertEquals(['master'], $categoryFilter['value']);
+        $this->assertEquals(['parent'], $categoryFilter['value']);
     }
 
     public function testValuesFilterAreDeletedInJobInstance()


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix [PIM-7890](https://akeneo.atlassian.net/browse/PIM-7890)  
When a category or parent category is removed, the filter stay in the job instance and there is no way to remove it.  
Now when we remove a category, we also remove the filter in job instances.  

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed


Before, one category was still selected in the filters when we remove the category:
![PIM-7890_before](https://user-images.githubusercontent.com/4737390/65153594-4e616c80-da2a-11e9-83b8-601e4319f844.png)

After, the filter is removed automatically when the category is removed:
![PIM-7890_after](https://user-images.githubusercontent.com/4737390/65153626-61743c80-da2a-11e9-80e5-873ffcdc2b04.png)
