### PR TITLE
PIM-8778: replace 500 error code by 422 in product API

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 ## Bug fixes
 
 - PIM-8738: Fix memory leak executing "akeneo:batch:purge-job-execution" command
+- PIM-8778: Fix error code when request is bad formatted in product API
 
 # 2.3.62 (2019-09-13)
 

--- a/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
+++ b/src/Akeneo/Component/StorageUtils/Exception/InvalidObjectException.php
@@ -3,7 +3,7 @@
 namespace Akeneo\Component\StorageUtils\Exception;
 
 /**
- * Exception thrown when perfoming an action on an unsupported object.
+ * Exception thrown when performing an action on an unsupported object.
  *
  * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)

--- a/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
+++ b/src/Pim/Bundle/ApiBundle/Controller/ProductController.php
@@ -461,6 +461,12 @@ class ProductController
                 ),
                 $exception
             );
+        } catch (PropertyException $exception) {
+            throw new DocumentedHttpException(
+                Documentation::URL . 'patch_products__code_',
+                sprintf('%s Check the expected format on the API documentation.', $exception->getMessage()),
+                $exception
+            );
         }
 
         return $data;

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -191,7 +191,7 @@ JSON;
 
         $expectedContent = [
             'code'    => 422,
-            'message' => 'Property "a_metric" expects an array with valid data, one of the values is not an array.. Check the expected format on the API documentation.',
+            'message' => 'Property "a_metric" expects an array with valid data, one of the values is not an array. Check the expected format on the API documentation.',
             '_links' => [
                 'documentation' => ['href' => 'http://api.akeneo.com/api-reference.html#patch_products__code_'],
             ],
@@ -224,7 +224,7 @@ JSON;
 
         $expectedContent = [
             'code'    => 422,
-            'message' => 'Property "a_metric" expects an array with valid data, one of the values is not an array.. Check the expected format on the API documentation.',
+            'message' => 'Property "a_metric" expects an array with valid data, one of the values is not an array. Check the expected format on the API documentation.',
             '_links' => [
                 'documentation' => ['href' => 'http://api.akeneo.com/api-reference.html#patch_products__code_'],
             ],

--- a/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/Controller/Product/PartialUpdateProductIntegration.php
@@ -171,6 +171,72 @@ JSON;
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
+    public function testProductCreationWithInvalidValues()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "identifier": "new_identifier",
+        "values": {
+            "a_metric": {
+                "locale": null,
+                "scope": null,
+                "data": null
+            }
+        }
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "a_metric" expects an array with valid data, one of the values is not an array.. Check the expected format on the API documentation.',
+            '_links' => [
+                'documentation' => ['href' => 'http://api.akeneo.com/api-reference.html#patch_products__code_'],
+            ],
+        ];
+
+        $client->request('PATCH', 'api/rest/v1/products/new_identifier', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testProductUpdateWithInvalidValues()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+<<<JSON
+    {
+        "identifier": "product_family",
+        "values": {
+            "a_metric": {
+                "locale": null,
+                "scope": null,
+                "data": null
+            }
+        }
+    }
+JSON;
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "a_metric" expects an array with valid data, one of the values is not an array.. Check the expected format on the API documentation.',
+            '_links' => [
+                'documentation' => ['href' => 'http://api.akeneo.com/api-reference.html#patch_products__code_'],
+            ],
+        ];
+
+        $client->request('PATCH', 'api/rest/v1/products/product_family', [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
     public function testProductPartialUpdateWithIdenticalIdentifiers()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Pim/Component/Catalog/Comparator/Filter/EntityWithValuesFilter.php
+++ b/src/Pim/Component/Catalog/Comparator/Filter/EntityWithValuesFilter.php
@@ -2,6 +2,7 @@
 
 namespace Pim\Component\Catalog\Comparator\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Component\StorageUtils\Exception\UnknownPropertyException;
 use Pim\Component\Catalog\Comparator\ComparatorRegistry;
 use Pim\Component\Catalog\Model\EntityWithValuesInterface;
@@ -109,6 +110,15 @@ class EntityWithValuesFilter implements FilterInterface
             $comparator = $this->comparatorRegistry->getAttributeComparator($this->attributeTypeByCodes[$code]);
 
             foreach ($value as $data) {
+                if (!is_array($data)) {
+                    throw InvalidPropertyTypeException::validArrayStructureExpected(
+                        $code,
+                        'one of the values is not an array.',
+                        static::class,
+                        $values
+                    );
+                }
+
                 $diff = $comparator->compare($data, $this->getOriginalAttribute($originalValues, $data, $code));
 
                 if (null !== $diff) {

--- a/src/Pim/Component/Catalog/Comparator/Filter/EntityWithValuesFilter.php
+++ b/src/Pim/Component/Catalog/Comparator/Filter/EntityWithValuesFilter.php
@@ -113,7 +113,7 @@ class EntityWithValuesFilter implements FilterInterface
                 if (!is_array($data)) {
                     throw InvalidPropertyTypeException::validArrayStructureExpected(
                         $code,
-                        'one of the values is not an array.',
+                        'one of the values is not an array',
                         static::class,
                         $values
                     );

--- a/src/Pim/Component/Catalog/Updater/EntityWithValuesUpdater.php
+++ b/src/Pim/Component/Catalog/Updater/EntityWithValuesUpdater.php
@@ -93,7 +93,7 @@ class EntityWithValuesUpdater implements ObjectUpdaterInterface
                 if (!is_array($value)) {
                     throw InvalidPropertyTypeException::validArrayStructureExpected(
                         $code,
-                        'one of the values is not an array.',
+                        'one of the values is not an array',
                         static::class,
                         $values
                     );

--- a/src/Pim/Component/Catalog/spec/Comparator/Filter/EntityWithValuesFilterSpec.php
+++ b/src/Pim/Component/Catalog/spec/Comparator/Filter/EntityWithValuesFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Pim\Component\Catalog\Comparator\Filter;
 
+use Akeneo\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 use Pim\Component\Catalog\Comparator\ComparatorInterface;
 use Pim\Component\Catalog\Comparator\ComparatorRegistry;
@@ -224,5 +225,43 @@ class EntityWithValuesFilterSpec extends ObjectBehavior
                 'filter',
                 [$product, $newValues]
             );
+    }
+
+    function it_throws_an_exception_if_new_values_are_bad_formatted(
+        NormalizerInterface $normalizer,
+        AttributeRepositoryInterface $attributeRepository,
+        ProductInterface $product
+    ) {
+        $originalValues = [
+            'family' => 'tshirt',
+            'values' => [
+                'description'   => [
+                    [
+                        'locale' => 'en_US',
+                        'scope'  => 'ecommerce',
+                        'value'  => 'My description'
+                    ],
+                ],
+            ],
+        ];
+        $newValues = [
+            'family' => 'tshirt',
+            'values' => [
+                'description' => [
+                    'locale' => 'en_US',
+                    'scope'  => 'ecommerce',
+                    'value'  => 'My description',
+                ],
+            ],
+        ];
+
+        $normalizer->normalize($product, 'standard')->willReturn($originalValues);
+        $attributeRepository->getAttributeTypeByCodes(array_keys($newValues['values']))->willReturn([
+            'description' => 'pim_catalog_textarea'
+        ]);
+
+        $this
+            ->shouldThrow(InvalidPropertyTypeException::class)
+            ->during('filter', [$product, $newValues]);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

[PIM-8778](https://akeneo.atlassian.net/browse/PIM-8778)  
- Add exception when values are bad formatted
- Returns 422 error code instead of 500, with explicit message



**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
