### PR TITLE
PIM-8787: Fix missing search_scope in API links

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes:
 
 - PIM-8767: Fix user security token check
+- PIM-8787: Fix API search-after - missing search_scope in first, next, previous, current links
 
 # 3.2.8 (2019-09-17)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -637,6 +637,9 @@ class ProductController
         if (null !== $query->channelCode) {
             $queryParameters['scope'] = $query->channelCode;
         }
+        if (null !== $query->searchChannelCode) {
+            $queryParameters['search_scope'] = $query->searchChannelCode;
+        }
         if (null !== $query->localeCodes) {
             $queryParameters['locales'] = join(',', $query->localeCodes);
         }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
@@ -466,6 +466,9 @@ class ProductModelController
         if (null !== $query->channelCode) {
             $queryParameters['scope'] = $query->channelCode;
         }
+        if (null !== $query->searchChannelCode) {
+            $queryParameters['search_scope'] = $query->searchChannelCode;
+        }
         if (null !== $query->localeCodes) {
             $queryParameters['locales'] = join(',', $query->localeCodes);
         }


### PR DESCRIPTION
Fix missing search_scope query parameter in API first, next, previous, current pagination links

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
