### PR TITLE
TIP-1159: Refactor completeness calculation command

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CalculateCompletenessCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CalculateCompletenessCommand.php
@@ -5,7 +5,6 @@ namespace Akeneo\Pim\Enrichment\Bundle\Command;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductAndAncestorsIndexer;
 use Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -73,7 +72,7 @@ class CalculateCompletenessCommand extends Command
         foreach ($this->getProductIdentifiers() as $productIdentifiers) {
             $this->computeAndPersistProductCompleteness->fromProductIdentifiers($productIdentifiers);
             $this->productAndAncestorsIndexer->indexFromProductIdentifiers($productIdentifiers);
-            $progressBar->advance(self::BATCH_SIZE);
+            $progressBar->advance(count($productIdentifiers));
         }
         $progressBar->finish();
         $output->writeln('');

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
@@ -2,12 +2,9 @@ services:
     akeneo.pim.enrichment.command.calculate_product_completeness:
         class: 'Akeneo\Pim\Enrichment\Bundle\Command\CalculateCompletenessCommand'
         arguments:
-            - '@akeneo_elasticsearch.client.product_and_product_model'
-            - '@pim_catalog.query.product_query_builder_factory'
+            - '@akeneo.pim.enrichment.elasticsearch.indexer.product_and_ancestors'
             - '@pim_catalog.completeness.product.compute_and_persist'
-            - '@pim_catalog.elasticsearch.indexer.product'
-            - '@pim_connector.doctrine.cache_clearer'
-            - '%pim_job_product_batch_size%'
+            - '@database_connection'
         tags:
             - { name: 'console.command' }
 

--- a/tests/back/Pim/Enrichment/Integration/Completeness/CalculateCompletenessCommandIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/CalculateCompletenessCommandIntegration.php
@@ -4,66 +4,183 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Completeness;
 
-use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\CommandLauncher;
+use Doctrine\DBAL\Connection;
+use Elasticsearch\Common\Exceptions\Missing404Exception;
+use PHPUnit\Framework\Assert;
 
-class CalculateCompletenessCommandIntegration extends AbstractCompletenessTestCase
+class CalculateCompletenessCommandIntegration extends TestCase
 {
-    public function testToCalculeCompletenessAfterPurge()
-    {
-        $family = $this->createFamilyWithRequirement(
-            'another_family',
-            'ecommerce',
-            'a_text',
-            AttributeTypes::TEXT,
-            false,
-            false
-        );
+    private $productIds = [];
+    private $productModelIds = [];
 
-        $product = $this->createProductWithStandardValues(
-            $family,
-            'product_complete',
-            [
-                'values' => [
-                    'a_text' => [
-                        [
-                            'locale' => null,
-                            'scope'  => null,
-                            'data'   => 'juste un texte'
-                        ],
-                    ]
-                ]
-            ]
-        );
+    public function test_that_it_computes_completeness_and_reindexes_all_products_and_their_ancestors()
+    {
+        $commandLauncher = new CommandLauncher(static::$kernel);
+        $commandLauncher->execute('pim:completeness:calculate');
 
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
 
-        $this->assertSame(1, $this->getCountRowCompleteness());
-
-        $this->removeAllCompletenesses($product);
-        $this->assertSame(0, $this->getCountRowCompleteness());
-
-        $this->get('pim_connector.doctrine.cache_clearer')->clear();
-
-        $commandLauncher = new CommandLauncher(static::$kernel);
-        $exitCode = $commandLauncher->execute('pim:completeness:calculate');
-        $this->assertSame(0, $exitCode);
-        $this->assertSame(1, $this->getCountRowCompleteness());
+        $identifiers = ['simple_product', 'variant_A_yes', 'variant_A_no'];
+        $this->assertCompletenessWasComputedForProducts($identifiers);
+        foreach ($identifiers as $identifier) {
+            Assert::assertTrue($this->isProductIndexed($this->productIds[$identifier]));
+        }
+        foreach (['sub_pm_A', 'root_pm'] as $productModelCode) {
+            Assert::assertTrue($this->isProductModelIndexed($this->productModelIds[$productModelCode]));
+        }
+        // sub_pm_B has no variant product, the command should not reindex it
+        Assert::assertFalse($this->isProductModelIndexed($this->productModelIds['sub_pm_B']));
     }
 
-    private function getCountRowCompleteness()
+    protected function setUp(): void
     {
-        $sql = 'SELECT count(*) AS count FROM pim_catalog_completeness';
-        $stmt = $this->get('doctrine.orm.entity_manager')->getConnection()->prepare($sql);
-        $stmt->execute();
+        parent::setUp();
+        $this->createProductModel(
+            [
+                'code' => 'root_pm',
+                'family_variant' => 'familyVariantA1',
+            ]
+        );
+        $this->createProductModel(
+            [
+                'code' => 'sub_pm_A',
+                'parent' => 'root_pm',
+                'values' => [
+                    'a_simple_select' => [['scope' => null, 'locale' => null, 'data' => 'optionA']],
+                ],
+            ]
+        );
+        $this->createProductModel(
+            [
+                'code' => 'sub_pm_B',
+                'parent' => 'root_pm',
+                'values' => [
+                    'a_simple_select' => [['scope' => null, 'locale' => null, 'data' => 'optionB']],
+                ],
+            ]
+        );
+        $this->createProduct(
+            'variant_A_yes',
+            [
+                'parent' => 'sub_pm_A',
+                'values' => [
+                    'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => true]],
+                ],
+            ]
+        );
+        $this->createProduct(
+            'variant_A_no',
+            [
+                'parent' => 'sub_pm_A',
+                'values' => [
+                    'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => false]],
+                ],
+            ]
+        );
+        $this->createProduct(
+            'simple_product',
+            [
+                'family' => 'familyA3',
+                'values' => [
+                    'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => true]],
+                ],
+            ]
+        );
 
-        return (int) $stmt->fetch()['count'];
+        $this->purgeCompletenessAndResetIndex();
     }
 
-    private function removeAllCompletenesses($product)
+    protected function getConfiguration(): Configuration
     {
-        $this->get('database_connection')->executeQuery('DELETE FROM pim_catalog_completeness');
+        return $this->catalog->useTechnicalCatalog();
+    }
 
-        $this->get('pim_catalog.elasticsearch.indexer.product')->indexFromProductIdentifier($product->getIdentifier());
+    private function purgeCompletenessAndResetIndex(): void
+    {
+        $this->get('database_connection')->executeUpdate('DELETE c.* from pim_catalog_completeness c');
+        $client = $this->get('akeneo_elasticsearch.client.product_and_product_model');
+        $client->refreshIndex();
+        $client->bulkDelete(
+            array_map(
+                function (int $productModelId): string {
+                    return sprintf('product_model_%d', $productModelId);
+                },
+                $this->productModelIds
+            )
+        );
+        $client->bulkDelete(
+            array_map(
+                function (int $productId): string {
+                    return sprintf('product_%d', $productId);
+                },
+                $this->productIds
+            )
+        );
+    }
+
+    private function createProduct(string $identifier, array $data): void
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $this->productIds[$identifier] = $product->getId();
+    }
+
+    private function createProductModel(array $data): void
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+
+        $this->productModelIds[$productModel->getCode()] = $productModel->getId();
+    }
+
+    private function assertCompletenessWasComputedForProducts(array $identifiers): void
+    {
+        $sql = <<<SQL
+SELECT identifier, count(c.id) as completeness_count
+FROM pim_catalog_product p
+LEFT JOIN pim_catalog_completeness c ON c.product_id = p.id
+WHERE p.identifier IN (:identifiers)
+GROUP BY p.identifier
+SQL;
+
+        $rows = $this->get('database_connection')->executeQuery(
+            $sql,
+            [
+                'identifiers' => $identifiers,
+            ],
+            [
+                'identifiers' => Connection::PARAM_STR_ARRAY,
+            ]
+        )->fetchAll();
+
+        foreach ($rows as $row) {
+            Assert::assertContains($row['identifier'], $identifiers);
+            Assert::assertSame(6, (int)($row['completeness_count'])); // 3 channels * 2 locales
+        }
+    }
+
+    private function isProductIndexed(int $productId): bool
+    {
+        return null !== $this->get('akeneo_elasticsearch.client.product_and_product_model')
+                             ->get(sprintf('product_%d', $productId));
+    }
+
+    private function isProductModelIndexed(int $productModelId): bool
+    {
+        try {
+            $this->get('akeneo_elasticsearch.client.product_and_product_model')->get(
+                sprintf('product_model_%d', $productModelId)
+            );
+        } catch (Missing404Exception $e) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Refactor the `pim:completeness:calculate` command:
- recompute completeness for all products (not only the ones with missing completeness)
- do not hydrate products whereas only identifiers are needed


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
