### PR TITLE
PIM-6424: update exports when a locale is removed from a channel

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-6424: update exports when a locale is removed from a channel
+
 # 2.3.63 (2019-09-23)
 
 

--- a/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/GetChannelActiveLocaleCodes.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/ORM/Query/GetChannelActiveLocaleCodes.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2019 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pim\Bundle\CatalogBundle\Doctrine\ORM\Query;
+
+use Doctrine\DBAL\Connection;
+
+class GetChannelActiveLocaleCodes
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function execute(string $channelCode): array
+    {
+        $sql = <<<SQL
+SELECT DISTINCT locale.code
+FROM pim_catalog_channel AS channel
+  INNER JOIN akeneo_pim.pim_catalog_channel_locale AS channel_locale ON (channel.id = channel_locale.channel_id)
+  INNER JOIN akeneo_pim.pim_catalog_locale AS locale ON (channel_locale.locale_id = locale.id)
+WHERE channel.code = :channel_code
+SQL;
+        $statement = $this->connection->executeQuery(
+            $sql,
+            ['channel_code' => $channelCode],
+            ['channel_code' => \PDO::PARAM_STR]
+        );
+
+        return array_map(function ($value) {
+            return $value['code'];
+        }, $statement->fetchAll());
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveLocaleFilterInJobInstancesSubscriber.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveLocaleFilterInJobInstancesSubscriber.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2019 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\GetChannelActiveLocaleCodes;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Store the channel original locale codes during the pre-save events
+ * and remove the channel deleted locales in all exports during the post-save events
+ */
+class RemoveLocaleFilterInJobInstancesSubscriber implements EventSubscriberInterface
+{
+    private $localeCodesByChannel = [];
+
+    /** @var GetChannelActiveLocaleCodes */
+    private $getChannelLocaleCodes;
+
+    /** @var ObjectRepository */
+    private $jobInstanceRepository;
+
+    /** @var BulkSaverInterface */
+    private $bulkSaver;
+
+    public function __construct(GetChannelActiveLocaleCodes $getChannelLocaleCodes, ObjectRepository $jobInstanceRepository, BulkSaverInterface $bulkSaver)
+    {
+        $this->getChannelLocaleCodes = $getChannelLocaleCodes;
+        $this->jobInstanceRepository = $jobInstanceRepository;
+        $this->bulkSaver = $bulkSaver;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            StorageEvents::PRE_SAVE => 'storeChannelLocaleCodes',
+            StorageEvents::PRE_SAVE_ALL => 'storeChannelLocaleCodes',
+            StorageEvents::POST_SAVE => 'removeDeletedLocalesFromJobInstancesFilters',
+            StorageEvents::POST_SAVE_ALL => 'removeDeletedLocalesFromJobInstancesFilters',
+        ];
+    }
+
+    public function storeChannelLocaleCodes(GenericEvent $event): void
+    {
+        $subject = $event->getSubject();
+        if ($event->getSubject() instanceof ChannelInterface) {
+            if ($subject->getId() !== null) {
+                $this->localeCodesByChannel[$subject->getCode()] = $this->getChannelLocaleCodes->execute($subject->getCode());
+            }
+
+            return;
+        }
+
+        if (is_array($subject) && current($subject) instanceof ChannelInterface) {
+            foreach ($subject as $channel) {
+                if ($channel->getId() !== null) {
+                    $this->localeCodesByChannel[$channel->getCode()] = $this->getChannelLocaleCodes->execute($channel->getCode());
+                }
+            }
+        }
+    }
+
+    public function removeDeletedLocalesFromJobInstancesFilters(GenericEvent $event): void
+    {
+        $subject = $event->getSubject();
+        if ($event->getSubject() instanceof ChannelInterface) {
+            $this->removeChannelDeletedLocales($subject);
+        }
+
+        if (is_array($subject) && current($subject) instanceof ChannelInterface) {
+            foreach ($subject as $channel) {
+                $this->removeChannelDeletedLocales($channel);
+            }
+        }
+    }
+
+    private function removeChannelDeletedLocales(ChannelInterface $channel): void
+    {
+        if (isset($this->localeCodesByChannel[$channel->getCode()])) {
+            $channelLocaleCodes = $channel->getLocaleCodes();
+            sort($channelLocaleCodes);
+            $removedLocaleCodes = array_diff($this->localeCodesByChannel[$channel->getCode()], $channelLocaleCodes);
+            if (!empty($removedLocaleCodes)) {
+                $this->updateJobInstancesFilters($channel->getCode(), $removedLocaleCodes);
+            }
+        }
+    }
+
+    private function updateJobInstancesFilters(string $channelCode, array $removedLocaleCodes): void
+    {
+        $jobsToUpdate = [];
+
+        foreach ($this->jobInstanceRepository->findBy(['type' => JobInstance::TYPE_EXPORT]) as $jobInstance) {
+            $rawParameters = $jobInstance->getRawParameters();
+            if (
+                isset($rawParameters['filters']['structure']['locales']) &&
+                isset($rawParameters['filters']['structure']['scope']) &&
+                $channelCode === $rawParameters['filters']['structure']['scope']
+            ) {
+                $jobLocales = $rawParameters['filters']['structure']['locales'];
+                sort($jobLocales);
+                $newLocaleCodes = array_diff($jobLocales, $removedLocaleCodes);
+                $rawParameters['filters']['structure']['locales'] = $newLocaleCodes;
+                $jobInstance->setRawParameters($rawParameters);
+
+                $jobsToUpdate[] = $jobInstance;
+            }
+        }
+
+        if (!empty($jobsToUpdate)) {
+            $this->bulkSaver->saveAll($jobsToUpdate);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/event_subscribers.yml
@@ -196,3 +196,12 @@ services:
             - '@pim_catalog.query.get_attribute_options_max_sort_order'
         tags:
             - { name: kernel.event_subscriber }
+
+    pim_catalog.event_subscriber.remove_locale_filter_in_job_instances:
+        class: 'Pim\Bundle\CatalogBundle\EventSubscriber\RemoveLocaleFilterInJobInstancesSubscriber'
+        arguments:
+            - '@pim_catalog.query.get_channel_active_locale_codes'
+            - '@akeneo_batch.job.job_instance_repository'
+            - '@akeneo_batch.saver.job_instance'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/queries.yml
@@ -94,3 +94,8 @@ services:
         class: 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\GetAttributeOptionsMaxSortOrder'
         arguments:
             - '@database_connection'
+
+    pim_catalog.query.get_channel_active_locale_codes:
+        class: 'Pim\Bundle\CatalogBundle\Doctrine\ORM\Query\GetChannelActiveLocaleCodes'
+        arguments:
+            - '@database_connection'

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/ORM/Query/GetChannelActiveLocaleCodesIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/Doctrine/ORM/Query/GetChannelActiveLocaleCodesIntegration.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Bundle\CatalogBundle\tests\integration\Doctrine\ORM\Query;
+
+use Akeneo\Test\Integration\TestCase;
+
+class GetChannelActiveLocaleCodesIntegration extends TestCase
+{
+    public function testItGetsAllActiveLocalesForAChannel()
+    {
+        $localeCodes = $this->getFromTestContainer('pim_catalog.query.get_channel_active_locale_codes')->execute('tablet');
+        sort($localeCodes);
+        $this->assertSame(['de_DE', 'en_US', 'fr_FR'], $localeCodes);
+
+        $localeCodes = $this->getFromTestContainer('pim_catalog.query.get_channel_active_locale_codes')->execute('ecommerce_china');
+        sort($localeCodes);
+        $this->assertSame(['en_US', 'zh_CN'], $localeCodes);
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/RemoveLocaleFilterInJobInstanceSubscriberIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/RemoveLocaleFilterInJobInstanceSubscriberIntegration.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace tests\integration\Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\ORM\EntityManager;
+use Pim\Component\Catalog\Model\ChannelInterface;
+
+class RemoveLocaleFilterInJobInstanceSubscriberIntegration extends TestCase
+{
+    public function testRemoveOneLocaleFromAChannel()
+    {
+        $jobInstance = $this->createJobInstanceWithLocaleFilter('job1', 'tablet', ['en_US', 'fr_FR', 'de_DE']);
+
+        $rawParameters = $jobInstance->getRawParameters();
+        $locales = $rawParameters['filters']['structure']['locales'];
+        sort($locales);
+        $this->assertSame(['de_DE', 'en_US', 'fr_FR'], $locales);
+
+        $channel = $this->removeFrenchFromTabletChannel();
+        $this->getFromTestContainer('pim_catalog.saver.channel')->save($channel);
+
+        $rawParameters = $this->getJobParameters($jobInstance);
+
+        $this->assertSame(['de_DE', 'en_US'], $rawParameters['filters']['structure']['locales']);
+    }
+
+    public function testRemoveMultipleLocalesOnMultipleChannels()
+    {
+        $jobInstance1 = $this->createJobInstanceWithLocaleFilter('job1', 'tablet', ['en_US', 'fr_FR', 'de_DE']);
+        $jobInstance2 = $this->createJobInstanceWithLocaleFilter('job2', 'ecommerce_china', ['en_US', 'zh_CN']);
+
+        $rawParameters = $jobInstance1->getRawParameters();
+        $locales = $rawParameters['filters']['structure']['locales'];
+        sort($locales);
+        $this->assertSame(['de_DE', 'en_US', 'fr_FR'], $locales);
+
+        $rawParameters = $jobInstance2->getRawParameters();
+        $locales = $rawParameters['filters']['structure']['locales'];
+        sort($locales);
+        $this->assertSame(['en_US', 'zh_CN'], $locales);
+
+        $tabletChannel = $this->removeFrenchFromTabletChannel();
+        $ecommerceChinaChannel = $this->removeEnglishFromEcommerceChinaChannel();
+
+        $this->getFromTestContainer('pim_catalog.saver.channel')->saveAll([$tabletChannel, $ecommerceChinaChannel]);
+
+        $rawParameters = $this->getJobParameters($jobInstance1);
+        $this->assertSame(['de_DE', 'en_US'], $rawParameters['filters']['structure']['locales']);
+
+        $rawParameters = $this->getJobParameters($jobInstance2);
+        $this->assertSame(['zh_CN'], $rawParameters['filters']['structure']['locales']);
+    }
+
+    private function createJobInstanceWithLocaleFilter(string $jobCode, string $scope, array $locales)
+    {
+        /** @var EntityManager $entityManager */
+        $entityManager = $this->getFromTestContainer('doctrine.orm.default_entity_manager');
+
+        $jobInstance = new JobInstance('connector', JobInstance::TYPE_EXPORT, 'job_name');
+        $jobInstance->setCode($jobCode);
+        $jobInstance->setLabel($jobCode);
+        $jobInstance->setRawParameters([
+            'filters' => [
+                'structure' => [
+                    'scope' => $scope,
+                    'locales' => $locales,
+                ],
+            ],
+        ]);
+        $entityManager->persist($jobInstance);
+        $entityManager->flush();
+
+        return $jobInstance;
+    }
+
+    private function removeFrenchFromTabletChannel(): ChannelInterface
+    {
+        $repository = $this->getFromTestContainer('pim_catalog.repository.channel');
+        $channel = $repository->findOneByIdentifier('tablet');
+
+        $data = [
+            'locales' => ['en_US', 'de_DE'],
+        ];
+
+        $this->getFromTestContainer('pim_catalog.updater.channel')->update($channel, $data);
+
+        return $channel;
+    }
+
+    private function removeEnglishFromEcommerceChinaChannel(): ChannelInterface
+    {
+        $repository = $this->getFromTestContainer('pim_catalog.repository.channel');
+        $channel = $repository->findOneByIdentifier('ecommerce_china');
+
+        $data = [
+            'locales' => ['zh_CN'],
+        ];
+
+        $this->getFromTestContainer('pim_catalog.updater.channel')->update($channel, $data);
+
+        return $channel;
+    }
+
+    private function getJobParameters(JobInstance $jobInstance): array
+    {
+        $sql = <<<SQL
+SELECT raw_parameters
+FROM akeneo_pim.akeneo_batch_job_instance
+WHERE id = :jobId
+SQL;
+        $stmt = $this->getFromTestContainer('doctrine.orm.entity_manager')->getConnection()->prepare($sql);
+        $stmt->bindValue('jobId', $jobInstance->getId());
+        $stmt->execute();
+        $rawParameters = unserialize($stmt->fetchColumn(0));
+
+        return $rawParameters;
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Product exports are now updated when a locale is removed of a channel : if the removed locale was used as a filter in an export, the locale filter is removed.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
