### PR TITLE
TIP-1262 Make datagrid actions public

### DIFF
--- a/src/Oro/Bundle/DataGridBundle/Resources/config/actions.yml
+++ b/src/Oro/Bundle/DataGridBundle/Resources/config/actions.yml
@@ -5,24 +5,28 @@ parameters:
 
 services:
     oro_datagrid.extension.action.type.navigate:
+        public: true
         class: '%oro_datagrid.extension.action.type.navigate.class%'
         shared: false
         tags:
             - { name:  oro_datagrid.extension.action.type, type: navigate }
 
     oro_datagrid.extension.action.type.ajax:
+        public: true
         class: '%oro_datagrid.extension.action.type.ajax.class%'
         shared: false
         tags:
             - { name: oro_datagrid.extension.action.type, type: ajax }
 
     oro_datagrid.extension.action.type.delete:
+        public: true
         class: '%oro_datagrid.extension.action.type.delete.class%'
         shared: false
         tags:
             - { name: oro_datagrid.extension.action.type, type: delete }
 
     oro_datagrid.extension.action.type.revoke:
+        public: true
         class: '%oro_datagrid.extension.action.type.delete.class%'
         shared: false
         tags:

--- a/src/Oro/Bundle/DataGridBundle/Resources/config/services.yml
+++ b/src/Oro/Bundle/DataGridBundle/Resources/config/services.yml
@@ -16,6 +16,7 @@ parameters:
 
 services:
     oro_datagrid.datagrid.manager:
+        public: true
         class: '%oro_datagrid.datagrid.manager.class%'
         arguments:
             - '@oro_datagrid.datagrid.builder'

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/mass_actions.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/mass_actions.yml
@@ -27,12 +27,14 @@ services:
             - { name: pim_datagrid.extension.mass_action.handler, alias: mass_edit }
 
     pim_datagrid.extension.mass_action.type.edit:
+        public: true
         class: Oro\Bundle\PimDataGridBundle\Extension\MassAction\Actions\Redirect\EditMassAction
         shared: false
         tags:
             - { name: oro_datagrid.extension.mass_action.type, type: edit }
 
     pim_datagrid.extension.mass_action.type.sequential_edit:
+        public: true
         class: Oro\Bundle\PimDataGridBundle\Extension\MassAction\Actions\Redirect\SequentialEditMassAction
         shared: false
         tags:
@@ -40,18 +42,21 @@ services:
 
     # Mass actions
     pim_datagrid.extension.mass_action.type.export:
+        public: true
         class: '%pim_datagrid.extension.mass_action.type.export.class%'
         shared: false
         tags:
             - { name: oro_datagrid.extension.mass_action.type, type: export }
 
     pim_datagrid.extension.mass_action.type.delete:
+        public: true
         class: '%pim_datagrid.extension.mass_action.type.delete.class%'
         shared: false
         tags:
             - { name: oro_datagrid.extension.mass_action.type, type: delete }
 
     pim_datagrid.extension.mass_action.type.product_mass_delete:
+        public: true
         class: '%pim_datagrid.extension.mass_action.type.delete.class%'
         shared: false
         tags:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Getting services from the container is deprecated since Symfony 3.2 and will fail in 4.0. It quite impossible to easily refactor the datagrid that is why we decided to make some services public like datagrid action.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
