### PR TITLE
TIP-1262 Add strict mode to choice validation constraint

### DIFF
--- a/src/Akeneo/Tool/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExport.php
+++ b/src/Akeneo/Tool/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvExport.php
@@ -51,6 +51,7 @@ class SimpleCsvExport implements ConstraintCollectionProviderInterface
                         new NotBlank(['groups' => ['Default', 'FileConfiguration']]),
                         new Choice(
                             [
+                                'strict' => true,
                                 'choices' => [",", ";", "|"],
                                 'message' => 'The value must be one of , or ; or |',
                                 'groups'  => ['Default', 'FileConfiguration'],
@@ -62,6 +63,7 @@ class SimpleCsvExport implements ConstraintCollectionProviderInterface
                             new NotBlank(['groups' => ['Default', 'FileConfiguration']]),
                             new Choice(
                                 [
+                                    'strict' => true,
                                     'choices' => ['"', "'"],
                                     'message' => 'The value must be one of " or \'',
                                     'groups'  => ['Default', 'FileConfiguration'],

--- a/src/Akeneo/Tool/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvImport.php
+++ b/src/Akeneo/Tool/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleCsvImport.php
@@ -52,6 +52,7 @@ class SimpleCsvImport implements ConstraintCollectionProviderInterface
                         new NotBlank(),
                         new Choice(
                             [
+                                'strict' => true,
                                 'choices' => [",", ";", "|"],
                                 'message' => 'The value must be one of , or ; or |'
                             ]
@@ -62,6 +63,7 @@ class SimpleCsvImport implements ConstraintCollectionProviderInterface
                             new NotBlank(),
                             new Choice(
                                 [
+                                    'strict' => true,
                                     'choices' => ['"', "'"],
                                     'message' => 'The value must be one of " or \''
                                 ]


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Not setting the strict option of the Choice constraint to true is deprecated since Symfony 3.4 and will throw an exception in 4.0

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
