### PR TITLE
PIM-7891: update exports when an attribute is deleted

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7891: Update exports when an attribute is deleted
+
 # 2.3.63 (2019-09-23)
 
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletion.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletion.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2019 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pim\Bundle\CatalogBundle\EventSubscriber;
+
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Pim\Component\Catalog\Model\AttributeInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class RemoveAttributeFiltersInJobInstancesOnAttributeDeletion implements EventSubscriberInterface
+{
+    /** @var ObjectRepository */
+    private $jobInstanceRepository;
+
+    /** @var BulkSaverInterface */
+    private $bulkSaver;
+
+    public function __construct(ObjectRepository $jobInstanceRepository, BulkSaverInterface $bulkSaver)
+    {
+        $this->jobInstanceRepository = $jobInstanceRepository;
+        $this->bulkSaver = $bulkSaver;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            StorageEvents::POST_REMOVE => 'removeDeletedAttributeFromJobInstancesFilters',
+        ];
+    }
+
+    public function removeDeletedAttributeFromJobInstancesFilters(GenericEvent $event): void
+    {
+        $subject = $event->getSubject();
+        if (! $subject instanceof AttributeInterface) {
+            return;
+        }
+
+        $jobsToUpdate = [];
+        foreach ($this->jobInstanceRepository->findBy(['type' => JobInstance::TYPE_EXPORT]) as $jobInstance) {
+            $rawParameters = $jobInstance->getRawParameters();
+            if (isset($rawParameters['filters']['structure']['attributes'])) {
+                $jobAttributeFilters = $rawParameters['filters']['structure']['attributes'];
+                $newAttributeFilter = array_diff($jobAttributeFilters, [$subject->getCode()]);
+                $rawParameters['filters']['structure']['attributes'] = $newAttributeFilter;
+                $jobInstance->setRawParameters($rawParameters);
+
+                $jobsToUpdate[] = $jobInstance;
+            }
+        }
+
+        if (!empty($jobsToUpdate)) {
+            $this->bulkSaver->saveAll($jobsToUpdate);
+        }
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletion.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletion.php
@@ -54,7 +54,8 @@ class RemoveAttributeFiltersInJobInstancesOnAttributeDeletion implements EventSu
             $rawParameters = $jobInstance->getRawParameters();
             if (isset($rawParameters['filters']['structure']['attributes'])) {
                 $jobAttributeFilters = $rawParameters['filters']['structure']['attributes'];
-                $newAttributeFilter = array_diff($jobAttributeFilters, [$subject->getCode()]);
+                $newAttributeFilter = array_values(array_diff($jobAttributeFilters, [$subject->getCode()]));
+
                 $rawParameters['filters']['structure']['attributes'] = $newAttributeFilter;
                 $jobInstance->setRawParameters($rawParameters);
 

--- a/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletion.php
+++ b/src/Pim/Bundle/CatalogBundle/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletion.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2019 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Pim\Bundle\CatalogBundle\EventSubscriber;
 
 use Akeneo\Component\Batch\Model\JobInstance;
@@ -21,6 +12,11 @@ use Pim\Component\Catalog\Model\AttributeInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
+/**
+ * @author    Julian Prud'Homme <julian.prudhomme@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 class RemoveAttributeFiltersInJobInstancesOnAttributeDeletion implements EventSubscriberInterface
 {
     /** @var ObjectRepository */

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletionIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletionIntegration.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Channel\Integration\Channel\EventListener;
+
+use Akeneo\Component\Batch\Model\JobInstance;
+use Akeneo\Test\Integration\TestCase;
+use Pim\Bundle\CatalogBundle\Entity\Attribute;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class RemoveAttributeFiltersInJobInstancesOnAttributeDeletionIntegration extends TestCase
+{
+    public function testUpdateExportsFiltersOnAttributeDeletion()
+    {
+        $jobInstance = $this->createJobInstanceWithAttributeFilter('job1', ['a_yes_no', 'a_text', 'a_date']);
+        $rawParameters = $jobInstance->getRawParameters();
+        $attributes = $rawParameters['filters']['structure']['attributes'];
+        $this->assertSame(['a_yes_no', 'a_text', 'a_date'], $attributes);
+
+        $this
+            ->getFromTestContainer('pim_enrich.event_listener.remove_attribute_filter_in_job_instances')
+            ->removeDeletedAttributeFromJobInstancesFilters(new GenericEvent((new Attribute())->setCode('a_text')));
+
+        $rawParameters = $this->getJobParameters($jobInstance);
+        $this->assertSame(['a_yes_no', 'a_date'], array_values($rawParameters['filters']['structure']['attributes']));
+    }
+
+    private function createJobInstanceWithAttributeFilter(string $jobCode, array $attributes)
+    {
+        $entityManager = $this->getFromTestContainer('doctrine.orm.default_entity_manager');
+        $jobInstance = new JobInstance('connector', JobInstance::TYPE_EXPORT, 'job_name');
+        $jobInstance->setCode($jobCode);
+        $jobInstance->setLabel($jobCode);
+        $jobInstance->setRawParameters([
+            'filters' => [
+                'structure' => [
+                    'attributes' => $attributes,
+                ],
+            ],
+        ]);
+        $entityManager->persist($jobInstance);
+        $entityManager->flush();
+
+        return $jobInstance;
+    }
+
+    private function getJobParameters(JobInstance $jobInstance): array
+    {
+        $sql = <<<SQL
+SELECT raw_parameters
+FROM akeneo_pim.akeneo_batch_job_instance
+WHERE id = :jobId
+SQL;
+        $stmt = $this->getFromTestContainer('doctrine.orm.entity_manager')->getConnection()->prepare($sql);
+        $stmt->bindValue('jobId', $jobInstance->getId());
+        $stmt->execute();
+        $rawParameters = unserialize($stmt->fetchColumn(0));
+
+        return $rawParameters;
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletionIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletionIntegration.php
@@ -14,9 +14,7 @@ class RemoveAttributeFiltersInJobInstancesOnAttributeDeletionIntegration extends
     public function testUpdateExportsFiltersOnAttributeDeletion()
     {
         $jobInstance = $this->createJobInstanceWithAttributeFilter('job1', ['a_yes_no', 'a_text', 'a_date']);
-        $rawParameters = $jobInstance->getRawParameters();
-        $attributes = $rawParameters['filters']['structure']['attributes'];
-        $this->assertSame(['a_yes_no', 'a_text', 'a_date'], $attributes);
+        $jobInstance2 = $this->createJobInstanceWithAttributeFilter('job2', ['a_number', 'a_date', 'a_text']);
 
         $this
             ->getFromTestContainer('pim_enrich.event_listener.remove_attribute_filter_in_job_instances')
@@ -24,6 +22,9 @@ class RemoveAttributeFiltersInJobInstancesOnAttributeDeletionIntegration extends
 
         $rawParameters = $this->getJobParameters($jobInstance);
         $this->assertSame(['a_yes_no', 'a_date'], $rawParameters['filters']['structure']['attributes']);
+
+        $rawParameters = $this->getJobParameters($jobInstance2);
+        $this->assertSame(['a_number', 'a_date'], $rawParameters['filters']['structure']['attributes']);
     }
 
     private function createJobInstanceWithAttributeFilter(string $jobCode, array $attributes)

--- a/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletionIntegration.php
+++ b/src/Pim/Bundle/CatalogBundle/tests/integration/EventSubscriber/RemoveAttributeFiltersInJobInstancesOnAttributeDeletionIntegration.php
@@ -23,7 +23,7 @@ class RemoveAttributeFiltersInJobInstancesOnAttributeDeletionIntegration extends
             ->removeDeletedAttributeFromJobInstancesFilters(new GenericEvent((new Attribute())->setCode('a_text')));
 
         $rawParameters = $this->getJobParameters($jobInstance);
-        $this->assertSame(['a_yes_no', 'a_date'], array_values($rawParameters['filters']['structure']['attributes']));
+        $this->assertSame(['a_yes_no', 'a_date'], $rawParameters['filters']['structure']['attributes']);
     }
 
     private function createJobInstanceWithAttributeFilter(string $jobCode, array $attributes)

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/event_listeners.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/event_listeners.yml
@@ -62,3 +62,11 @@ services:
             - '@akeneo_batch.saver.job_instance'
         tags:
             - { name: kernel.event_subscriber }
+
+    pim_enrich.event_listener.remove_attribute_filter_in_job_instances:
+        class: Pim\Bundle\CatalogBundle\EventSubscriber\RemoveAttributeFiltersInJobInstancesOnAttributeDeletion
+        arguments:
+            - '@akeneo_batch.job.job_instance_repository'
+            - '@akeneo_batch.saver.job_instance'
+        tags:
+            - { name: kernel.event_subscriber }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
When an attribute is deleted in the PIM, product exports are now updated is the attribute was used as a filter

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
