### PR TITLE
TIP-1262 Use Inflector instead of StringUtils because it is deprecated

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/ReferenceData/MethodNameGuesser.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/ReferenceData/MethodNameGuesser.php
@@ -2,7 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\ReferenceData;
 
-use Symfony\Component\PropertyAccess\StringUtil;
+use Symfony\Component\Inflector\Inflector;
 
 /**
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
@@ -35,7 +35,7 @@ class MethodNameGuesser
         $name = $dataName;
 
         if ($singularify) {
-            $name = StringUtil::singularify($dataName);
+            $name = Inflector::singularize($dataName);
 
             if (is_array($name)) {
                 throw new \LogicException(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

`\Symfony\Component\PropertyAccess\StringUtil` is deprecated since version 3.1 and will be removed in 4.0. It is replaced by `Symfony\Component\Inflector\Inflector`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
