### PR TITLE
TIP-1262 Make context services public to avoid failure in SF4.3

### DIFF
--- a/tests/back/Acceptance/Resources/config/behat/services.yml
+++ b/tests/back/Acceptance/Resources/config/behat/services.yml
@@ -58,6 +58,7 @@ services:
             - '@validator'
 
     test.locale.context:
+        public: true
         class: 'Akeneo\Test\Acceptance\Locale\LocaleContext'
         arguments:
             - '@pim_catalog.repository.locale'
@@ -65,6 +66,7 @@ services:
 
 
     test.channel.context:
+        public: true
         class: 'Akeneo\Test\Acceptance\Channel\ChannelContext'
         arguments:
             - '@pim_catalog.repository.locale'
@@ -77,6 +79,7 @@ services:
 
 
     test.attribute.context:
+        public: true
         class: 'Akeneo\Test\Acceptance\Attribute\AttributeContext'
         arguments:
             - '@pim_catalog.repository.attribute'
@@ -86,6 +89,7 @@ services:
 
 
     test.catalog.product_creation.context:
+        public: true
         class: 'Akeneo\Test\Acceptance\Catalog\Context\ProductCreation'
         arguments:
             - '@pim_catalog.repository.attribute'
@@ -94,6 +98,7 @@ services:
 
 
     test.catalog.product_validation.context:
+        public: true
         class: 'Akeneo\Test\Acceptance\Catalog\Context\ProductValidation'
         arguments:
             - '@test.catalog.product.builder'

--- a/tests/back/Pim/Enrichment/Acceptance/Resources/config/behat/services.yml
+++ b/tests/back/Pim/Enrichment/Acceptance/Resources/config/behat/services.yml
@@ -1,4 +1,5 @@
 services:
     test.enrichment.enrichment_follow_up_context:
+        public: true
         class: 'AkeneoTest\Pim\Enrichment\Acceptance\Context\EnrichmentFollowUpContext'
 

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Resources/config/behat/services.yml
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Resources/config/behat/services.yml
@@ -1,23 +1,27 @@
 services:
     test.catalog_volume_limits.system_info_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\SystemInfoContext'
         arguments:
             - '@pim_analytics.data_collector.database'
 
 
     test.catalog_volume_limits.system_info_attribute_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\SystemInfoAttributeContext'
         arguments:
             - '@pim_analytics.data_collector.attribute'
 
 
     test.catalog_volume_limits.report_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\ReportContext'
         arguments:
             - '@pim_volume_monitoring.volume.normalizer.volumes'
 
 
     test.catalog_volume_limits.attribute_per_family_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\AttributePerFamilyContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -25,6 +29,7 @@ services:
 
 
     test.catalog_volume_limits.localizable_attribute_per_family_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\LocalizableAttributePerFamilyContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -32,6 +37,7 @@ services:
 
 
     test.catalog_volume_limits.scopable_attribute_per_family_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\ScopableAttributePerFamilyContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -39,6 +45,7 @@ services:
 
 
     test.catalog_volume_limits.localizable_and_scopable_attribute_per_family_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\LocalizableAndScopableAttributePerFamilyContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -46,6 +53,7 @@ services:
 
 
     test.catalog_volume_limits.product_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\ProductContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -53,6 +61,7 @@ services:
 
 
     test.catalog_volume_limits.channel_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\ChannelContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -60,6 +69,7 @@ services:
 
 
     test.catalog_volume_limits.locale_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\LocaleContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -67,6 +77,7 @@ services:
 
 
     test.catalog_volume_limits.scopable_attribute_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\ScopableAttributeContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -74,6 +85,7 @@ services:
 
 
     test.catalog_volume_limits.localizable_attribute_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\LocalizableAttributeContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -81,6 +93,7 @@ services:
 
 
     test.catalog_volume_limits.localizable_and_scopable_attribute_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\LocalizableAndScopableAttributeContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -88,6 +101,7 @@ services:
 
 
     test.catalog_volume_limits.family_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\FamilyContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -95,6 +109,7 @@ services:
 
 
     test.catalog_volume_limits.product_value_per_family_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\ProductValuePerFamilyContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -102,6 +117,7 @@ services:
 
 
     test.catalog_volume_limits.attribute_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\AttributeContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -109,6 +125,7 @@ services:
 
 
     test.catalog_volume_limits.useable_as_grid_filter_attribute_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\UseableAsGridFilterAttributeContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -116,6 +133,7 @@ services:
 
 
     test.catalog_volume_limits.option_per_attribute_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\OptionPerAttributeContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -123,6 +141,7 @@ services:
 
 
     test.catalog_volume_limits.category_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\CategoryContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -130,6 +149,7 @@ services:
 
 
     test.catalog_volume_limits.category_tree_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\CategoryTreeContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -137,6 +157,7 @@ services:
 
 
     test.catalog_volume_limits.variant_product_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\VariantProductContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -144,6 +165,7 @@ services:
 
 
     test.catalog_volume_limits.product_model_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\ProductModelContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -151,6 +173,7 @@ services:
 
 
     test.catalog_volume_limits.product_value_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\ProductValueContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -159,6 +182,7 @@ services:
 
 
     test.catalog_volume_limits.user_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\UserContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -166,6 +190,7 @@ services:
 
 
     test.catalog_volume_limits.category_in_one_category_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\CategoryInOneCategoryContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'
@@ -173,6 +198,7 @@ services:
 
 
     test.catalog_volume_limits.category_level_context:
+        public: true
         class: 'AkeneoTest\Platform\Acceptance\CatalogVolumeMonitoring\Context\CategoryLevelContext'
         arguments:
             - '@test.catalog_volume_limits.report_context'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In symfony 4.0 all services are private by default that means our Behat services are private too. Behat Symfony extension need to get those services that why we declare them as public.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
