### PR TITLE
TIP-1263: fix check requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ composer.lock: composer.json
 	$(PHP_RUN) -d memory_limit=4G /usr/local/bin/composer update
 
 vendor: composer.lock
+	$(PHP_RUN) bin/console pim:installer:check-requirements
 	$(PHP_RUN) -d memory_limit=4G /usr/local/bin/composer install
 
 .PHONY: database

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/CheckRequirementsCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/CheckRequirementsCommand.php
@@ -30,16 +30,21 @@ class CheckRequirementsCommand extends Command
     /** @var string */
     private $env;
 
+    /** @var string */
+    private $rootDirectory;
+
     public function __construct(
         PimDirectoriesRegistry $pimDirectoriesRegistry,
         string $pimVersion,
-        string $env
+        string $env,
+        string $rootDirectory
     ) {
         parent::__construct();
 
         $this->pimDirectoriesRegistry = $pimDirectoriesRegistry;
         $this->pimVersion = $pimVersion;
         $this->env = $env;
+        $this->rootDirectory = $rootDirectory;
     }
 
     /**
@@ -62,18 +67,12 @@ class CheckRequirementsCommand extends Command
 
     protected function getRequirements(): Requirements
     {
-        $baseDirectory = __DIR__.'/../../../';
-
-        if (CommunityVersion::class !== $this->pimVersion) {
-            $baseDirectory = $baseDirectory.'../../../';
-        }
-
         $directories = [];
         if ($this->env !== 'behat') {
             $directories = $this->pimDirectoriesRegistry->getDirectories();
         }
 
-        return new Requirements($baseDirectory, $directories);
+        return new Requirements($this->rootDirectory, $directories);
     }
 
     /**

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/cli_command.yml
@@ -23,6 +23,7 @@ services:
             - '@pim_installer.directories_registry'
             - '%pim_catalog.version.class%'
             - '%kernel.environment%'
+            - '%kernel.project_dir%'
         tags:
             - { name: console.command }
 

--- a/src/Akeneo/Platform/PimRequirements.php
+++ b/src/Akeneo/Platform/PimRequirements.php
@@ -24,8 +24,8 @@ class PimRequirements
     const REQUIRED_GD_VERSION = '2.0';
     const REQUIRED_CURL_VERSION = '7.0';
     const REQUIRED_ICU_VERSION = '4.2';
-    const LOWEST_REQUIRED_MYSQL_VERSION = '8.0.17';
-    const GREATEST_REQUIRED_MYSQL_VERSION = '8.1.0';
+    const LOWEST_REQUIRED_MYSQL_VERSION = '8.0.16';
+    const GREATEST_REQUIRED_MYSQL_VERSION = '8.0.17';
 
     const REQUIRED_EXTENSIONS = [
         'apcu',

--- a/src/Akeneo/Platform/PimRequirements.php
+++ b/src/Akeneo/Platform/PimRequirements.php
@@ -158,8 +158,8 @@ class PimRequirements
 
         foreach ($this->directoriesToCheck as $directoryToCheck) {
             $requirements[] = new Requirement(
-                is_writable($directoryToCheck),
-                sprintf('%s directory must be writable', $directoryToCheck),
+                $this->directoryIsWritableIfExists($directoryToCheck),
+                sprintf('%s directory must be writable if it exists', $directoryToCheck),
                 sprintf('Change the permissions of the "<strong>%s</strong>" directory', $directoryToCheck)
             );
         }
@@ -246,5 +246,23 @@ class PimRequirements
         }
 
         return (float) $val;
+    }
+
+    /**
+     * This checks is only useful for PIM instances that use a local filesystem for storage.
+     * In that case, we have to check the directories are writable when the directory already exists.
+     * If the directories do not exist, no problem, FlySystem will create them when needed.
+     *
+     * @param string $directory
+     *
+     * @return bool
+     */
+    private function directoryIsWritableIfExists(string $directory): bool
+    {
+        if (is_dir($directory)) {
+            return is_writable($directory);
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
This is kind of a hot/dirty fix just to be able to deploy a EE PIM with Ansible.
Ideally, the `check-requirements` command should not check the same thing between an onprem and a SaaS instance. I'll fix that with TIP-1295.