### PR TITLE
PIM-8769: Fix 'SKU' filter disappearing from the filter options

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8769: Fix 'SKU' filter disappearing from the filter options
+
 # 3.0.43 (2019-09-24)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListAttributesUseableInProductGrid.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListAttributesUseableInProductGrid.php
@@ -41,13 +41,14 @@ class ListAttributesUseableInProductGrid implements ListAttributesUseableInProdu
 SELECT DISTINCT 
   att.code, att.attribute_type AS type, att.sort_order AS `order`, att.metric_family AS metricFamily, g.sort_order AS groupOrder,
   COALESCE(att_trans.label, CONCAT('[', att.code, ']')) AS label,
-  COALESCE(group_trans.label, CONCAT('[', g.code, ']')) AS `group`
+  COALESCE(group_trans.label, CONCAT('[', g.code, ']')) AS `group`,
+  IF (att.attribute_type = 'pim_catalog_identifier', 0, 1) AS identifier_priority
 FROM pim_catalog_attribute AS att
 INNER JOIN pim_catalog_attribute_group AS g ON att.group_id = g.id
 LEFT JOIN pim_catalog_attribute_translation AS att_trans ON att.id = att_trans.foreign_key AND att_trans.locale = :locale
 LEFT JOIN pim_catalog_attribute_group_translation AS group_trans ON g.id = group_trans.foreign_key AND group_trans.locale = :locale
 WHERE att.useable_as_grid_filter = 1 AND COALESCE(att_trans.label, att.code) LIKE :search
-ORDER BY g.sort_order ASC, att.sort_order ASC
+ORDER BY identifier_priority, g.sort_order ASC, att.sort_order ASC
 LIMIT $limit OFFSET $offset
 SQL;
 

--- a/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListAttributesUseableInProductGrid.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListAttributesUseableInProductGrid.php
@@ -62,6 +62,7 @@ SQL;
         $attributes = array_map(function ($attribute) {
             $attribute['order'] = (int) $attribute['order'];
             $attribute['groupOrder'] = (int) $attribute['groupOrder'];
+            unset($attribute['identifier_priority']);
 
             return $attribute;
         }, $attributes);


### PR DESCRIPTION
The SKU (identifier) filter is displayed as selected for filter but does not appear on the sidebar. You have to unselect it, then reselect it to see it appearing on the menu. This is because it was not fetched in the first page of filters. The fix add a special 'ORDER BY' to make the identifier the first to be returned by the filter list so that it will always be displayed.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
