### PR TITLE
TIP-1262: proper dependency injection in the test services

### DIFF
--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -45,16 +45,17 @@ abstract class ApiTestCase extends WebTestCase
     protected function setUp(): void
     {
         static::bootKernel(['debug' => false]);
-        $authenticator = new SystemUserAuthenticator(static::$kernel->getContainer());
-        $authenticator->createSystemUser();
 
         $this->testKernel = new \AppKernelTest('test', false);
         $this->testKernel->boot();
 
-        $this->catalog = $this->testKernel->getContainer()->get('akeneo_integration_tests.configuration.catalog');
+        $authenticator = $this->getFromTestContainer('akeneo_integration_tests.security.system_user_authenticator');
+        $authenticator->createSystemUser();
+
+        $this->catalog = $this->getFromTestContainer('akeneo_integration_tests.configuration.catalog');
         $this->testKernel->getContainer()->set('akeneo_integration_tests.catalog.configuration', $this->getConfiguration());
 
-        $fixturesLoader = $this->testKernel->getContainer()->get('akeneo_integration_tests.loader.fixtures_loader');
+        $fixturesLoader = $this->getFromTestContainer('akeneo_integration_tests.loader.fixtures_loader');
         $fixturesLoader->load();
     }
 

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -49,6 +49,8 @@ abstract class ApiTestCase extends WebTestCase
         $this->testKernel = new \AppKernelTest('test', false);
         $this->testKernel->boot();
 
+        $this->catalog = $this->getFromTestContainer('akeneo_integration_tests.configuration.catalog');
+        
         $authenticator = new SystemUserAuthenticator(
             $this->get('pim_user.factory.user'),
             $this->get('pim_user.repository.group'),
@@ -57,7 +59,6 @@ abstract class ApiTestCase extends WebTestCase
         );
         $authenticator->createSystemUser();
 
-        $this->catalog = $this->getFromTestContainer('akeneo_integration_tests.configuration.catalog');
         $this->testKernel->getContainer()->set('akeneo_integration_tests.catalog.configuration', $this->getConfiguration());
 
         $fixturesLoader = $this->getFromTestContainer('akeneo_integration_tests.loader.fixtures_loader');

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -49,7 +49,12 @@ abstract class ApiTestCase extends WebTestCase
         $this->testKernel = new \AppKernelTest('test', false);
         $this->testKernel->boot();
 
-        $authenticator = $this->getFromTestContainer('akeneo_integration_tests.security.system_user_authenticator');
+        $authenticator = new SystemUserAuthenticator(
+            $this->get('pim_user.factory.user'),
+            $this->get('pim_user.repository.group'),
+            $this->get('pim_user.repository.role'),
+            $this->get('security.token_storage')
+        );
         $authenticator->createSystemUser();
 
         $this->catalog = $this->getFromTestContainer('akeneo_integration_tests.configuration.catalog');

--- a/tests/back/Integration/IntegrationTestsBundle/Loader/DatabaseSchemaHandler.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Loader/DatabaseSchemaHandler.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Test\IntegrationTestsBundle\Loader;
 
+use Doctrine\DBAL\Connection;
 use Pim\Behat\Context\DBALPurger;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -14,19 +15,20 @@ use Symfony\Component\HttpKernel\KernelInterface;
 class DatabaseSchemaHandler
 {
     /** @var KernelInterface */
-    protected $kernel;
+    private $kernel;
 
     /** @var Application */
-    protected $cli;
+    private $cli;
 
-    /**
-     * @param KernelInterface $kernel
-     */
-    public function __construct(KernelInterface $kernel)
+    /** @var Connection */
+    private $dbConnection;
+
+    public function __construct(KernelInterface $kernel, Connection $dbConnection)
     {
         $this->kernel = $kernel;
         $this->cli = new Application($this->kernel);
         $this->cli->setAutoExit(false);
+        $this->dbConnection = $dbConnection;
     }
 
     /**
@@ -37,12 +39,11 @@ class DatabaseSchemaHandler
      */
     public function reset()
     {
-        $connection = $this->kernel->getContainer()->get('database_connection');
-        $schemaManager = $connection->getSchemaManager();
+        $schemaManager = $this->dbConnection->getSchemaManager();
         $tables = $schemaManager->listTableNames();
 
         $purger = new DBALPurger(
-            $this->kernel->getContainer()->get('database_connection'),
+            $this->dbConnection,
             $tables,
             [
                 'pim_catalog_product',

--- a/tests/back/Integration/IntegrationTestsBundle/Resources/config/services.yml
+++ b/tests/back/Integration/IntegrationTestsBundle/Resources/config/services.yml
@@ -25,11 +25,22 @@ services:
             - '@akeneo_integration_tests.loader.database_schema_handler'
             - '@akeneo_integration_tests.security.system_user_authenticator'
             - '@akeneo_integration_tests.catalog.configuration'
+            - '@akeneo_integration_tests.loader.reference_data_loader'
+            - '@oneup_flysystem.archivist_filesystem'
+            - '@akeneo_batch.job_repository'
+            - '@pim_installer.fixture_loader.job_loader'
+            - '@oro_security.acl.manager'
+            - '@pim_catalog.elasticsearch.indexer.product'
+            - '@pim_catalog.elasticsearch.indexer.product_model'
+            - '@akeneo_elasticsearch.registry.clients'
+            - '@akeneo_elasticsearch.client.product_and_product_model'
+            - '@database_connection'
 
     akeneo_integration_tests.loader.database_schema_handler:
         class: '%akeneo_integration_tests.loader.database_schema_handler.class%'
         arguments:
             - '@kernel'
+            - '@database_connection'
 
     akeneo_integration_tests.doctrine.connection.connection_closer:
         class: '%akeneo_integration_tests.doctrine.connection.connection_closer.class%'
@@ -39,12 +50,29 @@ services:
     akeneo_integration_tests.security.system_user_authenticator:
         class: '%akeneo_integration_tests.security.system_user_authenticator.class%'
         arguments:
-            - '@service_container'
+            - '@pim_user.factory.user'
+            - '@pim_user.repository.group'
+            - '@pim_user.repository.role'
+            - '@security.token_storage'
 
     akeneo_integration_tests.catalog.fixture.build_entity:
         class: 'AkeneoTest\Pim\Enrichment\Integration\Fixture\EntityBuilder'
         arguments:
-            - '@service_container'
+            - '@akeneo_integration_tests.launcher.job_launcher'
+            - '@validator'
+            - '@pim_catalog.builder.entity_with_values'
+            - '@pim_catalog.builder.product'
+            - '@pim_catalog.updater.product'
+            - '@pim_catalog.saver.product'
+            - '@pim_catalog.factory.product_model'
+            - '@pim_catalog.updater.product_model'
+            - '@pim_catalog.saver.product_model'
+            - '@pim_catalog.repository.family_variant'
+            - '@pim_catalog.factory.family_variant'
+            - '@pim_catalog.updater.family_variant'
+            - '@pim_catalog.saver.family_variant'
+            - '@pim_catalog.repository.attribute'
+            - '@akeneo_elasticsearch.client.product_and_product_model'
 
     akeneo_integration_tests.catalog.fixture.completeness_filter:
         class: 'AkeneoTest\Pim\Enrichment\Integration\Fixture\CompletenessFilter'

--- a/tests/back/Integration/TestCase.php
+++ b/tests/back/Integration/TestCase.php
@@ -48,7 +48,7 @@ abstract class TestCase extends KernelTestCase
         }
 
         // authentication should be done after loading the database as the user is created with first activated locale as default locale
-        $authenticator = new SystemUserAuthenticator(static::$kernel->getContainer());
+        $authenticator = $this->getFromTestContainer('akeneo_integration_tests.security.system_user_authenticator');
         $authenticator->createSystemUser();
         $this->get('doctrine.orm.default_entity_manager')->clear();
 

--- a/tests/back/Integration/TestCase.php
+++ b/tests/back/Integration/TestCase.php
@@ -48,7 +48,12 @@ abstract class TestCase extends KernelTestCase
         }
 
         // authentication should be done after loading the database as the user is created with first activated locale as default locale
-        $authenticator = $this->getFromTestContainer('akeneo_integration_tests.security.system_user_authenticator');
+        $authenticator = new SystemUserAuthenticator(
+            $this->get('pim_user.factory.user'),
+            $this->get('pim_user.repository.group'),
+            $this->get('pim_user.repository.role'),
+            $this->get('security.token_storage')
+        );
         $authenticator->createSystemUser();
         $this->get('doctrine.orm.default_entity_manager')->clear();
 

--- a/tests/back/Integration/TestCase.php
+++ b/tests/back/Integration/TestCase.php
@@ -40,10 +40,10 @@ abstract class TestCase extends KernelTestCase
         $this->testKernel = new \AppKernelTest('test', false);
         $this->testKernel->boot();
 
-        $this->catalog = $this->testKernel->getContainer()->get('akeneo_integration_tests.configuration.catalog');
+        $this->catalog = $this->getFromTestContainer('akeneo_integration_tests.configuration.catalog');
         if (null !== $this->getConfiguration()) {
             $this->testKernel->getContainer()->set('akeneo_integration_tests.catalog.configuration', $this->getConfiguration());
-            $fixturesLoader = $this->testKernel->getContainer()->get('akeneo_integration_tests.loader.fixtures_loader');
+            $fixturesLoader = $this->getFromTestContainer('akeneo_integration_tests.loader.fixtures_loader');
             $fixturesLoader->load();
         }
 

--- a/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductModelIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductModelIntegration.php
@@ -116,7 +116,7 @@ class ClassifyProductModelIntegration extends TestCase
     {
         parent::setUp();
 
-        $builder = new EntityBuilder($this->testKernel->getContainer());
+        $builder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
 
         $productModel = $builder->createProductModel('model-tee', 'clothing_color_size', null, []);
         $this->getFromTestContainer('pim_catalog.updater.product_model')->update($productModel, ['categories' => ['supplier_zaro']]);

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/SavingProductModelDescendantsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/SavingProductModelDescendantsIntegration.php
@@ -156,7 +156,7 @@ class SavingProductModelDescendantsIntegration extends TestCase
      */
     private function createProductsAndProductModelsTree(string $seed)
     {
-        $entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
 
         $rootProductModel = $entityBuilder->createProductModel($seed . '_root_product_model', 'familyVariantA1', null, []);
         $subProductModel1 = $entityBuilder->createProductModel($seed . '_sub_product_model_1', 'familyVariantA1', $rootProductModel, []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/ParentFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/ParentFilterIntegration.php
@@ -15,7 +15,7 @@ class ParentFilterIntegration extends AbstractProductAndProductModelQueryBuilder
 {
     public function testQueryParentInList()
     {
-        $entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
 
         $bikerJacket = $this->getFromTestContainer('pim_catalog.repository.product_model')->findOneByIdentifier('model-biker-jacket');
         $entityBuilder->createVariantProduct(
@@ -55,7 +55,7 @@ class ParentFilterIntegration extends AbstractProductAndProductModelQueryBuilder
 
     public function testQueryParentInListCaseInsensitive()
     {
-        $entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
         $productModel = $entityBuilder->createProductModel(
             'MODEL_test',
             'clothing_color_size',

--- a/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/GetCategoryCodesByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/GetCategoryCodesByProductIdentifiersIntegration.php
@@ -19,7 +19,7 @@ class GetCategoryCodesByProductIdentifiersIntegration extends TestCase
         parent::setUp();
 
         $fixturesLoader = new CategoryTreeFixturesLoader($this->testKernel->getContainer());
-        $this->entityBuilder =  new EntityBuilder($this->testKernel->getContainer());
+        $this->entityBuilder =  $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
 
         $fixturesLoader->givenTheCategoryTrees([
             'root_master' => [

--- a/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/GetGroupAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/GetGroupAssociationsByProductIdentifiersIntegration.php
@@ -21,7 +21,7 @@ class GetGroupAssociationsByProductIdentifiersIntegration extends TestCase
     {
         parent::setUp();
 
-        $entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
 
         $this->givenGroup(['groupA', 'groupB', 'groupC', 'groupD', 'groupE', 'groupF', 'groupG']);
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/GetProductAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/GetProductAssociationsByProductIdentifiersIntegration.php
@@ -21,7 +21,7 @@ class GetProductAssociationsByProductIdentifiersIntegration extends TestCase
     {
         parent::setUp();
 
-        $entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
         $this->givenBooleanAttributes(['first_yes_no', 'second_yes_no']);
         $this->givenFamilies([['code' => 'aFamily', 'attribute_codes' => ['first_yes_no', 'second_yes_no']]]);
         $entityBuilder->createFamilyVariant(

--- a/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/GetProductModelAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/GetProductModelAssociationsByProductIdentifiersIntegration.php
@@ -25,7 +25,7 @@ class GetProductModelAssociationsByProductIdentifiersIntegration extends TestCas
     {
         parent::setUp();
 
-        $entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
         $this->entityBuilder = $entityBuilder;
 
         $this->givenTheFollowingProductModels(

--- a/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/GetValuesAndPropertiesFromProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Query/Sql/GetValuesAndPropertiesFromProductIdentifiersIntegration.php
@@ -30,7 +30,7 @@ class GetValuesAndPropertiesFromProductIdentifiersIntegration extends TestCase
         ]);
         $this->get('pim_catalog.saver.family')->save($family);
 
-        $entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
         $this->givenBooleanAttributes(['first_yes_no', 'second_yes_no']);
         $this->givenFamilies([['code' => 'FamilyWithVariant', 'attribute_codes' => ['first_yes_no', 'second_yes_no']]]);
         $this->givenGroups(['group1', 'group2']);
@@ -151,7 +151,7 @@ class GetValuesAndPropertiesFromProductIdentifiersIntegration extends TestCase
      */
     public function testVariantProductWithEmptyValuesFromParent()
     {
-        $entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
         $entityBuilder->createFamilyVariant(
             [
                 'code' => 'familyVariantWithOneLevel',

--- a/tests/back/Pim/Enrichment/Integration/ProductModel/Query/Sql/GetCategoryCodesByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductModel/Query/Sql/GetCategoryCodesByProductModelCodesIntegration.php
@@ -23,7 +23,7 @@ class GetCategoryCodesByProductModelCodesIntegration extends TestCase
         parent::setUp();
 
         $this->fixturesLoader = new CategoryTreeFixturesLoader($this->testKernel->getContainer());
-        $this->entityBuilder =  new EntityBuilder($this->testKernel->getContainer());
+        $this->entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
 
         $this->givenTheFollowingCategoryTrees([
             'root_master' => [

--- a/tests/back/Pim/Enrichment/Integration/ProductModel/Query/Sql/GetGroupAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductModel/Query/Sql/GetGroupAssociationsByProductModelCodesIntegration.php
@@ -26,7 +26,7 @@ class GetGroupAssociationsByProductModelCodesIntegration extends TestCase
     {
         parent::setUp();
 
-        $this->entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $this->entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
 
         $this->givenGroup(['groupA', 'groupB', 'groupC', 'groupD', 'groupE', 'groupF', 'groupG']);
 

--- a/tests/back/Pim/Enrichment/Integration/ProductModel/Query/Sql/GetProductAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductModel/Query/Sql/GetProductAssociationsByProductModelCodesIntegration.php
@@ -72,7 +72,7 @@ class GetProductAssociationsByProductModelCodesIntegration extends TestCase
     {
         parent::setUp();
 
-        $entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
         $this->givenBooleanAttributes(['first_yes_no']);
         $this->givenFamilies([['code' => 'aFamily', 'attribute_codes' => ['first_yes_no']]]);
         $entityBuilder->createFamilyVariant(

--- a/tests/back/Pim/Enrichment/Integration/ProductModel/Query/Sql/GetProductModelsAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductModel/Query/Sql/GetProductModelsAssociationsByProductModelCodesIntegration.php
@@ -98,7 +98,7 @@ class GetProductModelsAssociationsByProductModelCodesIntegration extends TestCas
     {
         parent::setUp();
 
-        $this->entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $this->entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
 
         $this->givenTheFollowingProductModels([
             'productModelA',

--- a/tests/back/Pim/Enrichment/Integration/ProductModel/Query/Sql/GetValuesAndPropertiesFromProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductModel/Query/Sql/GetValuesAndPropertiesFromProductModelCodesIntegration.php
@@ -30,7 +30,7 @@ class GetValuesAndPropertiesFromProductModelCodesIntegration extends TestCase
     {
         parent::setUp();
 
-        $this->entityBuilder = new EntityBuilder($this->testKernel->getContainer());
+        $this->entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
 
         $this->givenTheFollowingProductModelsWithValues([
             'root_product_model_1' => [


### PR DESCRIPTION
When trying to upgrade to SF4, we face a problem: all services are now private by default. In the test, you can bypass that problem by setting `test: true` in the `framework` configuration.

In our PhpUnit tests, we have a weird "double kernel booted". We sometimes inject `@service_container` or `@kernel` to retrieve some services inside the test services. It seems, but we are not sure, that those injected containers are not built with the `test` configuration set to `true`.

Anyway, even if this PR doesn't fix our problem, it's better to properly inject only what we need.