### PR TITLE
TIP-1262 Make datagrid actions public

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid_actions.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid_actions.yml
@@ -6,24 +6,28 @@ parameters:
 
 services:
     pim_enrich.extension.action.type.navigate_product_and_product_model:
+        public: true
         class: '%pim_enrich.extension.action.type.navigate_product_and_product_model.class%'
         shared: false
         tags:
             - { name: oro_datagrid.extension.action.type, type: navigate-product-and-product-model }
 
     pim_enrich.extension.action.type.edit_in_modal:
+        public: true
         class: '%pim_enrich.extension.action.type.edit_in_modal.class%'
         shared: false
         tags:
             - { name: oro_datagrid.extension.action.type, type: edit-in-modal }
 
     pim_enrich.extension.action.type.delete_product:
+        public: true
         class: '%pim_enrich.extension.action.type.delete_product.class%'
         shared: false
         tags:
             - { name: oro_datagrid.extension.action.type, type: delete-product }
 
     pim_enrich.extension.action.type.toggle_product:
+        public: true
         class: '%pim_enrich.extension.action.type.toggle_product.class%'
         shared: false
         tags:

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/actions.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/actions.yml
@@ -3,6 +3,7 @@ parameters:
 
 services:
     pim_datagrid.extension.action.type.tab_redirect:
+        public: true
         class: '%pim_datagrid.extension.action.type.tab_redirect.class%'
         shared: false
         tags:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Getting services from the container is deprecated since Symfony 3.2 and will fail in 4.0. It quite impossible to easily refactor the datagrid that is why we decided to make some services public like datagrid action.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
