### PR TITLE
PIM-8820: Avoid multiple refresh of the product grid on product delete

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-8820: Avoid multiple refresh of the product grid on product delete
+
 # 3.2.9 (2019-09-23)
 
 ## Bug fixes:

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/grid.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/grid.js
@@ -287,6 +287,11 @@ define(
             _listenToCommands: function () {
                 var grid = this;
 
+                mediator.clear('datagrid:setParam:' + grid.name);
+                mediator.clear('datagrid:removeParam:' + grid.name);
+                mediator.clear('datagrid:restoreState:' + grid.name);
+                mediator.clear('datagrid:doRefresh:' + grid.name);
+
                 mediator.on('datagrid:setParam:' + grid.name, function (param, value) {
                     grid.setAdditionalParameter(param, value);
                 });


### PR DESCRIPTION
If you go to the product grid, then PEF, then product grid, it will register 2 times the events of the datagrid and refresh 2 times the grid on product deletion.
This PR removes the previous events before adding new ones.