### PR TITLE
PIM-8838: Force display of label and image in gallery mode even if they are not in the column list

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,8 @@
 ## Bug fixes:
 
 - PIM-8838: Force display of label and image in gallery mode even if they are not in the column list
+- PIM-8820: Avoid multiple refresh of the product grid on product delete
+- PIM-8838: Force display of identifier, label and image in gallery mode even if they are not in the column list
 
 # 3.2.10 (2019-10-02)
 

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-8838: Force display of label and image in gallery mode even if they are not in the column list
+
 # 3.2.10 (2019-10-02)
 
 ## Bug fixes:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
@@ -70,6 +70,13 @@ datagrid:
             identifier:
                 type:          field
                 data_name:     identifier
+            completeness:
+                type:          field
+                frontend_type: completeness
+            complete_variant_products:
+                type:          field
+                data_name:     complete_variant_product
+                frontend_type: complete-variant-product
             document_type: ~
             technical_id: ~
             delete_link:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
@@ -67,6 +67,9 @@ datagrid:
             image:
                 data_name:     image
                 frontend_type: product-and-product-model-image
+            identifier:
+                type:          field
+                data_name:     identifier
             document_type: ~
             technical_id: ~
             delete_link:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
@@ -61,6 +61,12 @@ datagrid:
             id:
                 type:          field
                 data_name:     search_id
+            label:
+                type:          field
+                data_name:     label
+            image:
+                data_name:     image
+                frontend_type: product-and-product-model-image
             document_type: ~
             technical_id: ~
             delete_link:

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/product-row.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/product-row.js
@@ -34,9 +34,7 @@ define(
              * @return {Array} An array of column names
              */
             getRenderableColumns() {
-                const type = this.getCompletenessCellType();
-
-                return [type, 'massAction', 'rowActions'];
+                return ['massAction', 'rowActions'];
             },
 
             /**
@@ -52,7 +50,9 @@ define(
                     useLayerStyle: isProductModel,
                     label,
                     identifier: this.model.get('identifier'),
-                    imagePath: this.getThumbnailImagePath()
+                    imagePath: this.getThumbnailImagePath(),
+                    completenessText: this.getCompletenessText(),
+                    completenessClass: this.getCompletenessClass(),
                 };
             },
 
@@ -152,6 +152,49 @@ define(
                 } else if (columnName === 'rowActions') {
                     $('.AknIconButton', cellElement).addClass('AknIconButton--white');
                 }
+            },
+
+            getCompletenessText() {
+                if (this.isProductModel()) {
+                    const complete = this.model.get('complete_variant_products').complete;
+                    const total = this.model.get('complete_variant_products').total;
+
+                    return complete + ' / ' + total;
+                } else {
+                    const completeness = this.model.get('completeness');
+                    if (null !== completeness) {
+                        return completeness + '%';
+                    }
+                }
+
+                return null;
+            },
+
+            getCompletenessClass() {
+                if (this.isProductModel()) {
+                    const complete = this.model.get('complete_variant_products').complete;
+                    const total = this.model.get('complete_variant_products').total;
+                    if (complete === total) {
+                        return 'AknBadge--success';
+                    } else if (complete === 0) {
+                        return 'AknBadge--important';
+                    } else {
+                        return 'AknBadge--warning';
+                    }
+                } else {
+                    const completeness = this.model.get('completeness');
+                    if (null !== completeness) {
+                        if (completeness <= 0) {
+                            return 'AknBadge--important';
+                        } else if (completeness >= 100) {
+                            return 'AknBadge--success';
+                        } else {
+                            return 'AknBadge--warning';
+                        }
+                    }
+                }
+
+                return null;
             }
         });
     });

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/row/product-thumbnail.html
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/row/product-thumbnail.html
@@ -1,3 +1,8 @@
 <div class="AknGrid-fullImage" style="background-image: url('<%- imagePath %>')"></div>
 <div class="AknGrid-title"><%- label %></div>
 <div class="AknGrid-subTitle"><%- identifier %></div>
+<% if (completenessText !== null) { %>
+    <div class="AknGrid-bodyCell string-cell AknBadge--topRight">
+        <span class="AknBadge <%- completenessClass %>"><%- completenessText %></span>
+    </div>
+<% } %>


### PR DESCRIPTION
It does not change the display of the standard grid because only the "values" are displayed.
It only always return the image and label "properties" in the product grid.