### PR TITLE
PIM-8331: Fix display of category tree in the product grid when user does not have access to its default tree

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8331: Fix display of category tree in the product grid when user does not have access to its default tree
+
 # 3.0.44 (2019-10-02)
 
 # 3.0.43 (2019-09-24)

--- a/src/Akeneo/Pim/Enrichment/Component/Category/CategoryTree/UseCase/ListRootCategoriesWithCountHandler.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Category/CategoryTree/UseCase/ListRootCategoriesWithCountHandler.php
@@ -56,7 +56,7 @@ class ListRootCategoriesWithCountHandler
             $this->categoryRepository->find($query->categoryIdSelectedAsFilter()) : null;
 
         if (null === $categorySelectedAsFilter) {
-            $categorySelectedAsFilter = $this->userContext->getUserProductCategoryTree();
+            $categorySelectedAsFilter = $this->userContext->getAccessibleUserTree();
         }
         $rootCategoryIdToExpand = $categorySelectedAsFilter->getRoot();
 

--- a/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
+++ b/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
@@ -313,6 +313,14 @@ class UserContext
             'channel'  => $this->getUserChannelCode()
         ];
     }
+    
+    /**
+     * @return CategoryInterface
+     */
+    public function getAccessibleUserTree()
+    {
+        return $this->getUserProductCategoryTree();
+    }
 
     /**
      * Returns the request locale


### PR DESCRIPTION
The called method was not aware of any permission to get the default catalog tree.
It implies a bug on front.