### PR TITLE
TIP-1174: Fix elasticsearch product model projection for root product models

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
@@ -177,7 +177,7 @@ SQL;
                 'ancestor_category_codes' => json_decode($row['ancestor_category_codes']),
                 'parent_code' => $row['parent_code'],
                 'values' => $values,
-                'parent_id' => (int) $row['parent_id'],
+                'parent_id' => $row['parent_id'] ? (int) $row['parent_id'] : null,
                 'labels' => isset($values[$row['attribute_as_label_code']]) ? $values[$row['attribute_as_label_code']] : [],
             ];
         }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fixes a `null` => 0 conversion while hydrating ElasticsearchProductModelProjection instances

