### PR TITLE
Fix MaskItemGenerator for EE attribute types

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/MaskItemGenerator/DefaultMaskItemGenerator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/MaskItemGenerator/DefaultMaskItemGenerator.php
@@ -41,10 +41,9 @@ class DefaultMaskItemGenerator implements MaskItemGeneratorForAttributeType
             AttributeTypes::REFERENCE_DATA_MULTI_SELECT,
             AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT,
             AttributeTypes::REFERENCE_ENTITY_SIMPLE_SELECT,
-            AttributeTypes::ASSET_MULTIPLE_LINK,
+            AttributeTypes::REFERENCE_ENTITY_COLLECTION,
+            AttributeTypes::ASSET_COLLECTION,
             AttributeTypes::ASSETS_COLLECTION,
-            // TODO rework with AssetManager
-            'pim_assets_collection'
         ];
     }
 }

--- a/src/Akeneo/Pim/Structure/Component/AttributeTypes.php
+++ b/src/Akeneo/Pim/Structure/Component/AttributeTypes.php
@@ -26,8 +26,9 @@ final class AttributeTypes
     const REFERENCE_DATA_MULTI_SELECT = 'pim_reference_data_multiselect';
     const REFERENCE_DATA_SIMPLE_SELECT = 'pim_reference_data_simpleselect';
     const REFERENCE_ENTITY_SIMPLE_SELECT = 'akeneo_reference_entity';
-    const ASSET_MULTIPLE_LINK = 'akeneo_asset_multiple_link';
-    const ASSETS_COLLECTION = 'pim_catalog_asset_collection';
+    const REFERENCE_ENTITY_COLLECTION = 'akeneo_reference_entity_collection';
+    const ASSET_COLLECTION = 'pim_catalog_asset_collection';
+    const ASSETS_COLLECTION = 'pim_assets_collection';
 
     const BACKEND_TYPE_BOOLEAN = 'boolean';
     const BACKEND_TYPE_COLLECTION = 'collections';


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fixes an error during the last 3.2 -> master pull-up (2 very similar constants were added).
Also, defaultMaskItemGenerator can now handle EE  refentity collections attributes

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
