### PR TITLE
TIP-1249: Update MySQL requirements

### DIFF
--- a/src/Akeneo/Platform/PimRequirements.php
+++ b/src/Akeneo/Platform/PimRequirements.php
@@ -25,7 +25,7 @@ class PimRequirements
     const REQUIRED_CURL_VERSION = '7.0';
     const REQUIRED_ICU_VERSION = '4.2';
     const LOWEST_REQUIRED_MYSQL_VERSION = '8.0.16';
-    const GREATEST_REQUIRED_MYSQL_VERSION = '8.0.17';
+    const GREATEST_REQUIRED_MYSQL_VERSION = '8.1.0';
 
     const REQUIRED_EXTENSIONS = [
         'apcu',


### PR DESCRIPTION
OK... Well...
There is this [MySQL bug](https://bugs.mysql.com/bug.php?id=96823) in 8.0.17. The previous requirements were here to force us to install 8.0.16, and so, to avoid this bug.
It works well for the CI as we use Docker containers.

For our test features environments, we use the scripts Ansible scripts. Which themselves use the official MySQL repository. Which only provides MySQL 8.0.17. That means, currently we can't deploy a test dev environment. And yes, with this PR, that means we'll be able to deploy a test dev env, but it will have the MySQL bug... 

This is the less worse we can do. We have to wait for MySQL to release a 8.0.18 :crossed_fingers:   When they'll do, I'll update again the requirements.