### PR TITLE
PIM-7332: show an error message when a number attribute field reaches the PHP_INT_MAX

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-6424: update exports when a locale is removed from a channel
+- PIM-7332: show an error message when a number attribute field reaches the PHP_INT_MAX.
 
 # 2.3.63 (2019-09-23)
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
@@ -41,6 +41,7 @@ pim_catalog:
         cannot_have_parent: 'The product model "%product_model%" cannot have a parent'
         attribute_does_not_belong_to_family: 'Attribute "%attribute%" does not belong to the family "%family%"'
         variant_product_invalid_family: 'The variant product family must be the same than its parent'
+        php_int_max_reached: 'The maximum number must be lower than %php_int_max%.'
         not_null_family: The family can't be "null" because your product with the identifier "%sku%" is a variant product.
         variant_product_has_parent: 'The variant product "%variant_product%" must have a parent'
         invalid_variant_product_parent: 'The variant product "%variant_product%" cannot have product model "%product_model%" as parent, (this product model can only have other product models as children)'

--- a/src/Pim/Component/Catalog/Validator/ConstraintGuesser/RangeGuesser.php
+++ b/src/Pim/Component/Catalog/Validator/ConstraintGuesser/RangeGuesser.php
@@ -49,6 +49,10 @@ class RangeGuesser implements ConstraintGuesserInterface
             }
         }
 
+        if (AttributeTypes::NUMBER === $attribute->getType() && (null === $max || PHP_INT_MAX < $max)) {
+            $max = PHP_INT_MAX;
+        }
+
         if (null !== $min || null !== $max) {
             $constraints[] = new Range(['min' => $min, 'max' => $max]);
         }

--- a/src/Pim/Component/Catalog/Validator/Constraints/ValidNumberRange.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/ValidNumberRange.php
@@ -13,6 +13,7 @@ use Symfony\Component\Validator\Constraint;
  */
 class ValidNumberRange extends Constraint
 {
+    public const PHP_INT_MAX_REACHED = 'pim_catalog.constraint.php_int_max_reached';
     public $message = 'The max number must be greater than the min number';
     public $invalidNumberMessage = 'This number is not valid';
 

--- a/src/Pim/Component/Catalog/Validator/Constraints/ValidNumberRangeValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/ValidNumberRangeValidator.php
@@ -24,14 +24,17 @@ class ValidNumberRangeValidator extends ConstraintValidator
     {
         $min = $entity->getNumberMin();
         $max = $entity->getNumberMax();
-
         if ($min && !$this->isNumberValid($entity, $min)) {
             $this->context->buildViolation($constraint->invalidNumberMessage)
                 ->atPath('numberMin')
                 ->addViolation();
         }
 
-        if ($max && !$this->isNumberValid($entity, $max)) {
+        if ($max && PHP_INT_MAX < $max) {
+            $this->context->buildViolation(ValidNumberRange::PHP_INT_MAX_REACHED, [
+                '%php_int_max%' => PHP_INT_MAX
+            ])->atPath('numberMax')->addViolation();
+        } elseif ($max && !$this->isNumberValid($entity, $max)) {
             $this->context->buildViolation($constraint->invalidNumberMessage)
                 ->atPath('numberMax')
                 ->addViolation();

--- a/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/RangeGuesserSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/ConstraintGuesser/RangeGuesserSpec.php
@@ -3,13 +3,17 @@
 namespace spec\Pim\Component\Catalog\Validator\ConstraintGuesser;
 
 use PhpSpec\ObjectBehavior;
+use Pim\Bundle\CatalogBundle\Entity\Attribute;
+use Pim\Component\Catalog\AttributeTypes;
 use Pim\Component\Catalog\Model\AttributeInterface;
+use Pim\Component\Catalog\Validator\ConstraintGuesserInterface;
+use Pim\Component\Catalog\Validator\Constraints\Range;
 
 class RangeGuesserSpec extends ObjectBehavior
 {
     function it_is_an_attribute_constraint_guesser()
     {
-        $this->shouldImplement('Pim\Component\Catalog\Validator\ConstraintGuesserInterface');
+        $this->shouldImplement(ConstraintGuesserInterface::class);
     }
 
     function it_enforces_attribute_type(AttributeInterface $attribute)
@@ -55,7 +59,7 @@ class RangeGuesserSpec extends ObjectBehavior
         $constraints->shouldHaveCount(1);
 
         $constraint = $constraints[0];
-        $constraint->shouldBeAnInstanceOf('Pim\Component\Catalog\Validator\Constraints\Range');
+        $constraint->shouldBeAnInstanceOf(Range::class);
         $constraint->min->shouldBe(doubleval(5));
         $constraint->max->shouldBe(null);
     }
@@ -75,7 +79,7 @@ class RangeGuesserSpec extends ObjectBehavior
         $constraints->shouldHaveCount(1);
 
         $constraint = $constraints[0];
-        $constraint->shouldBeAnInstanceOf('Pim\Component\Catalog\Validator\Constraints\Range');
+        $constraint->shouldBeAnInstanceOf(Range::class);
         $constraint->min->shouldBe(null);
         $constraint->max->shouldBe(doubleval(10));
     }
@@ -95,7 +99,7 @@ class RangeGuesserSpec extends ObjectBehavior
         $constraints->shouldHaveCount(1);
 
         $constraint = $constraints[0];
-        $constraint->shouldBeAnInstanceOf('Pim\Component\Catalog\Validator\Constraints\Range');
+        $constraint->shouldBeAnInstanceOf(Range::class);
         $constraint->min->shouldBe(doubleval(5));
         $constraint->max->shouldBe(doubleval(10));
     }
@@ -112,7 +116,7 @@ class RangeGuesserSpec extends ObjectBehavior
         $constraints->shouldHaveCount(1);
 
         $constraint = $constraints[0];
-        $constraint->shouldBeAnInstanceOf('Pim\Component\Catalog\Validator\Constraints\Range');
+        $constraint->shouldBeAnInstanceOf(Range::class);
         $constraint->min->shouldBe(doubleval(-5));
         $constraint->max->shouldBe(null);
     }
@@ -129,7 +133,7 @@ class RangeGuesserSpec extends ObjectBehavior
         $constraints->shouldHaveCount(1);
 
         $constraint = $constraints[0];
-        $constraint->shouldBeAnInstanceOf('Pim\Component\Catalog\Validator\Constraints\Range');
+        $constraint->shouldBeAnInstanceOf(Range::class);
         $constraint->min->shouldBe(doubleval(0));
         $constraint->max->shouldBe(null);
     }
@@ -149,7 +153,7 @@ class RangeGuesserSpec extends ObjectBehavior
         $constraints->shouldHaveCount(1);
 
         $constraint = $constraints[0];
-        $constraint->shouldBeAnInstanceOf('Pim\Component\Catalog\Validator\Constraints\Range');
+        $constraint->shouldBeAnInstanceOf(Range::class);
         $constraint->min->shouldBe('1970-01-01');
         $constraint->max->shouldBe(null);
     }
@@ -169,7 +173,7 @@ class RangeGuesserSpec extends ObjectBehavior
         $constraints->shouldHaveCount(1);
 
         $constraint = $constraints[0];
-        $constraint->shouldBeAnInstanceOf('Pim\Component\Catalog\Validator\Constraints\Range');
+        $constraint->shouldBeAnInstanceOf(Range::class);
         $constraint->min->shouldBe(null);
         $constraint->max->shouldBe('2038-01-19');
     }
@@ -189,7 +193,7 @@ class RangeGuesserSpec extends ObjectBehavior
         $constraints->shouldHaveCount(1);
 
         $constraint = $constraints[0];
-        $constraint->shouldBeAnInstanceOf('Pim\Component\Catalog\Validator\Constraints\Range');
+        $constraint->shouldBeAnInstanceOf(Range::class);
         $constraint->min->shouldBe('1970-01-01');
         $constraint->max->shouldBe('2038-01-19');
     }
@@ -240,5 +244,17 @@ class RangeGuesserSpec extends ObjectBehavior
         $constraints = $this->guessConstraints($attribute);
 
         $constraints->shouldReturn([]);
+    }
+
+    function it_forces_number_max_if_nothing_was_specified()
+    {
+        $number = new Attribute();
+        $number->setType(AttributeTypes::NUMBER);
+
+        $constraints = $this->guessConstraints($number);
+        $constraints->shouldHaveCount(1);
+        $range = $constraints[0];
+        $range->shouldBeAnInstanceOf(Range::class);
+        $range->max->shouldBe(floatval(PHP_INT_MAX));
     }
 }


### PR DESCRIPTION
It adds an error message when you edit a product and you try to put a number higher than PHP_INT_MAX.
It adds an error message when you edit an attribute and you try to put as the maximum a number higher than PHP_INT_MAX. (It was the case before but now you have an explicit error message) .

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
