### PR TITLE
PIM-8852: Fix display of locale specific metric attribute in PEF

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8331: Fix display of category tree in the product grid when user does not have access to its default tree
+- PIM-8852: Locale specific and localized metric attribute is well displayed in product edit form.
 
 # 3.0.44 (2019-10-02)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/metric.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/metric.html
@@ -4,9 +4,9 @@
         <div class="AknTextField-layer AknTextField-layer--second"></div>
     <% } %>
     <input class="AknTextField AknTextField--noRightRadius data" id="<%- fieldId %>" type="text" data-locale="<%- locale %>" data-scope="<%- scope %>" value="<%- value ? value.data.amount : null %>" <%- editMode === 'view' ? 'disabled' : '' %>/>
-    <select class="AknMetricField-unit unit select-field" data-locale="<%- value.locale %>" data-scope="<%- value.scope %>" <%- editMode === 'view' ? 'disabled' : '' %>>
+    <select class="AknMetricField-unit unit select-field" data-locale="<%- value ? value.locale : null %>" data-scope="<%- value ? value.scope : null %>" <%- editMode === 'view' ? 'disabled' : '' %>>
         <% _.each(_.keys(measures[attribute.metric_family].units), function(unit) { %>
-            <option value="<%- unit %>"<% if ((null === value.data.unit && unit === attribute.empty_value.unit) || value.data.unit === unit) { %> selected<% } %>>
+            <option value="<%- unit %>"<% if (undefined !== value && ((null === value.data.unit && unit === attribute.empty_value.unit) || value.data.unit === unit)) { %> selected<% } %>>
                 <%- __(`pim_measure.units.${unit}`) %>
             </option>
         <% }); %>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

![screenshot-localhost-8080-2019 10 02-16-44-19](https://user-images.githubusercontent.com/7206368/66054219-f51e3080-e533-11e9-8c56-025d3203e432.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
