### PR TITLE
PIM-7644: Fix 500 error on thumbnail of TIFF images

### DIFF
--- a/src/Pim/Bundle/EnrichBundle/Controller/FileController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/FileController.php
@@ -86,7 +86,7 @@ class FileController
             if (FileTypes::IMAGE === $fileType) {
                 try {
                     $result = $this->imagineController->filterAction($request, $filename, $filter);
-                } catch (NotFoundHttpException $exception) {
+                } catch (NotFoundHttpException|\RuntimeException $exception) {
                     $result = $this->renderDefaultImage(FileTypes::IMAGE, $filter);
                 }
             }

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/MediaField.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/product-edit-form/MediaField.less
@@ -12,6 +12,11 @@
   border-radius: 3px;
   border: 1px solid @AknMediumGrey;
 
+  &-img {
+    width: @height;
+    height: @height;
+  }
+
   &-fileUploaderInput {
     position: absolute;
     width: 100%;


### PR DESCRIPTION
In Imagine (vendor/imagine/imagine/lib/Imagine/Gd/Imagine.php:187) when you try to create an image from TIFF, it throws a RuntimeException.
I added a catch to render the default image.