### PR TITLE
PIM-8773: Add missing delegateEvents() in the render of the user-navigation dropdown

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-8773: Fix logout after opening a select2 dropdown
+
 # 3.2.11 (2019-10-07)
 
 ## Bug fixes:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/user-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/user-navigation.js
@@ -69,6 +69,8 @@ define(
                 notificationView.setElement(this.$('.notification')).render();
                 notificationView.refresh();
 
+                this.delegateEvents();
+
                 return BaseForm.prototype.render.apply(this, arguments);
             },
 


### PR DESCRIPTION
**Description**

In the user-navigation dropdown, the delegateEvents method was only called during initialize, not in the render. Click events on this menu items were not registered after a re-render.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
