### PR TITLE
TIP-1287: move product model queries

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -228,6 +228,12 @@
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\VariantProductRatio` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Completeness\VariantProductRatio` and mark it as final
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\CountVariantProducts` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\CountVariantProducts`
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Attribute\AttributeIsAFamilyVariantAxis` to `Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\AttributeIsAFamilyVariantAxis`
+- Move class from `Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\CountProductModelsAndChildrenProductModels` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\CountProductModelsAndChildrenProductModels`
+- Move class from `Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetCategoryCodesByProductModelCodes` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetCategoryCodesByProductModelCodes`
+- Move class from `Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetGroupAssociationsByProductModelCodes` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetGroupAssociationsByProductModelCodes`
+- Move class from `Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetProductAssociationsByProductModelCodes` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetProductAssociationsByProductModelCodes`
+- Move class from `Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetProductModelsAssociationsByProductModelCodes` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetProductModelsAssociationsByProductModelCodes`
+- Move class from `Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetValuesAndPropertiesFromProductModelCodes` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetValuesAndPropertiesFromProductModelCodes`
 
 ### CLI Commands
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -215,17 +215,27 @@
     and `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\Product\OnDelete\ComputeProductsAndAncestorsSubscriber`
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\AscendantCategories` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Category\AscendantCategories` and mark it as final
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\AttributeIsAFamilyVariantAxis` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Attribute\AttributeIsAFamilyVariantAxis`
-- Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\CountEntityWithFamilyVariant` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Family\CountEntityWithFamilyVariant` and mark it as final
+- Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\CountEntityWithFamilyVariant` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Family\CountEntityWithFamilyVariant`, mark it as final and change constructor:
+    - remove `Doctrine\ORM\EntityManagerInterface`
+    - add `Doctrine\DBAL\Connection`
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\CountImpactedProducts` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductGrid\CountImpactedProducts`
-- Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\CountProductsWithFamily` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Family\CountProductsWithFamily` and mark it as final
+- Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\CountProductsWithFamily` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Family\CountProductsWithFamily`, mark it as final, and change constructor:
+    - remove `Doctrine\ORM\EntityManagerInterface`
+    - add `Doctrine\DBAL\Connection`
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\DescendantProductIdsQuery` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\DescendantProductIdsQuery` and mark it as final
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\DescendantProductModelIdsQuery` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\DescendantProductModelIdsQuery` and mark it as final
-- Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\FindAttributesForFamily` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Family\FindAttributesForFamily`
-- Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\GetAssociatedProductCodesByProductFromDB` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\GetAssociatedProductCodesByProductFromDB` and mark it as final
+- Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\FindAttributesForFamily` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Family\FindAttributesForFamily` and change constructor:
+    - remove `Doctrine\ORM\EntityManagerInterface`
+    - add `Doctrine\DBAL\Connection`
+- Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\GetAssociatedProductCodesByProductFromDB` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\GetAssociatedProductCodesByProductFromDB`, mark it as final, and change constructor:
+    - remove `Doctrine\ORM\EntityManagerInterface`
+    - add `Doctrine\DBAL\Connection`
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\GetAttributeOptionsMaxSortOrder` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Attribute\GetAttributeOptionsMaxSortOrder`
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\GetDescendentCategoryCodes` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Category\GetDescendentCategoryCodes`
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\SqlGetValuesOfSiblings` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlGetValuesOfSiblings`
-- Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\VariantProductRatio` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Completeness\VariantProductRatio` and mark it as final
+- Move class from `Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\VariantProductRatio` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Completeness\VariantProductRatio`, mark it as final and change constructor:
+    - remove `Doctrine\ORM\EntityManagerInterface`
+    - add `Doctrine\DBAL\Connection`
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Product\Query\Sql\CountVariantProducts` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\CountVariantProducts`
 - Move class from `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Attribute\AttributeIsAFamilyVariantAxis` to `Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\AttributeIsAFamilyVariantAxis`
 - Move class from `Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\CountProductModelsAndChildrenProductModels` to `Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\CountProductModelsAndChildrenProductModels`

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -156,27 +156,27 @@ services:
             - '@pim_reference_data.repository_resolver'
 
     akeneo.pim.enrichment.category.query.category_codes_by_product_model_codes:
-        class: 'Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetCategoryCodesByProductModelCodes'
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetCategoryCodesByProductModelCodes'
         arguments:
             - '@database_connection'
 
     akeneo.pim.enrichment.product_model.query.get_models_associations_by_product_model_codes:
-        class: 'Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetProductModelsAssociationsByProductModelCodes'
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetProductModelsAssociationsByProductModelCodes'
         arguments:
             - '@database_connection'
 
     akeneo.pim.enrichment.product_model.query.get_group_associations_by_product_model_codes:
-        class: 'Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetGroupAssociationsByProductModelCodes'
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetGroupAssociationsByProductModelCodes'
         arguments:
             - '@database_connection'
 
     akeneo.pim.enrichment.product_model.query.get_values_and_properties_from_product_model_codes:
-        class: 'Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetValuesAndPropertiesFromProductModelCodes'
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetValuesAndPropertiesFromProductModelCodes'
         arguments:
             - '@database_connection'
 
     akeneo.pim.enrichment.product_model.query.get_product_associations_by_product_model_codes:
-        class: 'Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetProductAssociationsByProductModelCodes'
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetProductAssociationsByProductModelCodes'
         arguments:
             - '@database_connection'
 
@@ -203,7 +203,7 @@ services:
 
 
     akeneo.pim.enrichment.product_model.query.count_product_models_and_children_product_models:
-        class: Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\CountProductModelsAndChildrenProductModels
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\CountProductModelsAndChildrenProductModels'
         arguments:
             - '@database_connection'
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -2,22 +2,22 @@ services:
     pim_catalog.doctrine.query.find_variant_product_completeness:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Completeness\VariantProductRatio'
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@database_connection'
 
     pim_catalog.doctrine.query.count_entity_with_family_variant:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Family\CountEntityWithFamilyVariant'
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@database_connection'
 
     pim_catalog.doctrine.query.find_attributes_for_family:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Family\FindAttributesForFamily'
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@database_connection'
 
     pim_catalog.doctrine.query.count_products_with_family:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Family\CountProductsWithFamily'
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@database_connection'
 
     pim_catalog.doctrine.query.find_family_variants_identifiers_by_attribute_axes:
         class: 'Akeneo\Pim\Structure\Bundle\Doctrine\ORM\Query\FamilyVariantsByAttributeAxes'
@@ -32,8 +32,7 @@ services:
     pim_catalog.query.get_associated_product_codes_by_product:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\GetAssociatedProductCodesByProductFromDB'
         arguments:
-            - '@doctrine.orm.entity_manager'
-            - '%pim_catalog.entity.association.class%'
+            - '@database_connection'
 
     pim_enrich.doctrine.query.ascendant_categories:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Category\AscendantCategories'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/VariantProductRatio.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/VariantProductRatio.php
@@ -113,7 +113,7 @@ SQL;
             }
         }
 
-        $statement = $this->entityManager->getConnection()->prepare($query);
+        $statement = $this->connection->prepare($query);
 
         foreach ($parameters as $parameter) {
             $statement->bindValue($parameter['name'], $parameter['value']);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/VariantProductRatio.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/VariantProductRatio.php
@@ -6,7 +6,7 @@ namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Completeness;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\CompleteVariantProducts;
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\VariantProductRatioInterface;
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\DBAL\Connection;
 
 /**
  * Query variant product completenesses to build the complete variant product ratio on the PMEF
@@ -17,17 +17,12 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 final class VariantProductRatio implements VariantProductRatioInterface
 {
-    /** @var EntityManagerInterface */
-    private $entityManager;
+    /** @var Connection */
+    private $connection;
 
-    /**
-     * VariantProductRatio constructor.
-     *
-     * @param EntityManagerInterface $entityManager
-     */
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(Connection $connection)
     {
-        $this->entityManager = $entityManager;
+        $this->connection = $connection;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductModels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductModels.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult;
-use Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetCategoryCodesByProductModelCodes;
-use Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetGroupAssociationsByProductModelCodes;
-use Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetProductAssociationsByProductModelCodes;
-use Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetProductModelsAssociationsByProductModelCodes;
-use Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetValuesAndPropertiesFromProductModelCodes;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetCategoryCodesByProductModelCodes;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetGroupAssociationsByProductModelCodes;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetProductAssociationsByProductModelCodes;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetProductModelsAssociationsByProductModelCodes;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetValuesAndPropertiesFromProductModelCodes;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModelList;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Family/CountProductsWithFamily.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Family/CountProductsWithFamily.php
@@ -28,7 +28,7 @@ final class CountProductsWithFamily implements CountProductsWithFamilyInterface
     public function count(FamilyInterface $family): int
     {
         return (int) $this->connection->executeQuery(
-            'SELECT COUNT(id) FROM pim_catalog_product WHERE family = :family_id',
+            'SELECT COUNT(id) FROM pim_catalog_product WHERE family_id = :family_id',
             ['family_id' => $family->getId()]
         )->fetchColumn();
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Family/CountProductsWithFamily.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Family/CountProductsWithFamily.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Family;
 
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\ProductAndProductModel\Query\CountProductsWithFamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\DBAL\Connection;
 
 /**
  * Count the number of products belonging to the given family
@@ -18,24 +17,19 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 final class CountProductsWithFamily implements CountProductsWithFamilyInterface
 {
-    /** @var EntityManagerInterface */
-    private $entityManager;
+    /** @var Connection */
+    private $connection;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(Connection $connection)
     {
-        $this->entityManager = $entityManager;
+        $this->connection = $connection;
     }
 
     public function count(FamilyInterface $family): int
     {
-        $queryBuilder = $this->entityManager->createQueryBuilder();
-        $productCount = $queryBuilder->select('COUNT(p)')
-            ->from(ProductInterface::class, 'p')
-            ->where('p.family = :family_id')
-            ->setParameter(':family_id', $family->getId())
-            ->getQuery()
-            ->getSingleScalarResult();
-
-        return (int) $productCount;
+        return (int) $this->connection->executeQuery(
+            'SELECT COUNT(id) FROM pim_catalog_product WHERE family = :family_id',
+            ['family_id' => $family->getId()]
+        )->fetchColumn();
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Family/FindAttributesForFamily.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Family/FindAttributesForFamily.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Family;
 
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Statement;
-use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Checks if an attribute is part of the family attributes.
@@ -17,12 +17,12 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class FindAttributesForFamily
 {
-    /** @var EntityManagerInterface */
-    private $entityManager;
+    /** @var Connection */
+    private $connection;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(Connection $connection)
     {
-        $this->entityManager = $entityManager;
+        $this->connection = $connection;
     }
 
     /**
@@ -41,7 +41,7 @@ class FindAttributesForFamily
           INNER JOIN pim_catalog_attribute a ON fa.attribute_id = a.id
         WHERE (f.code = :family_code)
 SQL;
-        $stmt = $this->entityManager->getConnection()->executeQuery($sql, ['family_code' => $family->getCode()]);
+        $stmt = $this->connection->executeQuery($sql, ['family_code' => $family->getCode()]);
 
         return $this->getAttributeCodes($stmt);
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/GetAssociatedProductCodesByProductFromDB.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/GetAssociatedProductCodesByProductFromDB.php
@@ -6,20 +6,15 @@ use Akeneo\Pim\Enrichment\Component\Product\Association\Query\GetAssociatedProdu
 use Akeneo\Pim\Enrichment\Component\Product\Model\AssociationInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelAssociationInterface;
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManagerInterface;
 
 final class GetAssociatedProductCodesByProductFromDB implements GetAssociatedProductCodesByProduct
 {
     /** @var Connection */
     private $connection;
 
-    /** @var EntityManagerInterface */
-    private $entityManager;
-
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(Connection $connection)
     {
-        $this->entityManager = $entityManager;
-        $this->connection = $entityManager->getConnection();
+        $this->connection = $connection;
     }
 
     /**
@@ -49,10 +44,6 @@ SQL;
             ]
         );
 
-        $codes = array_map(function ($row) {
-            return $row['code'];
-        }, $stmt->fetchAll(\PDO::FETCH_ASSOC));
-
-        return $codes;
+        return $stmt->fetchColumn();
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/GetAssociatedProductCodesByProductFromDB.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/GetAssociatedProductCodesByProductFromDB.php
@@ -6,6 +6,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Association\Query\GetAssociatedProdu
 use Akeneo\Pim\Enrichment\Component\Product\Model\AssociationInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelAssociationInterface;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\FetchMode;
 
 final class GetAssociatedProductCodesByProductFromDB implements GetAssociatedProductCodesByProduct
 {
@@ -33,7 +34,8 @@ FROM $associationTable a
 WHERE a.owner_id = :ownerId AND a.association_type_id = :associationTypeId
 ORDER BY p.identifier ASC;
 SQL;
-        $stmt = $this->connection->executeQuery($sql,
+        $stmt = $this->connection->executeQuery(
+            $sql,
             [
                 'ownerId'           => $productId,
                 'associationTypeId' => $association->getAssociationType()->getId()
@@ -44,6 +46,6 @@ SQL;
             ]
         );
 
-        return $stmt->fetchColumn();
+        return $stmt->fetchAll(FetchMode::COLUMN);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/SqlGetValuesOfSiblings.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/SqlGetValuesOfSiblings.php
@@ -61,7 +61,7 @@ SQL;
             $sql,
             [
                 'parentId' => $entity->getParent()->getId(),
-                'identifier' => $identifier
+                'identifier' => $identifier,
             ]
         );
         foreach ($rows as $row) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -33,7 +33,7 @@ final class ProductModelImagesFromCodes
     /** @var Connection */
     private $connection;
 
-    /** @var \Akeneo\Pim\Enrichment\Component\Product\Factory\Read\WriteValueCollectionFactory */
+    /** @var WriteValueCollectionFactory */
     private $valueCollectionFactory;
 
     public function __construct(Connection $connection, WriteValueCollectionFactory $valueCollectionFactory)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/CountProductModelsAndChildrenProductModels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/CountProductModelsAndChildrenProductModels.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql;
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel;
 
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\CountProductModelsAndChildrenProductModelsInterface;
 use Doctrine\DBAL\Connection;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetCategoryCodesByProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetCategoryCodesByProductModelCodes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql;
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel;
 
 use Doctrine\DBAL\Connection;
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetGroupAssociationsByProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetGroupAssociationsByProductModelCodes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql;
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel;
 
 use Doctrine\DBAL\Connection;
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetProductAssociationsByProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetProductAssociationsByProductModelCodes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql;
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel;
 
 use Doctrine\DBAL\Connection;
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetProductModelsAssociationsByProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetProductModelsAssociationsByProductModelCodes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql;
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel;
 
 use Doctrine\DBAL\Connection;
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetValuesAndPropertiesFromProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetValuesAndPropertiesFromProductModelCodes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql;
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjectionIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjectionIntegration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AkeneoTest\Pim\Enrichment\Integration\ProductModel\Query\Sql;
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\ElasticsearchProjection;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\GetElasticsearchProductModelProjectionInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/CountProductModelsAndChildrenProductModelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/CountProductModelsAndChildrenProductModelsIntegration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AkeneoTest\Pim\Enrichment\Integration\ProductModel\Query\Sql;
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\ProductModel;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\CountProductModelsAndChildrenProductModelsInterface;

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetCategoryCodesByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetCategoryCodesByProductModelCodesIntegration.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace AkeneoTest\Pim\Enrichment\Integration\ProductModel\Query\Sql;
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\ProductModel;
 
-use Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetCategoryCodesByProductModelCodes;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetCategoryCodesByProductModelCodes;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Integration\TestCase;

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetGroupAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetGroupAssociationsByProductModelCodesIntegration.php
@@ -2,131 +2,51 @@
 
 declare(strict_types=1);
 
-namespace AkeneoTest\Pim\Enrichment\Integration\ProductModel\Query\Sql;
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\ProductModel;
 
-use Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetProductModelsAssociationsByProductModelCodes;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetGroupAssociationsByProductModelCodes;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Integration\TestCase;
 use AkeneoTest\Pim\Enrichment\Integration\Fixture\EntityBuilder;
-use PHPUnit\Framework\Assert as PHPUnitAssert;
 use Webmozart\Assert\Assert;
+use PHPUnit\Framework\Assert as PHPUnitAssert;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class GetProductModelsAssociationsByProductModelCodesIntegration extends TestCase
+class GetGroupAssociationsByProductModelCodesIntegration extends TestCase
 {
     /** @var EntityBuilder */
     private $entityBuilder;
 
-    public function testWithoutAnyProductModels(): void
-    {
-        $expected = [];
-        $actual = $this->getQuery()->fromProductModelCodes([]);
-
-        PHPUnitAssert::assertEqualsCanonicalizing($expected, $actual);
-    }
-
-    public function testWithMixingAllKindsOfModelsForProductModelsAssociationsAndInheritance()
-    {
-        $expected = [
-            'root_product_model_1' => [
-                'PACK' => ['product_models' => ['productModelA', 'productModelC']],
-                'UPSELL' => ['product_models' => []],
-                'X_SELL' => ['product_models' => ['productModelF']],
-                'A_NEW_TYPE' => ['product_models' => []],
-                'SUBSTITUTION' => ['product_models' => []],
-            ],
-            'root_product_model_2' => [
-                'PACK' => ['product_models' => []],
-                'UPSELL' => ['product_models' => []],
-                'X_SELL' => ['product_models' => []],
-                'A_NEW_TYPE' => ['product_models' => []],
-                'SUBSTITUTION' => ['product_models' => []],
-            ],
-            'sub_product_model_1_1' => [
-                'PACK' => ['product_models' => ['productModelA', 'productModelC']],
-                'UPSELL' => ['product_models' => []],
-                'X_SELL' => ['product_models' => ['productModelD', 'productModelF']],
-                'A_NEW_TYPE' => ['product_models' => []],
-                'SUBSTITUTION' => ['product_models' => ['productModelB']],
-            ],
-            'sub_product_model_1_2' => [
-                'PACK' => ['product_models' => ['productModelA', 'productModelG', 'productModelC']],
-                'UPSELL' => ['product_models' => ['productModelE']],
-                'X_SELL' => ['product_models' => ['productModelF']],
-                'A_NEW_TYPE' => ['product_models' => []],
-                'SUBSTITUTION' => ['product_models' => []],
-            ],
-            'sub_product_model_2_1' => [
-                'PACK' => ['product_models' => []],
-                'UPSELL' => ['product_models' => []],
-                'X_SELL' => ['product_models' => []],
-                'A_NEW_TYPE' => ['product_models' => []],
-                'SUBSTITUTION' => ['product_models' => []],
-            ],
-            'sub_product_model_2_2' => [
-                'PACK' => ['product_models' => ['productModelC']],
-                'UPSELL' => ['product_models' => []],
-                'X_SELL' => ['product_models' => []],
-                'A_NEW_TYPE' => ['product_models' => []],
-                'SUBSTITUTION' => ['product_models' => []],
-            ],
-        ];
-
-        $actual = $this->getQuery()->fromProductModelCodes(
-            [
-                'root_product_model_1',
-                'sub_product_model_1_1',
-                'sub_product_model_1_2',
-                'root_product_model_2',
-                'sub_product_model_2_1',
-                'sub_product_model_2_2',
-            ]
-        );
-
-        $this->recursiveSort($expected);
-        $this->recursiveSort($actual);
-
-        PHPUnitAssert::assertEqualsCanonicalizing($expected, $actual);
-    }
-
-    protected function setUp(): void
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->entityBuilder = $this->getFromTestContainer('akeneo_integration_tests.catalog.fixture.build_entity');
 
-        $this->givenTheFollowingProductModels([
-            'productModelA',
-            'productModelB',
-            'productModelC',
-            'productModelD',
-            'productModelE',
-            'productModelF',
-            'productModelG',
-        ]);
+        $this->givenGroup(['groupA', 'groupB', 'groupC', 'groupD', 'groupE', 'groupF', 'groupG']);
 
-        $this->givenTheFollowingProductModelsWithProductModelsAssociations([
+        $this->givenTheFollowingProductModelsWithGroupAssociations([
             'root_product_model_1' => [
                 'associations' => [
-                    'X_SELL' => ['product_models' => ['productModelF']],
-                    'PACK' => ['product_models' => ['productModelA', 'productModelC']],
+                    'X_SELL' => ['groups' => ['groupF']],
+                    'PACK' => ['groups' => ['groupA', 'groupC']],
                 ],
                 'sub_product_models' => [
                     'sub_product_model_1_1' => [
                         'associations' => [
-                            'X_SELL' => ['product_models' => ['productModelD']],
-                            'SUBSTITUTION' => ['product_models' => ['productModelB']],
+                            'X_SELL' => ['groups' => ['groupD']],
+                            'SUBSTITUTION' => ['groups' => ['groupB']],
                         ],
                     ],
                     'sub_product_model_1_2' => [
                         'associations' => [
-                            'PACK' => ['product_models' => ['productModelG']],
-                            'UPSELL' => ['product_models' => ['productModelE']],
+                            'PACK' => ['groups' => ['groupG']],
+                            'UPSELL' => ['groups' => ['groupE']],
                         ],
                     ],
                 ]
@@ -139,7 +59,7 @@ class GetProductModelsAssociationsByProductModelCodesIntegration extends TestCas
                     ],
                     'sub_product_model_2_2' => [
                         'associations' => [
-                            'PACK' => ['product_models' => ['productModelC']],
+                            'PACK' => ['groups' => ['groupC']],
                         ],
                     ]
                 ]
@@ -147,6 +67,76 @@ class GetProductModelsAssociationsByProductModelCodesIntegration extends TestCas
         ]);
 
         $this->givenAssociationTypes(['A_NEW_TYPE']);
+    }
+
+    public function testWithoutAnyProductModels(): void
+    {
+        $expected = [];
+        $actual = $this->getQuery()->fromProductModelCodes([]);
+
+        PHPUnitAssert::assertEqualsCanonicalizing($expected, $actual);
+    }
+
+    public function testWithMixingAllKindsOfModelsForGroupAssociationsAndInheritance()
+    {
+        $expected = [
+            'root_product_model_1' => [
+                'PACK' => ['groups' => ['groupA', 'groupC']],
+                'UPSELL' => ['groups' => []],
+                'X_SELL' => ['groups' => ['groupF']],
+                'A_NEW_TYPE' => ['groups' => []],
+                'SUBSTITUTION' => ['groups' => []],
+            ],
+            'root_product_model_2' => [
+                'PACK' => ['groups' => []],
+                'UPSELL' => ['groups' => []],
+                'X_SELL' => ['groups' => []],
+                'A_NEW_TYPE' => ['groups' => []],
+                'SUBSTITUTION' => ['groups' => []],
+            ],
+            'sub_product_model_1_1' => [
+                'PACK' => ['groups' => ['groupA', 'groupC']],
+                'UPSELL' => ['groups' => []],
+                'X_SELL' => ['groups' => ['groupD', 'groupF']],
+                'A_NEW_TYPE' => ['groups' => []],
+                'SUBSTITUTION' => ['groups' => ['groupB']],
+            ],
+            'sub_product_model_1_2' => [
+                'PACK' => ['groups' => ['groupA', 'groupG', 'groupC']],
+                'UPSELL' => ['groups' => ['groupE']],
+                'X_SELL' => ['groups' => ['groupF']],
+                'A_NEW_TYPE' => ['groups' => []],
+                'SUBSTITUTION' => ['groups' => []],
+            ],
+            'sub_product_model_2_1' => [
+                'PACK' => ['groups' => []],
+                'UPSELL' => ['groups' => []],
+                'X_SELL' => ['groups' => []],
+                'A_NEW_TYPE' => ['groups' => []],
+                'SUBSTITUTION' => ['groups' => []],
+            ],
+            'sub_product_model_2_2' => [
+                'PACK' => ['groups' => ['groupC']],
+                'UPSELL' => ['groups' => []],
+                'X_SELL' => ['groups' => []],
+                'A_NEW_TYPE' => ['groups' => []],
+                'SUBSTITUTION' => ['groups' => []],
+            ]
+        ];
+
+        $actual = $this->getQuery()->fromProductModelCodes([
+            'root_product_model_1',
+            'sub_product_model_1_1',
+            'sub_product_model_1_2',
+            'root_product_model_2',
+            'sub_product_model_2_1',
+            'sub_product_model_2_2',
+        ]);
+
+        $this->recursiveSort($expected);
+        $this->recursiveSort($actual);
+
+        PHPUnitAssert::assertEqualsCanonicalizing($expected, $actual);
     }
 
     private function recursiveSort(&$array): bool
@@ -174,7 +164,7 @@ class GetProductModelsAssociationsByProductModelCodesIntegration extends TestCas
         $this->get('pim_catalog.saver.association_type')->saveAll($associationTypes);
     }
 
-    private function givenTheFollowingProductModels(array $productModelCodes): void
+    private function givenGroup(array $codes): void
     {
         $this->givenBooleanAttributes(['first_yes_no', 'second_yes_no']);
         $this->givenFamilies([['code' => 'aFamily', 'attribute_codes' => ['first_yes_no', 'second_yes_no']]]);
@@ -197,14 +187,25 @@ class GetProductModelsAssociationsByProductModelCodesIntegration extends TestCas
             ]
         );
 
-        foreach ($productModelCodes as $productModelCode) {
-            $this->entityBuilder->createProductModel($productModelCode, 'familyVariantWithTwoLevels', null, []);
-        }
+        $groups = array_map(function (string $code) {
+            $group = $this->get('pim_catalog.factory.group')->createGroup('RELATED');
+            $this->get('pim_catalog.updater.group')->update($group, [
+                'code' => $code
+            ]);
+
+            $errors = $this->get('validator')->validate($group);
+
+            Assert::count($errors, 0);
+
+            return $group;
+        }, $codes);
+
+        $this->get('pim_catalog.saver.group')->saveAll($groups);
     }
 
-    private function getQuery(): GetProductModelsAssociationsByProductModelCodes
+    private function getQuery(): GetGroupAssociationsByProductModelCodes
     {
-        return $this->testKernel->getContainer()->get('akeneo.pim.enrichment.product_model.query.get_models_associations_by_product_model_codes');
+        return $this->testKernel->getContainer()->get('akeneo.pim.enrichment.product_model.query.get_group_associations_by_product_model_codes');
     }
 
     private function givenBooleanAttributes(array $codes): void
@@ -251,12 +252,12 @@ class GetProductModelsAssociationsByProductModelCodesIntegration extends TestCas
         $this->get('pim_catalog.saver.family')->saveAll($families);
     }
 
-    private function givenTheFollowingProductModelsWithProductModelsAssociations(array $productModelsTree, ?ProductModelInterface $parent = null): void
+    private function givenTheFollowingProductModelsWithGroupAssociations(array $productModelsTree, ?ProductModelInterface $parent = null): void
     {
         foreach ($productModelsTree as $productModelCode => $data) {
             $associations = $data['associations'] ?? [];
             $productModel = $this->entityBuilder->createProductModel($productModelCode, 'familyVariantWithTwoLevels', $parent, ['associations' => $associations]);
-            $this->givenTheFollowingProductModelsWithProductModelsAssociations($data['sub_product_models'] ?? [], $productModel);
+            $this->givenTheFollowingProductModelsWithGroupAssociations($data['sub_product_models'] ?? [], $productModel);
         }
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetProductAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetProductAssociationsByProductModelCodesIntegration.php
@@ -3,12 +3,11 @@
 
 declare(strict_types=1);
 
-namespace AkeneoTest\Pim\Enrichment\Integration\ProductModel\Query\Sql;
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\ProductModel;
 
-use Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetProductAssociationsByProductModelCodes;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetProductAssociationsByProductModelCodes;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Integration\TestCase;
-use AkeneoTest\Pim\Enrichment\Integration\Fixture\EntityBuilder;
 use Webmozart\Assert\Assert;
 use PHPUnit\Framework\Assert as PHPUnitAssert;
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetValuesAndPropertiesFromProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetValuesAndPropertiesFromProductModelCodesIntegration.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace AkeneoTest\Pim\Enrichment\Integration\Product\Query\Sql;
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\ProductModel;
 
-use Akeneo\Pim\Enrichment\Bundle\ProductModel\Query\Sql\GetValuesAndPropertiesFromProductModelCodes;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetValuesAndPropertiesFromProductModelCodes;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Integration\TestCase;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- Move Enrichment queries from `ProductModel\Query\Sql` to `Storage\Sql`
- Update queries to use DBAL connection instead of Entity Manager when possible

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
