### PR TITLE
Reactivate foreign key after loading the dump

### DIFF
--- a/tests/legacy/features/Behat/Context/DBALPurger.php
+++ b/tests/legacy/features/Behat/Context/DBALPurger.php
@@ -53,7 +53,8 @@ class DBALPurger implements PurgerInterface
             $sql .= sprintf('TRUNCATE TABLE %s;', $table);
         }
 
-        $sql .= 'SET FOREIGN_KEY_CHECKS = 1;';
+        // this query can fail without triggering any error, if a table does not exist
         $this->connection->exec($sql);
+        $this->connection->exec('SET FOREIGN_KEY_CHECKS = 1');
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**Problem**

When renoving a product model, the delete cascade does not delete child product.
Not reproducible in a dedicated transaction, with the same queries.

**Cause**

When loading the dump, we reset the database. To reset it, we deactivate the foreign key check and then delete + truncate tables and then reactivate it.

In a same query:
`SET FOREIGN_KEY_CHECKS = 0; delete...; truncate ... ; SET FOREIGN_KEY_CHECKS = 1`

The problem is that we try to truncate EE tables, and the query silently fail until this instruction. Therefore, the `SET FOREIGN_KEY_CHECKS = 1` is never called (but not error raised).

**Solution**
Do not truncate EE tables (just to be clean). Isolate in a dedicated query the reactivation of the checks.


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
