### PR TITLE
TIP-1278 Catalog installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ check-requirements:
 
 .PHONY: database
 database:
-	$(PHP_RUN) bin/console pim:installer:db
+	$(PHP_RUN) bin/console pim:installer:db ${O}
 
 ##
 ## PIM install
@@ -109,7 +109,7 @@ pim-dev:
 	$(MAKE) assets
 	$(MAKE) css
 	$(MAKE) javascript-dev
-	APP_ENV=dev $(MAKE) database
+	APP_ENV=dev O="--catalog src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev" $(MAKE) database
 
 .PHONY: pim-prod
 pim-prod:

--- a/config/services/behat/parameters.yml
+++ b/config/services/behat/parameters.yml
@@ -1,2 +1,0 @@
-parameters:
-    installer_data: PimInstallerBundle:minimal

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -22,12 +22,6 @@ parameters:
     tmp_storage_dir:      '/tmp/pim/file_storage'
     upload_tmp_dir:       '/tmp/pim/upload_tmp_dir'
 
-    # You can use installer_data to install an outside catalog (like one from akeneo/catalogs)
-    # installer_data: %kernel.root_dir%/../vendor/akeneo/catalogs/master/community/small/fixtures
-    # or you can use one of the provided catalogs
-    # use PimInstallerBundle:minimal for minimal data set
-    installer_data:       PimInstallerBundle:icecat_demo_dev
-
     max_products_category_removal: 100
 
     pim_catalog_image_allowed_extensions: [gif, jfif, jif, jpeg, jpg, pdf, png, psd, tif, tiff]

--- a/config/services/test/parameters.yml
+++ b/config/services/test/parameters.yml
@@ -1,6 +1,5 @@
 parameters:
     max_products_category_removal: 20
-    installer_data:       PimInstallerBundle:minimal
     upload_dir:           '%kernel.root_dir%/../var/cache/uploads/product'
     archive_dir:          '%kernel.root_dir%/../var/cache/archive'
     catalog_storage_dir:  '%kernel.root_dir%/../var/cache/file_storage/catalog'

--- a/config/services/test_fake/parameters.yml
+++ b/config/services/test_fake/parameters.yml
@@ -1,2 +1,0 @@
-parameters:
-    installer_data: PimInstallerBundle:minimal

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -55,8 +55,6 @@ class DatabaseCommand extends Command
     private $eventDispatcher;
 
     /** @var string */
-    private $installerData;
-    /** @var string */
     private $env;
 
     public function __construct(
@@ -65,7 +63,6 @@ class DatabaseCommand extends Command
         Connection $connection,
         FixtureJobLoader $fixtureJobLoader,
         EventDispatcherInterface $eventDispatcher,
-        string $installerData,
         string $env
     ) {
         parent::__construct();
@@ -75,7 +72,6 @@ class DatabaseCommand extends Command
         $this->connection = $connection;
         $this->fixtureJobLoader = $fixtureJobLoader;
         $this->eventDispatcher = $eventDispatcher;
-        $this->installerData = $installerData;
         $this->env = $env;
     }
 
@@ -107,6 +103,13 @@ class DatabaseCommand extends Command
                 InputOption::VALUE_OPTIONAL,
                 'Should the command install any fixtures',
                 false
+            )
+            ->addOption(
+                'catalog',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Should the command install any fixtures',
+                'src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal'
             );
     }
 
@@ -250,10 +253,10 @@ class DatabaseCommand extends Command
         $output->writeln(
             sprintf(
                 '<info>Load jobs for fixtures. (data set: %s)</info>',
-                $this->installerData
+                $input->getOption('catalog')
             )
         );
-        $this->fixtureJobLoader->loadJobInstances();
+        $this->fixtureJobLoader->loadJobInstances($input->getOption('catalog'));
 
         $jobInstances = $this->fixtureJobLoader->getLoadedJobInstances();
         foreach ($jobInstances as $jobInstance) {

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -108,7 +108,7 @@ class DatabaseCommand extends Command
                 'catalog',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Should the command install any fixtures',
+                'Directory of the fixtures to install',
                 'src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal'
             );
     }

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -181,7 +181,9 @@ class DatabaseCommand extends Command
 
             $this->eventDispatcher->dispatch(
                 InstallerEvents::POST_LOAD_FIXTURES,
-                new InstallerEvent($this->commandExecutor)
+                new InstallerEvent($this->commandExecutor, null, [
+                    'catalog' => $input->getOption('catalog')
+                ])
             );
         }
 

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -246,6 +246,7 @@ class DatabaseCommand extends Command
      */
     protected function loadFixturesStep(InputInterface $input, OutputInterface $output)
     {
+        $catalog = $input->getOption('catalog');
         if ($input->getOption('env') === 'behat') {
             $input->setOption('fixtures', self::LOAD_BASE);
         }
@@ -253,7 +254,7 @@ class DatabaseCommand extends Command
         $output->writeln(
             sprintf(
                 '<info>Load jobs for fixtures. (data set: %s)</info>',
-                $input->getOption('catalog')
+                $catalog
             )
         );
         $this->fixtureJobLoader->loadJobInstances($input->getOption('catalog'));
@@ -269,7 +270,9 @@ class DatabaseCommand extends Command
 
             $this->eventDispatcher->dispatch(
                 InstallerEvents::PRE_LOAD_FIXTURE,
-                new InstallerEvent($this->commandExecutor, $jobInstance->getCode())
+                new InstallerEvent($this->commandExecutor, $jobInstance->getCode(), [
+                    'catalog' => $catalog
+                ])
             );
             if ($input->getOption('verbose')) {
                 $output->writeln(

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/FixtureLoader/FixtureJobLoader.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/FixtureLoader/FixtureJobLoader.php
@@ -21,9 +21,6 @@ class FixtureJobLoader
     /** @staticvar */
     const JOB_TYPE = 'fixtures';
 
-    /** @var FixturePathProvider */
-    private $pathProvider;
-
     /** @var JobInstancesBuilder */
     private $jobInstancesBuilder;
 
@@ -39,23 +36,13 @@ class FixtureJobLoader
     /** @var ObjectRepository */
     private $jobInstanceRepository;
 
-    /**
-     * @param FixturePathProvider      $pathProvider
-     * @param JobInstancesBuilder      $jobInstancesBuilder
-     * @param JobInstancesConfigurator $jobInstancesConfigurator
-     * @param BulkSaverInterface       $jobInstanceSaver
-     * @param BulkRemoverInterface     $jobInstanceRemover
-     * @param ObjectRepository         $jobInstanceRepository
-     */
     public function __construct(
-        FixturePathProvider $pathProvider,
         JobInstancesBuilder $jobInstancesBuilder,
         JobInstancesConfigurator $jobInstancesConfigurator,
         BulkSaverInterface $jobInstanceSaver,
         BulkRemoverInterface $jobInstanceRemover,
         ObjectRepository $jobInstanceRepository
     ) {
-        $this->pathProvider = $pathProvider;
         $this->jobInstancesBuilder = $jobInstancesBuilder;
         $this->jobInstancesConfigurator = $jobInstancesConfigurator;
         $this->jobInstanceSaver = $jobInstanceSaver;
@@ -70,10 +57,10 @@ class FixtureJobLoader
      *
      * @throws \Exception
      */
-    public function loadJobInstances(array $replacePaths = [])
+    public function loadJobInstances(string $catalogPath, array $replacePaths = [])
     {
         $jobInstances = $this->jobInstancesBuilder->build();
-        $configuredJobInstances = $this->configureJobInstances($jobInstances, $replacePaths);
+        $configuredJobInstances = $this->configureJobInstances($catalogPath, $jobInstances, $replacePaths);
         $this->jobInstanceSaver->saveAll($configuredJobInstances, ['is_installation' => true]);
     }
 
@@ -104,10 +91,10 @@ class FixtureJobLoader
      * @throws \Exception
      * @return JobInstance[]
      */
-    protected function configureJobInstances(array $jobInstances, array $replacePaths)
+    protected function configureJobInstances(string $catalogPath, array $jobInstances, array $replacePaths)
     {
         if (0 === count($replacePaths)) {
-            return $this->jobInstancesConfigurator->configureJobInstancesWithInstallerData($jobInstances);
+            return $this->jobInstancesConfigurator->configureJobInstancesWithInstallerData($catalogPath, $jobInstances);
         } else {
             return $this->jobInstancesConfigurator->configureJobInstancesWithReplacementPaths(
                 $jobInstances,

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/FixtureLoader/FixturePathProvider.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/FixtureLoader/FixturePathProvider.php
@@ -32,7 +32,7 @@ class FixturePathProvider
             $reflection = new \ReflectionClass($this->bundles[$matches['bundle']]);
             $installerDataDir = dirname($reflection->getFilename()) . '/Resources/fixtures/' . $matches['directory'];
         } else {
-            $installerDataDir = $this->installerData;
+            $installerDataDir = $catalogPath;
         }
 
         if (null === $installerDataDir || !is_dir($installerDataDir)) {

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/FixtureLoader/FixturePathProvider.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/FixtureLoader/FixturePathProvider.php
@@ -14,17 +14,9 @@ class FixturePathProvider
     /** @var array */
     protected $bundles;
 
-    /** @var string */
-    protected $installerData;
-
-    /**
-     * @param array  $bundles
-     * @param string $installerData
-     */
-    public function __construct(array $bundles, $installerData)
+    public function __construct(array $bundles)
     {
         $this->bundles = $bundles;
-        $this->installerData = $installerData;
     }
 
     /**
@@ -32,11 +24,11 @@ class FixturePathProvider
      *
      * @return string
      */
-    public function getFixturesPath()
+    public function getFixturesPath(string $catalogPath)
     {
         $installerDataDir = null;
 
-        if (preg_match('/^(?P<bundle>\w+):(?P<directory>\w+)$/', $this->installerData, $matches)) {
+        if (preg_match('/^(?P<bundle>\w+):(?P<directory>\w+)$/', $catalogPath, $matches)) {
             $reflection = new \ReflectionClass($this->bundles[$matches['bundle']]);
             $installerDataDir = dirname($reflection->getFilename()) . '/Resources/fixtures/' . $matches['directory'];
         } else {

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/FixtureLoader/JobInstancesConfigurator.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/FixtureLoader/JobInstancesConfigurator.php
@@ -31,13 +31,12 @@ class JobInstancesConfigurator
     /**
      * The standard method to configure job instances with files provided in an install fixtures set
      *
-     * @param JobInstance[] $jobInstances
      * @throws \Exception
      * @return JobInstance[]
      */
-    public function configureJobInstancesWithInstallerData(array $jobInstances)
+    public function configureJobInstancesWithInstallerData(string $catalogPath, array $jobInstances)
     {
-        $installerDataPath = $this->pathProvider->getFixturesPath();
+        $installerDataPath = $this->pathProvider->getFixturesPath($catalogPath);
         if (!is_dir($installerDataPath)) {
             throw new \Exception(sprintf('Path "%s" not found', $installerDataPath));
         }

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/cli_command.yml
@@ -35,7 +35,6 @@ services:
             - '@database_connection'
             - '@pim_installer.fixture_loader.job_loader'
             - '@event_dispatcher'
-            - '%installer_data%'
             - '%kernel.environment%'
         tags:
             - { name: console.command }

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/fixture_loader.yml
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/fixture_loader.yml
@@ -10,7 +10,6 @@ services:
         class: '%pim_installer.fixture_loader.path_provider.class%'
         arguments:
             - '%kernel.bundles%'
-            - '%installer_data%'
 
     pim_installer.fixture_loader.job_instances_builder:
         class: '%pim_installer.fixture_loader.job_instances_builder.class%'
@@ -28,7 +27,6 @@ services:
     pim_installer.fixture_loader.job_loader:
         class: '%pim_installer.fixture_loader.job_loader.class%'
         arguments:
-            - '@pim_installer.fixture_loader.path_provider'
             - '@pim_installer.fixture_loader.job_instances_builder'
             - '@pim_installer.fixture_loader.job_instances_configurator'
             - '@akeneo_batch.saver.job_instance'

--- a/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
@@ -252,7 +252,7 @@ class FixturesLoader implements FixturesLoaderInterface
         }
 
         // configure and load job instances in database
-        $this->fixtureJobLoader->loadJobInstances($replacePaths);
+        $this->fixtureJobLoader->loadJobInstances('src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal', $replacePaths);
 
         // install the catalog via the job instances
         $jobInstances = $this->fixtureJobLoader->getLoadedJobInstances();

--- a/tests/back/Platform/Specification/Bundle/InstallerBundle/FixtureLoader/FixturePathProviderSpec.php
+++ b/tests/back/Platform/Specification/Bundle/InstallerBundle/FixtureLoader/FixturePathProviderSpec.php
@@ -14,11 +14,10 @@ class FixturePathProviderSpec extends ObjectBehavior
             'PimDashboardBundle' => PimDashboardBundle::class,
             'PimInstallerBundle' => PimInstallerBundle::class
         ];
-        $installerData = 'PimInstallerBundle:minimal';
-        $this->beConstructedWith($bundles, $installerData);
+        $this->beConstructedWith($bundles);
         $reflection = new \ReflectionClass(PimInstallerBundle::class);
-        $expected = $installerDataDir = dirname($reflection->getFilename()) . '/Resources/fixtures/minimal/';
-        $this->getFixturesPath()->shouldReturn($expected);
+        $expected = dirname($reflection->getFilename()) . '/Resources/fixtures/minimal/';
+        $this->getFixturesPath('PimInstallerBundle:minimal')->shouldReturn($expected);
     }
 
     function it_provides_a_full_path_when_no_short_definition_is_provided()
@@ -29,8 +28,8 @@ class FixturePathProviderSpec extends ObjectBehavior
         ];
         $reflection = new \ReflectionClass(PimInstallerBundle::class);
         $installerData = dirname($reflection->getFileName());
-        $this->beConstructedWith($bundles, $installerData);
-        $this->getFixturesPath()->shouldReturn($installerData.DIRECTORY_SEPARATOR);
+        $this->beConstructedWith($bundles);
+        $this->getFixturesPath($installerData)->shouldReturn($installerData.DIRECTORY_SEPARATOR);
     }
 
     function it_throws_an_exception_when_the_directory_does_not_exist()
@@ -39,8 +38,7 @@ class FixturePathProviderSpec extends ObjectBehavior
             'PimDashboardBundle' => PimDashboardBundle::class,
             'PimInstallerBundle' => 'Akeneo\Platform\Bundle\InstallerBundle\PimYoloBundle'
         ];
-        $installerData = '/tmp/FakeProject/YoloBundle';
-        $this->beConstructedWith($bundles, $installerData);
-        $this->shouldThrow('\RuntimeException')->during('getFixturesPath', []);
+        $this->beConstructedWith($bundles);
+        $this->shouldThrow('\RuntimeException')->during('getFixturesPath', ['/tmp/FakeProject/YoloBundle']);
     }
 }

--- a/tests/back/Platform/Specification/Bundle/InstallerBundle/FixtureLoader/JobInstancesConfiguratorSpec.php
+++ b/tests/back/Platform/Specification/Bundle/InstallerBundle/FixtureLoader/JobInstancesConfiguratorSpec.php
@@ -18,11 +18,11 @@ class JobInstancesConfiguratorSpec extends ObjectBehavior
         $myFilePath = __FILE__;
         $myInstallerPath = dirname($myFilePath);
         $myFileName = str_replace($myInstallerPath, '', $myFilePath);
-        $pathProvider->getFixturesPath()->willReturn($myInstallerPath);
+        $pathProvider->getFixturesPath('minimal')->willReturn($myInstallerPath);
         $instance->getRawParameters()->willReturn(['filePath' => $myFileName]);
         $instance->setRawParameters(['filePath' => $myInstallerPath.$myFileName])->shouldBeCalled();
 
-        $this->configureJobInstancesWithInstallerData([$instance]);
+        $this->configureJobInstancesWithInstallerData('minimal', [$instance]);
     }
 
     function it_configures_job_instances_with_a_single_replacement_path(JobInstance $instance)

--- a/tests/legacy/features/Context/CatalogConfigurationContext.php
+++ b/tests/legacy/features/Context/CatalogConfigurationContext.php
@@ -114,7 +114,7 @@ class CatalogConfigurationContext extends PimContext
         }
 
         // configure and load job instances in database
-        $this->getFixtureJobLoader()->loadJobInstances($replacePaths);
+        $this->getFixtureJobLoader()->loadJobInstances('src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal', $replacePaths);
 
         // setup application to be able to run akeneo:batch:job command
         $application = new Application($this->getContainer()->get('kernel'));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The parameter `%installer_data%` has been removed in this PR and the installation command has been improved too. We want to install the minimal catalog by default except for the symfony dev environement `ice cat demo dev` will be installed.

To install `icecat demo dev` you need to run the following command:
```
$ O="--catalog src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev" make database
// OR
$ bin/console pim:install:db --catalog src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev
```
The options `catalog` is not mandatory, its default value is the path where is the minimal catalog. Don't worry, the target `pim-dev` will still install the `ice cat demo dev` catalog!

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
