### PR TITLE
PIM-6437: Remove empty or already added attribute groups from family edit screen

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -4,6 +4,7 @@
 
 - PIM-7332: show an error message when a number attribute field reaches the PHP_INT_MAX.
 - PIM-7691: Users were able to edit their own roles
+- PIM-6437: Remove empty or already added attribute groups from family edit screen
 
 # 2.3.66 (2019-10-09)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute-group/select.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute-group/select.js
@@ -12,16 +12,44 @@ define(
         'jquery',
         'underscore',
         'oro/translator',
-        'pim/common/add-select'
+        'pim/common/add-select',
+        'pim/fetcher-registry'
     ],
     function (
         $,
         _,
         __,
-        BaseAddSelect
+        BaseAddSelect,
+        FetcherRegistry
     ) {
         return BaseAddSelect.extend({
-            className: 'AknButtonList-item add-attribute-group'
+            className: 'AknButtonList-item add-attribute-group',
+
+            getFilteredGroups(loadedGroups) {
+                const familyData = this.getRoot().getFormData();
+                const familyGroups = {};
+
+                familyData.attributes.forEach(attribute => {
+                    familyGroups[attribute.group] = familyGroups[attribute.group] || []
+                    familyGroups[attribute.group].push(attribute.code);
+                })
+
+                const groupsToExclude = Object.entries(loadedGroups).filter(([group, data]) => {
+                    const familyGroupAttributes = familyGroups[group];
+                    const loadedGroupAttribute = data.attributes;
+                    console.log('family', familyGroupAttributes)
+                    console.log('loaded', loadedGroupAttribute);
+                })
+            },
+
+            fetchItems(searchParameters) {
+                return FetcherRegistry.getFetcher(this.mainFetcher)
+                    .search(searchParameters)
+                    .then((loadedGroups) => {
+                        const filteredGroups = this.getFilteredGroups(loadedGroups)
+                        return loadedGroups;
+                    })
+            },
         });
     }
 );

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute-group/select.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute-group/select.js
@@ -25,30 +25,38 @@ define(
         return BaseAddSelect.extend({
             className: 'AknButtonList-item add-attribute-group',
 
-            getFilteredGroups(loadedGroups) {
-                const familyData = this.getRoot().getFormData();
-                const familyGroups = {};
+            /**
+             * Returns a set of attribute groups that are not empty, and not already added to the family.
+             *
+             * @param {Object} loadedGroups
+             */
+            filterAllowedAttributeGroups(loadedGroups) {
+                const allowedGroups = {}
 
-                familyData.attributes.forEach(attribute => {
-                    familyGroups[attribute.group] = familyGroups[attribute.group] || []
-                    familyGroups[attribute.group].push(attribute.code);
+                Object.entries(loadedGroups).forEach(([group, data]) => {
+                    const familyAttributes = this.getRoot().getFormData().attributes.filter((attribute) => {
+                        return attribute.group === group;
+                    }).map(attribute => attribute.code);
+                    const groupIsNotEmpty = data.attributes.length > 0;
+                    const groupIsIncomplete = data.attributes.length !== familyAttributes.length;
+
+                    if (groupIsNotEmpty && groupIsIncomplete) {
+                        allowedGroups[group] = data;
+                    }
                 })
 
-                const groupsToExclude = Object.entries(loadedGroups).filter(([group, data]) => {
-                    const familyGroupAttributes = familyGroups[group];
-                    const loadedGroupAttribute = data.attributes;
-                    console.log('family', familyGroupAttributes)
-                    console.log('loaded', loadedGroupAttribute);
-                })
+                return allowedGroups;
             },
 
+            /**
+             * Fetches filtered attribute groups for the select
+             *
+             * @param {Promise} searchParameters
+             */
             fetchItems(searchParameters) {
                 return FetcherRegistry.getFetcher(this.mainFetcher)
                     .search(searchParameters)
-                    .then((loadedGroups) => {
-                        const filteredGroups = this.getFilteredGroups(loadedGroups)
-                        return loadedGroups;
-                    })
+                    .then((loadedGroups) => this.filterAllowedAttributeGroups(loadedGroups))
             },
         });
     }

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute-group/select.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute-group/select.js
@@ -57,7 +57,7 @@ define(
                 return FetcherRegistry.getFetcher(this.mainFetcher)
                     .search(searchParameters)
                     .then((loadedGroups) => this.filterAllowedAttributeGroups(loadedGroups))
-            },
+            }
         });
     }
 );


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR filters out the attribute groups in the "Add by Groups" select for the family edit screen if all their attributes have already been added to the family, or if they are empty. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
