### PR TITLE
PIM-7691: Users were able to edit their own roles

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7691: Users were able to edit their own roles
+
 # 2.3.66 (2019-10-09)
 
 # 2.3.65 (2019-10-04)

--- a/src/Pim/Bundle/UserBundle/Form/Type/UserType.php
+++ b/src/Pim/Bundle/UserBundle/Form/Type/UserType.php
@@ -61,20 +61,20 @@ class UserType extends AbstractType
 
     /**
      * @param TokenStorageInterface     $tokenStorage
+     * @param SecurityFacade            $securityFacade
      * @param UserPreferencesSubscriber $subscriber
      * @param RoleRepository            $roleRepository
      * @param GroupRepository           $groupRepository
      * @param EventDispatcherInterface  $eventDispatcher
-     * @param SecurityFacade            $securityFacade
      * @param string                    $productGridFilterTypeClassName
      */
     public function __construct(
         TokenStorageInterface $tokenStorage,
+        SecurityFacade $securityFacade,
         UserPreferencesSubscriber $subscriber,
         RoleRepository $roleRepository,
         GroupRepository $groupRepository,
         EventDispatcherInterface $eventDispatcher,
-        SecurityFacade $securityFacade,
         string $productGridFilterTypeClassName
     ) {
         $this->tokenStorage = $tokenStorage;

--- a/src/Pim/Bundle/UserBundle/Form/Type/UserType.php
+++ b/src/Pim/Bundle/UserBundle/Form/Type/UserType.php
@@ -90,9 +90,9 @@ class UserType extends AbstractType
     ) {
         $this->tokenStorage = $tokenStorage;
         $this->isMyProfilePage = 'oro_user_profile_update' === $requestStack
-            ->getCurrentRequest()
-            ->attributes
-            ->get('_route');
+                ->getCurrentRequest()
+                ->attributes
+                ->get('_route');
 
         $this->isEditRolesAllowed = null !== $securityFacade ?
             $securityFacade->isGranted('pim_user_role_edit') : !$this->isMyProfilePage;

--- a/src/Pim/Bundle/UserBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/form_types.yml
@@ -22,12 +22,11 @@ services:
         class: '%pim_user.form.type.user.class%'
         arguments:
             - '@security.token_storage'
-            - '@request_stack'
+            - '@oro_security.security_facade'
             - '@pim_user.form.subscriber.user_preferences'
             - '@pim_user.repository.role'
             - '@pim_user.repository.group'
             - '@event_dispatcher'
-            - '@oro_security.security_facade'
             - '%pim_enrich.form.type.product_grid_filter_choice.class%'
         tags:
             - { name: form.type, alias: pim_user_user }

--- a/src/Pim/Bundle/UserBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/form_types.yml
@@ -27,6 +27,7 @@ services:
             - '@pim_user.repository.role'
             - '@pim_user.repository.group'
             - '@event_dispatcher'
+            - '@oro_security.security_facade'
             - '%pim_enrich.form.type.product_grid_filter_choice.class%'
         tags:
             - { name: form.type, alias: pim_user_user }

--- a/src/Pim/Bundle/UserBundle/Resources/config/form_types.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/form_types.yml
@@ -22,12 +22,13 @@ services:
         class: '%pim_user.form.type.user.class%'
         arguments:
             - '@security.token_storage'
-            - '@oro_security.security_facade'
+            - '@request_stack'
             - '@pim_user.form.subscriber.user_preferences'
             - '@pim_user.repository.role'
             - '@pim_user.repository.group'
             - '@event_dispatcher'
             - '%pim_enrich.form.type.product_grid_filter_choice.class%'
+            - '@oro_security.security_facade'
         tags:
             - { name: form.type, alias: pim_user_user }
 

--- a/tests/legacy/features/user/edit_user.feature
+++ b/tests/legacy/features/user/edit_user.feature
@@ -66,3 +66,31 @@ Feature: Edit a user
     And I reload the page
     And I visit the "Interfaces" tab
     Then I should see the text "Panama EST (UTC-05:00)"
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7691
+  Scenario: Fail to change a user role without correct permissions
+    Given I edit the "User" Role
+    When I visit the "Permissions" tab
+    And I grant rights to group System
+    And I revoke rights to resource Edit roles
+    And I save the Role
+    When I logout
+    And I am logged in as "Mary"
+    And I edit the "mary" user
+    And I visit the "Groups and Roles" tab
+    And I check "Administrator"
+    Then the "Administrator" checkbox should be unchecked
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7691
+  Scenario: Fail to change a user group without correct permissions
+    Given I edit the "User" Role
+    When I visit the "Permissions" tab
+    And I grant rights to group System
+    And I revoke rights to resource Edit user groups
+    And I save the Role
+    When I logout
+    And I am logged in as "Mary"
+    And I edit the "mary" user
+    And I visit the "Groups and Roles" tab
+    And I check "Manager"
+    Then the "Manager" checkbox should be unchecked


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Users without the permissions `Edit roles` or `Edit user groups` could escalate their own role from `User` to `Administrator`. The previous security check was only on the current route, if it was `oro_user_profile_update`, they were not allowed to change their own roles.
The problem was, this form was since accessible in other pages.
The solution is to use the SecurityFacade service to check if the logged user has the correct permissions.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | yes
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
