### PR TITLE
Optimize loading of mysql dump and deletion of documents in ES for phpunit tests

### DIFF
--- a/config/services/test/test_services.yml
+++ b/config/services/test/test_services.yml
@@ -46,6 +46,7 @@ services:
             - '%env(APP_DATABASE_USER)%'
             - '%env(APP_DATABASE_PASSWORD)%'
             - '%kernel.cache_dir%/sql-dump/'
+            - '%index_hosts%'
 
     akeneo_integration_tests.loader.category_tree_loader:
         class: 'AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\CategoryTree\CategoryTreeFixturesLoader'

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/tests/integration/BulkIndexationIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/tests/integration/BulkIndexationIntegration.php
@@ -54,6 +54,8 @@ class BulkIndexationIntegration extends TestCase
         parent::setUp();
 
         $this->esProductClient = $this->get('akeneo_elasticsearch.client.product_and_product_model');
+        $this->esProductClient->resetIndex(); // reset versioning number
+
         $products = [
             [
                 'identifier'           => 'product_1',

--- a/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
@@ -156,8 +156,8 @@ class FixturesLoader implements FixturesLoaderInterface
         $dumpFile = $this->sqlDumpDirectory . $fixturesHash . '.sql';
         if (file_exists($dumpFile)) {
             $this->databaseSchemaHandler->reset();
-
             $this->restoreDatabase($dumpFile);
+
             $this->clearAclCache();
 
             $this->systemUserAuthenticator->createSystemUser();
@@ -212,14 +212,7 @@ class FixturesLoader implements FixturesLoaderInterface
     protected function loadSqlFiles(array $files): void
     {
         foreach ($files as $file) {
-            $this->execCommand([
-                'mysql',
-                '-h '.$this->databaseHost,
-                '-u '.$this->databaseUser,
-                '-p'.$this->databasePassword,
-                $this->databaseName,
-                sprintf('< %s', $file),
-            ]);
+            $this->dbConnection->exec(file_get_contents($file));
         }
     }
 
@@ -376,6 +369,8 @@ class FixturesLoader implements FixturesLoaderInterface
             '-p'.$this->databasePassword,
             '--no-create-info',
             '--quick',
+            '--skip-add-locks',
+            '--skip-disable-keys',
             $this->databaseName,
             '> '.$filepath,
         ]);
@@ -386,14 +381,7 @@ class FixturesLoader implements FixturesLoaderInterface
      */
     protected function restoreDatabase($filepath): void
     {
-        $this->execCommand([
-            'mysql',
-            '-h '.$this->databaseHost,
-            '-u '.$this->databaseUser,
-            '-p'.$this->databasePassword,
-            $this->databaseName,
-            '< '.$filepath,
-        ]);
+        $this->dbConnection->exec(file_get_contents($filepath));
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogProductModel.php
+++ b/tests/back/Pim/Enrichment/Integration/Elasticsearch/IndexConfiguration/AbstractPimCatalogProductModel.php
@@ -163,7 +163,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-rockstar.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-rockstar.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-rockstar.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'color-option'     => [
@@ -366,7 +374,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-grey.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-grey.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-grey.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -409,7 +425,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-blue.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-blue.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-blue.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -452,7 +476,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-red.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-red.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-red.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -695,7 +727,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-grey.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-grey.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-grey.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -752,7 +792,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-grey.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-grey.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-grey.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -809,7 +857,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-grey.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-grey.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-grey.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -866,7 +922,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-grey.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-grey.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-grey.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -924,7 +988,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-blue.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-blue.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-blue.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -981,7 +1053,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-blue.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-blue.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-blue.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -1038,7 +1118,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-blue.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-blue.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-blue.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -1095,7 +1183,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-blue.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-blue.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-blue.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -1153,7 +1249,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-red.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-red.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-red.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -1210,7 +1314,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-red.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-red.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-red.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -1267,7 +1379,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-red.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-red.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-red.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -1324,7 +1444,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-red.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-red.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-red.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'material-option'  => [
@@ -1378,7 +1506,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-rockstar.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-rockstar.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-rockstar.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'color-option'     => [
@@ -1425,7 +1561,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-rockstar.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-rockstar.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-rockstar.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'color-option'     => [
@@ -1472,7 +1616,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-rockstar.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-rockstar.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-rockstar.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'color-option'     => [
@@ -1519,7 +1671,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-rockstar.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-rockstar.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-rockstar.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'color-option'     => [
@@ -1709,7 +1869,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-unique-size-blue.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-unique-size-blue.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-unique-size-blue.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'size-option'      => [
@@ -1758,7 +1926,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-unique-size-red.jpg',
+                            '<all_locales>' => [
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-unique-size-red.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-unique-size-red.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'size-option'      => [
@@ -1807,7 +1983,15 @@ abstract class AbstractPimCatalogProductModel extends AbstractPimCatalogTestCase
                     ],
                     'image-media'      => [
                         '<all_channels>' => [
-                            '<all_locales>' => 'tshirt-unique-size-yellow.jpg',
+                            '<all_locales>' =>[
+                                'extension' => 'jpg',
+                                'key' => 'c/3/7/c/c37cd4f2b1b137fc30c76686a16f85a37b8768a3_tshirt-unique-size-yellow.jpg',
+                                'hash' => 'cf2c863861dde58f45bdb32496d42ee3dc2b3c44',
+                                'mime_type' => 'image/jpeg',
+                                'original_filename' => 'tshirt-unique-size-red.jpg',
+                                'size' => 10584,
+                                'storage' => 'catalogStorage',
+                            ],
                         ],
                     ],
                     'size-option'      => [


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

 **Mysql dump optimization** 

It load the dumps through the connection instead of the mysql utility (a needed step if we want to wrap it in a transcation in the future).
I did some optimization of the dump also.

**Elasticsearch optimization**

We delete the documents (in one request) instead of resetting the indexes. In EE, we have 5 indexes. It can between 50 ms to 200 ms to reset an index. It's much faster to do it this way.

The only problem is the dynamic mapping. If a field (for example `image-media` in the PR` is of type "scalar" in a test and an object in another test, it will fail. This kind of coupling between the test worths the performance gain.

In EE: 

- before 19 min
- after 15 min

In CE:
- before 8m40
- after 7min40

Randomly, I looked at some tests: some test that last 1s30 before last 0,5 sec now.
It does not improve by 2 the performance because some tests are so slow that it makes this improvement anecdotic. The slowest test last 22s50 instead of 23s2 for example...

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
