### PR TITLE
PIM-8585: fix incorrect displayed order in attributes groups

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8585: fix incorrect displayed order in attributes groups
+
 # 3.0.45 (2019-10-04)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -134,11 +134,12 @@ define([
                     )
                 ).then((channels, attributeGroups) => {
                     this.channels = channels;
-                    const groupedAttributes = _.groupBy(data.attributes, 'group');
 
-                    _.sortBy(groupedAttributes, (attributes, group) => {
-                        return _.findWhere(attributeGroups, {code: group}).sort_order;
+                    const sortedAttributes = _.sortBy(data.attributes, (attribute) => {
+                       return _.findWhere(attributeGroups, {code: attribute.group}).sort_order;
                     });
+
+                    const groupedAttributes = _.groupBy(sortedAttributes, 'group');
 
                     _.each(groupedAttributes, (attributes, group) => {
                         attributes = _.sortBy(attributes, (attribute) => attribute.sort_order);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -307,7 +307,7 @@ define([
                 if (attributeAsLabel === attributeToRemove) {
                     Messenger.notify(
                         'error',
-                        __('pim_enrich.entity.family.flash.update.can_remove_attribute_as_label')
+                        __('pim_enrich.entity.family.flash.update.cant_remove_attribute_as_label')
                     );
 
                     return false;

--- a/tests/legacy/features/pim/structure/family/remove_attribute_from_a_family.feature
+++ b/tests/legacy/features/pim/structure/family/remove_attribute_from_a_family.feature
@@ -56,6 +56,7 @@ Feature: Remove attribute from a family
     And I should see the text "Model picture"
     When I press the cancel button in the popin
     And I visit the "Attributes" tab
+    And I scroll
     And I remove the "weight" attribute
     And I remove the "image" attribute
     And I save the family

--- a/tests/legacy/features/pim/structure/family/remove_attribute_from_a_family.feature
+++ b/tests/legacy/features/pim/structure/family/remove_attribute_from_a_family.feature
@@ -41,6 +41,7 @@ Feature: Remove attribute from a family
     Then I should see the flash message "Cannot remove attribute used as label"
     When I remove the "variation_image" attribute
     Then I should see the flash message "Cannot remove used as the main picture"
+    And I scroll down
     When I remove the "size" attribute
     Then I should see the flash message "Cannot remove this attribute used as a variant axis in a family variant"
     And I should see the text "size"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

`_.sortBy` does return the sorted collection, the previous version was not storing in a variable nor using it.
The attributes need to be sorted and then grouped to be displayed correctly.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
