### PR TITLE
Allow to not filter process tracker lists for given user roles

### DIFF
--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -77,3 +77,5 @@ parameters:
     count_product_model_values_limit: -1
     count_product_and_product_model_values_limit: -1
     count_users_limit: -1
+
+    pim_datagrid.event_listener.add_username_to_grid_listener.not_restricted_roles: []

--- a/src/Oro/Bundle/PimDataGridBundle/EventListener/AddUsernameToGridListener.php
+++ b/src/Oro/Bundle/PimDataGridBundle/EventListener/AddUsernameToGridListener.php
@@ -17,9 +17,13 @@ class AddUsernameToGridListener
      */
     protected $tokenStorage;
 
-    public function __construct(TokenStorageInterface $tokenStorage)
+    /** @var array */
+    protected $notRestrictedRoles;
+
+    public function __construct(TokenStorageInterface $tokenStorage, array $notRestrictedRoles = [])
     {
         $this->tokenStorage = $tokenStorage;
+        $this->notRestrictedRoles = $notRestrictedRoles;
     }
 
     public function onBuildAfter(BuildAfter $event)
@@ -27,6 +31,9 @@ class AddUsernameToGridListener
         $dataSource = $event->getDatagrid()->getDatasource();
 
         $token = $this->tokenStorage->getToken();
+        if ($token && count(array_intersect($token->getRoles(), $this->notRestrictedRoles)) > 0) {
+            return;
+        }
         $user = null !== $token ? $token->getUsername() : null;
 
         $parameters = $dataSource->getParameters();

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/datagrid_listeners.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/datagrid_listeners.yml
@@ -169,6 +169,7 @@ services:
         class: '%pim_datagrid.event_listener.add_username_to_grid_listener.class%'
         arguments:
             - '@security.token_storage'
+            - '%pim_datagrid.event_listener.add_username_to_grid_listener.not_restricted_roles%'
         tags:
             - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.after.job-tracker-grid, method: onBuildAfter }
             - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.after.last-import-executions-grid, method: onBuildAfter }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

A lot of clients that have migrated from Akeneo 1.x were disappointed because the process tracker lists are now filtered on the current logged in user. But they often want to be able to see all executed processes, even if they did not start the jobs. 

This PR allows to configure a list of user roles that won't be filtered when displaying process tracker list.