### PR TITLE
PIM-8369: Remove flex from families dropdown css

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8369: Remove flex from families dropdown css
+
 # 3.0.45 (2019-10-04)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -104,12 +104,13 @@
   }
 
   .select2-result-label, .select2-no-results {
-    height: @AknSelectLineHeight;
-    padding: 0 6px;
+    line-height: @AknSelectLineHeight;
     min-height: 0;
-    display: flex;
-    align-items: center;
-    flex: 1;
+    overflow: hidden;
+    padding: 0 6px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 100%;
 
     .select2-result-label-main {
       flex: 1;

--- a/tests/legacy/features/pim/enrichment/product-model/create_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/create_product_model.feature
@@ -173,5 +173,4 @@ Feature: Create a product model
     Then I should see 20 items in the autocomplete
     And I should not see the choices [variant_23] and [variant_30] in Variant
     When I search "3" in the Variant select field
-    # The real display is [variant_3] but the search style will split the HTML
-    Then I should see the choices [variant_ 3 ], [variant_1 3 ], [variant_2 3 ] and [variant_ 3 0] in Variant
+    Then I should see the choices [variant_3], [variant_13], [variant_23] and [variant_30] in Variant


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

`display: flex` on `.select2-result-label` was breaking the rendering of highlighted matches when searching inside select2, the solution is to avoid using flex and only use line-height + ellipsis.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

