### PR TITLE
PIM-7691: Users were able to edit their own roles

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
@@ -85,7 +85,7 @@ class UserController
     private $securityFacade;
 
     /**
-     * @todo merge 3.2:
+     * @todo merge master:
      *       - remove the $objectManager argument
      *       - the last three arguments ($translator $remover $securityFacade) must not be nullable anymore
      */

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
@@ -21,6 +21,7 @@ services:
             - '@doctrine.orm.entity_manager' # todo merge 3.2: remove this line
             - '@pim_user.remover.user'
             - '@translator'
+            - '@oro_security.security_facade'
 
     pim_user.controller.security_rest:
         class: '%pim_user.controller.security_rest.class%'

--- a/tests/legacy/features/user-management/group/edit_user_group_assignations.feature
+++ b/tests/legacy/features/user-management/group/edit_user_group_assignations.feature
@@ -90,3 +90,19 @@ Feature: Edit a user groups and roles
     When I edit the "Manager" UserGroup
     And I visit the "Users" tab
     Then the last page number should be 2
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7691
+  Scenario: Fail to change a user group without correct permissions
+    Given I edit the "User" Role
+    When I visit the "Permissions" tab
+    And I grant rights to group System
+    And I revoke rights to resource Edit user groups
+    And I save the Role
+    When I logout
+    And I am logged in as "Mary"
+    And I edit the "mary" user
+   And I visit the "Groups and roles" tab
+    And I fill in the following information:
+      | User groups | Manager, Redactor |
+    And I save the user
+    And the user "mary" should have 1 role

--- a/tests/legacy/features/user-management/role/edit_user_role_assignations.feature
+++ b/tests/legacy/features/user-management/role/edit_user_role_assignations.feature
@@ -48,3 +48,19 @@ Feature: Edit a user groups and roles
     When I logout
     And I am logged in as "Peter"
     Then I am on the Role index page
+
+  @jira https://akeneo.atlassian.net/browse/PIM-7691
+  Scenario: Fail to change a user role without correct permissions
+    Given I edit the "User" Role
+    When I visit the "Permissions" tab
+    And I grant rights to group System
+    And I revoke rights to resource Edit roles
+    And I save the Role
+    When I logout
+    And I am logged in as "Mary"
+    And I edit the "mary" user
+    And I visit the "Groups and roles" tab
+    And I fill in the following information:
+      | Roles | Administrator, User |
+    And I save the user
+    And the user "mary" should have 1 role


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Users without the permissions `Edit roles` or `Edit user groups` could escalate their own role from `User` to `Administrator`. Submitted roles and groups were only ignored in the controller of `updateProfileAction`.
The solution is to use the SecurityFacade service to check if the logged user has the correct permissions, if it's not the case, submitted roles & groups are ignored.

Same as https://github.com/akeneo/pim-community-dev/pull/10868 but the current PR targets 3.0.x

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | yes
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
