### PR TITLE
PIM-6976: fix max_characters attribute field not being nullable

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-6976: fix max_characters attribute field not being nullable
+
 # 2.3.67 (2019-10-14)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
+++ b/src/Pim/Bundle/EnrichBundle/Controller/Rest/AttributeController.php
@@ -428,6 +428,10 @@ class AttributeController
             ]);
         }
 
+        if (isset($data['max_characters'])) {
+            $data['max_characters'] = $this->numberLocalizer->delocalize($data['max_characters']);
+        }
+
         $this->updater->update($attribute, $data);
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When editing a text or text-area attribute, removing the value in the `max_characters` field resulted in a bad request from the server, this was because the empty string value was not being treated as `null`.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
