### PR TITLE
Remove misleading docblock of the locale property

### DIFF
--- a/src/Akeneo/Pim/Structure/Component/Model/AttributeOptionValue.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AttributeOptionValue.php
@@ -22,8 +22,6 @@ class AttributeOptionValue implements AttributeOptionValueInterface
     protected $option;
 
     /**
-     * LocaleInterface scope
-     *
      * @var string
      */
     protected $locale;


### PR DESCRIPTION
**Description**

This PR proposes to remove the `LocaleInterface scope` from the docblock of the AttributeOptionValue::locale.

This property has the type `string` and not `LocaleInterface`. 
This property defines a locale and not a scope.

Please ignore if there was another intention of this docblock comment.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
