### PR TITLE
Allow only default filters without calling a dynamic attributes query

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
@@ -96,6 +96,10 @@ class FiltersColumn extends BaseView {
   }
 
   fetchFilters(search?: string | null, page: number = this.page) {
+    if (undefined === this.config.attributeFiltersRoute) {
+      return $.Deferred().resolve([]).promise();
+    }
+
     const locale = this.getLocale();
     const url = Routing.generate(this.config.attributeFiltersRoute);
     return $.get(search ? `${url}?search=${search}&locale=${locale}` : `${url}?page=${page}&locale=${locale}`);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
