### PR TITLE
Allow to show only specific operators

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
@@ -50,11 +50,21 @@ define(
                     };
                 }
 
-                this.operatorChoices = {
+                const operatorChoices = {
                     'in': __('pim_datagrid.filters.common.in_list'),
                     'empty': __('pim_datagrid.filters.common.empty'),
                     'not empty': __('pim_datagrid.filters.common.not_empty')
                 };
+
+                if (undefined !== this.options.onlyOperators) {
+                    for (var operatorChoice in operatorChoices) {
+                        if (-1 === this.options.onlyOperators.indexOf(operatorChoice)) {
+                            delete operatorChoices[operatorChoice];
+                        }
+                    }
+                }
+
+                this.operatorChoices = operatorChoices;
 
                 TextFilter.prototype.initialize.apply(this, arguments);
             },


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
By default, we show always "in list", "empty", "not empty" operators for a choice filter. For some use case, it's a non sense. Allow to show only specific operators.
<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
