### PR TITLE
PIM-7963: fix datepicker width not adapting to the dropdown

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -34,6 +34,7 @@
 
 # 2.3.63 (2019-09-23)
 
+
 ## Bug fixes
 
 - PIM-8738: Fix memory leak executing "akeneo:batch:purge-job-execution" command
@@ -66,7 +67,7 @@
 ## Bug fixes
 
 - PIM-8461: Do not display 'Compare/translate' if user has no permission to edit product attributes
-- PIM-7583: Allow user to import custom locales without '\_'
+- PIM-7583: Allow user to import custom locales without '_'
 - PIM-8630: Fix revert action when it exists an association type with integer as code
 
 # 2.3.57 (2019-07-31)
@@ -130,8 +131,8 @@
 ## BC Break
 
 - Change constructor of `src/Pim/Component/Catalog/Job/ComputeFamilyVariantStructureChangesTasklet.php`:
-  added: `Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface` and `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
-  removed: `Pim\Component\Catalog\Repository\ProductModelRepositoryInterface` and `Pim\Component\Catalog\Repository\ProductRepositoryInterface`
+    added: `Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface` and `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
+    removed: `Pim\Component\Catalog\Repository\ProductModelRepositoryInterface` and `Pim\Component\Catalog\Repository\ProductRepositoryInterface`
 
 ## Improvement
 
@@ -358,9 +359,9 @@
 - PIM-7910: Search parent filter is now case insensitive
 - PIM-7936: Missing breadcrumb when you create Attribute group or Channel
 
-## Elasticsearch
+ ## Elasticsearch
 
-- Please re-index the products and product models by launching the commands `console akeneo:elasticsearch:reset-indexes -e prod` and `pim:product:index --all -e prod`.
+ - Please re-index the products and product models by launching the commands `console akeneo:elasticsearch:reset-indexes -e prod` and `pim:product:index --all -e prod`.
 
 # 2.3.21 (2018-12-07)
 
@@ -575,6 +576,7 @@ PIM-7810: Fix to mass delete products and product models
 ## Migration
 
 **IMPORTANT** Please run the doctrine migrations command to fix the product models export profiles : `bin/console doctrine:migrations:migrate --env=prod`
+
 
 # 2.3.1 (2018-07-04)
 

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7963: fix datepicker width not adapting to the dropdown
+
 # 2.3.68 (2019-10-18)
 
 ## Bug fixes
@@ -29,7 +33,6 @@
 - PIM-7891: Update exports when an attribute is deleted
 
 # 2.3.63 (2019-09-23)
-
 
 ## Bug fixes
 
@@ -63,7 +66,7 @@
 ## Bug fixes
 
 - PIM-8461: Do not display 'Compare/translate' if user has no permission to edit product attributes
-- PIM-7583: Allow user to import custom locales without '_'
+- PIM-7583: Allow user to import custom locales without '\_'
 - PIM-8630: Fix revert action when it exists an association type with integer as code
 
 # 2.3.57 (2019-07-31)
@@ -127,8 +130,8 @@
 ## BC Break
 
 - Change constructor of `src/Pim/Component/Catalog/Job/ComputeFamilyVariantStructureChangesTasklet.php`:
-    added: `Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface` and `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
-    removed: `Pim\Component\Catalog\Repository\ProductModelRepositoryInterface` and `Pim\Component\Catalog\Repository\ProductRepositoryInterface`
+  added: `Pim\Component\Catalog\Query\ProductQueryBuilderFactoryInterface` and `Akeneo\Component\StorageUtils\Cache\EntityManagerClearerInterface`
+  removed: `Pim\Component\Catalog\Repository\ProductModelRepositoryInterface` and `Pim\Component\Catalog\Repository\ProductRepositoryInterface`
 
 ## Improvement
 
@@ -355,9 +358,9 @@
 - PIM-7910: Search parent filter is now case insensitive
 - PIM-7936: Missing breadcrumb when you create Attribute group or Channel
 
- ## Elasticsearch
+## Elasticsearch
 
- - Please re-index the products and product models by launching the commands `console akeneo:elasticsearch:reset-indexes -e prod` and `pim:product:index --all -e prod`.
+- Please re-index the products and product models by launching the commands `console akeneo:elasticsearch:reset-indexes -e prod` and `pim:product:index --all -e prod`.
 
 # 2.3.21 (2018-12-07)
 
@@ -572,7 +575,6 @@ PIM-7810: Fix to mass delete products and product models
 ## Migration
 
 **IMPORTANT** Please run the doctrine migrations command to fix the product models export profiles : `bin/console doctrine:migrations:migrate --env=prod`
-
 
 # 2.3.1 (2018-07-04)
 

--- a/src/Pim/Bundle/UIBundle/Resources/config/assets.yml
+++ b/src/Pim/Bundle/UIBundle/Resources/config/assets.yml
@@ -10,6 +10,7 @@ css:
 
     lib_customization:
         - bundles/pimui/less/lib/bootstrap.switch.less
+        - bundles/pimui/less/lib/bootstrap.datepicker.less
         - bundles/pimui/less/lib/bootstrap.dropdown.less
         - bundles/pimui/less/lib/bootstrap.tooltip.less
         - bundles/pimui/less/lib/dialog.less

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/lib/bootstrap.datepicker.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/lib/bootstrap.datepicker.less
@@ -1,0 +1,3 @@
+.datepicker table {
+  width: 100%;
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The datepicker was not adapting its width when changing the month or the year, I added a lib customization to fix it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
