### PR TITLE
PIM-7963: Fix datepicker width not adapting to the dropdown

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,7 @@
 # 3.2.x
 
+- PIM-7963: Fix datepicker width not adapting to the dropdown
+
 # 3.2.13 (2019-10-18)
 
 ## Bug fixes:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/index.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/index.less
@@ -7,6 +7,7 @@
 @import (less) "./web/bundles/pimui/lib/summernote/summernote.css";
 
 @import "./web/bundles/pimui/less/lib/bootstrap.switch.less";
+@import "./web/bundles/pimui/less/lib/bootstrap.datepicker.less";
 @import "./web/bundles/pimui/less/lib/bootstrap.dropdown.less";
 @import "./web/bundles/pimui/less/lib/dialog.less";
 @import "./web/bundles/pimui/less/lib/dropdown.less";

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/bootstrap.datepicker.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/bootstrap.datepicker.less
@@ -1,3 +1,3 @@
 .datepicker table {
-  margin: 100%;
+  width: 100%;
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/bootstrap.datepicker.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/bootstrap.datepicker.less
@@ -1,0 +1,3 @@
+.datepicker table {
+  margin: 100%;
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The datepicker was not adapting its width when changing the month or the year, I added a lib customization to fix it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
