### PR TITLE
Filters

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,10 @@
 # 3.0.x
 
+## Bug fixes
+
+AOB-691: Allow to show only specific operators in datagrid
+AOB-691: Allow only default filters without calling a dynamic attributes query in datagrid
+
 # 3.0.47 (2019-10-21)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select2-rest-choice-filter.js
@@ -50,11 +50,21 @@ define(
                     };
                 }
 
-                this.operatorChoices = {
+                const operatorChoices = {
                     'in': __('pim_datagrid.filters.common.in_list'),
                     'empty': __('pim_datagrid.filters.common.empty'),
                     'not empty': __('pim_datagrid.filters.common.not_empty')
                 };
+
+                if (undefined !== this.options.onlyOperators) {
+                    for (var operatorChoice in operatorChoices) {
+                        if (-1 === this.options.onlyOperators.indexOf(operatorChoice)) {
+                            delete operatorChoices[operatorChoice];
+                        }
+                    }
+                }
+
+                this.operatorChoices = operatorChoices;
 
                 TextFilter.prototype.initialize.apply(this, arguments);
             },

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
@@ -8,6 +8,7 @@ const Routing = require('routing');
 interface FiltersConfig {
   title: string;
   description: string;
+  onlyDefaultFilters: boolean;
 }
 
 interface GridFilter {
@@ -66,9 +67,10 @@ class FiltersColumn extends BaseView {
     </ul>`;
 
   constructor(options: {config: FiltersConfig}) {
+
     super(options);
 
-    this.config = {...this.config, ...options.config};
+    this.config = {...this.config, ...{onlyDefaultFilters: false}, ...options.config};
     this.defaultFilters = [];
     this.gridCollection = {};
     this.ignoredFilters = ['scope'];
@@ -124,6 +126,10 @@ class FiltersColumn extends BaseView {
   }
 
   fetchFilters(search?: string | null, page: number = this.page) {
+    if (this.config.onlyDefaultFilters) {
+      return $.Deferred().resolve([]).promise();
+    }
+
     const locale = this.getLocale();
     const url = Routing.generate('pim_datagrid_productgrid_attributes_filters');
     return $.get(search ? `${url}?search=${search}&locale=${locale}` : `${url}?page=${page}&locale=${locale}`);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
Backport from 3.2 to 3.0
- [x] Allow to show only specific operators in datagrid
- [x] Allow only default filters without calling a dynamic attributes query in datagrid

This backport for the commit e59f639 (Allow only default filters without calling a dynamic attributes query) is a little bit different from the 3.2 version (see https://github.com/akeneo/pim-community-dev/pull/10892) because on 3.0, url was not dynamic and I had to adapt the code in consequence 
<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
