### PR TITLE
PIM-8906: Fix file storage UUID generator

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+# Improvements
+
+- PIM-8906: Fix file storage UUID generator
+
 # 3.0.48 (2019-10-23)
 
 ## Bug fixes

--- a/src/Akeneo/Tool/Component/FileStorage/PathGenerator.php
+++ b/src/Akeneo/Tool/Component/FileStorage/PathGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Tool\Component\FileStorage;
 
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
@@ -29,7 +30,7 @@ class PathGenerator implements PathGeneratorInterface
      *
      * @return array
      */
-    public function generate(\SplFileInfo $file)
+    public function generate(\SplFileInfo $file): array
     {
         $originalFileName = ($file instanceof UploadedFile) ? $file->getClientOriginalName() : $file->getFilename();
         $uuid = $this->generateUuid($originalFileName);
@@ -54,8 +55,8 @@ class PathGenerator implements PathGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generateUuid($fileName)
+    public function generateUuid($fileName): string
     {
-        return sha1($fileName . microtime());
+        return sha1(Uuid::uuid4()->toString());
     }
 }


### PR DESCRIPTION
Actual storage UUID is `sha1(filename . microsecond())`

We ran into issue with API with more than 1000 calls per second because of duplicated UUID.

This PR uses real random UUID and we will not rely on the creation time anymore.