### PR TITLE
PIM-8908: Fix default image always showing

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-8908: Fix asset default image always showing
+
 # 3.2.14 (2019-10-22)
 
 ## Features

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/FileController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/FileController.php
@@ -83,6 +83,7 @@ class FileController
         }
 
         $fileType = $this->fileTypeGuesser->guess($fileInfo->getMimeType());
+        $result = $this->renderDefaultImage($fileType, $filter);
 
         if (self::DEFAULT_IMAGE_KEY !== $filename) {
             $fileType = $this->fileTypeGuesser->guess($this->getMimeType($filename));
@@ -97,7 +98,7 @@ class FileController
             }
         }
 
-        return $this->renderDefaultImage($fileType, $filter);
+        return $result;
     }
 
     /**


### PR DESCRIPTION
We were not able to display thumbnails in the grid

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
