### PR TITLE
TIP-1327 Fix docker script (wait for elasticsearch)

### DIFF
--- a/docker/wait_docker_up.sh
+++ b/docker/wait_docker_up.sh
@@ -19,7 +19,7 @@ echo "MySQL server is running!"
 
 COUNTER=1
 echo "Waiting for Elasticsearch server…"
-while ! docker-compose run --rm elasticsearch curl http://elasticsearch:9200/_cat/health | grep green > /dev/null 2>&1; do
+while ! docker-compose exec elasticsearch curl -s -k --fail "http://elasticsearch:9200/_cluster/health?wait_for_status=green&timeout=1s" > /dev/null; do
     COUNTER=$((${COUNTER} + 1))
     if [ ${COUNTER} -gt ${MAX_COUNTER} ]; then
         echo "We have been waiting for Elasticsearch too long already; failing." >&2


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since few day we have used `wait_docker_up.sh` in the MakeFile but some targets have been broken (pim-XXX, for example). This script checks that MySQL and Elasticsearch are alive. To know if ES is up we need to call an URL: `http://elasticsearch:9200/_cat/health` and find the word green. ES provides a better service: "http://elasticsearch:9200/_cluster/health?wait_for_status=green`. We don't need to use `grep` anymore. 

The main problem is that we use `docker-composer run` to call this URL instead  `docker-composer exec`. `docker-composer run` boots a container but  `docker-composer exec` uses the existing container.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
