### PR TITLE
PIM-8668: use an Asset Collection attribute as main image

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validators.yml
@@ -15,7 +15,7 @@ services:
     pim_catalog.validator.constraint.family_attribute_as_image:
         class: 'Akeneo\Pim\Structure\Component\Validator\Constraints\FamilyAttributeAsImageValidator'
         arguments:
-            - [ 'pim_catalog_image', 'pim_assets_collection' ]
+            - [ 'pim_catalog_image', 'pim_assets_collection', 'pim_catalog_asset_collection' ]
         tags:
             - { name: validator.constraint_validator, alias: pim_family_attribute_as_image_validator }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/generator/media-url-generator.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/generator/media-url-generator.js
@@ -21,6 +21,11 @@ define([
             getMediaShowUrl: function (filePath, filter) {
                 var filename = encodeURIComponent(filePath);
 
+                // In case the filepath is already a direct URL to an asset preview, directly returns it
+                if (filePath && filePath.includes('rest/asset_manager/image_preview')) {
+                    return filePath;
+                }
+
                 return Routing.generate('pim_enrich_media_show', {
                     filename: filename,
                     filter: filter

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
@@ -28,6 +28,7 @@ Feature: Export products and product models
 
   Scenario: Successfully export 2 files on quick export
     When I display in the products grid the columns Label, Model description
+    And I filter by "label_or_identifier" with operator "equals" and value "amor"
     And I select row amor
     And I press "CSV (Grid context)" on the "Quick Export" dropdown button
     And I wait for the "csv_product_grid_context_quick_export" quick export to finish

--- a/tests/legacy/features/pim/structure/family/import/import_families.feature
+++ b/tests/legacy/features/pim/structure/family/import/import_families.feature
@@ -177,7 +177,7 @@ Feature: Import families
     And I launch the import job
     And I wait for the "csv_footwear_family_import" job to finish
     Then I should see the text "Skipped 3"
-    And I should see the text "Property \"attribute_as_image\" only supports \"pim_catalog_image\", \"pim_assets_collection\" attribute type for the family: [wrong_family1]"
+    And I should see the text "Property \"attribute_as_image\" only supports \"pim_catalog_image\", \"pim_assets_collection\", \"pim_catalog_asset_collection\" attribute type for the family: [wrong_family1]"
     And I should see the text "Property \"attribute_as_image\" must not be scopable nor localizable for this family: [wrong_family1]"
     And I should see the text "Property \"attribute_as_image\" must belong to the family: [wrong_family2]"
     And I should see the text "Property \"attribute_as_image\" must not be scopable nor localizable for this family: [wrong_family3]"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PRs adds the support of Asset Manager **assets as main image for products**.

As Asset Manager **already provides direct url** for assets preview, we need to tweak the MediaUrlGenerator to display correct filepath.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
