### PR TITLE
PIM-8894: Change product identifier validation to forbid surrounding spaces

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 # Bug fixes
 
 - GITHUB-10247: Fix regex to compile the frontend assets. Thanks @liamjtoohey!
+- PIM-8894: Change product identifier validation to forbid surrounding spaces
 
 # Technical Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
@@ -22,8 +22,8 @@ Akeneo\Pim\Enrichment\Component\Product\Model\Product:
         identifier:
             - NotBlank: ~
             - Regex:
-                pattern: '/^[^,;]+$/'
-                message: 'regex.comma_or_semicolon.message'
+                pattern: '/^(?!\s)[^,;]+(?<!\s)$/'
+                message: 'regex.comma_or_semicolon_or_surrounding_space.message'
             - Length:
                 max: 255
     getters:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/productmodel.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/productmodel.yml
@@ -16,8 +16,8 @@ Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel:
             - NotBlank:
                 message: 'product_model.code.not_blank.message'
             - Regex:
-                pattern: '/^[^,;]+$/'
-                message: 'regex.comma_or_semicolon.message'
+                pattern: '/^(?!\s)[^,;]+(?<!\s)$/'
+                message: 'regex.comma_or_semicolon_or_surrounding_space.message'
             - Length:
                 max: 255
         familyVariant:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
@@ -15,7 +15,7 @@ This value should not be a decimal.:                                            
 'The file extension is not allowed (allowed extensions: %extensions%).':                  'The file extension is not allowed (allowed extensions: %extensions%).'
 The value %value% is already set on another product for the unique attribute %attribute%: The value %value% is already set on another product for the unique attribute %attribute%
 The same identifier is already set on another product:                                    The same identifier is already set on another product
-regex.comma_or_semicolon.message:                                                         This field should not contain any comma or semicolon.
+regex.comma_or_semicolon_or_surrounding_space.message:                                    This field should not contain any comma or semicolon or surrounding space.
 file.extensions.message:                                                                  'The file extension is not allowed (allowed extensions: %extensions%).'
 "This type of value expects the use of {{ decimal_separator }} to separate decimals.": This type of value expects the use of {{ decimal_separator }} to separate decimals.
 "This type of value expects the use of dot (.) to separate decimals.": This type of value expects the use of a dot (.) to separate decimals.

--- a/tests/back/Acceptance/Catalog/Context/ProductCreation.php
+++ b/tests/back/Acceptance/Catalog/Context/ProductCreation.php
@@ -46,14 +46,20 @@ final class ProductCreation implements Context
      */
     public function aProductWithAnIdentifier(string $identifier): void
     {
+        $product = $this->productBuilder->withIdentifier($identifier)->build();
+        $this->productRepository->save($product);
+    }
+
+    /**
+     * @Given a catalog with the attribute :identifierAttributeCode as product identifier
+     */
+    public function aCatalogWithTheAttributeAsProductIdentifier(string $identifierAttributeCode)
+    {
         $attribute = (new Attribute\Builder())->aIdentifier()
-            ->withCode(self::IDENTIFIER_ATTRIBUTE)
+            ->withCode($identifierAttributeCode)
             ->build();
 
         $this->attributeSaver->save($attribute);
-
-        $product = $this->productBuilder->withIdentifier($identifier)->build();
-        $this->productRepository->save($product);
     }
 
     /**

--- a/tests/back/Acceptance/Catalog/Context/ProductValidation.php
+++ b/tests/back/Acceptance/Catalog/Context/ProductValidation.php
@@ -43,7 +43,7 @@ final class ProductValidation implements Context
     }
 
     /**
-     * @When another product is created with identifier :identifier
+     * @When /^a(?:nother)? product is created with identifier "([^"]*)"$/
      */
     public function aProductIsCreatedWithIdentifier(string $identifier): void
     {

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
@@ -274,7 +274,7 @@ JSON;
 
         $expectedContent =
 <<<JSON
-{"line":1,"identifier":"foo,","status_code":422,"message":"Validation failed.","errors":[{"property":"identifier","message":"This field should not contain any comma or semicolon."}]}
+{"line":1,"identifier":"foo,","status_code":422,"message":"Validation failed.","errors":[{"property":"identifier","message":"This field should not contain any comma or semicolon or surrounding space."}]}
 JSON;
 
 

--- a/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
@@ -10,8 +10,6 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  * @author    Damien Carcel (damien.carcel@akeneo.com)
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- *
- *            This field should not contain any comma or semicolon.
  */
 class ProductIdentifierValidationIntegration extends TestCase
 {
@@ -30,26 +28,6 @@ class ProductIdentifierValidationIntegration extends TestCase
         $this->assertCount(1, $violations);
         $this->assertSame($violations->get(0)->getMessage(), 'The same identifier is already set on another product');
         $this->assertSame($violations->get(0)->getPropertyPath(), 'identifier');
-    }
-
-    public function testForbiddenIdentifierCharactersValidation()
-    {
-        $product1 = $this->createProduct('a,product,with,comma');
-        $product2 = $this->createProduct('a;product;with;semi-column');
-
-        $product1Violations = $this->validateProduct($product1);
-        $product2Violations = $this->validateProduct($product2);
-
-        $this->assertCount(1, $product1Violations);
-        $this->assertCount(1, $product2Violations);
-        $this->assertSame(
-            $product1Violations->get(0)->getMessage(),
-            'This field should not contain any comma or semicolon.'
-        );
-        $this->assertSame(
-            $product1Violations->get(0)->getMessage(),
-            'This field should not contain any comma or semicolon.'
-        );
     }
 
     public function testMaxCharactersValidation()

--- a/tests/features/pim/enrichment/product/value/product_identifier.feature
+++ b/tests/features/pim/enrichment/product/value/product_identifier.feature
@@ -1,10 +1,33 @@
+@acceptance-back
 Feature: Validate identifier attribute of a product
   In order to keep my data consistent
   As a regular user
   I need to be able to see validation errors for identifier attribute
 
-  @acceptance-back
+  Background:
+    Given a catalog with the attribute "sku" as product identifier
+
   Scenario: Validate the unique constraint of identifier attribute
     Given a product with an identifier "foo"
     When another product is created with identifier "foo"
     Then the error "The same identifier is already set on another product" is raised
+
+  Scenario: Fail to create a product with an identifier that contains a comma
+    When a product is created with identifier "foo,bar"
+    Then the error "This field should not contain any comma or semicolon or surrounding space." is raised
+
+  Scenario: Fail to create a product with an identifier that contains a semicolon
+    When a product is created with identifier "foo;bar"
+    Then the error "This field should not contain any comma or semicolon or surrounding space." is raised
+
+  Scenario: Fail to create a product with an identifier that ends with a space
+    When a product is created with identifier "foo "
+    Then the error "This field should not contain any comma or semicolon or surrounding space." is raised
+
+  Scenario: Fail to create a product with an identifier that starts with a space
+    When a product is created with identifier " foo"
+    Then the error "This field should not contain any comma or semicolon or surrounding space." is raised
+
+  Scenario: Fail to create a product with an identifier surrounded by spaces
+    When a product is created with identifier " foo "
+    Then the error "This field should not contain any comma or semicolon or surrounding space." is raised

--- a/tests/legacy/features/Context/WebUser.php
+++ b/tests/legacy/features/Context/WebUser.php
@@ -2676,6 +2676,7 @@ class WebUser extends PimContext
             case 'attribute creation.description':
                 return $this->lorem(256);
             case 'product edit.sku':
+                return str_repeat('foobar_', 50);
             case 'product edit.description':
                 return str_repeat('foobar ', 50);
             case 'product edit.longtext':

--- a/tests/legacy/features/pim/enrichment/product/create_product.feature
+++ b/tests/legacy/features/pim/enrichment/product/create_product.feature
@@ -32,26 +32,3 @@ Feature: Product creation
     Then I should be on the product "caterpillar_1" edit page
     And I should see the text "caterpillar_1"
     And I should see the text "Family sandals"
-
-  Scenario: Fail to create a product with an already used code
-    Given I create a product
-    And I fill in the following information in the popin:
-      | SKU | sandals |
-    And I press the "Save" button in the popin
-    Then I should see validation error "The same identifier is already set on another product"
-
-  @jira https://akeneo.atlassian.net/browse/PIM-4706
-  Scenario: Fail to create a product with a comma in the identifier
-    Given I create a product
-    And I fill in the following information in the popin:
-      | SKU | to,to |
-    And I press the "Save" button in the popin
-    Then I should see validation error "This field should not contain any comma or semicolon."
-
-  @jira https://akeneo.atlassian.net/browse/PIM-4706
-  Scenario: Fail to create a product with a semicolon in the identifier
-    Given I create a product
-    And I fill in the following information in the popin:
-      | SKU | to;to |
-    And I press the "Save" button in the popin
-    Then I should see validation error "This field should not contain any comma or semicolon."


### PR DESCRIPTION
All the characters except comma “,“ and semicolon “;“ are accepted for the product identifiers. If there is a space at the beginning or end of an identifier, it will be saved with it in the database.

The problem, in this case, is that the trailing spaces are ignored when we search a product by its identifier. It’s due to MySQL where all CHAR, VARCHAR, and TEXT values are compared without regard to any trailing spaces (it's according to the collation, and all the collations in MySQL 5.x have this behavior).

For instance, with an existing product with the identifier "foo". If a product is imported with the identifier " foo", a new product will be created, but with an identifier "foo ", the product "foo" will be updated. If there's a space at the beginning, the product repository doesn't find the existing product. But if there's a trailing space, the product repository finds the existing product.

As discussed with the PMs, the chosen solution is to change the validation of the product identifier (and the product model code) to forbid spaces at the beginning and at the end. The existing products having this problem can no longer be updated without fixing their identifiers. We chose to not fix that ourselves by a database migration script, to let the clients decide what to do with these identifiers (especially if there is duplication)