### PR TITLE
TIP-1262: make services public for test env

### DIFF
--- a/tests/back/Integration/IntegrationTestsBundle/AkeneoIntegrationTestsBundle.php
+++ b/tests/back/Integration/IntegrationTestsBundle/AkeneoIntegrationTestsBundle.php
@@ -2,6 +2,9 @@
 
 namespace Akeneo\Test\IntegrationTestsBundle;
 
+use Akeneo\Test\IntegrationTestsBundle\DependencyInjection\MakeServicesPublicForTestEnv;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -13,4 +16,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class AkeneoIntegrationTestsBundle extends Bundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new MakeServicesPublicForTestEnv(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
+    }
 }

--- a/tests/back/Integration/IntegrationTestsBundle/DependencyInjection/MakeServicesPublicForTestEnv.php
+++ b/tests/back/Integration/IntegrationTestsBundle/DependencyInjection/MakeServicesPublicForTestEnv.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Akeneo\Test\IntegrationTestsBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Make all services public for test environment.
+ * Dirty trick made to upgrade to Symfony 4 :(
+ * See https://github.com/akeneo/pim-community-dev/pull/10773.
+ *
+ * @author    Julien Janvier <j.janvier@gmail.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MakeServicesPublicForTestEnv implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (0 === strpos($id, 'pim') || 0 === strpos($id, 'akeneo') || 0 === strpos($id, 'oro')) {
+                $definition->setPublic(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR simply put the compiler pass responsible to make the services public for in test env in Community Edition.

See https://github.com/akeneo/pim-community-dev/pull/10773