### PR TITLE
PIM-8925: fix PDF export when there is no option for a given locale for a select attribute

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-8925: Fix PDF export when there is no option for a given locale for a select attribute
+
 # 3.2.16 (2019-10-24)
 
 ## Bug fixes:

--- a/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
@@ -4,6 +4,8 @@ namespace Akeneo\Pim\Enrichment\Bundle\PdfGeneration\Renderer;
 
 use Akeneo\Pim\Enrichment\Bundle\PdfGeneration\Builder\PdfBuilderInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionsValue;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
 use Akeneo\Pim\Structure\Bundle\Doctrine\ORM\Repository\AttributeRepository;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
@@ -206,22 +208,28 @@ class ProductPdfRenderer implements RendererInterface
             $scope = $attribute->isScopable() ? $scopeCode : null;
 
             if (null !== $attribute && AttributeTypes::OPTION_SIMPLE_SELECT === $attribute->getType()) {
-                $optionCode = $product->getValue($attributeCode, $locale, $scope)->getData();
-                $option = $this->attributeOptionRepository->findOneByIdentifier($attributeCode.'.'.$optionCode);
-                $option->setLocale($localeCode);
-                $translation = $option->getTranslation();
-                $options[$attributeCode] = null !== $translation->getValue() ? $translation->getValue() : sprintf('[%s]', $option->getCode());
-            }
-            if (null !== $attribute && AttributeTypes::OPTION_MULTI_SELECT === $attribute->getType()) {
-                $optionCodes = $product->getValue($attributeCode, $locale, $scope)->getData();
-                $labels = [];
-                foreach ($optionCodes as $optionCode) {
-                    $option = $this->attributeOptionRepository->findOneByIdentifier($attributeCode.'.'.$optionCode);
+                $optionValue = $product->getValue($attributeCode, $locale, $scope);
+                if ($optionValue instanceof OptionValue) {
+                    $optionCode = $optionValue->getData();
+                    $option = $this->attributeOptionRepository->findOneByIdentifier($attributeCode . '.' . $optionCode);
                     $option->setLocale($localeCode);
                     $translation = $option->getTranslation();
-                    $labels[] = null !== $translation->getValue() ? $translation->getValue() : sprintf('[%s]', $option->getCode());
+                    $options[$attributeCode] = null !== $translation->getValue() ? $translation->getValue() : sprintf('[%s]', $option->getCode());
                 }
-                $options[$attributeCode] = implode(', ', $labels);
+            }
+            if (null !== $attribute && AttributeTypes::OPTION_MULTI_SELECT === $attribute->getType()) {
+                $optionValue = $product->getValue($attributeCode, $locale, $scope);
+                if ($optionValue instanceof OptionsValue) {
+                    $optionCodes = $optionValue->getData();
+                    $labels = [];
+                    foreach ($optionCodes as $optionCode) {
+                        $option = $this->attributeOptionRepository->findOneByIdentifier($attributeCode.'.'.$optionCode);
+                        $option->setLocale($localeCode);
+                        $translation = $option->getTranslation();
+                        $labels[] = null !== $translation->getValue() ? $translation->getValue() : sprintf('[%s]', $option->getCode());
+                    }
+                    $options[$attributeCode] = implode(', ', $labels);
+                }
             }
         }
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/PdfGeneration/Renderer/ProductPdfRendererSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/PdfGeneration/Renderer/ProductPdfRendererSpec.php
@@ -220,4 +220,54 @@ class ProductPdfRendererSpec extends ObjectBehavior
             ['locale' => 'en_US', 'scope' => 'ecommerce', 'renderingDate' => $renderingDate]
         );
     }
+
+    function it_renders_a_simple_select_without_any_option_for_a_given_locale(
+        EngineInterface $templating,
+        IdentifiableObjectRepositoryInterface $attributeRepository,
+        IdentifiableObjectRepositoryInterface $attributeOptionRepository
+    ) {
+        $colors = new Attribute();
+        $colors->setCode('colors');
+        $colors->setType(AttributeTypes::OPTION_SIMPLE_SELECT);
+        $colors->setLocale('en_US');
+        $colors->setLabel('Colors');
+        $group = new AttributeGroup();
+        $group->setLocale('en_US');
+        $group->setLabel('Marketing');
+        $colors->setGroup($group);
+        $colors->setLocalizable(true);
+        $colors->setScopable(true);
+        $attributeRepository->findOneByIdentifier('colors')->willReturn($colors);
+
+        $product = new Product();
+        $product->setValues(
+            new WriteValueCollection(
+                [
+                    OptionsValue::scopableLocalizableValue('colors', [], 'ecommerce', 'fr_FR'),
+                ]
+            )
+        );
+
+        $renderingDate = new \DateTime();
+        $templating->render(
+            self::TEMPLATE_NAME,
+            [
+                'product' => $product,
+                'locale' => 'en_US',
+                'scope' => 'ecommerce',
+                'groupedAttributes' => ['Marketing' => ['colors' => $colors]],
+                'imagePaths' => [],
+                'customFont' => null,
+                'optionLabels' => [],
+                'filter' => 'pdf_thumbnail',
+                'renderingDate' => $renderingDate,
+            ]
+        )->shouldBeCalled();
+
+        $this->render(
+            $product,
+            'pdf',
+            ['locale' => 'en_US', 'scope' => 'ecommerce', 'renderingDate' => $renderingDate]
+        );
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
A sanity check was missing on the option value before accessing its data : in some case, a simple or a multi select won't have any option for one or multiple locales.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
