### PR TITLE
PIM-8924: fix permission on attribute group sorting

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8924: Fix permission of sorting attribute groups
+
 # 3.0.50 (2019-10-28)
 
 # 3.0.49 (2019-10-24)

--- a/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeGroupController.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeGroupController.php
@@ -319,6 +319,8 @@ class AttributeGroupController
      *
      * @param  Request $request
      *
+     * @AclAncestor("pim_enrich_attributegroup_sort")
+     *
      * @return Response
      */
     public function sortAction(Request $request)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/list.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/list.js
@@ -59,29 +59,33 @@ define([
              * {@inheritdoc}
              */
             render: function () {
+                const canSortAttributeGroup = securityContext.isGranted('pim_enrich_attributegroup_sort');
                 this.$el.html(this.template({
                     attributeGroups: _.sortBy(_.values(this.attributeGroups), function (attributeGroup) {
                         return attributeGroup.sort_order;
                     }),
                     i18n: i18n,
-                    uiLocale: UserContext.get('catalogLocale')
+                    uiLocale: UserContext.get('catalogLocale'),
+                    canSortAttributeGroup
                 }));
 
-                this.$('tbody').sortable({
-                    handle: '.handle',
-                    containment: 'parent',
-                    tolerance: 'pointer',
-                    update: this.updateAttributeOrders.bind(this),
-                    helper: function (e, tr) {
-                        var $originals = tr.children();
-                        var $helper = tr.clone();
-                        $helper.children().each(function (index) {
-                            $(this).width($originals.eq(index).width());
-                        });
+                if (canSortAttributeGroup) {
+                    this.$('tbody').sortable({
+                        handle: '.handle',
+                        containment: 'parent',
+                        tolerance: 'pointer',
+                        update: this.updateAttributeOrders.bind(this),
+                        helper: function (e, tr) {
+                            var $originals = tr.children();
+                            var $helper = tr.clone();
+                            $helper.children().each(function (index) {
+                                $(this).width($originals.eq(index).width());
+                            });
 
-                        return $helper;
-                    }
-                });
+                            return $helper;
+                        }
+                    });
+                }
 
                 this.renderExtensions();
             },

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-group/list.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-group/list.html
@@ -2,11 +2,13 @@
     <table class="AknGrid AknGrid--unclickable groups">
         <% _.each(attributeGroups, function (attributeGroup) { %>
         <tr class="AknGrid-bodyRow attribute-group" data-attribute-group-code="<%- attributeGroup.code %>">
+            <% if (canSortAttributeGroup) { %>
             <td class="AknGrid-bodyCell AknGrid-bodyCell--tight">
                 <span class="handle">
                     <i class="icon-reorder"></i>
                 </span>
             </td>
+            <% } %>
             <td class="AknGrid-bodyCell attribute-group-link" data-attribute-group-code="<%- attributeGroup.code %>"><%- i18n.getLabel(attributeGroup.labels, uiLocale, attributeGroup.code) %></td>
         </tr>
         <% }); %>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix permission on attribute group sorting. Sort was always allowed even if the permission was uncheck.  
Backport of https://github.com/akeneo/pim-community-dev/pull/10277

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
