### PR TITLE
TIP-1327: Introduce new targets to run our tests (locally and on the CI)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,8 @@ jobs:
               sudo chown -R 1000:1000 ~/.composer
               sudo chown -R 1000:1000 ~/.cache/yarn
       - run:
-            name: Install back dependencies
-            command: make vendor
-      - run:
-            name: Install front dependencies
-            command: make node_modules
+            name: Install back and front dependencies
+            command: make dependencies
       - run:
             name: Check PIM requirements
             command: |
@@ -85,35 +82,23 @@ jobs:
                 name: Load archived docker image
                 command: docker load -i php-pim-image.tar
           - run:
-                name: Generate dev cache for Symfony's Phpstan extension
-                command: APP_ENV=dev make cache
-          - run:
-                name: PhpSpec
-                command: docker-compose run -u www-data --rm -T php vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
-          - run:
-                name: Find non executed PhpSpec files
-                command: ./.circleci/find_non_executed_phpspec.sh
-          - run:
-                name: PhpCsFixer
-                command: docker-compose run --rm -T php vendor/bin/php-cs-fixer fix --diff --dry-run --config=.php_cs.php
+                name: Check Pullup
+                command: make check-pullup
                 when: always
           - run:
-                name: PhpCoupling Detector
+                name: Analyzes source code to flag programming errors, bugs, stylistic errors, and suspicious constructs
+                command: make lint-back
+          - run:
+                name: Code Coupling Detection
                 command: make coupling
                 when: always
           - run:
-                name: PHPStan
-                command: docker-compose run --rm -T php vendor/bin/phpstan analyse src/Akeneo/Pim -l 1
-                when: always
+                name: Unit tests
+                command: make unit-back
           - run:
-                name: Check Pullup
-                command: docker-compose run --rm -T php bin/check-pullup
-                when: always
-          - run:
-                name: Acceptance back
-                command: |
-                    docker-compose run -u www-data --rm -T php vendor/bin/behat --strict -p acceptance -vv
-                    docker-compose run -u www-data --rm php php vendor/bin/behat --strict --config src/Akeneo/Apps/back/tests/Acceptance/behat.yml
+                name: Acceptance tests
+                command: make acceptance-back + docker-compose run -u www-data --rm php php vendor/bin/behat --strict --config src/Akeneo/Apps/back/tests/Acceptance/behat.yml
+
                 when: always
           - store_test_results:
                 path: var/tests
@@ -220,27 +205,17 @@ jobs:
         - attach_workspace:
             at: ~/
         - run:
-            name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
-            command: sudo chown -R 1000:1000 ../project
+              name: Front linter
+              command: make lint-front + make apps-front-lint
         - run:
-            name: Front linter
-            command: |
-                docker-compose run --rm node yarn run lint
-                make apps-front-lint
+              name: Front unit tests
+              command: make unit-front + make apps-front-tests
         - run:
-            name: Front unit tests
-            command: |
-                docker-compose run --rm node yarn run unit
-                make apps-front-tests
-            when: always
+              name: Front acceptance tests
+              command: make acceptance-front
         - run:
-            name: Front acceptance tests
-            command: MAX_RANDOM_LATENCY_MS=100 docker-compose run --rm node yarn run acceptance ./tests/features
-            when: always
-        - run:
-            name: Front integration tests
-            command: docker-compose run --rm node yarn run integration
-            when: always
+              name: Front integration tests
+              command: make integration-front
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,11 +90,11 @@ jobs:
                 command: make lint-back
           - run:
                 name: Code Coupling Detection
-                command: make coupling
+                command: make coupling-back
                 when: always
           - run:
                 name: Unit tests
-                command: make unit-back
+                command: make unit-back CI=1
           - run:
                 name: Acceptance tests
                 command: make acceptance-back + docker-compose run -u www-data --rm php php vendor/bin/behat --strict --config src/Akeneo/Apps/back/tests/Acceptance/behat.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
                 command: make unit-back CI=1
           - run:
                 name: Acceptance tests
-                command: make acceptance-back + docker-compose run -u www-data --rm php php vendor/bin/behat --strict --config src/Akeneo/Apps/back/tests/Acceptance/behat.yml
+                command: make acceptance-back
 
                 when: always
           - store_test_results:
@@ -206,10 +206,10 @@ jobs:
             at: ~/
         - run:
               name: Front linter
-              command: make lint-front + make apps-front-lint
+              command: make lint-front
         - run:
               name: Front unit tests
-              command: make unit-front + make apps-front-tests
+              command: make unit-front
         - run:
               name: Front acceptance tests
               command: make acceptance-front

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,12 @@ jobs:
         - attach_workspace:
             at: ~/
         - run:
+            name: Create yarn cache folder
+            command: mkdir -p  ~/.cache/yarn
+        - run:
+              name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+              command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
+        - run:
               name: Front linter
               command: make lint-front
         - run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       YARN_CACHE_FOLDER: '~/.yarn'
     volumes:
       - './:/srv/pim'
-      - '${HOST_YARN_CACHE_FOLDER:-~/.cache/yarn}:~/.yarn'
+      - '${HOST_YARN_CACHE_FOLDER:-~/.cache/yarn}:/home/node/.yarn'
     working_dir: '/srv/pim'
     networks:
       - 'pim'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
   node:
     image: 'akeneo/node:10'
     environment:
-      YARN_CACHE_FOLDER: '~/.yarn'
+      YARN_CACHE_FOLDER: '/home/node/.yarn'
     volumes:
       - './:/srv/pim'
       - '${HOST_YARN_CACHE_FOLDER:-~/.cache/yarn}:/home/node/.yarn'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,10 +40,10 @@ services:
   node:
     image: 'akeneo/node:10'
     environment:
-      YARN_CACHE_FOLDER: '/var/www/.yarn'
+      YARN_CACHE_FOLDER: '~/.yarn'
     volumes:
       - './:/srv/pim'
-      - '${HOST_YARN_CACHE_FOLDER:-~/.cache/yarn}:/var/www/.yarn'
+      - '${HOST_YARN_CACHE_FOLDER:-~/.cache/yarn}:~/.yarn'
     working_dir: '/srv/pim'
     networks:
       - 'pim'

--- a/make-file/apps.mk
+++ b/make-file/apps.mk
@@ -2,14 +2,13 @@ _APPS_YARN_RUN = $(YARN_EXEC) run --cwd=src/Akeneo/Apps/front/
 
 # Tests Back
 
-apps-back-coupling:
+apps-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Apps/back/tests/.php_cd.php src/Akeneo/Apps/back
 
-apps-back-phpspec:
+apps-unit-back:
 	$(PHP_RUN) vendor/bin/phpspec run src/Akeneo/Apps/back/tests/Unit/spec/
 
-apps-back-acceptance:
-	docker-compose stop
+apps-acceptance-back:
 	$(PHP_RUN) vendor/bin/behat --strict --config src/Akeneo/Apps/back/tests/Acceptance/behat.yml
 
 apps-back-integration:

--- a/make-file/apps.mk
+++ b/make-file/apps.mk
@@ -8,8 +8,8 @@ apps-coupling-back:
 apps-unit-back:
 	$(PHP_RUN) vendor/bin/phpspec run src/Akeneo/Apps/back/tests/Unit/spec/
 
-apps-acceptance-back:
-	$(PHP_RUN) vendor/bin/behat --strict --config src/Akeneo/Apps/back/tests/Acceptance/behat.yml
+apps-acceptance-back: var/tests/behat/apps
+	$(PHP_RUN) vendor/bin/behat --config src/Akeneo/Apps/back/tests/Acceptance/behat.yml --format pim --out var/tests/behat/apps --format progress --out std --colors
 
 apps-back-integration:
 	$(PHP_RUN) vendor/bin/phpunit -c phpunit.xml.dist --testsuite=Akeneo_Apps_Integration

--- a/make-file/channel.mk
+++ b/make-file/channel.mk
@@ -2,6 +2,6 @@
 ## Target used run command related on Channel Bounded context
 ##
 
-.PHONY: channel-coupling
-channel-coupling:
+.PHONY: channel-coupling-back
+channel-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Channel/.php_cd.php src/Akeneo/Channel

--- a/make-file/dev.mk
+++ b/make-file/dev.mk
@@ -2,13 +2,12 @@
 ## Run tests suite
 ##
 
-.PHONY: coupling
-coupling: structure-coupling user-management-coupling channel-coupling enrichment-coupling apps-back-coupling
-
+# @deprecated please use the target unit-back or add target for your bounded context
 .PHONY: phpspec
 phpspec:
 	${PHP_RUN} vendor/bin/phpspec run ${F}
 
+# @deprecated please use the target acceptance-back or add target for your bounded context
 .PHONY: acceptance
 acceptance:
 	${PHP_RUN} vendor/bin/behat -p acceptance ${F}

--- a/make-file/enrichment.mk
+++ b/make-file/enrichment.mk
@@ -2,6 +2,6 @@
 ## Target used run command related on Enrichment Bounded context
 ##
 
-.PHONY: enrichment-coupling
-enrichment-coupling:
+.PHONY: enrichment-coupling-back
+enrichment-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Pim/Enrichment/.php_cd.php src/Akeneo/Pim/Enrichment

--- a/make-file/structure.mk
+++ b/make-file/structure.mk
@@ -2,6 +2,6 @@
 ## Target used run command related on Structure Bounded context
 ##
 
-.PHONY: structure-coupling
-structure-coupling:
+.PHONY: structure-coupling-back
+structure-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Pim/Structure/.php_cd.php src/Akeneo/Pim/Structure

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -1,0 +1,41 @@
+.PHONY: coupling
+coupling: structure-coupling user-management-coupling channel-coupling enrichment-coupling
+
+.PHONY: check-pullup
+check-pullup:
+	${PHP_RUN} bin/check-pullup
+
+### Lint tests
+.PHONY: lint-back
+lint-back: var/cache/dev
+	${PHP_RUN} vendor/bin/phpstan analyse src/Akeneo/Pim -l 1
+	${PHP_RUN} vendor/bin/php-cs-fixer fix --diff --dry-run --config=.php_cs.php
+
+.PHONY: lint-front
+lint-front:
+	$(YARN_RUN) lint
+
+### Unit tests
+.PHONY: unit-back
+unit-back:
+	${PHP_RUN} vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
+	./.circleci/find_non_executed_phpspec.sh
+
+.PHONY: unit-front
+unit-front:
+	$(YARN_RUN) unit
+
+### Acceptance tests
+.PHONY: acceptance-back
+acceptance-back:
+	${PHP_RUN} vendor/bin/behat --strict -p acceptance -vv
+
+.PHONY: acceptance-front
+acceptance-front:
+	MAX_RANDOM_LATENCY_MS=100 $(YARN_RUN) acceptance run acceptance ./tests/features
+
+### Integration tests
+.PHONY: integration-front
+integration-front:
+	$(YARN_RUN) integration
+

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -1,5 +1,5 @@
 var/tests/%:
-	mkdir -p $@
+	$(DOCKER_COMPOSE) run -u www-data --rm php mkdir -p $@
 
 .PHONY: coupling-back
 coupling-back: structure-coupling-back user-management-coupling-back channel-coupling-back enrichment-coupling-back apps-coupling-back
@@ -32,7 +32,7 @@ unit-front:
 ### Acceptance tests
 .PHONY: acceptance-back
 acceptance-back: apps-acceptance-back
-	${PHP_RUN} vendor/bin/behat -p acceptance --format pim --out var/tests/behat --format pretty --out std --colors
+	${PHP_RUN} vendor/bin/behat -p acceptance --format pim --out var/tests/behat --format progress --out std --colors
 
 .PHONY: acceptance-front
 acceptance-front:

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -2,7 +2,7 @@ var/tests/%:
 	mkdir -p $@
 
 .PHONY: coupling-back
-coupling-back: structure-coupling-back user-management-coupling-back channel-coupling-back enrichment-coupling-back
+coupling-back: structure-coupling-back user-management-coupling-back channel-coupling-back enrichment-coupling-back apps-coupling-back
 
 .PHONY: check-pullup
 check-pullup:
@@ -20,7 +20,7 @@ lint-front:
 
 ### Unit tests
 .PHONY: unit-back
-unit-back:
+unit-back: apps-unit-back
 	$(call configure_ci_options, --format=junit > var/tests/phpspec/specs.xml)
 	${PHP_RUN} vendor/bin/phpspec run $(O)
 	$(call execute_on_ci_only, .circleci/find_non_executed_phpspec.sh)
@@ -31,7 +31,7 @@ unit-front:
 
 ### Acceptance tests
 .PHONY: acceptance-back
-acceptance-back:
+acceptance-back: apps-acceptance-back
 	${PHP_RUN} vendor/bin/behat -p acceptance --format pim --out var/tests/behat --format pretty --out std --colors
 
 .PHONY: acceptance-front

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -21,9 +21,12 @@ lint-front:
 ### Unit tests
 .PHONY: unit-back
 unit-back: apps-unit-back
-	$(call configure_ci_options, --format=junit > var/tests/phpspec/specs.xml)
+ifeq ($(CI),1)
+	${PHP_RUN} vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
+	.circleci/find_non_executed_phpspec.sh
+else
 	${PHP_RUN} vendor/bin/phpspec run $(O)
-	$(call execute_on_ci_only, .circleci/find_non_executed_phpspec.sh)
+endif
 
 .PHONY: unit-front
 unit-front:
@@ -42,36 +45,3 @@ acceptance-front:
 .PHONY: integration-front
 integration-front:
 	$(YARN_RUN) integration
-
-# This function will set the var "O" with the given argument if the var CI is set to "1".
-# You need to use this function to configure your targets to run them on the CI:
-# $(call configure_ci_options, XXX) where XXX is the target options.
-#
-# Example: $(call configure_ci_options, --format=junit > spec.xml)
-#
-# How to run tests? Let's take an example: run asset manager unit tests.
-#
-# Locally, I want the default formatter, I use the following command:
-# make asset-manager-unit-back
-#
-# On the CI, I want to generate a JUnit file, I use the following command:
-# make asset-manager-unit-back CI=1
-#
-# CAUTION:
-#  - use this function if your test tools do not support mutiple output format
-#  - the command in your target must use the var O
-#
-# unit-back:
-#	$(PHP_RUN) vendor/bin/phpspec run $(O)
-
-define configure_ci_options
-    $(if $(filter $(CI),1),$(eval O=$(1)))
-endef
-
-# This function execution a command if the var CI is set to "1".
-#
-# Example: $(call execute_on_ci_only, my/script.sh) where my/script.sh is the script you want to run only in the CI.
-
-define execute_on_ci_only
-    $(if $(filter $(CI),1), $(1))
-endef

--- a/make-file/user-management.mk
+++ b/make-file/user-management.mk
@@ -2,6 +2,6 @@
 ## Target used run command related on User management Bounded context
 ##
 
-.PHONY: user-management-coupling
-user-management-coupling:
+.PHONY: user-management-coupling-back
+user-management-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/UserManagement/.php_cd.php src/Akeneo/UserManagement

--- a/src/Akeneo/Apps/back/tests/Acceptance/behat.yml
+++ b/src/Akeneo/Apps/back/tests/Acceptance/behat.yml
@@ -1,5 +1,6 @@
 default:
     extensions:
+        Pim\Behat\Extension\PimFormatter\PimFormatterExtension: ~
         Behat\Symfony2Extension:
             kernel:
                 bootstrap: 'config/bootstrap.php'


### PR DESCRIPTION
### Description

This PR introduces some new targets to run our tests, they are located in `make-file/test.mk`. At the end the purpose of this PR and the next ones is to be able to run tests the same way on the CI and locally. We won't rework the targets phpunit and behat-legacy in this PR. We want to keep it as simpler as possible for now.

For your information this new file contains the following targets:

   * coupling: checks if the bounded context are well "de-coupled" (moved from `make-file/dev.mk`)
   * check-pullup: checks is there are not mistake during the pull up
   * lint-back and lint-front analyzes source code to flag programming errors, bugs, stylistic errors, and suspicious constructs. [Why this name?](https://en.wikipedia.org/wiki/Lint_(software))
   * unit-back and unit-front: run all unit tests (back and front)
   * acceptance-back and acceptance-front run all acceptance tests (back and front)
   * integration-front: run front integration tests

Those targets will be used on the CI to run tests but you can use them locally (you might need to run unit tests, for instance).

### How should we build those targets?

`make-file/test.mk` contains the main target (which run all tests) and there are one other file per bounded context (`asset-manager.mk`, `franklin-insights.mk`, etc).

Let's take an example: `coupling-back`.
Each team needs to build its own target named `XXX-coupling-back` where XXX is the name of the bounded context.

For instance, asset manager:
```
.PHONY: asset-manager-coupling-back
asset-manager-coupling-back:
	$(PHP_RUN) vendor/bin/php-coupling-detector detect "command option"
```
Then the target coupling-back will depend on all bounded context coupling targets.
```
.PHONY: coupling
coupling: reference-entity-coupling asset-manager-coupling franklin-insights-coupling #etc.
```
### How should we use those targets?

For instance, I am a member of the raccoon team and I am working on the asset manager bounded context. I am designing domain objects so I only want to run my unit tests. So I will define a target if it does not already exit in the make file `make-file/asset-manage.mk` named asset-manager-unit-back which will run my specs. Then I just need to use make asset-manager-unit-back to run the pecs of my bounded context. If my bounded context is well decoupled I don't need to run unit tests from other bounded contexts.

### What is the perfect world?

For the next days we will introduce the rest of the missing targets in the `make-file/test.mk` and then we/you will create the missing targets in the file bounded context make files.

### Are our tools perfect?

No, for instance PHPSpec does not manage multiple output formats like Behat does. To be able to enable junit format only on the CircleCi an new environment variable named CI have been added. Its default value is 0.

This var will allow to configure our test tools on the CI. To ease the creation of the Makefile targets functions have been created. Please, have a look to https://github.com/akeneo/pim-enterprise-dev/pull/7155/files#diff-2f76e25665bd6978e8952ff248835785R43

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
