### PR TITLE
PIM-8927: fix translation on product model creation page

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8924: Fix permission of sorting attribute groups
+- PIM-8927: fix label translation on product model creation page
 
 # 3.0.50 (2019-10-28)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product-model/form/add-child/fields-container.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product-model/form/add-child/fields-container.js
@@ -177,7 +177,7 @@ define(
                         newFormMeta.config.fieldName = `values.${attribute.code}`;
                         newFormMeta.config.label = i18n.getLabel(
                             attribute.labels,
-                            UserContext.get('uiLocale'),
+                            UserContext.get('catalogLocale'),
                             attribute.code
                         );
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Use catalog locale instead of UI locale. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
