### PR TITLE
PIM-7027: fix completeness visibility on PEF

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7027: fix completeness visibility on product edit form
+
 # 2.3.69 (2019-10-24)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-completeness.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/product-completeness.js
@@ -88,10 +88,10 @@ define(
                         currentLocale: options.locale,
                         missingValues: 'pim_enrich.form.product.panel.completeness.missing_values',
                         i18n: i18n
-                    }));
+                    })).show();
                 } else {
-                    // We drop the element for design issues, to avoid blank spaces.
-                    this.$el.remove();
+                    // We hide the element for design issues, to avoid blank spaces.
+                    this.$el.hide();
                 }
 
                 return this;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When we change locale on PEF and the ratio can not be calculated on this locale, completeness widget element was removed. So it can be display again when we change back to a locale with ratio. The element was removed to fix design issues. Here the solution is to hide it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
