### PR TITLE
PIM-8879: Case insensitive validation of attribute option codes 

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/AttributeOptionsExistValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/AttributeOptionsExistValidator.php
@@ -52,10 +52,13 @@ class AttributeOptionsExistValidator extends ConstraintValidator
         }
 
         $existingOptionCodes = $this->getExistingOptionCodesIndexedByAttributeCodes($optionValues);
+        array_walk_recursive($existingOptionCodes, function (string &$value) {
+            $value = strtolower($value);
+        });
 
         foreach ($optionValues as $key => $value) {
             if ($value instanceof OptionValueInterface) {
-                if (!in_array($value->getData(), ($existingOptionCodes[$value->getAttributeCode()] ?? []))) {
+                if (!in_array(strtolower($value->getData()), ($existingOptionCodes[$value->getAttributeCode()] ?? []))) {
                     $this->context->buildViolation(
                         $constraint->message,
                         [
@@ -65,7 +68,7 @@ class AttributeOptionsExistValidator extends ConstraintValidator
                     )->atPath(sprintf('[%s]', $key))->addViolation();
                 }
             } elseif ($value instanceof OptionsValueInterface) {
-                $notExistingOptionCodes = array_diff($value->getData(), ($existingOptionCodes[$value->getAttributeCode()] ?? []));
+                $notExistingOptionCodes = array_diff(array_map('strtolower', $value->getData()), ($existingOptionCodes[$value->getAttributeCode()] ?? []));
                 if (!empty($notExistingOptionCodes)) {
                     $this->context->buildViolation(
                         $constraint->messagePlural,

--- a/tests/back/Acceptance/AttributeOption/InMemoryAttributeOptionRepository.php
+++ b/tests/back/Acceptance/AttributeOption/InMemoryAttributeOptionRepository.php
@@ -47,8 +47,8 @@ class InMemoryAttributeOptionRepository implements AttributeOptionRepositoryInte
         [$attributeCode, $attributeOptionCode] = \explode('.', $identifier);
 
         foreach ($this->attributeOptions as $attributeOption) {
-            if ($attributeOption->getCode() === $attributeOptionCode
-                && $attributeOption->getAttribute()->getCode() === $attributeCode) {
+            if (strtolower($attributeOption->getCode()) === strtolower($attributeOptionCode)
+                && strtolower($attributeOption->getAttribute()->getCode()) === strtolower($attributeCode)) {
                 return $attributeOption;
             }
         }

--- a/tests/back/Acceptance/spec/AttributeOption/InMemoryAttributeOptionRepositorySpec.php
+++ b/tests/back/Acceptance/spec/AttributeOption/InMemoryAttributeOptionRepositorySpec.php
@@ -47,6 +47,7 @@ class InMemoryAttributeOptionRepositorySpec extends ObjectBehavior
         );
 
         $this->findOneByIdentifier('hair_color.brown')->shouldReturn($brownHairColor);
+        $this->findOneByIdentifier('Eye_Color.Brown')->shouldReturn($brownEyeColor);
     }
 
     function it_does_not_find_an_attribute_option_by_identifier()

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/AttributeOptionsExistValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/AttributeOptionsExistValidatorSpec.php
@@ -164,6 +164,35 @@ class AttributeOptionsExistValidatorSpec extends ObjectBehavior
         $this->validate($values, $constraint);
     }
 
+    function it_does_not_take_case_into_account_when_comparing_options(
+        GetExistingAttributeOptionCodes $getExistingAttributeOptionCodes,
+        ExecutionContextInterface $context
+    ) {
+        $getExistingAttributeOptionCodes->fromOptionCodesByAttributeCode(
+            [
+                'color' => ['RED', 'Green'],
+                'fabrics' => ['cotton', 'WOOL', 'leATheR'],
+            ]
+        )->willReturn(
+            [
+                'color' => ['red', 'green'],
+                'fabrics' => ['Cotton', 'Wool', 'Leather'],
+            ]
+        );
+        $context->buildViolation(Argument::any(), Argument::any())->shouldNotBeCalled();
+
+        $this->validate(
+            new WriteValueCollection(
+                [
+                    OptionValue::localizableValue('color', 'RED', 'en_US'),
+                    OptionValue::localizableValue('color', 'Green', 'fr_FR'),
+                    OptionsValue::value('fabrics',['cotton', 'WOOL', 'leATheR']),
+                ]
+            ),
+            new AttributeOptionsExist()
+        );
+    }
+
     // @todo @merge master/4.0: remove this test
     function it_does_not_build_violations_for_empty_values(
         GetExistingAttributeOptionCodes $getExistingAttributeOptionCodes,

--- a/tests/features/pim/enrichment/product/validation/option_values.feature
+++ b/tests/features/pim/enrichment/product/validation/option_values.feature
@@ -37,6 +37,14 @@ Feature: Validate simple and multi-select attributes of a product
     Then no error is raised
 
   @acceptance-back
+  Scenario: Providing existing options with the wrong case should not raise an error
+    When a product is created with values:
+      | attribute   | data                    | scope | locale |
+      | color       | Red                     |       |        |
+      | collections | Spring_2019,SUMMER_2019 |       |        |
+    Then no error is raised
+
+  @acceptance-back
   Scenario: Providing non-existing simple select options should raise an error
     When a product is created with values:
       | attribute   | data                                          | scope | locale |


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Fixes a regression introduced in #10895: The validation of attribute option codes existence should be case insensitive

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | OK
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
