### PR TITLE
PIM-8928: Fix permission of sorting attributes inside an attribute group

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,6 +4,7 @@
 
 - PIM-8924: Fix permission of sorting attribute groups
 - PIM-8927: fix label translation on product model creation page
+- PIM-8928: Fix permission of sorting attributes inside an attribute group
 
 # 3.0.50 (2019-10-28)
 

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,7 +4,7 @@
 
 - PIM-8924: Fix permission of sorting attribute groups
 - PIM-8927: fix label translation on product model creation page
-- PIM-8928: Fix permission of sorting attributes inside an attribute group
+- PIM-8928: Fix permission for sorting attributes inside an attribute group
 
 # 3.0.50 (2019-10-28)
 

--- a/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeGroupController.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeGroupController.php
@@ -295,10 +295,12 @@ class AttributeGroupController
 
         $this->saver->save($attributeGroup);
 
-        $attributes = $this->attributeRepository->findBy(['code' => array_keys($sortOrder)]);
-        foreach ($attributes as $attribute) {
-            $this->attributeUpdater->update($attribute, ['sort_order' => $sortOrder[$attribute->getCode()]]);
-            $this->attributeSaver->save($attribute);
+        if ($this->securityFacade->isGranted('pim_enrich_attribute_sort')) {
+            $attributes = $this->attributeRepository->findBy(['code' => array_keys($sortOrder)]);
+            foreach ($attributes as $attribute) {
+                $this->attributeUpdater->update($attribute, ['sort_order' => $sortOrder[$attribute->getCode()]]);
+                $this->attributeSaver->save($attribute);
+            }
         }
 
         $this->eventDispatcher->dispatch(

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute_group/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute_group/edit.yml
@@ -159,6 +159,7 @@ extensions:
                 buttonText: pim_common.remove
             removeAttributeACL: pim_enrich_attributegroup_remove_attribute
             addAttributeACL: pim_enrich_attributegroup_add_attribute
+            sortAttributesACL: pim_enrich_attribute_sort
 
     pim-attribute-group-edit-form-attribute-add-attribute:
         module: pim/attribute-group/add-select/attribute

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/attribute.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/attribute.js
@@ -97,7 +97,8 @@ define(
                             i18n: i18n,
                             UserContext: UserContext,
                             __: __,
-                            hasRightToRemove: this.hasRightToRemove()
+                            hasRightToRemove: this.hasRightToRemove(),
+                            canSortAttributes: SecurityContext.isGranted(this.config.sortAttributesACL)
                         }));
 
                         this.$('.attribute-list').sortable({

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-group/tab/attribute.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-group/tab/attribute.html
@@ -9,7 +9,9 @@
             <table class="AknGrid AknGrid--unclickable table attributes">
                 <thead>
                     <tr>
-                        <th class="AknGrid-headerCell">&nbsp;</th>
+                        <% if (canSortAttributes) { %>
+                            <th class="AknGrid-headerCell">&nbsp;</th>
+                        <% } %>
                         <th class="AknGrid-headerCell"><%- __('pim_enrich.entity.attribute.property.name') %></th>
                         <th class="AknGrid-headerCell"><%- __('pim_common.type') %></th>
                         <th class="AknGrid-headerCell"><%- __('pim_enrich.entity.attribute.property.scopable') %></th>
@@ -22,11 +24,13 @@
                 <tbody class="attribute-list">
                     <% _.each(attributes, function (attribute) { %>
                         <tr class="AknGrid-bodyRow attribute" data-attribute-code="<%- attribute.code %>">
-                            <td class="AknGrid-bodyCell AknGrid-bodyCell--tight">
-                                <span class="handle">
-                                    <i class="icon-reorder"></i>
-                                </span>
-                            </td>
+                            <% if (canSortAttributes) { %>
+                                <td class="AknGrid-bodyCell AknGrid-bodyCell--tight">
+                                    <span class="handle">
+                                        <i class="icon-reorder"></i>
+                                    </span>
+                                </td>
+                            <% } %>
                             <td class="AknGrid-bodyCell"><%- i18n.getLabel(attribute.labels, UserContext.get('uiLocale'), attribute.code) %></td>
                             <td class="AknGrid-bodyCell"><%- __('pim_enrich.entity.attribute.property.type.' + attribute.type) %></td>
                             <td class="AknGrid-bodyCell">


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
A user that didn't have the permission to sort attributes could do it. This PR fix it.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
