### PR TITLE
TIP-1327: Refactor makefile functions

### DIFF
--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -20,7 +20,7 @@ lint-front:
 
 ### Unit tests
 .PHONY: unit-back
-unit-back: apps-unit-back
+unit-back: var/tests/phpspec apps-unit-back
 ifeq ($(CI),1)
 	${PHP_RUN} vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
 	.circleci/find_non_executed_phpspec.sh

--- a/make-file/utils.mk
+++ b/make-file/utils.mk
@@ -1,8 +1,9 @@
-# This function will set the var "O" with the given argument if the var CI is set to "1".
-# You need to use this function to configure your targets to run them on the CI:
-# $(call execute, XXX) where XXX is the target options.
+# This function will execute a command (first argument) and add command options (second argument) if CI=1
+# You need to use this function to configure your targets if they need specific options to be ran on the CI
 #
-# Example: $(call execute, --format=junit > spec.xml)
+# $(call execute, command, options)
+#
+# Example: $(call execute, vendor/bin/phpspec run, --format=junit > spec.xml)
 #
 # How to run tests? Let's take an example: run asset manager unit tests.
 #
@@ -14,10 +15,6 @@
 #
 # CAUTION:
 #  - use this function if your test tools do not support mutiple output format
-#  - the command in your target must use the var O
-#
-# unit-back:
-#	$(PHP_RUN) vendor/bin/phpspec run $(O)
 
 define execute
     $(if $(filter $(CI),1),$(1) $(2), $(1))

--- a/make-file/utils.mk
+++ b/make-file/utils.mk
@@ -1,8 +1,8 @@
 # This function will set the var "O" with the given argument if the var CI is set to "1".
 # You need to use this function to configure your targets to run them on the CI:
-# $(call configure_ci_options, XXX) where XXX is the target options.
+# $(call execute, XXX) where XXX is the target options.
 #
-# Example: $(call configure_ci_options, --format=junit > spec.xml)
+# Example: $(call execute, --format=junit > spec.xml)
 #
 # How to run tests? Let's take an example: run asset manager unit tests.
 #
@@ -19,7 +19,7 @@
 # unit-back:
 #	$(PHP_RUN) vendor/bin/phpspec run $(O)
 
-define configure_ci_options
+define execute
     $(if $(filter $(CI),1),$(1) $(2), $(1))
 endef
 

--- a/make-file/utils.mk
+++ b/make-file/utils.mk
@@ -1,0 +1,32 @@
+# This function will set the var "O" with the given argument if the var CI is set to "1".
+# You need to use this function to configure your targets to run them on the CI:
+# $(call configure_ci_options, XXX) where XXX is the target options.
+#
+# Example: $(call configure_ci_options, --format=junit > spec.xml)
+#
+# How to run tests? Let's take an example: run asset manager unit tests.
+#
+# Locally, I want the default formatter, I use the following command:
+# make asset-manager-unit-back
+#
+# On the CI, I want to generate a JUnit file, I use the following command:
+# make asset-manager-unit-back CI=1
+#
+# CAUTION:
+#  - use this function if your test tools do not support mutiple output format
+#  - the command in your target must use the var O
+#
+# unit-back:
+#	$(PHP_RUN) vendor/bin/phpspec run $(O)
+
+define configure_ci_options
+    $(if $(filter $(CI),1),$(eval O=$(1)))
+endef
+
+# This function execution a command if the var CI is set to "1".
+#
+# Example: $(call execute_on_ci_only, my/script.sh) where my/script.sh is the script you want to run only in the CI.
+
+define execute_on_ci_only
+    $(if $(filter $(CI),1), $(1))
+endef

--- a/make-file/utils.mk
+++ b/make-file/utils.mk
@@ -20,7 +20,7 @@
 #	$(PHP_RUN) vendor/bin/phpspec run $(O)
 
 define configure_ci_options
-    $(if $(filter $(CI),1),$(eval O=$(1)))
+    $(if $(filter $(CI),1),$(1) $(2), $(1))
 endef
 
 # This function execution a command if the var CI is set to "1".


### PR DESCRIPTION
**Description**

Makefile functions have been moved in a dedicated file named `make-file\utils.mk`. To avoid duplication this file **only exist** in CE and included in EE.

The function `configure_ci_options` has been refactored and renamed to `execute`, here a translation of this refactoring in PHP: 

Before:
```php
global $commandOptions = '';
function configure_ci_options ($options) {
    if ('1' ===  getEnv('CI') {
        $commandOptions = $options
    }  
}

configure_ci_options('my option')
exec('my command'.$commandOptions)
```
After:
```php
function execute ($command, $options) {
    if ('1' ===  getEnv('CI') {
        $command = $command." ".options
    }      

     exec($command);
}

execute('my command', 'my options');
```


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
