### PR TITLE
TIP-1327: Introduce new targets to run our tests (locally and on the CI) 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,14 +128,10 @@ jobs:
                 command: APP_ENV=test make database
           - run:
                 name: PHPunit Integration
-                command: |
-                    TESTFILES=$(docker-compose run --rm -T php php .circleci/find_phpunit.php --testsuite PIM_Integration_Test | circleci tests split --split-by=timings)
-                    .circleci/run_phpunit.sh . $TESTFILES
+                command: make integration-back . PIM_Integration_Test
           - run:
                 name: PHPunit End to end
-                command: |
-                    TESTFILES=$(docker-compose run --rm -T php php .circleci/find_phpunit.php --testsuite End_to_End | circleci tests split --split-by=timings)
-                    .circleci/run_phpunit.sh . $TESTFILES
+                command: make integration-back . End_to_End
           - store_test_results:
                 path: var/tests/phpunit
           - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
                 docker save -o php-pim-image.tar akeneo/pim-dev/php:7.3
       - run:
           name: Setup tests results folder and log folder
-          command: mkdir -p var/tests/phpunit var/tests/behat var/tests/phpspec var/tests/csfixer var/logs var/tests/screenshots ~/.cache/yarn ~/.composer
+          command: mkdir -p var/tests/behat var/tests/csfixer var/logs var/tests/screenshots ~/.cache/yarn ~/.composer
       - run:
           name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
           command: sudo chown -R 1000:1000 ../project
@@ -128,10 +128,10 @@ jobs:
                 command: APP_ENV=test make database
           - run:
                 name: PHPunit Integration
-                command: make integration-back . PIM_Integration_Test
+                command: make integration-back CI=1
           - run:
                 name: PHPunit End to end
-                command: make integration-back . End_to_End
+                command: make end-to-end-back CI=1
           - store_test_results:
                 path: var/tests/phpunit
           - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
                 docker save -o php-pim-image.tar akeneo/pim-dev/php:7.3
       - run:
           name: Setup tests results folder and log folder
-          command: mkdir -p var/tests/behat var/tests/csfixer var/logs var/tests/screenshots ~/.cache/yarn ~/.composer
+          command: mkdir -p var/tests/behat var/tests/phpspec var/tests/csfixer var/logs var/tests/screenshots ~/.cache/yarn ~/.composer
       - run:
           name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
           command: sudo chown -R 1000:1000 ../project

--- a/.circleci/run_phpunit.sh
+++ b/.circleci/run_phpunit.sh
@@ -1,17 +1,18 @@
 #!/bin/sh
 
 # Usage:
-#   run_phpunit.sh path/to/phpunit.xml PIM_Integration_Test
+#   run_phpunit.sh path/to/phpunit.xml .circleci/find_phpunit.php PIM_Integration_Test
 
-CONFIGDIR=$1
-TESTSUITES=$2
+CONFIG_DIRECTORY=$1
+FIND_PHPUNIT_SCRIPT=$2
+TEST_SUITES=$3
 
-TESTFILES=$(docker-compose run -u www-data --rm -T php php .circleci/find_phpunit.php -c $CONFIGDIR --testsuite $TESTSUITES | circleci tests split --split-by=timings)
+TEST_FILES=$(docker-compose run -u www-data --rm -T php php $FIND_PHPUNIT_SCRIPT -c $CONFIG_DIRECTORY --testsuite $TEST_SUITES | circleci tests split --split-by=timings)
 
 fail=0
-for TESTFILE in $TESTFILES; do
-    echo $TESTFILE
-    docker-compose exec -u www-data -T fpm ./vendor/bin/phpunit -c $CONFIGDIR --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml $TESTFILE
+for TEST_FILE in $TEST_FILES; do
+    echo $TEST_FILE
+    docker-compose exec -u www-data -T fpm ./vendor/bin/phpunit -c $CONFIG_DIRECTORY --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml $TEST_FILE
     fail=$(($fail + $?))
 done
 

--- a/.circleci/run_phpunit.sh
+++ b/.circleci/run_phpunit.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 
 # Usage:
-#   run_phpunit.sh path/to/phpunit.xml test_file_1 test_file_2 test_file_3 test_file_4...
+#   run_phpunit.sh path/to/phpunit.xml PIM_Integration_Test
 
 CONFIGDIR=$1
-shift
-TESTFILES=$@
+TESTSUITES=$2
+
+TESTFILES=$(docker-compose run -u www-data --rm -T php php .circleci/find_phpunit.php -c $CONFIGDIR --testsuite $TESTSUITES | circleci tests split --split-by=timings)
 
 fail=0
 for TESTFILE in $TESTFILES; do

--- a/make-file/apps.mk
+++ b/make-file/apps.mk
@@ -12,7 +12,11 @@ apps-acceptance-back: var/tests/behat/apps
 	$(PHP_RUN) vendor/bin/behat --config src/Akeneo/Apps/back/tests/Acceptance/behat.yml --format pim --out var/tests/behat/apps --format progress --out std --colors
 
 apps-integration-back:
-	$(PHP_RUN) vendor/bin/phpunit -c phpunit.xml.dist --testsuite=Akeneo_Apps_Integration
+ifeq ($(CI),1)
+	.circleci/run_phpunit.sh . Akeneo_Apps_Integration
+else
+	${PHP_RUN} vendor/bin/phpunit -c . --testsuite Akeneo_Apps_Integration $(O)
+endif
 
 apps-back:
 	make apps-coupling-back

--- a/make-file/apps.mk
+++ b/make-file/apps.mk
@@ -13,7 +13,7 @@ apps-acceptance-back: var/tests/behat/apps
 
 apps-integration-back:
 ifeq ($(CI),1)
-	.circleci/run_phpunit.sh . Akeneo_Apps_Integration
+	.circleci/run_phpunit.sh . .circleci/find_phpunit.php Akeneo_Apps_Integration
 else
 	${PHP_RUN} vendor/bin/phpunit -c . --testsuite Akeneo_Apps_Integration $(O)
 endif

--- a/make-file/dev.mk
+++ b/make-file/dev.mk
@@ -12,6 +12,7 @@ phpspec:
 acceptance:
 	${PHP_RUN} vendor/bin/behat -p acceptance ${F}
 
+# @deprecated please use the targets integration-back/end-to-end-back or add target for your bounded context
 .PHONY: phpunit
 phpunit:
 	${PHP_RUN} vendor/bin/phpunit -c phpunit.xml.dist ${F}

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -45,3 +45,11 @@ acceptance-front:
 .PHONY: integration-front
 integration-front:
 	$(YARN_RUN) integration
+
+.PHONY: integration-back
+integration-back:
+ifeq ($(CI),1)
+	.circleci/run_phpunit.sh . PIM_Integration_Test
+else
+	${PHP_RUN} vendor/bin/phpunit -c . $(O)
+endif

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -49,7 +49,7 @@ integration-front:
 .PHONY: integration-back
 integration-back: var/tests/phpunit apps-integration-back
 ifeq ($(CI),1)
-	.circleci/run_phpunit.sh . PIM_Integration_Test
+	.circleci/run_phpunit.sh . .circleci/find_phpunit.php PIM_Integration_Test
 else
 	${PHP_RUN} vendor/bin/phpunit -c . --testsuite PIM_Integration_Test $(O)
 endif
@@ -58,7 +58,7 @@ endif
 .PHONY: end-to-end-back
 end-to-end-back: var/tests/phpunit
 ifeq ($(CI),1)
-	.circleci/run_phpunit.sh . End_to_End
+	.circleci/run_phpunit.sh . .circleci/find_phpunit.php End_to_End
 else
 	${PHP_RUN} vendor/bin/phpunit -c . --testsuite End_to_End $(O)
 endif

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -20,7 +20,7 @@ lint-front:
 
 ### Unit tests
 .PHONY: unit-back
-unit-back: apps-unit-back
+unit-back: var/tests/phpspec
 ifeq ($(CI),1)
 	${PHP_RUN} vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
 	.circleci/find_non_executed_phpspec.sh
@@ -47,9 +47,18 @@ integration-front:
 	$(YARN_RUN) integration
 
 .PHONY: integration-back
-integration-back:
+integration-back: var/tests/phpunit apps-integration-back
 ifeq ($(CI),1)
 	.circleci/run_phpunit.sh . PIM_Integration_Test
 else
-	${PHP_RUN} vendor/bin/phpunit -c . $(O)
+	${PHP_RUN} vendor/bin/phpunit -c . --testsuite PIM_Integration_Test $(O)
+endif
+
+### Integration tests
+.PHONY: end-to-end-back
+end-to-end-back: var/tests/phpunit
+ifeq ($(CI),1)
+	.circleci/run_phpunit.sh . End_to_End
+else
+	${PHP_RUN} vendor/bin/phpunit -c . --testsuite End_to_End $(O)
 endif


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Please have a look to this [PR](https://github.com/akeneo/pim-community-dev/pull/10984).

This PR adds two new target `integration-back` and `end-to-end-back` to run integration and end to end tests with phpunit.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
