### PR TITLE
PIM-7851: Disable session on stateless firewalls

### DIFF
--- a/src/Pim/Bundle/ApiBundle/EventSubscriber/SessionSubscriber.php
+++ b/src/Pim/Bundle/ApiBundle/EventSubscriber/SessionSubscriber.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\EventSubscriber;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
+use Symfony\Component\Security\Http\FirewallMapInterface;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+
+/**
+ * Sets the session in the request only if the security firewall is not stateless.
+ * The default SessionListener doesn't care about the authentication and only use the 'session' setting of the framework.
+ * In the same way, the 'stateless' setting of the firewall only affect the use of the session for authentication purpose.
+ *
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SessionSubscriber extends AbstractSessionListener
+{
+    private $session;
+    private $requestStack;
+    private $firewallMap;
+
+    public function __construct(SessionInterface $session = null, RequestStack $requestStack, FirewallMapInterface $firewallMap)
+    {
+        $this->session = $session;
+        $this->requestStack = $requestStack;
+        $this->firewallMap = $firewallMap;
+    }
+
+    protected function getSession(): ?SessionInterface
+    {
+        if ($this->firewallMap instanceof FirewallMap) {
+            $firewallConfig = $this->firewallMap->getFirewallConfig($this->requestStack->getCurrentRequest());
+            if (null !== $firewallConfig && $firewallConfig->isStateless() === true) {
+                return null;
+            }
+        }
+
+        return $this->session;
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/Resources/config/event_subscribers.yml
+++ b/src/Pim/Bundle/ApiBundle/Resources/config/event_subscribers.yml
@@ -9,3 +9,13 @@ services:
             - '@pim_api.negotiator.content_type_negotiator'
         tags:
             - { name: kernel.event_subscriber, event: kernel.request, method: onKernelRequest }
+
+    pim_api.event_subscriber.session:
+        class: Pim\Bundle\ApiBundle\EventSubscriber\SessionSubscriber
+        arguments:
+            - '@session'
+            - '@request_stack'
+            - '@security.firewall.map'
+        tags:
+            - { name: kernel.event_subscriber  }
+        decorates: 'session_listener'

--- a/src/Pim/Bundle/ApiBundle/spec/EventSubscriber/SessionSubscriberSpec.php
+++ b/src/Pim/Bundle/ApiBundle/spec/EventSubscriber/SessionSubscriberSpec.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace spec\Pim\Bundle\ApiBundle\EventSubscriber;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Http\FirewallMapInterface;
+
+class SessionSubscriberSpec extends ObjectBehavior
+{
+    public function let(
+        SessionInterface $session,
+        RequestStack $requestStack,
+        FirewallMapInterface $firewallMap
+    ) {
+        $this->beConstructedWith($session, $requestStack, $firewallMap);
+    }
+}

--- a/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/SessionSubscriberIntegration.php
+++ b/src/Pim/Bundle/ApiBundle/tests/integration/EventSubscriber/SessionSubscriberIntegration.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Pim\Bundle\ApiBundle\tests\integration\EventSubscriber;
+
+use Akeneo\Test\Integration\Configuration;
+use Pim\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class SessionSubscriberIntegration extends ApiTestCase
+{
+    public function testThereIsNoSessionCookieOnTheApi(): void
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/categories');
+
+        $response = $client->getResponse();
+        $sessionCookie = $client->getCookieJar()->get('MOCKSESSID');
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertNull($sessionCookie);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Sets the session in the request only if the security firewall is not stateless.

The default SessionListener doesn't care about the authentication and only use the 'session' setting of the framework.

In the same way, the 'stateless' setting of the firewall only affect the use of the session for authentication purpose.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
