### PR TITLE
TIP-1327: Use make to run behat legacy tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,17 +87,17 @@ jobs:
                 when: always
           - run:
                 name: Analyzes source code to flag programming errors, bugs, stylistic errors, and suspicious constructs
-                command: make lint-back CI=1
+                command: make lint-back
           - run:
                 name: Code Coupling Detection
-                command: make coupling-back CI=1
+                command: make coupling-back
                 when: always
           - run:
                 name: Unit tests
-                command: make unit-back CI=1
+                command: make unit-back
           - run:
                 name: Acceptance tests
-                command: make acceptance-back CI=1
+                command: make acceptance-back
 
                 when: always
           - store_test_results:
@@ -128,10 +128,10 @@ jobs:
                 command: APP_ENV=test make database
           - run:
                 name: PHPunit Integration
-                command: make integration-back CI=1
+                command: make integration-back
           - run:
                 name: PHPunit End to end
-                command: make end-to-end-back CI=1
+                command: make end-to-end-back
           - store_test_results:
                 path: var/tests/phpunit
           - store_artifacts:
@@ -169,7 +169,7 @@ jobs:
             command: APP_ENV=behat make database
       - run:
             name: Behat legacy
-            command: make end-to-end-legacy SUITE=$TESTSUITE CI=1
+            command: make end-to-end-legacy SUITE=$TESTSUITE
       - run:
           name: Gather Junit test result files in the same directory to improve the render of failing tests
           command: |
@@ -201,16 +201,16 @@ jobs:
               command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
         - run:
               name: Front linter
-              command: make lint-front CI=1
+              command: make lint-front
         - run:
               name: Front unit tests
-              command: make unit-front CI=1
+              command: make unit-front
         - run:
               name: Front acceptance tests
-              command: make acceptance-front CI=1
+              command: make acceptance-front
         - run:
               name: Front integration tests
-              command: make integration-front CI=1
+              command: make integration-front
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,17 +87,17 @@ jobs:
                 when: always
           - run:
                 name: Analyzes source code to flag programming errors, bugs, stylistic errors, and suspicious constructs
-                command: make lint-back
+                command: make lint-back CI=1
           - run:
                 name: Code Coupling Detection
-                command: make coupling-back
+                command: make coupling-back CI=1
                 when: always
           - run:
                 name: Unit tests
                 command: make unit-back CI=1
           - run:
                 name: Acceptance tests
-                command: make acceptance-back
+                command: make acceptance-back CI=1
 
                 when: always
           - store_test_results:
@@ -168,15 +168,8 @@ jobs:
             name: Install database
             command: APP_ENV=behat make database
       - run:
-            name: Non critical Behat
-            command: |
-                TESTFILES=$(docker-compose run --rm -T php vendor/bin/behat --list-scenarios -p legacy -s $TESTSUITE | circleci tests split --split-by=timings)
-                .circleci/run_behat.sh $TESTSUITE $TESTFILES
-      - run:
-            name: Critical Behat
-            command: |
-                TESTFILES=$(docker-compose run --rm -T php vendor/bin/behat --list-scenarios -p legacy -s critical | circleci tests split --split-by=timings)
-                .circleci/run_behat.sh critical $TESTFILES
+            name: Behat legacy
+            command: make end-to-end-legacy SUITE=$TESTSUITE CI=1
       - run:
           name: Gather Junit test result files in the same directory to improve the render of failing tests
           command: |
@@ -208,16 +201,16 @@ jobs:
               command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
         - run:
               name: Front linter
-              command: make lint-front
+              command: make lint-front CI=1
         - run:
               name: Front unit tests
-              command: make unit-front
+              command: make unit-front CI=1
         - run:
               name: Front acceptance tests
-              command: make acceptance-front
+              command: make acceptance-front CI=1
         - run:
               name: Front integration tests
-              command: make integration-front
+              command: make integration-front CI=1
 
 workflows:
   version: 2

--- a/.circleci/run_behat.sh
+++ b/.circleci/run_behat.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-SUITE=$1
-shift
-TESTFILES=$@
+TEST_SUITE=$1
+
+TEST_FILES=$(docker-compose run --rm -T php vendor/bin/behat --list-scenarios -p legacy -s $TEST_SUITE | circleci tests split --split-by=timings)
 
 fail=0
 counter=1
-total=$(($(echo $TESTFILES | grep -o ' ' | wc -l) + 1))
+total=$(($(echo $TEST_FILES | grep -o ' ' | wc -l) + 1))
 
-for TESTFILE in $TESTFILES; do
-    echo "$TESTFILE ($counter/$total):"
-    output=$(basename $TESTFILE)_$(uuidgen)
+for TEST_FILE in $TEST_FILES; do
+    echo "$TEST_FILE ($counter/$total):"
+    output=$(basename $TEST_FILE)_$(uuidgen)
 
-    docker-compose exec -u www-data -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $SUITE $TESTFILE ||
-    docker-compose exec -u www-data -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $SUITE $TESTFILE
+    docker-compose exec -u www-data -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE ||
+    docker-compose exec -u www-data -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE
     fail=$(($fail + $?))
     counter=$(($counter + 1))
 done

--- a/make-file/apps.mk
+++ b/make-file/apps.mk
@@ -1,3 +1,57 @@
+# Define here the targets your team needs to work and the targets to run tests on CI
+#
+# Which kind of tests do/should we have in the PIM?
+# =================================================
+# - lint (back and front)
+# - unit (back and front)
+# - acceptance (back and front)
+# - integration (back and front)
+# - end to end
+#
+# You should at least define a target for every kind of tests we previously list with the following pattern:
+#
+# bounded-context-(lint|unit|acceptance|integration|end-to-end)-(back|front)
+#
+# Examples: asset-unit-back, asset-acceptance-front, asset-integration-back.
+#
+# How to define targets with a specfic configuration for the CI?
+# ==============================================================
+# For instance phpspec does not support multiple formats that means you can run the same command on the CI and locally.
+# If you need to do that you can use an environment variable named CI which is a "boolean".
+# If its value equals 1 run the command configured for the CI otherwise configure it to run it locally.
+#
+# Example:
+# -------
+# target-name:
+# ifeq ($(CI),1)
+#	execute a command on the CI
+# else
+#	execute a command locally
+# endif
+#
+# How can I can run test tools with specfic configuration?
+# ========================================================
+# You can define an environement variable to make targets configurable. Let's name O for *O*ption but it does not matter.
+#
+# Example:
+# --------
+# bounded-context-unit-back: var/tests/phpspec
+#	 ${PHP_RUN} vendor/bin/phpspec run $(O)
+#
+# Run a spec
+# ----------
+#
+# make bounded-context-unit-back O=my/spec.php
+#
+# How to run them on the CI?
+# ==========================
+# You should add them as dependency of the "main targets" which in `make-file/test.mk`.
+# You should have a look to `coupling-back` this target does not run a command but only depends on other ones.
+#
+# /!\ CAUTION /!\ By default some "main targets" run commands because of our legacy code (hard to reconfigure all tools).
+# Make sure the tests run by the targets defined here does not run by the main targets too
+#
+
 _APPS_YARN_RUN = $(YARN_EXEC) run --cwd=src/Akeneo/Apps/front/
 
 # Tests Back

--- a/make-file/apps.mk
+++ b/make-file/apps.mk
@@ -8,7 +8,7 @@
 # - integration (back and front)
 # - end to end
 #
-# You should at least define a target for every kind of tests we previously list with the following pattern:
+# You should at least define a target for every kind of tests we previously listed with the following pattern:
 #
 # bounded-context-(lint|unit|acceptance|integration|end-to-end)-(back|front)
 #
@@ -17,13 +17,13 @@
 # How to define targets with a specfic configuration for the CI?
 # ==============================================================
 # For instance phpspec does not support multiple formats that means you can run the same command on the CI and locally.
-# If you need to do that you can use an environment variable named CI which is a "boolean".
+# If you need to do that you can use an environment variable named CI which is a "boolean" (don't forget, env vars are strings).
 # If its value equals 1 run the command configured for the CI otherwise configure it to run it locally.
 #
 # Example:
 # -------
 # target-name:
-# ifeq ($(CI),1)
+# ifeq ($(CI),true)
 #	execute a command on the CI
 # else
 #	execute a command locally
@@ -66,7 +66,7 @@ apps-acceptance-back: var/tests/behat/apps
 	$(PHP_RUN) vendor/bin/behat --config src/Akeneo/Apps/back/tests/Acceptance/behat.yml --format pim --out var/tests/behat/apps --format progress --out std --colors
 
 apps-integration-back:
-ifeq ($(CI),1)
+ifeq ($(CI),true)
 	.circleci/run_phpunit.sh . .circleci/find_phpunit.php Akeneo_Apps_Integration
 else
 	${PHP_RUN} vendor/bin/phpunit -c . --testsuite Akeneo_Apps_Integration $(O)

--- a/make-file/channel.mk
+++ b/make-file/channel.mk
@@ -8,7 +8,7 @@
 # - integration (back and front)
 # - end to end
 #
-# You should at least define a target for every kind of tests we previously list with the following pattern:
+# You should at least define a target for every kind of tests we previously listed with the following pattern:
 #
 # bounded-context-(lint|unit|acceptance|integration|end-to-end)-(back|front)
 #
@@ -17,13 +17,13 @@
 # How to define targets with a specfic configuration for the CI?
 # ==============================================================
 # For instance phpspec does not support multiple formats that means you can run the same command on the CI and locally.
-# If you need to do that you can use an environment variable named CI which is a "boolean".
+# If you need to do that you can use an environment variable named CI which is a "boolean" (don't forget, env vars are strings).
 # If its value equals 1 run the command configured for the CI otherwise configure it to run it locally.
 #
 # Example:
 # -------
 # target-name:
-# ifeq ($(CI),1)
+# ifeq ($(CI),true)
 #	execute a command on the CI
 # else
 #	execute a command locally

--- a/make-file/channel.mk
+++ b/make-file/channel.mk
@@ -1,6 +1,56 @@
-##
-## Target used run command related on Channel Bounded context
-##
+# Define here the targets your team needs to work and the targets to run tests on CI
+#
+# Which kind of tests do/should we have in the PIM?
+# =================================================
+# - lint (back and front)
+# - unit (back and front)
+# - acceptance (back and front)
+# - integration (back and front)
+# - end to end
+#
+# You should at least define a target for every kind of tests we previously list with the following pattern:
+#
+# bounded-context-(lint|unit|acceptance|integration|end-to-end)-(back|front)
+#
+# Examples: asset-unit-back, asset-acceptance-front, asset-integration-back.
+#
+# How to define targets with a specfic configuration for the CI?
+# ==============================================================
+# For instance phpspec does not support multiple formats that means you can run the same command on the CI and locally.
+# If you need to do that you can use an environment variable named CI which is a "boolean".
+# If its value equals 1 run the command configured for the CI otherwise configure it to run it locally.
+#
+# Example:
+# -------
+# target-name:
+# ifeq ($(CI),1)
+#	execute a command on the CI
+# else
+#	execute a command locally
+# endif
+#
+# How can I can run test tools with specfic configuration?
+# ========================================================
+# You can define an environement variable to make targets configurable. Let's name O for *O*ption but it does not matter.
+#
+# Example:
+# --------
+# bounded-context-unit-back: var/tests/phpspec
+#	 ${PHP_RUN} vendor/bin/phpspec run $(O)
+#
+# Run a spec
+# ----------
+#
+# make bounded-context-unit-back O=my/spec.php
+#
+# How to run them on the CI?
+# ==========================
+# You should add them as dependency of the "main targets" which in `make-file/test.mk`.
+# You should have a look to `coupling-back` this target does not run a command but only depends on other ones.
+#
+# /!\ CAUTION /!\ By default some "main targets" run commands because of our legacy code (hard to reconfigure all tools).
+# Make sure the tests run by the targets defined here does not run by the main targets too
+#
 
 .PHONY: channel-coupling-back
 channel-coupling-back:

--- a/make-file/dev.mk
+++ b/make-file/dev.mk
@@ -1,37 +1,50 @@
-##
-## Run tests suite
-##
+# @deprecated Those target are deprecated we keep them because the public api of the makefile is not quite stable
 
-# @deprecated please use the target unit-back or add target for your bounded context
+# Please
+# - add a new target `bounded-context-unit-back` in `make-file/bounded-context.mk`
+# - add it as `unit-back` dependency
+# - make sure `unit-back` does not run your tests
+#
+# Example:
+# .PHONY: unit-back
+# unit-back: var/tests/phpspec bounded-context-unit-back
 .PHONY: phpspec
 phpspec:
 	${PHP_RUN} vendor/bin/phpspec run ${F}
 
-# @deprecated please use the target acceptance-back or add target for your bounded context
+# Please
+# - add a new target `bounded-context-acceptance-back` in `make-file/bounded-context.mk`
+# - add it as `acceptance-back` dependency
+# - make sure `acceptance-back` does not run your tests
+#
+# Example:
+# .PHONY: unit-back
+# acceptance-back: var/tests/phpspec bounded-context-acceptance-back
 .PHONY: acceptance
 acceptance:
 	${PHP_RUN} vendor/bin/behat -p acceptance ${F}
 
-# @deprecated please use the targets integration-back/end-to-end-back or add target for your bounded context
+# Please
+# - add a new target `bounded-context-integration-back` in `make-file/bounded-context.mk`
+# - add it as `integration-back` dependency
+# - make sure `integration-back` does not run your tests
+#
+# Example:
+# .PHONY: unit-back
+# integration-back: var/tests/phpspec bounded-context-integration-back
 .PHONY: phpunit
 phpunit:
 	${PHP_RUN} vendor/bin/phpunit -c phpunit.xml.dist ${F}
 
+# Please use the target `end-to-end-legacy` instead
 .PHONY: behat-legacy
 behat-legacy:
 	APP_ENV=behat $(PHP_RUN) vendor/bin/behat -p legacy -s all ${F}
 
-##
-## Xdebug
-##
-
-## Enable Xdebug
 .PHONY: xdebug-on
 xdebug-on:
 	XDEBUG_ENABLED=1 $(MAKE) up
 
-## Disable Xdebug
 .PHONY: xdebug-off
 xdebug-off:
 	XDEBUG_ENABLED=0 $(MAKE) up
-

--- a/make-file/enrichment.mk
+++ b/make-file/enrichment.mk
@@ -8,7 +8,7 @@
 # - integration (back and front)
 # - end to end
 #
-# You should at least define a target for every kind of tests we previously list with the following pattern:
+# You should at least define a target for every kind of tests we previously listed with the following pattern:
 #
 # bounded-context-(lint|unit|acceptance|integration|end-to-end)-(back|front)
 #
@@ -17,13 +17,13 @@
 # How to define targets with a specfic configuration for the CI?
 # ==============================================================
 # For instance phpspec does not support multiple formats that means you can run the same command on the CI and locally.
-# If you need to do that you can use an environment variable named CI which is a "boolean".
+# If you need to do that you can use an environment variable named CI which is a "boolean" (don't forget, env vars are strings).
 # If its value equals 1 run the command configured for the CI otherwise configure it to run it locally.
 #
 # Example:
 # -------
 # target-name:
-# ifeq ($(CI),1)
+# ifeq ($(CI),true)
 #	execute a command on the CI
 # else
 #	execute a command locally

--- a/make-file/enrichment.mk
+++ b/make-file/enrichment.mk
@@ -1,6 +1,56 @@
-##
-## Target used run command related on Enrichment Bounded context
-##
+# Define here the targets your team needs to work and the targets to run tests on CI
+#
+# Which kind of tests do/should we have in the PIM?
+# =================================================
+# - lint (back and front)
+# - unit (back and front)
+# - acceptance (back and front)
+# - integration (back and front)
+# - end to end
+#
+# You should at least define a target for every kind of tests we previously list with the following pattern:
+#
+# bounded-context-(lint|unit|acceptance|integration|end-to-end)-(back|front)
+#
+# Examples: asset-unit-back, asset-acceptance-front, asset-integration-back.
+#
+# How to define targets with a specfic configuration for the CI?
+# ==============================================================
+# For instance phpspec does not support multiple formats that means you can run the same command on the CI and locally.
+# If you need to do that you can use an environment variable named CI which is a "boolean".
+# If its value equals 1 run the command configured for the CI otherwise configure it to run it locally.
+#
+# Example:
+# -------
+# target-name:
+# ifeq ($(CI),1)
+#	execute a command on the CI
+# else
+#	execute a command locally
+# endif
+#
+# How can I can run test tools with specfic configuration?
+# ========================================================
+# You can define an environement variable to make targets configurable. Let's name O for *O*ption but it does not matter.
+#
+# Example:
+# --------
+# bounded-context-unit-back: var/tests/phpspec
+#	 ${PHP_RUN} vendor/bin/phpspec run $(O)
+#
+# Run a spec
+# ----------
+#
+# make bounded-context-unit-back O=my/spec.php
+#
+# How to run them on the CI?
+# ==========================
+# You should add them as dependency of the "main targets" which in `make-file/test.mk`.
+# You should have a look to `coupling-back` this target does not run a command but only depends on other ones.
+#
+# /!\ CAUTION /!\ By default some "main targets" run commands because of our legacy code (hard to reconfigure all tools).
+# Make sure the tests run by the targets defined here does not run by the main targets too
+#
 
 .PHONY: enrichment-coupling-back
 enrichment-coupling-back:

--- a/make-file/structure.mk
+++ b/make-file/structure.mk
@@ -8,7 +8,7 @@
 # - integration (back and front)
 # - end to end
 #
-# You should at least define a target for every kind of tests we previously list with the following pattern:
+# You should at least define a target for every kind of tests we previously listed with the following pattern:
 #
 # bounded-context-(lint|unit|acceptance|integration|end-to-end)-(back|front)
 #
@@ -17,13 +17,13 @@
 # How to define targets with a specfic configuration for the CI?
 # ==============================================================
 # For instance phpspec does not support multiple formats that means you can run the same command on the CI and locally.
-# If you need to do that you can use an environment variable named CI which is a "boolean".
+# If you need to do that you can use an environment variable named CI which is a "boolean" (don't forget, env vars are strings).
 # If its value equals 1 run the command configured for the CI otherwise configure it to run it locally.
 #
 # Example:
 # -------
 # target-name:
-# ifeq ($(CI),1)
+# ifeq ($(CI),true)
 #	execute a command on the CI
 # else
 #	execute a command locally

--- a/make-file/structure.mk
+++ b/make-file/structure.mk
@@ -1,6 +1,56 @@
-##
-## Target used run command related on Structure Bounded context
-##
+# Define here the targets your team needs to work and the targets to run tests on CI
+#
+# Which kind of tests do/should we have in the PIM?
+# =================================================
+# - lint (back and front)
+# - unit (back and front)
+# - acceptance (back and front)
+# - integration (back and front)
+# - end to end
+#
+# You should at least define a target for every kind of tests we previously list with the following pattern:
+#
+# bounded-context-(lint|unit|acceptance|integration|end-to-end)-(back|front)
+#
+# Examples: asset-unit-back, asset-acceptance-front, asset-integration-back.
+#
+# How to define targets with a specfic configuration for the CI?
+# ==============================================================
+# For instance phpspec does not support multiple formats that means you can run the same command on the CI and locally.
+# If you need to do that you can use an environment variable named CI which is a "boolean".
+# If its value equals 1 run the command configured for the CI otherwise configure it to run it locally.
+#
+# Example:
+# -------
+# target-name:
+# ifeq ($(CI),1)
+#	execute a command on the CI
+# else
+#	execute a command locally
+# endif
+#
+# How can I can run test tools with specfic configuration?
+# ========================================================
+# You can define an environement variable to make targets configurable. Let's name O for *O*ption but it does not matter.
+#
+# Example:
+# --------
+# bounded-context-unit-back: var/tests/phpspec
+#	 ${PHP_RUN} vendor/bin/phpspec run $(O)
+#
+# Run a spec
+# ----------
+#
+# make bounded-context-unit-back O=my/spec.php
+#
+# How to run them on the CI?
+# ==========================
+# You should add them as dependency of the "main targets" which in `make-file/test.mk`.
+# You should have a look to `coupling-back` this target does not run a command but only depends on other ones.
+#
+# /!\ CAUTION /!\ By default some "main targets" run commands because of our legacy code (hard to reconfigure all tools).
+# Make sure the tests run by the targets defined here does not run by the main targets too
+#
 
 .PHONY: structure-coupling-back
 structure-coupling-back:

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -58,7 +58,7 @@ endif
 .PHONY: end-to-end-back
 end-to-end-back: var/tests/phpunit
 ifeq ($(CI),1)
-	.circleci/run_phpunit.sh . PIM_Integration_Test
+	.circleci/run_phpunit.sh . .circleci/find_phpunit.php End_to_End
 else
 	@echo Run end to end test locally is too long, please use the target define for your bounded context (ex: bounded-context-end-to-end-back)
 endif

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -25,7 +25,7 @@ ifeq ($(CI),1)
 	${PHP_RUN} vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
 	.circleci/find_non_executed_phpspec.sh
 else
-	${PHP_RUN} vendor/bin/phpspec run $(O)
+	${PHP_RUN} vendor/bin/phpspec run
 endif
 
 .PHONY: unit-front
@@ -51,14 +51,33 @@ integration-back: var/tests/phpunit apps-integration-back
 ifeq ($(CI),1)
 	.circleci/run_phpunit.sh . .circleci/find_phpunit.php PIM_Integration_Test
 else
-	${PHP_RUN} vendor/bin/phpunit -c . --testsuite PIM_Integration_Test $(O)
+	@echo Run integration test locally is too long, please use the target define for your bounded context (ex: bounded-context-integration-back)
 endif
 
-### Integration tests
+### End to end tests
 .PHONY: end-to-end-back
 end-to-end-back: var/tests/phpunit
 ifeq ($(CI),1)
-	.circleci/run_phpunit.sh . .circleci/find_phpunit.php End_to_End
+	.circleci/run_phpunit.sh . PIM_Integration_Test
 else
-	${PHP_RUN} vendor/bin/phpunit -c . --testsuite End_to_End $(O)
+	@echo Run end to end test locally is too long, please use the target define for your bounded context (ex: bounded-context-end-to-end-back)
 endif
+
+# How to debug a behat locally?
+# -----------------------------
+#
+# Run the following command:
+# make end-to-end-legacy O=my/feature/file.feature:23
+#
+# Don't forget to pass *O*ption to avoid to run the whole suite.
+# Please add dependencies to this tagert and let it die
+
+.PHONY: end-to-end-legacy
+end-to-end-legacy: var/tests/behat
+ifeq ($(CI),1)
+	.circleci/run_behat.sh $(SUITE)
+	.circleci/run_behat.sh critical
+else
+	${PHP_RUN} vendor/bin/behat -p legacy -s all ${0}
+endif
+

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -21,7 +21,7 @@ lint-front:
 ### Unit tests
 .PHONY: unit-back
 unit-back: var/tests/phpspec
-ifeq ($(CI),1)
+ifeq ($(CI),true)
 	${PHP_RUN} vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
 	.circleci/find_non_executed_phpspec.sh
 else
@@ -48,19 +48,19 @@ integration-front:
 
 .PHONY: integration-back
 integration-back: var/tests/phpunit apps-integration-back
-ifeq ($(CI),1)
+ifeq ($(CI),true)
 	.circleci/run_phpunit.sh . .circleci/find_phpunit.php PIM_Integration_Test
 else
-	@echo Run integration test locally is too long, please use the target define for your bounded context (ex: bounded-context-integration-back)
+	@echo Run integration test locally is too long, please use the target defined for your bounded context (ex: bounded-context-integration-back)
 endif
 
 ### End to end tests
 .PHONY: end-to-end-back
 end-to-end-back: var/tests/phpunit
-ifeq ($(CI),1)
+ifeq ($(CI),true)
 	.circleci/run_phpunit.sh . .circleci/find_phpunit.php End_to_End
 else
-	@echo Run end to end test locally is too long, please use the target define for your bounded context (ex: bounded-context-end-to-end-back)
+	@echo Run end to end test locally is too long, please use the target defined for your bounded context (ex: bounded-context-end-to-end-back)
 endif
 
 # How to debug a behat locally?
@@ -74,7 +74,7 @@ endif
 
 .PHONY: end-to-end-legacy
 end-to-end-legacy: var/tests/behat
-ifeq ($(CI),1)
+ifeq ($(CI),true)
 	.circleci/run_behat.sh $(SUITE)
 	.circleci/run_behat.sh critical
 else

--- a/make-file/user-management.mk
+++ b/make-file/user-management.mk
@@ -8,7 +8,7 @@
 # - integration (back and front)
 # - end to end
 #
-# You should at least define a target for every kind of tests we previously list with the following pattern:
+# You should at least define a target for every kind of tests we previously listed with the following pattern:
 #
 # bounded-context-(lint|unit|acceptance|integration|end-to-end)-(back|front)
 #
@@ -17,13 +17,13 @@
 # How to define targets with a specfic configuration for the CI?
 # ==============================================================
 # For instance phpspec does not support multiple formats that means you can run the same command on the CI and locally.
-# If you need to do that you can use an environment variable named CI which is a "boolean".
+# If you need to do that you can use an environment variable named CI which is a "boolean" (don't forget, env vars are strings).
 # If its value equals 1 run the command configured for the CI otherwise configure it to run it locally.
 #
 # Example:
 # -------
 # target-name:
-# ifeq ($(CI),1)
+# ifeq ($(CI),true)
 #	execute a command on the CI
 # else
 #	execute a command locally

--- a/make-file/user-management.mk
+++ b/make-file/user-management.mk
@@ -1,6 +1,56 @@
-##
-## Target used run command related on User management Bounded context
-##
+# Define here the targets your team needs to work and the targets to run tests on CI
+#
+# Which kind of tests do/should we have in the PIM?
+# =================================================
+# - lint (back and front)
+# - unit (back and front)
+# - acceptance (back and front)
+# - integration (back and front)
+# - end to end
+#
+# You should at least define a target for every kind of tests we previously list with the following pattern:
+#
+# bounded-context-(lint|unit|acceptance|integration|end-to-end)-(back|front)
+#
+# Examples: asset-unit-back, asset-acceptance-front, asset-integration-back.
+#
+# How to define targets with a specfic configuration for the CI?
+# ==============================================================
+# For instance phpspec does not support multiple formats that means you can run the same command on the CI and locally.
+# If you need to do that you can use an environment variable named CI which is a "boolean".
+# If its value equals 1 run the command configured for the CI otherwise configure it to run it locally.
+#
+# Example:
+# -------
+# target-name:
+# ifeq ($(CI),1)
+#	execute a command on the CI
+# else
+#	execute a command locally
+# endif
+#
+# How can I can run test tools with specfic configuration?
+# ========================================================
+# You can define an environement variable to make targets configurable. Let's name O for *O*ption but it does not matter.
+#
+# Example:
+# --------
+# bounded-context-unit-back: var/tests/phpspec
+#	 ${PHP_RUN} vendor/bin/phpspec run $(O)
+#
+# Run a spec
+# ----------
+#
+# make bounded-context-unit-back O=my/spec.php
+#
+# How to run them on the CI?
+# ==========================
+# You should add them as dependency of the "main targets" which in `make-file/test.mk`.
+# You should have a look to `coupling-back` this target does not run a command but only depends on other ones.
+#
+# /!\ CAUTION /!\ By default some "main targets" run commands because of our legacy code (hard to reconfigure all tools).
+# Make sure the tests run by the targets defined here does not run by the main targets too
+#
 
 .PHONY: user-management-coupling-back
 user-management-coupling-back:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Please have a look to this [PR](https://github.com/akeneo/pim-community-dev/pull/10984).

This PR adds a new target `end-to-end-legacy-back` to run behat legacy and end to end tests with behat.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
