### PR TITLE
PIM-8943: Display validation messages on family translations

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-8943: Display validation messages on family translations
+
 # 3.2.17 (2019-10-30)
 
 ## Bug fixes:

--- a/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/FamilyController.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/FamilyController.php
@@ -305,7 +305,7 @@ class FamilyController
                 ];
             }
 
-            return new JsonResponse($errors, Response::HTTP_CONFLICT);
+            return new JsonResponse($errors, Response::HTTP_BAD_REQUEST);
         }
 
         $this->saver->save($family);

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/model/doctrine/Family.orm.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/model/doctrine/Family.orm.yml
@@ -49,6 +49,7 @@ Akeneo\Pim\Structure\Component\Model\Family:
                 - detach
                 - remove
             orphanRemoval: true
+            indexBy: locale
         requirements:
             targetEntity: Akeneo\Pim\Structure\Component\Model\AttributeRequirementInterface
             mappedBy: family

--- a/src/Akeneo/Pim/Structure/Component/Model/Family.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/Family.php
@@ -305,10 +305,8 @@ class Family implements FamilyInterface
         if (null === $locale) {
             return null;
         }
-        foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() == $locale) {
-                return $translation;
-            }
+        if ($this->translations->containsKey($locale)) {
+            return $this->translations->get($locale);
         }
 
         $translationClass = $this->getTranslationFQCN();
@@ -326,7 +324,7 @@ class Family implements FamilyInterface
     public function addTranslation(TranslationInterface $translation)
     {
         if (!$this->translations->contains($translation)) {
-            $this->translations->add($translation);
+            $this->translations->set($translation->getLocale(), $translation);
         }
 
         return $this;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/properties/translation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/properties/translation.js
@@ -86,6 +86,12 @@ define([
              */
             onValidationError: function (event) {
                 this.validationErrors = event.response.translations ? event.response.translations : {};
+                this.locales.forEach((locale) => {
+                    const key = 'translations[' + locale.code + '].label';
+                    if (event.response[key]) {
+                        this.validationErrors[locale.code] = event.response[key];
+                    }
+                });
 
                 this.render();
             },

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/properties/translation.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/properties/translation.html
@@ -15,8 +15,8 @@
             >
         </div>
         <% if (errors[locale.code]) { %>
-            <div class="AknFieldContainer-footer">
-                <span class="validation-error">
+            <div class="AknFieldContainer-footer AknFieldContainer-validationErrors">
+                <span class="AknFieldContainer-validationError validation-error">
                     <span class="error-message"><%- errors[locale.code].message %></span>
                 </span>
             </div>


### PR DESCRIPTION
Before, the back was sending validation errors in this format:

    [
    'translations[0].label': { message: 'Too long' },
    ]

And the front was expecting 

    [
      'translations': { en_US: { message; 'Too long' } }
    ]

After investigation, the [0] comes from the translation relation. Once validation are created, they does not include at all any information about the failing locale. So we choose to index the translations with the current locale (with indexBy).
From the front point of view, we transform "translations[en_US].label: { ... }" into "translations: { en_US : ... } }"
