### PR TITLE
PIM-8953: User without 'list users' permission can not access to other user pages

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-8953: User without "list users" permission can not access to other user pages
+
 # 2.3.69 (2019-10-24)
 
 ## Bug fixes

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,9 +1,5 @@
 # 2.3.x
 
-## Bug fixes
-
-- PIM-8953: User without "list users" permission can not access to other user pages
-
 # 2.3.69 (2019-10-24)
 
 ## Bug fixes

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes:
 
 - PIM-8943: Display validation messages on family translations
+- PIM-8953: User without "list users" permission can not access to other user pages
 
 # 3.2.17 (2019-10-30)
 

--- a/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
@@ -149,6 +149,17 @@ class UserController
      */
     public function getAction(int $identifier): JsonResponse
     {
+        $token = $this->tokenStorage->getToken();
+        $currentUserIdentifier = null !== $token ? $token->getUser()->getId() : null;
+
+        // @todo remove this check when $securityFacade is not nullable anymore
+        if (null !== $this->securityFacade) {
+            if ($currentUserIdentifier !== $identifier &&
+                !$this->securityFacade->isGranted('pim_user_user_index')) {
+                throw new AccessDeniedHttpException();
+            }
+        }
+
         $user = $this->getUserOr404($identifier);
 
         return new JsonResponse($this->normalizer->normalize($user, 'internal_api'));

--- a/tests/legacy/features/user-management/user/edit_user.feature
+++ b/tests/legacy/features/user-management/user/edit_user.feature
@@ -45,6 +45,7 @@ Feature: Edit a user
       | Role (required) | Tata role |
     And I visit the "Permissions" tab
     And I grant rights to resource Edit users
+    And I grant rights to resource List users
     Then I save the role
     When I edit the "mary" user
     And I visit the "Groups and roles" tab


### PR DESCRIPTION
When you didn't have the permission to "list users", you didn't have the users list, but you could continue to access a user page with its path.
This PR forbid it.