### PR TITLE
TIP-1353: use LRU cached attributes query in LocalizableValuesValidator

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
@@ -173,7 +173,7 @@ services:
         arguments:
             - '@pim_catalog.repository.cached_locale'
             - '@pim_catalog.repository.cached_channel'
-            - '@pim_catalog.repository.cached_attribute'
+            - '@akeneo.pim.structure.query.get_attributes'
         tags:
             - { name: validator.constraint_validator, alias: pim_localizable_values_validator }
 

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
@@ -33,6 +33,9 @@ final class Attribute
     /** @var string */
     private $backendType;
 
+    /** @var string[] */
+    private $availableLocaleCodes;
+
     public function __construct(
         string $attributeCode,
         string $attributeType,
@@ -41,7 +44,8 @@ final class Attribute
         bool $isScopable,
         ?string $metricFamily,
         ?bool $decimalsAllowed,
-        string $backendType
+        string $backendType,
+        array $availableLocaleCodes
     ) {
         $this->attributeCode = $attributeCode;
         $this->attributeType = $attributeType;
@@ -51,6 +55,7 @@ final class Attribute
         $this->metricFamily = $metricFamily;
         $this->decimalsAllowed = $decimalsAllowed;
         $this->backendType = $backendType;
+        $this->availableLocaleCodes = $availableLocaleCodes;
     }
 
     public function code(): string
@@ -96,5 +101,15 @@ final class Attribute
     public function backendType(): string
     {
         return $this->backendType;
+    }
+
+    public function isLocaleSpecific(): bool
+    {
+        return !empty($this->availableLocaleCodes);
+    }
+
+    public function availableLocaleCodes(): array
+    {
+        return $this->availableLocaleCodes;
     }
 }

--- a/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
+++ b/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
@@ -37,7 +37,8 @@ class InMemoryGetAttributes implements GetAttributes
                     (bool) $attribute->isScopable(),
                     $attribute->getMetricFamily(),
                     $attribute->isDecimalsAllowed(),
-                    $attribute->getBackendType()
+                    $attribute->getBackendType(),
+                    $attribute->getAvailableLocaleCodes()
                 );
             }
         }

--- a/tests/back/Acceptance/spec/Attribute/InMemoryGetAttributesSpec.php
+++ b/tests/back/Acceptance/spec/Attribute/InMemoryGetAttributesSpec.php
@@ -43,7 +43,8 @@ class InMemoryGetAttributesSpec extends ObjectBehavior
                 false,
                 null,
                 false,
-                AttributeTypes::BACKEND_TYPE_TEXT
+                AttributeTypes::BACKEND_TYPE_TEXT,
+                []
             ),
             'sku_2' => new Attribute(
                 'sku_2',
@@ -53,7 +54,8 @@ class InMemoryGetAttributesSpec extends ObjectBehavior
                 false,
                 null,
                 false,
-                AttributeTypes::BACKEND_TYPE_TEXT
+                AttributeTypes::BACKEND_TYPE_TEXT,
+                []
             ),
         ]);
     }

--- a/tests/back/Pim/Enrichment/Integration/Product/LoadEntityWithValuesSubscriberIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/LoadEntityWithValuesSubscriberIntegration.php
@@ -4,8 +4,6 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Product;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
-use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\SqlGetAttributes;
-use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Test\Integration\TestCase;
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Builder/EntityWithValuesBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Builder/EntityWithValuesBuilderSpec.php
@@ -21,13 +21,13 @@ class EntityWithValuesBuilderSpec extends ObjectBehavior
         GetAttributes $getAttributesQuery
     ) {
         $getAttributesQuery->forCode('size')->willReturn(
-            new Attribute('size', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false, 'option')
+            new Attribute('size', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false, 'option', [])
         );
         $getAttributesQuery->forCode('color')->willReturn(
-            new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], true, true, null, false, 'option')
+            new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], true, true, null, false, 'option', [])
         );
         $getAttributesQuery->forCode('label')->willReturn(
-            new Attribute('label', AttributeTypes::TEXT, [], true, true, null, false, 'option')
+            new Attribute('label', AttributeTypes::TEXT, [], true, true, null, false, 'option', [])
         );
 
 
@@ -51,8 +51,8 @@ class EntityWithValuesBuilderSpec extends ObjectBehavior
         $product->removeValue($sizeValue)->willReturn($product);
         $product->removeValue($colorValue)->willReturn($product);
 
-        $sizeAttribute = new Attribute('size', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false, 'option');
-        $colorAttribute = new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], true, true, null, false, 'option');
+        $sizeAttribute = new Attribute('size', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false, 'option', []);
+        $colorAttribute = new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], true, true, null, false, 'option', []);
         $productValueFactory->createByCheckingData($sizeAttribute, null, null, null)->willReturn($sizeValue);
         $productValueFactory->createByCheckingData($colorAttribute, 'ecommerce', 'en_US', null)->willReturn($colorValue);
 
@@ -79,8 +79,8 @@ class EntityWithValuesBuilderSpec extends ObjectBehavior
         $product->removeValue($sizeValue)->willReturn($product);
         $product->removeValue($colorValue)->willReturn($product);
 
-        $sizeAttribute = new Attribute('size', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false, 'option');
-        $colorAttribute = new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], true, true, null, false, 'option');
+        $sizeAttribute = new Attribute('size', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false, 'option', []);
+        $colorAttribute = new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], true, true, null, false, 'option', []);
 
         $productValueFactory->createByCheckingData($sizeAttribute, null, null, null)->willReturn($sizeValue);
         $productValueFactory->createByCheckingData($colorAttribute, 'ecommerce', 'en_US', 'red')->willReturn($colorValue);
@@ -104,7 +104,7 @@ class EntityWithValuesBuilderSpec extends ObjectBehavior
 
         $product->removeValue(Argument::any())->shouldNotBeCalled();
 
-        $labelAttribute = new Attribute('label', AttributeTypes::TEXT, [], true, true, null, false, 'option');
+        $labelAttribute = new Attribute('label', AttributeTypes::TEXT, [], true, true, null, false, 'option', []);
         $productValueFactory->createByCheckingData($labelAttribute, null, null, 'foobar')->willReturn($value);
 
         $product->addValue($value)->willReturn($product);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilterSpec.php
@@ -46,8 +46,8 @@ final class ChainedNonExistentValuesFilterSpec extends ObjectBehavior
         $channelRepository->findOneByIdentifier('ecommerce')->willReturn($ecommerce);
         $channelRepository->findOneByIdentifier('tablet')->willReturn(null);
 
-        $description = new Attribute('description', AttributeTypes::TEXTAREA, [], true, true, null, false, 'textarea');
-        $color = new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false, 'option');
+        $description = new Attribute('description', AttributeTypes::TEXTAREA, [], true, true, null, false, 'textarea', []);
+        $color = new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, false, 'option', []);
 
         $getAttributes->forCodes(['attribute_that_does_not_exists'])->willReturn(['unknown_attribute' => null]);
         $getAttributes->forCodes(['color'])->willReturn(['color' => $color]);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/ValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/ValueFactorySpec.php
@@ -28,14 +28,14 @@ final class ValueFactorySpec extends ObjectBehavior
 
     public function it_calls_the_right_factory_without_checking_data(SingleValueFactory $factory2, ValueInterface $value)
     {
-        $attribute = new Attribute('an_attribute', 'an_attribute_type2', [], false, false, null, false, 'backend_type');
+        $attribute = new Attribute('an_attribute', 'an_attribute_type2', [], false, false, null, false, 'backend_type', []);
         $factory2->createWithoutCheckingData($attribute, null, null, 'data')->willReturn($value);
         $this->createWithoutCheckingData($attribute, null, null, 'data')->shouldReturn($value);
     }
 
     public function it_calls_the_right_factory_by_checking_data(SingleValueFactory $factory2, ValueInterface $value)
     {
-        $attribute = new Attribute('an_attribute', 'an_attribute_type2', [], false, false, null, false, 'backend_type');
+        $attribute = new Attribute('an_attribute', 'an_attribute_type2', [], false, false, null, false, 'backend_type', []);
         $factory2->createByCheckingData($attribute, null, null, 'data')->willReturn($value);
         $this->createByCheckingData($attribute, null, null, 'data')->shouldReturn($value);
     }
@@ -45,7 +45,7 @@ final class ValueFactorySpec extends ObjectBehavior
         $this->shouldThrow(OutOfBoundsException::class)->during(
             'createWithoutCheckingData',
             [
-                new Attribute('an_attribute', 'non_supported_attribute_type', [], false, false, null, false, 'backend_type'),
+                new Attribute('an_attribute', 'non_supported_attribute_type', [], false, false, null, false, 'backend_type', []),
                 null,
                 null,
                 'data'
@@ -58,7 +58,7 @@ final class ValueFactorySpec extends ObjectBehavior
         $this->shouldThrow(InvalidAttributeException::class)->during(
             'createByCheckingData',
             [
-                new Attribute('an_attribute', 'an_attribute_type1', [], false, false, null, false, 'backend_type'),
+                new Attribute('an_attribute', 'an_attribute_type1', [], false, false, null, false, 'backend_type', []),
                 'ecommerce',
                 null,
                 'data'

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/TransformRawValuesCollectionsSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/TransformRawValuesCollectionsSpec.php
@@ -24,10 +24,10 @@ class TransformRawValuesCollectionsSpec extends ObjectBehavior
     {
         $getAttributes->forCodes(['number', 'number2', '123', 'number3'])->willReturn(
             [
-                'number' => new Attribute('number', AttributeTypes::NUMBER, [], false, false, null, false, 'decimal'),
-                'number2' => new Attribute('number2', AttributeTypes::NUMBER, [], false, false, null, false, 'decimal'),
-                'number3' => new Attribute('number3', AttributeTypes::NUMBER, [], false, false, null, false, 'decimal'),
-                '123' => new Attribute('123', AttributeTypes::NUMBER, [], false, false, null, false, 'decimal'),
+                'number' => new Attribute('number', AttributeTypes::NUMBER, [], false, false, null, false, 'decimal', []),
+                'number2' => new Attribute('number2', AttributeTypes::NUMBER, [], false, false, null, false, 'decimal', []),
+                'number3' => new Attribute('number3', AttributeTypes::NUMBER, [], false, false, null, false, 'decimal', []),
+                '123' => new Attribute('123', AttributeTypes::NUMBER, [], false, false, null, false, 'decimal', []),
             ]
         );
         $this->toValueCollectionsIndexedByType([

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/BooleanValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/BooleanValueFactorySpec.php
@@ -92,6 +92,6 @@ final class BooleanValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::BOOLEAN, [], $isLocalizable, $isScopable, null, false, 'boolean');
+        return new Attribute('an_attribute', AttributeTypes::BOOLEAN, [], $isLocalizable, $isScopable, null, false, 'boolean', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/DateValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/DateValueFactorySpec.php
@@ -124,6 +124,6 @@ final class DateValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::DATE, [], $isLocalizable, $isScopable, null, false, 'date');
+        return new Attribute('an_attribute', AttributeTypes::DATE, [], $isLocalizable, $isScopable, null, false, 'date', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/FileValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/FileValueFactorySpec.php
@@ -93,6 +93,6 @@ final class FileValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::FILE, [], $isLocalizable, $isScopable, null, false, 'file');
+        return new Attribute('an_attribute', AttributeTypes::FILE, [], $isLocalizable, $isScopable, null, false, 'file', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/IdentifierValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/IdentifierValueFactorySpec.php
@@ -9,7 +9,6 @@ use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
-use stdClass;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -83,6 +82,6 @@ final class IdentifierValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::IDENTIFIER, [], $isLocalizable, $isScopable, null, false, 'text');
+        return new Attribute('an_attribute', AttributeTypes::IDENTIFIER, [], $isLocalizable, $isScopable, null, false, 'text', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ImageValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ImageValueFactorySpec.php
@@ -91,6 +91,6 @@ final class ImageValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::IMAGE, [], $isLocalizable, $isScopable, null, false, 'file');
+        return new Attribute('an_attribute', AttributeTypes::IMAGE, [], $isLocalizable, $isScopable, null, false, 'file', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/MetricValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/MetricValueFactorySpec.php
@@ -138,6 +138,6 @@ final class MetricValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::METRIC, [], $isLocalizable, $isScopable, 'distance', false, 'metric');
+        return new Attribute('an_attribute', AttributeTypes::METRIC, [], $isLocalizable, $isScopable, 'distance', false, 'metric', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/NumberValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/NumberValueFactorySpec.php
@@ -81,6 +81,6 @@ final class NumberValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::NUMBER, [], $isLocalizable, $isScopable, null, false, 'decimal');
+        return new Attribute('an_attribute', AttributeTypes::NUMBER, [], $isLocalizable, $isScopable, null, false, 'decimal', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/OptionValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/OptionValueFactorySpec.php
@@ -78,6 +78,6 @@ final class OptionValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::OPTION_SIMPLE_SELECT, [], $isLocalizable, $isScopable, null, false, 'option');
+        return new Attribute('an_attribute', AttributeTypes::OPTION_SIMPLE_SELECT, [], $isLocalizable, $isScopable, null, false, 'option', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/OptionsValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/OptionsValueFactorySpec.php
@@ -96,6 +96,6 @@ final class OptionsValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::OPTION_MULTI_SELECT, [], $isLocalizable, $isScopable, null, false, 'options');
+        return new Attribute('an_attribute', AttributeTypes::OPTION_MULTI_SELECT, [], $isLocalizable, $isScopable, null, false, 'options', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/PriceCollectionValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/PriceCollectionValueFactorySpec.php
@@ -87,6 +87,6 @@ final class PriceCollectionValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::PRICE_COLLECTION, [], $isLocalizable, $isScopable, null, false, 'prices');
+        return new Attribute('an_attribute', AttributeTypes::PRICE_COLLECTION, [], $isLocalizable, $isScopable, null, false, 'prices', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ReferenceDataCollectionValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ReferenceDataCollectionValueFactorySpec.php
@@ -67,6 +67,6 @@ final class ReferenceDataCollectionValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::REFERENCE_DATA_MULTI_SELECT, ['reference_data_name' => 'color'], $isLocalizable, $isScopable, null, false, 'reference_data_options');
+        return new Attribute('an_attribute', AttributeTypes::REFERENCE_DATA_MULTI_SELECT, ['reference_data_name' => 'color'], $isLocalizable, $isScopable, null, false, 'reference_data_options', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ReferenceDataValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ReferenceDataValueFactorySpec.php
@@ -68,6 +68,6 @@ final class ReferenceDataValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT, ['reference_data_name' => 'color'], $isLocalizable, $isScopable, null, false, 'reference_data_option');
+        return new Attribute('an_attribute', AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT, ['reference_data_name' => 'color'], $isLocalizable, $isScopable, null, false, 'reference_data_option', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/TextAreaValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/TextAreaValueFactorySpec.php
@@ -81,6 +81,6 @@ final class TextAreaValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::TEXTAREA, [], $isLocalizable, $isScopable, null, false, 'textarea');
+        return new Attribute('an_attribute', AttributeTypes::TEXTAREA, [], $isLocalizable, $isScopable, null, false, 'textarea', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/TextValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/TextValueFactorySpec.php
@@ -81,6 +81,6 @@ final class TextValueFactorySpec extends ObjectBehavior
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::TEXT, [], $isLocalizable, $isScopable, null, false, 'text');
+        return new Attribute('an_attribute', AttributeTypes::TEXT, [], $isLocalizable, $isScopable, null, false, 'text', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ValidateAttributeSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ValidateAttributeSpec.php
@@ -127,6 +127,6 @@ final class ValidateAttributeSpec extends ObjectBehavior
 
     private function getAttribute(bool $isScopable, bool $isLocalizable): Attribute
     {
-        return new Attribute('an_attribute', AttributeTypes::BOOLEAN, [], $isLocalizable, $isScopable, null, false, 'boolean');
+        return new Attribute('an_attribute', AttributeTypes::BOOLEAN, [], $isLocalizable, $isScopable, null, false, 'boolean', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/ValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/ValueCollectionFactorySpec.php
@@ -2,8 +2,6 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Factory;
 
-use Akeneo\Channel\Component\Model\Channel;
-use Akeneo\Channel\Component\Model\Locale;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\ChainedNonExistentValuesFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\ValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\Value\BooleanValueFactory;
@@ -18,30 +16,14 @@ use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
-use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 
 class ValueCollectionFactorySpec extends ObjectBehavior
 {
     function let(
         GetAttributes $getAttributeByCodes,
-        ChainedNonExistentValuesFilterInterface $chainedObsoleteValueFilter,
-        IdentifiableObjectRepositoryInterface $localeRepository,
-        IdentifiableObjectRepositoryInterface $channelRepository
+        ChainedNonExistentValuesFilterInterface $chainedObsoleteValueFilter
     ) {
-        $ecommerce = new Channel();
-        $tablet = new Channel();
-
-        $enUS = new Locale();
-        $enUS->setCode('en_US');
-        $enUS->addChannel($ecommerce);
-
-        $localeRepository->findOneByIdentifier('en_US')->willReturn($enUS);
-        $localeRepository->findOneByIdentifier('fr_FR')->willReturn(null);
-
-        $channelRepository->findOneByIdentifier('ecommerce')->willReturn($ecommerce);
-        $channelRepository->findOneByIdentifier('ecommerce')->willReturn($tablet);
-
         $valueFactory = new ValueFactory(
             [
                 new OptionValueFactory(),
@@ -50,9 +32,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
                 new IdentifierValueFactory(),
                 new TextAreaValueFactory(),
                 new TextValueFactory(),
-            ],
-            $localeRepository->getWrappedObject(),
-            $channelRepository->getWrappedObject()
+            ]
         );
 
         $this->beConstructedWith(
@@ -71,8 +51,8 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         GetAttributes $getAttributeByCodes,
         ChainedNonExistentValuesFilterInterface $chainedObsoleteValueFilter
     ) {
-        $sku = new Attribute('sku', AttributeTypes::IDENTIFIER, [], false, false, null, false, 'text');
-        $description = new Attribute('description', AttributeTypes::TEXTAREA, [], true, true, null, false, 'textarea');
+        $sku = new Attribute('sku', AttributeTypes::IDENTIFIER, [], false, false, null, false, 'text', []);
+        $description = new Attribute('description', AttributeTypes::TEXTAREA, [], true, true, null, false, 'textarea', []);
 
         $rawValues = [
             'sku' => [

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/BooleanNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/BooleanNormalizerSpec.php
@@ -43,7 +43,8 @@ class BooleanNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'boolean'
+            'boolean',
+            []
         ));
         $getAttributes->forCode('my_text_attribute')->willReturn(new Attribute(
             'my_text_attribute',
@@ -53,7 +54,8 @@ class BooleanNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
@@ -80,7 +82,8 @@ class BooleanNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'boolean'
+            'boolean',
+            []
         ));
 
         $value->getLocaleCode()->willReturn(null);
@@ -109,7 +112,8 @@ class BooleanNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'boolean'
+            'boolean',
+            []
         ));
 
         $value->getLocaleCode()->willReturn('fr_FR');
@@ -138,7 +142,8 @@ class BooleanNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'boolean'
+            'boolean',
+            []
         ));
 
         $value->getLocaleCode()->willReturn(null);
@@ -167,7 +172,8 @@ class BooleanNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'boolean'
+            'boolean',
+            []
         ));
 
         $value->getLocaleCode()->willReturn('fr_FR');
@@ -196,7 +202,8 @@ class BooleanNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'boolean'
+            'boolean',
+            []
         ));
 
         $value->getLocaleCode()->willReturn(null);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/MediaNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/MediaNormalizerSpec.php
@@ -71,7 +71,8 @@ class MediaNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'media'
+            'media',
+            []
         ));
 
         $this->normalize($mediaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -117,7 +118,8 @@ class MediaNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'media'
+            'media',
+            []
         ));
 
         $this->normalize($mediaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -163,7 +165,8 @@ class MediaNormalizerSpec extends ObjectBehavior
             true,
             null,
             true,
-            'media'
+            'media',
+            []
         ));
 
         $this->normalize($mediaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -209,7 +212,8 @@ class MediaNormalizerSpec extends ObjectBehavior
             true,
             null,
             true,
-            'media'
+            'media',
+            []
         ));
 
         $this->normalize($mediaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -246,7 +250,8 @@ class MediaNormalizerSpec extends ObjectBehavior
             true,
             null,
             true,
-            'media'
+            'media',
+            []
         ));
 
         $this->normalize($mediaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/MetricNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/MetricNormalizerSpec.php
@@ -45,7 +45,8 @@ class MetricNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'metric'
+            'metric',
+            []
         ));
         $getAttributes->forCode('my_text_attribute')->willReturn(new Attribute(
             'my_text_attribute',
@@ -55,7 +56,8 @@ class MetricNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
@@ -87,7 +89,8 @@ class MetricNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'metric'
+            'metric',
+            []
         ));
 
         $this->normalize($metricValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -122,7 +125,8 @@ class MetricNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'metric'
+            'metric',
+            []
         ));
 
         $this->normalize($metricValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -162,7 +166,8 @@ class MetricNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'metric'
+            'metric',
+            []
         ));
 
         $this->normalize($metricValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -202,7 +207,8 @@ class MetricNormalizerSpec extends ObjectBehavior
             true,
             null,
             false,
-            'metric'
+            'metric',
+            []
         ));
 
         $this->normalize($metricValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/NumberNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/NumberNormalizerSpec.php
@@ -43,7 +43,8 @@ class NumberNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'decimal'
+            'decimal',
+            []
         ));
         $getAttributes->forCode('my_text_attribute')->willReturn(new Attribute(
             'my_text_attribute',
@@ -53,7 +54,8 @@ class NumberNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
@@ -86,7 +88,8 @@ class NumberNormalizerSpec extends ObjectBehavior
             false,
             null,
             false,
-            'decimal'
+            'decimal',
+            []
         ));
 
         $this->normalize($integerValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -115,7 +118,8 @@ class NumberNormalizerSpec extends ObjectBehavior
             false,
             null,
             false,
-            'decimal'
+            'decimal',
+            []
         ));
 
         $this->normalize($integerValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -144,7 +148,8 @@ class NumberNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'decimal'
+            'decimal',
+            []
         ));
 
         $this->normalize($decimalValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -173,7 +178,8 @@ class NumberNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'decimal'
+            'decimal',
+            []
         ));
 
         $this->normalize($decimalValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -202,7 +208,8 @@ class NumberNormalizerSpec extends ObjectBehavior
             false,
             null,
             false,
-            'decimal'
+            'decimal',
+            []
         ));
 
         $this->normalize($decimalValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -231,7 +238,8 @@ class NumberNormalizerSpec extends ObjectBehavior
             false,
             null,
             false,
-            'decimal'
+            'decimal',
+            []
         ));
 
         $this->normalize($decimalValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/OptionNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/OptionNormalizerSpec.php
@@ -44,7 +44,8 @@ class OptionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'option'
+            'option',
+            []
         ));
         $getAttributes->forCode('my_text_attribute')->willReturn(new Attribute(
             'my_text_attribute',
@@ -54,7 +55,8 @@ class OptionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
@@ -82,7 +84,8 @@ class OptionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'option'
+            'option',
+            []
         ));
 
         $optionValue->getLocaleCode()->willReturn(null);
@@ -116,7 +119,8 @@ class OptionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'option'
+            'option',
+            []
         ));
 
         $optionValue->getData()->willReturn('red');
@@ -145,7 +149,8 @@ class OptionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'option'
+            'option',
+            []
         ));
 
         $optionValue->getLocaleCode()->willReturn('en_US');
@@ -180,7 +185,8 @@ class OptionNormalizerSpec extends ObjectBehavior
             true,
             null,
             true,
-            'option'
+            'option',
+            []
         ));
 
         $optionValue->getData()->willReturn('red');
@@ -209,7 +215,8 @@ class OptionNormalizerSpec extends ObjectBehavior
             true,
             null,
             true,
-            'option'
+            'option',
+            []
         ));
 
         $optionValue->getLocaleCode()->willReturn('en_US');

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/OptionsNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/OptionsNormalizerSpec.php
@@ -45,7 +45,8 @@ class OptionsNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'options'
+            'options',
+            []
         ));
         $getAttributes->forCode('my_text_attribute')->willReturn(new Attribute(
             'my_text_attribute',
@@ -55,7 +56,8 @@ class OptionsNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
@@ -82,7 +84,8 @@ class OptionsNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'options'
+            'options',
+            []
         ));
 
         $optionsValue->getLocaleCode()->willReturn(null);
@@ -114,7 +117,8 @@ class OptionsNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'options'
+            'options',
+            []
         ));
 
         $optionsValue->getLocaleCode()->willReturn(null);
@@ -149,7 +153,8 @@ class OptionsNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'options'
+            'options',
+            []
         ));
 
         $optionsValue->getLocaleCode()->willReturn('en_US');
@@ -183,7 +188,8 @@ class OptionsNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'options'
+            'options',
+            []
         ));
 
         $optionsValue->getLocaleCode()->willReturn(null);
@@ -218,7 +224,8 @@ class OptionsNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'options'
+            'options',
+            []
         ));
 
         $optionsValue->getLocaleCode()->willReturn('en_US');

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/PriceCollectionNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/PriceCollectionNormalizerSpec.php
@@ -46,7 +46,8 @@ class PriceCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'prices'
+            'prices',
+            []
         ));
         $getAttributes->forCode('my_text_attribute')->willReturn(new Attribute(
             'my_text_attribute',
@@ -56,7 +57,8 @@ class PriceCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
@@ -91,7 +93,8 @@ class PriceCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'prices'
+            'prices',
+            []
         ));
 
         $this->normalize($priceCollection, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -128,7 +131,8 @@ class PriceCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'prices'
+            'prices',
+            []
         ));
 
         $this->normalize($priceCollection, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -168,7 +172,8 @@ class PriceCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'prices'
+            'prices',
+            []
         ));
 
         $this->normalize($priceCollection, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -208,7 +213,8 @@ class PriceCollectionNormalizerSpec extends ObjectBehavior
             true,
             null,
             true,
-            'prices'
+            'prices',
+            []
         ));
 
         $this->normalize($priceCollection, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -248,7 +254,8 @@ class PriceCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'prices'
+            'prices',
+            []
         ));
 
         $this->normalize($priceCollection, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -288,7 +295,8 @@ class PriceCollectionNormalizerSpec extends ObjectBehavior
             true,
             null,
             true,
-            'prices'
+            'prices',
+            []
         ));
 
         $this->normalize($priceCollection, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -328,7 +336,8 @@ class PriceCollectionNormalizerSpec extends ObjectBehavior
             true,
             null,
             true,
-            'prices'
+            'prices',
+            []
         ));
 
         $this->normalize($priceCollection, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/ReferenceDataCollectionNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/ReferenceDataCollectionNormalizerSpec.php
@@ -44,7 +44,8 @@ class ReferenceDataCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_options'
+            'reference_data_options',
+            []
         ));
         $getAttributes->forCode('my_text_attribute')->willReturn(new Attribute(
             'my_text_attribute',
@@ -54,7 +55,8 @@ class ReferenceDataCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->supportsNormalization(new \stdClass(), ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
@@ -84,7 +86,8 @@ class ReferenceDataCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_options'
+            'reference_data_options',
+            []
         ));
 
         $referenceDataCollectionProductValue->getLocaleCode()->willReturn(null);
@@ -117,7 +120,8 @@ class ReferenceDataCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_options'
+            'reference_data_options',
+            []
         ));
 
         $referenceDataCollectionProductValue->getLocaleCode()->willReturn(null);
@@ -153,7 +157,8 @@ class ReferenceDataCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_options'
+            'reference_data_options',
+            []
         ));
 
         $referenceDataCollectionProductValue->getLocaleCode()->willReturn('en_US');
@@ -189,7 +194,8 @@ class ReferenceDataCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_options'
+            'reference_data_options',
+            []
         ));
 
         $referenceDataCollectionProductValue->getLocaleCode()->willReturn(null);
@@ -225,7 +231,8 @@ class ReferenceDataCollectionNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_options'
+            'reference_data_options',
+            []
         ));
 
         $referenceDataCollectionProductValue->getLocaleCode()->willReturn('en_US');

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/ReferenceDataNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/ReferenceDataNormalizerSpec.php
@@ -44,7 +44,8 @@ class ReferenceDataNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_option'
+            'reference_data_option',
+            []
         ));
         $getAttributes->forCode('my_text_attribute')->willReturn(new Attribute(
             'my_text_attribute',
@@ -54,7 +55,8 @@ class ReferenceDataNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->supportsNormalization(new \stdClass(), ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)
@@ -81,7 +83,8 @@ class ReferenceDataNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_option'
+            'reference_data_option',
+            []
         ));
 
         $referenceDataValue->getLocaleCode()->willReturn(null);
@@ -113,7 +116,8 @@ class ReferenceDataNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_option'
+            'reference_data_option',
+            []
         ));
 
         $referenceDataValue->getLocaleCode()->willReturn(null);
@@ -145,7 +149,8 @@ class ReferenceDataNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_option'
+            'reference_data_option',
+            []
         ));
 
         $referenceDataValue->getLocaleCode()->willReturn('en_US');
@@ -177,7 +182,8 @@ class ReferenceDataNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_option'
+            'reference_data_option',
+            []
         ));
 
         $referenceDataValue->getLocaleCode()->willReturn(null);
@@ -209,7 +215,8 @@ class ReferenceDataNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'reference_data_option'
+            'reference_data_option',
+            []
         ));
 
         $referenceDataValue->getLocaleCode()->willReturn('en_US');

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/TextAreaNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/TextAreaNormalizerSpec.php
@@ -43,7 +43,8 @@ class TextAreaNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'textarea'
+            'textarea',
+            []
         ));
         $getAttributes->forCode('my_number_attribute')->willReturn(new Attribute(
             'my_number_attribute',
@@ -53,7 +54,8 @@ class TextAreaNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'decimal'
+            'decimal',
+            []
         ));
 
         $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
@@ -84,7 +86,8 @@ class TextAreaNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'textarea'
+            'textarea',
+            []
         ));
 
         $this->normalize($textAreaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -113,7 +116,8 @@ class TextAreaNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'textarea'
+            'textarea',
+            []
         ));
 
         $this->normalize($textAreaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -143,7 +147,8 @@ description\r\n");
             false,
             null,
             true,
-            'textarea'
+            'textarea',
+            []
         ));
 
         $this->normalize($textAreaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -172,7 +177,8 @@ description\r\n");
             false,
             null,
             true,
-            'textarea'
+            'textarea',
+            []
         ));
 
         $this->normalize($textAreaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -202,7 +208,8 @@ description\r\n");
             false,
             null,
             true,
-            'textarea'
+            'textarea',
+            []
         ));
 
         $this->normalize($textAreaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -231,7 +238,8 @@ description\r\n");
             false,
             null,
             true,
-            'textarea'
+            'textarea',
+            []
         ));
 
         $this->normalize($textAreaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -260,7 +268,8 @@ description\r\n");
             true,
             null,
             true,
-            'textarea'
+            'textarea',
+            []
         ));
 
         $this->normalize($textAreaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -289,7 +298,8 @@ description\r\n");
             true,
             null,
             true,
-            'textarea'
+            'textarea',
+            []
         ));
 
         $this->normalize($textAreaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/TextNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/TextNormalizerSpec.php
@@ -43,7 +43,8 @@ class TextNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
         $getAttributes->forCode('my_number_attribute')->willReturn(new Attribute(
             'my_number_attribute',
@@ -53,7 +54,8 @@ class TextNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'decimal'
+            'decimal',
+            []
         ));
 
         $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
@@ -85,7 +87,8 @@ class TextNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->normalize($textValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -114,7 +117,8 @@ class TextNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->normalize($textValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -143,7 +147,8 @@ class TextNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->normalize($textValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -172,7 +177,8 @@ class TextNormalizerSpec extends ObjectBehavior
             false,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->normalize($textValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -201,7 +207,8 @@ class TextNormalizerSpec extends ObjectBehavior
             true,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->normalize($textValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
@@ -230,7 +237,8 @@ class TextNormalizerSpec extends ObjectBehavior
             true,
             null,
             true,
-            'text'
+            'text',
+            []
         ));
 
         $this->normalize($textValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Standard/Product/ProductValueNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Standard/Product/ProductValueNormalizerSpec.php
@@ -59,7 +59,8 @@ class ProductValueNormalizerSpec extends ObjectBehavior
             false,
             null,
             false,
-            'text'
+            'text',
+            []
         );
 
         $getAttributes->forCode('attribute')->willReturn($attribute);
@@ -95,7 +96,8 @@ class ProductValueNormalizerSpec extends ObjectBehavior
             false,
             null,
             false,
-            'text'
+            'text',
+            []
         );
 
         $getAttributes->forCode('attribute')->willReturn($attribute);
@@ -131,7 +133,8 @@ class ProductValueNormalizerSpec extends ObjectBehavior
             true,
             null,
             false,
-            'text'
+            'text',
+            []
         );
 
         $getAttributes->forCode('attribute')->willReturn($attribute);
@@ -166,7 +169,8 @@ class ProductValueNormalizerSpec extends ObjectBehavior
             true,
             null,
             true,
-            'integer'
+            'integer',
+            []
         );
 
         $getAttributes->forCode('attribute')->willReturn($attribute);
@@ -201,7 +205,8 @@ class ProductValueNormalizerSpec extends ObjectBehavior
             true,
             null,
             false,
-            'integer'
+            'integer',
+            []
         );
 
         $getAttributes->forCode('attribute')->willReturn($attribute);
@@ -237,7 +242,8 @@ class ProductValueNormalizerSpec extends ObjectBehavior
             false,
             null,
             false,
-            'option'
+            'option',
+            []
         );
 
         $getAttributes->forCode('attribute')->willReturn($attribute);
@@ -273,7 +279,8 @@ class ProductValueNormalizerSpec extends ObjectBehavior
             false,
             null,
             false,
-            'options'
+            'options',
+            []
         );
 
         $getAttributes->forCode('attribute')->willReturn($attribute);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/ValuesFiller/FillMissingProductValuesSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/ValuesFiller/FillMissingProductValuesSpec.php
@@ -180,11 +180,11 @@ class FillMissingProductValuesSpec extends ObjectBehavior
     function it_correctly_merges_the_null_values_without_replacing_existing_values(GetAttributes $getAttributes)
     {
         $getAttributes->forCodes(['name', 123, 'localizable_name', 'scopable_name', 'localizable_scopable_name'])->willReturn([
-            'name' => new Attribute('name', AttributeTypes::TEXT, [], false, false, null, false, 'text'),
-            '123' => new Attribute('123', AttributeTypes::TEXT, [], false, false, null, false, 'text'),
-            'localizable_name' => new Attribute('localizable_name', AttributeTypes::TEXT, [], true, false, null, false, 'text'),
-            'scopable_name' => new Attribute('scopable_name', AttributeTypes::TEXT, [], false, true, null, false, 'text'),
-            'localizable_scopable_name' => new Attribute('localizable_scopable_name', AttributeTypes::TEXT, [], true, true, null, false, 'text')
+            'name' => new Attribute('name', AttributeTypes::TEXT, [], false, false, null, false, 'text', []),
+            '123' => new Attribute('123', AttributeTypes::TEXT, [], false, false, null, false, 'text', []),
+            'localizable_name' => new Attribute('localizable_name', AttributeTypes::TEXT, [], true, false, null, false, 'text', []),
+            'scopable_name' => new Attribute('scopable_name', AttributeTypes::TEXT, [], false, true, null, false, 'text', []),
+            'localizable_scopable_name' => new Attribute('localizable_scopable_name', AttributeTypes::TEXT, [], true, true, null, false, 'text', []),
         ]);
 
         $this->fromStandardFormat([
@@ -450,10 +450,10 @@ class FillMissingProductValuesSpec extends ObjectBehavior
     function it_does_not_replace_existing_price_values(GetAttributes $getAttributes)
     {
         $getAttributes->forCodes(['price', 'scopable_price', 'localizable_price', 'localizable_scopable_price'])->willReturn([
-            'price' => new Attribute('price', AttributeTypes::PRICE_COLLECTION, [], false, false, null, false, 'text'),
-            'scopable_price' => new Attribute('scopable_price', AttributeTypes::PRICE_COLLECTION, [], false, true, null, false, 'text'),
-            'localizable_price' => new Attribute('localizable_price', AttributeTypes::PRICE_COLLECTION, [], true, false, null, false, 'text'),
-            'localizable_scopable_price' => new Attribute('localizable_scopable_price', AttributeTypes::PRICE_COLLECTION, [], true, true, null, false, 'text')
+            'price' => new Attribute('price', AttributeTypes::PRICE_COLLECTION, [], false, false, null, false, 'text', []),
+            'scopable_price' => new Attribute('scopable_price', AttributeTypes::PRICE_COLLECTION, [], false, true, null, false, 'text', []),
+            'localizable_price' => new Attribute('localizable_price', AttributeTypes::PRICE_COLLECTION, [], true, false, null, false, 'text', []),
+            'localizable_scopable_price' => new Attribute('localizable_scopable_price', AttributeTypes::PRICE_COLLECTION, [], true, true, null, false, 'text', []),
         ]);
 
         $this->fromStandardFormat(

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributesIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributesIntegration.php
@@ -59,6 +59,14 @@ final class SqlGetAttributesIntegration extends TestCase
                 'scopable' => false,
                 'group' => 'other'
             ],
+            [
+                'code' => 'a_locale_specific_attribute',
+                'type' => AttributeTypes::BOOLEAN,
+                'localizable' => true,
+                'scopable' => false,
+                'group' => 'other',
+                'available_locales' => ['en_US'],
+            ],
         ]);
     }
 
@@ -66,7 +74,7 @@ final class SqlGetAttributesIntegration extends TestCase
     {
         $expected = $this->getExpected();
         $query = $this->getQuery();
-        $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123']);
+        $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123', 'a_locale_specific_attribute']);
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
@@ -74,18 +82,19 @@ final class SqlGetAttributesIntegration extends TestCase
     {
         $expected = $this->getExpected();
         $query = $this->getCachedQuery();
-        $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123']);
+        $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123', 'a_locale_specific_attribute']);
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
     public function getExpected(): array
     {
         return [
-            'a_text' => new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, false, 'text'),
-            'a_textarea' => new Attribute('a_textarea', AttributeTypes::TEXTAREA, [], false, false, null, false, 'textarea'),
-            'a_boolean' => new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, false, 'boolean'),
+            'a_text' => new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, false, 'text', []),
+            'a_textarea' => new Attribute('a_textarea', AttributeTypes::TEXTAREA, [], false, false, null, false, 'textarea', []),
+            'a_boolean' => new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, false, 'boolean', []),
             'unknown_attribute_code' => null,
-            '123' => new Attribute('123', AttributeTypes::TEXT, [], false, false, null, false, 'text')
+            '123' => new Attribute('123', AttributeTypes::TEXT, [], false, false, null, false, 'text', []),
+            'a_locale_specific_attribute' => new Attribute('a_locale_specific_attribute', AttributeTypes::BOOLEAN, [], true, false, null, null, 'boolean', ['en_US']),
         ];
     }
 
@@ -112,9 +121,9 @@ final class SqlGetAttributesIntegration extends TestCase
         $attributes = array_map(function (array $attributeData) {
             $attribute = $this->get('pim_catalog.factory.attribute')->create();
             $this->get('pim_catalog.updater.attribute')->update($attribute, $attributeData);
-            $constraints = $this->get('validator')->validate($attribute);
+            $constraintViolationss = $this->get('validator')->validate($attribute);
 
-            Assert::count($constraints, 0);
+            Assert::count($constraintViolationss, 0);
 
             return $attribute;
         }, $attributes);

--- a/tests/back/Pim/Structure/Specification/Bundle/Query/PublicApi/Attribute/Cache/LRUCachedGetAttributesSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/Query/PublicApi/Attribute/Cache/LRUCachedGetAttributesSpec.php
@@ -21,17 +21,17 @@ final class LRUCachedGetAttributesSpec extends ObjectBehavior
 
     public function it_gets_attributes_by_doing_a_query_if_the_cache_is_not_hit(GetAttributes $getAttributes)
     {
-        $aText = new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, false, 'text');
-        $aTextarea = new Attribute('a_textarea', AttributeTypes::TEXTAREA, [], false, false, null, false, 'textarea');
-        $aBoolean = new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, false, 'boolean');
+        $aText = new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, false, 'text', []);
+        $aTextarea = new Attribute('a_textarea', AttributeTypes::TEXTAREA, [], false, false, null, false, 'textarea', []);
+        $aBoolean = new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, false, 'boolean', []);
         $getAttributes->forCodes(['a_text', 'a_textarea', 'a_boolean'])->willReturn(['a_text' => $aText, 'a_textarea' => $aTextarea, 'a_boolean' => $aBoolean]);
         $this->forCodes(['a_text', 'a_textarea', 'a_boolean'])->shouldReturn(['a_text' => $aText, 'a_textarea' => $aTextarea, 'a_boolean' => $aBoolean]);
     }
 
     public function it_gets_attributes_from_the_cache_when_the_cache_is_hit(GetAttributes $getAttributes) {
-        $aText = new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, false, 'text');
-        $aTextarea = new Attribute('a_textarea', AttributeTypes::TEXTAREA, [], false, false, null, false, 'textarea');
-        $aBoolean = new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, false, 'boolean');
+        $aText = new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, false, 'text', []);
+        $aTextarea = new Attribute('a_textarea', AttributeTypes::TEXTAREA, [], false, false, null, false, 'textarea', []);
+        $aBoolean = new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, false, 'boolean', []);
         $getAttributes->forCodes(['a_text', 'a_textarea', 'a_boolean', 'michel'])->willReturn(['a_text' => $aText, 'a_textarea' => $aTextarea, 'a_boolean' => $aBoolean, 'michel' => null]);
         $getAttributes->forCodes(['a_text', 'a_textarea', 'a_boolean', 'michel'])->shouldBeCalled(1);
         $getAttributes->forCodes([])->willReturn([]);
@@ -41,9 +41,9 @@ final class LRUCachedGetAttributesSpec extends ObjectBehavior
     }
 
     public function it_mixes_the_call_between_the_cache_and_the_non_cached(GetAttributes $getAttributes) {
-        $aText = new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, false, 'text');
-        $aTextarea = new Attribute('a_textarea', AttributeTypes::TEXTAREA, [], false, false, null, false, 'textarea');
-        $aBoolean = new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, false, 'boolean');
+        $aText = new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, false, 'text', []);
+        $aTextarea = new Attribute('a_textarea', AttributeTypes::TEXTAREA, [], false, false, null, false, 'textarea', []);
+        $aBoolean = new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, false, 'boolean', []);
         $getAttributes->forCodes(['a_text', 'a_textarea', 'a_boolean'])->willReturn(['a_text' => $aText, 'a_textarea' => $aTextarea, 'a_boolean' => $aBoolean]);
         $getAttributes->forCodes(['michel'])->willReturn(['michel' => null]);
 
@@ -55,7 +55,7 @@ final class LRUCachedGetAttributesSpec extends ObjectBehavior
         $attributes = [];
         for ($i = 0; $i < 1500; $i++) {
             $attributeCode = "an_attribute_$i";
-            $attributes[$attributeCode] = new Attribute($attributeCode, AttributeTypes::TEXT, [], false, false, null, false, 'text');
+            $attributes[$attributeCode] = new Attribute($attributeCode, AttributeTypes::TEXT, [], false, false, null, false, 'text', []);
         }
 
         $getAttributes->forCodes(array_keys($attributes))->willReturn(array_values($attributes));


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- add locale specific information in Structure's public API attribute
- use LRU cached get attributes query in the LocalizableValuesValidator

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
