### PR TITLE
Remove values filtering before indexing

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
@@ -408,7 +408,9 @@ SQL;
             $rawValuesCollection[$code] = $rowIndexedByProductModelCode['raw_values'];
         }
 
-        $valueCollections = $this->readValueCollectionFactory->createMultipleFromStorageFormat($rawValuesCollection);
+        $valueCollections = $this->readValueCollectionFactory->createMultipleFromStorageFormatWithoutFilter(
+            $rawValuesCollection
+        );
         foreach ($valueCollections as $code => $valueCollection) {
             $rowsIndexedByProductModelCode[$code]['values'] = $valueCollection;
         }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
@@ -408,7 +408,7 @@ SQL;
             $rawValuesCollection[$code] = $rowIndexedByProductModelCode['raw_values'];
         }
 
-        $valueCollections = $this->readValueCollectionFactory->createMultipleFromStorageFormatWithoutFilter(
+        $valueCollections = $this->readValueCollectionFactory->createMultipleFromStorageFormatWithoutFilteringInconsistentData(
             $rawValuesCollection
         );
         foreach ($valueCollections as $code => $valueCollection) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
@@ -370,7 +370,9 @@ SQL;
             $rawValuesCollection[$identifier] = $rowIndexedByProductIdentifier['raw_values'];
         }
 
-        $valueCollections = $this->readValueCollectionFactory->createMultipleFromStorageFormat($rawValuesCollection);
+        $valueCollections = $this->readValueCollectionFactory->createMultipleFromStorageFormatWithoutFilter(
+            $rawValuesCollection
+        );
         foreach ($valueCollections as $identifier => $valueCollection) {
             $rowsIndexedByProductIdentifier[$identifier]['values'] = $valueCollection;
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
@@ -39,30 +39,22 @@ class ReadValueCollectionFactory
         return $this->createMultipleFromStorageFormat([$notUsedIdentifier => $rawValues])[$notUsedIdentifier];
     }
 
+    /**
+     * @param array $rawValueCollections
+     * @return ReadValueCollection[]
+     */
     public function createMultipleFromStorageFormat(array $rawValueCollections): array
     {
         $filteredRawValuesCollection = $this->chainedNonExistentValuesFilter->filterAll($rawValueCollections);
-        $valueCollections = $this->createValues($filteredRawValuesCollection);
 
-        return $valueCollections;
+        return $this->createMultipleFromStorageFormatWithoutFilter($filteredRawValuesCollection);
     }
 
-    private function getAttributesUsedByProducts(array $rawValueCollections): array
-    {
-        $attributeCodes = [];
-
-        foreach ($rawValueCollections as $productIdentifier => $rawValues) {
-            foreach (array_keys($rawValues) as $attributeCode) {
-                $attributeCodes[] = (string) $attributeCode;
-            }
-        }
-
-        $attributes = $this->getAttributeByCodes->forCodes(array_unique($attributeCodes));
-
-        return $attributes;
-    }
-
-    private function createValues(array $rawValueCollections): array
+    /**
+     * @param array $rawValueCollections
+     * @return ReadValueCollection[]
+     */
+    public function createMultipleFromStorageFormatWithoutFilter(array $rawValueCollections): array
     {
         $entities = [];
         $attributes = $this->getAttributesUsedByProducts($rawValueCollections);
@@ -97,5 +89,20 @@ class ReadValueCollectionFactory
         }
 
         return $entities;
+    }
+
+    private function getAttributesUsedByProducts(array $rawValueCollections): array
+    {
+        $attributeCodes = [];
+
+        foreach ($rawValueCollections as $productIdentifier => $rawValues) {
+            foreach (array_keys($rawValues) as $attributeCode) {
+                $attributeCodes[] = (string) $attributeCode;
+            }
+        }
+
+        $attributes = $this->getAttributeByCodes->forCodes(array_unique($attributeCodes));
+
+        return $attributes;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
@@ -51,6 +51,9 @@ class ReadValueCollectionFactory
     }
 
     /**
+     * Warning: use this method only for internal operations. Data can be inconsistent
+     * (cf. ChainedNonExistentValuesFilterInterface)
+     *
      * @param array $rawValueCollections
      * @return ReadValueCollection[]
      */

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
@@ -67,6 +67,9 @@ class ReadValueCollectionFactory
 
             foreach ($valueCollection as $attributeCode => $channelRawValue) {
                 $attribute = $attributes[$attributeCode];
+                if ($attribute === null) {
+                    continue;
+                }
 
                 foreach ($channelRawValue as $channelCode => $localeRawValue) {
                     if ('<all_channels>' === $channelCode) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/WriteValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/WriteValueCollectionFactory.php
@@ -14,9 +14,8 @@ class WriteValueCollectionFactory
     /** @var ReadValueCollectionFactory */
     private $readValueCollectionFactory;
 
-    public function __construct(
-        ReadValueCollectionFactory $readValueCollectionFactory
-    ) {
+    public function __construct(ReadValueCollectionFactory $readValueCollectionFactory)
+    {
         $this->readValueCollectionFactory = $readValueCollectionFactory;
     }
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/ReadValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/ReadValueCollectionFactorySpec.php
@@ -88,4 +88,45 @@ class ReadValueCollectionFactorySpec extends ObjectBehavior
             ]
         ));
     }
+
+    function it_creates_multiple_value_collections_without_filter(GetAttributes $getAttributeByCodes)
+    {
+        $sku = new Attribute('sku', AttributeTypes::IDENTIFIER, [], false, false, null, false, 'text', []);
+        $description = new Attribute('description', AttributeTypes::TEXTAREA, [], true, true, null, false, 'textarea', []);
+
+        $rawValues = [
+            'identifier1' => [
+                'sku' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => 'foo'
+                    ],
+                ],
+                'description' => [
+                    'ecommerce' => [
+                        'en_US' => 'a text area for ecommerce in English',
+                    ],
+                    'tablet' => [
+                        'en_US' => 'a text area for tablets in English',
+                        'fr_FR' => 'une zone de texte pour les tablettes en français',
+
+                    ],
+                ],
+            ],
+        ];
+
+        $getAttributeByCodes->forCodes(['sku', 'description'])->willReturn(['sku' => $sku, 'description' => $description]);
+
+        $actualValues = $this->createMultipleFromStorageFormatWithoutFilter($rawValues);
+
+        $actualValues->shouldBeArray();
+        $actualValues['identifier1']->shouldReturnAnInstanceOf(ReadValueCollection::class);
+        $actualValues['identifier1']->shouldBeLike(new ReadValueCollection(
+            [
+                ScalarValue::value('sku', 'foo'),
+                ScalarValue::scopableLocalizableValue('description', 'a text area for ecommerce in English', 'ecommerce', 'en_US'),
+                ScalarValue::scopableLocalizableValue('description', 'a text area for tablets in English', 'tablet', 'en_US'),
+                ScalarValue::scopableLocalizableValue('description', 'une zone de texte pour les tablettes en français', 'tablet', 'fr_FR'),
+            ]
+        ));
+    }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/ReadValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/ReadValueCollectionFactorySpec.php
@@ -89,8 +89,9 @@ class ReadValueCollectionFactorySpec extends ObjectBehavior
         ));
     }
 
-    function it_creates_multiple_value_collections_without_filter(GetAttributes $getAttributeByCodes)
-    {
+    function it_creates_multiple_value_collections_without_filtering_inconsistent_data(
+        GetAttributes $getAttributeByCodes
+    ) {
         $sku = new Attribute('sku', AttributeTypes::IDENTIFIER, [], false, false, null, false, 'text', []);
         $description = new Attribute('description', AttributeTypes::TEXTAREA, [], true, true, null, false, 'textarea', []);
 
@@ -111,12 +112,18 @@ class ReadValueCollectionFactorySpec extends ObjectBehavior
 
                     ],
                 ],
+                'unknown' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => 'bar'
+                    ],
+                ],
             ],
         ];
 
-        $getAttributeByCodes->forCodes(['sku', 'description'])->willReturn(['sku' => $sku, 'description' => $description]);
+        $getAttributeByCodes->forCodes(['sku', 'description', 'unknown'])
+            ->willReturn(['sku' => $sku, 'description' => $description]);
 
-        $actualValues = $this->createMultipleFromStorageFormatWithoutFilter($rawValues);
+        $actualValues = $this->createMultipleFromStorageFormatWithoutFilteringInconsistentData($rawValues);
 
         $actualValues->shouldBeArray();
         $actualValues['identifier1']->shouldReturnAnInstanceOf(ReadValueCollection::class);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Values come from source of truth (DB) and we don't need to filter the values before send data to Elasticsearch. For performance reason we now drop the filtering.

There is several ways to do it, none of them seem perfect to me.

Variant solution:
We can consider it's not the responsibility of the `ReadValueCollectionFactory` to filter, so maybe we can directly remove the filtering from `createMultipleFromStorageFormat()`.  
The services that use this method must decide if they have to filter the values or not before calling it. This seem to be cleaner in term of responsibility but not in term of security: we can easily forget the step to filter the values.
Others solution: we can create a InternalReadValueCollectionFactory. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
