### PR TITLE
Pull-up: Fix Asset Manager integration tests

### DIFF
--- a/config/services/test_fake/services.yml
+++ b/config/services/test_fake/services.yml
@@ -11,3 +11,9 @@ imports:
     - { resource: ../../../src/Akeneo/Apps/back/tests/Acceptance/Resources/config/queries.yml }
     - { resource: ../../../src/Akeneo/Apps/back/tests/Acceptance/Resources/config/repositories.yml }
     - { resource: ../../../src/Akeneo/Apps/back/tests/Acceptance/Resources/config/services.yml }
+
+services:
+    akeneo_integration_tests.doctrine.connection.connection_closer:
+        class: Akeneo\Test\IntegrationTestsBundle\Doctrine\Connection\ConnectionCloser
+        arguments:
+            - '@doctrine'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In 3.2, we experienced an issue on the asset manager BC regarding the integration tests of controllers. Every 404th+ tests would fail, but they would pass if run one by one.

We figured this issue happened because the SSO Repository had no InMemory implementation for the `test_fake` environment, so it would call the database anyway.
This repo was called for each HTTP request made to the PIM.

To fix this issue, we decided to close openned connection even on the for kernel built with the `test_fake` env.

On master, this service was not part of the `test_fake` env (_as it should_).

Today, we are currenlty blocked by this in the 3.2 -> master pull-up.

**Solution:**
Add the `akeneo_integration_tests.doctrine.connection.connection_closer` service into the `test_fake` environement.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
