### PR TITLE
TIP-1290 Fix CI to avoid "^@^@" character

### DIFF
--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -22,7 +22,7 @@ lint-front:
 .PHONY: unit-back
 unit-back: var/tests/phpspec
 ifeq ($(CI),true)
-	${PHP_RUN} vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
+	$(DOCKER_COMPOSE) run -T -u www-data --rm php php vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
 	.circleci/find_non_executed_phpspec.sh
 else
 	${PHP_RUN} vendor/bin/phpspec run


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Some builds have failed since a while because some weird characters (^@^@) appear in the output of some commands. For instance, the phpspec junit was not valid because at the beginning of the file we have "^@^@". Running command thought docker with the option -T prevent this errors. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
