### PR TITLE
PIM-8985: Fix label translation on family product selection

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8985: Fix label translation on family product selection
+
 # 3.0.53 (2019-11-12)
 
 # 3.0.52 (2019-11-08)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/select2/family.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/select2/family.js
@@ -41,7 +41,7 @@ define(
                                 options: {
                                     limit: 20,
                                     page: page,
-                                    locale: UserContext.get('uiLocale')
+                                    locale: UserContext.get('catalogLocale')
                                 }
                             };
                         },
@@ -55,7 +55,7 @@ define(
                                     id: key,
                                     text: i18n.getLabel(
                                         value.labels,
-                                        UserContext.get('uiLocale'),
+                                        UserContext.get('catalogLocale'),
                                         value.code
                                     )
                                 });
@@ -73,7 +73,7 @@ define(
                                         id: family.code,
                                         text: i18n.getLabel(
                                             family.labels,
-                                            UserContext.get('uiLocale'),
+                                            UserContext.get('catalogLocale'),
                                             family.code
                                         )
                                     });


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This pull request aims to fix label translation on product family selection. The translation language of the family labels is the catalog locale.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
