### PR TITLE
API-719: Restrict Apps access

### DIFF
--- a/src/Akeneo/Apps/back/Infrastructure/Symfony/Resources/config/requirejs.yml
+++ b/src/Akeneo/Apps/back/Infrastructure/Symfony/Resources/config/requirejs.yml
@@ -4,8 +4,10 @@ config:
             controllers:
                 akeneo_apps_index:
                     module: pim/controller/apps
+                    aclResourceId: akeneo_apps_manage_settings
                 akeneo_apps_any:
                     module: pim/controller/apps
+                    aclResourceId: akeneo_apps_manage_settings
     
     paths:
         pim/controller/apps: akeneoapps/js/controller/apps.tsx


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Restrict the access to the Apps settings for frontend routes.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
