### PR TITLE
 PIM-8954: Forbid access to any user data when the permission 'list users' is not granted

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,7 +3,7 @@
 ## Bug fixes
 
 - PIM-7027: fix completeness visibility on product edit form
-- PIM-8954: Forbid user without "list users" permission to access to other user data
+- PIM-8954: Forbid user without "list users" permission to access other user data
 
 # 2.3.69 (2019-10-24)
 

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7027: fix completeness visibility on product edit form
+- PIM-8954: Forbid user without "list users" permission to access to other user data
 
 # 2.3.69 (2019-10-24)
 

--- a/src/Pim/Bundle/UserBundle/Controller/UserRestController.php
+++ b/src/Pim/Bundle/UserBundle/Controller/UserRestController.php
@@ -76,6 +76,7 @@ class UserRestController
         $token = $this->tokenStorage->getToken();
         $currentUserId = null !== $token ? $token->getUser()->getId() : null;
 
+        // To not report in 3.x (it's already fixed)
         if (null !== $this->securityFacade) {
             if ($currentUserId !== $user->getId() &&
                 !$this->securityFacade->isGranted('pim_user_user_index')) {

--- a/src/Pim/Bundle/UserBundle/Controller/UserRestController.php
+++ b/src/Pim/Bundle/UserBundle/Controller/UserRestController.php
@@ -3,7 +3,9 @@
 namespace Pim\Bundle\UserBundle\Controller;
 
 use Akeneo\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -26,19 +28,25 @@ class UserRestController
     /** @var IdentifiableObjectRepositoryInterface */
     protected $userRepository;
 
+    /** @var SecurityFacade|null */
+    private $securityFacade;
+
     /**
-     * @param TokenStorageInterface                 $tokenStorage
-     * @param NormalizerInterface                   $normalizer
+     * @param TokenStorageInterface $tokenStorage
+     * @param NormalizerInterface $normalizer
      * @param IdentifiableObjectRepositoryInterface $userRepository
+     * @param SecurityFacade|null $securityFacade
      */
     public function __construct(
         TokenStorageInterface $tokenStorage,
         NormalizerInterface $normalizer,
-        IdentifiableObjectRepositoryInterface $userRepository
+        IdentifiableObjectRepositoryInterface $userRepository,
+        SecurityFacade $securityFacade = null
     ) {
         $this->tokenStorage = $tokenStorage;
         $this->normalizer = $normalizer;
         $this->userRepository = $userRepository;
+        $this->securityFacade = $securityFacade;
     }
 
     /**
@@ -64,6 +72,16 @@ class UserRestController
     public function getAction($identifier)
     {
         $user = $this->userRepository->findOneByIdentifier($identifier);
+
+        $token = $this->tokenStorage->getToken();
+        $currentUserId = null !== $token ? $token->getUser()->getId() : null;
+
+        if (null !== $this->securityFacade) {
+            if ($currentUserId !== $user->getId() &&
+                !$this->securityFacade->isGranted('pim_user_user_index')) {
+                throw new AccessDeniedHttpException();
+            }
+        }
 
         return new JsonResponse($this->normalizer->normalize($user, 'internal_api'));
     }

--- a/src/Pim/Bundle/UserBundle/Resources/config/controllers.yml
+++ b/src/Pim/Bundle/UserBundle/Resources/config/controllers.yml
@@ -10,6 +10,7 @@ services:
             - '@security.token_storage'
             - '@pim_internal_api_serializer'
             - '@pim_user.repository.user'
+            - '@oro_security.security_facade'
 
     pim_user.controller.security_rest:
         class: '%pim_user.controller.security_rest.class%'


### PR DESCRIPTION
Every user can access to the data of any other user with the end-point "pim_user_user_rest_get", even if the permission "List users" is not granted. 

It's a backport of https://github.com/akeneo/pim-community-dev/pull/11036 for the 2.3 with the difference that in 2.3, the user identifier of the end-point is not the integer id, but the user name or its email.