### PR TITLE
PIM-8989: fix attribute sort order in select

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -5,6 +5,7 @@
 - PIM-7027: fix completeness visibility on product edit form
 - PIM-8965: Fix misleading error messages due to all-caps formatting
 - PIM-8954: Forbid user without "list users" permission to access other user data
+- PIM-8989: fix attributes order in the list of attributes
 
 # 2.3.69 (2019-10-24)
 

--- a/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeSearchableRepository.php
+++ b/src/Pim/Bundle/EnrichBundle/Doctrine/ORM/Repository/AttributeSearchableRepository.php
@@ -145,7 +145,7 @@ class AttributeSearchableRepository implements SearchableRepositoryInterface
             $qb->setParameter('groups', $options['attribute_groups']);
         }
 
-        $qb->orderBy('ag.sortOrder');
+        $qb->orderBy('ag.sortOrder, a.sortOrder');
 
         $qb->groupBy('a.id');
 

--- a/tests/legacy/features/attribute-group/display_attribute_group_history.feature
+++ b/tests/legacy/features/attribute-group/display_attribute_group_history.feature
@@ -8,8 +8,8 @@ Feature: Display the attribute group history
     Given the "default" catalog configuration
     And I am logged in as "Julia"
     And the following attributes:
-      | label-en_US | group | type             | code        |
-      | Description | other | pim_catalog_text | description |
+      | label-en_US | group | type             | code        | sort_order |
+      | Description | other | pim_catalog_text | description | 2          |
 
   @ce
   Scenario: Successfully edit a group and see the history


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When listing a list of attributes, make sure they are sorted by:
- their attribute groups' sort_order
- their own sort_order

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
