### PR TITLE
PIM-8965: Fix misleading error messages due to all-caps formatting

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-7027: fix completeness visibility on product edit form
+- PIM-8965: Fix misleading error messages due to all-caps formatting
 
 # 2.3.69 (2019-10-24)
 

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/job-execution/summary-table.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/job-execution/summary-table.html
@@ -79,7 +79,7 @@
                                 <span class="AknMessageBox-title title"><%- failure.label.toUpperCase() %></span>
                                 <%- failure %>
                             <% } else { %>
-                                <%- failure.toUpperCase() %>
+                                <%- failure %>
                             <% } %>
                         </div>
                     </td>


### PR DESCRIPTION
The following error message is thrown when the field "sku" in an import is submitted as "SKU." 

<img width="1007" alt="Screen Shot 2019-11-08 at 10 55 59 AM" src="https://user-images.githubusercontent.com/1516770/69068590-56875980-0a25-11ea-8276-34cf27dd7d29.png">

However, since the error message states "SKU" it is unclear where the error actually comes from (that case-sensitivity is not respected). The error message should reflect the error - that "sku" is missing from the imported file, not the caps lock "SKU." 

New error screen:

![image](https://user-images.githubusercontent.com/1516770/69068414-03150b80-0a25-11ea-8877-c8a725c36317.png)
