### PR TITLE
PIM-8992: Do not allow to import attribute code with line-feed characters

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8992: Do not allow to import attribute code with line-feed characters
+
 # 3.0.54 (2019-11-18)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
@@ -1,6 +1,7 @@
 An identifier attribute already exists.:                                                  An identifier attribute already exists.
 Attribute code may contain only letters, numbers and underscore:                          Attribute code may contain only letters, numbers and underscore
 Attribute code may contain only letters (at least one), numbers and underscores:          Attribute code may contain only letters (at least one), numbers and underscores
+Attribute code may not contain line-feed characters:                                      Attribute code may not contain line-feed characters
 This attribute type can't be used as a grid filter:                                       This attribute type can't be used as a grid filter
 This code is not available:                                                               This code is not available
 This attribute type must be required:                                                     This attribute type must be required

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/attribute.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/attribute.yml
@@ -78,6 +78,9 @@ Akeneo\Pim\Structure\Component\Model\Attribute:
             - Regex:
                 pattern: /^(?!(id|iD|Id|ID|associationTypes|categories|categoryId|completeness|enabled|(?i)\bfamily\b|groups|associations|products|scope|treeId|values|category|parent|label|(.)*_(products|groups)|entity_type|attributes)$)/
                 message: This code is not available
+            - Regex:
+                pattern: /^[^\n]+$/D
+                message: Attribute code may not contain line-feed characters
         localizable:
             - Type: bool
             - NotNull: ~


### PR DESCRIPTION
By the import, it's possible to create an attribute with a code with a line-feed as the last character.

The regex that validates an attribute code doesn't take account of that `/^[a-zA-Z0-9_]+$/` 
Per default, the trailing line-feeds are ignored after the `$` 
It could be fixed by adding the regex modifier `D` but I added another regex to be able to display a specific message, because the line-feeds are not displayed.