### PR TITLE
AST-11: Use imagick as liip_imagine driver

### DIFF
--- a/config/packages/liip_imagine.yml
+++ b/config/packages/liip_imagine.yml
@@ -1,4 +1,5 @@
 liip_imagine:
+    driver: imagick
     data_loader: flysystem_data_loader
     filter_sets:
         avatar_med:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Change `LiipImagine` conf to use `imagick` as driver, in order to be able to generate `tiff` and simple `psd` previews.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
