### PR TITLE
Use relative paths instead of absolute ones in require-paths.js

### DIFF
--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DumpRequirePathsCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DumpRequirePathsCommand.php
@@ -62,16 +62,19 @@ class DumpRequirePathsCommand extends Command
 
     /**
      * Collect an array of requirejs.yml paths for each bundle
+     * @param string $rootDir
      * @return array
      */
-    protected function collectConfigPaths()
+    protected function collectConfigPaths(string $rootDir)
     {
         $paths = array();
+        $rootDir = realpath($rootDir . '/../') . '/';
 
         foreach ($this->bundles as $bundle) {
             $reflection = new \ReflectionClass($bundle);
             $fileName = dirname($reflection->getFilename());
-            $paths[] = $fileName;
+            $relativeFileName = substr($fileName, strlen($rootDir));
+            $paths[] = $relativeFileName;
         }
 
         return $paths;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

With this PR, instead of generating absolute paths in the `require-paths.js`, we generate relative ones.
This resolve an issue with docker where the paths generated in a container does not match the paths on the host, preventing any yarn command to be run in the host.

This was a real handicap for debugging cucumber-js tests.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

