### PR TITLE
API-656: Fix App code and label validation

### DIFF
--- a/src/Akeneo/Apps/back/Application/Validation/App/CodeMustBeUnique.php
+++ b/src/Akeneo/Apps/back/Application/Validation/App/CodeMustBeUnique.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraint;
  */
 class CodeMustBeUnique extends Constraint
 {
-    public $message = 'akeneo_apps.constraint.code.must_be_unique';
+    public $message = 'akeneo_apps.app.constraint.code.must_be_unique';
 
     public function getTargets()
     {

--- a/src/Akeneo/Apps/back/Domain/Model/ValueObject/AppCode.php
+++ b/src/Akeneo/Apps/back/Domain/Model/ValueObject/AppCode.php
@@ -16,6 +16,8 @@ class AppCode
 
     public function __construct(string $code)
     {
+        $code = trim($code);
+        
         if (empty($code)) {
             throw new \InvalidArgumentException(sprintf(self::CONSTRAINT_KEY, 'required'));
         }

--- a/src/Akeneo/Apps/back/Domain/Model/ValueObject/AppLabel.php
+++ b/src/Akeneo/Apps/back/Domain/Model/ValueObject/AppLabel.php
@@ -16,6 +16,8 @@ class AppLabel
 
     public function __construct(string $label)
     {
+        $label = trim($label);
+
         if (empty($label)) {
             throw new \InvalidArgumentException(sprintf(self::CONSTRAINT_KEY, 'required'));
         }

--- a/src/Akeneo/Apps/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Apps/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -43,14 +43,15 @@ pim_apps:
             error: Sorry, an error occurred while editing the App.
 
 akeneo_apps:
-    constraint:
-        code:
-            required: App code is required.
-            invalid: App code may contain only letters, numbers and underscores.
-            too_long: App code is too long. It should have 100 characters or less.
-            must_be_unique: App code must be unique.
-        label:
-            required: App label is required.
-            too_long: App label is too long. It should have 100 characters or less.
-        flow_type:
-            invalid: App flow type can only be 'data_source', 'data_destination' or 'other'.
+    app:
+        constraint:
+            code:
+                required: App code is required.
+                invalid: App code may contain only letters, numbers and underscores.
+                too_long: App code is too long. It should have 100 characters or less.
+                must_be_unique: App code must be unique.
+            label:
+                required: App label is required.
+                too_long: App label is too long. It should have 100 characters or less.
+            flow_type:
+                invalid: App flow type can only be 'data_source', 'data_destination' or 'other'.

--- a/src/Akeneo/Apps/back/tests/Acceptance/Context/AppContext.php
+++ b/src/Akeneo/Apps/back/tests/Acceptance/Context/AppContext.php
@@ -178,7 +178,7 @@ class AppContext implements Context
 
         foreach ($this->violations->getConstraintViolationList() as $violation) {
             if ('code' === $violation->getPropertyPath() &&
-                'akeneo_apps.constraint.code.must_be_unique' === $violation->getMessage()
+                'akeneo_apps.app.constraint.code.must_be_unique' === $violation->getMessage()
             ) {
                 return;
             }

--- a/src/Akeneo/Apps/back/tests/Unit/spec/Application/Validation/App/CodeMustBeUniqueValidatorSpec.php
+++ b/src/Akeneo/Apps/back/tests/Unit/spec/Application/Validation/App/CodeMustBeUniqueValidatorSpec.php
@@ -55,7 +55,7 @@ class CodeMustBeUniqueValidatorSpec extends ObjectBehavior
                 new App('magento', 'Magento connector', FlowType::DATA_DESTINATION, new ClientId(42), new UserId(50))
             );
 
-        $context->buildViolation('akeneo_apps.constraint.code.must_be_unique')
+        $context->buildViolation('akeneo_apps.app.constraint.code.must_be_unique')
             ->shouldBeCalled()
             ->willReturn($builder);
         $builder->addViolation()->shouldBeCalled();

--- a/src/Akeneo/Apps/front/src/application/apps/actions/create-form-actions.ts
+++ b/src/Akeneo/Apps/front/src/application/apps/actions/create-form-actions.ts
@@ -1,52 +1,54 @@
 const CHANGE = 'CHANGE';
 interface ChangeAction {
-  type: typeof CHANGE;
-  name: string;
-  value: string;
+    type: typeof CHANGE;
+    name: string;
+    value: string;
 }
-const inputChanged = (name: string, value: string): ChangeAction => (
-  {type: CHANGE, name, value}
-);
+const inputChanged = (name: string, value: string): ChangeAction => ({type: CHANGE, name, value});
 
 const SET_ERROR = 'SET_ERROR';
 interface SetErrorAction {
-  type: typeof SET_ERROR;
-  name: string;
-  code: string;
+    type: typeof SET_ERROR;
+    name: string;
+    code: string;
 }
 const setError = (name: string, code: string): SetErrorAction => ({type: SET_ERROR, name, code});
 
 const VALID_FORM = 'VALID_FORM';
-interface ValidFormAction { type: typeof VALID_FORM }
-const formIsValid = (): ValidFormAction => ({ type: VALID_FORM });
+interface ValidFormAction {
+    type: typeof VALID_FORM;
+}
+const formIsValid = (): ValidFormAction => ({type: VALID_FORM});
 
 const INVALID_FORM = 'INVALID_FORM';
-interface InvalidFormAction { type: typeof INVALID_FORM }
-const formIsInvalid = (): InvalidFormAction => ({ type: INVALID_FORM });
+interface InvalidFormAction {
+    type: typeof INVALID_FORM;
+}
+const formIsInvalid = (): InvalidFormAction => ({type: INVALID_FORM});
 
 const CODE_GENERATED = 'CODE_GENERATED';
 interface CodeGeneratedAction {
-  type: typeof CODE_GENERATED;
-  value: string;
+    type: typeof CODE_GENERATED;
+    value: string;
 }
-const codeGenerated = (value: string): CodeGeneratedAction => ({ type: CODE_GENERATED, value });
+const codeGenerated = (value: string): CodeGeneratedAction => ({type: CODE_GENERATED, value});
 
 export type CreateFormAction =
-  ChangeAction |
-  SetErrorAction |
-  ValidFormAction |
-  InvalidFormAction |
-  CodeGeneratedAction;
+    | ChangeAction
+    | SetErrorAction
+    | ValidFormAction
+    | InvalidFormAction
+    | CodeGeneratedAction;
 
 export {
-  CHANGE,
-  SET_ERROR,
-  VALID_FORM,
-  INVALID_FORM,
-  CODE_GENERATED,
-  inputChanged,
-  codeGenerated,
-  setError,
-  formIsValid,
-  formIsInvalid
+    CHANGE,
+    SET_ERROR,
+    VALID_FORM,
+    INVALID_FORM,
+    CODE_GENERATED,
+    inputChanged,
+    codeGenerated,
+    setError,
+    formIsValid,
+    formIsInvalid,
 };

--- a/src/Akeneo/Apps/front/src/application/apps/components/AppCreateForm.tsx
+++ b/src/Akeneo/Apps/front/src/application/apps/components/AppCreateForm.tsx
@@ -1,21 +1,21 @@
-import React, {Dispatch, ChangeEvent, useRef, useEffect, useReducer, RefObject} from 'react';
+import React, {ChangeEvent, Dispatch, RefObject, useEffect, useReducer, useRef} from 'react';
 import {FlowType} from '../../../domain/apps/flow-type.enum';
 import {ApplyButton, Form, FormGroup, FormInput} from '../../common';
-import {FlowTypeHelper} from './FlowTypeHelper';
-import {FlowTypeSelect} from './FlowTypeSelect';
-import {appFormReducer, CreateFormState} from '../reducers/app-form-reducer';
-import {
-    inputChanged,
-    setError,
-    formIsInvalid,
-    formIsValid,
-    codeGenerated,
-    CreateFormAction
-} from '../actions/create-form-actions';
 import {isErr} from '../../shared/fetch/result';
 import {sanitize} from '../../shared/sanitize';
 import {Translate} from '../../shared/translate';
-import {useCreateApp, CreateAppData} from '../use-create-app';
+import {
+    codeGenerated,
+    CreateFormAction,
+    formIsInvalid,
+    formIsValid,
+    inputChanged,
+    setError,
+} from '../actions/create-form-actions';
+import {appFormReducer, CreateFormState} from '../reducers/app-form-reducer';
+import {CreateAppData, useCreateApp} from '../use-create-app';
+import {FlowTypeHelper} from './FlowTypeHelper';
+import {FlowTypeSelect} from './FlowTypeSelect';
 
 const initialState: CreateFormState = {
     controls: {
@@ -38,14 +38,7 @@ const useFormValidation = (
     codeInputRef: RefObject<HTMLInputElement>,
     labelInputRef: RefObject<HTMLInputElement>
 ) => {
-    const isFirstRender = useRef(true);
-
     useEffect(() => {
-        if (isFirstRender.current) {
-            isFirstRender.current = false;
-
-            return;
-        }
         [codeInputRef, labelInputRef].forEach(inputRef => {
             const input = inputRef.current;
             if (null === input) {
@@ -53,9 +46,10 @@ const useFormValidation = (
             }
 
             const name = input.name;
-            if (false === input.checkValidity() &&
-              0 === Object.keys(state.controls[name].errors).length &&
-              true === state.controls[name].dirty
+            if (
+                false === input.checkValidity() &&
+                0 === Object.keys(state.controls[name].errors).length &&
+                true === state.controls[name].dirty
             ) {
                 if (input.validity.valueMissing) {
                     dispatch(setError(name, `akeneo_apps.app.constraint.${name}.required`));
@@ -65,18 +59,16 @@ const useFormValidation = (
                 }
             }
         });
-    }, [state.controls.code.value, state.controls.label.value, dispatch, codeInputRef, labelInputRef]);
+    }, [dispatch, codeInputRef, labelInputRef, state.controls]);
 
     useEffect(() => {
-        if (false === state.controls.label.valid ||
-          false === state.controls.code.valid
-        ) {
+        if (false === state.controls.label.valid || false === state.controls.code.valid) {
             dispatch(formIsInvalid());
 
             return;
         }
         dispatch(formIsValid());
-    }, [state.controls.label.valid, state.controls.code.valid]);
+    }, [dispatch, state.controls.label.valid, state.controls.code.valid]);
 };
 
 export const AppCreateForm = () => {
@@ -98,7 +90,7 @@ export const AppCreateForm = () => {
         }
 
         dispatch(codeGenerated(value));
-    }, [state.controls.label.value, dispatch, state.controls.code.dirty, state.controls.code.value]);
+    }, [dispatch, state.controls.label.value, state.controls.code.value, state.controls.code.dirty]);
 
     const handleSave = async () => {
         if (false === state.valid) {

--- a/src/Akeneo/Apps/front/src/application/apps/components/AppCreateForm.tsx
+++ b/src/Akeneo/Apps/front/src/application/apps/components/AppCreateForm.tsx
@@ -58,10 +58,10 @@ const useFormValidation = (
               true === state.controls[name].dirty
             ) {
                 if (input.validity.valueMissing) {
-                    dispatch(setError(name, `akeneo_apps.constraint.${name}.required`));
+                    dispatch(setError(name, `akeneo_apps.app.constraint.${name}.required`));
                 }
                 if (input.validity.patternMismatch) {
-                    dispatch(setError(name, `akeneo_apps.constraint.${name}.invalid`));
+                    dispatch(setError(name, `akeneo_apps.app.constraint.${name}.invalid`));
                 }
             }
         });

--- a/src/Akeneo/Apps/front/src/application/apps/components/AppEditForm.tsx
+++ b/src/Akeneo/Apps/front/src/application/apps/components/AppEditForm.tsx
@@ -44,7 +44,7 @@ export const AppEditForm = forwardRef(({app, onChange}: Props, ref: Ref<{submit:
         if (false === input.checkValidity() && 0 === labelControl.errors.length) {
             const errors = [];
             if (input.validity.valueMissing) {
-                errors.push('akeneo_apps.constraint.label.required');
+                errors.push('akeneo_apps.app.constraint.label.required');
             }
             setLabelControl({...labelControl, errors});
         }

--- a/src/Akeneo/Apps/front/src/application/apps/reducers/app-form-reducer.ts
+++ b/src/Akeneo/Apps/front/src/application/apps/reducers/app-form-reducer.ts
@@ -1,11 +1,11 @@
 import {Reducer} from 'react';
 import {
     CHANGE,
+    CODE_GENERATED,
+    CreateFormAction,
+    INVALID_FORM,
     SET_ERROR,
     VALID_FORM,
-    INVALID_FORM,
-    CODE_GENERATED,
-    CreateFormAction
 } from '../actions/create-form-actions';
 
 export interface CreateFormState {

--- a/src/Akeneo/Apps/front/src/application/apps/use-create-app.ts
+++ b/src/Akeneo/Apps/front/src/application/apps/use-create-app.ts
@@ -1,11 +1,11 @@
 import {useContext} from 'react';
+import {useHistory} from 'react-router';
+import {FlowType} from '../../domain/apps/flow-type.enum';
 import {fetch} from '../shared/fetch';
 import {isErr} from '../shared/fetch/result';
 import {NotificationLevel, useNotify} from '../shared/notify';
 import {useRoute} from '../shared/router';
 import {TranslateContext} from '../shared/translate';
-import {useHistory} from "react-router";
-import {FlowType} from "../../domain/apps/flow-type.enum";
 
 interface ResultError {
     message: string;

--- a/src/Akeneo/Apps/front/tests/unit/application/apps/components/AppEditForm.spec.tsx
+++ b/src/Akeneo/Apps/front/tests/unit/application/apps/components/AppEditForm.spec.tsx
@@ -61,6 +61,6 @@ describe('App', () => {
         (input.instance() as any).value = '';
         input.simulate('change');
 
-        expect(component.text()).toContain('akeneo_apps.constraint.label.required');
+        expect(component.text()).toContain('akeneo_apps.app.constraint.label.required');
     });
 });


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- Fix App code and label validation to not allow empty string
- Fix translation keys usage (missing `.app.`)
- Fix style lint (not runned in the CI, I will do a PR to enable it again)
- Remove unused code in create App form

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
