### PR TITLE
PIM-8995: Adds the supports of the completeness widget for channels having no translations

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,7 @@
 # 3.2.x
 
+- PIM-8995: Fix the completeness widget (dashboard) for channels having no translations
+
 # 3.2.20 (2019-11-20)
 
 # 3.2.19 (2019-11-15)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocale.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocale.php
@@ -72,7 +72,7 @@ class GetCompletenessPerChannelAndLocale implements GetCompletenessPerChannelAnd
         $sql = <<<SQL
             SELECT
                 channel.code as channel_code,
-                channel_translation.json_labels as channel_labels,
+                channel_translation.labels as channel_labels,
                 JSON_ARRAY_APPEND(COALESCE(child.children_codes, "[]"), '$', root.code) as category_codes_in_channel,
                 pim_locales.json_locales as locales
             FROM
@@ -93,12 +93,14 @@ class GetCompletenessPerChannelAndLocale implements GetCompletenessPerChannelAnd
                 LEFT JOIN
                 (
                     SELECT
-                        channel.code as channel_code,
-                        JSON_OBJECTAGG(channel_translation.locale, channel_translation.label) as json_labels
-                    FROM pim_catalog_channel as channel
-                    LEFT JOIN pim_catalog_channel_translation as channel_translation ON channel.id = channel_translation.foreign_key
-                    GROUP BY
-                        channel.code
+                        channel.channel_code,
+                        JSON_OBJECTAGG(locale.code, channel_translation.label) as labels
+                    FROM
+                        (SELECT DISTINCT code as channel_code, id as channel_id FROM pim_catalog_channel) AS channel
+                    CROSS JOIN pim_catalog_locale locale
+                    LEFT JOIN pim_catalog_channel_translation channel_translation ON channel_translation.foreign_key = channel.channel_id AND channel_translation.locale = locale.code
+                    WHERE locale.is_activated = true
+                    GROUP BY channel.channel_code
                 ) AS channel_translation on channel_translation.channel_code = channel.code
                 LEFT JOIN
                 (

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocaleIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocaleIntegration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\FollowUp;
 
 use Akeneo\Channel\Component\Model\ChannelInterface;
+use Akeneo\Pim\Enrichment\Bundle\Storage\ElasticsearchAndSql\FollowUp\GetCompletenessPerChannelAndLocale;
 use Akeneo\Pim\Enrichment\Component\FollowUp\ReadModel\ChannelCompleteness;
 use Akeneo\Pim\Enrichment\Component\FollowUp\ReadModel\CompletenessWidget;
 use Akeneo\Pim\Enrichment\Component\FollowUp\ReadModel\LocaleCompleteness;
@@ -18,112 +19,29 @@ use PHPUnit\Framework\Assert;
  */
 class GetCompletenessPerChannelAndLocaleIntegration extends AbstractProductQueryBuilderTestCase
 {
-    /**
-     * @inheritDoc
-     */
-    protected function setUp(): void
+    /** @var GetCompletenessPerChannelAndLocale */
+    private $getCompletenessPerChannelAndLocale;
+
+    public function setUp(): void
     {
         parent::setUp();
-
-        $this->updateChannel('ecommerce', [
-            'category_tree' => 'master',
-            'currencies'    => ['USD'],
-            'locales'       => ['fr_FR', 'en_US'],
-            'labels' => [
-                'de_DE' => 'Ecommerce DE',
-                'fr_FR' => 'Ecommerce FR',
-                'en_US' => 'Ecommerce US',
-            ]
-        ]);
-
-        $this->createChannel([
-            'code'          => 'mobile',
-            'category_tree' => 'master',
-            'currencies'    => ['USD'],
-            'locales'       => ['en_US'],
-            'labels' => [
-                'fr_FR' => 'Mobile FR',
-                'en_US' => 'Mobile US',
-            ]
-        ]);
-
-        $this->createCategory(['code' => 'shoes', 'parent' => 'master']);
-
-        $this->createAttribute([
-            'code'              => 'name',
-            'type'              => AttributeTypes::TEXT,
-            'available_locales' => ['fr_FR', 'en_US'],
-            'localizable'       => true,
-            'scopable'          => true,
-            'labels'            => [
-                'fr_FR' => 'French name',
-                'en_US' => 'English label',
-            ],
-        ]);
-
-        $this->createAttribute([
-            'code'              => 'description',
-            'type'              => 'pim_catalog_textarea',
-            'available_locales' => ['fr_FR', 'en_US'],
-            'localizable'       => true,
-            'scopable'          => true,
-            'labels'            => [
-                'fr_FR' => 'French description',
-                'en_US' => 'English description',
-            ],
-        ]);
-
-        $this->createFamily([
-            'code'        => 'family_for_complete',
-            'attributes'  => ['sku', 'name', 'description'],
-            'attribute_requirements' => [
-                'ecommerce' => ['sku', 'name'],
-                'mobile' => ['sku', 'name'],
-
-            ]
-        ]);
-
-        $this->createFamily([
-            'code'        => 'family_for_incomplete',
-            'attributes'  => ['sku', 'name', 'description'],
-            'attribute_requirements' => [
-                'ecommerce' => ['sku', 'name', 'description'],
-                'mobile' => ['sku', 'name', 'description']
-            ]
-        ]);
-
-        $this->createProducts(5, 5);
+        $this->getCompletenessPerChannelAndLocale = $this->get('akeneo.pim.enrichment.follow_up.completeness_widget_query');
     }
 
     public function test_complete_completeness_widget()
     {
-        $localeCompletenessesEcommerce = [
-            new LocaleCompleteness('English (United States)', 5),
-            new LocaleCompleteness('French (France)', 5)
-        ];
-        $localeCompletenessesMobile = [
-            new LocaleCompleteness('English (United States)', 5)
-        ];
-        $channelCompletenesses = [
-            new ChannelCompleteness('ecommerce', 10, 10, $localeCompletenessesEcommerce, [
-                'de_DE' => 'Ecommerce DE',
-                'en_US' => 'Ecommerce US',
-                'fr_FR' => 'Ecommerce FR'
-            ]),
-            new ChannelCompleteness('mobile', 5, 10, $localeCompletenessesMobile, [
-                'en_US' => 'Mobile US',
-                'fr_FR' => 'Mobile FR'
-            ])
-        ];
-        $completenessWidget = new CompletenessWidget($channelCompletenesses);
+        $this->givenSomeChannels();
+        $this->andACategory();
+        $this->andSomeAttributes();
+        $this->andSomeFamilies();
+        $this->andSomeProducts();
 
-        $translationLocale = $this->get('pim_user.context.user')->getCurrentLocaleCode();
-        $results = $this->get('akeneo.pim.enrichment.follow_up.completeness_widget_query')->fetch($translationLocale);
+        $results = $this->WhenIFetchTheCompletenessForAllChannelsAndTheCurrentLocale();
 
-        $this->assertSame($completenessWidget->toArray(), $results->toArray());
+        $this->thenTheCalculatedCompletenessesShouldBeCorrect($results);
     }
 
-    protected function createProducts($numberComplete, $numberIncomplete)
+    private function createProducts($numberComplete, $numberIncomplete)
     {
         for ($i = 0; $i < $numberComplete; $i++) {
             $this->createProduct('product_complete_'.$i, [
@@ -156,7 +74,7 @@ class GetCompletenessPerChannelAndLocaleIntegration extends AbstractProductQuery
         }
     }
 
-    protected function createChannel(array $data = []): ChannelInterface
+    private function createChannel(array $data = []): ChannelInterface
     {
         $channel = $this->get('pim_catalog.factory.channel')->create();
         $this->get('pim_catalog.updater.channel')->update($channel, $data);
@@ -169,7 +87,7 @@ class GetCompletenessPerChannelAndLocaleIntegration extends AbstractProductQuery
         return $channel;
     }
 
-    protected function updateChannel($code, array $data = []): ChannelInterface
+    private function updateChannel($code, array $data = []): ChannelInterface
     {
         $channel = $this->get('pim_catalog.repository.channel')->findOneByIdentifier($code);
         $this->get('pim_catalog.updater.channel')->update($channel, $data);
@@ -188,5 +106,134 @@ class GetCompletenessPerChannelAndLocaleIntegration extends AbstractProductQuery
     protected function getConfiguration(): Configuration
     {
         return $this->catalog->useMinimalCatalog();
+    }
+
+    private function givenSomeChannels(): void
+    {
+        $this->updateChannel(
+            'ecommerce',
+            [
+                'category_tree' => 'master',
+                'currencies'    => ['USD'],
+                'locales'       => ['fr_FR', 'en_US'],
+                'labels'        => [
+                    'de_DE' => 'Ecommerce DE',
+                    'fr_FR' => 'Ecommerce FR',
+                    'en_US' => 'Ecommerce US',
+                ]
+            ]
+        );
+        $this->createChannel([
+            'code'          => 'mobile',
+            'category_tree' => 'master',
+            'currencies'    => ['USD'],
+            'locales'       => ['en_US'],
+            'labels'        => [
+                'fr_FR' => 'Mobile FR',
+                'en_US' => 'Mobile US',
+            ]
+        ]
+        );
+    }
+
+    private function andSomeAttributes(): void
+    {
+        $this->createAttribute([
+            'code'              => 'name',
+            'type'              => AttributeTypes::TEXT,
+            'available_locales' => ['fr_FR', 'en_US'],
+            'localizable'       => true,
+            'scopable'          => true,
+            'labels'            => [
+                'fr_FR' => 'French name',
+                'en_US' => 'English label',
+            ],
+        ]
+        );
+
+        $this->createAttribute([
+            'code'              => 'description',
+            'type'              => 'pim_catalog_textarea',
+            'available_locales' => ['fr_FR', 'en_US'],
+            'localizable'       => true,
+            'scopable'          => true,
+            'labels'            => [
+                'fr_FR' => 'French description',
+                'en_US' => 'English description',
+            ],
+        ]
+        );
+    }
+
+    private function andSomeFamilies(): void
+    {
+        $this->createFamily([
+            'code'                   => 'family_for_complete',
+            'attributes'             => ['sku', 'name', 'description'],
+            'attribute_requirements' => [
+                'ecommerce' => ['sku', 'name'],
+                'mobile'    => ['sku', 'name'],
+
+            ]
+        ]
+        );
+
+        $this->createFamily([
+            'code'                   => 'family_for_incomplete',
+            'attributes'             => ['sku', 'name', 'description'],
+            'attribute_requirements' => [
+                'ecommerce' => ['sku', 'name', 'description'],
+                'mobile'    => ['sku', 'name', 'description']
+            ]
+        ]
+        );
+    }
+
+    private function andACategory(): void
+    {
+        $this->createCategory(['code' => 'shoes', 'parent' => 'master']);
+    }
+
+    private function WhenIFetchTheCompletenessForAllChannelsAndTheCurrentLocale(): CompletenessWidget
+    {
+        $translationLocale = $this->get('pim_user.context.user')->getCurrentLocaleCode();
+        $result = $this->getCompletenessPerChannelAndLocale->fetch($translationLocale);
+
+        return $result;
+    }
+
+    /**
+     * @param CompletenessWidget $results
+     *
+     */
+    private function thenTheCalculatedCompletenessesShouldBeCorrect(CompletenessWidget $results): void
+    {
+        $localeCompletenessesEcommerce = [
+            new LocaleCompleteness('English (United States)', 5),
+            new LocaleCompleteness('French (France)', 5)
+        ];
+        $localeCompletenessesMobile = [
+            new LocaleCompleteness('English (United States)', 5)
+        ];
+        $channelCompletenesses = [
+            new ChannelCompleteness('ecommerce', 10, 10, $localeCompletenessesEcommerce, [
+                'de_DE' => 'Ecommerce DE',
+                'en_US' => 'Ecommerce US',
+                'fr_FR' => 'Ecommerce FR'
+            ]
+            ),
+            new ChannelCompleteness('mobile', 5, 10, $localeCompletenessesMobile, [
+                'en_US' => 'Mobile US',
+                'fr_FR' => 'Mobile FR'
+            ]
+            )
+        ];
+        $expectedCompletenessWidget = new CompletenessWidget($channelCompletenesses);
+        $this->assertSame($expectedCompletenessWidget->toArray(), $results->toArray());
+    }
+
+    private function andSomeProducts(): void
+    {
+        $this->createProducts(5, 5);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When a channel would have no translations, the sql query responsible for generating the completeness widget read model would fail.

This was due to the fact when generating all the labels for the channels in a JSON object using JSON_OBJECTAGG with such a usecase, mysql would throw an error stating that it cannot build a JSON_OBJECT having a NULL key.

**Solution** (Found by alex)

Instead of creating the json object from the available translations, we now create them by starting with the activated locales in the PIM and try to find the labels for all the locales. In this case, it's possible to create a json object having a NULL value.

I've tried to improve the integration test, let me know if you dislike the style

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | Ok
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
