### PR TITLE
Fix broken CI on integration tests

### DIFF
--- a/tests/back/Integration/IntegrationTestsBundle/Security/SystemUserAuthenticator.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Security/SystemUserAuthenticator.php
@@ -5,7 +5,7 @@ namespace Akeneo\Test\IntegrationTestsBundle\Security;
 use Akeneo\UserManagement\Component\Factory\UserFactory;
 use Akeneo\UserManagement\Component\Repository\GroupRepositoryInterface;
 use Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
@@ -24,14 +24,14 @@ final class SystemUserAuthenticator
     /** @var RoleRepositoryInterface */
     private $roleRepository;
 
-    /** @var TokenStorage */
+    /** @var TokenStorageInterface */
     private $tokenStorage;
 
     public function __construct(
         UserFactory $userFactory,
         GroupRepositoryInterface $groupRepository,
         RoleRepositoryInterface $roleRepository,
-        TokenStorage $tokenStorage
+        TokenStorageInterface $tokenStorage
     ) {
         $this->userFactory = $userFactory;
         $this->groupRepository = $groupRepository;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This PR aims to fix deprecated TokenStorage dependency in SystemUserAuthenticator class use for integration tests

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
