### PR TITLE
PIM-8990: Improve the performance of the creation of the attributes requirements

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -12,6 +12,7 @@
 - TIP-1225: Improve the performance of the indexation of the products
 - TIP-1174: Improve the performance of the indexation of the product models
 - TIP-1176: Improve the performance of the computation of product model descendant when updating a product. The "compute product model descendant" job does not exist anymore. The computation is now done synchronously thanks the improvement done in TIP-1225 and TIP-1174.
+- PIM-8990: Improve the performance of the creation of the attributes requirements when a channel is created
 
 ## BC breaks
 
@@ -327,6 +328,8 @@
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Connector\Job\EnsureConsistentAttributeGroupOrderTasklet` to
     - remove `Akeneo\Pim\Structure\Bundle\Doctrine\ORM\Query\FindAttributeGroupOrdersEqualOrSuperiorTo` (implementation class)
     - add `Akeneo\Pim\Structure\Component\AttributeGroup\Query\FindAttributeGroupOrdersEqualOrSuperiorTo` (interface)
+- Change constructor of `Akeneo\Pim\Structure\Bundle\EventSubscriber\CreateAttributeRequirementSubscriber` to add `Doctrine\DBAL\Connection`
+- Remove method `prePersist` from `Akeneo\Pim\Structure\Bundle\EventSubscriber\CreateAttributeRequirementSubscriber`
 
 ### CLI Commands
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
@@ -50,5 +50,6 @@ services:
         class: 'Akeneo\Pim\Structure\Bundle\EventSubscriber\CreateAttributeRequirementSubscriber'
         arguments:
             - '@pim_catalog.factory.attribute_requirement'
+            - '@database_connection'
         tags:
             - { name: doctrine.event_subscriber }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When a channel is created, all the attribute requirements are created and persisted in the same process, e. So one line is inserted per attribute of each family.

For a catalog with a lot of families and a lot of attributes per family, the creation of a channel reaches the maximum time execution.

The proposed solution is simply to create only the attribute requirements for the identifier.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
