### PR TITLE
PIM-8952: Add sticky header for attribute option grid

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/choices/options-grid.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/choices/options-grid.js
@@ -11,7 +11,8 @@ define([
     'pim/form',
     'pim/fetcher-registry',
     'pim/attributeoptionview',
-    'pim/template/attribute/tab/choices/options-grid'
+    'pim/initselect2',
+    'pim/template/attribute/tab/choices/options-grid',
 ],
 function (
     $,
@@ -19,11 +20,13 @@ function (
     BaseForm,
     fetcherRegistry,
     AttributeOptionGrid,
+    initSelect2,
     template
 ) {
     return BaseForm.extend({
         template: _.template(template),
         locales: [],
+        selectedLocales: [],
 
         /**
          * {@inheritdoc}
@@ -45,8 +48,22 @@ function (
             this.$el.html(this.template({
                 attributeId: this.getFormData().meta.id,
                 sortable: !this.getFormData().auto_option_sorting,
-                localeCodes: _.pluck(this.locales, 'code')
+                locales: this.locales,
+                localeCodes: this.selectedLocales.length > 0 ? this.selectedLocales : _.pluck(this.locales, 'code')
             }));
+
+            var $select = this.$('#test');
+            var opts = {
+                placeholder: 'All locales',
+                allowClear: true,
+            };
+
+            $select = initSelect2.init($select, opts);
+            $select.select2('val', this.selectedLocales);
+            $select.on('change', e => {
+                this.selectedLocales = e.val;
+                this.render();
+            });
 
             AttributeOptionGrid(this.$('.attribute-option-grid'));
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-option/index.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-option/index.html
@@ -5,13 +5,11 @@
 </colgroup>
 <thead>
     <tr>
-        <th class="AknGrid-headerCell"><%- code_label %></th>
+        <th class="AknGrid-headerCell" style="position: sticky; top: 133px; z-index: 1; background-color: white; background-clip: padding-box;"><%- code_label %></th>
         <% _.each(locales, function (locale) { %>
-            <th class="AknGrid-headerCell">
-                <%- locale %>
-            </th>
+            <th class="AknGrid-headerCell" style="position: sticky; top: 133px; z-index: 1; background-color: white; background-clip: padding-box;"><%- locale %></th>
         <% }); %>
-        <th class="AknGrid-headerCell AknGrid-headerCell--right"><%- _.__('pim_common.actions') %></th>
+        <th class="AknGrid-headerCell AknGrid-headerCell--right" style="position: sticky; top: 133px; z-index: 1; background-color: white; background-clip: padding-box;"><%- _.__('pim_common.actions') %></th>
     </tr>
 </thead>
 <tbody></tbody>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute/tab/choices/options-grid.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute/tab/choices/options-grid.html
@@ -1,3 +1,11 @@
+<div>
+    <select name="" id="test" multiple="multiple" class="select-field">
+        <% _.each(locales, function (locale) { %>
+            <option value="<%- locale.code %>"><%- locale.label %></option>
+        <% }); %>
+    </select>
+</div>
+
 <div
     class="AknGridContainer attribute-option-grid"
     data-attribute-id="<%- attributeId %>"


### PR DESCRIPTION
As of today, the list of attribute options is displayed using the <table> html element. The CSS `position: sticky` is not available for such HTML elements. (see https://caniuse.com/#feat=css-sticky and note #3).

However, making the header sticky depends on the navigator’s support of the `CSS position: sticky` property. there still is a way to make it work (see https://css-tricks.com/position-sticky-and-table-headers/)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
