### PR TITLE
PIM-8990: Fix channel creation taking too much time

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8990: Create only the attributes requirements of the identifier attribute when a channel is created
+
 # 3.0.55 (2019-11-22)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CreateAttributeRequirementSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CreateAttributeRequirementSubscriber.php
@@ -3,9 +3,9 @@
 namespace Akeneo\Pim\Structure\Bundle\EventSubscriber;
 
 use Akeneo\Channel\Component\Model\ChannelInterface;
-use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Factory\AttributeRequirementFactory;
-use Akeneo\Pim\Structure\Component\Model\Family;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 
@@ -54,18 +54,19 @@ class CreateAttributeRequirementSubscriber implements EventSubscriber
         }
 
         $entityManager = $event->getEntityManager();
-        $families = $entityManager->getRepository(Family::class)->findAll();
+        $families = $entityManager->getRepository(FamilyInterface::class)->findAll();
+
+        $attributeRepository = $entityManager->getRepository(AttributeInterface::class);
+        $identifierAttribute = $attributeRepository->getIdentifier();
 
         foreach ($families as $family) {
-            foreach ($family->getAttributes() as $attribute) {
-                $requirement = $this->requirementFactory->createAttributeRequirement(
-                    $attribute,
-                    $entity,
-                    AttributeTypes::IDENTIFIER === $attribute->getType()
-                );
-                $requirement->setFamily($family);
-                $entityManager->persist($requirement);
-            }
+            $requirement = $this->requirementFactory->createAttributeRequirement(
+                $identifierAttribute,
+                $entity,
+                true
+            );
+            $requirement->setFamily($family);
+            $entityManager->persist($requirement);
         }
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When a channel is created, all the attribute requirements are created and persisted in the same process. So one line is inserted per attribute of each family.

For a catalog with a lot of families and a lot of attributes per family, the creation of a channel reaches the maximum time execution. (PS: it's not a memory leak. The process could run for hours if we don't limit it)

The proposed solution is simply to create only the attribute requirements for the identifier.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
