### PR TITLE
PIM-8950: PoC on Content Security Policy

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/_scripts.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/_scripts.html.twig
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ js_nonce() }}">
     require(
         ['jquery', 'pim/tree/manage'],
         function($, TreeManage){

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/edit.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/edit.html.twig
@@ -6,11 +6,11 @@
     {% include "AkeneoPimEnrichmentBundle:CategoryTree:_scripts.html.twig" %}
 {% endblock %}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ js_nonce() }}">
     window.flashMessages = JSON.parse('{{ app.session.flashbag.all|json_encode()|raw }}');
 </script>
 
-<script>
+<script nonce="{{ js_nonce() }}">
     require(
         [
             'pim/common/breadcrumbs',

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/form.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/form.html.twig
@@ -89,7 +89,7 @@
 
 {{ form_end(form) }}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ js_nonce() }}">
     window.flashMessages = JSON.parse('{{ app.session.flashbag.all|json_encode()|raw }}');
 
     require(['pim/menu/resizable'], function(Resizable) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/index.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/index.html.twig
@@ -31,7 +31,7 @@
 </div>
 {% endblock %}
 
-<script>
+<script nonce="{{ js_nonce() }}">
     window.flashMessages = JSON.parse('{{ app.session.flashbag.all|json_encode()|raw }}');
 
     require(

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/Widget/completeness.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/Widget/completeness.html.twig
@@ -5,7 +5,7 @@
 {% set widgetContent %}
     <div id="completeness-widget" class="completeness-widget"></div>
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ js_nonce() }}">
         require(
             ['jquery', 'pim/dashboard/widget-container', 'pim/dashboard/completeness-widget'],
             function ($, widgetContainer, CompletenessWidget) {

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/SystemInfo/index.html.twig
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/SystemInfo/index.html.twig
@@ -31,7 +31,7 @@
         </table>
     </div>
 
-    <script>
+    <script nonce="{{ js_nonce() }}">
         require(
             [
                 'pim/common/breadcrumbs',

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/Update/last_patch.html.twig
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/Update/last_patch.html.twig
@@ -1,7 +1,7 @@
 {% if is_last_patch_enabled() %}
     <div class="AknFooter-item last-version"><span>{{ 'pim_analytics.new_patch_available'|trans }}:</span><span></span></div>
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ js_nonce() }}">
         require(
             ['jquery', 'pim/patch-fetcher'],
             function ($, Fetcher) {

--- a/src/Akeneo/Platform/Bundle/DashboardBundle/Resources/views/Dashboard/index.html.twig
+++ b/src/Akeneo/Platform/Bundle/DashboardBundle/Resources/views/Dashboard/index.html.twig
@@ -17,7 +17,7 @@
             {% embed 'PimAnalyticsBundle:Update:last_patch.html.twig' %}{% endembed %}
         </div>
     </div>
-    <script>
+    <script nonce="{{ js_nonce() }}">
         require(
             [
                 'pim/common/breadcrumbs',

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/views/Widget/last_operations.html.twig
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/views/Widget/last_operations.html.twig
@@ -5,7 +5,7 @@
 {% set widgetContent %}
     <table id="last-operations-widget" class="AknGrid AknGrid--unclickable"></table>
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ js_nonce() }}">
         require(
             ['jquery', 'pim/dashboard/widget-container', 'pim/importexport/widget/last-operations-widget'],
             function ($, widgetContainer, LastOperationsWidget) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/AddContentSecurityPolicyListener.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/AddContentSecurityPolicyListener.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Akeneo\Platform\Bundle\UIBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Inject CSP headers in response object
+ *
+ * @author JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AddContentSecurityPolicyListener implements EventSubscriberInterface
+{
+    /** @var string */
+    private $generatedNonce;
+
+    public function __construct(ScriptNonceGenerator $nonceGenerator)
+    {
+        $this->generatedNonce = $nonceGenerator->getGeneratedNonce();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => 'addCspHeaders',
+        ];
+    }
+
+    public function addCspHeaders(FilterResponseEvent $event): void
+    {
+        $policy = sprintf(
+            "default-src 'self' *.akeneo.com 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'nonce-%s'",
+            $this->generatedNonce
+        );
+
+        $response = $event->getResponse();
+        $response->headers->set('Content-Security-Policy', $policy);
+        $response->headers->set('X-Content-Security-Policy', $policy);
+        $response->headers->set('X-WebKit-CSP', $policy);
+    }
+}

--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Akeneo\Platform\Bundle\UIBundle\EventListener;
+
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Generate and return the CSP javascript nonce
+ *
+ * @author JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ScriptNonceGenerator
+{
+    /** @var string */
+    private $generatedNonce;
+
+    public function getGeneratedNonce(): string
+    {
+        if (null === $this->generatedNonce) {
+            $this->generatedNonce = Uuid::uuid4()->toString();
+        }
+
+        return $this->generatedNonce;
+    }
+}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
@@ -55,3 +55,13 @@ services:
         class: 'Akeneo\Platform\Bundle\UIBundle\Http\FormAuthenticationEntryPoint'
         arguments:
             - '@http_kernel'
+
+    security.event_listener.add_csp:
+        class: Akeneo\Platform\Bundle\UIBundle\EventListener\AddContentSecurityPolicyListener
+        arguments:
+            - '@security.script_nonce_generator'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    security.script_nonce_generator:
+        class: Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/twig.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/twig.yml
@@ -58,3 +58,12 @@ services:
         class: 'Akeneo\Platform\Bundle\UIBundle\Twig\ObjectClassExtension'
         tags:
             - { name: twig.extension }
+
+    pim_enrich.twig.content_security_policy_extension:
+        class: Akeneo\Platform\Bundle\UIBundle\Twig\ContentSecurityPolicyExtension
+        arguments:
+            - '@security.script_nonce_generator'
+        tags:
+            - { name: twig.extension }
+
+

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Default/page_elements.html.twig
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Default/page_elements.html.twig
@@ -138,7 +138,7 @@
     <div id="entity-updated" style="opacity: 0">
         <span class="AknState">{{ 'info.updated'|trans }}</span>
     </div>
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ js_nonce() }}">
         require(
             ['jquery', 'pim/formupdatelistener'],
             function ($, FormUpdateListener) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Default/pim_uservoice.js.twig
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Default/pim_uservoice.js.twig
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ js_nonce() }}">
     UserVoice=window.UserVoice||[];(function(){var uv=document.createElement('script');uv.type='text/javascript';uv.async=true;uv.src='//widget.uservoice.com/{{ uservoice_key }}.js';var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(uv,s)})();
     UserVoice.push(['set', { accent_color: '#66279c', trigger_color: 'white', trigger_background_color: '#66279c'}]);
     UserVoice.push(['identify', {}]);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Form/pim-fields.html.twig
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Form/pim-fields.html.twig
@@ -168,7 +168,7 @@
 
 {% block form_errors %}{% spaceless %}
     {% if errors|length > 0 %}
-        <script type="text/javascript">
+        <script type="text/javascript" nonce="{{ js_nonce() }}">
             var el = document.getElementById('{{ _self.getRootId(form) }}');
 
             if (el) {
@@ -251,7 +251,7 @@
                 {{ form_widget(form.id) }}
             </div>
         </div>
-        <script type="text/javascript">
+        <script type="text/javascript" nonce="{{ js_nonce() }}">
             require(
                 ['pim/fileinput'],
                 function(fileinput) {
@@ -293,7 +293,7 @@
         <input id="{{ originalId }}" type="checkbox" {% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}{% if disabled %} disabled="disabled"{% endif %}>
         <input type="hidden" {{ block('widget_attributes') }}{% if checked or attr.checked is defined and attr.checked %} value="1"{% endif %}>
     </div>
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ js_nonce() }}">
     require(
         ['jquery'],
         function ($) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ContentSecurityPolicyExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ContentSecurityPolicyExtension.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Akeneo\Platform\Bundle\UIBundle\Twig;
+
+use Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator;
+
+/**
+ * CSP twig extension.
+ *
+ * This extension can inject a nonce in javascript tags to make them pass the CSP policy..
+ *
+ * @author JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ContentSecurityPolicyExtension extends \Twig_Extension
+{
+    /** @var ScriptNonceGenerator */
+    private $scriptNonceGenerator;
+
+    public function __construct(ScriptNonceGenerator $scriptNonceGenerator)
+    {
+        $this->scriptNonceGenerator = $scriptNonceGenerator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('js_nonce', [$this, 'getScriptNonce']),
+        ];
+    }
+
+    public function getScriptNonce()
+    {
+        return $this->scriptNonceGenerator->getGeneratedNonce();
+    }
+}

--- a/src/Akeneo/UserManagement/Bundle/Resources/views/Group/update.html.twig
+++ b/src/Akeneo/UserManagement/Bundle/Resources/views/Group/update.html.twig
@@ -58,13 +58,13 @@
         </div>
 
     {{ form_end(form) }}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ js_nonce() }}">
         require('pim/page-title').set({'group': '{{ form.vars.value.name }}'});
 
         window.flashMessages = JSON.parse('{{ app.session.flashbag.all|json_encode()|raw }}');
     </script>
 
-    <script>
+    <script nonce="{{ js_nonce() }}">
         require(
             [
                 'pim/common/breadcrumbs',

--- a/src/Akeneo/UserManagement/Bundle/Resources/views/Role/update.html.twig
+++ b/src/Akeneo/UserManagement/Bundle/Resources/views/Role/update.html.twig
@@ -3,7 +3,7 @@
 {% import 'PimUIBundle::macros.html.twig' as UI %}
 
 {% block head_script %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ js_nonce() }}">
         require(
             ['jquery', 'pim/security-context'],
             function ($, securityContext) {
@@ -233,7 +233,7 @@
 
     {{ form_end(form) }}
 
-    <script>
+    <script nonce="{{ js_nonce() }}">
         require(
             [
                 'pim/common/breadcrumbs',

--- a/src/Akeneo/UserManagement/Bundle/Resources/views/Security/login.html.twig
+++ b/src/Akeneo/UserManagement/Bundle/Resources/views/Security/login.html.twig
@@ -3,7 +3,7 @@
 {% block bodyClass %}AknLogin{% endblock %}
 
 {% block content %}
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ js_nonce() }}">
     sessionStorage.clear();
     document.title = '{{ 'Login'|trans }}';
 </script>

--- a/src/Akeneo/UserManagement/Bundle/Resources/views/layout.html.twig
+++ b/src/Akeneo/UserManagement/Bundle/Resources/views/layout.html.twig
@@ -34,7 +34,7 @@
         </div>
     </div>
     {# we had to do this to prevent loading js stack when not logged in#}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ js_nonce() }}">
         const tooltip = document.querySelector('[data-toggle="tooltip"]');
         if (null !== tooltip) {
             tooltip.addEventListener('mouseover', function(event){
@@ -53,7 +53,6 @@
                 event.currentTarget.parentNode.querySelectorAll('.tooltip').forEach((tooltip) => tooltip.remove());
             });
         }
-
     </script>
 </body>
 </html>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/views/macros.html.twig
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/views/macros.html.twig
@@ -7,7 +7,7 @@
     <div id="grid-{{ name }}" data-type="datagrid" data-data="{{ oro_datagrid_data(name, params)|escape }}"
          {% if renderParams.cssClass is defined %} class="{{ renderParams.cssClass }}" {% endif %}
          data-metadata="{{ metaData|json_encode }}"></div>
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ js_nonce() }}">
         require(['jquery', 'oro/datagrid-builder', 'underscore'].concat({{ metaData.requireJSModules|json_encode|raw }}),
         function ($, datagridBuilder, _) {
             var builders = _.toArray(arguments).slice(3);
@@ -23,7 +23,7 @@
 #}
 {% macro renderStatefulGrid(name, params = {}, renderParams = {}, defaultView = {}, categoryBaseRoute = null, includeFilters = false) %}
     <div id="grid-{{ name }}" data-type="datagrid" {% if renderParams.cssClass is defined %} class="{{ renderParams.cssClass }}" {% endif %}></div>
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ js_nonce() }}">
         require(
             [
                 'underscore',


### PR DESCRIPTION
This PR add a Content Security Policy to prevent the execution of javascript `<script></script>` tags in the PIM, mainly to void direct execution in WYSIWYG editors. Sadly, we still have some legacy and legit scripts tags that still must be executed. For these tags, CSP allows to identify them as legit by adding them a nonce string that must correspond to the same nonce in the CSP headers.

To do that, we add a very simple nonce generator using Uuid. This Uuid is the same for all the request. It is used by a Twig extension to add it in templates and by a response subscriber to add it in the headers.

To sum up the request process:
- twig templates are rendered and the twig extension call the nonce generator. First call will generate it, subsequent calls will just use the cached value.
- before sending the response, the subscriber inject the CSP header. The headers call the nonce generator, again using the cached value
- the response is sent with the same nonce in twig templates and in the headers
