### PR TITLE
PIM-8997: Fix incorrect empty value stored for wysiwyg editor

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8990: Create only the attributes requirements of the identifier attribute when a channel is created
+- PIM-8997: Fix incorrect empty value stored for wysiwyg editor
 
 # 3.0.55 (2019-11-22)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -75,6 +75,7 @@ define(
              */
             updateModel: function () {
                 var data = this.$('.field-input:first textarea:first').code();
+                data = '<p><br></p>' === data ? this.attribute.empty_value : data;
                 data = '' === data ? this.attribute.empty_value : data;
 
                 this.setCurrentValue(data);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

WYSIWYG editor use `<p><br></p>` as empty value (for [compatibility issue](https://github.com/summernote/summernote/pull/313)), to avoid saving this value we have to set empty value ourself on submit.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
