### PR TITLE
PIM-8984: Fix css on records dropdowns

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-8984: Fix css on records dropdowns
+
 # 3.2.21 (2019-11-22)
 
 - PIM-8995: Fix the completeness widget (dashboard) for channels having no translations

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/select2.less
@@ -674,6 +674,15 @@
     }
   }
 
+  .select2-result {
+    border-bottom: 1px solid #D8DCE1;
+    min-height: 64px;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
   .select2-result, .select2-choice, .select2-choices {
     flex-direction: row;
     align-items: center;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

For `records`, the height of a row in the select2 dropdown did not match the design.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
