### PR TITLE
PIM-8996: Display an error when a file upload failed

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+ - PIM-8996: Display an error when a file upload failed
+
 # 3.2.21 (2019-11-22)
 
 - PIM-8995: Fix the completeness widget (dashboard) for channels having no translations

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/media-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/media-field.js
@@ -101,7 +101,7 @@ define([
                     var message = xhr.responseJSON && xhr.responseJSON.message ?
                         xhr.responseJSON.message :
                         _.__('pim_enrich.entity.product.flash.update.file_upload');
-                    messenger.enqueueMessage('error', message);
+                    messenger.notify('error', message);
                 })
                 .always(function () {
                     this.$('> .akeneo-media-uploader-field .progress').css({opacity: 0});


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When uploading a file in the media field, a failure (file too big, for example) did not display an error in the UI.
Using `messenger.notify` instead of `messenger.enqueueMessage` will ensure the message is shown.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
