### PR TITLE
Makes script fails in case of failure to get tests list

### DIFF
--- a/.circleci/run_behat.sh
+++ b/.circleci/run_behat.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -eo pipefail
 
 TEST_SUITE=$1
 
@@ -12,10 +14,12 @@ for TEST_FILE in $TEST_FILES; do
     echo "$TEST_FILE ($counter/$total):"
     output=$(basename $TEST_FILE)_$(uuidgen)
 
+    set +e
     docker-compose exec -u www-data -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE ||
     docker-compose exec -u www-data -T fpm ./vendor/bin/behat --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE
     fail=$(($fail + $?))
     counter=$(($counter + 1))
+    set -eo pipefail
 done
 
-return $fail
+exit $fail

--- a/.circleci/run_phpunit.sh
+++ b/.circleci/run_phpunit.sh
@@ -1,7 +1,10 @@
-#!/bin/sh
-
+#!/bin/bash
+#
 # Usage:
 #   run_phpunit.sh path/to/phpunit.xml .circleci/find_phpunit.php PIM_Integration_Test
+#
+
+set -eo pipefail
 
 CONFIG_DIRECTORY=$1
 FIND_PHPUNIT_SCRIPT=$2
@@ -12,8 +15,11 @@ TEST_FILES=$(docker-compose run -u www-data --rm -T php php $FIND_PHPUNIT_SCRIPT
 fail=0
 for TEST_FILE in $TEST_FILES; do
     echo $TEST_FILE
+
+    set +e
     docker-compose exec -u www-data -T fpm ./vendor/bin/phpunit -c $CONFIG_DIRECTORY --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml $TEST_FILE
     fail=$(($fail + $?))
+    set -eo pipefail
 done
 
-return $fail
+exit $fail


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Make sure phpunit and behat fails properly when failing on listing tests.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
