### PR TITLE
PIM-9003: fix product variant navigation when there is no completeness for a given channel

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-9003: Fix product variant nvigation when there is no completeness for a given channel
+- PIM-9003: Fix product variant navigation when there is no completeness for a given channel
 
 # 2.3.72 (2019-12-02)
 

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-9003: Fix product variant nvigation when there is no completeness for a given channel
+
 # 2.3.72 (2019-12-02)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -335,6 +335,11 @@ define(
 
                 if ('product' === entity.model_type) {
                     const channelCompletenesses = _.findWhere(entity.completeness, {channel: catalogScope});
+                    if (channelCompletenesses === undefined) {
+                        return {
+                            ratio: 0
+                        };
+                    }
                     const localeCompleteness = channelCompletenesses.locales[catalogLocale].completeness;
 
                     return {


### PR DESCRIPTION
This PR fix a bug that can happen when selecting a newly created channel and choosing a variant product that has no completeness yet.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
