### PR TITLE
PIM-9002: Allow command "pim:product:clean-removed-attributes" to work with --no-interaction parameter

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,8 @@
 # 3.0.x
 
+## Enhancements
+- PIM-9002: Allow command `pim:product:clean-removed-attributes` to work with --no-interaction parameter
+
 # 3.0.56 (2019-11-27)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
@@ -52,7 +52,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends ContainerA
         $io->title('Clean removed attributes values');
         $answer = $io->confirm(
             'This command with removes all values of deleted attributes on all products and product models' . "\n" .
-            'Do you want to proceed?', false);
+            'Do you want to proceed?', true);
 
         if (!$answer) {
             $io->text('That\'s ok, see you!');


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
