### PR TITLE
PIM-6437: Remove empty or already added attribute groups from family edit screen

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,10 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-9003: Fix product variant navigation when there is no completeness for a given channel
+- PIM-6437: Remove empty or already added attribute groups from family edit screen
+
 # 2.3.72 (2019-12-02)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/product/form/variant-navigation.js
@@ -335,6 +335,11 @@ define(
 
                 if ('product' === entity.model_type) {
                     const channelCompletenesses = _.findWhere(entity.completeness, {channel: catalogScope});
+                    if (channelCompletenesses === undefined) {
+                        return {
+                            ratio: 0
+                        };
+                    }
                     const localeCompleteness = channelCompletenesses.locales[catalogLocale].completeness;
 
                     return {

--- a/tests/legacy/features/attribute-group/list_attribute_groups.feature
+++ b/tests/legacy/features/attribute-group/list_attribute_groups.feature
@@ -84,7 +84,7 @@ Feature: List attribute groups
     And I press the "Save" button in the popin
     And I wait to be on the "big_family" family page
     And I visit the "Attributes" tab
-    And I add attributes by group "attribute_group_1, attribute_group_2, attribute_group_3, attribute_group_4, attribute_group_5, attribute_group_6, attribute_group_7, attribute_group_8, attribute_group_9, attribute_group_10"
+    And I add attributes by group "attribute_group_2, attribute_group_3, attribute_group_4, attribute_group_5, attribute_group_6, attribute_group_7, attribute_group_8, attribute_group_9, attribute_group_10"
     And I add attributes by group "attribute_group_11, attribute_group_12, attribute_group_13, attribute_group_14, attribute_group_15, attribute_group_16, attribute_group_17, attribute_group_18, attribute_group_19, attribute_group_20"
     And I add attributes by group "attribute_group_21, attribute_group_22"
     And I should see the text "attribute_group_1"

--- a/tests/legacy/features/family/add_attributes_to_family_by_group.feature
+++ b/tests/legacy/features/family/add_attributes_to_family_by_group.feature
@@ -12,7 +12,7 @@ Feature: Add attributes by attribute groups to a family
   Scenario: Successfully list available attribute groups
     Given I am on the "Sandals" family page
     And I visit the "Attributes" tab
-    Then I should see available attribute group "Product information, Marketing, Sizes, Colors, Media and Other"
+    Then I should see available attribute group "Product information, Marketing, Colors, Media and Other"
 
   @info https://akeneo.atlassian.net/browse/PIM-6095
   Scenario: Successfully add attributes by attribute groups to a family


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
I just used the initial fix from Tamara (https://github.com/akeneo/pim-community-dev/pull/10866), wich was already good because Pierre's fix couldn't be backported as she suggested (his fix was for the attribute select, not the attribute group select).

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
