### PR TITLE
PIM-8988: Remove useless "Remove" button when editing exported attributes (in export profile)

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -4,6 +4,7 @@
 
 - PIM-8996: Display an error when a file upload failed
 - PIM-8984: Fix css on records dropdowns
+- PIM-8988: Remove useless "Remove" button when editing exported attributes (in export profile)
 
 # 3.2.21 (2019-11-22)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/product/edit/content/structure/attributes-selector.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/product/edit/content/structure/attributes-selector.js
@@ -203,6 +203,8 @@ define(
                                 })
                             );
 
+                            this.toggleRemoveButtons();
+
                             if (0 !== attributes.length) {
                                 this.attributeListPage++;
                                 this.isFetching = false;
@@ -224,6 +226,8 @@ define(
                         this.setSelected(_.map(this.$('.selected-attributes li'), function (element) {
                             return element.dataset.attributeCode;
                         }));
+
+                        this.toggleRemoveButtons();
                     }.bind(this)
                 }).disableSelection();
             },
@@ -242,6 +246,21 @@ define(
                 this.setSelected(selectedAttributes);
 
                 this.$('.attributes > div ul').append(element);
+                this.toggleRemoveButtons();
+            },
+
+            /**
+             * Toggle all "remove" buttons depending on whether the attribute is in the
+             * selected or available column (we need to display "remove" buttons only in the selected column)
+             */
+            toggleRemoveButtons: function () {
+                _.map(this.$('.selected-attributes li'), function (element) {
+                    $(element).find('.remove').removeClass('AknIconButton--hide');
+                });
+
+                _.map(this.$('.attributes li'), function (element) {
+                    $(element).find('.remove').addClass('AknIconButton--hide');
+                });
             }
         });
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We were displaying the "Remove" button when editing attributes to export on a product export profile edition:
![7yDK4h4](https://user-images.githubusercontent.com/301169/69972250-910eed00-1521-11ea-9a34-5ce65ce5f3a8.png)
 (middle column should not have "Remove" button) 🠕

This PR fixes this behavior by displaying "Remove" button only when the item is in the "Selected" column:
![Z81F3JN](https://user-images.githubusercontent.com/301169/69972327-b3086f80-1521-11ea-886e-0d4d75e8697f.png)



**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
