### PR TITLE
PIM-6672: prevent a product from being classified in a root category via imports or API

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/product.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/product.yml
@@ -17,6 +17,7 @@ Pim\Component\Catalog\Model\Product:
             groups: [UniqueAxis]
         - Pim\Component\Catalog\Validator\Constraints\ImmutableVariantAxesValues: ~
         - Pim\Component\Catalog\Validator\Constraints\OnlyExpectedAttributes: ~
+        - Pim\Component\Catalog\Validator\Constraints\Product\ProductCategories: ~
 
     properties:
         identifier:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/productmodel.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/productmodel.yml
@@ -11,6 +11,7 @@ Pim\Component\Catalog\Model\ProductModel:
         - Pim\Component\Catalog\Validator\Constraints\NotEmptyVariantAxes: ~
         - Pim\Component\Catalog\Validator\Constraints\Product\UniqueProductModelEntity:
             message: pim_catalog.constraint.pim_immutable_product_model_validator
+        - Pim\Component\Catalog\Validator\Constraints\Product\ProductCategories: ~
     properties:
         code:
             - NotBlank:

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validators.yml
@@ -472,3 +472,8 @@ services:
             - '@pim_catalog.repository.cached_locale'
         tags:
             - { name: validator.constraint_validator, alias: pim_activated_locale_validator }
+
+    pim_catalog.validator.constraints.product_categories:
+        class: 'Pim\Component\Catalog\Validator\Constraints\Product\ProductCategoriesValidator'
+        tags:
+            - { name: validator.constraint_validator, alias: pim_product_categories_validator }

--- a/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/translations/validators.en.yml
@@ -82,4 +82,4 @@ pim_catalog:
         303: This field expects a valid association format.
         pim_immutable_product_validator: The same identifier is already set on another product
         pim_immutable_product_model_validator: The same code is already set on another product model.
-
+        product_cannot_be_classified_in_root_category: A product cannot be classified in a root category

--- a/src/Pim/Component/Catalog/Validator/Constraints/Product/ProductCategories.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/Product/ProductCategories.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Component\Catalog\Validator\Constraints\Product;
+
+use Symfony\Component\Validator\Constraint;
+
+class ProductCategories extends Constraint
+{
+    public const ERROR_MESSAGE = 'pim_catalog.constraint.product_cannot_be_classified_in_root_category';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy(): string
+    {
+        return 'pim_product_categories_validator';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Pim/Component/Catalog/Validator/Constraints/Product/ProductCategoriesValidator.php
+++ b/src/Pim/Component/Catalog/Validator/Constraints/Product/ProductCategoriesValidator.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Pim\Component\Catalog\Validator\Constraints\Product;
+
+use Akeneo\Component\Classification\CategoryAwareInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class ProductCategoriesValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($entity, Constraint $constraint): void
+    {
+        if (! $entity instanceof CategoryAwareInterface) {
+            return;
+        }
+
+        foreach ($entity->getCategories() as $category) {
+            if (null === $category->getParent()) {
+                $this->context
+                    ->buildViolation(ProductCategories::ERROR_MESSAGE)
+                    ->addViolation();
+
+                return;
+            }
+        }
+    }
+}

--- a/src/Pim/Component/Catalog/spec/Validator/Constraints/Product/ProductCategoriesValidatorSpec.php
+++ b/src/Pim/Component/Catalog/spec/Validator/Constraints/Product/ProductCategoriesValidatorSpec.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace spec\Pim\Component\Catalog\Validator\Constraints\Product;
+
+use PhpSpec\ObjectBehavior;
+use Pim\Component\Catalog\Model\CategoryInterface;
+use Pim\Component\Catalog\Model\ProductInterface;
+use Pim\Component\Catalog\Validator\Constraints\Product\ProductCategories;
+use Pim\Component\Catalog\Validator\Constraints\Product\ProductCategoriesValidator;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class ProductCategoriesValidatorSpec extends ObjectBehavior
+{
+    function let(
+        ExecutionContextInterface $context
+    ) {
+        $this->initialize($context);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ProductCategoriesValidator::class);
+    }
+
+    function it_validates_nothing_if_entity_does_not_have_any_category(
+        $context,
+        ProductInterface $product,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder
+    ) {
+        $constraint = new ProductCategories();
+
+        $product->getCategories()->willReturn([]);
+
+        $context->buildViolation(ProductCategories::ERROR_MESSAGE)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldNotBeCalled();
+
+        $this->validate($product, $constraint)->shouldReturn(null);
+    }
+
+    function it_does_not_add_any_violation_if_no_categoryis_root(
+        $context,
+        CategoryInterface $category1,
+        CategoryInterface $category2,
+        ProductInterface $product,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder
+    ) {
+        $constraint = new ProductCategories();
+
+        $product->getCategories()->willReturn([$category1]);
+        $category1->getParent()->willReturn($category2);
+
+        $context->buildViolation(ProductCategories::ERROR_MESSAGE)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldNotBeCalled();
+
+        $this->validate($product, $constraint)->shouldReturn(null);
+    }
+
+    function it_adds_violation_to_the_context_if_the_product_is_updated_with_a_root_category(
+        $context,
+        CategoryInterface $category1,
+        CategoryInterface $category2,
+        CategoryInterface $category3,
+        ProductInterface $product,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder
+    ) {
+        $constraint = new ProductCategories();
+
+        $product->getCategories()->willReturn([$category1, $category2]);
+        $category1->getParent()->willReturn($category3);
+        $category2->getParent()->willReturn(null);
+
+        $context->buildViolation(ProductCategories::ERROR_MESSAGE)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($product, $constraint)->shouldReturn(null);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
