### PR TITLE
DAPI-660 - add mbstring extension as official requirement

### DIFF
--- a/src/Akeneo/Platform/PimRequirements.php
+++ b/src/Akeneo/Platform/PimRequirements.php
@@ -39,7 +39,8 @@ class PimRequirements
         'xml',
         'zip',
         'exif',
-        'imagick'
+        'imagick',
+        'mbstring',
     ];
 
     /** @var string[] */


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Add the `mbstring` extension as part of the requirements.

Already in the documentation: https://docs.akeneo.com/master/install_pim/manual/system_requirements/system_requirements.html
Already in the production docker image: https://github.com/akeneo/pim-community-dev/blob/master/Dockerfile#L31

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
