### PR TITLE
PIM-9005: Fix display of long option labels in the Product Edit Form

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes:
 
 - PIM-9008: Fix product models API when the filter "completenes" was used with a sub-filter "locale"
+- PIM-9005: Fix display of long option labels in the Product Edit Form
 
 # 3.2.22 (2019-12-03)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/multi-select-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/multi-select-field.js
@@ -160,6 +160,9 @@ define(
                                 callback(_.compact(choices));
                             }.bind(this));
                         }.bind(this),
+                        formatSelection: function(data, container) {
+                            container.attr('title', data.text).text(data.text);
+                        },
                         multiple: true
                     };
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/select2/select2.css
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/select2/select2.css
@@ -502,6 +502,12 @@ disabled look for disabled choices in the results dropdown
     float: left;
     list-style: none;
 }
+.select2-container-multi .select2-choices li div {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 415px;
+}
 .select2-container-multi .select2-choices .select2-search-field {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix the display of very long option labels in the Product Edit Form (_truncate it with CSS, adds an ellipsis and a title on hover_).

**Before**:
![Screenshot at 2019-12-03 14-03-25](https://user-images.githubusercontent.com/301169/70058769-d265d200-15df-11ea-975b-6f9804d31099.png)

**After**:
![Screenshot at 2019-12-03 14-05-39](https://user-images.githubusercontent.com/301169/70058780-d72a8600-15df-11ea-87c8-25a7b2a89b6f.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -