### PR TITLE
Fishing hook: print out failed integration tests

### DIFF
--- a/.circleci/run_phpunit.sh
+++ b/.circleci/run_phpunit.sh
@@ -18,7 +18,11 @@ for TEST_FILE in $TEST_FILES; do
 
     set +e
     docker-compose exec -u www-data -T fpm ./vendor/bin/phpunit -c $CONFIG_DIRECTORY --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml $TEST_FILE
-    fail=$(($fail + $?))
+    TEST_RESULT=$?
+    if [ $TEST_RESULT -ne 0 ]; then
+        echo "Test has failed (with code $TEST_RESULT): $TEST_FILE"
+    fi
+    fail=$(($fail + $TEST_RESULT))
     set -eo pipefail
 done
 


### PR DESCRIPTION
Some back integration tests fails because they endup with a segmentation fault (like this one https://circleci.com/gh/akeneo/pim-enterprise-dev/22764#tests/containers/3)

This PR attempts to print out the integration test file that failed directly after it failed.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
