### PR TITLE
Fix bad naming of migration script making migration failing

### DIFF
--- a/upgrades/schema/Version_4_0_20191031000000_modify_session_lifetime_type.php
+++ b/upgrades/schema/Version_4_0_20191031000000_modify_session_lifetime_type.php
@@ -9,7 +9,7 @@ use Doctrine\Migrations\AbstractMigration;
  * In symfony 4.4, there is a BC break: the type of the lifetime session is an UNSIGNED INT now,
  * @see https://github.com/symfony/symfony/issues/34491
  */
-final class Version_4_0_20191031_modify_session_lifetime_type extends AbstractMigration
+final class Version_4_0_20191031000000_modify_session_lifetime_type extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Master broken in EE:
https://circleci.com/gh/akeneo/pim-community-dev/23012?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link


```
Launch branch migrations...
                                                      
                    PIM Migrations                    
                                                      

WARNING! You have 1 previously executed migrations in the database that are not registered migrations.
    >>  (_4_0_20191202144736_create_app_audit_table)
Migrating up to _4_0_20191031_modify_session_lifetime_type from _4_0_20191031124707_update_from_clients_to_apps
14:44:20 ERROR     [console] Error thrown while running command "doctrine:migrations:migrate --env=test --no-interaction". Message: "Could not find any migrations to execute." ["exception" => Doctrine\DBAL\Migrations\MigrationException]8;;file:///srv/pim/vendor/doctrine/migrations/lib/Doctrine/DBAL/Migrations/MigrationException.php#L15\^]8;;\ { …},"command" => "doctrine:migrations:migrate --env=test --no-interaction","message" => "Could not find any migrations to execute."]
```

**Why?**

The script was named `Version_4_0_20191031_modify_session_lifetime_type` instead of `Version_4_0_20191031000000_modify_session_lifetime_type`.

I investigated just to precisely know how this tool is working:

When it gets the current version installed, it gets it from database ORDERED by DESC:
```
SELECT version FROM migration_versions WHERE version IN ('_4_0_20190801084247_remove_native_json_type', '_4_0_20190813091149_remove_missing_attributes_and_ratio_from_completeness', '_4_0_20190822090606_update_empty_raw_values', '_4_0_20190916122239_remove_product_empty_raw_values', '_4_0_20190917080512_remove_product_model_empty_raw_values', '_4_0_20191004145507_remove_compute_model_descendant_jobs', '_4_0_20191014111427_create_apps_table', '_4_0_20191031124707_update_from_clients_to_apps', '_4_0_20191031_modify_session_lifetime_type') ORDER BY version DESC;
```
Response:
```
'_4_0_20191031124707_update_from_clients_to_apps'
'_4_0_20191031_modify_session_lifetime_type'
'_4_0_20191014111427_create_apps_table'
'_4_0_20191004145507_remove_compute_model_descendant_jobs'
'_4_0_20190917080512_remove_product_model_empty_raw_values'
'_4_0_20190916122239_remove_product_empty_raw_values'
'_4_0_20190822090606_update_empty_raw_values'
'_4_0_20190813091149_remove_missing_attributes_and_ratio_from_completeness'
'_4_0_20190801084247_remove_native_json_type'
```

When it gets the last version, it gets it from PHP array sorted with `ksort`:
https://github.com/doctrine/migrations/blob/1.8/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php#L452

And it's not the same order between a ksort and a sort from the DB for `_` character. So the last version is `_4_0_20191031_modify_session_lifetime_type` with `ksort`.

It's an incoherent state for Doctrine migration... and it throws an exception.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
