### PR TITLE
PIM-9007: [SLA] Cancelling category selection in export profile does not work

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-9007: Fix cancelling category selection in export profile
+
 # 3.0.57 (2019-12-02)
 
 ## Enhancements

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/filter/product/category.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/filter/product/category.js
@@ -99,7 +99,7 @@ define([
                 el: modal.$el.find('.modal-body'),
                 attributes: {
                     channel: this.getParentForm().getFilters().structure.scope,
-                    categories: 'IN CHILDREN' === this.getOperator() ? [] : this.getValue()
+                    categories: 'IN CHILDREN' === this.getOperator() ? [] : [...this.getValue()]
                 }
             });
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This PR fix a bug on product export when cancelling a category selection. The chosen categories were synced by reference to the backbone "state" when the user selected / unselected a category, so the cancel operation didn't erase the user choices.

This fix is pretty simple : I send to the modal only a copy of the categories in the current backbone state, so the user clicks won't be synced. And only the modal validation button will sync the chosen categories.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
