### PR TITLE
Remove APP_ENV=test in the phpunit.xml to be specified outside of the process in the makefile

### DIFF
--- a/make-file/dev.mk
+++ b/make-file/dev.mk
@@ -34,7 +34,7 @@ acceptance:
 # integration-back: var/tests/phpspec bounded-context-integration-back
 .PHONY: phpunit
 phpunit:
-	${PHP_RUN} vendor/bin/phpunit -c phpunit.xml.dist ${F}
+	APP_ENV=test ${PHP_RUN} vendor/bin/phpunit -c phpunit.xml.dist ${F}
 
 # Please use the target `end-to-end-legacy` instead
 .PHONY: behat-legacy

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,7 +17,6 @@
         <ini name="intl.error_level" value="0"/>
         <ini name="memory_limit" value="-1"/>
         <ini name="zend.enable_gc" value="1"/>
-        <server name="APP_ENV" value="test" force="true" />
         <server name="KERNEL_CLASS" value="Kernel" force="true" />
     </php>
 


### PR DESCRIPTION
… 

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
I broke the command `make phpunit` since this PR. Actually, you can't specify the environment on the fly because I removed this magic stuff:
```
$_SERVER += $_ENV;
$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
```

Now, you must specify the environment from the outside ot the `.env`: we use the makefile. It's the same as for the other commands, so it's simpler.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
