### PR TITLE
PIM-9008: Fix product models API when the filter "completenes" was used with a sub-filter "locale"

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9008: Fix product models API when the filter "completenes" was used with a sub-filter "locale"
+
 # 3.2.22 (2019-12-03)
 
 ## Bug fixes:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/Validator/ValidateSearchLocale.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/Validator/ValidateSearchLocale.php
@@ -60,12 +60,6 @@ final class ValidateSearchLocale
         foreach ($search as $propertyCode => $filters) {
             foreach ($filters as $filter) {
                 if ($propertyCode === self::COMPLETENESS_PROPERTY) {
-                    if (isset($filter['locale'])) {
-                        throw new InvalidQueryException(
-                            sprintf('Property "completeness" expects an array with the key "locales".')
-                        );
-                    }
-
                     if (isset($filter['locales'])) {
                         if (!is_array($filter['locales'])) {
                             throw new InvalidQueryException(

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/Validator/ValidateSearchLocaleSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/Validator/ValidateSearchLocaleSpec.php
@@ -51,16 +51,7 @@ class ValidateSearchLocaleSpec extends ObjectBehavior
             'completeness' => [['locales' => ['en_US']]]
         ], null]);
     }
-
-    function it_throws_an_exception_when_locale_key_is_provided_for_completeness_filter_instead_of_locales(
-        IdentifiableObjectRepositoryInterface $localeRepository
-    ) {
-        $localeRepository->findOneByIdentifier(Argument::cetera())->shouldNotBeCalled();
-        $this->shouldThrow(InvalidQueryException::class)->during('validate', [[
-            'completeness' => [['locale' => ['en_US']]]
-        ], 'en_US']);
-    }
-
+    
     function it_throws_an_exception_when_locales_key_is_provided_for_any_filter_except_completeness_filter(
         IdentifiableObjectRepositoryInterface $localeRepository
     ) {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
The `locale` field of the completeness filter was forbidden but according to the API documentation, we should be able to use the `locale` filter for only one locale. But to filter on multiple locales, the `locales` filter must be used.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
