### PR TITLE
PIM-8998: Avoid error 500 on asset list & product list when a user has no permission on categories & asset categories

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-8998: Fix error 500 on asset list & product list when a user has no permission on categories & asset categories
+
 # 3.2.23 (2019-12-05)
 
 ## Bug fixes:

--- a/src/Akeneo/Pim/Enrichment/Component/Category/CategoryTree/UseCase/ListRootCategoriesWithCountHandler.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Category/CategoryTree/UseCase/ListRootCategoriesWithCountHandler.php
@@ -57,6 +57,9 @@ class ListRootCategoriesWithCountHandler
 
         if (null === $categorySelectedAsFilter) {
             $categorySelectedAsFilter = $this->userContext->getAccessibleUserTree();
+            if ($categorySelectedAsFilter === null) {
+                return [];
+            }
         }
         $rootCategoryIdToExpand = $categorySelectedAsFilter->getRoot();
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Category/CategoryTree/UseCase/ListRootCategoriesWithCountHandlerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Category/CategoryTree/UseCase/ListRootCategoriesWithCountHandlerSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Specification\Akeneo\Pim\Enrichment\Component\Category\CategoryTree\Usecase;
+namespace Specification\Akeneo\Pim\Enrichment\Component\Category\CategoryTree\UseCase;
 
 use Akeneo\Tool\Component\Classification\Model\CategoryInterface;
 use Akeneo\Tool\Component\Classification\Repository\CategoryRepositoryInterface;
@@ -73,7 +73,7 @@ class ListRootCategoriesWithCountHandlerSpec extends ObjectBehavior
         $listNotIncludingSubCategories,
         CategoryInterface $treeToExpand
     ) {
-        $userContext->getUserProductCategoryTree()->willReturn($treeToExpand);
+        $userContext->getAccessibleUserTree()->willReturn($treeToExpand);
         $treeToExpand->getRoot()->willReturn(1);
 
         $listNotIncludingSubCategories->list('en_US', 1, 1, null)->willReturn([
@@ -84,5 +84,13 @@ class ListRootCategoriesWithCountHandlerSpec extends ObjectBehavior
         $this->handle($query)->shouldBeLike([
             new RootCategory(1, 'code', 'label', 10, true)
         ]);
+    }
+
+    function it_handles_query_for_users_that_have_no_access_to_any_category($userContext)
+    {
+        $userContext->getAccessibleUserTree()->willReturn(null);
+
+        $query = new ListRootCategoriesWithCount(-1, false, 1, 'en_US');
+        $this->handle($query)->shouldBeLike([]);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
CF https://github.com/akeneo/pim-enterprise-dev/pull/7435

Also, this PR fix a spec that was not executed because of the a bad namespace.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
