### PR TITLE
Removes unused tmpStorage filesystem

### DIFF
--- a/config/packages/oneup_flysystem.yml
+++ b/config/packages/oneup_flysystem.yml
@@ -6,9 +6,6 @@ oneup_flysystem:
         jobs_storage_adapter:
             local:
                 directory: '%tmp_storage_dir%'
-        tmp_storage_adapter:
-            local:
-                directory: '%tmp_storage_dir%'
         archivist_adapter:
             local:
                 directory: '%archive_dir%'
@@ -16,11 +13,6 @@ oneup_flysystem:
         catalog_storage:
             adapter: catalog_storage_adapter
             mount: catalogStorage
-        tmp_storage:
-            adapter: tmp_storage_adapter
-            mount: tmpStorage
-            plugins:
-                - oneup_flysystem.plugin.list_files
         archivist:
             adapter: archivist_adapter
             mount: archivist

--- a/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/file_storage.yml
+++ b/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/file_storage.yml
@@ -18,7 +18,7 @@ services:
     akeneo_file_storage.file_storage.file.file_fetcher:
         class: '%akeneo_file_storage.file_storage.file.file_fetcher.class%'
         arguments:
-            - '@oneup_flysystem.tmp_storage_filesystem'
+            - '%tmp_storage_dir%'
 
     akeneo_file_storage.file_storage.file.output_file_fetcher:
         class: '%akeneo_file_storage.file_storage.file.output_file_fetcher.class%'

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
@@ -15,15 +15,12 @@ use League\Flysystem\FilesystemInterface;
  */
 class FileFetcher implements FileFetcherInterface
 {
-    /** @var FilesystemInterface */
-    protected $tmpFilesystem;
+    /** @var string */
+    protected $tmpDir;
 
-    /**
-     * @param FilesystemInterface $tmpFilesystem
-     */
-    public function __construct(FilesystemInterface $tmpFilesystem)
+    public function __construct(string $tmpDir)
     {
-        $this->tmpFilesystem = $tmpFilesystem;
+        $this->tmpDir = $tmpDir;
     }
 
     /**
@@ -47,7 +44,7 @@ class FileFetcher implements FileFetcherInterface
 
         // TODO: we should not get the path prefix like that
         // TODO: it should be injected in the constructor
-        $localPathname = $this->tmpFilesystem->getAdapter()->getPathPrefix() . $fileKey;
+        $localPathname = $this->tmpDir . $fileKey;
 
         if (false === file_put_contents($localPathname, $stream)) {
             throw new FileTransferException(

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
@@ -4,6 +4,7 @@ namespace Akeneo\Tool\Component\FileStorage\File;
 
 use Akeneo\Tool\Component\FileStorage\Exception\FileTransferException;
 use League\Flysystem\FilesystemInterface;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Fetch the raw file of a file stored in a virtual filesystem
@@ -38,13 +39,13 @@ class FileFetcher implements FileFetcherInterface
             );
         }
 
-        if (!$this->tmpFilesystem->has(dirname($fileKey))) {
-            $this->tmpFilesystem->createDir(dirname($fileKey));
+        $fsTools = new Filesystem();
+
+        if (!$fsTools->exists($this->tmpDir . DIRECTORY_SEPARATOR. dirname($fileKey))) {
+            $fsTools->mkdir($this->tmpDir . DIRECTORY_SEPARATOR . dirname($fileKey));
         }
 
-        // TODO: we should not get the path prefix like that
-        // TODO: it should be injected in the constructor
-        $localPathname = $this->tmpDir . $fileKey;
+        $localPathname = $this->tmpDir . DIRECTORY_SEPARATOR . $fileKey;
 
         if (false === file_put_contents($localPathname, $stream)) {
             throw new FileTransferException(

--- a/src/Akeneo/Tool/Component/FileStorage/spec/File/FileFetcherSpec.php
+++ b/src/Akeneo/Tool/Component/FileStorage/spec/File/FileFetcherSpec.php
@@ -4,18 +4,17 @@ namespace spec\Akeneo\Tool\Component\FileStorage\File;
 
 use Akeneo\Tool\Component\FileStorage\Exception\FileTransferException;
 use League\Flysystem\Adapter\Local;
-use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemInterface;
 use PhpSpec\ObjectBehavior;
 
 class FileFetcherSpec extends ObjectBehavior
 {
-    function let(Filesystem $tmpFilesystem)
+    function let()
     {
-        $this->beConstructedWith($tmpFilesystem);
+        $this->beConstructedWith(sys_get_temp_dir());
     }
 
-    function it_fetches_a_file($tmpFilesystem, Local $adapter, FilesystemInterface $filesystem)
+    function it_fetches_a_file(Local $adapter, FilesystemInterface $filesystem)
     {
         if (!is_dir(sys_get_temp_dir() . '/spec/path/to')) {
             mkdir(sys_get_temp_dir() . '/spec/path/to', 0777, true);
@@ -23,12 +22,6 @@ class FileFetcherSpec extends ObjectBehavior
 
         $filesystem->has('path/to/file.txt')->willReturn(true);
         $filesystem->readStream('path/to/file.txt')->shouldBeCalled();
-
-        $tmpFilesystem->getAdapter()->willReturn($adapter);
-        $adapter->getPathPrefix()->willReturn(sys_get_temp_dir() . '/spec/');
-
-        $tmpFilesystem->has('path/to')->willReturn(false);
-        $tmpFilesystem->createDir('path/to')->shouldBeCalled();
 
         $rawFile = $this->fetch($filesystem, 'path/to/file.txt');
         $rawFile->shouldBeAnInstanceOf('\SplFileInfo');

--- a/tests/back/Pim/Enrichment/Integration/Normalizer/Standard/FileIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Normalizer/Standard/FileIntegration.php
@@ -14,7 +14,7 @@ class FileIntegration extends AbstractStandardNormalizerTestCase
     public function testNormalizedFile()
     {
         $fileStorer = $this->get('akeneo_file_storage.file_storage.file.file_storer');
-        $fileStorer->store(new \SplFileInfo($this->getFixturePath('akeneo.jpg')), 'tmpStorage');
+        $fileStorer->store(new \SplFileInfo($this->getFixturePath('akeneo.jpg')), 'catalogStorage');
 
         $expected = [
             'code'              => '1/8/c/d/18cd06901ca3bd633afc0c178e347ffba20cbd11_akeneo.jpg',


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The tmpStorage filesystem cannot be something else than a local filesytem (otherwise the code will not work) and in the code was only used to get access to the `tmp_sotrage_dir` path.

This PR removes this filesystem and provide the `tmp_storage_dir` parameter directly to the FileFetch that needs it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
