### PR TITLE
PIM-6427: Wrong label update on attribute through the API

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,6 +1,7 @@
 # 2.3.x
 
 - PIM-9017: Remove "Add an attribute to a product" ACL
+- PIM-6427: Fix wrong label update on attribute through the API
 
 # 2.3.73 (2019-12-06)
 

--- a/src/Pim/Bundle/CatalogBundle/Entity/AssociationType.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/AssociationType.php
@@ -146,7 +146,7 @@ class AssociationType implements AssociationTypeInterface
             return null;
         }
         foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() == $locale) {
+            if ($translation->getLocale() === $locale) {
                 return $translation;
             }
         }

--- a/src/Pim/Bundle/CatalogBundle/Entity/AttributeGroup.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/AttributeGroup.php
@@ -249,7 +249,7 @@ class AttributeGroup implements AttributeGroupInterface
             return null;
         }
         foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() == $locale) {
+            if ($translation->getLocale() === $locale) {
                 return $translation;
             }
         }

--- a/src/Pim/Bundle/CatalogBundle/Entity/Category.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Category.php
@@ -122,7 +122,7 @@ class Category extends BaseCategory implements CategoryInterface
             return null;
         }
         foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() == $locale) {
+            if ($translation->getLocale() === $locale) {
                 return $translation;
             }
         }

--- a/src/Pim/Bundle/CatalogBundle/Entity/Channel.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Channel.php
@@ -114,7 +114,7 @@ class Channel implements ChannelInterface
             return null;
         }
         foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() == $locale) {
+            if ($translation->getLocale() === $locale) {
                 return $translation;
             }
         }

--- a/src/Pim/Bundle/CatalogBundle/Entity/Family.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Family.php
@@ -309,7 +309,7 @@ class Family implements FamilyInterface
             return null;
         }
         foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() == $locale) {
+            if ($translation->getLocale() === $locale) {
                 return $translation;
             }
         }

--- a/src/Pim/Bundle/CatalogBundle/Entity/Group.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/Group.php
@@ -124,7 +124,7 @@ class Group implements GroupInterface
             return null;
         }
         foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() == $locale) {
+            if ($translation->getLocale() === $locale) {
                 return $translation;
             }
         }

--- a/src/Pim/Bundle/CatalogBundle/Entity/GroupType.php
+++ b/src/Pim/Bundle/CatalogBundle/Entity/GroupType.php
@@ -116,7 +116,7 @@ class GroupType implements GroupTypeInterface
             return null;
         }
         foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() == $locale) {
+            if ($translation->getLocale() === $locale) {
                 return $translation;
             }
         }

--- a/src/Pim/Component/Catalog/Model/AbstractAttribute.php
+++ b/src/Pim/Component/Catalog/Model/AbstractAttribute.php
@@ -927,7 +927,7 @@ abstract class AbstractAttribute implements AttributeInterface
             return null;
         }
         foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() == $locale) {
+            if ($translation->getLocale() === $locale) {
                 return $translation;
             }
         }

--- a/src/Pim/Component/Catalog/Model/FamilyVariant.php
+++ b/src/Pim/Component/Catalog/Model/FamilyVariant.php
@@ -191,7 +191,7 @@ class FamilyVariant implements FamilyVariantInterface
         }
 
         foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() == $locale) {
+            if ($translation->getLocale() === $locale) {
                 return $translation;
             }
         }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The comparison was not strict in the method that returns an attribute translation from a code. And because of that, if an attribute was updated using an array like `{"labels":["a_string"]}` instead of the standard format `{"labels":{"en_US": "a_string"}}` , the comparison always returned true because the locale code was 0 (instead of "en_US" for example), and in PHP `"en_US" == 0` is true. So the first locale was always updated because the script stopped after the first loop iteration.

After this fix, the API attribute patch method returns a 422 error with this type of request (`{"labels":["a_string"]}`), like every other API request of the PIM, instead of updating the label of the first locale of the PIM. 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
