### PR TITLE
PIM-8950: Store script in session for ajax calls

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
@@ -3,6 +3,8 @@
 namespace Akeneo\Platform\Bundle\UIBundle\EventListener;
 
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * Generate and return the CSP javascript nonce
@@ -15,11 +17,28 @@ class ScriptNonceGenerator
 {
     /** @var string */
     private $generatedNonce;
+    /** @var RequestStack */
+    private $request;
+    /** @var Session */
+    private $session;
+
+    public function __construct(RequestStack $request, Session $session)
+    {
+        $this->request = $request;
+        $this->session = $session;
+    }
 
     public function getGeneratedNonce(): string
     {
         if (null === $this->generatedNonce) {
+            $this->generatedNonce = $this->session->get('nonce', null);
+        }
+
+        if (null === $this->generatedNonce) {
             $this->generatedNonce = Uuid::uuid4()->toString();
+            if (!$this->request->getCurrentRequest()->isXmlHttpRequest()) {
+                $this->session->set('nonce', $this->generatedNonce);
+            }
         }
 
         return $this->generatedNonce;

--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
@@ -19,13 +19,10 @@ class ScriptNonceGenerator
     private $generatedNonce;
     /** @var RequestStack */
     private $request;
-    /** @var Session */
-    private $session;
 
-    public function __construct(RequestStack $request, Session $session)
+    public function __construct(RequestStack $request)
     {
         $this->request = $request;
-        $this->session = $session;
     }
 
     /**
@@ -34,17 +31,17 @@ class ScriptNonceGenerator
     public function getGeneratedNonce(): string
     {
         if (!$this->request->getCurrentRequest()->isXmlHttpRequest()) {
-            $this->session->set('nonce', null);
+            $this->request->getCurrentRequest()->getSession()->set('nonce', null);
         }
 
         if (null === $this->generatedNonce) {
-            $this->generatedNonce = $this->session->get('nonce', null);
+            $this->generatedNonce = $this->request->getCurrentRequest()->getSession()->get('nonce', null);
         }
 
         if (null === $this->generatedNonce) {
             $this->generatedNonce = Uuid::uuid4()->toString();
             if (!$this->request->getCurrentRequest()->isXmlHttpRequest()) {
-                $this->session->set('nonce', $this->generatedNonce);
+                $this->request->getCurrentRequest()->getSession()->set('nonce', $this->generatedNonce);
             }
         }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
- * Generate and return the CSP javascript nonce
+ * Generate and return the CSP javascript nonce.
  *
  * @author JM Leroux <jean-marie.leroux@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
@@ -28,6 +28,9 @@ class ScriptNonceGenerator
         $this->session = $session;
     }
 
+    /**
+    * For XML http requests, the nonce is read from session to ensure it is the same than the original request.
+    */
     public function getGeneratedNonce(): string
     {
         if (!$this->request->getCurrentRequest()->isXmlHttpRequest()) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
@@ -30,6 +30,10 @@ class ScriptNonceGenerator
 
     public function getGeneratedNonce(): string
     {
+        if (!$this->request->getCurrentRequest()->isXmlHttpRequest()) {
+            $this->session->set('nonce', null);
+        }
+
         if (null === $this->generatedNonce) {
             $this->generatedNonce = $this->session->get('nonce', null);
         }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
@@ -49,15 +49,18 @@ services:
         arguments:
             - '@http_kernel'
 
-#    security.event_listener.add_csp:
-#      class: Akeneo\Platform\Bundle\UIBundle\EventListener\AddContentSecurityPolicyListener
-#      arguments:
-#        - '@security.script_nonce_generator'
-#      tags:
-#        - { name: kernel.event_subscriber }
+    security.event_listener.add_csp:
+      class: Akeneo\Platform\Bundle\UIBundle\EventListener\AddContentSecurityPolicyListener
+      arguments:
+        - '@security.script_nonce_generator'
+      tags:
+        - { name: kernel.event_subscriber }
 
     security.script_nonce_generator:
       class: Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator
+      arguments:
+          - '@request_stack'
+          - '@session'
 
     pim_enrich.normalizer.constraint_violation_list:
         class: 'Akeneo\Platform\Bundle\UIBundle\Normalizer\ConstraintViolationListNormalizer'

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
@@ -60,7 +60,6 @@ services:
       class: Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator
       arguments:
           - '@request_stack'
-          - '@session'
 
     pim_enrich.normalizer.constraint_violation_list:
         class: 'Akeneo\Platform\Bundle\UIBundle\Normalizer\ConstraintViolationListNormalizer'

--- a/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/AddContentSecurityPolicyListenerSpec.php
+++ b/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/AddContentSecurityPolicyListenerSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Specification\Akeneo\Platform\Bundle\UIBundle\EventListener;
+
+use Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class AddContentSecurityPolicyListenerSpec extends ObjectBehavior
+{
+    function let(ScriptNonceGenerator $scriptNonceGenerator)
+    {
+        $scriptNonceGenerator->getGeneratedNonce()->willReturn('generated_nonce');
+        $this->beConstructedWith($scriptNonceGenerator);
+    }
+
+    function it_subscribes_to_kernel_response()
+    {
+        $this->getSubscribedEvents()->shouldReturn([KernelEvents::RESPONSE => 'addCspHeaders']);
+    }
+}

--- a/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/ScriptNonceGeneratorSpec.php
+++ b/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/ScriptNonceGeneratorSpec.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Specification\Akeneo\Platform\Bundle\UIBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class ScriptNonceGeneratorSpec extends ObjectBehavior
+{
+    function let(RequestStack $requestStack, Request $request)
+    {
+        $requestStack->getCurrentRequest()->willReturn($request);
+        $this->beConstructedWith($requestStack);
+    }
+
+    function it_generate_a_new_nonce_on_first_request(Request $request, SessionInterface $session)
+    {
+        $request->isXmlHttpRequest()->willReturn(false);
+        $request->getSession()->willReturn($session);
+        $session->set('nonce', null)->shouldBeCalledTimes(1);
+        $session->get('nonce', null)->willReturn(null);
+        $session->set('nonce', Argument::type('string'))->shouldBeCalledTimes(1);
+
+        $this->getGeneratedNonce()->shouldMatch('/\w{8}-\w{4}-\w{4}-\w{4}-\w{8}/');
+    }
+
+    function it_get_the_nonce_from_session_for_xmlhttprequest(Request $request, SessionInterface $session)
+    {
+        $request->isXmlHttpRequest()->willReturn(true);
+        $request->getSession()->willReturn($session);
+        $session->set('nonce', null)->shouldNotBeCalled();
+        $session->get('nonce', null)->willReturn('session_nonce');
+        $session->set('nonce', Argument::type('string'))->shouldNotBeCalled();
+
+        $this->getGeneratedNonce()->shouldReturn('session_nonce');
+    }
+}


### PR DESCRIPTION
The nonce used to authorize our inline scripts must not be regenerated on ajax calls.
We regenerate it on every first request and store it in session to retrieve it for ajax requests.
