### PR TITLE
AST-40: Allows base64 images in CSP

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/AddContentSecurityPolicyListener.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/AddContentSecurityPolicyListener.php
@@ -33,7 +33,7 @@ class AddContentSecurityPolicyListener implements EventSubscriberInterface
     public function addCspHeaders(FilterResponseEvent $event): void
     {
         $policy = sprintf(
-            "default-src 'self' *.akeneo.com 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'nonce-%s'",
+            "default-src 'self' *.akeneo.com 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'nonce-%s'; img-src 'self' data:",
             $this->generatedNonce
         );
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We will display a preview of uploading images using base64.
This PR add a rule in the CSP allowing `<img src="data:`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

