### PR TITLE
PIM-9016: Fix error message not translated for attribute code

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes:
 
 - PIM-8998: Fix error 500 on asset list & product list when a user has no permission on categories & asset categories
+- PIM-9016: Fix error message not translated for attribute code
 
 # 3.2.23 (2019-12-05)
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/attribute.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/attribute.yml
@@ -72,7 +72,7 @@ Akeneo\Pim\Structure\Component\Model\Attribute:
             - NotBlank: ~
             - Regex:
                 pattern: /^[a-zA-Z0-9_]+$/
-                message: Attribute code may contain only letters, numbers and underscores
+                message: Attribute code may contain only letters, numbers and underscore
             - Length:
                 max: 255
             - Regex:

--- a/tests/back/Pim/Structure/EndToEnd/Attribute/ExternalApi/PartialUpdateListAttributeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/Attribute/ExternalApi/PartialUpdateListAttributeEndToEnd.php
@@ -274,7 +274,7 @@ JSON;
 
         $expectedContent =
 <<<JSON
-{"line":1,"code":"foo,","status_code":422,"message":"Validation failed.","errors":[{"property":"code","message":"Attribute code may contain only letters, numbers and underscores"}]}
+{"line":1,"code":"foo,","status_code":422,"message":"Validation failed.","errors":[{"property":"code","message":"Attribute code may contain only letters, numbers and underscore"}]}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/attributes', [], [], [], $data);

--- a/tests/back/Pim/Structure/Integration/Attribute/Validation/GlobalConstraintsIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Validation/GlobalConstraintsIntegration.php
@@ -215,7 +215,7 @@ class GlobalConstraintsIntegration extends AbstractAttributeTestCase
         $violations = $this->validateAttribute($attribute);
 
         $this->assertCount(1, $violations);
-        $this->assertSame('Attribute code may contain only letters, numbers and underscores', $violations->get(0)->getMessage());
+        $this->assertSame('Attribute code may contain only letters, numbers and underscore', $violations->get(0)->getMessage());
         $this->assertSame('code', $violations->get(0)->getPropertyPath());
     }
 

--- a/tests/legacy/features/pim/structure/attribute/create_text_attribute.feature
+++ b/tests/legacy/features/pim/structure/attribute/create_text_attribute.feature
@@ -22,7 +22,7 @@ Feature: Create an attribute
     Given I change the Code to an invalid value
     And I change the "Attribute group" to "Other"
     And I save the attribute
-    Then I should see validation error "Attribute code may contain only letters, numbers and underscores"
+    Then I should see validation error "Attribute code may contain only letters, numbers and underscore"
 @jira https://akeneo.atlassian.net/browse/PIM-8865
   @info Codes 'id', associationTypes', 'categories', 'categoryId', 'completeness', 'enabled', 'family', 'groups', 'associations', 'products', 'scope', 'treeId', 'values', 'entity_type' '*_groups' and '*_products' are reserved for grid filters and import/export column names
   Scenario: Fail to create a text attribute with a reserved code


### PR DESCRIPTION
I changed the translation key and not the message to not break every translation in every languages we have.