### PR TITLE
PIM-9015: Fix validation message display on attribute group creation failure

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes:
 
 - PIM-8998: Fix error 500 on asset list & product list when a user has no permission on categories & asset categories
+- PIM-9015: Fix validation message display on attribute group creation failure
 
 # 3.2.23 (2019-12-05)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute_group/create.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute_group/create.yml
@@ -70,13 +70,25 @@ extensions:
             template: pim/template/form/tab/sections
 
     pim-attribute-group-create-form-properties-general:
-        module: pim/create/properties/general
+        module: pim/common/simple-view
         parent: pim-attribute-group-create-form-properties
         targetZone: accordion
         position: 100
         config:
-            sectionTitle: pim_common.general_properties
-            codeLabel: pim_common.code
+            template: pim/template/form/tab/section
+            templateParams:
+                sectionTitle: pim_common.general_properties
+                dropZone: content
+
+    pim-attribute-group-create-form-properties-general-code:
+        module: pim/form/common/fields/text
+        parent: pim-attribute-group-create-form-properties-general
+        targetZone: content
+        position: 90
+        config:
+            fieldName: code
+            label: pim_common.code
+            required: true
 
     pim-attribute-group-create-form-properties-translation-section:
         module: pim/common/simple-view


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fixes the validation error messages not displaying when trying to create an Attribute Group.
The module used to display the code field was not handling the errors correctly so I switched it for the same as in the Attribute form (`pim/form/common/fields/text`).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
