### PR TITLE
PIM-9017: Remove "Add an attribute to a product" ACL

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,7 @@
 # 2.3.x
 
+- PIM-9017: Remove "Add an attribute to a product" ACL
+
 # 2.3.73 (2019-12-06)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/acl.yml
@@ -32,10 +32,6 @@ pim_enrich_product_remove:
     label: pim_enrich.acl.product.remove
     group_name: pim_enrich.acl_group.product
 
-pim_enrich_product_add_attribute:
-    type: action
-    label: pim_enrich.acl.product.add_attribute
-    group_name: pim_enrich.acl_group.product
 pim_enrich_product_remove_attribute:
     type: action
     label: pim_enrich.acl.product.remove_attribute


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR removes the "Add an attribute to a product" ACL, as it was unable in the PIM.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
