### PR TITLE
AST-152: Add liip imagine config for pdf on filesystem

### DIFF
--- a/config/packages/liip_imagine.yml
+++ b/config/packages/liip_imagine.yml
@@ -76,3 +76,18 @@ liip_imagine:
             data_loader:      stream_pdf_loader
             filters:
                 thumbnail:    { size: [320, 320], mode: inset }
+
+        am_binary_pdf_preview:
+            quality:          95
+            format:           jpg
+            data_loader:      flysystem_pdf_loader
+            filters:
+                background:
+                    color: "#ffffff"
+
+        am_binary_pdf_thumbnail:
+            quality:          95
+            format:           png
+            data_loader:      flysystem_pdf_loader
+            filters:
+                thumbnail:    { size: [320, 320], mode: inset }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We add liip imagine configuration for Asset Manager PDF thumbnail & preview.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
