### PR TITLE
PIM-8950: Deactivate CSP before reworking it

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
@@ -49,12 +49,12 @@ services:
         arguments:
             - '@http_kernel'
 
-    security.event_listener.add_csp:
-      class: Akeneo\Platform\Bundle\UIBundle\EventListener\AddContentSecurityPolicyListener
-      arguments:
-        - '@security.script_nonce_generator'
-      tags:
-        - { name: kernel.event_subscriber }
+#    security.event_listener.add_csp:
+#      class: Akeneo\Platform\Bundle\UIBundle\EventListener\AddContentSecurityPolicyListener
+#      arguments:
+#        - '@security.script_nonce_generator'
+#      tags:
+#        - { name: kernel.event_subscriber }
 
     security.script_nonce_generator:
       class: Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator


### PR DESCRIPTION
Deactivate the injection of Content Security Policy.
We need to rework the way we implement CSP and I deactivate it in the meantime.