### PR TITLE
PIM-9011: Fix display issue on read-only categories

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,7 @@
 # 3.0.x
 
+- PIM-9011: Fix display issue on read-only categories
+
 # 3.0.59 (2019-12-09)
 
 # 3.0.58 (2019-12-05)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
@@ -167,10 +167,9 @@
   }
 
   .jstree-lockeditem {
-    height: 35px;
-    display: inline-block;
-    font-size: 14px;
-    padding: 0;
+    display: inline-flex;
+    font-size: 15px;
+    padding: 14px 0 0 2px;
     color: @AknDarkBlue !important;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -178,14 +177,20 @@
     overflow: hidden;
     cursor: not-allowed;
     font-weight: bold;
+
+    .AknSelectButton--disabled {
+      width: 23px;
+      height: 23px;
+      background-size: 21px;
+    }
   }
 
   .jstree-lockedicon {
     background: url("/bundles/pimui/images/jstree/icon-folderfull.svg") no-repeat center 0;
     display: inline-block;
-    width: 20px;
-    height: 20px;
-    margin: 0 4px 0 8px;
+    width: 18px;
+    height: 18px;
+    margin: 2px 5px 0 8px;
   }
 }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fixes the broken style on read-only categories, a specific template (with its specific CSS) was already used.

Before/After:

<img src="https://user-images.githubusercontent.com/3492179/70551199-5cc9ab00-1b77-11ea-9da4-2557f6c4e85c.png" width=200 /><img src="https://user-images.githubusercontent.com/3492179/70551180-53404300-1b77-11ea-8a76-ab53dddb2265.png" width=200 />



**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
