### PR TITLE
PIM-8950: Use BAPID cookie to generate JS nonce

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
@@ -42,16 +42,8 @@ class ScriptNonceGenerator
     public function getGeneratedNonce(): string
     {
         $request = $this->request->getCurrentRequest();
-        $bapid = $request->cookies->get('BAPID');
+        $bapId = $request->cookies->get('BAPID');
 
-        // If the BAPID id null because of a tricked request, we could have the same nonce opening a security hole
-        // because the generated nonce would always be the same.
-        // We can prevent it by generationg a random UUID string. It will probably break the PIM inline scripts,
-        // but also protect us against other inline scripts (like in wysiwig)
-        if (null === $bapid || '' === trim($bapid)) {
-            return Uuid::uuid4()->toString();
-        }
-
-        return hash_hmac('ripemd160', $bapid, $this->kernelSecret);
+        return hash_hmac('ripemd160', $bapId, $this->kernelSecret);
     }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
@@ -30,19 +30,13 @@ class ScriptNonceGenerator
     */
     public function getGeneratedNonce(): string
     {
-        if (!$this->request->getCurrentRequest()->isXmlHttpRequest()) {
-            $this->request->getCurrentRequest()->getSession()->set('nonce', null);
-        }
-
         if (null === $this->generatedNonce) {
             $this->generatedNonce = $this->request->getCurrentRequest()->getSession()->get('nonce', null);
         }
 
         if (null === $this->generatedNonce) {
             $this->generatedNonce = Uuid::uuid4()->toString();
-            if (!$this->request->getCurrentRequest()->isXmlHttpRequest()) {
-                $this->request->getCurrentRequest()->getSession()->set('nonce', $this->generatedNonce);
-            }
+            $this->request->getCurrentRequest()->getSession()->set('nonce', $this->generatedNonce);
         }
 
         return $this->generatedNonce;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
@@ -53,6 +53,7 @@ services:
       class: Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator
       arguments:
           - '@request_stack'
+          - '%kernel.secret%'
 
     security.event_listener.add_csp:
         class: Akeneo\Platform\Bundle\UIBundle\EventListener\AddContentSecurityPolicyListener

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/services.yml
@@ -49,17 +49,17 @@ services:
         arguments:
             - '@http_kernel'
 
-#    security.event_listener.add_csp:
-#      class: Akeneo\Platform\Bundle\UIBundle\EventListener\AddContentSecurityPolicyListener
-#      arguments:
-#        - '@security.script_nonce_generator'
-#      tags:
-#        - { name: kernel.event_subscriber }
-
     security.script_nonce_generator:
       class: Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator
       arguments:
           - '@request_stack'
+
+    security.event_listener.add_csp:
+        class: Akeneo\Platform\Bundle\UIBundle\EventListener\AddContentSecurityPolicyListener
+        arguments:
+            - '@security.script_nonce_generator'
+        tags:
+            - { name: kernel.event_subscriber }
 
     pim_enrich.normalizer.constraint_violation_list:
         class: 'Akeneo\Platform\Bundle\UIBundle\Normalizer\ConstraintViolationListNormalizer'

--- a/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/ScriptNonceGeneratorSpec.php
+++ b/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/ScriptNonceGeneratorSpec.php
@@ -24,28 +24,4 @@ class ScriptNonceGeneratorSpec extends ObjectBehavior
 
         $this->getGeneratedNonce()->shouldReturn('94d18804ef7db19a4654c6be2e9a581fb1551dbf');
     }
-
-    function it_generate_a_random_nonce_if_bapid_is_null(Request $request, ParameterBag $cookies)
-    {
-        $cookies->get('BAPID')->willReturn(null);
-        $request->cookies = $cookies;
-
-        $this->getGeneratedNonce()->shouldMatch('/\w{8}-\w{4}-\w{4}-\w{4}-\w{8}/');
-    }
-
-    function it_generate_a_random_nonce_if_bapid_is_empty(Request $request, ParameterBag $cookies)
-    {
-        $cookies->get('BAPID')->willReturn('');
-        $request->cookies = $cookies;
-
-        $this->getGeneratedNonce()->shouldMatch('/\w{8}-\w{4}-\w{4}-\w{4}-\w{8}/');
-    }
-
-    function it_generate_a_random_nonce_if_bapid_is_blank(Request $request, ParameterBag $cookies)
-    {
-        $cookies->get('BAPID')->willReturn('  ');
-        $request->cookies = $cookies;
-
-        $this->getGeneratedNonce()->shouldMatch('/\w{8}-\w{4}-\w{4}-\w{4}-\w{8}/');
-    }
 }

--- a/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/ScriptNonceGeneratorSpec.php
+++ b/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/ScriptNonceGeneratorSpec.php
@@ -4,6 +4,7 @@ namespace Specification\Akeneo\Platform\Bundle\UIBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -13,25 +14,38 @@ class ScriptNonceGeneratorSpec extends ObjectBehavior
     function let(RequestStack $requestStack, Request $request)
     {
         $requestStack->getCurrentRequest()->willReturn($request);
-        $this->beConstructedWith($requestStack);
+        $this->beConstructedWith($requestStack, 'my_secret');
     }
 
-    function it_generate_a_new_nonce_on_first_request(Request $request, SessionInterface $session)
+    function it_gets_the_nonce_from_bapid_cookie(Request $request, ParameterBag $cookies)
     {
-        $request->getSession()->willReturn($session);
-        $session->get('nonce', null)->willReturn(null);
-        $session->set('nonce', Argument::type('string'))->shouldBeCalledTimes(1);
+        $cookies->get('BAPID')->willReturn('my_bap_id');
+        $request->cookies = $cookies;
+
+        $this->getGeneratedNonce()->shouldReturn('94d18804ef7db19a4654c6be2e9a581fb1551dbf');
+    }
+
+    function it_generate_a_random_nonce_if_bapid_is_null(Request $request, ParameterBag $cookies)
+    {
+        $cookies->get('BAPID')->willReturn(null);
+        $request->cookies = $cookies;
 
         $this->getGeneratedNonce()->shouldMatch('/\w{8}-\w{4}-\w{4}-\w{4}-\w{8}/');
     }
 
-    function it_gets_the_nonce_from_session(Request $request, SessionInterface $session)
+    function it_generate_a_random_nonce_if_bapid_is_empty(Request $request, ParameterBag $cookies)
     {
-        $request->getSession()->willReturn($session);
-        $session->set('nonce', null)->shouldNotBeCalled();
-        $session->get('nonce', null)->willReturn('session_nonce');
-        $session->set('nonce', Argument::type('string'))->shouldNotBeCalled();
+        $cookies->get('BAPID')->willReturn('');
+        $request->cookies = $cookies;
 
-        $this->getGeneratedNonce()->shouldReturn('session_nonce');
+        $this->getGeneratedNonce()->shouldMatch('/\w{8}-\w{4}-\w{4}-\w{4}-\w{8}/');
+    }
+
+    function it_generate_a_random_nonce_if_bapid_is_blank(Request $request, ParameterBag $cookies)
+    {
+        $cookies->get('BAPID')->willReturn('  ');
+        $request->cookies = $cookies;
+
+        $this->getGeneratedNonce()->shouldMatch('/\w{8}-\w{4}-\w{4}-\w{4}-\w{8}/');
     }
 }

--- a/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/ScriptNonceGeneratorSpec.php
+++ b/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/ScriptNonceGeneratorSpec.php
@@ -18,18 +18,15 @@ class ScriptNonceGeneratorSpec extends ObjectBehavior
 
     function it_generate_a_new_nonce_on_first_request(Request $request, SessionInterface $session)
     {
-        $request->isXmlHttpRequest()->willReturn(false);
         $request->getSession()->willReturn($session);
-        $session->set('nonce', null)->shouldBeCalledTimes(1);
         $session->get('nonce', null)->willReturn(null);
         $session->set('nonce', Argument::type('string'))->shouldBeCalledTimes(1);
 
         $this->getGeneratedNonce()->shouldMatch('/\w{8}-\w{4}-\w{4}-\w{4}-\w{8}/');
     }
 
-    function it_get_the_nonce_from_session_for_xmlhttprequest(Request $request, SessionInterface $session)
+    function it_get_the_nonce_from_session(Request $request, SessionInterface $session)
     {
-        $request->isXmlHttpRequest()->willReturn(true);
         $request->getSession()->willReturn($session);
         $session->set('nonce', null)->shouldNotBeCalled();
         $session->get('nonce', null)->willReturn('session_nonce');

--- a/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/ScriptNonceGeneratorSpec.php
+++ b/tests/back/Platform/Specification/Bundle/UIBundle/EventListener/ScriptNonceGeneratorSpec.php
@@ -25,7 +25,7 @@ class ScriptNonceGeneratorSpec extends ObjectBehavior
         $this->getGeneratedNonce()->shouldMatch('/\w{8}-\w{4}-\w{4}-\w{4}-\w{8}/');
     }
 
-    function it_get_the_nonce_from_session(Request $request, SessionInterface $session)
+    function it_gets_the_nonce_from_session(Request $request, SessionInterface $session)
     {
         $request->getSession()->willReturn($session);
         $session->set('nonce', null)->shouldNotBeCalled();


### PR DESCRIPTION
The PR to re-re-re-re-implement Content Security Policy.

**Previously on PIM Content Security Policy, season 4**

*To put a strong defense against the evil forces of XSS, the PIM team implemented the ultimate CSP weapon (similar to the Doom's BFG) in order to eradicate these little gremlins in one shot.*

But our heroes faced multiple obstacles in this fierce battle: they had to generate a incredibly complicated nonce (well... a UUID) to protect all our precious (but dirty) inline JS from the evil XSS forces and inject this antidote in every response before releasing it in the wild world

This was without counting on the forces of AJAX horde, firing request in every direction at every moment. The nonce was re-generated too many times and the great CSP weapon was completely screwed.

To regain control on the XHTML galaxy, PIM batalions enforced a session implementation to check that this nonce was calculated only for original requests, leaving the AJAX rebels use the same nonce stored in session. And it was good

But then came the thumbnail problem, media sources requesting for thumbnails in pure non ajax requests, thus resetting this so precious unique nonce each time they were called in the field.

To alleviate this issue, the PIM alliance decided to enforce a simplest yet strong version of the CSP solution: the nonce will be generated (again with quantic computers generating an incredibly complicated... uuid) only **once per user sesssion**. This way all requests of the universe will use the same golden number, no matter their origin or acceptable content. There is a (little) drawback to use always the same number for all the session, but it's also way simpler and less prone to errors.

All was well in the best of all worlds.

Almost...

Blackhawk inspection squadron captain Alex Popeye saw this artillery and invocated the "I don't like statefull services" galactic clause.

CSP must be reworked.

**The final battle**

In order to put an end to this endless war, PIM governance, speaking with the voice of Benoit Palpatine supported by captain Popeye, decided to enforce an even simplest yet stil strong version of the CSP solution: the nonce will be not be generated anymore, saving billions of quantic blips. The golden number will be computed from the BAPID cookie, which is common to every user request too. But this way we will not use a statefull service, nor will we risk to lock the database because of session access.

**What's next: kill'em all!**

All these efforts are made to protect the inline JS gobelins, small creatures very helpful but tricky. We should get rid of them as soon as possible to have a more secure universe.


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
