### PR TITLE
PIM-9020: Add missing attribute group code validation message translation key

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,7 @@
 # 3.2.x
 
+- PIM-9020: Add missing attribute group code validation message translation key
+
 # 3.2.24 (2019-12-10)
 
 ## Bug fixes:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
@@ -2,6 +2,7 @@ An identifier attribute already exists.:                                        
 Attribute code may contain only letters, numbers and underscore:                          Attribute code may contain only letters, numbers and underscore
 Attribute code may contain only letters (at least one), numbers and underscores:          Attribute code may contain only letters (at least one), numbers and underscores
 Attribute code may not contain line-feed characters:                                      Attribute code may not contain line-feed characters
+Attribute group code may contain only letters, numbers and underscores:                   Attribute group code may contain only letters, numbers and underscores
 This attribute type can't be used as a grid filter:                                       This attribute type can't be used as a grid filter
 This code is not available:                                                               This code is not available
 This attribute type must be required:                                                     This attribute type must be required

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.fr_FR.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.fr_FR.yml
@@ -1,6 +1,7 @@
 An identifier attribute already exists.: Un attribut identifiant existe déjà.
 Attribute code may contain only letters, numbers and underscore: Le code d'un attribut ne doit contenir que des lettres, des chiffres et des traits de soulignement
 Attribute code may contain only letters (at least one), numbers and underscores: Le code d'un attribut peut contenir uniquement des lettres (au moins une), des chiffres et des traits de soulignement
+Attribute group code may contain only letters, numbers and underscores: Le code d'un groupe d'attributs ne doit contenir que des lettres, des chiffres et des traits de soulignement
 This attribute type can't be used as a grid filter: Ce type d'attribut ne peut pas être utilisé comme filtre dans la grille
 This code is not available: Ce code n'est pas disponible
 This attribute type must be required: Ce type d'attribut doit être requis


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR adds the missing translation key for the Attribute group code validation message.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
