### PR TITLE
API-901: Add user context and date formatter to front

### DIFF
--- a/src/Akeneo/Apps/back/Infrastructure/Symfony/Resources/public/js/dependencies.ts
+++ b/src/Akeneo/Apps/back/Infrastructure/Symfony/Resources/public/js/dependencies.ts
@@ -2,10 +2,12 @@ const router = require('pim/router');
 const translate = require('oro/translator');
 const viewBuilder = require('pim/form-builder');
 const messenger = require('oro/messenger');
+const userContext = require('pim/user-context');
 
 export const dependencies = {
   router,
   translate,
   viewBuilder,
   notify: messenger.notify.bind(messenger),
+  user: userContext
 };

--- a/src/Akeneo/Apps/front/src/application/shared/date-formatter/use-date-formatter.ts
+++ b/src/Akeneo/Apps/front/src/application/shared/date-formatter/use-date-formatter.ts
@@ -1,0 +1,10 @@
+import {useContext} from 'react';
+import {UserContext} from '../user';
+
+export const useDateFormatter = () => {
+    const user = useContext(UserContext);
+
+    return (date: string, options?: Intl.DateTimeFormatOptions) => {
+        return new Intl.DateTimeFormat(user.get('catalogLocale').replace('_', '-'), options).format(new Date(date));
+    };
+};

--- a/src/Akeneo/Apps/front/src/application/shared/user/index.ts
+++ b/src/Akeneo/Apps/front/src/application/shared/user/index.ts
@@ -1,0 +1,4 @@
+import {User as UserInterface} from './user.interface';
+import {UserContext} from './user-context';
+
+export {UserContext, UserInterface};

--- a/src/Akeneo/Apps/front/src/application/shared/user/user-context.ts
+++ b/src/Akeneo/Apps/front/src/application/shared/user/user-context.ts
@@ -1,0 +1,7 @@
+import {createContext} from 'react';
+import {User} from './user.interface';
+
+export const UserContext = createContext<User>({
+    get: (data: string) => data,
+    set: () => undefined,
+});

--- a/src/Akeneo/Apps/front/src/application/shared/user/user.interface.ts
+++ b/src/Akeneo/Apps/front/src/application/shared/user/user.interface.ts
@@ -1,0 +1,4 @@
+export interface User {
+    get: (data: string) => string;
+    set: (key: string, value: string, options: {}) => void;
+}

--- a/src/Akeneo/Apps/front/src/infrastructure/with-contexts.tsx
+++ b/src/Akeneo/Apps/front/src/infrastructure/with-contexts.tsx
@@ -6,16 +6,18 @@ import {RouterContext, RouterInterface} from '../application/shared/router';
 import {TranslateContext, TranslateInterface} from '../application/shared/translate';
 import {LegacyContext} from './legacy-context';
 import {ViewBuilder} from './pim-view/view-builder';
+import {UserContext, UserInterface} from '../application/shared/user';
 
 interface Props {
     router: RouterInterface;
     translate: TranslateInterface;
     viewBuilder: ViewBuilder;
     notify: NotifyInterface;
+    user: UserInterface;
 }
 
 export const withContexts = (Component: ElementType) => {
-    return ({router, translate, viewBuilder, notify, ...props}: Props) => (
+    return ({router, translate, viewBuilder, notify, user, ...props}: Props) => (
         <RouterContext.Provider value={router}>
             <TranslateContext.Provider value={translate}>
                 <NotifyContext.Provider value={notify}>
@@ -25,7 +27,9 @@ export const withContexts = (Component: ElementType) => {
                         }}
                     >
                         <ThemeProvider theme={theme}>
-                            <Component {...props} />
+                            <UserContext.Provider value={user}>
+                                <Component {...props} />
+                            </UserContext.Provider>
                         </ThemeProvider>
                     </LegacyContext.Provider>
                 </NotifyContext.Provider>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

```
export const Dashboard = withContexts(() => {
    const anyDate = '2004-12-02T22:00';
    const formatDate = useDateFormatter();

    const toto = formatDate(anyDate, {weekday: 'long', month: 'short', day: 'numeric'});
    return (
        <div>{toto}</div>
    );
});
```

Displays the date: "Thursday, Dec 2" in terms of the user catalog locale.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
