### PR TITLE
PIM-9021: Fix input displaying when selecting empty/not empty filter

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,7 @@
 # 3.2.x
 
+- PIM-9021: Fix input displaying when selecting empty/not empty filter operator
+
 # 3.2.25 (2019-12-11)
 
 - PIM-9020: Add missing attribute group code validation message translation key

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -169,11 +169,11 @@ define(
                     this._showCriteria();
 
                     if (_.contains(['empty', 'not empty'], this.getValue().type)) {
-                      this._disableInput();
+                        this._disableInput();
                     } else {
-                      initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config())
-                        .select2('data', this._getCachedResults(this.getValue().value))
-                        .select2('open');
+                        initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config())
+                            .select2('data', this._getCachedResults(this.getValue().value))
+                            .select2('open');
                     }
                 } else {
                     this._hideCriteria();

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -168,9 +168,13 @@ define(
                 if (!this.popupCriteriaShowed) {
                     this._showCriteria();
 
-                    initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config())
+                    if (_.contains(['empty', 'not empty'], this.getValue().type)) {
+                      this._disableInput();
+                    } else {
+                      initSelect2.init(this.$(this.criteriaValueSelectors.value), this._getSelect2Config())
                         .select2('data', this._getCachedResults(this.getValue().value))
                         .select2('open');
+                    }
                 } else {
                     this._hideCriteria();
                 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fixes the Select2 input displaying when selecting an empty/not empty operator on a filter.

Before:
![before](https://user-images.githubusercontent.com/3492179/70636962-b8a73900-1c36-11ea-89b0-7ea312cf8bc0.gif)

After:
![after](https://user-images.githubusercontent.com/3492179/70636977-be9d1a00-1c36-11ea-939f-ef9af2318bcf.gif)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
