### PR TITLE
Removes tmp_storage_dir parameter

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,7 +6,6 @@
 - PIM-8894: Change product identifier validation to forbid surrounding spaces
 
 # Technical Improvements
-
 - TIP-1185: Use a single index "product_and_product_model_index" to search on product and product models, instead dedicated product/product model indexes
 - TIP-1159: Improve the performance of the calculation of the completeness
 - TIP-1225: Improve the performance of the indexation of the products
@@ -14,6 +13,9 @@
 - TIP-1176: Improve the performance of the computation of product model descendant when updating a product. The "compute product model descendant" job does not exist anymore. The computation is now done synchronously thanks the improvement done in TIP-1225 and TIP-1174.
 
 ## BC breaks
+
+### Storage configuration
+- Removes the "%tmp_storage_dir%" parameter. Please use "sys_get_temp_dir()" in your code instead.
 
 ### Elasticsearch
 

--- a/config/packages/oneup_flysystem.yml
+++ b/config/packages/oneup_flysystem.yml
@@ -5,7 +5,7 @@ oneup_flysystem:
                 directory: '%catalog_storage_dir%'
         jobs_storage_adapter:
             local:
-                directory: '%tmp_storage_dir%'
+                directory: '%jobs_storage_dir%'
         archivist_adapter:
             local:
                 directory: '%archive_dir%'

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -19,7 +19,7 @@ parameters:
     upload_dir:           '%kernel.project_dir%/var/uploads/product'
     archive_dir:          '%kernel.project_dir%/var/archive'
     catalog_storage_dir:  '%kernel.project_dir%/var/file_storage/catalog'
-    tmp_storage_dir:      '/tmp/pim/file_storage'
+    jobs_storage_dir:     '%kernel.project_dir%/var/jobs'
     upload_tmp_dir:       '/tmp/pim/upload_tmp_dir'
 
     max_products_category_removal: 100

--- a/config/services/test/parameters.yml
+++ b/config/services/test/parameters.yml
@@ -3,5 +3,4 @@ parameters:
     upload_dir:           '%kernel.root_dir%/../var/cache/uploads/product'
     archive_dir:          '%kernel.root_dir%/../var/cache/archive'
     catalog_storage_dir:  '%kernel.root_dir%/../var/cache/file_storage/catalog'
-    tmp_storage_dir:      '%kernel.root_dir%/../var/cache/tmp/pim/file_storage'
     upload_tmp_dir:       '%kernel.root_dir%/../var/cache/tmp/pim/upload_tmp_dir'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/MediaController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/MediaController.php
@@ -28,22 +28,13 @@ class MediaController
     /** @var PathGeneratorInterface */
     protected $pathGenerator;
 
-    /** @var string */
-    protected $uploadDir;
-
     /** @var FileStorer */
     private $fileStorer;
 
-    /**
-     * @param ValidatorInterface     $validator
-     * @param PathGeneratorInterface $pathGenerator
-     * @param string                 $uploadDir
-     */
-    public function __construct(ValidatorInterface $validator, PathGeneratorInterface $pathGenerator, $uploadDir, FileStorer $fileStorer)
+    public function __construct(ValidatorInterface $validator, PathGeneratorInterface $pathGenerator, FileStorer $fileStorer)
     {
         $this->validator = $validator;
         $this->pathGenerator = $pathGenerator;
-        $this->uploadDir = $uploadDir;
         $this->fileStorer = $fileStorer;
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -254,7 +254,6 @@ services:
         arguments:
             - '@validator'
             - '@akeneo_file_storage.file_storage.path_generator'
-            - '%tmp_storage_dir%'
             - '@akeneo_file_storage.file_storage.file.file_storer'
 
     pim_enrich.controller.rest.versioning:

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/services.yml
@@ -12,4 +12,4 @@ services:
     pim_installer.directories_registry:
         class: '%pim_installer.directories_registry.class%'
         arguments:
-            - ['%catalog_storage_dir%', '%tmp_storage_dir%', '%archive_dir%', '%upload_dir%', '%kernel.logs_dir%', '%upload_tmp_dir%']
+            - ['%catalog_storage_dir%', '%archive_dir%', '%jobs_storage_dir%', '%upload_dir%', '%kernel.logs_dir%', '%upload_tmp_dir%']

--- a/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/file_storage.yml
+++ b/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/file_storage.yml
@@ -17,8 +17,6 @@ services:
 
     akeneo_file_storage.file_storage.file.file_fetcher:
         class: '%akeneo_file_storage.file_storage.file.file_fetcher.class%'
-        arguments:
-            - '%tmp_storage_dir%'
 
     akeneo_file_storage.file_storage.file.output_file_fetcher:
         class: '%akeneo_file_storage.file_storage.file.output_file_fetcher.class%'

--- a/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
+++ b/src/Akeneo/Tool/Component/FileStorage/File/FileFetcher.php
@@ -16,14 +16,6 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class FileFetcher implements FileFetcherInterface
 {
-    /** @var string */
-    protected $tmpDir;
-
-    public function __construct(string $tmpDir)
-    {
-        $this->tmpDir = $tmpDir;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -40,12 +32,13 @@ class FileFetcher implements FileFetcherInterface
         }
 
         $fsTools = new Filesystem();
+        $tmpDir = sys_get_temp_dir();
 
-        if (!$fsTools->exists($this->tmpDir . DIRECTORY_SEPARATOR. dirname($fileKey))) {
-            $fsTools->mkdir($this->tmpDir . DIRECTORY_SEPARATOR . dirname($fileKey));
+        if (!$fsTools->exists($tmpDir . DIRECTORY_SEPARATOR. dirname($fileKey))) {
+            $fsTools->mkdir($tmpDir . DIRECTORY_SEPARATOR . dirname($fileKey));
         }
 
-        $localPathname = $this->tmpDir . DIRECTORY_SEPARATOR . $fileKey;
+        $localPathname = $tmpDir . DIRECTORY_SEPARATOR . $fileKey;
 
         if (false === file_put_contents($localPathname, $stream)) {
             throw new FileTransferException(

--- a/src/Akeneo/Tool/Component/FileStorage/spec/File/FileFetcherSpec.php
+++ b/src/Akeneo/Tool/Component/FileStorage/spec/File/FileFetcherSpec.php
@@ -9,17 +9,8 @@ use PhpSpec\ObjectBehavior;
 
 class FileFetcherSpec extends ObjectBehavior
 {
-    function let()
-    {
-        $this->beConstructedWith(sys_get_temp_dir());
-    }
-
     function it_fetches_a_file(Local $adapter, FilesystemInterface $filesystem)
     {
-        if (!is_dir(sys_get_temp_dir() . '/spec/path/to')) {
-            mkdir(sys_get_temp_dir() . '/spec/path/to', 0777, true);
-        }
-
         $filesystem->has('path/to/file.txt')->willReturn(true);
         $filesystem->readStream('path/to/file.txt')->shouldBeCalled();
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The tmp_storage_dir parameter is misleading and creates complex bugs. We should use the temporary directory provided by the system (sys_get_temp_dir()), which can be configured through the TMPDIR env variable if needed for the target env.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
