### PR TITLE
API-837: Hide API users in the user grids of the PIM

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Resources/config/datagrid/user-relation.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/datagrid/user-relation.yml
@@ -11,6 +11,9 @@ datagrid:
                     - u.lastName
                 from:
                     - { table: '%pim_user.entity.user.class%', alias: u }
+                where:
+                    and:
+                        - u.type = '%pim_user.entity.user.class%::TYPE_USER'
 
         columns: []
 

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/datagrid/user.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/datagrid/user.yml
@@ -19,6 +19,9 @@ datagrid:
                     - u.enabled
                 from:
                     - { table: '%pim_user.entity.user.class%', alias: u }
+                where:
+                    and:
+                        - u.type = '%pim_user.entity.user.class%::TYPE_USER'
         columns:
             username:
                 label: pim_user.user.fields.username

--- a/tests/legacy/features/Context/DataGridContext.php
+++ b/tests/legacy/features/Context/DataGridContext.php
@@ -694,6 +694,7 @@ class DataGridContext extends PimContext implements PageObjectAware
      * @Then /^I should not see (?:(?:entit|currenc)(?:y|ies)) (.*)$/
      * @Then /^I should not see group(?: type)?s? (.*)$/
      * @Then /^I should not see association (?:types? )?(.*)$/
+     * @Then /^I should not see users? (.*)$/
      * @Then /^I should not see famil(?:y|ies) (.*)$/
      * @Then /^I should not see client(?:|s) (.*)$/
      */

--- a/tests/legacy/features/Context/FixturesContext.php
+++ b/tests/legacy/features/Context/FixturesContext.php
@@ -4,6 +4,8 @@ namespace Context;
 
 use Acme\Bundle\AppBundle\Entity\Color;
 use Acme\Bundle\AppBundle\Entity\Fabric;
+use Akeneo\Apps\Application\Command\CreateAppCommand;
+use Akeneo\Apps\Domain\Model\ValueObject\FlowType;
 use Akeneo\Channel\Component\Model\Channel;
 use Akeneo\Channel\Component\Model\LocaleInterface;
 use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
@@ -87,6 +89,15 @@ class FixturesContext extends BaseFixturesContext
     ];
 
     protected $username;
+
+    /**
+     * @Given There is a :appCode app
+     */
+    public function thereIsAApp($appCode)
+    {
+        $createAppCommand = new CreateAppCommand($appCode, $appCode, FlowType::DATA_SOURCE);
+        $this->getContainer()->get('akeneo_app.application.handler.create_app')->handle($createAppCommand);
+    }
 
     /**
      * @param array|string $data

--- a/tests/legacy/features/user-management/user/browse_users.feature
+++ b/tests/legacy/features/user-management/user/browse_users.feature
@@ -13,4 +13,3 @@ Feature: Browse users
     Given I am on the users page
     Then I should see users "admin", "Peter", "Julia", "Mary" and "Sandra"
     But I should not see users "magento"
-    

--- a/tests/legacy/features/user-management/user/browse_users.feature
+++ b/tests/legacy/features/user-management/user/browse_users.feature
@@ -13,3 +13,4 @@ Feature: Browse users
     Given I am on the users page
     Then I should see users "admin", "Peter", "Julia", "Mary" and "Sandra"
     But I should not see users "magento"
+    

--- a/tests/legacy/features/user-management/user/browse_users.feature
+++ b/tests/legacy/features/user-management/user/browse_users.feature
@@ -1,0 +1,15 @@
+@javascript
+Feature: Browse users
+  In order to manage the users and rights
+  As an administrator
+  I need to be able to see users
+
+  Background:
+    Given the "default" catalog configuration
+    And There is a "magento" app
+    And I am logged in as "Peter"
+
+  Scenario: Successfully display users
+    Given I am on the users page
+    Then I should see users "admin", "Peter", "Julia", "Mary" and "Sandra"
+    But I should not see users "magento"


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Hide API user from the user grids

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | OK
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
