### PR TITLE
PIM-9023: Add login details on user profile page

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,6 +1,7 @@
 # 3.0.x
 
 - PIM-9011: Fix display issue on read-only categories
+- PIM-9023: Add login details on user profile page
 
 # 3.0.59 (2019-12-09)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
@@ -971,6 +971,7 @@ config:
     pim/form/common/creation/job:                        pimui/js/form/common/creation/job
     pim/form/common/product/create-button:               pimui/js/form/common/product/create-button
     pim/form/common/section:                             pimui/js/form/common/section.ts
+    pim/form/user/login-details:                         pimui/js/form/user/login-details
 
     pim/menu/menu:                                       pimui/js/menu/menu
     pim/menu/tab:                                        pimui/js/menu/tab
@@ -1108,6 +1109,7 @@ config:
     pim/template/form/column-tabs-navigation:                 pimui/templates/form/column-tabs-navigation.html
     pim/template/form/subsection:                             pimui/templates/form/subsection.html
     pim/template/form/main-image:                             pimui/templates/form/main-image.html
+    pim/template/form/user/login-details:                     pimui/templates/form/user/login-details.html
 
     pim/template/form/common/fields/field:                    pimui/templates/form/common/fields/field.html
     pim/template/form/common/fields/boolean:                  pimui/templates/form/common/fields/boolean.html

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/user/login-details.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/user/login-details.js
@@ -1,0 +1,40 @@
+'use strict';
+/**
+ * Display formatted user login details
+ *
+ * @author    Valentin Dijkstra <valentin.dijkstra@akeneo.com>
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'underscore',
+        'oro/translator',
+        'pim/form',
+        'pim/template/form/user/login-details'
+    ],
+    function (_, __, BaseForm, template) {
+        return BaseForm.extend({
+            template: _.template(template),
+
+            /**
+             * {@inheritdoc}
+             */
+            render: function () {
+                var user = this.getFormData();
+                var createdDate = new Date(user.meta.created * 1000);
+                var updatedDate = new Date(user.meta.updated * 1000);
+                var lastLoginDate = new Date(user.last_login * 1000);
+                this.$el.html(this.template({
+                    __,
+                    created: createdDate.toLocaleString(),
+                    updated: updatedDate.toLocaleString(),
+                    lastLoggedIn: lastLoginDate.toLocaleString(),
+                    loginCount: user.login_count
+                }));
+               
+                return BaseForm.prototype.render.apply(this, arguments);
+            }
+        });
+    }
+);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/user/login-details.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/user/login-details.js
@@ -32,7 +32,7 @@ define(
                     lastLoggedIn: lastLoginDate.toLocaleString(),
                     loginCount: user.login_count
                 }));
-               
+
                 return BaseForm.prototype.render.apply(this, arguments);
             }
         });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/user/login-details.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/user/login-details.html
@@ -1,0 +1,12 @@
+<span class="AknTitleContainer-metaItem">
+    <%- __('pim_user_management.entity.user.meta.created') %>: <%- created %>
+</span>
+<span class="AknTitleContainer-metaItem">
+    <%- __('pim_user_management.entity.user.meta.updated') %>: <%- updated %>
+</span>
+<span class="AknTitleContainer-metaItem">
+    <%- __('pim_user_management.entity.user.properties.last_logged_in') %>: <%- lastLoggedIn %>
+</span>
+<span class="AknTitleContainer-metaItem">
+    <%- __('pim_user_management.entity.user.properties.login_count') %>: <%- loginCount %>
+</span>

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
@@ -38,6 +38,12 @@ extensions:
         config:
             field: username
 
+    pim-user-edit-form-login-details:
+        module: pim/form/user/login-details
+        parent: pim-user-edit-form
+        targetZone: meta
+        position: 110
+
     pim-user-edit-form-save-buttons:
         module: pim/form/common/save-buttons
         parent: pim-user-edit-form

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -68,12 +68,17 @@ pim_user_management:
                 new_password_repeat: New password (repeat)
                 password: Password
                 password_repeat: Password (repeat)
+                last_logged_in: Last logged in
+                login_count: Login count
                 ui_locale: UI locale
                 timezone: Timezone
                 default_product_grid_view: Default product grid view
                 default_published_product_grid_view: Default published product grid view # EE Only
                 proposals_to_review_notification: When new proposal to review # EE Only
                 proposals_state_notifications: When proposal is accepted or rejected # EE Only
+            meta:
+                created: Created
+                updated: Updated
             module:
                 create:
                     button: Create user

--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -103,9 +103,11 @@ class UserNormalizer implements NormalizerInterface
                 'originalFilename' => null,
             ] : $this->fileNormalizer->normalize($user->getAvatar()),
             'meta'                      => [
-                'id'    => $user->getId(),
-                'form'  => $this->getFormName($user),
-                'image' => [
+                'id'      => $user->getId(),
+                'created' => $user->getCreatedAt() ? $user->getCreatedAt()->getTimestamp() : null,
+                'updated' => $user->getUpdatedAt() ? $user->getUpdatedAt()->getTimestamp() : null,
+                'form'    => $this->getFormName($user),
+                'image'   => [
                     'filePath' => null === $user->getAvatar() ?
                         null :
                         $this->fileNormalizer->normalize($user->getAvatar())['filePath']

--- a/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
@@ -84,9 +84,11 @@ class UserNormalizerSpec extends ObjectBehavior
                 'originalFilename' => null,
             ],
             'meta'                      => [
-                'id'    => null,
-                'form'  => 'pim-user-show',
-                'image' => [
+                'id'      => null,
+                'created' => null,
+                'updated' => null,
+                'form'    => 'pim-user-show',
+                'image'   => [
                     'filePath' => null
                 ]
             ],


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since `v3.0`, user login details (created date, updated date, last login date and login count) were removed from the user profile page.
This PR adds them back using a simple backbone form and using the same style as in `v2.3`.

![image](https://user-images.githubusercontent.com/3492179/70730590-903a4000-1d05-11ea-8912-f6b00b00aa1b.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
