### PR TITLE
AST-182: Add CSP rules to allow youtube embedded

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/AddContentSecurityPolicyListener.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/AddContentSecurityPolicyListener.php
@@ -33,7 +33,7 @@ class AddContentSecurityPolicyListener implements EventSubscriberInterface
     public function addCspHeaders(FilterResponseEvent $event): void
     {
         $policy = sprintf(
-            "default-src 'self' *.akeneo.com 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'nonce-%s'; img-src 'self' data:",
+            "default-src 'self' *.akeneo.com 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'nonce-%s'; img-src 'self' data: ; frame-src * ; font-src 'self' data:",
             $this->generatedNonce
         );
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add a CSP rules to allow youtube embedded as explained in: https://developers.google.com/web/fundamentals/security/csp (look for youtube.com)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
