### PR TITLE
PIM-9030: Fix date formatting for non UTC values

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,6 +1,12 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-9030: Fix date formatting for non UTC values
+
 # 3.0.60 (2019-12-13)
+
+## Bug fixes
 
 - PIM-9011: Fix display issue on read-only categories
 - PIM-9023: Add login details on user profile page

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
@@ -34,18 +34,17 @@ class DateValueFactory extends AbstractValueFactory
             );
         }
 
-
         try {
-            $date = new \DateTime($data);
-
             if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data)) {
                 $this->throwsInvalidDateException($attribute, $data);
             }
+            $date = new \DateTime($data);
+            $utcDate = \DateTime::createFromFormat('U', $date->format('U'));
         } catch (\Exception $e) {
             $this->throwsInvalidDateException($attribute, $data);
         }
 
-        return $date;
+        return $utcDate;
     }
 
     /**


### PR DESCRIPTION
We can have values for date that are not formatted for UTC. When using API for example.
We need to convert them to UTC before making any operations on them.
We didn't have the issue with values for product because Doctrine knows how to do the conversion, but we have other side effects, like in versioning where the value in history is not converted to UTC.