### PR TITLE
PIM-9030: Fix date formatting for non UTC values

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,6 +1,12 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-9030: Fix date formatting for non UTC values
+
 # 3.0.60 (2019-12-13)
+
+## Bug fixes
 
 - PIM-9011: Fix display issue on read-only categories
 - PIM-9023: Add login details on user profile page

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_versioning.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_versioning.yml
@@ -41,6 +41,8 @@ services:
 
     pim_versioning.serializer.normalizer.flat.datetime:
         class: '%pim_serializer.normalizer.flat.datetime.class%'
+        arguments:
+            - 'c'
         tags:
             - { name: pim_versioning.serializer.normalizer, priority: 90 }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_versioning.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_versioning.yml
@@ -41,8 +41,6 @@ services:
 
     pim_versioning.serializer.normalizer.flat.datetime:
         class: '%pim_serializer.normalizer.flat.datetime.class%'
-        arguments:
-            - 'c'
         tags:
             - { name: pim_versioning.serializer.normalizer, priority: 90 }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
@@ -34,17 +34,17 @@ class DateValueFactory extends AbstractValueFactory
             );
         }
 
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data)) {
+            $this->throwsInvalidDateException($attribute, $data);
+        }
+
         try {
-            if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data)) {
-                $this->throwsInvalidDateException($attribute, $data);
-            }
             $date = new \DateTime($data);
-            $utcDate = \DateTime::createFromFormat('U', $date->format('U'));
         } catch (\Exception $e) {
             $this->throwsInvalidDateException($attribute, $data);
         }
 
-        return $utcDate;
+        return $date;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
@@ -34,18 +34,17 @@ class DateValueFactory extends AbstractValueFactory
             );
         }
 
-
         try {
-            $date = new \DateTime($data);
-
             if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data)) {
                 $this->throwsInvalidDateException($attribute, $data);
             }
+            $date = new \DateTime($data);
+            $utcDate = \DateTime::createFromFormat('U', $date->format('U'));
         } catch (\Exception $e) {
             $this->throwsInvalidDateException($attribute, $data);
         }
 
-        return $date;
+        return $utcDate;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Versioning/Product/DateTimeNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Versioning/Product/DateTimeNormalizer.php
@@ -22,7 +22,7 @@ class DateTimeNormalizer extends AbstractValueDataNormalizer
     /**
      * @param string $format see http://www.php.net/date
      */
-    public function __construct($format = 'Y-m-d')
+    public function __construct($format = 'c')
     {
         $this->format = $format;
     }

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/tests/integration/Manager/VersionManagerIntegration.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/tests/integration/Manager/VersionManagerIntegration.php
@@ -119,6 +119,11 @@ class VersionManagerIntegration extends TestCase
         $this->productUpdater->update($product, $updates);
         $this->productSaver->save($product);
 
+        $this->assertEquals(
+            $product->getRawValues()['a_date']['<all_channels>']['<all_locales>'],
+            '2017-02-01T00:00:00+01:00'
+        );
+
         $productVersions = $this->versionRepository->getLogEntries(ClassUtils::getClass($product), $product->getId());
 
         $this->assertCount(2, $productVersions);
@@ -134,7 +139,7 @@ class VersionManagerIntegration extends TestCase
             'groups'     => 'groupB',
             'categories' => '',
             'parent'     => '',
-            'a_date'     => '2017-02-01',
+            'a_date'     => '2017-02-01T00:00:00+01:00',
             'enabled'    => 1,
         ]);
 
@@ -145,7 +150,7 @@ class VersionManagerIntegration extends TestCase
             ],
             'a_date' => [
                 'old' => '',
-                'new' => '2017-02-01',
+                'new' => '2017-02-01T00:00:00+01:00',
             ],
         ]);
     }
@@ -153,6 +158,7 @@ class VersionManagerIntegration extends TestCase
     public function testCreateProductVersionOnAttributeAndFieldDeletion()
     {
         $product = $this->get('pim_catalog.builder.product')->createProduct('versioned-product');
+
         $updates = [
             'groups' => ['groupB'],
             'values' => [
@@ -188,7 +194,7 @@ class VersionManagerIntegration extends TestCase
         ]);
         $this->assertEquals($version->getChangeset(), [
             'a_date' => [
-                'old' => '2017-02-01',
+                'old' => '2017-02-01T00:00:00+01:00',
                 'new' => '',
             ],
         ]);

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
@@ -15,6 +15,12 @@ class ProductIntegration extends TestCase
     public function testProduct()
     {
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('foo');
+
+        $this->assertEquals(
+            $product->getRawValues()['a_date']['<all_channels>']['<all_locales>'],
+            '2016-06-13T00:00:00+02:00'
+        );
+
         $flatProduct = $this->get('pim_versioning.serializer')->normalize($product, 'flat');
         $mediaAttributes = ['a_file', 'an_image', 'a_localizable_image-en_US', 'a_localizable_image-fr_FR'];
         $flatProduct = $this->sanitizeMediaAttributeData($flatProduct, $mediaAttributes);
@@ -36,7 +42,7 @@ class ProductIntegration extends TestCase
             'PACK-groups' => '',
             'PACK-products' => 'bar,baz',
             'PACK-product_models' => '',
-            'a_date' => '2016-06-13',
+            'a_date' => '2016-06-13T00:00:00+02:00',
             'a_file' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_fileA.txt',
             'a_localizable_image-en_US' => '6/2/e/3/62e376e75300d27bfec78878db4d30ff1490bc53_imageB_en_US.jpg',
             'a_localizable_image-fr_FR' => '0/f/5/0/0f5058de76f68446bb6b2371f19cd2234b245c00_imageB_fr_FR.jpg',

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/tests/integration/Normalizer/Flat/ProductIntegration.php
@@ -83,6 +83,11 @@ class ProductIntegration extends TestCase
         $expected = $this->sanitizeMediaAttributeData($expected, $mediaAttributes);
 
         $this->assertEquals($expected, $flatProduct);
+
+        $this->assertEquals(
+            $product->getRawValues()['a_date']['<all_channels>']['<all_locales>'],
+            $flatProduct['a_date']
+        );
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Versioning/Product/DateTimeNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Versioning/Product/DateTimeNormalizerSpec.php
@@ -33,7 +33,7 @@ class DateTimeNormalizerSpec extends ObjectBehavior
 
         $this
             ->normalize($date, null, ['field_name' => 'release_date'])
-            ->shouldReturn(['release_date' => $date->format('Y-m-d')]);
+            ->shouldReturn(['release_date' => $date->format('c')]);
     }
 
     function it_normalizes_date_value_using_the_context_format()


### PR DESCRIPTION
Date attributes values are stored in UTC format for the product raw_values.
Versioning was only storing `Y-m-d` dates and we could have a difference between history and the actual value of the attribute because of a difference timezone.
By storing dates versions in UTC format, we ensure to have the same value in history and current value.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
