### PR TITLE
Lock phpspec/prophecy to 1.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,6 +129,7 @@
         "behat/mink-selenium2-driver": "1.3.x-dev",
         "behat/symfony2-extension": "2.1.5",
         "phpspec/phpspec": "~6.0.0",
+        "phpspec/prophecy": "~1.9.0",
         "phpunit/phpunit": "^8.0",
         "sebastian/exporter": "~3.1.0",
         "sensiolabs/behat-page-object-extension": "2.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef328a7babeb1d65ca8a758a3753b602",
+    "content-hash": "c2748397b75a128e9a4e8991bc823676",
     "packages": [
         {
             "name": "ass/xmlsecurity",


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The new release of `phpspec/prophecy` (1.10.0) is breaking tests on EE, so we lock to the previous version.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
