### PR TITLE
PIM-9028: Fix error on JSON_EXTRACT where a_image.code is numerical

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes:
 
 - PIM-9027: Translations missing on metrics
+- PIM-9028: Fix error on JSON_EXTRACT where a_image.code is numerical
 
 # 3.2.26 (2019-12-16)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -239,7 +239,7 @@ SQL;
                 a_image.is_scopable,
                 JSON_EXTRACT(
                     pm_child.raw_values,
-                    CONCAT('$.', a_image.code, '.', IF(is_scopable = 1, '":channel_code"', '"<all_channels>"'), '.', IF(is_localizable = 1, '":locale_code"', '"<all_locales>"'))
+                    CONCAT('$."', a_image.code, '".', IF(is_scopable = 1, '":channel_code"', '"<all_channels>"'), '.', IF(is_localizable = 1, '":locale_code"', '"<all_locales>"'))
                 ) as image_value
             FROM
                 pim_catalog_product_model pm_root
@@ -320,7 +320,7 @@ SQL;
                 product_child.raw_values,
                 JSON_EXTRACT(
                     product_child.raw_values,
-                    CONCAT('$.', a_image.code, '.', IF(is_scopable = 1, '":channel_code"', '"<all_channels>"'), '.', IF(is_localizable = 1, '":locale_code"', '"<all_locales>"'))
+                    CONCAT('$."', a_image.code, '".', IF(is_scopable = 1, '":channel_code"', '"<all_channels>"'), '.', IF(is_localizable = 1, '":locale_code"', '"<all_locales>"'))
                 ) as image_value
             FROM
                 pim_catalog_product_model pm_root


### PR DESCRIPTION
In the fixed request, if `a_image.code` is numerical (ex: 001), it raises a MySQL error 

`Invalid JSON path expression. The error is around character position 5.`

It is because of the following request

```
SELECT JSON_EXTRACT(
               raw_values,
               '$.001."<all_channels>"."<all_locales>"'
           )
FROM pim_catalog_product_model
where id=2;
```

It failed with the same error
If I replace 001 by "001", it will be executed without problems.