### PR TITLE
AST-197: Generate jpg tumbnails instead of pngs for asset manager

### DIFF
--- a/config/packages/liip_imagine.yml
+++ b/config/packages/liip_imagine.yml
@@ -44,7 +44,7 @@ liip_imagine:
 
         am_url_image_thumbnail:
             quality:          95
-            format:           png
+            format:           jpg
             data_loader:      stream_data_loader
             filters:
                 thumbnail:    { size: [320, 320], mode: inset }
@@ -58,9 +58,11 @@ liip_imagine:
 
         am_binary_image_thumbnail:
             quality:          95
-            format:           png
+            format:           jpg
             filters:
                 thumbnail:    { size: [320, 320], mode: inset }
+                background:
+                    color: "#ffffff"
 
         am_url_pdf_preview:
             quality:          95
@@ -72,10 +74,12 @@ liip_imagine:
 
         am_url_pdf_thumbnail:
             quality:          95
-            format:           png
+            format:           jpg
             data_loader:      stream_pdf_loader
             filters:
                 thumbnail:    { size: [320, 320], mode: inset }
+                background:
+                    color: "#ffffff"
 
         am_binary_pdf_preview:
             quality:          95
@@ -87,7 +91,9 @@ liip_imagine:
 
         am_binary_pdf_thumbnail:
             quality:          95
-            format:           png
+            format:           jpg
             data_loader:      flysystem_pdf_loader
             filters:
                 thumbnail:    { size: [320, 320], mode: inset }
+                background:
+                    color: "#ffffff"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We are doing this to better support the "Other" preview without losing quality in rendering the rest of the media types.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
