### PR TITLE
PIM-9029: fix catalog locale usage on family variant grid

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+PIM-9029: Use Catalog locale in variant families datagrid
+
 # 3.2.27 (2019-12-19)
 
 ## Bug fixes:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/family-variant.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/family-variant.js
@@ -67,7 +67,7 @@ define(
                         this.config.gridName,
                         {
                             family_id: this.getFormData().meta.id,
-                            localeCode: UserContext.get('uiLocale')
+                            localeCode: UserContext.get('catalogLocale')
                         }
                     );
                 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
