### PR TITLE
API-917: Add liip_imagine filter for dropdown picture

### DIFF
--- a/config/packages/liip_imagine.yml
+++ b/config/packages/liip_imagine.yml
@@ -27,6 +27,12 @@ liip_imagine:
             filters:
                 thumbnail:    { size: [280, 280], mode: outbound }
                 strip:        ~
+        dropdown_select_picture:
+            quality:          95
+            format:           png
+            filters:
+                thumbnail:    { size: [28, 28], mode: outbound }
+                strip:        ~
         pdf_thumbnail:
             quality:          95
             format:           png

--- a/src/Akeneo/Connectivity/Connection/front/src/audit/components/ConnectionSelect.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/components/ConnectionSelect.tsx
@@ -18,7 +18,7 @@ export const ConnectionSelect = ({connections, onChange}: Props) => {
     const data = connections.reduce((data, connection) => {
         data[connection.code] = {
             label: connection.label,
-            imageSrc: (connection.image && generate(connection.image)) || undefined,
+            imageSrc: (connection.image && generate(connection.image, 'dropdown_select_picture')) || undefined,
         };
         return data;
     }, {} as {[code: string]: {label: string; imageSrc?: string}});


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
