### PR TITLE
PIM-9043: Archive every jobs in flysystem

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,8 +1,9 @@
 # 3.2.x
 
-## Bug fixes
+## Bug fixes:
 
-PIM-9029: Use Catalog locale in variant families datagrid
+- PIM-9043: Do not filter archivable jobs to be able to download all logs
+- PIM-9029: Use Catalog locale in variant families datagrid
 
 # 3.2.27 (2019-12-19)
 

--- a/src/Akeneo/Tool/Component/Connector/LogArchiver.php
+++ b/src/Akeneo/Tool/Component/Connector/LogArchiver.php
@@ -31,10 +31,6 @@ class LogArchiver implements EventSubscriberInterface
     public function archive(JobExecutionEvent $event): void
     {
         $jobExecution = $event->getJobExecution();
-        if (!$this->isImportOrExport($jobExecution)) {
-            return;
-        }
-
         $logPath = $jobExecution->getLogFile();
 
         if (is_file($logPath)) {
@@ -51,13 +47,5 @@ class LogArchiver implements EventSubscriberInterface
         return [
             EventInterface::BEFORE_JOB_STATUS_UPGRADE => 'archive'
         ];
-    }
-
-    private function isImportOrExport(JobExecution $jobExecution): bool
-    {
-        return in_array(
-            $jobExecution->getJobInstance()->getType(),
-            [JobInstance::TYPE_EXPORT, JobInstance::TYPE_IMPORT]
-        );
     }
 }


### PR DESCRIPTION
The logs were not stored through JobArchiver, so logs cannot be downloaded.