### PR TITLE
PIM-9041: Fix performance issue on "Add to existing product model" mass action

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -5,6 +5,7 @@
 ## Bug fixes
 
 - PIM-9030: Fix date formatting for non UTC values
+- PIM-9041: Fix performance issue on "Add to existing product model" mass action
 
 # 3.0.60 (2019-12-13)
 

--- a/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/FamilyController.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/FamilyController.php
@@ -374,7 +374,11 @@ class FamilyController
 
         $normalizedFamilies = [];
         foreach ($families as $family) {
-            $normalizedFamilies[$family->getCode()] = $this->normalizer->normalize($family, 'internal_api');
+            $normalizedFamilies[$family->getCode()] = $this->normalizer->normalize(
+                $family,
+                'internal_api',
+                ['expanded' => false]
+            );
         }
 
         return new JsonResponse($normalizedFamilies);


### PR DESCRIPTION
# Description

The mass edit action "Add to existing product model" is quite slow with a huge set of families.
The query is OK (very quick and not optimizable), but the normalization is still complex (it normalize all the family, attributes, requirements, etc).
It exists an option in the normalizer to only return code and labels, this PR use it.

With icecat, the previous query was 250ms ~, now it's 60ms ~.