### PR TITLE
PIM-7699: Fix multi-select filter design with a lot of filtered items

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7699: Fix multi-select filter design with a lot of filtered items
+
 ## Technical improvement
 
 - Update composer dependencies to fix PhpSpec Prohecy version to 1.9.*

--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select-filter.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datafilter/filter/select-filter.js
@@ -324,6 +324,9 @@ function(_, __, AbstractFilter, MultiselectDecorator) {
                 this._updateCriteriaSelectorPosition();
                 this.selectWidget.multiselect('refresh');
             }
+
+            const label = this.$(this.buttonSelector).find('.filter-criteria-hint');
+            label.attr('title', label.html());
         },
 
         /**
@@ -331,6 +334,7 @@ function(_, __, AbstractFilter, MultiselectDecorator) {
          */
         _writeDOMValue: function(value) {
             this._setInputValue(this.inputSelector, value.value);
+
             return this;
         },
 

--- a/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Pim/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -108,6 +108,13 @@
     color: @AknDarkBlue;
     font-size: @AknDefaultFontSize;
 
+    & .filter-criteria-hint {
+      max-width: 300px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
     &.ui-multiselect {
       // jQuery select adds style for the button, we need to remove it for the filters.
       width: auto !important;


### PR DESCRIPTION
It glitched a lot before, because the text was way too long.

Now:
![Selection_194](https://user-images.githubusercontent.com/1590933/71670379-f1d35480-2d6f-11ea-99db-d0f2bc6989e1.png)
