### PR TITLE
DAPI - Add events on before and after the rendering of the PEF

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes.js
@@ -180,6 +180,8 @@ define(
                     return this;
                 }
 
+                this.getRoot().trigger('pim_enrich:form:attributes:render:before');
+
                 this.rendering = true;
                 this.$el.html(this.template({}));
 
@@ -238,6 +240,9 @@ define(
                             this.delegateEvents();
 
                             _.defer(this.sticky.bind(this));
+                        })
+                        .then(() => {
+                            this.getRoot().trigger('pim_enrich:form:attributes:render:after');
                         });
                     });
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/column-tabs-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/column-tabs-navigation.js
@@ -56,6 +56,7 @@ define(
 
                 this.listenTo(this.getRoot(), 'column-tab:register', this.registerTab);
                 this.listenTo(this.getRoot(), 'column-tab:select-tab', this.setCurrentTab);
+                this.listenTo(this.getRoot(), 'column-tab:change-tab', this.selectTab);
 
                 return BaseForm.prototype.configure.apply(this, arguments);
             },


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Trigger dedicated events before and after the rendering of the Attributes Tab on the PEF.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
