### PR TITLE
API-926: Rename defineAsUserApp() and isAUserApp()

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/User/Internal/CreateUser.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/User/Internal/CreateUser.php
@@ -48,7 +48,7 @@ class CreateUser implements CreateUserInterface
         $username = $this->generateUsername($username);
 
         $user = $this->userFactory->create();
-        $user->defineAsUserApp();
+        $user->defineAsUserApi();
         $this->userUpdater->update(
             $user,
             [

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/User/Internal/CreateUser.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/User/Internal/CreateUser.php
@@ -48,7 +48,7 @@ class CreateUser implements CreateUserInterface
         $username = $this->generateUsername($username);
 
         $user = $this->userFactory->create();
-        $user->defineAsUserApi();
+        $user->defineAsApiUser();
         $this->userUpdater->update(
             $user,
             [

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/User/Internal/CreateUserSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/User/Internal/CreateUserSpec.php
@@ -42,7 +42,7 @@ class CreateUserSpec extends ObjectBehavior
         $validator->validate($user)->willReturn($violations);
         $userSaver->save($user)->shouldBeCalled();
         $user->getId()->willReturn(1);
-        $user->defineAsUserApp()->shouldBeCalled();
+        $user->defineAsUserApi()->shouldBeCalled();
 
         $readUser = $this->execute('foo', 'bar', 'baz');
         $readUser->shouldBeAnInstanceOf(ReadUser::class);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/User/Internal/CreateUserSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/User/Internal/CreateUserSpec.php
@@ -42,7 +42,7 @@ class CreateUserSpec extends ObjectBehavior
         $validator->validate($user)->willReturn($violations);
         $userSaver->save($user)->shouldBeCalled();
         $user->getId()->willReturn(1);
-        $user->defineAsUserApi()->shouldBeCalled();
+        $user->defineAsApiUser()->shouldBeCalled();
 
         $readUser = $this->execute('foo', 'bar', 'baz');
         $readUser->shouldBeAnInstanceOf(ReadUser::class);

--- a/src/Akeneo/UserManagement/Component/Model/User.php
+++ b/src/Akeneo/UserManagement/Component/Model/User.php
@@ -23,7 +23,7 @@ class User implements UserInterface
     const ROLE_ANONYMOUS = 'IS_AUTHENTICATED_ANONYMOUSLY';
     const DEFAULT_TIMEZONE = 'UTC';
     const TYPE_USER = 'user';
-    const TYPE_APP = 'app';
+    const TYPE_API = 'api';
 
     /** @var int|string */
     protected $id;
@@ -1092,14 +1092,14 @@ class User implements UserInterface
         return $this;
     }
 
-    public function isAUserApp(): bool
+    public function isAUserApi(): bool
     {
-        return self::TYPE_APP === $this->type;
+        return self::TYPE_API === $this->type;
     }
 
-    public function defineAsUserApp(): void
+    public function defineAsUserApi(): void
     {
-        $this->type = self::TYPE_APP;
+        $this->type = self::TYPE_API;
     }
 
     /**

--- a/src/Akeneo/UserManagement/Component/Model/User.php
+++ b/src/Akeneo/UserManagement/Component/Model/User.php
@@ -1092,12 +1092,12 @@ class User implements UserInterface
         return $this;
     }
 
-    public function isAUserApi(): bool
+    public function isApiUser(): bool
     {
         return self::TYPE_API === $this->type;
     }
 
-    public function defineAsUserApi(): void
+    public function defineAsApiUser(): void
     {
         $this->type = self::TYPE_API;
     }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountUsersIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountUsersIntegration.php
@@ -58,7 +58,7 @@ class CountUsersIntegration extends QueryTestCase
         $this->get('pim_user.updater.user')->update($user, $data, []);
 
         if ($type === User::TYPE_API) {
-            $user->defineAsUserApi();
+            $user->defineAsApiUser();
         }
 
         $validation = $this->get('validator')->validate($user);

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountUsersIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountUsersIntegration.php
@@ -15,7 +15,7 @@ class CountUsersIntegration extends QueryTestCase
     {
         $query = $this->get('pim_volume_monitoring.persistence.query.count_users');
         $this->createUsers(4, User::TYPE_USER);
-        $this->createUsers(2, User::TYPE_APP);
+        $this->createUsers(2, User::TYPE_API);
 
         $volume = $query->fetch();
 
@@ -57,8 +57,8 @@ class CountUsersIntegration extends QueryTestCase
         $user = $this->get('pim_user.factory.user')->create();
         $this->get('pim_user.updater.user')->update($user, $data, []);
 
-        if ($type === User::TYPE_APP) {
-            $user->defineAsUserApp();
+        if ($type === User::TYPE_API) {
+            $user->defineAsUserApi();
         }
 
         $validation = $this->get('validator')->validate($user);

--- a/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
@@ -21,12 +21,12 @@ class UserSpec extends ObjectBehavior
 
     function it_initializes_the_user_as_a_non_app()
     {
-        $this->isAUserApi()->shouldReturn(false);
+        $this->isApiUser()->shouldReturn(false);
     }
 
     function it_defines_the_user_as_a_user_app()
     {
-        $this->defineAsUserApi();
-        $this->isAUserApi()->shouldReturn(true);
+        $this->defineAsApiUser();
+        $this->isApiUser()->shouldReturn(true);
     }
 }

--- a/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Model/UserSpec.php
@@ -21,12 +21,12 @@ class UserSpec extends ObjectBehavior
 
     function it_initializes_the_user_as_a_non_app()
     {
-        $this->isAUserApp()->shouldReturn(false);
+        $this->isAUserApi()->shouldReturn(false);
     }
 
     function it_defines_the_user_as_a_user_app()
     {
-        $this->defineAsUserApp();
-        $this->isAUserApp()->shouldReturn(true);
+        $this->defineAsUserApi();
+        $this->isAUserApi()->shouldReturn(true);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Rename :

- defineAsUserApp() to defineAsUserApi
- isAUserApp() to isUserApi()
- TYPE_APP to TYPE_API

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
