### PR TITLE
Download docker images in parallel (using cache is not efficient)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,20 @@
 version: 2
+
+aliases:
+
+    - &installLastDockerComposeVersion
+          name: Install last docker-compose version allowing to pull in parallel docker images
+          command: |
+              sudo curl -L "https://github.com/docker/compose/releases/download/1.25.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+              sudo chmod +x /usr/local/bin/docker-compose
+
 jobs:
   build_dev:
     machine:
       image: ubuntu-1604:201903-01
     steps:
       - checkout
+      - run: *installLastDockerComposeVersion
       - run:
           name: Copy docker-compose.override.yml.dist
           command: cp .circleci/docker-compose.override.yml.dist docker-compose.override.yml
@@ -28,6 +38,9 @@ jobs:
               sudo chown -R 1000:1000 ../project
               sudo chown -R 1000:1000 ~/.composer
               sudo chown -R 1000:1000 ~/.cache/yarn
+      - run:
+           name: Pull docker images in parallel
+           command:  docker-compose pull elasticsearch mysql node php
       - run:
             name: Install back and front dependencies
             command: make dependencies
@@ -106,12 +119,14 @@ jobs:
       steps:
           - attach_workspace:
                 at: ~/
+          - run: *installLastDockerComposeVersion
           - run:
                 name: Change owner on project dir in order to archive the project into the workspace
                 command: sudo chown -R 1000:1000 ../project
           - run:
                 name: Start containers
                 command: |
+                    docker-compose pull php fpm mysql elasticsearch object-storage
                     APP_ENV=test C='fpm mysql elasticsearch object-storage' make up
                     docker/wait_docker_up.sh
           - run:
@@ -137,6 +152,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run: *installLastDockerComposeVersion
       - run:
             name: Get Behat Suite name to run
             command: |
@@ -152,6 +168,7 @@ jobs:
       - run:
             name: Start containers
             command: |
+                docker-compose pull php fpm mysql elasticsearch httpd object-storage selenium
                 APP_ENV=behat C='fpm mysql elasticsearch httpd object-storage selenium' make up
                 docker/wait_docker_up.sh
       - run:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
The goal of this PR is to try to save the docker images in the Circle CI cache, in order to avoid to pull it in every jobs.
This is mainly done for performance purpose. 

**3 caches for Mysql, Elasticsearch, Node images**
https://circleci.com/gh/akeneo/pim-community-dev/25150

At first, I tried to create 3 different cache for the images (Mysql, Elasticsearch, Node), as a cache should not weight more than 500 Mo in Circle CI, to have the integrity check.

Restoring cache: 35 sec

- Mysql 8 sec (134 Mo)
- Elasticsearch 15 sec (324 Mo)
- Node 12 sec (229 Mo)
Total: 

`docker load` commands: 75 sec

Total: 110 sec

**1 caches for Mysql, Elasticsearch, Node images**
https://circleci.com/gh/akeneo/pim-community-dev/25241

Then I tried to create only one cache for the images. It weights more than 500 Mo, so it's not recommended by Circle CI but it seems to works.

Restoring cache: 21 sec (664 Mo)

`docker load` commands: 75 sec

Total: 110 sec

**1 caches for Mysql, Elasticsearch, Node images + overlay2 on tmpfs**

I analyzed with a basic `top` why a docker save is so slow: it's mainly IO wait (90% wait). So, I would like to test to load the images in RAM instead. With the help of @BitOne, we put `/var/lib/docker` in memory (=tmpfs). It means that all images and containers are in RAM.

Restoring cache: 21 sec (664 Mo), same time as not in RAM

`docker load` commands: 20 sec

Total: 40 sec

We tried to run a behat, and we had an error as minio does not allow to store a file if there is not 1Go left on the disk (which is not the case of our tmpfs). It's hardcoded and not configurable. We would have probably other errors like that (there is a threshold with ES too).
It's fun, but maybe too much unstable..

**Loading images Mysql, Elasticsearch, Node images with docker pull **

Let's test if our cache is efficient comparing to the download of the images.
Time: 40 sec

The cache is useless...

**Loading images Mysql, Elasticsearch, Node images with docker-compose 1.25**
Circle CI docker-version: 1.23
Last version: 1.25

In last version, pull of docker images is done in parallel! This simple feature is actually the faster way to improve the loading.

Time: 27 sec


**Conclusion**

We should just update docker-compose and use `docker pull`. It parallelizes by default the pull of the images since 1.25. It does not parallelize with `docker up -d` though.

For now, I prefer to test it in CE and backport it in EE in two weeks if it's reliable.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
