### PR TITLE
Fix ArrayToStringConversion notice during product export.

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
@@ -81,12 +81,29 @@ class ProductWriter extends AbstractItemMediaWriter implements
     public function write(array $items)
     {
         foreach ($items as $item) {
-            if (isset($item['family']) && !in_array($item['family'], $this->familyCodes)) {
-                $this->familyCodes[] = $item['family'];
+            if (isset($item['family'])) {
+                if (is_array($item['family'])) {
+                    foreach ($item['family'] as $valFamily) {
+                        $this->addToFamilyCodes($valFamily);
+                    }
+                } else {
+                    $this->addToFamilyCodes($item['family']);
+                }
             }
         }
 
         parent::write($items);
+    }
+
+    /**
+     * Adds the familyCode to current class property familyCodes:array if it doesn't already exist.
+     * @param $familyCode
+     * @author Akash M. Pai <makashpai@gmail.com>
+     */
+    private function addToFamilyCodes($familyCode){
+        if (!in_array($familyCode, $this->familyCodes)) {
+            $this->familyCodes[] = $familyCode;
+        }
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
@@ -81,12 +81,29 @@ class ProductWriter extends AbstractItemMediaWriter implements
     public function write(array $items)
     {
         foreach ($items as $item) {
-            if (isset($item['family']) && !in_array($item['family'], $this->familyCodes)) {
-                $this->familyCodes[] = $item['family'];
+            if (isset($item['family'])) {
+                if (is_array($item['family'])) {
+                    foreach ($item['family'] as $valFamily) {
+                        $this->addToFamilyCodes($valFamily);
+                    }
+                } else {
+                    $this->addToFamilyCodes($item['family']);
+                }
             }
         }
 
         parent::write($items);
+    }
+
+    /**
+     * Adds the familyCode to current class property familyCodes:array if it doesn't already exist.
+     * @param $familyCode
+     * @author Akash M. Pai <makashpai@gmail.com>
+     */
+    private function addToFamilyCodes($familyCode){
+        if (!in_array($familyCode, $this->familyCodes)) {
+            $this->familyCodes[] = $familyCode;
+        }
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

familyCodes was passed as multidimensional array for the mysql IN values in the query at:
\Akeneo\Pim\Permission\Bundle\Enrichment\Storage\Sql\Connector\Writer\File\Flat\GenerateHeadersFromFamilyCodes::fetchGrantedAttributesData
Hence extra for loop is added to pass the familyCode one by one to the class property in the modified files.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
