### PR TITLE
PIM-7971: Fix filters being incorrectly disabled in the attributes grid

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- PIM-7971: Fix filters being incorrectly disabled in the attributes grid
+
 # 2.3.75 (2020-01-03)
 
 ## Bug fixes

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/attribute.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/attribute.yml
@@ -4,6 +4,7 @@ datagrid:
             locale_parameter: localeCode
             entityHint: attribute
             manageFilters: false
+            removeFiltersNotUsableInGrid: false
         source:
             type: pim_datasource_attribute
             acl_resource: pim_enrich_attribute_index


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

There is an extension in EE where filters are dynamically removed on some criteria.
This `removeFiltersNotUsableInGrid` will prevent the attribute datagrid to be affected.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

