### PR TITLE
PIM-9051: Avoid cropping on assets preview

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-9051: Fix cropping on assets preview
+
 # 3.0.62 (2020-01-03)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
@@ -89,6 +89,8 @@
     margin: auto;
     width: 100%;
     transition: filter 0.3s;
+    object-fit: contain;
+    height: inherit;
   }
 
   &-imageUpdater {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/AssetCollectionField.less
@@ -50,7 +50,7 @@
   &-assetThumbnail {
     width: @itemWidth - 2 * (@padding + 1px);
     height: @itemHeight - 2 * (@padding + 1px);
-    background-size: 100% auto;
+    background-size: contain;
     background-position: center center;
     background-repeat: no-repeat;
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When the image was too small, the preview was incorrectly displayed.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -