### PR TITLE
API-720: fix amigration using a wrong namespace by removing rollback

### DIFF
--- a/upgrades/schema/Version_4_0_20191031124707_update_from_clients_to_apps.php
+++ b/upgrades/schema/Version_4_0_20191031124707_update_from_clients_to_apps.php
@@ -28,42 +28,11 @@ final class Version_4_0_20191031124707_update_from_clients_to_apps
 
     public function up(Schema $schema) : void
     {
-        try {
-            $this->migrateToConnections();
-        } catch (\Exception $e) {
-            $this->down($schema);
-            throw $e;
-        }
+        $this->migrateToConnections();
     }
 
     public function down(Schema $schema) : void
     {
-        $getConnectionsDataToClean = <<< SQL
-        SELECT code, user_id
-        FROM akeneo_app
-SQL;
-        $statement = $this->dbalConnection()->executeQuery($getConnectionsDataToClean);
-        $dataToClean = $statement->fetchAll();
-
-        $deleteConnections = <<< SQL
-        DELETE FROM akeneo_app
-        WHERE code IN (:apps)
-SQL;
-        $this->dbalConnection()->executeQuery(
-            $deleteConnections,
-            ['apps' => array_column($dataToClean, 'code')],
-            ['apps' => Connection::PARAM_STR_ARRAY]
-        );
-
-        $removeGeneratedUsers = <<< SQL
-        DELETE FROM oro_user
-        WHERE id IN (:users)
-SQL;
-        $this->dbalConnection()->executeQuery(
-            $removeGeneratedUsers,
-            ['users' => array_column($dataToClean, 'user_id')],
-            ['users' => Connection::PARAM_STR_ARRAY]
-        );
     }
 
     private function migrateToConnections(): void


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

The migration cannot be executed because a wrong namespace is used `Connection` instead of `DbalConnection` in the rollback section. I deleted the rollback section, as we don't handle it in the PIM.

Note: and if you had to do a rollback in a other application, please use a transaction to wrap everything, it's one of purpose of a transaction and it avoids a lot of boilerplate code.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
