### PR TITLE
PIM-9053: Update product label when locale is changed

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9053: Update product label when locale is changed
+
 # 3.2.29 (2020-01-03)
 
 # 3.2.28 (2019-12-31)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/label.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/label.js
@@ -26,7 +26,7 @@ define(
              */
             configure: function () {
                 UserContext.off('change:catalogLocale', this.render);
-                this.listenTo(UserContext, 'change:catalogScope', this.render);
+                this.listenTo(UserContext, 'change:catalogLocale', this.render);
                 this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_update', this.render);
 
                 return BaseForm.prototype.configure.apply(this, arguments);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/label.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/label.js
@@ -25,8 +25,9 @@ define(
              * {@inheritdoc}
              */
             configure: function () {
-                UserContext.off('change:catalogLocale', this.render);
+                UserContext.off('change:catalogLocale change:catalogScope', this.render);
                 this.listenTo(UserContext, 'change:catalogLocale', this.render);
+                this.listenTo(UserContext, 'change:catalogScope', this.render);
                 this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_update', this.render);
 
                 return BaseForm.prototype.configure.apply(this, arguments);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-label.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-label.js
@@ -46,6 +46,7 @@ define(
                 var locale = UserContext.get('catalogLocale');
 
                 var values = this.getFormData().values[attributeAsLabelIdentifier];
+
                 return values.find(value => {
                     return (false === scopable || value.scope === scope)
                       && (false === localizable || value.locale === locale);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-label.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-label.js
@@ -8,14 +8,51 @@
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 define(
-    ['pim/form/common/label', 'pim/user-context'],
-    function (Label, UserContext) {
+    ['pim/form/common/label', 'pim/user-context', 'pim/fetcher-registry'],
+    function (Label, UserContext, FetcherRegistry) {
         return Label.extend({
+            family: null,
+
             /**
-             * Provide the object label
-             * @return {String}
+             * {@inheritdoc}
+             */
+            render: function () {
+                this.fetchFamily(this.getFormData().family);
+
+                return Label.prototype.render.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritdoc}
              */
             getLabel: function () {
+                if (!this.getFormData().family) {
+                    return this.getLabelFromMeta();
+                }
+
+                if (!this.family) {
+                    return null;
+                }
+
+                return this.getLabelFromAttribute() || this.getFormData().identifier;
+            },
+
+            getLabelFromAttribute: function () {
+                var attributeAsLabelIdentifier = this.family.attribute_as_label;
+                var attribute = this.family.attributes.find(attribute => attribute.code === attributeAsLabelIdentifier);
+                var scopable = attribute.scopable;
+                var localizable = attribute.localizable;
+                var scope = UserContext.get('catalogScope');
+                var locale = UserContext.get('catalogLocale');
+
+                var values = this.getFormData().values[attributeAsLabelIdentifier];
+                return values.find(value => {
+                    return (false === scopable || value.scope === scope)
+                      && (false === localizable || value.locale === locale);
+                }).data;
+            },
+
+            getLabelFromMeta: function () {
                 var meta = this.getFormData().meta;
 
                 if (meta && meta.label) {
@@ -23,7 +60,24 @@ define(
                 }
 
                 return null;
-            }
+            },
+
+            fetchFamily: function(code) {
+                if (!code) {
+                    return;
+                }
+
+                if (this.family && this.family.code === code) {
+                    return;
+                }
+
+                FetcherRegistry.getFetcher('family')
+                    .fetch(code)
+                    .then(function(family) {
+                      this.family = family;
+                      this.render();
+                    }.bind(this));
+            },
         });
     }
 );


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

1) The product label in the PEF was listening to the scope change, not the locale change for re-rendering.
2) The legacy label collection in the product meta is not scopable, only localizable. For retrieving the valid label, I load the asset family for retrieving attribute_as_label.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
