### PR TITLE
TIP-1174 improve performance of the SQL query to get completeness of the products

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -7,10 +7,10 @@
 
 # Technical Improvements
 - TIP-1185: Use a single index "product_and_product_model_index" to search on product and product models, instead dedicated product/product model indexes
-- TIP-1159: Improve the performance of the calculation of the completeness
+- TIP-1159: Improve the performance of the calculation of the completeness for the products
 - TIP-1225: Improve the performance of the indexation of the products
 - TIP-1174: Improve the performance of the indexation of the product models
-- TIP-1176: Improve the performance of the computation of product model descendant when updating a product. The "compute product model descendant" job does not exist anymore. The computation is now done synchronously thanks the improvement done in TIP-1225 and TIP-1174.
+- TIP-1176: Improve the performance of the computation of product model descendant when updating a product model. The "compute product model descendant" job does not exist anymore. The computation is now done synchronously in the API thanks the improvement done in TIP-1225 and TIP-1174.
 
 ## BC breaks
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Context**
When creating the ES projection of a product model, we need to know if all products are complete or incomplete for each channel.


**Problem description**
On a server with 800 000 products of the reference catalog, including variant products, the ES indexation was VERY slow (1000 products every 2/3 minutes). Even with ORM it was way faster.

The part of the query which is very slow is this the query to get the completeness of children products:
```
        SELECT
            product_model.code AS product_model_code,
            completeness.locale_id,
            completeness.channel_id,
            SUM(completeness.missing_count) = 0 AS all_complete,
            MIN(completeness.missing_count) <> 0 AS all_incomplete
        FROM pim_catalog_product_model product_model
        INNER JOIN pim_catalog_product product ON product.product_model_id = product_model.id
        INNER JOIN pim_catalog_completeness completeness ON product.id = completeness.product_id
        WHERE product_model.code IN (1000 product model codes)
        GROUP BY product_model_code, completeness.locale_id, completeness.channel_id
```

This request is good. The optimizer is not :trollface: 

When requesting for 100 product model codes, the Mysql optimizer takes the good path (some milliseconds to return the query):

```
mysql> EXPLAIN SELECT         product_model.code AS code,         locale.code AS locale_code,         channel.code AS channel_code,         SUM(completeness.missing_count) = 0 AS all_complete,         MIN(completeness.missing_count) <> 0 AS all_incomplete     FROM pim_catalog_product_model product_model     INNER JOIN pim_catalog_product product ON product.product_model_id = product_model.id     INNER JOIN pim_catalog_completeness completeness ON product.id = completeness.product_id     INNER JOIN pim_catalog_locale locale ON completeness.locale_id = locale.id     INNER JOIN pim_catalog_channel channel ON completeness.channel_id = channel.id     WHERE product_model.code IN ('4755730715354', '0970806148377', '6461455345339', '6719468950805', '6271972204343', '5056216423091', '5485737483596', '0862940044496', '0848188412495', '6667818213899', '7614762384150', '0055057594057', '7308867934258', '9973254254356', '1765157057084', '5196112061345', '8387645257313', '3333769606006', '2887198220223', '5548829722239', '1483666011280', '6544503928033', '6078786051718', '4096336159495', '7451929177466', '5957642414335', '0949981400396', '1608460938636', '3897678147406', '4722190129373', '9855793322690', '5025165595203', '1536420225444', '9121496219224', '7398706245140', '8328924432328', '0603655603697', '8162792377448', '4257190624042', '0451713166628', '0036828737125', '5566587321709', '8445396204076', '2314350024547', '8259498535255', '9461551871333', '3374981397617', '5191981600978', '1278577208290', '9982576282640', '7387308139124', '9288949041679', '8243462193251', '8355910948372', '1233824152177', '0635518409337', '0179528975784')     GROUP BY code, locale_code, channel_code \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: product_model
   partitions: NULL
         type: range
possible_keys: PRIMARY,UNIQ_5943911E77153098
          key: UNIQ_5943911E77153098
      key_len: 1022
          ref: NULL
         rows: 57
     filtered: 100.00
        Extra: Using where; Using index; Using temporary
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: product
   partitions: NULL
         type: ref
possible_keys: PRIMARY,IDX_91CD19C0B2C5DD70
          key: IDX_91CD19C0B2C5DD70
      key_len: 5
          ref: akeneo_pim.product_model.id
         rows: 31
     filtered: 100.00
        Extra: Using index
*************************** 3. row ***************************
           id: 1
  select_type: SIMPLE
        table: completeness
   partitions: NULL
         type: ref
possible_keys: searchunique_idx,IDX_113BA854E559DFD1,IDX_113BA85472F5A1AA,IDX_113BA8544584665A
          key: IDX_113BA8544584665A
      key_len: 4
          ref: akeneo_pim.product.id
         rows: 29
     filtered: 100.00
        Extra: NULL
*************************** 4. row ***************************
           id: 1
  select_type: SIMPLE
        table: channel
   partitions: NULL
         type: eq_ref
possible_keys: PRIMARY
          key: PRIMARY
      key_len: 4
          ref: akeneo_pim.completeness.channel_id
         rows: 1
     filtered: 100.00
        Extra: NULL
*************************** 5. row ***************************
           id: 1
  select_type: SIMPLE
        table: locale
   partitions: NULL
         type: eq_ref
possible_keys: PRIMARY
          key: PRIMARY
      key_len: 4
          ref: akeneo_pim.completeness.locale_id
         rows: 1
     filtered: 100.00
        Extra: NULL
```

When requesting for 1000 product model codes, the Mysql optimizer takes the wrong path (2 minutes to return a response. It tries to first get all channel codes, join it with completeness table, etc, until reaching the product model table. In this last step, the product models are filtered.


```
mysql> EXPLAIN SELECT         product_model.code AS code,         locale.code AS locale_code,         channel.code AS channel_code,         SUM(completeness.missing_count) = 0 AS all_complete,         MIN(completeness.missing_count) <> 0 AS all_incomplete     FROM pim_catalog_product_model product_model     INNER JOIN pim_catalog_product product ON product.product_model_id = product_model.id     INNER JOIN pim_catalog_completeness completeness ON product.id = completeness.product_id     INNER JOIN pim_catalog_locale locale ON completeness.locale_id = locale.id     INNER JOIN pim_catalog_channel channel ON completeness.channel_id = channel.id     WHERE product_model.code IN ('4755730715354', '0970806148377', '6461455345339', '6719468950805', '6271972204343', '5056216423091', '5485737483596', '0862940044496', '0848188412495', '6667818213899', '7614762384150', '0055057594057', '7308867934258', '9973254254356', '1765157057084', '5196112061345', '8387645257313', '3333769606006', '2887198220223', '5548829722239', '1483666011280', '6544503928033', '6078786051718', '4096336159495', '7451929177466', '5957642414335', '0949981400396', '1608460938636', '3897678147406', '4722190129373', '9855793322690', '5025165595203', '1536420225444', '9121496219224', '7398706245140', '8328924432328', '0603655603697', '8162792377448', '4257190624042', '0451713166628', '0036828737125', '5566587321709', '8445396204076', '2314350024547', '8259498535255', '9461551871333', '3374981397617', '5191981600978', '1278577208290', '9982576282640', '7387308139124', '9288949041679', '8243462193251', '8355910948372', '1233824152177', '0635518409337', '0179528975784', '3626443927000', '2238027347121', '8148015064708', '1824250998332', '0498712413346', '2697397308079', '4445841372996', '5368101521943', '1241384612000', '7745182477211', '5243729006730', '9768846230258', '5913036870866', '2016495434297', '4004821544046', '8815194218290', '2037065145894', '4979714534469', '9555214754658', '4257692144895', '3599498151389', '5181587330812', '3551287795655', '4793186901365', '7490951595862', '5688564150253', '1906934322166', '5497153692056', '9573600073008', '8993872840831', '5743481801494', '4279634601792', '7761315280091', '9527661482149', '0387260699596', '0939214260934', '6293975287581', '2990161317230', '7295181739907', '4324385241916', '8136651380566', '6131834264079', '6093135080454', '9899612688123', '9443221682937', '8136945885654', '9977930928258', '8992541896278', '2811176631220', '4192227531798', '5681770709567', '6659864832032', '5220239524206', '3680171087900', '1814635874818', '7557115603082', '0421990755235', '5885988465691', '2001142676120', '0681662300297', '8814437560110', '6362950109429', '5842101446050', '2128181276880', '8374451224240', '1218622188368', '7783832639008', '0557178142624', '6224773903243', '6479311559042', '9616194257307', '2957261851057', '5559038760325', '9545230215332', '0728757052102', '6609758720129', '5743109197800', '2511230936611', '8614794139628', '2283455890787', '9493448790663', '6171287896939', '5607519228304', '1397737623022', '1896312337748', '1952693707416', '4601489551067', '9128622898490', '2606559039478', '2951800593095', '0595297458660', '3303753531003', '3451422422821', '0496988937467', '6149218077245', '3003057442035', '4973036716145', '9676565748230', '1699791953023', '0891620663559', '0017271228040', '6341068480361', '9601255240398', '3557333176157', '2844319711305', '3952112881435', '1714007305653', '2321944257335', '7264506317847', '0265454881203', '2473135599134', '0928649903882', '7748118028761', '5625067895243', '8876032653871', '1070883832165', '1783442092664', '4964004557099', '4745082724012', '2225988968205', '8966271563649', '8720505731606', '9035809104148', '6158291834836', '7663172716235', '8302158129261', '9884965958214', '0501247548015', '8393630593670', '0992180448164', '4804082051013', '6147951209329', '8244799294123', '9044639457614', '4282621679322', '0777788978066', '8852023056135', '7926365898607', '7624753195061', '0970802879336', '5089938987084', '8478610614801', '1263749914376', '0171131177272', '8105254653438', '0411120873793', '9542318730367', '4333830350950', '9798192290576', '1639965041781', '2775358193992', '4454539392444', '3455541649947', '6929776387044', '0289219456758', '2569869249282', '5073242670909', '1399680919740', '7763894758398', '1662913871529', '4458598642212', '1267679836609', '5251757357625', '7507666620618', '3918891312218', '4297456260843', '3348024436946', '5465516227665', '8220300421349', '0279432876136', '4111079485417', '5130606886069', '8002486908872', '2487418113436', '2215155120666', '0676616590312', '3655055442991', '1877525024823', '2177477392636', '5147206411300', '8114973956669', '3242768030562', '3068799071059', '6551561788974', '6992509068565', '8906166500229', '1916943313055', '4637899052641', '6324584563138', '9420958097470', '6601284992490', '8918795451858', '0586584170372', '5744142050176', '4181438649057', '2225949115181', '2485883880853', '0688795585683', '4840678385544', '7098871728461', '1684158649916', '5679518074916', '8154701635619', '6353376197688', '2123515971806', '9523321384280', '1796549350636', '9579575906037', '6623807404600', '0865758200276', '8388250772185')     GROUP BY code, locale_code, channel_code \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: channel
   partitions: NULL
         type: index
possible_keys: PRIMARY
          key: UNIQ_E07E932A77153098
      key_len: 402
          ref: NULL
         rows: 3
     filtered: 100.00
        Extra: Using index; Using temporary
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: completeness
   partitions: NULL
         type: ref
possible_keys: searchunique_idx,IDX_113BA854E559DFD1,IDX_113BA85472F5A1AA,IDX_113BA8544584665A
          key: searchunique_idx
      key_len: 4
          ref: akeneo_pim.channel.id
         rows: 17021
     filtered: 100.00
        Extra: NULL
*************************** 3. row ***************************
           id: 1
  select_type: SIMPLE
        table: locale
   partitions: NULL
         type: eq_ref
possible_keys: PRIMARY
          key: PRIMARY
      key_len: 4
          ref: akeneo_pim.completeness.locale_id
         rows: 1
     filtered: 100.00
        Extra: NULL
*************************** 4. row ***************************
           id: 1
  select_type: SIMPLE
        table: product
   partitions: NULL
         type: eq_ref
possible_keys: PRIMARY,IDX_91CD19C0B2C5DD70
          key: PRIMARY
      key_len: 4
          ref: akeneo_pim.completeness.product_id
         rows: 1
     filtered: 100.00
        Extra: Using where
*************************** 5. row ***************************
           id: 1
  select_type: SIMPLE
        table: product_model
   partitions: NULL
         type: eq_ref
possible_keys: PRIMARY,UNIQ_5943911E77153098
          key: PRIMARY
      key_len: 4
          ref: akeneo_pim.product.product_model_id
         rows: 1
     filtered: 5.00
        Extra: Using where
5 rows in set, 1 warning (0.01 sec)
```

In other terms, it means that we work on all the rows of the whole completeness table ((simple + variant product)* channel * locale ), to filter most of them in the last step with only the rows of the children products. 

**Solution**

I don't know why Mysql is doing that.... But an easy optimization is to fetch only the locale codes and the channel codes once all rows of the completeness are aggregated by the product model. The join is smaller, and it avoids Mysql to use this channel table as the first table to join.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
