### PR TITLE
PIM-9054: Fix the constraint on AttributeOption:code max length

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9054: Fix the constraint on AttributeOption:code max length
+
 # 3.2.30 (2020-01-10)
 
 # 3.2.29 (2020-01-03)

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/attribute.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/attribute.yml
@@ -464,7 +464,7 @@ Akeneo\Pim\Structure\Component\Model\AttributeOption:
                 pattern: /^[a-zA-Z0-9_]+$/
                 message: Option code may contain only letters, numbers and underscores
             - Length:
-                max: 255
+                max: 100
         attribute:
             - NotBlank: ~
             - Valid: ~


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

As you can see in [AttributeOption.orm.yml#L19](https://github.com/akeneo/pim-community-dev/blob/3.2/src/Akeneo/Pim/Structure/Bundle/Resources/config/model/doctrine/AttributeOption.orm.yml#L19), an AttributeOption code has a column length of 100.
The validation constraint was 255 characters.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
