### PR TITLE
Fix migration job execution

### DIFF
--- a/upgrades/schema/Version_4_0_20190801083247_remove_indexes.php
+++ b/upgrades/schema/Version_4_0_20190801083247_remove_indexes.php
@@ -15,6 +15,8 @@ final class Version_4_0_20190801083247_remove_indexes extends AbstractMigration 
 
     public function up(Schema $schema) : void
     {
+        $this->addSql('SELECT "disable migration warning"');
+
         $builder = $this->container->get('akeneo_elasticsearch.client_builder');
         $hosts = [$this->container->getParameter('index_hosts')];
 

--- a/upgrades/schema/Version_4_0_20190916122239_remove_product_empty_raw_values.php
+++ b/upgrades/schema/Version_4_0_20190916122239_remove_product_empty_raw_values.php
@@ -38,6 +38,8 @@ final class Version_4_0_20190916122239_remove_product_empty_raw_values
 
     private function cleanProducts()
     {
+        $this->addSql('SELECT "disable migration warning"');
+
         $productsToProcess = true;
         $productIdentifiersToIndex = [];
         $lastProductIdentifier = null;

--- a/upgrades/schema/Version_4_0_20190917080512_remove_product_model_empty_raw_values.php
+++ b/upgrades/schema/Version_4_0_20190917080512_remove_product_model_empty_raw_values.php
@@ -34,6 +34,8 @@ final class Version_4_0_20190917080512_remove_product_model_empty_raw_values
 
     public function up(Schema $schema) : void
     {
+        $this->addSql('SELECT "disable migration warning"');
+
         $productModelsToProcess = true;
         $productModelCodesToIndex = [];
         $lastProductModelCode = null;

--- a/upgrades/schema/Version_4_0_20191031124707_update_from_clients_to_apps.php
+++ b/upgrades/schema/Version_4_0_20191031124707_update_from_clients_to_apps.php
@@ -28,6 +28,8 @@ final class Version_4_0_20191031124707_update_from_clients_to_apps
 
     public function up(Schema $schema) : void
     {
+        $this->addSql('SELECT "disable migration warning"');
+
         $this->migrateToConnections();
     }
 

--- a/upgrades/test_schema/ExecuteMigrationTrait.php
+++ b/upgrades/test_schema/ExecuteMigrationTrait.php
@@ -30,7 +30,7 @@ trait ExecuteMigrationTrait
         $resultDown = $this->getCommandLauncher()->executeForeground(
             sprintf('doctrine:migrations:execute %s --down -n', $migrationLabel)
         );
-        Assert::assertEquals(0, $resultDown->getCommandStatus(), \json_encode($resultDown->getCommandOutput()));
+        Assert::assertEquals(1, $resultDown->getCommandStatus(),'Migration should be irreversible.');
 
         $resultUp = $this->getCommandLauncher()->executeForeground(
             sprintf('doctrine:migrations:execute %s --up -n', $migrationLabel)

--- a/upgrades/test_schema/Version_4_0_20191004145507_remove_compute_model_descendant_jobs_Integration.php
+++ b/upgrades/test_schema/Version_4_0_20191004145507_remove_compute_model_descendant_jobs_Integration.php
@@ -51,6 +51,9 @@ class Version_4_0_20191004145507_remove_compute_model_descendant_jobs_Integratio
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
 
         Assert::assertNull($this->getComputeProductModelDescendantJobId());
+        Assert::assertSame(0, $this->numberOfJobExecutions());
+        Assert::assertSame(0, $this->numberOfJobsInQueue());
+
         $productsFound = $this->getSearchQueryResults($ESQuery);
         Assert::assertCount(3, $productsFound);
     }
@@ -126,5 +129,15 @@ SQL;
      */
     protected function addDocuments()
     {
+    }
+
+    private function numberOfJobExecutions(): int
+    {
+        return (int) $this->getConnection()->executeQuery('SELECT COUNT(*) AS count FROM akeneo_batch_job_execution')->fetch()['count'];
+    }
+
+    private function numberOfJobsInQueue(): int
+    {
+        return (int) $this->getConnection()->executeQuery('SELECT COUNT(*) AS count FROM akeneo_batch_job_execution_queue')->fetch()['count'];
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
The goal of this migration is to delete the compute product model descendant job. Before doing that, we need to get all pending jobs to index product models.

We were using a search after after (key set pagination):
1. It cannot work as it is designed to search after a specific id. It means you have to fetch the whole product model table to apply the search after.
2. It cannot work as it does not filter on jobs that are pending (consumer is NULL in the queue). It filters on all jobs... 

So, it was taking too much time to be executed.

I tested the query on 800 000 jobs and it's pretty fast (4 seconds). It returns 120 000 product model codes (thanks to the DISTINCT), which is ok in term of memory. So, no need to have a search after pagination in my opinion.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
