### PR TITLE
PIM-9022: Fix behaviour of the 'Previous' button in product bulk actions modal

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -4,6 +4,7 @@
 
 - PIM-9054: Fix the constraint on AttributeOption:code max length
 - PIM-9053: Update product label when locale is changed
+- PIM-9022: Fix behaviour of the 'Previous' button in product bulk actions modal
 
 # 3.2.30 (2020-01-10)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/mass-edit/form.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/mass-edit/form.html
@@ -12,7 +12,7 @@
             <%- previousLabel %>
         </span>
     <% } else if (currentStep === 'confirm') { %>
-        <span class="<%- currentStep %> AknButton AknButton--grey AknFullPage-previous wizard-action" data-action-target="choose">
+        <span class="<%- currentStep %> AknButton AknButton--grey AknFullPage-previous wizard-action" data-action-target="configure">
             <%- previousLabel %>
         </span>
     <% } %>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

At the 'confirm' step of a product mass action, the 'Previous' button used to redirect at the bulk action selection step, instead of the configuration step

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
