### PR TITLE
PIM-6160: Fix update of 'unique' property in attribute updater

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-8163: Display messages when toggling curencies
+- PIM-6160: Fix update of 'unique' property in attribute updater when updating both unique and type properties
 
 # 3.0.63 (2020-01-10)
 

--- a/src/Akeneo/Pim/Structure/Component/Updater/AttributeUpdater.php
+++ b/src/Akeneo/Pim/Structure/Component/Updater/AttributeUpdater.php
@@ -299,7 +299,9 @@ class AttributeUpdater implements ObjectUpdaterInterface
 
         $attribute->setType($attributeType->getName());
         $attribute->setBackendType($attributeType->getBackendType());
-        $attribute->setUnique($attributeType->isUnique());
+        if (true === $attributeType->isUnique() || null === $attribute->isUnique()) {
+            $attribute->setUnique($attributeType->isUnique());
+        }
     }
 
     /**

--- a/tests/back/Pim/Structure/Specification/Component/Updater/AttributeUpdaterSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Updater/AttributeUpdaterSpec.php
@@ -299,4 +299,61 @@ class AttributeUpdaterSpec extends ObjectBehavior
             )
             ->during('update', [$attribute, $values, []]);
     }
+
+    function it_sets_the_default_unique_property_when_setting_an_attribute_type(
+        AttributeTypeRegistry $registry,
+        AttributeInterface $attribute,
+        AttributeTypeInterface $textAttributeType
+    ) {
+        $attribute->isUnique()->willReturn(null);
+
+        $textAttributeType->getName()->willReturn('pim_catalog_text');
+        $textAttributeType->getBackendType()->willReturn('text');
+        $textAttributeType->isUnique()->willReturn(false);
+        $registry->get('pim_catalog_text')->willReturn($textAttributeType);
+        $attribute->setType('pim_catalog_text')->shouldBeCalled();
+        $attribute->setBackendType('text')->shouldBeCalled();
+
+        $attribute->setUnique(false)->shouldBeCalled();
+
+        $this->update($attribute, ['type' => 'pim_catalog_text']);
+    }
+
+    function it_does_not_update_the_unique_property_if_it_is_already_defined(
+        AttributeTypeRegistry $registry,
+        AttributeInterface $attribute,
+        AttributeTypeInterface $textAttributeType
+    ) {
+        $attribute->isUnique()->willReturn(true);
+
+        $textAttributeType->getName()->willReturn('pim_catalog_text');
+        $textAttributeType->getBackendType()->willReturn('text');
+        $textAttributeType->isUnique()->willReturn(false);
+        $registry->get('pim_catalog_text')->willReturn($textAttributeType);
+        $attribute->setType('pim_catalog_text')->shouldBeCalled();
+        $attribute->setBackendType('text')->shouldBeCalled();
+
+        $attribute->setUnique(false)->shouldNotBeCalled();
+
+        $this->update($attribute, ['type' => 'pim_catalog_text']);
+    }
+
+    function it_sets_the_unique_property_to_true_if_the_attribute_type_must_be_unique(
+        AttributeTypeRegistry $registry,
+        AttributeInterface $attribute,
+        AttributeTypeInterface $identifierAttributeType
+    ) {
+        $attribute->isUnique()->willReturn(false);
+
+        $identifierAttributeType->getName()->willReturn('pim_catalog_identifier');
+        $identifierAttributeType->getBackendType()->willReturn('identifier');
+        $identifierAttributeType->isUnique()->willReturn(true);
+        $registry->get('pim_catalog_identifier')->willReturn($identifierAttributeType);
+        $attribute->setType('pim_catalog_identifier')->shouldBeCalled();
+        $attribute->setBackendType('identifier')->shouldBeCalled();
+
+        $attribute->setUnique(true)->shouldBeCalled();
+
+        $this->update($attribute, ['type' => 'pim_catalog_identifier']);
+    }
 }


### PR DESCRIPTION
Fix update of 'unique' property in attribute updater when updating both unique and type properties

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

In AttributeUpdater, when updating first the 'unique' property then the 'type' property (this can happen with imports), the 'unique' value is overridden by the attribute type's default `isUnique()` value.
This PR fixes that:
- if the attribute type must be unique (`AttributeType::isUnique()` is true, e.g identifier attribute type), then the attribute's `unique` property is forced to `true`
- else if the attribute's `unique` property is not set (attribute creation), the `unique` property is initialized with the attribute type's default value
- else we do not update the `unique` property

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
