### PR TITLE
PIM-8163 Show messages when toggle currency

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-8163: Display messages when toggling curencies
+
 # 3.0.63 (2020-01-10)
 
 ## Bug fixes

--- a/src/Akeneo/Channel/Bundle/Controller/UI/CurrencyController.php
+++ b/src/Akeneo/Channel/Bundle/Controller/UI/CurrencyController.php
@@ -52,28 +52,20 @@ class CurrencyController
      */
     public function toggleAction(Currency $currency)
     {
-        $request = $this->requestStack->getCurrentRequest();
-
         try {
             $currency->toggleActivation();
             $this->currencySaver->save($currency);
 
-            $request
-                ->getSession()
-                ->getFlashBag()
-                ->add('success', new Message('flash.currency.updated'));
         } catch (LinkedChannelException $e) {
-            $request
-                ->getSession()
-                ->getFlashBag()
-                ->add('error', new Message('flash.currency.error.linked_to_channel'));
-        } catch (\Exception $e) {
-            $request
-                ->getSession()
-                ->getFlashBag()
-                ->add('error', new Message('flash.error occurred'));
+            return new JsonResponse([
+                'successful' => false,
+                'message' => 'flash.currency.error.linked_to_channel'
+            ]);
         }
 
-        return new JsonResponse(['route' => 'pim_enrich_currency_index']);
+        return new JsonResponse([
+            'successful' => true,
+            'message' => 'flash.currency.updated'
+        ]);
     }
 }

--- a/src/Akeneo/Channel/Bundle/Controller/UI/CurrencyController.php
+++ b/src/Akeneo/Channel/Bundle/Controller/UI/CurrencyController.php
@@ -57,7 +57,6 @@ class CurrencyController
         try {
             $currency->toggleActivation();
             $this->currencySaver->save($currency);
-
         } catch (LinkedChannelException $e) {
             return new JsonResponse([
                 'successful' => false,

--- a/src/Akeneo/Channel/Bundle/Controller/UI/CurrencyController.php
+++ b/src/Akeneo/Channel/Bundle/Controller/UI/CurrencyController.php
@@ -30,6 +30,8 @@ class CurrencyController
     protected $currencySaver;
 
     /**
+     * @todo @merge remove RequestStack from the constructor
+     *
      * @param RequestStack    $requestStack
      * @param RouterInterface $router
      * @param SaverInterface  $currencySaver

--- a/src/Akeneo/Channel/Bundle/Controller/UI/CurrencyController.php
+++ b/src/Akeneo/Channel/Bundle/Controller/UI/CurrencyController.php
@@ -30,7 +30,7 @@ class CurrencyController
     protected $currencySaver;
 
     /**
-     * @todo @merge remove RequestStack from the constructor
+     * todo merge remove RequestStack from the constructor
      *
      * @param RequestStack    $requestStack
      * @param RouterInterface $router

--- a/src/Akeneo/Channel/Bundle/Resources/config/datagrid/currency.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/datagrid/currency.yml
@@ -28,7 +28,7 @@ datagrid:
             toggle:
                 launcherOptions:
                     className: AknIconButton AknIconButton--small AknIconButton--switch
-                type:         navigate
+                type:         ajax
                 label:        pim_datagrid.actions.change_status
                 link:         toggle_link
                 acl_resource: pim_enrich_currency_toggle

--- a/src/Akeneo/Channel/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -72,3 +72,9 @@ pim_enrich.entity.currency:
     plural_label: Currencies
     page_title:
         index: "]-Inf, 1]{{ count }} currency|]1, Inf[{{ count }} currencies"
+
+flash:
+    currency:
+        error:
+            linked_to_channel: You cannot disable a currency linked to a channel
+        updated: Currency successfully updated


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
The goal, here, is to:
- add a success flash message when you toggle a currency that isn't used in your Channel configuration.
- add an error flash message when you want to deactivate a currency that is used in your Channel configuration.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
