### PR TITLE
PIM-9058: Fix search products API with filters on numeric attribute codes

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes:
 
 - PIM-9056: Fix filters with numeric attribute codes for bulk actions
+- PIM-9058: Fix search products API with filters on numeric attribute codes
 
 # 3.2.31 (2020-01-14)
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
@@ -61,6 +61,7 @@ final class ApplyProductSearchQueryParametersToPQB
         }
 
         foreach ($searchParameters as $propertyCode => $filters) {
+            $propertyCode = (string) $propertyCode;
             foreach ($filters as $filter) {
                 $context['locale'] = $filter['locale'] ?? $searchLocaleCode;
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/Validator/ValidateProperties.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/Validator/ValidateProperties.php
@@ -44,6 +44,7 @@ final class ValidateProperties
     public function validate(array $search): void
     {
         foreach ($search as $propertyCode => $filters) {
+            $propertyCode = (string) $propertyCode;
             foreach ($filters as $filter) {
                 if (!(
                     $this->isProductField($propertyCode) ||

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/Validator/ValidatePropertiesSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/Validator/ValidatePropertiesSpec.php
@@ -35,6 +35,21 @@ class ValidatePropertiesSpec extends ObjectBehavior
         ]]);
     }
 
+    function it_does_not_throw_exception_if_attribute_code_is_numeric(
+        IdentifiableObjectRepositoryInterface $attributeRepository,
+        AttributeInterface $attribute
+    ) {
+        $attributeRepository->findOneByIdentifier('1000')->willReturn($attribute)->shouldBeCalled();
+        $this->shouldNotThrow(InvalidQueryException::class)->during(
+            'validate',
+            [
+                [
+                    1000 => [['operator' => Operators::IN_LIST]]
+                ]
+            ]
+        );
+    }
+
     function it_throws_exception_if_filter_is_not_a_field_neither_an_attribute(
         IdentifiableObjectRepositoryInterface $attributeRepository
     ) {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fixes #11412 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
