### PR TITLE
Papo requirements

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -28,6 +28,7 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
         php7.3-imagick \
         php7.3-apcu \
         php7.3-exif \
+        php7.3-ssh2 \
         php-memcached \
         aspell \
         aspell-en aspell-es aspell-de aspell-fr && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -28,7 +28,7 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
         php7.3-imagick \
         php7.3-apcu \
         php7.3-exif \
-        php7.3-ssh2 \
+        openssh-client \
         php-memcached \
         aspell \
         aspell-en aspell-es aspell-de aspell-fr && \


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

As PAPO uses a SSH connection to get the enterprise version, composer needs to be able to do SSH connection from the CLI.
