### PR TITLE
Attempt to fx unstable legacy behats

### DIFF
--- a/tests/legacy/features/pim/enrichment/product/mass-edit/mass_add_to_existing_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-edit/mass_add_to_existing_product_model.feature
@@ -9,7 +9,7 @@ Feature: Apply a add to products to existing product model
     And I am logged in as "Julia"
 
   Scenario: It automatically selects family variant when there is only one
-    Given I am on the products page
+    Given I am on the products grid
     And I select rows 1111111171
     And I press the "Bulk actions" button
     And I choose the "Add to an existing product model" operation
@@ -18,7 +18,7 @@ Feature: Apply a add to products to existing product model
     Then I should see the text "Accessories by size"
 
   Scenario: Successfully display leaf product models
-    Given I am on the products page
+    Given I am on the products grid
     And I select rows 1111111171
     And I press the "Bulk actions" button
     And I choose the "Add to an existing product model" operation
@@ -31,7 +31,7 @@ Feature: Apply a add to products to existing product model
     And the fields Family should be disabled
 
   Scenario: Successfully show validation error on family issues
-    Given I am on the products page
+    Given I am on the products grid
     And I select rows 1111111171
     And I press the "Bulk actions" button
     And I choose the "Add to an existing product model" operation
@@ -51,7 +51,7 @@ Feature: Apply a add to products to existing product model
     And I fill in the following information:
       | Size | S |
     And I save the product
-    And I am on the products page
+    And I am on the products grid
     And I select rows 1111111171
     And I press the "Bulk actions" bottom button
     And I choose the "Add to an existing product model" operation
@@ -65,7 +65,7 @@ Feature: Apply a add to products to existing product model
     And the parent of the product "1111111171" should be "model-braided-hat"
 
   Scenario: Fail to adds products to product model with null metric axis
-    Given I am on the products page
+    Given I am on the products grid
     And the following attributes:
       | code                  | label-en_US           | type                     | unique | group     | decimals_allowed | negative_allowed | metric_family | default_metric_unit | useable_as_grid_filter |
       | display_diagonal      | Display diagonal      | pim_catalog_metric       | 0      | other     | 0                | 0                | Length        | INCH                | 1                      |


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

Attempt to fix unstable legacy behats which often fail o the EE CI builds. I noticed that most of the other tests implying product bulk actions used the `I am on the products grid` step, which slightly differs from `I am on the products page`.
I ran an EE build (https://circleci.com/workflow-run/9db65ac7-b4fd-46f7-b21f-286b0322ed26) and it passes. This means nothing as the fails are random, but I think it can't hurt to try, we'll see in the next builds if the fix works.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
