### PR TITLE
API-946: Add e2e on fetch Audit events

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/InternalApi/Controller/AuditController.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/InternalApi/Controller/AuditController.php
@@ -28,10 +28,13 @@ class AuditController
     public function sourceConnectionsEvent(Request $request): JsonResponse
     {
         $eventType = $request->get('event_type', '');
-        $startPeriod = new \DateTime('-7 days', new \DateTimeZone('UTC'));
-        $today = new \DateTime('now', new \DateTimeZone('UTC'));
+        $endDate = $request->get(
+            'end_date',
+            (new \DateTime('now', new \DateTimeZone('UTC')))->format('Y-m-d')
+        );
+        $startDate = (new \DateTime($endDate, new \DateTimeZone('UTC')))->modify('-7 day')->format('Y-m-d');
 
-        $query = new CountDailyEventsByConnectionQuery($eventType, $startPeriod->format('Y-m-d'), $today->format('Y-m-d'));
+        $query = new CountDailyEventsByConnectionQuery($eventType, $startDate, $endDate);
         $countDailyEventsByConnection = $this->countDailyEventsByConnectionHandler->handle($query);
 
         $data = \array_reduce(

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/CountDailyEventsByConnectionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/CountDailyEventsByConnectionEndToEnd.php
@@ -8,6 +8,7 @@ use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Romain Monceau <romain@akeneo.com>
@@ -18,47 +19,120 @@ class CountDailyEventsByConnectionEndToEnd extends WebTestCase
 {
     public function test_it_finds_connections_event_by_created_product()
     {
-        $this->get('akeneo_connectivity.connection.fixtures.connection_loader')->createConnection('franklin', 'Franklin', FlowType::DATA_SOURCE);
-        $this->get('akeneo_connectivity.connection.fixtures.connection_loader')->createConnection('erp', 'ERP', FlowType::DATA_SOURCE);
+        $this->createConnection('franklin', 'Franklin', FlowType::DATA_SOURCE);
+        $this->createConnection('erp', 'ERP', FlowType::DATA_SOURCE);
+
+        $this->loadAuditData('2020-01-08');
+
         $this->authenticateAsAdmin();
+        $this->client->request(
+            'GET',
+            '/rest/connections/audit/source-connections-event',
+            [
+                'event_type' => 'product_created',
+                'end_date' => '2020-01-08'
+            ],
+        );
+        $result = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->client->request('GET', '/rest/connections/audit/source-connections-event', ['event_type' => 'product_created']);
-        $response = $this->client->getResponse();
+        $expectedResult = [
+            '<all>' =>  [
+                '2020-01-01' => 22,
+                '2020-01-02' => 25,
+                '2020-01-03' => 0,
+                '2020-01-04' => 0,
+                '2020-01-05' => 15,
+                '2020-01-06' => 12,
+                '2020-01-07' => 0,
+                '2020-01-08' => 8,
+            ],
+            'franklin' => [
+                '2020-01-01' => 0,
+                '2020-01-02' => 25,
+                '2020-01-03' => 0,
+                '2020-01-04' => 0,
+                '2020-01-05' => 20,
+                '2020-01-06' => 12,
+                '2020-01-07' => 0,
+                '2020-01-08' => 6,
+            ],
+            'erp' =>  [
+                '2020-01-01' => 22,
+                '2020-01-02' => 0,
+                '2020-01-03' => 0,
+                '2020-01-04' => 0,
+                '2020-01-05' => 5,
+                '2020-01-06' => 0,
+                '2020-01-07' => 0,
+                '2020-01-08' => 2,
+            ],
+        ];
 
-        Assert::assertTrue($response->isOk());
-        Assert::assertJsonStringNotEqualsJsonFile(
-            realpath(__DIR__ . '/../Resources/json_response/count_daily_events_by_connection.json'),
-            $response->getContent()
-        ); // TODO : use assertJsonStringEqualsJsonFile
+        Assert::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        Assert::assertEquals($expectedResult, $result);
     }
 
-    private function loadAuditData(): void
+    private function loadAuditData(string $endDate): void
     {
-        $eventDate = new \DateTime('2020-01-01', new \DateTimeZone('UTC'));
+        $date = new \DateTimeImmutable($endDate, new \DateTimeZone('UTC'));
+
+        $productCreatedEvents = [
+            '<all>' => [
+                [$date->modify('-8 day'), 666], // ignored
+                [$date->modify('-7 day'), 22],
+                [$date->modify('-6 day'), 25],
+                [$date->modify('-3 day'), 15],
+                [$date->modify('-2 day'), 12],
+                [$date, 8],
+            ],
+            'erp' => [
+                [$date->modify('-7 day'), 22],
+                [$date->modify('-3 day'), 5],
+                [$date, 2],
+            ],
+            'franklin' => [
+                [$date->modify('-8 day'), 666], // ignored
+                [$date->modify('-6 day'), 25],
+                [$date->modify('-3 day'), 20],
+                [$date->modify('-2 day'), 12],
+                [$date, 6],
+            ]
+        ];
+
+        $productUpdatedEvents = [
+            '<all>' => [
+                [$date, 16],
+                [$date->modify('-2 day'), 24],
+                [$date->modify('-5 day'), 28],
+                [$date->modify('-8 day'), 666],
+            ],
+            'erp' => [
+                [$date->modify('-5 day'), 28],
+                [$date->modify('-2 day'), 24],
+                [$date, 4],
+            ],
+            'franklin' => [
+                [$date->modify('-8 day'), 666], // ignored
+                [$date, 12],
+            ]
+        ];
+
         $auditLoader = $this->get('akeneo_connectivity.connection.fixtures.audit_loader');
 
-        // today
-        $auditLoader->insertData('<all>', $eventDate, 51, 'product_created');
-        $auditLoader->insertData('franklin', $eventDate, 11, 'product_created');
-        $auditLoader->insertData('erp', $eventDate, 37, 'product_created');
-        $auditLoader->insertData('erp', $eventDate, 28, 'product_updated');
-        // yesterday
-        $auditLoader->insertData('<all>', $eventDate->modify('-1 day'), 5, 'product_created');
-        $auditLoader->insertData('franklin', $eventDate, 5, 'product_created');
-        $auditLoader->insertData('franklin', $eventDate, 132, 'product_updated');
-        // 2 days ago
-        $auditLoader->insertData('<all>', $eventDate->modify('-1 day'), 10, 'product_created');
-        $auditLoader->insertData('franklin', $eventDate, 10, 'product_created');
-        $auditLoader->insertData('franklin', $eventDate, 7, 'product_updated');
-        // 10 days ago
-        $auditLoader->insertData('<all>', $eventDate->modify('-7 day'), 15, 'product_created');
-        $auditLoader->insertData('franklin', $eventDate, 15, 'product_created');
+        foreach ($productCreatedEvents as $code => $data) {
+            foreach ($data as [$date, $count]) {
+                $auditLoader->insertData($code, $date, $count, 'product_created');
+            }
+        }
+
+        foreach ($productUpdatedEvents as $code => $data) {
+            foreach ($data as [$date, $count]) {
+                $auditLoader->insertData($code, $date, $count, 'product_updated');
+            }
+        }
     }
 
-    /**
-     * @return Configuration
-     */
-    protected function getConfiguration()
+    protected function getConfiguration(): Configuration
     {
         return $this->catalog->useMinimalCatalog();
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Fixtures/AuditLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Fixtures/AuditLoader.php
@@ -21,8 +21,12 @@ class AuditLoader
         $this->dbalConnection = $dbalConnection;
     }
 
-    public function insertData(string $connectionCode, \DateTime $eventDate, int $eventCount, string $eventType)
-    {
+    public function insertData(
+        string $connectionCode,
+        \DateTimeInterface $eventDate,
+        int $eventCount,
+        string $eventType
+    ) {
         $sqlQuery = <<<SQL
 INSERT INTO akeneo_connectivity_connection_audit (connection_code, event_date, event_count, event_type)
 VALUES (:connection_code, :event_date, :event_count, :event_type)


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add e2e on fetch Audit events

I had to add the end_date as http query parameter to be able to do those tests.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
