### PR TITLE
PIM-9059: Fix catalog locale - user panel + attribute groups attributes

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9059: Fix catalog locale on user panel & attribute groups attributes
+
 # 3.2.32 (2020-01-17)
 
 ## Bug fixes:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-group/tab/attribute.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-group/tab/attribute.html
@@ -31,7 +31,7 @@
                                     </span>
                                 </td>
                             <% } %>
-                            <td class="AknGrid-bodyCell"><%- i18n.getLabel(attribute.labels, UserContext.get('uiLocale'), attribute.code) %></td>
+                            <td class="AknGrid-bodyCell"><%- i18n.getLabel(attribute.labels, UserContext.get('catalogLocale'), attribute.code) %></td>
                             <td class="AknGrid-bodyCell"><%- __('pim_enrich.entity.attribute.property.type.' + attribute.type) %></td>
                             <td class="AknGrid-bodyCell">
                                 <input type="checkbox" disabled="disabled"<%- attribute.scopable ? ' checked="checked"' : '' %>>

--- a/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/category-tree.ts
+++ b/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/category-tree.ts
@@ -32,7 +32,7 @@ class CategoryTree extends BaseSelect {
    */
   formatChoices(categories: InterfaceNormalizedCategory[]): { [key:string] : string } {
     return categories.reduce((result: { [key:string] : string }, category: InterfaceNormalizedCategory) => {
-      const label = category.labels[UserContext.get('uiLocale')];
+      const label = category.labels[UserContext.get('catalogLocale')];
       result[category.code] = label !== undefined ? label : '[' + category.code + ']';
 
       return result;

--- a/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/channel.ts
+++ b/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/channel.ts
@@ -32,7 +32,7 @@ class ChannelField extends BaseSelect {
    */
   formatChoices(scopes: InterfaceNormalizedChannel[]): { [key:string] : string } {
     return scopes.reduce((result: { [key:string] : string }, channel: InterfaceNormalizedChannel) => {
-      const label = channel.labels[UserContext.get('uiLocale')];
+      const label = channel.labels[UserContext.get('catalogLocale')];
       result[channel.code] = label !== undefined ? label : '[' + channel.code + ']';
 
       return result;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Fix catalog locale on: 
1. the user edit page > Additional tab (Catalog scope / Default tree)
2. settings > attribute groups > open one > tab "attributes"

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
