### PR TITLE
TIP-1367: make the completeness calculation work with legacy assets

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/MaskItemGenerator/DefaultMaskItemGenerator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/MaskItemGenerator/DefaultMaskItemGenerator.php
@@ -43,6 +43,7 @@ class DefaultMaskItemGenerator implements MaskItemGeneratorForAttributeType
             AttributeTypes::REFERENCE_ENTITY_SIMPLE_SELECT,
             AttributeTypes::REFERENCE_ENTITY_COLLECTION,
             AttributeTypes::ASSET_COLLECTION,
+            AttributeTypes::LEGACY_ASSET_COLLECTION,
         ];
     }
 }


### PR DESCRIPTION
In the migration scripts, we have something that removes the job "compute product model descendants". In case, when you migrate, you have some instances of this job in the queue, we need to recalculate the completeness of products. Today it does not work in case you have PAM assets.

This PR fixes it.