### PR TITLE
PIM-9065: Change the number decimal precision to 10

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-9065: Change the number decimal precision to 10
+
 # 3.0.64 (2020-01-21)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Standard/Product/ProductValueNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Standard/Product/ProductValueNormalizer.php
@@ -20,7 +20,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class ProductValueNormalizer implements NormalizerInterface
 {
-    const DECIMAL_PRECISION = 4;
+    const DECIMAL_PRECISION = 10;
 
     /** @var NormalizerInterface */
     private $normalizer;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Versioning/Product/ValueNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Versioning/Product/ValueNormalizer.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\Versioning\Product;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\ProductValueNormalizer;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
@@ -39,7 +40,7 @@ class ValueNormalizer implements NormalizerInterface, SerializerAwareInterface
     public function __construct(
         IdentifiableObjectRepositoryInterface $attributeRepository,
         IdentifiableObjectRepositoryInterface $attributeOptionRepository,
-        int $precision = 4
+        int $precision = ProductValueNormalizer::DECIMAL_PRECISION
     ) {
         $this->attributeRepository = $attributeRepository;
         $this->attributeOptionRepository = $attributeOptionRepository;

--- a/src/Akeneo/Tool/Component/Localization/Localizer/NumberLocalizer.php
+++ b/src/Akeneo/Tool/Component/Localization/Localizer/NumberLocalizer.php
@@ -58,7 +58,7 @@ class NumberLocalizer implements LocalizerInterface
 
             if (floor($number) != $number) {
                 $numberFormatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, 2);
-                $numberFormatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, 4);
+                $numberFormatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, 10);
             }
 
             return $numberFormatter->format($number);

--- a/src/Akeneo/Tool/Component/Localization/Presenter/NumberPresenter.php
+++ b/src/Akeneo/Tool/Component/Localization/Presenter/NumberPresenter.php
@@ -42,7 +42,7 @@ class NumberPresenter implements PresenterInterface
 
         if (floor($value) != $value) {
             $numberFormatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, 2);
-            $numberFormatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, 4);
+            $numberFormatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, 10);
         }
 
         return $numberFormatter->format($value);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
@@ -486,10 +486,10 @@ JSON;
                     ['locale' => null, 'scope' => null, 'data' => ['optionA', 'optionB']],
                 ],
                 'a_number_float'                     => [
-                    ['locale' => null, 'scope' => null, 'data' => '12.5678'],
+                    ['locale' => null, 'scope' => null, 'data' => '12.5678000000'],
                 ],
                 'a_number_float_negative'            => [
-                    ['locale' => null, 'scope' => null, 'data' => '-99.8732'],
+                    ['locale' => null, 'scope' => null, 'data' => '-99.8732000000'],
                 ],
                 'a_number_integer'                   => [
                     ['locale' => null, 'scope' => null, 'data' => 42]

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
@@ -101,10 +101,10 @@ class GetProductEndToEnd extends AbstractProductTestCase
                     ['locale' => null, 'scope' => null, 'data' => ['optionA', 'optionB']],
                 ],
                 'a_number_float'                     => [
-                    ['locale' => null, 'scope' => null, 'data' => '12.5678'],
+                    ['locale' => null, 'scope' => null, 'data' => '12.5678000000'],
                 ],
                 'a_number_float_negative'            => [
-                    ['locale' => null, 'scope' => null, 'data' => '-99.8732'],
+                    ['locale' => null, 'scope' => null, 'data' => '-99.8732000000'],
                 ],
                 'a_number_integer'                   => [
                     ['locale' => null, 'scope' => null, 'data' => 42]

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
@@ -64,7 +64,7 @@ JSON;
                     [
                         'locale' => null,
                         'scope'  => null,
-                        'data'   => '12.5000',
+                        'data'   => '12.5000000000',
                     ],
                 ],
             ],
@@ -136,7 +136,7 @@ JSON;
                     [
                         'locale' => null,
                         'scope'  => null,
-                        'data'   => '12.5000',
+                        'data'   => '12.5000000000',
                     ],
                 ],
             ],
@@ -311,7 +311,7 @@ JSON;
                     [
                         'locale' => null,
                         'scope'  => null,
-                        'data'   => '12.5000',
+                        'data'   => '12.5000000000',
                     ],
                 ],
             ],
@@ -652,7 +652,7 @@ JSON;
                     [
                         'locale' => null,
                         'scope'  => null,
-                        'data'   => '12.5000',
+                        'data'   => '12.5000000000',
                     ],
                 ],
             ],

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
@@ -107,7 +107,7 @@ JSON;
                         [
                             'locale' => null,
                             'scope'  => null,
-                            'data'   => '10.5000',
+                            'data'   => '10.5000000000',
                         ],
                     ],
                 ],
@@ -141,7 +141,7 @@ JSON;
                         [
                             'locale' => null,
                             'scope'  => null,
-                            'data'   => '10.5000',
+                            'data'   => '10.5000000000',
                         ],
                     ],
                 ],
@@ -175,7 +175,7 @@ JSON;
                         [
                             'locale' => null,
                             'scope'  => null,
-                            'data'   => '10.5000',
+                            'data'   => '10.5000000000',
                         ],
                     ],
                     'a_simple_select' => [
@@ -200,7 +200,7 @@ JSON;
                         [
                             'locale' => null,
                             'scope'  => null,
-                            'data'   => '13.0000',
+                            'data'   => '13.0000000000',
                         ],
                     ],
                 ],

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
@@ -388,7 +388,7 @@ JSON;
 
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_optionb_false');
         $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
-        $this->assertSame($standardizedProduct['values']['a_number_float'][0]['data'], '15.3000');
+        $this->assertSame($standardizedProduct['values']['a_number_float'][0]['data'], '15.3000000000');
 
     }
 
@@ -449,7 +449,7 @@ JSON;
                     [
                         'locale' => null,
                         'scope'  => null,
-                        'data'   => '12.5000',
+                        'data'   => '12.5000000000',
                     ],
                 ],
             ],
@@ -498,7 +498,7 @@ JSON;
                     [
                         'locale' => null,
                         'scope'  => null,
-                        'data'   => '12.5000',
+                        'data'   => '12.5000000000',
                     ],
                 ],
             ],
@@ -548,7 +548,7 @@ JSON;
                     [
                         'locale' => null,
                         'scope'  => null,
-                        'data'   => '12.5000',
+                        'data'   => '12.5000000000',
                     ],
                 ],
             ],

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
@@ -115,7 +115,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -198,7 +198,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -472,7 +472,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -556,7 +556,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -647,7 +647,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -897,7 +897,7 @@ JSON;
                     ['locale' => null, 'scope' => null, 'data' => 'product_variant_creation_product_values'],
                 ],
                 'a_number_float' => [
-                    ['locale' => null, 'scope' => null, 'data' => '12.5000'],
+                    ['locale' => null, 'scope' => null, 'data' => '12.5000000000'],
                 ],
                 'a_price' => [
                     [
@@ -1004,7 +1004,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateListVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateListVariantProductEndToEnd.php
@@ -121,7 +121,7 @@ JSON;
                         [
                             "locale" => null,
                             "scope"  => null,
-                            "data"   => "12.5000",
+                            "data"   => "12.5000000000",
                         ],
                     ],
                     "a_yes_no"                           => [
@@ -173,7 +173,7 @@ JSON;
                         [
                             "locale" => null,
                             "scope"  => null,
-                            "data"   => "12.5000",
+                            "data"   => "12.5000000000",
                         ],
                     ],
                     "a_yes_no"                           => [

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateProductToVariantEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateProductToVariantEndToEnd.php
@@ -31,7 +31,7 @@ JSON;
             'enabled' => true,
             'values' => [
                 'a_localized_and_scopable_text_area' => [['locale' => 'en_US', 'scope' => 'ecommerce', 'data' => 'my pink tshirt']],
-                'a_number_float' => [['locale' => null, 'scope' => null, 'data' => '12.5000']],
+                'a_number_float' => [['locale' => null, 'scope' => null, 'data' => '12.5000000000']],
                 'a_price'  => [
                     'data' => ['locale' => null, 'scope' => null, 'data' => [['amount' => '50.00', 'currency' => 'EUR']]],
                 ],

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
@@ -137,7 +137,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -451,7 +451,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -535,7 +535,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -620,7 +620,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -705,7 +705,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -799,7 +799,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -910,7 +910,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -1006,7 +1006,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -1097,7 +1097,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -1233,7 +1233,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -1437,7 +1437,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -1620,7 +1620,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -1703,7 +1703,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_yes_no" => [
@@ -1814,7 +1814,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => "12.5000",
+                        "data"   => "12.5000000000",
                     ],
                 ],
                 "a_price" => [

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/ProductSaverIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/ProductSaverIntegration.php
@@ -214,10 +214,10 @@ class ProductSaverIntegration extends TestCase
                     ['locale' => null, 'scope' => null, 'data' => ['optionA', 'optionB']],
                 ],
                 'a_number_float' => [
-                    ['locale' => null, 'scope' => null, 'data' => '12.5678'],
+                    ['locale' => null, 'scope' => null, 'data' => '12.5678000000'],
                 ],
                 'a_number_float_negative' => [
-                    ['locale' => null, 'scope' => null, 'data' => '-99.8732'],
+                    ['locale' => null, 'scope' => null, 'data' => '-99.8732000000'],
                 ],
                 'a_number_integer' => [
                     ['locale' => null, 'scope' => null, 'data' => 42]

--- a/tests/back/Pim/Enrichment/Integration/Normalizer/Standard/ProductStandardIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Normalizer/Standard/ProductStandardIntegration.php
@@ -135,10 +135,10 @@ class ProductStandardIntegration extends TestCase
                         ['locale' => null, 'scope' => null, 'data' => ['optionA', 'optionB']],
                     ],
                     'a_number_float'                     => [
-                        ['locale' => null, 'scope' => null, 'data' => '12.5678'],
+                        ['locale' => null, 'scope' => null, 'data' => '12.5678000000'],
                     ],
                     'a_number_float_negative'            => [
-                        ['locale' => null, 'scope' => null, 'data' => '-99.8732'],
+                        ['locale' => null, 'scope' => null, 'data' => '-99.8732000000'],
                     ],
                     'a_number_integer'                   => [
                         ['locale' => null, 'scope' => null, 'data' => 42]

--- a/tests/back/Pim/Enrichment/Integration/Product/LoadEntityWithValuesSubscriberIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/LoadEntityWithValuesSubscriberIntegration.php
@@ -283,10 +283,10 @@ class LoadEntityWithValuesSubscriberIntegration extends TestCase
                 ['locale' => null, 'scope' => null, 'data' => ['optionA', 'optionB']],
             ],
             'a_number_float'                     => [
-                ['locale' => null, 'scope' => null, 'data' => '12.5678'],
+                ['locale' => null, 'scope' => null, 'data' => '12.5678000000'],
             ],
             'a_number_float_negative'            => [
-                ['locale' => null, 'scope' => null, 'data' => '-99.8732'],
+                ['locale' => null, 'scope' => null, 'data' => '-99.8732000000'],
             ],
             'a_number_integer'                   => [
                 ['locale' => null, 'scope' => null, 'data' => 42]

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/ProductModelNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/ProductModelNormalizerSpec.php
@@ -124,7 +124,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             'categories'     => ['summer'],
             'values'         => [
                 'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
-                'number'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'number'              => [['data' => 12.5000000000, 'locale' => null, 'scope' => null]],
                 'metric'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
                 'prices'              => [['data' => 12.5, 'locale' => null, 'scope' => null]],
                 'date'                => [['data' => '2015-01-31', 'locale' => null, 'scope' => null]],
@@ -295,7 +295,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             'categories'     => ['summer'],
             'values'         => [
                 'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
-                'number'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'number'              => [['data' => 12.5000000000, 'locale' => null, 'scope' => null]],
                 'metric'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
                 'prices'              => [['data' => 12.5, 'locale' => null, 'scope' => null]],
                 'date'                => [['data' => '2015-01-31', 'locale' => null, 'scope' => null]],
@@ -444,7 +444,7 @@ class ProductModelNormalizerSpec extends ObjectBehavior
             'categories'     => ['summer'],
             'values'         => [
                 'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
-                'number'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'number'              => [['data' => 12.5000000000, 'locale' => null, 'scope' => null]],
                 'metric'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
                 'prices'              => [['data' => 12.5, 'locale' => null, 'scope' => null]],
                 'date'                => [['data' => '2015-01-31', 'locale' => null, 'scope' => null]],

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/ProductNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/ProductNormalizerSpec.php
@@ -131,7 +131,7 @@ class ProductNormalizerSpec extends ObjectBehavior
             'family'     => '',
             'values' => [
                 'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
-                'number'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'number'              => [['data' => 12.5000000000, 'locale' => null, 'scope' => null]],
                 'metric'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
                 'prices'              => [['data' => 12.5, 'locale' => null, 'scope' => null]],
                 'date'                => [['data' => '2015-01-31', 'locale' => null, 'scope' => null]],
@@ -289,7 +289,7 @@ class ProductNormalizerSpec extends ObjectBehavior
             'family'     => '',
             'values' => [
                 'normalized_property' => [['data' => 'a nice normalized property', 'locale' => null, 'scope' => null]],
-                'number'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
+                'number'              => [['data' => 12.5000000000, 'locale' => null, 'scope' => null]],
                 'metric'              => [['data' => 12.5000, 'locale' => null, 'scope' => null]],
                 'prices'              => [['data' => 12.5, 'locale' => null, 'scope' => null]],
                 'date'                => [['data' => '2015-01-31', 'locale' => null, 'scope' => null]],

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Standard/Product/ProductValueNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Standard/Product/ProductValueNormalizerSpec.php
@@ -145,7 +145,7 @@ class ProductValueNormalizerSpec extends ObjectBehavior
             [
                 'locale' => 'en_US',
                 'scope'  => 'ecommerce',
-                'data'   => '15.5000',
+                'data'   => '15.5000000000',
             ]
         );
     }

--- a/tests/legacy/features/pim/enrichment/product/export/export_products_with_localized_decimal.feature
+++ b/tests/legacy/features/pim/enrichment/product/export/export_products_with_localized_decimal.feature
@@ -38,10 +38,10 @@ Feature: Export products with localized numbers
     Then exported file of "ecommerce_product_export" should contain:
       """
       sku;categories;enabled;family;groups;cotton;metric;metric-unit
-      sandal-white;men_2013,men_2014,men_2015;1;sandal;;75,5500;;
-      sandal-black;men_2013,men_2014,men_2015;1;sandal;;75,0000;;
+      sandal-white;men_2013,men_2014,men_2015;1;sandal;;75,5500000000;;
+      sandal-black;men_2013,men_2014,men_2015;1;sandal;;75,0000000000;;
       sandal-yellow;men_2013,men_2014,men_2015;1;sandal;;;;
-      sandal-blue;men_2013,men_2014,men_2015;1;sandal;;75,0000;;
+      sandal-blue;men_2013,men_2014,men_2015;1;sandal;;75,0000000000;;
       """
 
   Scenario: Export metric attributes with the correct decimals formatting


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR changes the max fraction digits from 4 to 10, in the Number localizer & presenter and in the Product value normalizer, in order to be able to save values like `0.123456789` in a number type attribute.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
