### PR TITLE
Re-activate php7.3-gd extension in Docker image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -22,6 +22,7 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
         php7.3-mysql \
         php7.3-zip \
         php7.3-xml \
+        php7.3-gd \
         php7.3-curl \
         php7.3-mbstring \
         php7.3-bcmath \


### PR DESCRIPTION
Cannot be run on the CI, i have to merge it with admin rights.

See #11482 