### PR TITLE
API-936: Add React error boundaries

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -150,3 +150,8 @@ akeneo_connectivity.connection:
             message_without_permission:
                 message: Ask your administrator to create one.
                 link: Learn more about connections here...
+
+    runtime_error:
+        error_message: Oh snap! An error occurred...
+        reload_helper: Please reload the page and try again.
+        reload_button:  Reload

--- a/src/Akeneo/Connectivity/Connection/front/src/audit/pages/AuditErrorBoundary.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/pages/AuditErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import React, {Component} from 'react';
+import {Breadcrumb, PageContent, PageHeader, RuntimeError} from '../../common/components';
+import {PimView} from '../../infrastructure/pim-view/PimView';
+import {BreadcrumbRouterLink} from '../../shared/router';
+import {Translate} from '../../shared/translate';
+
+export class AuditErrorBoundary extends Component<unknown, {hasError: boolean}> {
+    constructor(props: unknown) {
+        super(props);
+        this.state = {hasError: false};
+    }
+
+    static getDerivedStateFromError() {
+        return {hasError: true};
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <>
+                    <PageHeader
+                        breadcrumb={
+                            <Breadcrumb>
+                                <BreadcrumbRouterLink route={'pim_dashboard_index'} isLast={false}>
+                                    <Translate id='pim_menu.tab.activity' />
+                                </BreadcrumbRouterLink>
+                            </Breadcrumb>
+                        }
+                        userButtons={
+                            <PimView
+                                className='AknTitleContainer-userMenuContainer AknTitleContainer-userMenu'
+                                viewName='pim-connectivity-connection-user-navigation'
+                            />
+                        }
+                    />
+
+                    <PageContent>
+                        <RuntimeError />
+                    </PageContent>
+                </>
+            );
+        }
+
+        return this.props.children;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/front/src/audit/pages/Index.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/pages/Index.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import {DashboardProvider} from '../dashboard-context';
+import {AuditErrorBoundary} from './AuditErrorBoundary';
 import {Dashboard} from './Dashboard';
 
 export const Index = () => (
-    <DashboardProvider>
-        <Dashboard />
-    </DashboardProvider>
+    <AuditErrorBoundary>
+        <DashboardProvider>
+            <Dashboard />
+        </DashboardProvider>
+    </AuditErrorBoundary>
 );

--- a/src/Akeneo/Connectivity/Connection/front/src/common/components/RuntimeError.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/common/components/RuntimeError.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import styled from 'styled-components';
+import {Translate} from '../../shared/translate';
+import {PropsWithTheme} from '../theme';
+import {ApplyButton} from '.';
+import imageUrl from '../assets/illustrations/api.svg';
+
+const Title = styled.div`
+    color: ${({theme}: PropsWithTheme) => theme.color.grey140};
+    font-size: 28px;
+`;
+
+const Content = styled.div`
+    color: ${({theme}: PropsWithTheme) => theme.color.grey120};
+    font-size: ${({theme}: PropsWithTheme) => theme.fontSize.big};
+    margin: 10px auto 20px;
+`;
+
+const Container = styled.div`
+    width: 740px;
+    margin: 10px auto;
+    text-align: center;
+`;
+
+const Illustration = styled.img`
+    margin: 0 auto;
+    width: 128px;
+`;
+
+export const RuntimeError = () => {
+    const handleClick = () => window.location.reload();
+    return (
+        <Container>
+            <Illustration src={imageUrl} />
+            <Title>
+                <Translate id='akeneo_connectivity.connection.runtime_error.error_message' />
+            </Title>
+            <Content>
+                <Translate id='akeneo_connectivity.connection.runtime_error.reload_helper' />
+            </Content>
+            <ApplyButton onClick={handleClick}>
+                <Translate id='akeneo_connectivity.connection.runtime_error.reload_button' />
+            </ApplyButton>
+        </Container>
+    );
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/common/components/index.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/common/components/index.ts
@@ -11,6 +11,7 @@ import {FormGroup} from './form/FormGroup';
 import {FormInput} from './form/FormInput';
 import {Helper, HelperLink, HelperTitle} from './Helper';
 import {InlineHelper} from './InlineHelper';
+import {RuntimeError} from './RuntimeError';
 import {Modal} from './Modal';
 import {PageContent} from './PageContent';
 import {PageError} from './PageError';
@@ -42,6 +43,7 @@ export {
     PageContent,
     PageError,
     PageHeader,
+    RuntimeError,
     SecondaryActionsDropdownButton,
     Section,
     Select,

--- a/src/Akeneo/Connectivity/Connection/front/src/settings/pages/Index.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/settings/pages/Index.tsx
@@ -7,28 +7,31 @@ import {EditConnection} from './EditConnection';
 import {ListConnections} from './ListConnections';
 import {RegenerateConnectionPassword} from './RegenerateConnectionPassword';
 import {RegenerateConnectionSecret} from './RegenerateConnectionSecret';
+import {SettingsErrorBoundary} from './SettingsErrorBoundary';
 
 export const Index = () => (
-    <ConnectionsProvider>
-        <Switch>
-            <Route path='/connections/:code/edit'>
-                <EditConnection />
-            </Route>
-            <Route path='/connections/:code/regenerate-secret'>
-                <RegenerateConnectionSecret />
-            </Route>
-            <Route path='/connections/:code/regenerate-password'>
-                <RegenerateConnectionPassword />
-            </Route>
-            <Route path='/connections/:code/delete'>
-                <DeleteConnection />
-            </Route>
-            <Route path='/connections/create'>
-                <CreateConnection />
-            </Route>
-            <Route path='/connections'>
-                <ListConnections />
-            </Route>
-        </Switch>
-    </ConnectionsProvider>
+    <SettingsErrorBoundary>
+        <ConnectionsProvider>
+            <Switch>
+                <Route path='/connections/:code/edit'>
+                    <EditConnection />
+                </Route>
+                <Route path='/connections/:code/regenerate-secret'>
+                    <RegenerateConnectionSecret />
+                </Route>
+                <Route path='/connections/:code/regenerate-password'>
+                    <RegenerateConnectionPassword />
+                </Route>
+                <Route path='/connections/:code/delete'>
+                    <DeleteConnection />
+                </Route>
+                <Route path='/connections/create'>
+                    <CreateConnection />
+                </Route>
+                <Route path='/connections'>
+                    <ListConnections />
+                </Route>
+            </Switch>
+        </ConnectionsProvider>
+    </SettingsErrorBoundary>
 );

--- a/src/Akeneo/Connectivity/Connection/front/src/settings/pages/SettingsErrorBoundary.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/settings/pages/SettingsErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import React, {Component} from 'react';
+import {Breadcrumb, BreadcrumbItem, PageContent, PageHeader, RuntimeError} from '../../common/components';
+import {PimView} from '../../infrastructure/pim-view/PimView';
+import {BreadcrumbRouterLink} from '../../shared/router';
+import {Translate} from '../../shared/translate';
+
+export class SettingsErrorBoundary extends Component<unknown, {hasError: boolean}> {
+    constructor(props: unknown) {
+        super(props);
+        this.state = {hasError: false};
+    }
+
+    static getDerivedStateFromError() {
+        return {hasError: true};
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <>
+                    <PageHeader
+                        breadcrumb={
+                            <Breadcrumb>
+                                <BreadcrumbRouterLink route={'oro_config_configuration_system'}>
+                                    <Translate id='pim_menu.tab.system' />
+                                </BreadcrumbRouterLink>
+                                <BreadcrumbItem onClick={() => undefined} isLast={false}>
+                                    <Translate id='pim_menu.item.connection_settings' />
+                                </BreadcrumbItem>
+                            </Breadcrumb>
+                        }
+                        userButtons={
+                            <PimView
+                                className='AknTitleContainer-userMenuContainer AknTitleContainer-userMenu'
+                                viewName='pim-connectivity-connection-user-navigation'
+                            />
+                        }
+                    />
+
+                    <PageContent>
+                        <RuntimeError />
+                    </PageContent>
+                </>
+            );
+        }
+
+        return this.props.children;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/front/tests/unit/common/__snapshots__/PageHeader.spec.tsx.snap
+++ b/src/Akeneo/Connectivity/Connection/front/tests/unit/common/__snapshots__/PageHeader.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PageHeader should render 1`] = `
 <header
-  className="sc-gqjmRU ideAHm"
+  className="sc-jzJRlG dsEWNY"
 >
   <div
     className="AknTitleContainer-line"

--- a/src/Akeneo/Connectivity/Connection/front/tests/unit/common/__snapshots__/Section.spec.tsx.snap
+++ b/src/Akeneo/Connectivity/Connection/front/tests/unit/common/__snapshots__/Section.spec.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`Section should render 1`] = `
 <header
-  className="sc-VigVT bqWYVJ"
+  className="sc-cSHVUG hQujCk"
 >
   <div
-    className="sc-jTzLTM gnUsfy"
+    className="sc-kAzzGY gikFWy"
   >
     title
   </div>
@@ -14,10 +14,10 @@ exports[`Section should render 1`] = `
 
 exports[`Section should render content 1`] = `
 <header
-  className="sc-VigVT bqWYVJ"
+  className="sc-cSHVUG hQujCk"
 >
   <div
-    className="sc-jTzLTM gnUsfy"
+    className="sc-kAzzGY gikFWy"
   >
     title
   </div>

--- a/src/Akeneo/Connectivity/Connection/front/tests/unit/settings/components/__snapshots__/ConnectionGrid.spec.tsx.snap
+++ b/src/Akeneo/Connectivity/Connection/front/tests/unit/settings/components/__snapshots__/ConnectionGrid.spec.tsx.snap
@@ -3,21 +3,21 @@
 exports[`ConnectionGrid should render 1`] = `
 Array [
   <header
-    className="sc-VigVT bqWYVJ"
+    className="sc-cSHVUG hQujCk"
   >
     <div
-      className="sc-jTzLTM gnUsfy"
+      className="sc-kAzzGY gikFWy"
     >
       others
     </div>
     <div
-      className="sc-kEYyzF uXDi"
+      className="sc-eHgmQL iKZfMK"
     >
       akeneo_connectivity.connection.connection_count?count=0
     </div>
   </header>,
   <div
-    className="sc-kkGfuU fGwjgM"
+    className="sc-cvbbAY bUumeS"
   />,
 ]
 `;

--- a/src/Akeneo/Connectivity/Connection/front/tests/unit/settings/components/__snapshots__/NoConnection.spec.tsx.snap
+++ b/src/Akeneo/Connectivity/Connection/front/tests/unit/settings/components/__snapshots__/NoConnection.spec.tsx.snap
@@ -2,24 +2,24 @@
 
 exports[`NoConnection should render 1`] = `
 <div
-  className="sc-htoDjs kkOYWO"
+  className="sc-gqjmRU kGBCDq"
 >
   <img
-    className="sc-dnqmqq kezHrQ"
+    className="sc-VigVT KRUGa"
     src="test-file-stub"
   />
   <div
-    className="sc-iwsKbI hvrcwP"
+    className="sc-jTzLTM blxAcO"
   >
     akeneo_connectivity.connection.no_connection.title
   </div>
   <div
-    className="sc-gZMcBi jVpjdn"
+    className="sc-fjdhpX kasnXz"
   >
     akeneo_connectivity.connection.no_connection.message
      
     <a
-      className="sc-kEYyzF hgSZNu"
+      className="sc-eHgmQL cBigQk"
       onClick={[Function]}
     >
       akeneo_connectivity.connection.no_connection.message_link


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

![Screenshot from 2020-01-27 15-48-56](https://user-images.githubusercontent.com/1671213/73184961-86399880-411d-11ea-8c5e-88d62807676f.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
