### PR TITLE
PIM-9067: fix product filter on mass edit action

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,7 @@
 # 3.2.x
 
+- PIM-9067: Fix mass action product edit when all rows are selected
+
 # 3.2.34 (2020-01-21)
 
 # 3.2.33 (2020-01-20)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/AncestorCodeFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/AncestorCodeFilter.php
@@ -65,7 +65,7 @@ class AncestorCodeFilter extends AbstractFieldFilter
             case Operators::NOT_IN_LIST:
                 $mustNotClause = [
                     'terms' => [
-                        self::ANCESTOR_ID_ES_FIELD => $values,
+                        self::ANCESTOR_CODES_ES_FIELD => $values,
                     ],
                 ];
                 $this->searchQueryBuilder->addMustNot($mustNotClause);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/AncestorCodeFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/AncestorCodeFilter.php
@@ -4,17 +4,13 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterHelper;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductModelRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 
 /**
- * This class filters data with the ancestor code, i.e. the parent code. We cannot use ParentFilter as it this
- * field is unfortunately not in product index. It is only in product and product model index.
- * This is temporary and is used into external API product list, and will be removed after TIP-1150.
- *
- * @see src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
- *
  * @author    Pierre Allard <pierre.allard@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
@@ -44,19 +40,45 @@ class AncestorCodeFilter extends AbstractFieldFilter
     /**
      * {@inheritdoc}
      */
-    public function addFieldFilter($field, $operator, $value, $locale = null, $channel = null, $options = []): void
+    public function addFieldFilter($field, $operator, $values, $locale = null, $channel = null, $options = []): void
     {
         if (null === $this->searchQueryBuilder) {
             throw new \LogicException('The search query builder is not initialized in the filter.');
         }
 
-        FieldFilterHelper::checkIdentifier($field, $value, static::class);
-        $clause = [
-            'terms' => [
-                self::ANCESTOR_CODES_ES_FIELD => [$value],
-            ],
-        ];
+        if (!is_array($values)) {
+            $values = [$values];
+        }
 
-        $this->searchQueryBuilder->addFilter($clause);
+        $this->checkValues($field, $values);
+
+        switch ($operator) {
+            case Operators::EQUALS:
+            case Operators::IN_LIST:
+                $clause = [
+                    'terms' => [
+                        self::ANCESTOR_CODES_ES_FIELD => $values,
+                    ],
+                ];
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+            case Operators::NOT_IN_LIST:
+                $mustNotClause = [
+                    'terms' => [
+                        self::ANCESTOR_ID_ES_FIELD => $values,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($mustNotClause);
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+    }
+
+    private function checkValues($field, array $values): void
+    {
+        foreach ($values as $value) {
+            FieldFilterHelper::checkIdentifier($field, $value, static::class);
+        }
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -436,7 +436,7 @@ services:
         arguments:
             - '@pim_catalog.repository.product_model'
             - ['ancestor.code']
-            - ['=']
+            - ['=', 'IN', 'NOT IN']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -439,6 +439,7 @@ services:
             - ['=', 'IN', 'NOT IN']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
 
     pim_catalog.query.elasticsearch.filter.self_and_ancestor:
         class: '%pim_catalog.query.elasticsearch.filter.self_and_ancestor.class%'

--- a/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
@@ -292,7 +292,7 @@ class MassActionDispatcher
 
     /**
      * When all rows are selected and the filter is activated on a root product model, then the query
-     * returns the sub product model bit not the variant product.
+     * returns the sub product model but not the variant product.
      * The field "parent" of the variant product cannot be used because it does not contain the root product model.
      * We have to use the ancestor.code field that contains all parent codes.
      *


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

On product grid when we filter on parent code and we select all rows, the variant product are not taken in account in bulk action.  
This is because we filter on a root product model and the parent of the variant products is the sub product model, not the root. So the products are not retrieved by the query.  
The selected solution is to use `ancestors.codes` (that contains all the parents) instead of `parent`.  

This will fix:
- number of products that are concerned by the bulk action bfore launch the job
- product fetching during the job

**Before**

No product number displayed  

**After**

![image](https://user-images.githubusercontent.com/4737390/73277774-eba78b00-41ea-11ea-911b-a010c4ec80eb.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
