### PR TITLE
Fix selenium public port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     volumes:
       - './:/srv/pim:ro'
     ports:
-      - '${DOCKER_PORT_HTTP:-5910}:5900'
+      - '${DOCKER_PORT_SELENIUM:-5910}:5900'
     networks:
       - 'pim'
 


### PR DESCRIPTION
Selenium container port can be configured with `DOCKER_PORT_HTTP` env. The problem is this env is also used to configure the http container.  
So if we set a `DOCKER_PORT_HTTP` we cannot up the containers because of a conflict between selenium and http port