### PR TITLE
AST-381: Fix media link preview black background

### DIFF
--- a/config/packages/liip_imagine.yml
+++ b/config/packages/liip_imagine.yml
@@ -54,6 +54,8 @@ liip_imagine:
             data_loader:      stream_data_loader
             filters:
                 thumbnail:    { size: [320, 320], mode: inset }
+                background:
+                    color: "#ffffff"
 
         am_binary_image_preview:
             quality:          95


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fixes the thumbnail background being black when media link is empty.

Before: 
![image](https://user-images.githubusercontent.com/3492179/73285395-40043800-41f6-11ea-8f3e-f639aaa30d56.png)

After:
![image](https://user-images.githubusercontent.com/3492179/73285425-4c889080-41f6-11ea-8f6e-00c54dc0d483.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
