### PR TITLE
PIM-9071: remove existence check on "do not contain" identifier filter

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,7 @@
 # 3.2.x
 
+- PIM-9071: Fix "does not contain" filter on SKU in product data grid
+
 # 3.2.35 (2020-01-29)
 
 - PIM-9067: Fix mass action product edit when all rows are selected

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilter.php
@@ -129,8 +129,8 @@ class IdentifierFilter extends AbstractAttributeFilter implements AttributeFilte
                     ],
                 ];
 
-                // PIM-9071: If we filter on "does not contain", it's not mandatory to check the existence
-                // of the field.
+                // PIM-9071: If we filter on "does not contain", we don't have to check the existence
+                // of the field. Otherwise entities that does not have this field would be excluded from the results.
 //                $filterClause = [
 //                    'exists' => ['field' => $attributePath],
 //                ];

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilter.php
@@ -134,9 +134,9 @@ class IdentifierFilter extends AbstractAttributeFilter implements AttributeFilte
 //                $filterClause = [
 //                    'exists' => ['field' => $attributePath],
 //                ];
+//                $this->searchQueryBuilder->addFilter($filterClause);
 
                 $this->searchQueryBuilder->addMustNot($mustNotClause);
-//                $this->searchQueryBuilder->addFilter($filterClause);
                 break;
 
             case Operators::EQUALS:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilter.php
@@ -129,12 +129,14 @@ class IdentifierFilter extends AbstractAttributeFilter implements AttributeFilte
                     ],
                 ];
 
-                $filterClause = [
-                    'exists' => ['field' => $attributePath],
-                ];
+                // PIM-9071: If we filter on "does not contain", it's not mandatory to check the existence
+                // of the field.
+//                $filterClause = [
+//                    'exists' => ['field' => $attributePath],
+//                ];
 
                 $this->searchQueryBuilder->addMustNot($mustNotClause);
-                $this->searchQueryBuilder->addFilter($filterClause);
+//                $this->searchQueryBuilder->addFilter($filterClause);
                 break;
 
             case Operators::EQUALS:

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilterSpec.php
@@ -125,7 +125,7 @@ class IdentifierFilterSpec extends ObjectBehavior
                     'field' => 'values.sku-identifier.<all_channels>.<all_locales>',
                 ],
             ]
-        )->shouldBeCalled();
+        )->shouldNotBeCalled();
 
         $sqb->addMustNot(
             [


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix https://akeneo.atlassian.net/browse/PIM-9071

On product grid, when we add a filter on SKU with "do not contain", the product models are not displayed in the grid results.  
The reason is because we check the existence of the SKU field on the entity. And as product models dont have SKU field, they are excluded from the results. 

The solution here is to remove the existence check only if the filter type is "do not contain".  

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
