### PR TITLE
Stabilize behat again

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -1,7 +1,7 @@
 contexts: &context
     -   Context\FeatureContext:
             -   base_url: 'http://httpd-behat/'
-                timeout: 20000
+                timeout: 25000
                 window_width: 1280
                 window_height: 1024
     -   Context\FixturesContext:

--- a/tests/legacy/features/pim/enrichment/product/validation/remove_validation_error_on_correction.feature
+++ b/tests/legacy/features/pim/enrichment/product/validation/remove_validation_error_on_correction.feature
@@ -25,5 +25,5 @@ Feature: Validate that validation is removed on correction
     And there should be 1 error in the "Other" tab
     Then I change the "Cost" to "10 USD"
     And I save the product
-    Then I should not see validation tooltip "This value should not be a decimal."
     And there should be 0 error in the "Other" tab
+    Then I should not see validation tooltip "This value should not be a decimal."


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Fix some unstable:
(tests/legacy/features/pim/enrichment/product/datagrid/datagrid_views.feature:50)

https://github.com/akeneo/pim-community-dev/issues/11481

The method to assert that a text is in the page take  A LOT of time. So when it's spinning, it can reach the timeout that I reduced to 20 sec.

I reduced it because a lot of time we wait something does not happen during the time of the timeout (a text does not appear, during 20 seconds for example).

Let's try with 25...

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
