### PR TITLE
PIM-9075: Fix mass_edit_rule key translation

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9075: Fix mass_edit_rule key translation
+
 # 3.2.35 (2020-01-29)
 
 - PIM-9067: Fix mass action product edit when all rows are selected

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -149,6 +149,7 @@ pim_import_export:
                 import: Import
                 export: Export
                 mass_edit: Mass edit
+                mass_edit_rule: Rules Settings
                 quick_export: Quick export
                 compute_product_models_descendants: Compute product models descendants
                 compute_family_variant_structure_changes: Compute family variant structure changes


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)** 
When running the rules job "calculate affected products", the job showed the key "pim_import_export.widget.last_operations.job_type.mass_edit_rule".
The goal, here, was to had a translation for the key "mass_edit_rule".


![Peek_PIM-9075](https://user-images.githubusercontent.com/57708349/73531242-4b37ad80-441a-11ea-8b64-50b244328f9e.gif)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
