### PR TITLE
PIM-9080: Fix overlapping jQuery.resizable handle

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9080: Fix overlapping jQuery.resizable handle
+
 # 3.2.36 (2020-02-03)
 
 ## Bug fixes:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/resizable.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/resizable.js
@@ -37,6 +37,7 @@ define(['jquery'], function($) {
             }
 
             $(container).resizable({
+                zIndex: 0,
                 maxWidth,
                 minWidth,
                 handles: 'e',


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix the jQuery.resizable handle overlapping on the page title while scrolling on the page

![Peek 2020-02-03 10-56](https://user-images.githubusercontent.com/1671213/73643552-fe4f1380-4673-11ea-8e48-27ed9f04d947.gif)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
