### PR TITLE
PIM-8952: Freeze headers of the attribute options tab

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Enhancements
+
+- PIM-8952: Freeze the first line and column of the attribute options tab
+
 # 3.0.65 (2020-02-03)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/assets.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/assets.yml
@@ -113,3 +113,4 @@ css:
         - bundles/pimui/less/pages/Default.less
         - bundles/pimui/less/pages/FullPage.less
         - bundles/pimui/less/pages/Login.less
+        - bundles/pimui/less/pages/AttributeOptions.less

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -7,7 +7,8 @@
 
   font-size: @AknDefaultFontSize;
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
 
   &-bodyRow {
     transition: background 0.2s ease-in;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/pages/AttributeOptions.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/pages/AttributeOptions.less
@@ -1,0 +1,18 @@
+.AknAttributeOptions {
+  &-columnHeader {
+    position: sticky;
+    top: 120px;
+    z-index: 1;
+    background-color: white;
+
+    &::before {
+        content: '';
+    }
+  }
+
+  &-rowHeader {
+    position: sticky;
+    left: -50px;
+    background-color: white;
+  }
+}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/pages/AttributeOptions.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/pages/AttributeOptions.less
@@ -4,10 +4,6 @@
     top: 120px;
     z-index: 1;
     background-color: white;
-
-    &::before {
-        content: '';
-    }
   }
 
   &-rowHeader {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-option/edit.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-option/edit.html
@@ -1,4 +1,4 @@
-<td class="AknGrid-bodyCell field-cell">
+<td class="AknGrid-bodyCell field-cell AknAttributeOptions-rowHeader">
     <div class="AknFieldContainer AknFieldContainer--withoutMargin">
         <div class="AknFieldContainer-inputContainer">
             <% if (item.id) { %>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-option/index.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-option/index.html
@@ -5,13 +5,13 @@
 </colgroup>
 <thead>
     <tr>
-        <th class="AknGrid-headerCell"><%- code_label %></th>
+        <th class="AknGrid-headerCell AknAttributeOptions-columnHeader"><%- code_label %></th>
         <% _.each(locales, function (locale) { %>
-            <th class="AknGrid-headerCell">
+            <th class="AknGrid-headerCell AknAttributeOptions-columnHeader">
                 <%- locale %>
             </th>
         <% }); %>
-        <th class="AknGrid-headerCell AknGrid-headerCell--right"><%- _.__('pim_common.actions') %></th>
+        <th class="AknGrid-headerCell AknGrid-headerCell--right AknAttributeOptions-columnHeader"><%- _.__('pim_common.actions') %></th>
     </tr>
 </thead>
 <tbody></tbody>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-option/show.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-option/show.html
@@ -1,4 +1,4 @@
-<td class="AknGrid-bodyCell">
+<td class="AknGrid-bodyCell AknAttributeOptions-rowHeader">
     <span class="handle ui-sortable-handle AknGrid-movableRow"><i class="icon-reorder"></i></span>
     <span class="option-code"><%- item.code %></span>
 </td>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

![Peek 2020-02-03 10-56](https://user-images.githubusercontent.com/1671213/73936701-b46c6480-48e3-11ea-8ddc-9a7e59b7bf46.gif)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
