### PR TITLE
Remove version from the index names when checking if missing migration

### DIFF
--- a/.circleci/detect_structure_changes.sh
+++ b/.circleci/detect_structure_changes.sh
@@ -85,6 +85,6 @@ echo "Compare database 40+PR migrations from database PR..."
 diff /tmp/dump_40_database_with_migrations.sql /tmp/dump_branch_database.sql --context=10
 
 echo "Compare index 40+PR migrations from index PR..."
-sed -i -r 's/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/uuid/g' /tmp/dump_40_index_with_migrations.json
-sed -i -r 's/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/uuid/g' /tmp/dump_branch_index.json
+sed -i -r 's/[0-9]+_[0-9]+_[0-9]+_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/version_uuid/g' /tmp/dump_40_index_with_migrations.json
+sed -i -r 's/[0-9]+_[0-9]+_[0-9]+_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/version_uuid/g' /tmp/dump_branch_index.json
 diff /tmp/dump_40_index_with_migrations.json /tmp/dump_branch_index.json --context=10


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Ignore the PIM version when comparing database migrations, same as https://github.com/akeneo/pim-community-dev/commit/52256711702ebbf9813413e7a67b03d5492b450c

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -