### PR TITLE
Fixed TypeError when checking for GhostScript

### DIFF
--- a/src/Akeneo/Platform/PimRequirements.php
+++ b/src/Akeneo/Platform/PimRequirements.php
@@ -247,17 +247,15 @@ class PimRequirements
 
     private function isGhostScriptVersionSupported(): bool
     {
-        $currentGhostScriptVersion = trim(shell_exec('gs --version'));
+        $currentGhostScriptVersion = shell_exec('gs --version');
         if (null === $currentGhostScriptVersion) {
             return false;
         }
 
-        $isGhostScriptVersionSupported = version_compare(
-            $currentGhostScriptVersion,
+        return version_compare(
+            trim($currentGhostScriptVersion),
             self::REQUIRED_GHOSTSCRIPT_VERSION,
             '>='
         );
-
-        return $isGhostScriptVersionSupported;
     }
 }


### PR DESCRIPTION
When strict_type is enabled, passing null to trim triggers a TypeError, which causes a FatalError.
As shell_exec returns string|null, function result cannot be trimmed directly

**Description (for Contributor and Core Developer)**

When trying to install Akeneo 4.0, I faced a TypeError. This was related to Ghostscript version checking.

So currently, if GhostScript is not installed, you got a FatalError.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
