### PR TITLE
PIM-9082: remove last release sentence when info not available

### DIFF
--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/Update/last_patch.html.twig
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/Update/last_patch.html.twig
@@ -8,15 +8,20 @@
                 $(function() {
                     try {
                         var updateServerUrl = '{{ get_update_server_url() }}';
-                        Fetcher.fetch(updateServerUrl).then(function (patch) {
-                            var currentVersionName = $('.current-version:first span:last').text();
-                            var currentVersion = currentVersionName.split(' ')[1];
-                            if (patch !== null && currentVersion < patch) {
-                                $('.last-version span:last').text(patch);
-                            } else {
+                        Fetcher.fetch(updateServerUrl)
+                            .then(function (patch) {
+                                var currentVersionName = $('.current-version:first span:last').text();
+                                var currentVersion = currentVersionName.split(' ')[1];
+                                if (patch !== null && currentVersion < patch) {
+                                    $('.last-version span:last').text(patch);
+                                } else {
+                                    $('.last-version').remove();
+                                }
+                            })
+                            .catch(function () {
                                 $('.last-version').remove();
-                            }
-                        });
+                            })
+                        ;
                     } catch (err) {
                         $('.last-version').remove();
                     }

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/Update/last_patch.html.twig
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/Update/last_patch.html.twig
@@ -1,30 +1,20 @@
 {% if is_last_patch_enabled() %}
-    <div class="AknFooter-item last-version"><span>{{ 'pim_analytics.new_patch_available'|trans }}:</span><span></span></div>
+    <div class="AknFooter-item last-version" style="display: none;"><span>{{ 'pim_analytics.new_patch_available'|trans }}:</span><span></span></div>
 
     <script type="text/javascript" nonce="{{ js_nonce() }}">
         require(
             ['jquery', 'pim/patch-fetcher'],
             function ($, Fetcher) {
                 $(function() {
-                    try {
-                        var updateServerUrl = '{{ get_update_server_url() }}';
-                        Fetcher.fetch(updateServerUrl)
-                            .then(function (patch) {
-                                var currentVersionName = $('.current-version:first span:last').text();
-                                var currentVersion = currentVersionName.split(' ')[1];
-                                if (patch !== null && currentVersion < patch) {
-                                    $('.last-version span:last').text(patch);
-                                } else {
-                                    $('.last-version').remove();
-                                }
-                            })
-                            .catch(function () {
-                                $('.last-version').remove();
-                            })
-                        ;
-                    } catch (err) {
-                        $('.last-version').remove();
-                    }
+                    var updateServerUrl = '{{ get_update_server_url() }}';
+                    Fetcher.fetch(updateServerUrl).then(function (patch) {
+                        var currentVersionName = $('.current-version:first span:last').text();
+                        var currentVersion = currentVersionName.split(' ')[1];
+                        if (patch !== null && currentVersion < patch) {
+                            $('.last-version span:last').text(patch);
+                            $('.last-version').show();
+                        }
+                    });
                 });
             }
         );


### PR DESCRIPTION
On the dashboard we display if a new version is available. To know that we do a request on this url for PIM in 4.0: https://updates.akeneo.com/CE-4.0.json  

The problem was we had "New patch available:" for a while (we should have "New patch available: 4.0.3" for example).  
It's not reproductible today, unless we simulate a PIM v5: the request becomes  https://updates.akeneo.com/CE-5.0.json (404 response) and the mention  "New patch available:" is displayed.  
To fix that, we hide the "New patch available:" by default and dispay it only if request succeeds