### PR TITLE
PIM-9089: add exception when category is unknown in ES queries

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9089: Fix error when a category is unknown during a product search
+
 # 3.2.37 (2020-02-04)
 
 ## Bug fixes:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/CategoryFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/CategoryFilter.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterHelper;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -135,6 +136,7 @@ class CategoryFilter extends AbstractFieldFilter implements FieldFilterInterface
      *
      * @param string $field
      * @param mixed  $values
+     * @throws ObjectNotFoundException
      */
     protected function checkValue($field, $values): void
     {
@@ -142,6 +144,12 @@ class CategoryFilter extends AbstractFieldFilter implements FieldFilterInterface
 
         foreach ($values as $value) {
             FieldFilterHelper::checkIdentifier($field, $value, static::class);
+
+            if (null === $this->categoryRepository->findOneBy(['code' => $value])) {
+                throw new ObjectNotFoundException(
+                    sprintf('Object "category" with code "%s" does not exist', $value)
+                );
+            }
         }
     }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The execution of the rules failed with a PHP error when a category was not found (specially when we wanted to have the children of a category with the "IN CHILDREN" operator). No message was displayed to the user.  
For family filter, we always check the existence of the families. This PR does the same for categories. A propper exception is thrown when a category does not exist and a message is now displayed:

![image](https://user-images.githubusercontent.com/4737390/74245885-04806800-4ce4-11ea-94e9-43d84e9ac403.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
