### PR TITLE
PIM-9079: add consistency between datagrid and quick export

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes:
 
 - PIM-9089: Fix error when a category is unknown during a product search
+- PIM-9079: Fix quick export when select all product models in the datagrid
 
 # 3.2.37 (2020-02-04)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -86,10 +86,17 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
      */
     public function execute()
     {
+        $this->addAutomaticProductVisibilityFilters();
+
+        return $this->pqb->execute();
+    }
+
+    public function addAutomaticProductVisibilityFilters(): void
+    {
         if ($this->shouldFilterOnlyOnProducts()) {
             $this->addFilter('entity_type', Operators::EQUALS, ProductInterface::class);
 
-            return $this->pqb->execute();
+            return;
         }
 
         if ($this->shouldSearchDocumentsWithoutParent()) {
@@ -99,8 +106,6 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
         if ($this->shouldAggregateResults()) {
             $this->searchAggregator->aggregateResults($this->getQueryBuilder(), $this->getRawFilters());
         }
-
-        return $this->pqb->execute();
     }
 
     /**

--- a/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
@@ -14,6 +14,7 @@ use Oro\Bundle\DataGridBundle\Extension\MassAction\MassActionResponseInterface;
 use Oro\Bundle\PimDataGridBundle\Datasource\ProductAndProductModelDatasource;
 use Oro\Bundle\PimDataGridBundle\Datasource\ProductDatasource;
 use Oro\Bundle\PimDataGridBundle\Extension\Filter\FilterExtension;
+use Oro\Bundle\PimDataGridBundle\Extension\MassAction\Actions\Export\ExportMassAction;
 use Oro\Bundle\PimDataGridBundle\Extension\MassAction\Handler\MassActionHandlerInterface;
 
 /**
@@ -92,6 +93,7 @@ class MassActionDispatcher
      */
     public function getRawFilters(array $parameters)
     {
+        $actionName = $parameters['actionName'] ?? '';
         $parameters = $this->prepareMassActionParameters($parameters);
         $datagrid = $parameters['datagrid'];
         $datasource = $datagrid->getDatasource();
@@ -104,8 +106,10 @@ class MassActionDispatcher
             $filters = [['field' => 'id', 'operator' => 'IN', 'value' => $parameters['values']]];
         } else {
             $productQueryBuilder = $datasource->getProductQueryBuilder();
-            if ($productQueryBuilder instanceof ProductAndProductModelQueryBuilder) {
-                // PIM-9079: add automatic filters to have the same behavior as the product datagrid filters.
+            if (strpos($actionName, 'quick_export_') !== false
+                && $productQueryBuilder instanceof ProductAndProductModelQueryBuilder
+            ) {
+                // PIM-9079: add automatic filters to have the same behavior between datagrid display and export.
                 $productQueryBuilder->addAutomaticProductVisibilityFilters();
             }
 

--- a/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
@@ -106,10 +106,13 @@ class MassActionDispatcher
             $filters = [['field' => 'id', 'operator' => 'IN', 'value' => $parameters['values']]];
         } else {
             $productQueryBuilder = $datasource->getProductQueryBuilder();
+
+            // PIM-9079: add automatic filters to have the same behavior between datagrid display and export.
+            // In PQB we add these filters before execution. We add then too for consistency.
+            // Only quick export is impacted, as we don't want to impact bulk actions (like edit attributes, ...)
             if (strpos($actionName, 'quick_export_') !== false
                 && $productQueryBuilder instanceof ProductAndProductModelQueryBuilder
             ) {
-                // PIM-9079: add automatic filters to have the same behavior between datagrid display and export.
                 $productQueryBuilder->addAutomaticProductVisibilityFilters();
             }
 

--- a/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
@@ -3,6 +3,7 @@
 namespace Oro\Bundle\PimDataGridBundle\Extension\MassAction;
 
 use Akeneo\Pim\Enrichment\Bundle\ProductQueryBuilder\ProductAndProductModelQueryBuilder;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Oro\Bundle\DataGridBundle\Datagrid\DatagridInterface;
 use Oro\Bundle\DataGridBundle\Datagrid\ManagerInterface;
 use Oro\Bundle\DataGridBundle\Datagrid\RequestParameters;
@@ -14,7 +15,6 @@ use Oro\Bundle\DataGridBundle\Extension\MassAction\MassActionResponseInterface;
 use Oro\Bundle\PimDataGridBundle\Datasource\ProductAndProductModelDatasource;
 use Oro\Bundle\PimDataGridBundle\Datasource\ProductDatasource;
 use Oro\Bundle\PimDataGridBundle\Extension\Filter\FilterExtension;
-use Oro\Bundle\PimDataGridBundle\Extension\MassAction\Actions\Export\ExportMassAction;
 use Oro\Bundle\PimDataGridBundle\Extension\MassAction\Handler\MassActionHandlerInterface;
 
 /**
@@ -315,7 +315,7 @@ class MassActionDispatcher
         if ($this->areAllRowsSelected($filters)) {
             foreach ($filters as &$filter) {
                 // PIM-9079: If the operator is EMPTY, we want specifically entities without parent => we must not change.
-                if ('parent' === $filter['field'] && $filter['operator'] !== 'EMPTY') {
+                if ('parent' === $filter['field'] && $filter['operator'] !== Operators::IS_EMPTY) {
                     $filter['field'] = 'ancestor.code';
                 }
             }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix https://akeneo.atlassian.net/browse/PIM-9079  

Given we are on the product datagrid and we filter on a family and have only product models.

- When we select 1 product model or all visible product models, and quick export : only root product models has been exported

- When we select all and quick export : sub product models are also exported

The fix adds consistency between the both use cases. We must remove sub product models from the export in both ones.  


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
