### PR TITLE
Fix missing translation for family variant deletion

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -40,6 +40,8 @@ pim_enrich.entity.family_variant:
             fail: The family variant could not be updated.
         create:
             success: Family variant successfully created
+        delete:
+            success: Family variant successfully deleted
     module:
         edit:
             common_attributes: Common attributes


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Missing translation for the confirmation popup
![Screenshot from 2020-02-13 15-54-11](https://user-images.githubusercontent.com/1671213/74738898-14ee9080-5258-11ea-9c8c-53b1d3536731.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
