### PR TITLE
PIM-9095: fix memory leak during family import

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9095: Fix memory leak during family import
+
 # 3.2.38 (2020-02-12)
 
 ## Bug fixes:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTasklet.php
@@ -66,17 +66,6 @@ class ComputeDataRelatedToFamilyProductsTasklet implements TaskletInterface, Ini
     /** @var int */
     private $batchSize;
 
-    /**
-     * @param IdentifiableObjectRepositoryInterface $familyRepository
-     * @param ProductQueryBuilderFactoryInterface   $productQueryBuilderFactory
-     * @param ItemReaderInterface                   $familyReader
-     * @param BulkSaverInterface                    $productSaver
-     * @param EntityManagerClearerInterface         $cacheClearer
-     * @param JobRepositoryInterface                $jobRepository
-     * @param KeepOnlyValuesForVariation            $keepOnlyValuesForVariation
-     * @param ValidatorInterface                    $validator
-     * @param int                                   $batchSize
-     */
     public function __construct(
         IdentifiableObjectRepositoryInterface $familyRepository,
         ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
@@ -147,7 +136,7 @@ class ComputeDataRelatedToFamilyProductsTasklet implements TaskletInterface, Ini
 
                 if (0 === count($productsToSave) % $this->batchSize) {
                     $this->saveProducts($productsToSave);
-                    $productsToSave= [];
+                    $productsToSave = [];
                     $this->cacheClearer->clear();
                 }
             }
@@ -155,6 +144,8 @@ class ComputeDataRelatedToFamilyProductsTasklet implements TaskletInterface, Ini
             if (!empty($productsToSave)) {
                 $this->saveProducts($productsToSave);
             }
+
+            $this->cacheClearer->clear();
         }
     }
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTaskletSpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\Job;
 
 use Akeneo\Pim\Enrichment\Bundle\ProductQueryBuilder\ProductAndProductModelQueryBuilder;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeDataRelatedToFamilyProductsTasklet;
 use Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\KeepOnlyValuesForVariation;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -15,7 +16,6 @@ use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
-use Akeneo\Tool\Component\Connector\Job\ComputeDataRelatedToFamilyVariantsTasklet;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
@@ -96,7 +96,7 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $stepExecution->incrementSummaryInfo('skip')->shouldNotBeCalled();
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
-        $cacheClearer->clear()->shouldBeCalledTimes(2);
+        $cacheClearer->clear()->shouldBeCalledTimes(3);
 
         $this->setStepExecution($stepExecution);
         $this->execute();
@@ -161,7 +161,7 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $stepExecution->incrementSummaryInfo('skip')->shouldNotBeCalled();
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
-        $cacheClearer->clear()->shouldBeCalledTimes(2);
+        $cacheClearer->clear()->shouldBeCalledTimes(3);
 
         $this->setStepExecution($stepExecution);
         $this->execute();
@@ -223,7 +223,7 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalledTimes(2);
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
-        $cacheClearer->clear()->shouldBeCalledTimes(1);
+        $cacheClearer->clear()->shouldBeCalledTimes(2);
 
         $this->setStepExecution($stepExecution);
         $this->execute();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix https://akeneo.atlassian.net/browse/PIM-9095  

When no product is valid, the entity manager was never cleared.  

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
