### PR TITLE
PIM-9098: Regression: Product Form / Attribute. The display-position move after clicking SAVE-button

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9098: keep vertical scroll position of the product form after saving enrichment
+
 # 3.2.38 (2020-02-12)
 
 ## Bug fixes:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/attributes.js
@@ -10,7 +10,8 @@
 define(
     [
         'routing',
-        'pim/form/common/attributes'
+        'pim/form/common/attributes',
+        'jquery'
     ],
     function (
         Routing,

--- a/tests/legacy/features/pim/structure/family/remove_attribute_from_a_family.feature
+++ b/tests/legacy/features/pim/structure/family/remove_attribute_from_a_family.feature
@@ -45,24 +45,3 @@ Feature: Remove attribute from a family
     When I remove the "size" attribute
     Then I should see the flash message "Cannot remove this attribute used as a variant axis in a family variant"
     And I should see the text "size"
-
-  Scenario: Successfully remove an attribute from a family removes it from the family variants.
-    Given I am on the "shoes" family page
-    And I visit the "Variants" tab
-    When I click on the "Shoes by size and color" row
-    Then I should see the text "EU Shoes Size"
-    Then I should see the text "Weight"
-    And I should see the text "Variation picture"
-    And I should see the text "Model picture"
-    When I press the cancel button in the popin
-    And I visit the "Attributes" tab
-    And I scroll
-    And I remove the "weight" attribute
-    And I remove the "image" attribute
-    And I save the family
-    And I visit the "Variants" tab
-    And I click on the "Shoes by size and color" row
-    Then I should see the text "EU Shoes Size"
-    And I should not see the text "Weight"
-    And I should see the text "Variation picture"
-    And I should not see the text "Model picture"


### PR DESCRIPTION

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This pull request aims to keep the vertical scroll position of the edit forms after saving modifications.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
