### PR TITLE
#11583: Remove useless GLOB_BRACE flag from standard Kernel

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Technical Improvements
+
+- #11583: Remove useless GLOB_BRACE flag from standard Kernel
+
 # 4.0.6 (2020-02-19)
 
 # 4.0.5 (2020-02-14)

--- a/std-build/Kernel.php
+++ b/std-build/Kernel.php
@@ -112,9 +112,9 @@ class Kernel extends BaseKernel
     private function loadPackagesConfigurationExceptSecurity(LoaderInterface $loader, string $confDir, string $environment): void
     {
         $files = array_merge(
-            glob($confDir . '/{packages}/*.yml', GLOB_BRACE),
-            glob($confDir . '/{packages}/' . $environment . '/*.yml', GLOB_BRACE),
-            glob($confDir . '/{packages}/' . $environment . '/**/*.yml', GLOB_BRACE)
+            glob($confDir . '/{packages}/*.yml),
+            glob($confDir . '/{packages}/' . $environment . '/*.yml'),
+            glob($confDir . '/{packages}/' . $environment . '/**/*.yml')
         );
 
         $files = array_filter(

--- a/std-build/Kernel.php
+++ b/std-build/Kernel.php
@@ -112,9 +112,9 @@ class Kernel extends BaseKernel
     private function loadPackagesConfigurationExceptSecurity(LoaderInterface $loader, string $confDir, string $environment): void
     {
         $files = array_merge(
-            glob($confDir . '/{packages}/*.yml),
-            glob($confDir . '/{packages}/' . $environment . '/*.yml'),
-            glob($confDir . '/{packages}/' . $environment . '/**/*.yml')
+            glob($confDir . '/packages/*.yml'),
+            glob($confDir . '/packages/' . $environment . '/*.yml'),
+            glob($confDir . '/packages/' . $environment . '/**/*.yml')
         );
 
         $files = array_filter(


### PR DESCRIPTION
Fixes #11583

> the braces could be removed altogether, as they only list one variant. "/{packages}/" is equivalent to "/packages/" as there is only the variant "packages". It would be a different story if it was "/{packages,}/" (notice the empty variant) or "/{packages,routes}/".