### PR TITLE
PIM-9108: Fix wrong message appearing when switching category tree

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9108: Fix 'unsaved changes' message wrongly displayed when switching category tree
+
 # 3.2.40 (2020-02-20)
 
 ## Bug fixes:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/jstree/jquery.jstree.tree_selector.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/jstree/jquery.jstree.tree_selector.js
@@ -33,7 +33,7 @@
                         id: tree_select_id,
                         'class': 'input-large'
                     });
-                    tree_select.addClass('jstree-tree-select');
+                    tree_select.addClass('jstree-tree-select').addClass('exclude');
 
                     tree_select.bind('change', function () {
                         _this.switch_tree();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

The state of the Settings / Category form is managed in the legacy `pim/formupdatelistener` (which itself is called in a twig macro :roll_eyes: ). 
The form uses a custom jQuery.jstree plugin (tree_selector), which allows to choose the category tree in a select2. Problem is, when this select2 is updated, `pim/formupdatelistener` will consider that the form was updated, thus displaying a 'unsaved changes' message.

My solution is to add the `exclude` class to the tree selector, so it will not be taken into account by the listener, as per these lines: https://github.com/akeneo/pim-community-dev/blob/299dac85b55a68adaf8ab18568c04d2bad67e5e3/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/pim-formupdatelistener.js#L20...L25

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
