### PR TITLE
PIM-9110: avoid deadlock error when loading products in parallel with the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Bug fixes
+
+- PIM-9110: avoid deadlock error when laoding products in parallel with the API


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description**

When loading with a parallelism of 7 threads to import products, Mysql dead lock issues can occur. As we don't handle it in our code (it triggers an uncatched exception), it's an error 500 returned by the API.

Do note that:
In any application, we can have deadlock: this is just a matter of probability. 
The bigger are you transaction, the bigger is your probability to have a dead lock.
The more you have concurrent transactions,  the bigger is your probability to have a dead lock.

Here, it happens when we DELETE then INSERT the rows for the completeness, because we batched things.

What _probably_  happens is:
```
TRANSACTION 1
DELETE FROM pim_catalog_completeness WHERE product_id IN ('1', '2', '3')
```
Exclusive locks on product_id 1 and 2.

```
TRANSACTION 2
INSERT INTO pim_catalog_completenes (locale_id, channel_id, product_id, missing_count, required_count) VALUES
                    ('36', '3', 3, 12, 31),('39', '3', 2, 12, 31),('49', '3', 1, 12, 31)
```
It gets a lock on '3'. 


- transaction 1 waits '3' to be unlocked and have lock on 2.
- transaction 1 waits '2' to be unlocked and have lock on 3.

Deadlock!

**Solution**

When you have a deadlock, Mysql automaticaly abort one of the transaction to let the other get the locks. The best approach is just to retry to persist the data. A retry at 3 seems a very reasonable approach.

Tested with a concurrency of 14 concurrent thread: we don't have any deadlock about the persistence of the completeness.

```
*************************** 1. row ***************************
  Type: InnoDB
  Name: 
Status: 
=====================================
2020-02-19 14:23:17 0x7fd41c2e3700 INNODB MONITOR OUTPUT
=====================================
Per second averages calculated from the last 21 seconds
-----------------
BACKGROUND THREAD
-----------------
srv_master_thread loops: 86914 srv_active, 0 srv_shutdown, 529417 srv_idle
srv_master_thread log flush and writes: 0
----------
SEMAPHORES
----------
OS WAIT ARRAY INFO: reservation count 20159
OS WAIT ARRAY INFO: signal count 512319
RW-shared spins 199742, rounds 201467, OS waits 1508
RW-excl spins 124344, rounds 506841, OS waits 6971
RW-sx spins 635, rounds 15035, OS waits 413
Spin rounds per wait: 1.01 RW-shared, 4.08 RW-excl, 23.68 RW-sx
------------------------
LATEST DETECTED DEADLOCK
------------------------
2020-02-19 10:13:44 0x7fd3cd5fc700
*** (1) TRANSACTION:
TRANSACTION 10152780, ACTIVE 0 sec inserting
mysql tables in use 1, locked 1
LOCK WAIT 78 lock struct(s), heap size 24784, 444 row lock(s), undo log entries 121
MySQL thread id 353178, OS thread handle 140549251237632, query id 56336289 10.48.35.47 akeneo_pim update
INSERT INTO pim_catalog_completeness
                    (locale_id, channel_id, product_id, missing_count, required_count)
                VALUES
                    ('36', '3', 289981, 12, 31),('39', '3', 289981, 12, 31),('49', '3', 289981, 12, 31),('36', '2', 289981, 16, 36),('39', '2', 289981, 16, 36),('49', '2', 289981, 16, 36),('36', '3', 289980, 12, 31),('39', '3', 289980, 12, 31),('49', '3', 289980, 12, 31),('36', '2', 289980, 16, 36),('39', '2', 289980, 16, 36),('49', '2', 289980, 16, 36),('36', '3', 290030, 12, 31),('39', '3', 290030, 12, 31),('49', '3', 290030, 12, 31),('36', '2', 290030, 16, 36),('39', '2', 290030, 16, 36),('49', '2', 290030, 16, 36),('36', '3', 289547, 17, 31),('39', '3', 289547, 17, 31),('49', '3', 289547, 17, 31),('36', '2', 289547, 21, 36),('39', '2', 289547, 21, 36),('49', '2', 289547, 21, 36),('36', '3', 289549, 17, 31),('39', '3', 289549, 17, 31),('49', '3', 289549, 17
*** (1) HOLDS THE LOCK(S):
RECORD LOCKS space id 595 page no 933 n bits 824 index searchunique_idx of table `akeneo_pim`.`pim_catalog_completeness` trx id 10152780 lock mode S
Record lock, heap no 639 PHYSICAL RECORD: n_fields 4; compact format; info bits 0
 0: len 4; hex 80000003; asc     ;;
 1: len 4; hex 80000024; asc    $;;
 2: len 4; hex 80046b0c; asc   k ;;
 3: len 4; hex 803f385f; asc  ?8_;;
Record lock, heap no 643 PHYSICAL RECORD: n_fields 4; compact format; info bits 0
 0: len 4; hex 80000003; asc     ;;
 1: len 4; hex 80000024; asc    $;;
 2: len 4; hex 80046b10; asc   k ;;
 3: len 4; hex 803e7df9; asc  >} ;;
Record lock, heap no 646 PHYSICAL RECORD: n_fields 4; compact format; info bits 0
 0: len 4; hex 80000003; asc     ;;
 1: len 4; hex 80000024; asc    $;;
 2: len 4; hex 80046b13; asc   k ;;
 3: len 4; hex 803f3865; asc  ?8e;;
*** (1) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 595 page no 955 n bits 824 index searchunique_idx of table `akeneo_pim`.`pim_catalog_completeness` trx id 10152780 lock mode S waiting
Record lock, heap no 717 PHYSICAL RECORD: n_fields 4; compact format; info bits 32
 0: len 4; hex 80000003; asc     ;;
 1: len 4; hex 80000024; asc    $;;
 2: len 4; hex 80045030; asc   P0;;
 3: len 4; hex 803e7c67; asc  >|g;;
*** (2) TRANSACTION:
TRANSACTION 10152778, ACTIVE 0 sec updating or deleting
mysql tables in use 1, locked 1
LOCK WAIT 19 lock struct(s), heap size 3520, 1968 row lock(s), undo log entries 907
MySQL thread id 353180, OS thread handle 140549251827456, query id 56336262 10.48.9.158 akeneo_pim updating
DELETE FROM pim_catalog_completeness WHERE product_id IN ('289566', '282674', '282676', '282679', '282682', '282668', '282757', '282771', '282779', '282752', '282759', '282774', '282767', '282777', '282784', '282790', '282803', '282717', '282763', '282709', '282716', '282722', '289609', '289613', '289616', '289618', '289620', '289622', '289619', '289621', '289624', '289625', '289581', '289606', '282874', '282893', '282750', '282802', '282817', '282835', '282885', '282783', '282795', '282810', '282826', '282840', '282845', '282850', '282858', '282868', '282730', '282739', '282749', '282765', '282807', '282732', '282743', '282755', '289593', '289587', '289592', '289598', '282723', '282733', '282744', '282736', '282698', '282703', '282706', '282713', '282719', '282728', '282737', '282754', '282854', '282864', '282878', '282889', '289586', '289590', '289594', '289596', '282797', '282727', '282735', '282745
*** (2) HOLDS THE LOCK(S):
RECORD LOCKS space id 595 page no 955 n bits 824 index searchunique_idx of table `akeneo_pim`.`pim_catalog_completeness` trx id 10152778 lock_mode X locks rec but not gap
Record lock, heap no 717 PHYSICAL RECORD: n_fields 4; compact format; info bits 32
 0: len 4; hex 80000003; asc     ;;
 1: len 4; hex 80000024; asc    $;;
 2: len 4; hex 80045030; asc   P0;;
 3: len 4; hex 803e7c67; asc  >|g;;
*** (2) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 595 page no 933 n bits 824 index searchunique_idx of table `akeneo_pim`.`pim_catalog_completeness` trx id 10152778 lock_mode X locks rec but not gap waiting
Record lock, heap no 643 PHYSICAL RECORD: n_fields 4; compact format; info bits 0
 0: len 4; hex 80000003; asc     ;;
 1: len 4; hex 80000024; asc    $;;
 2: len 4; hex 80046b10; asc   k ;;
 3: len 4; hex 803e7df9; asc  >} ;;
*** WE ROLL BACK TRANSACTION (1)
```

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
