### PR TITLE
PIM-9101: Fix ambiguous internal_api route paths

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+-PIM-9101: Be able to create a family, a family variant, a group type, an association type named "rest".
+
 # 3.2.67 (2020-08-07)
 
 ## Bug fixes:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing.yml
@@ -26,11 +26,11 @@ internal_api_attribute_group:
 
 internal_api_family:
     resource: '@AkeneoPimStructureBundle/Resources/config/routing/internal_api/family.yml'
-    prefix: /configuration/family
+    prefix: /configuration/rest/family
 
 internal_api_family_variant:
     resource: '@AkeneoPimStructureBundle/Resources/config/routing/internal_api/family_variant.yml'
-    prefix: /configuration/family-variant
+    prefix: /configuration/rest/family-variant
 
 internal_api_attribute_option:
     resource: '@AkeneoPimStructureBundle/Resources/config/routing/internal_api/attribute_option.yml'
@@ -42,7 +42,7 @@ internal_api_attribute_type:
 
 association:
     resource: '@AkeneoPimStructureBundle/Resources/config/routing/internal_api/associationtype.yml'
-    prefix: /configuration/association-type
+    prefix: /configuration/rest/association-type
 
 reference_data_configuration:
     resource: '@AkeneoPimStructureBundle/Resources/config/routing/internal_api/reference_data_configuration.yml'
@@ -50,7 +50,7 @@ reference_data_configuration:
 
 internal_api_grouptype:
     resource: '@AkeneoPimStructureBundle/Resources/config/routing/internal_api/grouptype.yml'
-    prefix: /configuration/group-type
+    prefix: /configuration/rest/group-type
 
 ### Front routes
 front_routes:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/front.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/front.yml
@@ -29,6 +29,9 @@ pim_enrich_family_edit:
     requirements:
         code: '[a-zA-Z0-9_]+'
 
+pim_enrich_associationtype_index:
+    path: '/configuration/associationtype/'
+
 pim_enrich_associationtype_edit:
     path: '/configuration/association-type/{code}/edit'
     requirements:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/front.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/front.yml
@@ -30,7 +30,7 @@ pim_enrich_family_edit:
         code: '[a-zA-Z0-9_]+'
 
 pim_enrich_associationtype_index:
-    path: '/configuration/associationtype/'
+    path: '/configuration/association-type/'
 
 pim_enrich_associationtype_edit:
     path: '/configuration/association-type/{code}/edit'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/associationtype.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/associationtype.yml
@@ -2,31 +2,31 @@ pim_enrich_associationtype_index:
     path: ''
 
 pim_enrich_associationtype_rest_create:
-    path: /rest
+    path: ''
     defaults: { _controller: pim_enrich.controller.rest.association_type:createAction }
     methods: [POST]
 
 pim_enrich_associationtype_rest_index:
-    path: /rest
+    path: ''
     defaults: { _controller: pim_enrich.controller.rest.association_type:indexAction }
     methods: [GET]
 
 pim_enrich_associationtype_rest_get:
-    path: /rest/{identifier}
+    path: /{identifier}
     defaults: { _controller: pim_enrich.controller.rest.association_type:getAction }
     methods: [GET]
     requirements:
         identifier: '[a-zA-Z0-9_]+'
 
 pim_enrich_associationtype_rest_post:
-    path: /rest/{identifier}
+    path: /{identifier}
     defaults: { _controller: pim_enrich.controller.rest.association_type:postAction }
     methods: [POST]
     requirements:
         identifier: '[a-zA-Z0-9_]+'
 
 pim_enrich_associationtype_rest_remove:
-    path: /rest/{code}
+    path: /{code}
     defaults: { _controller: pim_enrich.controller.rest.association_type:removeAction }
     methods: [DELETE]
     requirements:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/associationtype.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/associationtype.yml
@@ -1,6 +1,3 @@
-pim_enrich_associationtype_index:
-    path: ''
-
 pim_enrich_associationtype_rest_create:
     path: ''
     defaults: { _controller: pim_enrich.controller.rest.association_type:createAction }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/family.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/family.yml
@@ -1,48 +1,48 @@
 pim_enrich_family_rest_create:
-    path: /rest
+    path: ''
     defaults: { _controller: pim_enrich.controller.rest.family:createAction }
     methods: [POST]
 
 pim_enrich_family_rest_index:
-    path: /rest
+    path: ''
     defaults: { _controller: pim_enrich.controller.rest.family:indexAction }
     methods: [GET]
 
 pim_enrich_family_index_get_variants:
-    path: /rest/variants
+    path: /with-variants
     defaults: { _controller: pim_enrich.controller.rest.family:getWithVariantsAction }
     methods: [GET]
 
 pim_enrich_family_rest_get:
-    path: /rest/{identifier}
+    path: /{identifier}
     defaults: { _controller: pim_enrich.controller.rest.family:getAction }
     requirements:
         identifier: '[a-zA-Z0-9_]+'
     methods: [GET]
 
 pim_enrich_family_rest_put:
-    path: /rest/{code}
+    path: /{code}
     defaults: { _controller: pim_enrich.controller.rest.family:putAction }
     requirements:
         code: '[a-zA-Z0-9_]+'
     methods: [PUT]
 
 pim_enrich_family_rest_remove:
-    path: /rest/{code}
+    path: /{code}
     defaults: { _controller: pim_enrich.controller.rest.family:removeAction }
     requirements:
         code: '[a-zA-Z0-9_]+'
     methods: [DELETE]
 
 pim_enrich_family_variant_rest_get:
-    path: /rest/family_variant/{identifier}
+    path: /family-variant/{identifier}
     defaults: { _controller: pim_enrich.controller.rest.family_variant:getAction }
     requirements:
         identifier: '[a-zA-Z0-9_]+'
     methods: [GET]
 
 pim_enrich_family_rest_get_available_axes:
-    path: /rest/{code}/available_axes
+    path: /{code}/available-axes
     defaults: { _controller: pim_enrich.controller.rest.family:getAvailableAxesAction }
     requirements:
         code: '[a-zA-Z0-9_]+'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/family_variant.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/family_variant.yml
@@ -1,22 +1,22 @@
 pim_enrich_family_variant_rest_index:
-    path: /rest
+    path: ''
     defaults: { _controller: pim_enrich.controller.rest.family_variant:indexAction }
     methods: [GET]
 
 pim_enrich_family_variant_rest_create:
-    path: /rest
+    path: ''
     defaults: { _controller: pim_enrich.controller.rest.family_variant:createAction }
     methods: [POST]
 
 pim_enrich_family_variant_rest_put:
-    path: /rest/{identifier}
+    path: /{identifier}
     defaults: { _controller: pim_enrich.controller.rest.family_variant:putAction }
     requirements:
         identifier: '[a-zA-Z0-9_]+'
     methods: [PUT]
 
 pim_enrich_family_variant_rest_remove:
-    path: /rest/{familyVariantCode}
+    path: /{familyVariantCode}
     defaults: { _controller: pim_enrich.controller.rest.family_variant:removeAction }
     requirements:
         familyVariantCode: '[a-zA-Z0-9_]+'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/grouptype.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/grouptype.yml
@@ -1,29 +1,29 @@
 pim_enrich_grouptype_rest_create:
-    path: /rest
+    path: ''
     defaults: { _controller: pim_enrich.controller.rest.group_type:createAction }
     methods: [POST]
 
 pim_enrich_grouptype_rest_index:
-    path: /rest
+    path: ''
     defaults: { _controller: pim_enrich.controller.rest.group_type:indexAction }
     methods: [GET]
 
 pim_enrich_grouptype_rest_get:
-    path: /rest/{identifier}
+    path: /{identifier}
     defaults: { _controller: pim_enrich.controller.rest.group_type:getAction }
     methods: [GET]
     requirements:
         identifier: '[a-zA-Z0-9_]+'
 
 pim_enrich_grouptype_rest_post:
-    path: /rest/{identifier}
+    path: /{identifier}
     defaults: { _controller: pim_enrich.controller.rest.group_type:postAction }
     methods: [POST]
     requirements:
         identifier: '[a-zA-Z0-9_]+'
 
 pim_enrich_grouptype_rest_remove:
-    path: /rest/{code}
+    path: /{code}
     defaults: { _controller: pim_enrich.controller.rest.group_type:removeAction }
     methods: [DELETE]
     requirements:

--- a/tests/front/integration/pimenrich/fetcher/family-fetcher.integration.js
+++ b/tests/front/integration/pimenrich/fetcher/family-fetcher.integration.js
@@ -7,7 +7,7 @@ describe('Pimenrich > fetcher > family', () => {
 
   it('provide an empty list of axis', async () => {
     page.once('request', request => {
-      if (request.url().includes('/configuration/family/rest/camcorder/available_axes')) {
+      if (request.url().includes('/configuration/rest/family/camcorder/available-axes')) {
         request.respond({
           contentType: 'application/json',
           body: '[]',
@@ -28,7 +28,7 @@ describe('Pimenrich > fetcher > family', () => {
 
   it('provide an non empty list of axis', async () => {
     page.once('request', request => {
-      if (request.url().includes('/configuration/family/rest/camcorder/available_axes')) {
+      if (request.url().includes('/configuration/rest/family/camcorder/available-axes')) {
         request.respond({
           contentType: 'application/json',
           body: JSON.stringify([attribute]),


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Given the right parameters, a number of routes can be mistaken for one another.
For instance, after creating a `rest` family from the UI, the modal redirects to the `pim_enrich_family_edit` (`/configuration/family/{code =  rest}/edit`), but the front router first matches the `pim_enrich_family_rest_get` route (`/configuration/family/rest/{identifier = edit}`), resulting in a 404

This PR aims at fixing these routes, only modifying paths for `internal_api` routes, as frontend ones may be bookmarked by users. Obviously I didn't update the `external_api` ones.

I couldn't think of any side effect, as I didn't change the route names or their parameters, feel free to point out my mistake if you find a counterexample though.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
