### PR TITLE
PIM-9090: Pagination and infinite scroll on variants list for Product models

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes 
+
+- PIM-9090: Add infinite scroll on variants list for Product models
+
 # 3.0.68 (2020-02-19)
 
 # 3.0.67 (2020-02-10)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductModelController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductModelController.php
@@ -290,10 +290,14 @@ class ProductModelController
      */
     public function childrenAction(Request $request): JsonResponse
     {
+        $limit = $request->get('limit') ? (int) $request->get('limit') : null;
+        $page = $request->get('page') ? (int) $request->get('page') : null;
         $parent = $this->findProductModelOr404($request->get('id'));
-        $children = $this->productModelRepository->findChildrenProductModels($parent);
-        if (empty($children)) {
-            $children = $this->productModelRepository->findChildrenProducts($parent);
+
+        if (1 === $parent->getVariationLevel() || 1 === $parent->getFamilyVariant()->getNumberOfLevel()) {
+            $children = $this->productModelRepository->findChildrenProducts($parent, $limit, $page);
+        } else {
+            $children = $this->productModelRepository->findChildrenProductModels($parent, $limit, $page);
         }
 
         $normalizedChildren = [];

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
@@ -79,12 +79,15 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
     /**
      * {@inheritdoc}
      */
-    public function findChildrenProductModels(ProductModelInterface $productModel): array
+    public function findChildrenProductModels(ProductModelInterface $productModel, ?int $limit, ?int $page): array
     {
         $qb = $this
             ->createQueryBuilder('pm')
             ->where('pm.parent = :parent')
-            ->setParameter('parent', $productModel);
+            ->orderBy('pm.id', 'ASC')
+            ->setParameter('parent', $productModel)
+            ->setMaxResults($limit)
+            ->setFirstResult(($page - 1) * $limit);
 
         return $qb->getQuery()->execute();
     }
@@ -118,7 +121,7 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
     /**
      * {@inheritdoc}
      */
-    public function findChildrenProducts(ProductModelInterface $productModel): array
+    public function findChildrenProducts(ProductModelInterface $productModel, ?int $limit, ?int $page): array
     {
         $qb = $this
             ->_em
@@ -126,7 +129,10 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
             ->select('p')
             ->from(Product::class, 'p')
             ->where('p.parent = :parent')
-            ->setParameter('parent', $productModel);
+            ->setParameter('parent', $productModel)
+            ->orderBy('p.id', 'ASC')
+            ->setMaxResults($limit)
+            ->setFirstResult(($page - 1) * $limit);
 
         return $qb->getQuery()->execute();
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
@@ -79,7 +79,7 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
     /**
      * {@inheritdoc}
      */
-    public function findChildrenProductModels(ProductModelInterface $productModel, ?int $limit, ?int $page): array
+    public function findChildrenProductModels(ProductModelInterface $productModel, ?int $limit = null, ?int $page = null): array
     {
         $qb = $this
             ->createQueryBuilder('pm')
@@ -87,7 +87,7 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
             ->orderBy('pm.id', 'ASC')
             ->setParameter('parent', $productModel);
 
-        if (null !== $limit  && null !== $page) {
+        if (null !== $limit && null !== $page) {
             $qb->setMaxResults($limit)
                 ->setFirstResult(($page - 1) * $limit);
         }
@@ -124,7 +124,7 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
     /**
      * {@inheritdoc}
      */
-    public function findChildrenProducts(ProductModelInterface $productModel, ?int $limit, ?int $page): array
+    public function findChildrenProducts(ProductModelInterface $productModel, ?int $limit = null, ?int $page = null): array
     {
         $qb = $this
             ->_em

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
@@ -85,9 +85,12 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
             ->createQueryBuilder('pm')
             ->where('pm.parent = :parent')
             ->orderBy('pm.id', 'ASC')
-            ->setParameter('parent', $productModel)
-            ->setMaxResults($limit)
-            ->setFirstResult(($page - 1) * $limit);
+            ->setParameter('parent', $productModel);
+
+        if (null !== $limit  && null !== $page) {
+            $qb->setMaxResults($limit)
+                ->setFirstResult(($page - 1) * $limit);
+        }
 
         return $qb->getQuery()->execute();
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Repository/ProductModelRepositoryInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Repository/ProductModelRepositoryInterface.php
@@ -40,10 +40,12 @@ interface ProductModelRepositoryInterface extends
      * Find product models which are the direct children of the given $productModel
      *
      * @param ProductModelInterface $productModel
+     * @param int|null $limit
+     * @param int|null $page
      *
      * @return array|ProductModelInterface[]
      */
-    public function findChildrenProductModels(ProductModelInterface $productModel): array;
+    public function findChildrenProductModels(ProductModelInterface $productModel, ?int $limit, ?int $page): array;
 
     /**
      * Returns the identifiers of the products belonging to a product model descendants subtree
@@ -67,10 +69,12 @@ interface ProductModelRepositoryInterface extends
      * Find variant products which are the direct children of the given $productModel
      *
      * @param ProductModelInterface $productModel
+     * @param int|null $limit
+     * @param int|null $page
      *
      * @return array
      */
-    public function findChildrenProducts(ProductModelInterface $productModel): array;
+    public function findChildrenProducts(ProductModelInterface $productModel, ?int $limit, ?int $page): array;
 
     /**
      * Get root products models after the one provided. Mainly used to iterate

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
@@ -252,7 +252,7 @@ define(
              *
              * @param {String} parentCode
              */
-            openModal: function(parentCode) {
+            openModal: function (parentCode) {
                 const modalParameters = {
                     className: 'modal modal--fullPage add-product-model-child',
                     content: '',
@@ -261,7 +261,7 @@ define(
                     okCloses: false
                 };
 
-                this.isVariantProduct(parentCode)
+                this.isVariantProduct (parentCode)
                     .then((isVariantProduct) => {
                         const initialModalState = {
                             parent: parentCode,

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
@@ -161,12 +161,6 @@ define(
                                 };
                             }
                         }
-                        // query: (options) => {
-                        //     this.queryChildrenEntities(
-                        //         options,
-                        //         entity.meta.variant_navigation[index].selected.id
-                        //     );
-                        // }
                     };
 
                     const dropDown = initSelect2.init($select, options);
@@ -188,7 +182,7 @@ define(
              *
              * @param {Element} dropDown
              */
-            addSelect2Footer: function (dropDown) {
+            addSelect2Footer: function(dropDown) {
                 $('#select2-drop .select2-drop-footer').remove();
 
                 const targetLevel = dropDown[0].dataset.level;
@@ -207,11 +201,11 @@ define(
                                 $('#select2-drop')
                                     .append(footer)
                                     .find('.select2-drop-footer').on('click', '.add-child', () => {
-                                    dropDown.select2('close');
-                                    this.openModal(parentCode);
-                                });
+                                        dropDown.select2('close');
+                                        this.openModal(parentCode);
+                                    });
                             });
-                    });
+                    })
             },
 
             /**
@@ -221,7 +215,7 @@ define(
              *
              * @returns {Promise<boolean>}
              */
-            isCreationGranted: async function (isVariantProduct) {
+            isCreationGranted: async function(isVariantProduct) {
                 return (isVariantProduct && SecurityContext.isGranted('pim_enrich_product_create'))
                     || (!isVariantProduct && SecurityContext.isGranted('pim_enrich_product_model_create'));
             },
@@ -243,8 +237,7 @@ define(
                         .fetch(entity.parent)
                         .then((parent) => {
                             return parent.parent;
-                        })
-                        ;
+                        });
                 }
 
                 if (targetLevel > entityLevel) {
@@ -259,7 +252,7 @@ define(
              *
              * @param {String} parentCode
              */
-            openModal: function (parentCode) {
+            openModal: function(parentCode) {
                 const modalParameters = {
                     className: 'modal modal--fullPage add-product-model-child',
                     content: '',
@@ -337,7 +330,7 @@ define(
                                 const currentLevel = parent.meta.level + 1;
 
                                 return currentLevel === familyVariant.variant_attribute_sets.length;
-                            });
+                            })
                     });
             },
 
@@ -366,7 +359,7 @@ define(
                     };
                 } else {
                     const completenesses = entity.completeness.completenesses;
-                    const totalProducts = entity.completeness.total;
+                    const totalProducts  = entity.completeness.total;
                     let completeProducts = 0;
 
                     if (_.has(completenesses, catalogScope) &&

--- a/tests/back/Acceptance/ProductModel/InMemoryProductModelRepository.php
+++ b/tests/back/Acceptance/ProductModel/InMemoryProductModelRepository.php
@@ -81,7 +81,7 @@ class InMemoryProductModelRepository implements IdentifiableObjectRepositoryInte
         throw new NotImplementedException(__METHOD__);
     }
 
-    public function findChildrenProductModels(ProductModelInterface $productModel): array
+    public function findChildrenProductModels(ProductModelInterface $productModel, ?int $limit, ?int $page): array
     {
         throw new NotImplementedException(__METHOD__);
     }
@@ -96,7 +96,7 @@ class InMemoryProductModelRepository implements IdentifiableObjectRepositoryInte
         throw new NotImplementedException(__METHOD__);
     }
 
-    public function findChildrenProducts(ProductModelInterface $productModel): array
+    public function findChildrenProducts(ProductModelInterface $productModel, ?int $limit, ?int $page): array
     {
         throw new NotImplementedException(__METHOD__);
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->
Previously : On a product model page, when we displayed the variations list (sub product models or variations) all options are loaded, and if we had a lot of variations, it was taking a long time to be loaded.

I transformed the loading so that the variations list displays its children with a pagination and 20 children on each page. 
So, now, when we display the variations list,, all options are loaded quickly.


![infinit_scroll_product_models](https://user-images.githubusercontent.com/57708349/75258476-c9535e00-57e6-11ea-8efd-5db6a4142685.gif)




**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
