### PR TITLE
API-1007: Update charts to display only connection with audit enabled

### DIFF
--- a/src/Akeneo/Connectivity/Connection/front/src/audit/components/Charts.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/components/Charts.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect} from 'react';
 import {AuditEventType} from '../../model/audit-event-type.enum';
-import {Connection} from '../../model/connection';
 import {FlowType} from '../../model/flow-type.enum';
 import {fetchResult} from '../../shared/fetch-result';
 import {isOk} from '../../shared/fetch-result/result';
@@ -9,7 +8,7 @@ import {Translate} from '../../shared/translate';
 import {sourceConnectionsFetched} from '../actions/dashboard-actions';
 import {useDashboardDispatch, useDashboardState} from '../dashboard-context';
 import {blueTheme, purpleTheme} from '../event-chart-themes';
-import {SourceConnection} from '../model/source-connection';
+import {SourceConnection, Connection} from '../model/source-connection';
 import {EventChart} from './EventChart';
 import {NoConnection} from './NoConnection';
 import {UserSurvey} from './UserSurvey';
@@ -23,7 +22,8 @@ export const Charts = () => {
         fetchResult<Connection[], never>(route).then(result => {
             if (isOk(result) && !cancelled) {
                 const sourceConnections = result.value.filter(
-                    (connection): connection is SourceConnection => FlowType.DATA_SOURCE === connection.flowType
+                    (connection): connection is SourceConnection =>
+                        FlowType.DATA_SOURCE === connection.flowType && connection.auditable
                 );
 
                 dispatch(sourceConnectionsFetched(sourceConnections));

--- a/src/Akeneo/Connectivity/Connection/front/src/audit/components/EventChart.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/components/EventChart.tsx
@@ -65,6 +65,7 @@ export const EventChart: FC<Props> = ({title, eventType, theme}: Props) => {
         label: translate('akeneo_connectivity.connection.dashboard.connection_selector.all'),
         flowType: connections[0].flowType,
         image: null,
+        auditable: true,
     });
 
     return (

--- a/src/Akeneo/Connectivity/Connection/front/src/audit/model/source-connection.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/model/source-connection.ts
@@ -1,5 +1,12 @@
 import {FlowType} from '../../model/flow-type.enum';
-import {Connection} from '../../model/connection';
+
+export type Connection = {
+    code: string;
+    label: string;
+    image: string | null;
+    auditable: boolean;
+    flowType: FlowType;
+};
 
 export type SourceConnection = Connection & {
     flowType: FlowType.DATA_SOURCE;

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/audit/pages/Dashboard.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/audit/pages/Dashboard.test.tsx
@@ -18,6 +18,14 @@ describe('testing Dashboard page', () => {
                             label: 'Bynder',
                             flowType: 'data_source',
                             image: null,
+                            auditable: true,
+                        },
+                        {
+                            code: 'erp',
+                            label: 'ERP',
+                            flowType: 'data_source',
+                            image: null,
+                            auditable: false,
                         },
                     ];
                 case 'akeneo_connectivity_connection_rest_audit_source_connections_event?event_type=product_created':

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/audit/reducers/dashboard-reducer.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/audit/reducers/dashboard-reducer.test.ts
@@ -19,12 +19,14 @@ describe('Dashboard reducer', () => {
                 label: 'Franklin',
                 flowType: FlowType.DATA_SOURCE,
                 image: null,
+                auditable: true,
             },
             {
                 code: 'bynder',
                 label: 'Bynder',
                 flowType: FlowType.DATA_SOURCE,
                 image: null,
+                auditable: true,
             },
         ]);
 
@@ -37,12 +39,14 @@ describe('Dashboard reducer', () => {
                     label: 'Franklin',
                     flowType: FlowType.DATA_SOURCE,
                     image: null,
+                    auditable: true,
                 },
                 bynder: {
                     code: 'bynder',
                     label: 'Bynder',
                     flowType: FlowType.DATA_SOURCE,
                     image: null,
+                    auditable: true,
                 },
             },
             events: {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
