### PR TITLE
MET-48: Add create/update service to update measurements

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyCommand.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily;
+
+/**
+ * @author    Valentin Dijkstra <valentin.dijkstra@akeneo.com>
+ * @copyright 2020 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class SaveMeasurementFamilyCommand
+{
+    /** @var string */
+    public $code;
+
+    /** @var array */
+    public $labels;
+
+    /** @var string */
+    public $standardUnitCode;
+
+    /** @var array */
+    public $units;
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandler.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandler.php
@@ -27,7 +27,7 @@ class SaveMeasurementFamilyHandler
         $this->measurementFamilyRepository = $measurementFamilyRepository;
     }
 
-    public function __invoke(SaveMeasurementFamilyCommand $measurementFamilyCommand): void
+    public function handle(SaveMeasurementFamilyCommand $measurementFamilyCommand): void
     {
         $units = array_map(function (array $unit) {
             $operations = array_map(function (array $operation) {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandler.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+
+/**
+ * @author    Valentin Dijkstra <valentin.dijkstra@akeneo.com>
+ * @copyright 2020 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class SaveMeasurementFamilyHandler
+{
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+
+    public function __construct(MeasurementFamilyRepositoryInterface $measurementFamilyRepository)
+    {
+        $this->measurementFamilyRepository = $measurementFamilyRepository;
+    }
+
+    public function __invoke(SaveMeasurementFamilyCommand $measurementFamilyCommand): void
+    {
+        $units = array_map(function (array $unit) {
+            $operations = array_map(function (array $operation) {
+                return Operation::create(
+                    $operation['operator'],
+                    $operation['value']
+                );
+            }, $unit['convert_from_standard']);
+
+            return Unit::create(
+                UnitCode::fromString($unit['code']),
+                LabelCollection::fromArray($unit['labels']),
+                $operations,
+                $unit['symbol']
+            );
+        }, $measurementFamilyCommand->units);
+
+        $measurementFamily = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString($measurementFamilyCommand->code),
+            LabelCollection::fromArray($measurementFamilyCommand->labels),
+            UnitCode::fromString($measurementFamilyCommand->standardUnitCode),
+            $units
+        );
+
+        $this->measurementFamilyRepository->save($measurementFamily);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -51,6 +51,40 @@ class MeasurementFamilyRepository implements MeasurementFamilyRepositoryInterfac
         return $this->measurementFamilyCache[$measurementFamilyCode->normalize()];
     }
 
+    public function save(MeasurementFamily $measurementFamily)
+    {
+        $updateSql = <<<SQL
+    INSERT INTO akeneo_measurement
+        (code, labels, standard_unit, units)
+    VALUES
+        (:code, :labels, :standard_unit, :units)
+    ON DUPLICATE KEY UPDATE
+        labels = :labels,
+        standard_unit = :standard_unit,
+        units = :units;
+SQL;
+        $normalizedMeasurementFamily = $measurementFamily->normalize();
+
+        $affectedRows = $this->sqlConnection->executeUpdate(
+            $updateSql,
+            [
+                'code' => $normalizedMeasurementFamily['code'],
+                'labels' => json_encode($normalizedMeasurementFamily['labels']),
+                'standard_unit' => $normalizedMeasurementFamily['standard_unit_code'],
+                'units' => json_encode($normalizedMeasurementFamily['units'])
+            ]
+        );
+
+        if ($affectedRows !== 1 && $affectedRows !== 2) {
+            throw new \RuntimeException(
+                sprintf('Expected to create/update one measurement family, but %d were affected', $affectedRows)
+            );
+        }
+
+        $this->allMeasurementFamiliesCache[$normalizedMeasurementFamily['code']] = $measurementFamily;
+        $this->measurementFamilyCache[$normalizedMeasurementFamily['code']] = $measurementFamily;
+    }
+
     private function hydrateMeasurementFamily(
         string $code,
         string $normalizedLabels,

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -75,6 +75,7 @@ SQL;
             ]
         );
 
+        // 1 if INSERT, 2 if UPDATE
         if ($affectedRows !== 1 && $affectedRows !== 2) {
             throw new \RuntimeException(
                 sprintf('Expected to create/update one measurement family, but %d were affected', $affectedRows)
@@ -165,9 +166,9 @@ SQL;
         return $measurementFamiliesIndexByCodes;
     }
 
-	private function loadAssetFamily(MeasurementFamilyCode $measurementFamilyCode): ?MeasurementFamily
-	{
-		$sql = <<<SQL
+    private function loadAssetFamily(MeasurementFamilyCode $measurementFamilyCode): ?MeasurementFamily
+    {
+        $sql = <<<SQL
     SELECT
         code,
         labels,
@@ -177,21 +178,21 @@ SQL;
     WHERE `code` = :measurement_family_code;
 SQL;
 
-		$statement = $this->sqlConnection->executeQuery(
-			$sql,
-			['measurement_family_code' => $measurementFamilyCode->normalize()]
-		);
-		$result = $statement->fetch(\PDO::FETCH_ASSOC);
+        $statement = $this->sqlConnection->executeQuery(
+            $sql,
+            ['measurement_family_code' => $measurementFamilyCode->normalize()]
+        );
+        $result = $statement->fetch(\PDO::FETCH_ASSOC);
 
-		if (!$result) {
-			throw new MeasurementFamilyNotFoundException();
-		}
+        if (!$result) {
+            throw new MeasurementFamilyNotFoundException();
+        }
 
-		return $this->hydrateMeasurementFamily(
-			$result['code'],
-			$result['labels'],
-			$result['standard_unit'],
-			$result['units']
-		);
-	}
+        return $this->hydrateMeasurementFamily(
+            $result['code'],
+            $result['labels'],
+            $result['standard_unit'],
+            $result['units']
+        );
+    }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepositoryInterface.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepositoryInterface.php
@@ -12,4 +12,6 @@ interface MeasurementFamilyRepositoryInterface
     public function all(): array;
 
     public function getByCode(MeasurementFamilyCode $measurementFamilyCode): MeasurementFamily;
+
+    public function save(MeasurementFamily $measurementFamily);
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandlerSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandlerSpec.php
@@ -34,7 +34,7 @@ class SaveMeasurementFamilyHandlerSpec extends ObjectBehavior
         $this->shouldHaveType(SaveMeasurementFamilyHandler::class);
     }
 
-    function it_creates_and_save_a_new_measurement_family(
+    function it_creates_and_saves_a_new_measurement_family(
         MeasurementFamilyRepositoryInterface $measurementFamilyRepository,
         SaveMeasurementFamilyCommand $saveMeasurementFamilyCommand
     ) {
@@ -87,6 +87,6 @@ class SaveMeasurementFamilyHandlerSpec extends ObjectBehavior
             return true;
         }))->shouldBeCalled();
 
-        $this->__invoke($saveMeasurementFamilyCommand);
+        $this->handle($saveMeasurementFamilyCommand);
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandlerSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandlerSpec.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyHandler;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Webmozart\Assert\Assert;
+
+/**
+ * @author    Valentin Dijkstra <valentin.dijkstra@akeneo.com>
+ * @copyright 2020 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class SaveMeasurementFamilyHandlerSpec extends ObjectBehavior
+{
+    function let(MeasurementFamilyRepositoryInterface $measurementFamilyRepository)
+    {
+        $this->beConstructedWith($measurementFamilyRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(SaveMeasurementFamilyHandler::class);
+    }
+
+    function it_creates_and_save_a_new_measurement_family(
+        MeasurementFamilyRepositoryInterface $measurementFamilyRepository,
+        SaveMeasurementFamilyCommand $saveMeasurementFamilyCommand
+    ) {
+        $saveMeasurementFamilyCommand->code = 'Area';
+        $saveMeasurementFamilyCommand->labels = ["en_US" => "Area", "fr_FR" => "Surface"];
+        $saveMeasurementFamilyCommand->standardUnitCode = 'SQUARE_MILLIMETER';
+        $saveMeasurementFamilyCommand->units = [
+          [
+              'code' => 'SQUARE_MILLIMETER',
+              'labels' => ["en_US" => "Square millimeter", "fr_FR" => "Millimètre carré"],
+              'convert_from_standard' => [[
+                  'operator' => 'mul',
+                  'value' => '0.000001'
+              ]],
+              'symbol' => 'mm²'
+          ],
+          [
+              'code' => 'SQUARE_CENTIMETER',
+              'labels' => ["en_US" => "Square centimeter", "fr_FR" => "Centimètre carré"],
+              'convert_from_standard' => [[
+                  'operator' => 'mul',
+                  'value' => '0.0001'
+              ]],
+              'symbol' => 'cm²'
+          ]
+        ];
+
+        $expectedArea = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('Area'),
+            LabelCollection::fromArray(["en_US" => "Area", "fr_FR" => "Surface"]),
+            UnitCode::fromString('SQUARE_MILLIMETER'),
+            [
+                Unit::create(
+                    UnitCode::fromString('SQUARE_MILLIMETER'),
+                    LabelCollection::fromArray(["en_US" => "Square millimeter", "fr_FR" => "Millimètre carré"]),
+                    [Operation::create("mul", "0.000001")],
+                    "mm²",
+                ),
+                Unit::create(
+                    UnitCode::fromString('SQUARE_CENTIMETER'),
+                    LabelCollection::fromArray(["en_US" => "Square centimeter", "fr_FR" => "Centimètre carré"]),
+                    [Operation::create("mul", "0.0001")],
+                    "cm²",
+                )
+            ]
+        );
+
+        $measurementFamilyRepository->save(Argument::that(function ($area) use ($expectedArea) {
+            Assert::eq($expectedArea, $area);
+            return true;
+        }))->shouldBeCalled();
+
+        $this->__invoke($saveMeasurementFamilyCommand);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/Persistence/MeasurementFamilyRepositoryIntegration.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/Persistence/MeasurementFamilyRepositoryIntegration.php
@@ -44,7 +44,7 @@ class MeasurementFamilyRepositoryIntegration extends SqlIntegrationTestCase
         $measurementFamilies = $this->repository->all();
 
         $this->assertCount(2, $measurementFamilies);
-        $this->assertEquals($this->getMeasurementFamily(), $measurementFamilies[0]);
+        $this->assertEquals($this->createMeasurementFamily(), $measurementFamilies[0]);
     }
 
     /**
@@ -54,7 +54,7 @@ class MeasurementFamilyRepositoryIntegration extends SqlIntegrationTestCase
     {
         $measurementFamily = $this->repository->getByCode(MeasurementFamilyCode::fromString('Area'));
 
-        $this->assertEquals($this->getMeasurementFamily(), $measurementFamily);
+        $this->assertEquals($this->createMeasurementFamily(), $measurementFamily);
     }
 
     /**
@@ -72,7 +72,7 @@ class MeasurementFamilyRepositoryIntegration extends SqlIntegrationTestCase
      */
     public function it_updates_an_existing_measurement_family_if_it_exists(): void
     {
-        $area = $this->getMeasurementFamily('Area', ["en_US" => "New area label", "fr_FR" => "Nouveau surface label"]);
+        $area = $this->createMeasurementFamily('Area', ["en_US" => "New area label", "fr_FR" => "Nouveau surface label"]);
         $this->repository->save($area);
 
         $updatedArea = $this->repository->getByCode(MeasurementFamilyCode::fromString('Area'));
@@ -87,7 +87,7 @@ class MeasurementFamilyRepositoryIntegration extends SqlIntegrationTestCase
         $measurementFamilies = $this->repository->all();
         $this->assertCount(2, $measurementFamilies);
 
-        $area = $this->getMeasurementFamily('NewFamily', ["en_US" => "New family label", "fr_FR" => "Nouveau famille label"]);
+        $area = $this->createMeasurementFamily('NewFamily', ["en_US" => "New family label", "fr_FR" => "Nouveau famille label"]);
         $this->repository->save($area);
 
         $updatedArea = $this->repository->getByCode(MeasurementFamilyCode::fromString('NewFamily'));
@@ -97,7 +97,7 @@ class MeasurementFamilyRepositoryIntegration extends SqlIntegrationTestCase
         $this->assertCount(3, $measurementFamilies);
     }
 
-    private function getMeasurementFamily(string $code = 'Area', array $labels = ["en_US" => "Area", "fr_FR" => "Surface"]): MeasurementFamily
+    private function createMeasurementFamily(string $code = 'Area', array $labels = ["en_US" => "Area", "fr_FR" => "Surface"]): MeasurementFamily
     {
         return MeasurementFamily::create(
             MeasurementFamilyCode::fromString($code),

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/Persistence/MeasurementFamilyRepositoryIntegration.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/Persistence/MeasurementFamilyRepositoryIntegration.php
@@ -87,11 +87,11 @@ class MeasurementFamilyRepositoryIntegration extends SqlIntegrationTestCase
         $measurementFamilies = $this->repository->all();
         $this->assertCount(2, $measurementFamilies);
 
-        $area = $this->createMeasurementFamily('NewFamily', ["en_US" => "New family label", "fr_FR" => "Nouveau famille label"]);
-        $this->repository->save($area);
+        $newFamily = $this->createMeasurementFamily('NewFamily', ["en_US" => "New family label", "fr_FR" => "Nouveau famille label"]);
+        $this->repository->save($newFamily);
 
-        $updatedArea = $this->repository->getByCode(MeasurementFamilyCode::fromString('NewFamily'));
-        $this->assertEquals($area, $updatedArea);
+        $newFamilyFetched = $this->repository->getByCode(MeasurementFamilyCode::fromString('NewFamily'));
+        $this->assertEquals($newFamily, $newFamilyFetched);
 
         $measurementFamilies = $this->repository->all();
         $this->assertCount(3, $measurementFamilies);

--- a/tests/back/Acceptance/MeasurementFamily/InMemoryMeasurementFamilyRepository.php
+++ b/tests/back/Acceptance/MeasurementFamily/InMemoryMeasurementFamilyRepository.php
@@ -62,4 +62,9 @@ class InMemoryMeasurementFamilyRepository implements MeasurementFamilyRepository
             )
         ];
     }
+
+    public function save(MeasurementFamily $measurementFamily)
+    {
+        $this->measurementFamilies[$measurementFamily->normalize()['code']] = $measurementFamily;
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR:
- Adds a save method in `MeasurementFamilyRepository` which updates an existing family and creates it if it doesn't exist already
- Adds a `SaveMeasurementFamilyCommand` & `SaveMeasurementFamilyHandler`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
