### PR TITLE
PIM-9111: Fix the variant list when the channel does not support the selected locale

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9111: Fix the variant list when the channel does not support the selected locale
+
 # 3.2.41 (2020-02-26)
 
 ## Bug fixes:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
@@ -335,7 +335,7 @@ define(
 
                 if ('product' === entity.model_type) {
                     const channelCompletenesses = _.findWhere(entity.completeness, {channel: catalogScope});
-                    if (channelCompletenesses === undefined) {
+                    if (channelCompletenesses === undefined || channelCompletenesses.locales[catalogLocale] === undefined) {
                         return {
                             ratio: 0
                         };

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
@@ -335,8 +335,8 @@ define(
 
                 if ('product' === entity.model_type) {
                     const channelCompletenesses = _.findWhere(entity.completeness, {channel: catalogScope});
-                    if (channelCompletenesses === undefined ||
-                        channelCompletenesses.locales[catalogLocale] === undefined) {
+                    if (undefined === channelCompletenesses ||
+                        undefined === channelCompletenesses.locales[catalogLocale]) {
                         return {
                             ratio: 0
                         };

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
@@ -335,7 +335,8 @@ define(
 
                 if ('product' === entity.model_type) {
                     const channelCompletenesses = _.findWhere(entity.completeness, {channel: catalogScope});
-                    if (channelCompletenesses === undefined || channelCompletenesses.locales[catalogLocale] === undefined) {
+                    if (channelCompletenesses === undefined ||
+                        channelCompletenesses.locales[catalogLocale] === undefined) {
                         return {
                             ratio: 0
                         };


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

How to reproduce:
- create a new channel with only one locale (eg: fr_FR)
- open a product model PEF
- switch to a channel with several locales
- switch to a locale not used in the new channel (eg: en_US)
- open the variant list (everything is ok)
- switch to the new channel (selected locale is still en_US)
- open the variant list 

There is a fatal js error in the dropdown because the dropdown tries to retrieve the completeness using the selected locale, see https://github.com/akeneo/pim-community-dev/blob/f2be06998b7477eccead072a6d016d774a9f52ef/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js#L343

But this locale does not exists in this channel.

The proposed fix is to simply check if the selected locale exists for this channel, and if not, fallback to a completeness ratio of `0`.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
