### PR TITLE
Add design system CI configuration for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,34 @@ jobs:
           - store_artifacts:
                 path: var/logs
 
+  build_and_test_akeneo-design-system:
+      machine:
+          image: ubuntu-1604:201903-01
+      steps:
+          - attach_workspace:
+                at: ~/
+          - restore_cache:
+                name: Restore node_modules cache
+                keys:
+                  - akeneo-design-system-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+          - run:
+                name: Install node_modules
+                working_directory: akeneo-design-system
+                command: make _yarn
+          - save_cache:
+                name: Cache node_modules
+                paths:
+                  - node_modules
+                key: akeneo-design-system-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+          - run:
+                name: Run tests
+                working_directory: akeneo-design-system
+                command: make test
+          - persist_to_workspace:
+                root: ~/
+                paths:
+                  - project
+
 workflows:
   version: 2
   pull_request:
@@ -293,6 +321,9 @@ workflows:
                     - test_back_data_migrations
                     - test_back_missing_structure_migrations
                     - test_back_phpunit
+          - build_and_test_akeneo-design-system:
+                requires:
+                    - build_dev
 
   nightly:
       triggers:
@@ -317,5 +348,8 @@ workflows:
                 requires:
                     - build_dev
           - back_behat_legacy:
+                requires:
+                    - build_dev
+          - build_and_test_akeneo-design-system:
                 requires:
                     - build_dev

--- a/akeneo-design-system/Makefile
+++ b/akeneo-design-system/Makefile
@@ -11,3 +11,8 @@ _yarn:
 storybook: _yarn
 	@echo "\e[7m\e[92m Start Storybook development server on http://localhost:$(DOCKER_PORT_STORYBOOK)/ \e[0m"
 	$(_YARN) run start-storybook -h 0.0.0.0 -p 80 --ci
+
+# Run the tests
+.PHONY: test
+test: _yarn
+	$(_YARN) run jest


### PR DESCRIPTION
Add a specific job `build_and_test_akeneo-design-system` inside the PIM circleci workflow.

_Why not a separate workflow?_
So that the user/developer doesn't have to trigger a second workflow by hand.

_Why not separate jobs for build and test?_
CI is expensive and our steps are relatively simple for now.