### PR TITLE
PIM-9110: lock tables to insert completeness if we still have deadlocks after 5 attempts

### DIFF
--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -22,6 +22,7 @@ $rules = [
         'Liip\ImagineBundle',
         'Dompdf\Dompdf',
         'Webmozart\Assert\Assert',
+        'Psr\Log\LoggerInterface',
         // TODO the feature use the datagrid
         'Oro\Bundle\DataGridBundle',
         'Oro\Bundle\PimDataGridBundle',

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -114,6 +114,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Completeness\SqlSaveProductCompletenesses'
         arguments:
             - '@database_connection'
+            - '@logger'
 
     akeneo.pim.enrichment.product.query.category_codes_by_product_identifiers:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\GetCategoryCodesByProductIdentifiers'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlSaveProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlSaveProductCompletenesses.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\DeadlockException;
 use Doctrine\DBAL\ParameterType;
+use Psr\Log\LoggerInterface;
 
 /**
  * @author    Mathias METAYER <mathias.metayer@akeneo.com>
@@ -20,9 +21,13 @@ final class SqlSaveProductCompletenesses implements SaveProductCompletenesses
     /** @var Connection */
     private $connection;
 
-    public function __construct(Connection $connection)
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(Connection $connection, LoggerInterface $logger)
     {
         $this->connection = $connection;
+        $this->logger = $logger;
     }
 
     /**
@@ -40,75 +45,68 @@ final class SqlSaveProductCompletenesses implements SaveProductCompletenesses
      * @see https://dev.mysql.com/doc/refman/5.7/en/insert-optimization.html
      *
      * There is retry strategy to mitigate the risk of dead lock when loading data with high concurrency.
-     * To avoid to get several dead lock exceptions in a row, we sleep between the retry. It lets the database take a breath and finish the other concurrent transactions triggering the deadlock.
-     * There is a random sleep as well, to avoid to execute the retried transaction at the same time of other concurrent processes doing a retry as well.
+     * With a high concurrency (30 threads), despite the retry strategy, it's still possible to have dead locks.
+     * In that case, we serialize the queries by locking the completeness table.
+     *
+     * @see https://dev.mysql.com/doc/refman/8.0/en/innodb-deadlocks-handling.html
      *
      * {@inheritdoc}
      */
     public function saveAll(array $productCompletenessCollections): void
     {
-        $retry = 0;
-        $isError = true;
-        while (true === $isError) {
-            try {
-                $this->connection->transactional(function (Connection $connection) use ($productCompletenessCollections) {
-                    $productIds = array_unique(array_map(function (ProductCompletenessWithMissingAttributeCodesCollection $productCompletenessCollection) {
-                        return $productCompletenessCollection->productId();
-                    }, $productCompletenessCollections));
+        // it gets the data outside of the transaction to avoid to lock the tables "pim_catalog_locale" and "pim_catalog_channel"
+        // when it locks the completeness table as a last attempt after failing 5 times due to deadlocks
+        $localeIdsFromCode = $this->localeIdsIndexedByLocaleCodes();
+        $channelIdsFromCode = $this->channelIdsIndexedByChannelCodes();
 
-                    $localeIdsFromCode = $this->localeIdsIndexedByLocaleCodes();
-                    $channelIdsFromCode = $this->channelIdsIndexedByChannelCodes();
+        $deleteAndInsertFunction = function () use ($productCompletenessCollections, $localeIdsFromCode, $channelIdsFromCode) {
+            $productIds = array_unique(array_map(function (ProductCompletenessWithMissingAttributeCodesCollection $productCompletenessCollection) {
+                return $productCompletenessCollection->productId();
+            }, $productCompletenessCollections));
 
-                    $connection->executeQuery(
-                        'DELETE FROM pim_catalog_completeness WHERE product_id IN (:product_ids)',
-                        ['product_ids' => $productIds],
-                        ['product_ids' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
-                    );
+            $this->connection->executeQuery(
+                'DELETE FROM pim_catalog_completeness WHERE product_id IN (:product_ids)',
+                ['product_ids' => $productIds],
+                ['product_ids' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
+            );
 
-                    $numberCompletenessRow = 0;
-                    foreach ($productCompletenessCollections as $productCompletenessCollection) {
-                        $numberCompletenessRow += count($productCompletenessCollection);
-                    }
-                    $placeholders = implode(',', array_fill(0, $numberCompletenessRow, '(?, ?, ?, ?, ?)'));
+            $numberCompletenessRow = 0;
+            foreach ($productCompletenessCollections as $productCompletenessCollection) {
+                $numberCompletenessRow += count($productCompletenessCollection);
+            }
+            $placeholders = implode(',', array_fill(0, $numberCompletenessRow, '(?, ?, ?, ?, ?)'));
 
-                    if (empty($placeholders)) {
-                        return;
-                    }
+            if (empty($placeholders)) {
+                return;
+            }
 
-                    $insert = <<<SQL
+            $insert = <<<SQL
                         INSERT INTO pim_catalog_completeness
                             (locale_id, channel_id, product_id, missing_count, required_count)
                         VALUES
                             $placeholders
         SQL;
 
-                    $stmt = $this->connection->prepare($insert);
+            $stmt = $this->connection->prepare($insert);
 
-                    $placeholderIndex = 1;
-                    foreach ($productCompletenessCollections as $productCompletenessCollection) {
-                        foreach ($productCompletenessCollection as $productCompleteness) {
-                            $stmt->bindValue($placeholderIndex++, $localeIdsFromCode[$productCompleteness->localeCode()]);
-                            $stmt->bindValue($placeholderIndex++, $channelIdsFromCode[$productCompleteness->channelCode()]);
-                            $stmt->bindValue($placeholderIndex++, $productCompletenessCollection->productId(), ParameterType::INTEGER);
-                            $stmt->bindValue($placeholderIndex++, count($productCompleteness->missingAttributeCodes()), ParameterType::INTEGER);
-                            $stmt->bindValue($placeholderIndex++, $productCompleteness->requiredCount(), ParameterType::INTEGER);
-                        }
-                    }
-
-                    $stmt->execute();
-                });
-
-                $isError = false;
-            } catch (DeadlockException $e) {
-                $retry += 1;
-
-                usleep(300000);
-                usleep(rand(50000, $retry*100000));
-
-                if (5 === $retry) {
-                    throw $e;
+            $placeholderIndex = 1;
+            foreach ($productCompletenessCollections as $productCompletenessCollection) {
+                foreach ($productCompletenessCollection as $productCompleteness) {
+                    $stmt->bindValue($placeholderIndex++, $localeIdsFromCode[$productCompleteness->localeCode()]);
+                    $stmt->bindValue($placeholderIndex++, $channelIdsFromCode[$productCompleteness->channelCode()]);
+                    $stmt->bindValue($placeholderIndex++, $productCompletenessCollection->productId(), ParameterType::INTEGER);
+                    $stmt->bindValue($placeholderIndex++, count($productCompleteness->missingAttributeCodes()), ParameterType::INTEGER);
+                    $stmt->bindValue($placeholderIndex++, $productCompleteness->requiredCount(), ParameterType::INTEGER);
                 }
             }
+
+            $stmt->execute();
+        };
+
+        try {
+            $this->executeWithRetry($deleteAndInsertFunction);
+        } catch (DeadlockException $e) {
+            $this->executeWithLockOnTable($deleteAndInsertFunction);
         }
     }
 
@@ -137,5 +135,58 @@ final class SqlSaveProductCompletenesses implements SaveProductCompletenesses
         }
 
         return $result;
+    }
+
+    /**
+     * To avoid to get several dead lock exceptions in a row, we sleep between the retry. It lets the database take a breath and finish the other concurrent transactions triggering the deadlock.
+     * There is a random sleep as well, to avoid to restart at the same time the other concurrent processes doing a retry as well.
+     */
+    private function executeWithRetry(callable $function): void
+    {
+        $retry = 0;
+        $isError = true;
+        while (true === $isError) {
+            try {
+                $this->connection->transactional($function);
+
+                $isError = false;
+            } catch (DeadlockException $e) {
+                $retry += 1;
+
+                if (5 === $retry) {
+                    throw $e;
+                }
+
+                $this->logger->warning(sprintf('Deadlock occurred when persisting the completeness, %s/4 retry', $retry));
+                usleep(300000 + rand(50000, $retry * 100000));
+            }
+        }
+    }
+
+    /**
+     * We don't catch any exception if an error occurs, because it's the last attempt to insert the data by locking the
+     * completeness table.
+     * Do note that it locks also the table in READ mode for all the foreign keys (locale, channel, product).
+     * It means that you can't insert data in the product table also (just read).
+     */
+    private function executeWithLockOnTable(callable $function): void
+    {
+        $this->logger->warning('Locking the whole completeness table to persist the completeness, as it fails after trying 5 times to insert data due to deadlocks.');
+
+        $value = $this->connection->executeQuery('SELECT @@autocommit')->fetch();
+        if (!isset($value['@@autocommit']) && ((int) $value['@@autocommit'] !== 1 || (int) $value['@@autocommit'] !== 0)) {
+            throw new \LogicException('Error when getting autocommit parameter from Mysql.');
+        }
+
+        $formerAutocommitValue = (int) $value['@@autocommit'];
+        try {
+            $this->connection->executeQuery('SET autocommit=0');
+            $this->connection->executeQuery('LOCK TABLES pim_catalog_completeness WRITE');
+            $function();
+            $this->connection->executeQuery('COMMIT');
+            $this->connection->executeQuery('UNLOCK TABLES');
+        } finally {
+            $this->connection->executeQuery(sprintf('SET autocommit=%d', $formerAutocommitValue));
+        }
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
When loading data with the API with 30 threads, we had some deadlocks despite the retry strategy, during insertion of completeness.
We tried a lot of things to mitigate this risk of deadlock during insertion of the completeness:

- increasing the `sleep` drastically at each retry  (:red_circle: )
- increasing the number of retry drastically (20)  (worked with 10 thread, ? with 30 threads)
- to delete only unwanted row + INSERT (:red_circle: )
- SELECT id from rows and then only DELETE by id to know if it changes the locking strategy  (:red_circle: )
- DELETE index `locale_id` and `channel_id` in case of locking  (:red_circle: )
- use INSERT ON DUPLICATE KEY UPDATE (:heavy_check_mark: with 10 threads, :red_circle: with 30)
- use two different transactions(:heavy_check_mark: with 10 threads, :red_circle: with 30)
- use lock tables (:heavy_check_mark: with 10 threads, :heavy_check_mark:  with 30)

I close the PR https://github.com/akeneo/pim-community-dev/pull/11653 in favor of this one.

When it fails despite 5 attempts, we lock the table. This way, we serialize the transaction. It guarantees it works whatever is the number of threads at the cost of the performance when the table is locked. It means that all concurrent requests are pending.


**Note**: we can't test this as we can't simulate deadlock, so I deactivated the `retry` function to test that the lock tables behaves the same way when running the integration test. The test was green.
 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
