### PR TITLE
Move services definitions to Enrichment

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/DependencyInjection/AkeneoPimEnrichmentExtension.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/DependencyInjection/AkeneoPimEnrichmentExtension.php
@@ -29,6 +29,7 @@ class AkeneoPimEnrichmentExtension extends Extension
         $this->loadLocalizationConfiguration($container, $config);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('connector/archivers.yml');
         $loader->load('connector/cleaners.yml');
         $loader->load('connector/processors.yml');
         $loader->load('connector/use_cases.yml');

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/connector/archivers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/connector/archivers.yml
@@ -1,0 +1,24 @@
+services:
+    pim_connector.archiver.invalid_item_csv_writer:
+        class: 'Akeneo\Tool\Component\Connector\Archiver\CsvInvalidItemWriter'
+        arguments:
+            - '@pim_connector.event_listener.invalid_items_collector'
+            - '@pim_connector.writer.file.invalid_items_csv'
+            - '@pim_connector.reader.file.csv_iterator_factory'
+            - '@oneup_flysystem.archivist_filesystem'
+            - '@pim_connector.job.job_parameters.default_values_provider.product_csv_export'
+            - 'csv'
+        tags:
+            - { name: pim_connector.archiver }
+
+    pim_connector.archiver.invalid_item_xlsx_writer:
+        class: 'Akeneo\Tool\Component\Connector\Archiver\XlsxInvalidItemWriter'
+        arguments:
+            - '@pim_connector.event_listener.invalid_items_collector'
+            - '@pim_connector.writer.file.invalid_items_xlsx'
+            - '@pim_connector.reader.file.xlsx_iterator_factory'
+            - '@oneup_flysystem.archivist_filesystem'
+            - '@pim_connector.job.job_parameters.default_values_provider.product_xlsx_export'
+            - 'xlsx'
+        tags:
+            - { name: pim_connector.archiver }

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/Resources/config/archiving.yml
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/Resources/config/archiving.yml
@@ -5,8 +5,6 @@ parameters:
     pim_connector.archiver.file_reader_archiver.class:            Akeneo\Tool\Component\Connector\Archiver\FileReaderArchiver
     pim_connector.archiver.file_writer_archiver.class:            Akeneo\Tool\Component\Connector\Archiver\FileWriterArchiver
     pim_connector.archiver.archivable_file_writer_archiver.class: Akeneo\Tool\Component\Connector\Archiver\ArchivableFileWriterArchiver
-    pim_connector.archiver.invalid_item_csv_writer.class:         Akeneo\Tool\Component\Connector\Archiver\CsvInvalidItemWriter
-    pim_connector.archiver.invalid_item_xlsx_writer.class:        Akeneo\Tool\Component\Connector\Archiver\XlsxInvalidItemWriter
 
 services:
     pim_connector.event_listener.archivist:
@@ -44,30 +42,6 @@ services:
             - '@pim_connector.factory.zip_filesystem'
             - '@oneup_flysystem.archivist_filesystem'
             - '@akeneo_batch.job.job_registry'
-        tags:
-            - { name: pim_connector.archiver }
-
-    pim_connector.archiver.invalid_item_csv_writer:
-        class: '%pim_connector.archiver.invalid_item_csv_writer.class%'
-        arguments:
-            - '@pim_connector.event_listener.invalid_items_collector'
-            - '@pim_connector.writer.file.invalid_items_csv'
-            - '@pim_connector.reader.file.csv_iterator_factory'
-            - '@oneup_flysystem.archivist_filesystem'
-            - '@pim_connector.job.job_parameters.default_values_provider.product_csv_export'
-            - 'csv'
-        tags:
-            - { name: pim_connector.archiver }
-
-    pim_connector.archiver.invalid_item_xlsx_writer:
-        class: '%pim_connector.archiver.invalid_item_xlsx_writer.class%'
-        arguments:
-            - '@pim_connector.event_listener.invalid_items_collector'
-            - '@pim_connector.writer.file.invalid_items_xlsx'
-            - '@pim_connector.reader.file.xlsx_iterator_factory'
-            - '@oneup_flysystem.archivist_filesystem'
-            - '@pim_connector.job.job_parameters.default_values_provider.product_xlsx_export'
-            - 'xlsx'
         tags:
             - { name: pim_connector.archiver }
 


### PR DESCRIPTION
Those archivers rely on the services `pim_connector.job.job_parameters.default_values_provider.product_csv_export` and `pim_connector.job.job_parameters.default_values_provider.product_xlsx_export` that are defined in PimEnrichmentBundle.

It's a good thing that they are defined in PimEnrichmentBundle imo (as the AkeneoConnectorBundle should have no knowledge about products, attributes etc...), they should just be renamed (which I will not do in this PR).