### PR TITLE
[akeneo-design-system]: Add styled components tests

### DIFF
--- a/akeneo-design-system/extend-jest.d.ts
+++ b/akeneo-design-system/extend-jest.d.ts
@@ -1,0 +1,5 @@
+declare namespace jest {
+    interface Matchers<R> {
+      toHaveStyleRule: import("jest-styled-components").jest.Matchers<R>["toHaveStyleRule"]
+    }
+  }

--- a/akeneo-design-system/src/components/Buttons/CoreButton/CoreButton.test.tsx
+++ b/akeneo-design-system/src/components/Buttons/CoreButton/CoreButton.test.tsx
@@ -1,75 +1,104 @@
 import React from 'react';
-import { CoreButton } from "./CoreButton";
-import {
-    render, fireEvent
-} from "@testing-library/react";
+import 'jest-styled-components';
 
-describe("testing button", () => {
-    test("should display a button with the given children", () => {
+import { CoreButton } from './CoreButton';
+import { render, fireEvent } from '@testing-library/react';
+
+describe('testing button', () => {
+    test('should display a button with the given children', () => {
         // Given
-        const myLabel = "Click Here";
+        const myLabel = 'Click Here';
         // When
-        const { getByText } = render(
-            <CoreButton>{myLabel}</CoreButton>
-        );
+        const { getByText } = render(<CoreButton>{myLabel}</CoreButton>);
         // Then
-        expect(getByText("Click Here")).toBeInTheDocument();
+        expect(getByText('Click Here')).toBeInTheDocument();
     });
     test('should call the function callback when left mouse is clicked', () => {
         // Given
         const onClick = jest.fn();
-        const myLabel = "Click Here";
+        const myLabel = 'Click Here';
         // When
-        const { getByText } = render(
-            <CoreButton onClick={onClick}>{myLabel}</CoreButton>
-        );
-        fireEvent.click(getByText("Click Here"), { button: 0 })
+        const { getByText } = render(<CoreButton onClick={onClick}>{myLabel}</CoreButton>);
+        fireEvent.click(getByText('Click Here'), { button: 0 });
         // Then
-        expect(onClick).toHaveBeenCalledTimes(1)
+        expect(onClick).toHaveBeenCalledTimes(1);
     });
     test('should call the function callback when keyboard enter is pressed down', () => {
         // Given
         const onKeyDown = jest.fn();
-        const myLabel = "Click Here";
+        const myLabel = 'Click Here';
         // When
-        const { getByText } = render(
-            <CoreButton onKeyDown={onKeyDown}>{myLabel}</CoreButton>
-        );
-        fireEvent.keyDown(getByText("Click Here"), { keyCode: 13 })
+        const { getByText } = render(<CoreButton onKeyDown={onKeyDown}>{myLabel}</CoreButton>);
+        fireEvent.keyDown(getByText('Click Here'), { keyCode: 13 });
         // Then
-        expect(onKeyDown).toHaveBeenCalledTimes(1)
+        expect(onKeyDown).toHaveBeenCalledTimes(1);
     });
     test('should call the function callback when keyboard space is pressed down', () => {
         // Given
         const onKeyDown = jest.fn();
-        const myLabel = "Click Here";
+        const myLabel = 'Click Here';
         // When
-        const { getByText } = render(
-            <CoreButton onKeyDown={onKeyDown}>{myLabel}</CoreButton>
-        );
-        fireEvent.keyDown(getByText("Click Here"), { keyCode: 32 })
+        const { getByText } = render(<CoreButton onKeyDown={onKeyDown}>{myLabel}</CoreButton>);
+        fireEvent.keyDown(getByText('Click Here'), { keyCode: 32 });
         // Then
-        expect(onKeyDown).toHaveBeenCalledTimes(1)
+        expect(onKeyDown).toHaveBeenCalledTimes(1);
     });
     test('should not call the function callback when other keyboard is pressed down', () => {
         // Given
         const onKeyDown = jest.fn();
-        const myLabel = "Click Here";
+        const myLabel = 'Click Here';
         // When
-        const { getByText } = render(
-            <CoreButton onKeyDown={onKeyDown}>{myLabel}</CoreButton>
-        );
-        fireEvent.keyDown(getByText("Click Here"), { keyCode: 8 })
+        const { getByText } = render(<CoreButton onKeyDown={onKeyDown}>{myLabel}</CoreButton>);
+        fireEvent.keyDown(getByText('Click Here'), { keyCode: 8 });
         // Then
-        expect(onKeyDown).toHaveBeenCalledTimes(0)
+        expect(onKeyDown).toHaveBeenCalledTimes(0);
     });
     test('should assign a dom button to the passed ref', () => {
         // Given
-        const myLabel = "Click Here";
-        const ref = React.createRef<HTMLButtonElement>()
+        const myLabel = 'Click Here';
+        const ref = React.createRef<HTMLButtonElement>();
         // When
-        const { container } = render(<CoreButton ref={ref}>{myLabel}</CoreButton>)
+        const { container } = render(<CoreButton ref={ref}>{myLabel}</CoreButton>);
         // Then
-        expect(ref.current).toEqual(container.firstChild)
-    })
+        expect(ref.current).toEqual(container.firstChild);
+    });
+    test('should render the component, not disabled and in large mode', () => {
+        // Given
+        const myLabel = 'Click Here';
+        // When
+        const { container } = render(<CoreButton>{myLabel}</CoreButton>);
+        // Then
+        expect(container.firstChild).toMatchInlineSnapshot(`
+            .c0 {
+              border-radius: 16px;
+              cursor: pointer;
+              font-size: 13px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 32px;
+              padding: 0 15px;
+              text-transform: uppercase;
+            }
+
+            .c0:disabled {
+              cursor: not-allowed;
+            }
+
+            <button
+              class="c0"
+              role="button"
+            >
+              Click Here
+            </button>
+        `);
+    });
+    test('should render the component in small mode', () => {
+        // Given
+        const myLabel = 'Click Here';
+        // When
+        const { container } = render(<CoreButton sizeMode='small'>{myLabel}</CoreButton>);
+        // Then
+        expect(container.firstChild).toHaveStyleRule('height', '20px');
+        expect(container.firstChild).toHaveStyleRule('line-height', '20px');
+    });
 });

--- a/akeneo-design-system/src/components/Buttons/PrimaryButton/PrimaryButton.test.tsx
+++ b/akeneo-design-system/src/components/Buttons/PrimaryButton/PrimaryButton.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import 'jest-styled-components';
+import { PrimaryButton } from './PrimaryButton';
+import { render } from '@testing-library/react';
+
+test('should render the component', () => {
+    // Given
+    const myLabel = 'Click Here';
+    // When
+    const { container } = render(<PrimaryButton>{myLabel}</PrimaryButton>);
+    // Then
+    expect(container.firstChild).toMatchInlineSnapshot(`
+        .c0 {
+          border-radius: 16px;
+          cursor: pointer;
+          font-size: 13px;
+          font-weight: 400;
+          height: 32px;
+          line-height: 32px;
+          padding: 0 15px;
+          text-transform: uppercase;
+        }
+
+        .c0:disabled {
+          cursor: not-allowed;
+        }
+
+        .c1 {
+          color: white;
+          background-color: #67B373;
+        }
+
+        .c1:hover {
+          background-color: #528f5c;
+        }
+
+        .c1:active {
+          background-color: #3d6b45;
+        }
+
+        .c1:focus {
+          border-color: blue;
+        }
+
+        .c1:disabled {
+          background-color: #c2e1c7;
+        }
+
+        <button
+          class="c0 c1"
+          role="button"
+        >
+          Click Here
+        </button>
+    `);
+});

--- a/akeneo-design-system/tsconfig.json
+++ b/akeneo-design-system/tsconfig.json
@@ -24,5 +24,5 @@
         "strictPropertyInitialization": true,
         "suppressImplicitAnyIndexErrors": true,
         "target": "es5"
-    },
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Adding some styled components / css oriented tests.
The jest-styled-components encounters some typescript [issues](https://github.com/styled-components/jest-styled-components/issues/264).
A file extend-jest.d.ts has been added to extend properly the jest types, with a new function "toHaveStyleRule".
Doc about jest-styled-components is [here](https://github.com/styled-components/jest-styled-components).
Also for now I encounter a problem with the setupTests.ts file to avoid importing "import 'jest-styled-components';" in all tests file. It will be fixed in an another pr.


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
