### PR TITLE
MET-62: Use the uiLocale for translating the metric unit

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/metric-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/metric-field.js
@@ -15,8 +15,9 @@ define([
     'pim/fetcher-registry',
     'pim/template/product/field/metric',
     'pim/initselect2',
-    'pim/i18n'
-], function ($, Field, _, __, FetcherRegistry, fieldTemplate, initSelect2, i18n) {
+    'pim/i18n',
+    'pim/user-context'
+], function ($, Field, _, __, FetcherRegistry, fieldTemplate, initSelect2, i18n, UserContext) {
     return Field.extend({
         fieldTemplate: _.template(fieldTemplate),
         events: {
@@ -38,6 +39,7 @@ define([
                 templateContext.i18n = i18n;
                 templateContext.units = measurementFamily.units;
                 templateContext.locale = templateContext.locale || templateContext.context.locale;
+                templateContext.uiLocale = UserContext.get('uiLocale');
 
                 return templateContext;
             });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/metric.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/metric.html
@@ -7,7 +7,7 @@
     <select class="AknMetricField-unit unit select-field" data-locale="<%- value ? value.locale : null %>" data-scope="<%- value ? value.scope : null %>" <%- editMode === 'view' ? 'disabled' : '' %>>
         <% _.each(units, function(unit) { %>
             <option value="<%- unit.code %>"<% if (undefined !== value && ((null === value.data.unit && unit.code === attribute.empty_value.unit) || value.data.unit === unit.code)) { %> selected<% } %>>
-                <%- i18n.getLabel(unit.labels, locale, unit.code) %>
+                <%- i18n.getLabel(unit.labels, uiLocale, unit.code) %>
             </option>
         <% }); %>
     </select>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In the metric field, the metric unit was translated using the catalog locale. It should use the UI locale.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

