### PR TITLE
Remove nested set pattern in product models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 - PIM-9119: Fix missing warning when using mass edit with parent filter set to empty
 - PIM-9114: fix errors on mass action when the parent filter is set to empty
-- PIM-9110: avoid deadlock error when laoding products in parallel with the API
+- PIM-9110: avoid deadlock error when loading product and product models in parallel with the API
 - PIM-9113: Locale Specific attribute breaks product grid

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/doctrine/Product/ProductModel.orm.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/doctrine/Product/ProductModel.orm.yml
@@ -3,9 +3,6 @@ Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel:
     table: pim_catalog_product_model
     changeTrackingPolicy: DEFERRED_EXPLICIT
     repositoryClass: Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Repository\ProductModelRepository
-    gedmo:
-        tree:
-            type: nested
     fields:
         id:
             type: integer
@@ -24,25 +21,6 @@ Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel:
             type: datetime
         updated:
             type: datetime
-        root:
-            type: integer
-            gedmo:
-                - treeRoot
-        level:
-            type: integer
-            column: lvl
-            gedmo:
-                - treeLevel
-        left:
-            type: integer
-            column: lft
-            gedmo:
-                - treeLeft
-        right:
-            type: integer
-            column: rgt
-            gedmo:
-                - treeRight
     manyToMany:
         categories:
             targetEntity: Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface
@@ -64,7 +42,7 @@ Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel:
             targetEntity: Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface
             mappedBy: parent
             orderBy:
-                left: ASC
+                created: ASC
         associations:
             targetEntity: Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelAssociationInterface
             mappedBy: owner
@@ -80,8 +58,6 @@ Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel:
                 parent_id:
                     referencedColumnName: id
                     onDelete: CASCADE
-            gedmo:
-                - treeParent
         familyVariant:
             targetEntity: Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface
             joinColumn:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -118,7 +118,7 @@ final class ProductModelImagesFromCodes
                 SELECT 
                     pm.code as product_model_code,
                     COUNT(all_attribute_sets.family_variant_id) as number_level,
-                    pm.lvl as product_model_level,
+                    if(pm.parent_id is null, 0, 1) as product_model_level,
                     fv_set.level as image_code_level
                 FROM
                     pim_catalog_product_model pm

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
@@ -38,18 +38,6 @@ class ProductModel implements ProductModelInterface
     /** @var \DateTime $updated */
     protected $updated;
 
-    /** @var int */
-    protected $root;
-
-    /** @var int */
-    protected $level;
-
-    /** @var int */
-    protected $left;
-
-    /** @var int */
-    protected $right;
-
     /** @var Collection $categories */
     protected $categories;
 
@@ -342,81 +330,9 @@ class ProductModel implements ProductModelInterface
     /**
      * {@inheritdoc}
      */
-    public function setRoot(int $root): ProductModelInterface
-    {
-        $this->root = $root;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getRoot(): int
-    {
-        return $this->root;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function isRoot(): bool
     {
         return (null === $this->getParent());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setLevel(int $level): ProductModelInterface
-    {
-        $this->level = $level;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getLevel(): int
-    {
-        return $this->level;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setLeft(int $left): ProductModelInterface
-    {
-        $this->left = $left;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getLeft(): int
-    {
-        return $this->left;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setRight(int $right): ProductModelInterface
-    {
-        $this->right = $right;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getRight(): int
-    {
-        return $this->right;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModelInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModelInterface.php
@@ -71,18 +71,6 @@ interface ProductModelInterface extends
     public function removeProduct(ProductInterface $product): ProductModelInterface;
 
     /**
-     * @param int $root
-     *
-     * @return ProductModelInterface
-     */
-    public function setRoot(int $root): ProductModelInterface;
-
-    /**
-     * @return int
-     */
-    public function getRoot(): int;
-
-    /**
      * If a node is a tree root, it's the tree starting point and therefore
      * defines the tree itself.
      *
@@ -90,41 +78,6 @@ interface ProductModelInterface extends
      */
     public function isRoot(): bool;
 
-    /**
-     * @param int $level
-     *
-     * @return ProductModelInterface
-     */
-    public function setLevel(int $level): ProductModelInterface;
-
-    /**
-     * @return int
-     */
-    public function getLevel(): int;
-
-    /**
-     * @param int $left
-     *
-     * @return ProductModelInterface
-     */
-    public function setLeft(int $left): ProductModelInterface;
-
-    /**
-     * @return int
-     */
-    public function getLeft(): int;
-
-    /**
-     * @param int $right
-     *
-     * @return ProductModelInterface
-     */
-    public function setRight(int $right): ProductModelInterface;
-
-    /**
-     * @return int
-     */
-    public function getRight(): int;
 
     /**
      * Adds a child product model to this product model.

--- a/src/Akeneo/Pim/Enrichment/Component/Product/ProductModel/ImageAsLabel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/ProductModel/ImageAsLabel.php
@@ -59,11 +59,11 @@ class ImageAsLabel
             }
         }
 
-        if ($levelContainingAttribute <= $productModel->getLevel()) {
+        if ($levelContainingAttribute <= $this->getLevel($productModel)) {
             return $productModel->getImage();
         }
 
-        $currentLevel = $productModel->getLevel();
+        $currentLevel = $this->getLevel($productModel);
         $entity = $productModel;
 
         do {
@@ -91,5 +91,10 @@ class ImageAsLabel
         } while ($currentLevel < $levelContainingAttribute);
 
         return $entity->getImage();
+    }
+
+    private function getLevel(ProductModelInterface $productModel): int
+    {
+        return $productModel->isRoot() ? 0 : 1;
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/ProductModel/ImageAsLabelSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/ProductModel/ImageAsLabelSpec.php
@@ -54,7 +54,7 @@ class ImageAsLabelSpec extends ObjectBehavior
         $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
         $productModel->getFamily()->willReturn($family);
         $productModel->getFamilyVariant()->willReturn($familyVariant);
-        $productModel->getLevel()->willReturn(1);
+        $productModel->isRoot()->willReturn(false);
         $productModel->getImage()->willReturn($imageValue);
 
         $this->value($productModel)->shouldReturn($imageValue);
@@ -91,7 +91,7 @@ class ImageAsLabelSpec extends ObjectBehavior
         $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
         $productModel->getFamily()->willReturn($family);
         $productModel->getFamilyVariant()->willReturn($familyVariant);
-        $productModel->getLevel()->willReturn(1);
+        $productModel->isRoot()->willReturn(false);
         $productModel->getImage()->willReturn($imageValue);
 
         $this->value($productModel)->shouldReturn($imageValue);
@@ -124,14 +124,14 @@ class ImageAsLabelSpec extends ObjectBehavior
         $attributeSetTwo->getAttributes()->willReturn($attributeCollectionTwo);
         $attributeSetTwo->getLevel()->willReturn(2);
 
-        $attributeCollectionOne->contains($attributeAsImage)->willReturn(false);
-        $attributeCollectionTwo->contains($attributeAsImage)->willReturn(true);
+        $attributeCollectionOne->contains($attributeAsImage)->willReturn(true);
+        $attributeCollectionTwo->contains($attributeAsImage)->willReturn(false);
 
         $family->getAttributeAsImage()->willReturn($attributeAsImage);
         $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
         $productModel->getFamily()->willReturn($family);
         $productModel->getFamilyVariant()->willReturn($familyVariant);
-        $productModel->getLevel()->willReturn(1);
+        $productModel->isRoot()->willReturn(true);
 
         $productModelRepository->findBy(
             ['parent' => $productModel],
@@ -180,7 +180,7 @@ class ImageAsLabelSpec extends ObjectBehavior
         $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
         $productModel->getFamily()->willReturn($family);
         $productModel->getFamilyVariant()->willReturn($familyVariant);
-        $productModel->getLevel()->willReturn(1);
+        $productModel->isRoot()->willReturn(false);
 
         $productModelRepository->findBy(
             ['parent' => $productModel],
@@ -227,7 +227,7 @@ class ImageAsLabelSpec extends ObjectBehavior
         $familyVariant->getVariantAttributeSets()->willReturn($attributeSets);
         $productModel->getFamily()->willReturn($family);
         $productModel->getFamilyVariant()->willReturn($familyVariant);
-        $productModel->getLevel()->willReturn(1);
+        $productModel->isRoot()->willReturn(false);
 
         $productModelRepository->findBy(
             ['parent' => $productModel],

--- a/upgrades/schema/Version_5_0_20200304140000_remove_nested_set_columns_product_model.php
+++ b/upgrades/schema/Version_5_0_20200304140000_remove_nested_set_columns_product_model.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class Version_5_0_20200304140000_remove_nested_set_columns_product_model extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->addSql('ALTER TABLE pim_catalog_product_model DROP lvl');
+        $this->addSql('ALTER TABLE pim_catalog_product_model DROP lft');
+        $this->addSql('ALTER TABLE pim_catalog_product_model DROP root');
+        $this->addSql('ALTER TABLE pim_catalog_product_model DROP rgt');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/upgrades/test_schema/Version_4_0_20200117080512_remove_product_model_empty_raw_values_Integration.php
+++ b/upgrades/test_schema/Version_4_0_20200117080512_remove_product_model_empty_raw_values_Integration.php
@@ -25,13 +25,13 @@ class Version_4_0_20200117080512_remove_product_model_empty_raw_values_Integrati
         $familyId = $familySearch[0];
         $sql = <<<SQL
 INSERT INTO pim_catalog_product_model VALUES
-    (NULL, NULL, :familyId, 'pm1', '{"name": {"<all_channels>": {"<all_locales>": ""}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, :familyId, 'pm2', '{"name": {"<all_channels>": {"<all_locales>": []}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, :familyId, 'pm3', '{"name": {"<all_channels>": {"<all_locales>": [""]}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, :familyId, 'pm4', '{"name": {"<all_channels>": {"<all_locales>": null}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, :familyId, 'pm5', '{"name": {"<all_channels>": {"<all_locales>": ""}}, "foo": {"<all_channels>": {"<all_locales>": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, :familyId, 'pm6', '{"name": {"<all_channels>": {"fr_FR": "", "en_US": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (NULL, NULL, :familyId, 'pm7', '{"name": {"ecommerce": {"<all_locales>": ""}, "mobile": {"<all_locales>": "bar"}}}', NOW(), NOW(), 0, 0, 0, 0)
+    (NULL, NULL, :familyId, 'pm1', '{"name": {"<all_channels>": {"<all_locales>": ""}}}', NOW(), NOW()),
+    (NULL, NULL, :familyId, 'pm2', '{"name": {"<all_channels>": {"<all_locales>": []}}}', NOW(), NOW()),
+    (NULL, NULL, :familyId, 'pm3', '{"name": {"<all_channels>": {"<all_locales>": [""]}}}', NOW(), NOW()),
+    (NULL, NULL, :familyId, 'pm4', '{"name": {"<all_channels>": {"<all_locales>": null}}}', NOW(), NOW()),
+    (NULL, NULL, :familyId, 'pm5', '{"name": {"<all_channels>": {"<all_locales>": ""}}, "foo": {"<all_channels>": {"<all_locales>": "bar"}}}', NOW(), NOW()),
+    (NULL, NULL, :familyId, 'pm6', '{"name": {"<all_channels>": {"fr_FR": "", "en_US": "bar"}}}', NOW(), NOW()),
+    (NULL, NULL, :familyId, 'pm7', '{"name": {"ecommerce": {"<all_locales>": ""}, "mobile": {"<all_locales>": "bar"}}}', NOW(), NOW())
 SQL;
         $this->getConnection()->executeQuery($sql, ['familyId' => $familyId]);
 

--- a/upgrades/test_schema/Version_4_0_20200117145507_remove_compute_model_descendant_jobs_Integration.php
+++ b/upgrades/test_schema/Version_4_0_20200117145507_remove_compute_model_descendant_jobs_Integration.php
@@ -91,10 +91,10 @@ SQL;
         $familyVariantId = $familyVariant->getId();
 
         $sql = <<<SQL
-INSERT INTO pim_catalog_product_model (id, code, family_variant_id, raw_values, created, updated, root, lvl, lft, rgt)
+INSERT INTO pim_catalog_product_model (id, code, family_variant_id, raw_values, created, updated)
 VALUES
-    (3000, 'pm1', $familyVariantId, '{"name": {"<all_channels>": {"<all_locales>": ""}}}', NOW(), NOW(), 0, 0, 0, 0),
-    (3001, 'pm2', $familyVariantId, '{"name": {"<all_channels>": {"<all_locales>": []}}}', NOW(), NOW(), 0, 0, 0, 0)
+    (3000, 'pm1', $familyVariantId, '{"name": {"<all_channels>": {"<all_locales>": ""}}}', NOW(), NOW()),
+    (3001, 'pm2', $familyVariantId, '{"name": {"<all_channels>": {"<all_locales>": []}}}', NOW(), NOW())
 SQL;
         $this->getConnection()->exec($sql);
 


### PR DESCRIPTION
 Fix performance issues when deleting product model and also deadlock when inserting product model with parallelism through the PAI

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
We have two issues:
- performance problem when deleting a product model (and I suppose when inserting product models also...). An index is missing on `left` `right` `root`.
- deadlock when inserting product model

All of this is due to the nested set pattern we introduced for the product models. It is never used. Let's drop that, this dead code is not really dead code as there are bugs due to that.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
