### PR TITLE
PIM-9110: deactivate foreign keys check when locking the completeness table

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlSaveProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlSaveProductCompletenesses.php
@@ -166,8 +166,8 @@ final class SqlSaveProductCompletenesses implements SaveProductCompletenesses
     /**
      * We don't catch any exception if an error occurs, because it's the last attempt to insert the data by locking the
      * completeness table.
-     * Do note that it locks also the table in READ mode for all the foreign keys (locale, channel, product).
-     * It means that you can't insert data in the product table also (just read).
+     * Do note that it LOCK TABLE locks also the table in READ mode for all the foreign keys (locale, channel and product tables).
+     * It means that a concurrent transaction can't insert data in the product table at the same time (just read). That's why the foreign check constraint is deactivated to avoid these locks.
      */
     private function executeWithLockOnTable(callable $function): void
     {
@@ -181,12 +181,14 @@ final class SqlSaveProductCompletenesses implements SaveProductCompletenesses
         $formerAutocommitValue = (int) $value['@@autocommit'];
         try {
             $this->connection->executeQuery('SET autocommit=0');
+            $this->connection->executeQuery('SET foreign_key_checks=0');
             $this->connection->executeQuery('LOCK TABLES pim_catalog_completeness WRITE');
             $function();
             $this->connection->executeQuery('COMMIT');
             $this->connection->executeQuery('UNLOCK TABLES');
         } finally {
             $this->connection->executeQuery(sprintf('SET autocommit=%d', $formerAutocommitValue));
+            $this->connection->executeQuery('SET foreign_key_checks=1');
         }
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlSaveProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlSaveProductCompletenesses.php
@@ -166,7 +166,7 @@ final class SqlSaveProductCompletenesses implements SaveProductCompletenesses
     /**
      * We don't catch any exception if an error occurs, because it's the last attempt to insert the data by locking the
      * completeness table.
-     * Do note that it LOCK TABLE locks also the table in READ mode for all the foreign keys (locale, channel and product tables).
+     * Do note that LOCK TABLE locks also the table in READ mode for all the foreign keys (locale, channel and product tables).
      * It means that a concurrent transaction can't insert data in the product table at the same time (just read). That's why the foreign check constraint is deactivated to avoid these locks.
      */
     private function executeWithLockOnTable(callable $function): void


### PR DESCRIPTION
… 
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
It avoids to lock pim_catalog_product table when locking the completeness table.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
