### PR TITLE
MET-64: Add query to find measurement families linked to product attributes

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function execute(string $metricFamily): bool
+    {
+        $query = <<<SQL
+SELECT 1
+FROM pim_catalog_attribute
+WHERE metric_family = :metric_family
+AND attribute_type = 'pim_catalog_metric';
+SQL;
+        $stmt = $this->connection->executeQuery($query, ['metric_family' => $metricFamily]);
+        $result = $this->connection->convertToPHPValue($stmt->fetch(\PDO::FETCH_COLUMN), Type::BOOLEAN);
+
+        return $result;
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
@@ -9,6 +9,11 @@ services:
         arguments:
             $connection: '@database_connection'
 
+    akeneo.pim.structure.query.is_there_at_least_one_attribute_configured_with_measurement_family:
+        class: Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily
+        arguments:
+            - '@database_connection'
+
     akeneo.pim.structure.query.get_attributes:
         class: 'Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache\LRUCachedGetAttributes'
         arguments:

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/IsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/IsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyIntegration.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace AkeneoTest\Pim\Structure\Integration\Attribute\Query;
+
+use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+use Akeneo\Pim\Structure\Component\Model\Attribute;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+
+class IsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyIntegration extends TestCase
+{
+    /** @var IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily */
+    private $isThereAnAttributeConfiguredWithMeasurementFamily;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->isThereAnAttributeConfiguredWithMeasurementFamily = $this->get('akeneo.pim.structure.query.is_there_at_least_one_attribute_configured_with_measurement_family');
+    }
+
+    function testItReturnsFalseIfThereIsNoAttributeConfiguredWithTheMasurementFamily()
+    {
+        $expected = $this->isThereAnAttributeConfiguredWithMeasurementFamily->execute('weight');
+
+        self::assertFalse($expected);
+    }
+
+    function testItReturnsTrueIfThereIsAnAttributeConfiguredWithTheMasurementFamily()
+    {
+        $measurementFamily = 'weight';
+        $this->createAttributeConfiguredWithMeasurementFamily($measurementFamily);
+
+        $expected = $this->isThereAnAttributeConfiguredWithMeasurementFamily->execute($measurementFamily);
+
+        self::assertTrue($expected);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function createAttributeConfiguredWithMeasurementFamily(string $measurementFamily): void
+    {
+        $insertAttributeGroup = <<<SQL
+INSERT INTO `pim_catalog_attribute_group` (`id`, `code`, `sort_order`, `created`, `updated`)
+VALUES
+	(3, 'technical', 2, '2020-03-06 10:41:03', '2020-03-06 10:41:03');
+SQL;
+
+        $insertMetricAttribute = <<<SQL
+INSERT INTO `pim_catalog_attribute` (`id`, `group_id`, `sort_order`, `useable_as_grid_filter`, `max_characters`, `validation_rule`, `validation_regexp`, `wysiwyg_enabled`, `number_min`, `number_max`, `decimals_allowed`, `negative_allowed`, `date_min`, `date_max`, `metric_family`, `default_metric_unit`, `max_file_size`, `allowed_extensions`, `minimumInputLength`, `is_required`, `is_unique`, `is_localizable`, `is_scopable`, `code`, `entity_type`, `attribute_type`, `backend_type`, `properties`, `created`, `updated`)
+VALUES
+	(7, 3, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, 1, 0, NULL, NULL, 'Weight', 'KILOGRAM', NULL, '', NULL, 0, 0, 0, 0, :measurementFamily, 'Akeneo\\Pim\\Enrichment\\Component\\Product\\Model\\Product', 'pim_catalog_metric', 'metric', 'a:2:{s:19:\"auto_option_sorting\";N;s:19:\"reference_data_name\";N;}', '2020-03-06 10:41:04', '2020-03-06 10:41:04');
+SQL;
+        /** @var Connection $connection */
+        $connection = $this->get('database_connection');
+        $connection->executeUpdate($insertAttributeGroup);
+        $connection->executeUpdate($insertMetricAttribute, ['measurementFamily' => $measurementFamily]);
+    }
+}


### PR DESCRIPTION
Add query to find measurement families linked to product attributes in Enrichement/Structure public api.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | Ok
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
