### PR TITLE
MET-58: Add validation for Measurement Families limits

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -86,6 +86,21 @@ SQL;
         $this->measurementFamilyCache[$normalizedMeasurementFamily['code']] = $measurementFamily;
     }
 
+    public function countAllOthers(MeasurementFamilyCode $excludedMeasurementFamilyCode): int
+    {
+        $countQuery = <<<SQL
+    SELECT COUNT(code)
+    FROM akeneo_measurement
+    WHERE code != :code;
+SQL;
+
+        $statement = $this->sqlConnection->executeQuery($countQuery, [
+            'code' => $excludedMeasurementFamilyCode->normalize(),
+        ]);
+
+        return (int) $statement->fetch(\PDO::FETCH_COLUMN);
+    }
+
     private function hydrateMeasurementFamily(
         string $code,
         string $normalizedLabels,

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepositoryInterface.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepositoryInterface.php
@@ -14,4 +14,6 @@ interface MeasurementFamilyRepositoryInterface
     public function getByCode(MeasurementFamilyCode $measurementFamilyCode): MeasurementFamily;
 
     public function save(MeasurementFamily $measurementFamily);
+
+    public function countAllOthers(MeasurementFamilyCode $excludedMeasurementFamilyCode): int;
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
@@ -1,6 +1,7 @@
 parameters:
     akeneo_measure.convert.measure_converter.class: Akeneo\Tool\Bundle\MeasureBundle\Convert\MeasureConverter
     akeneo_measure.manager.measure_manager.class:   Akeneo\Tool\Bundle\MeasureBundle\Manager\MeasureManager
+    akeneo_measure.validation.measurement_family.operations_max: 5
 
 services:
     akeneo_measure.measure_converter:
@@ -38,3 +39,10 @@ services:
         class: Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyHandler
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'
+
+    akeneo_measure.validation.measurement_family.operation_count:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationCountValidator
+        arguments:
+            - '%akeneo_measure.validation.measurement_family.operations_max%'
+        tags:
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validation.measurement_family.operation_count' }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
@@ -2,6 +2,7 @@ parameters:
     akeneo_measure.convert.measure_converter.class: Akeneo\Tool\Bundle\MeasureBundle\Convert\MeasureConverter
     akeneo_measure.manager.measure_manager.class:   Akeneo\Tool\Bundle\MeasureBundle\Manager\MeasureManager
     akeneo_measure.validation.measurement_family.operations_max: 5
+    akeneo_measure.validation.measurement_family.unit_max: 50
 
 services:
     akeneo_measure.measure_converter:
@@ -46,3 +47,10 @@ services:
             - '%akeneo_measure.validation.measurement_family.operations_max%'
         tags:
             - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validation.measurement_family.operation_count' }
+
+    akeneo_measure.validation.measurement_family.unit_count:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\UnitCountValidator
+        arguments:
+            - '%akeneo_measure.validation.measurement_family.unit_max%'
+        tags:
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validation.measurement_family.unit_count' }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
@@ -2,7 +2,8 @@ parameters:
     akeneo_measure.convert.measure_converter.class: Akeneo\Tool\Bundle\MeasureBundle\Convert\MeasureConverter
     akeneo_measure.manager.measure_manager.class:   Akeneo\Tool\Bundle\MeasureBundle\Manager\MeasureManager
     akeneo_measure.validation.measurement_family.operations_max: 5
-    akeneo_measure.validation.measurement_family.unit_max: 50
+    akeneo_measure.validation.measurement_family.units_max: 50
+    akeneo_measure.validation.measurement_family.families_max: 100
 
 services:
     akeneo_measure.measure_converter:
@@ -51,6 +52,14 @@ services:
     akeneo_measure.validation.measurement_family.unit_count:
         class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\UnitCountValidator
         arguments:
-            - '%akeneo_measure.validation.measurement_family.unit_max%'
+            - '%akeneo_measure.validation.measurement_family.units_max%'
         tags:
             - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validation.measurement_family.unit_count' }
+
+    akeneo_measure.validation.measurement_family.count:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\CountValidator
+        arguments:
+            - '@akeneo_measure.persistence.measurement_family_repository'
+            - '%akeneo_measure.validation.measurement_family.families_max%'
+        tags:
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validation.measurement_family.count' }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
@@ -5,6 +5,7 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasureme
         labels:
             - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\LabelCollection: ~
         units:
+            - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\UnitCount: ~
             - All:
                 - Collection:
                     fields:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
@@ -17,6 +17,7 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasureme
                             - Length:
                                 max: 255
                         convert_from_standard:
+                            - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationCount: ~
                             - All:
                                 - Collection:
                                     fields:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
@@ -30,3 +30,4 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasureme
                                             - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationValue: ~
     constraints:
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCode: ~
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\Count: ~

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
@@ -1,4 +1,7 @@
 Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand:
+    group_sequence:
+        - SaveMeasurementFamilyCommand
+        - other_constraints
     properties:
         code:
             - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\Code: ~
@@ -30,4 +33,4 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasureme
                                             - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationValue: ~
     constraints:
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCode: ~
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\Count: ~
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\Count: { groups: [other_constraints] }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -8,3 +8,5 @@ pim_measurements:
             standard_unit_code_should_exist: 'The "%standard_unit_code%" standard unit code does not exist in the list of units for the measurement family.'
             convert:
                 value_should_be_a_number_in_a_string: 'The conversion value should be a number represented in a string (example: "0.2561")'
+                should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'
+                should_contain_max_elements: 'You’ve reached the limit of {{ limit }} conversion operations per unit.'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -6,6 +6,7 @@ pim_measurements:
                 limit_reached: 'You cannot create the "%measurement_family_code%" measurement family because you have reached the limit of %limit% measurement families'
         measurement_family:
             standard_unit_code_should_exist: 'The "%standard_unit_code%" standard unit code does not exist in the list of units for the measurement family.'
+            should_contain_max_elements: 'You’ve reached the limit of {{ limit }} measurement families.'
             convert:
                 value_should_be_a_number_in_a_string: 'The conversion value should be a number represented in a string (example: "0.2561")'
                 should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -3,7 +3,7 @@ pim_measurements:
         common:
             code:
                 pattern: 'This field can only contain letters, numbers, and underscores.'
-                limit_reached: 'You cannot create the "%measurement_family_code%" measurement family  because you have reached the limit of %limit% measurement families'
+                limit_reached: 'You cannot create the "%measurement_family_code%" measurement family because you have reached the limit of %limit% measurement families'
         measurement_family:
             standard_unit_code_should_exist: 'The "%standard_unit_code%" standard unit code does not exist in the list of units for the measurement family.'
             convert:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -10,3 +10,6 @@ pim_measurements:
                 value_should_be_a_number_in_a_string: 'The conversion value should be a number represented in a string (example: "0.2561")'
                 should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'
                 should_contain_max_elements: 'You’ve reached the limit of {{ limit }} conversion operations per unit.'
+            units:
+                should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'
+                should_contain_max_elements: 'You’ve reached the limit of {{ limit }} conversion operations per unit.'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/Code.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/Code.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /*
  * This file is part of the Akeneo PIM Enterprise Edition.
  *
- * (c) 2018 Akeneo SAS (http://www.akeneo.com)
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -14,10 +14,6 @@ namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\Common;
 
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
- * @copyright 2018 Akeneo SAS (https://www.akeneo.com)
- */
 class Code extends Constraint
 {
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/CodeValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/CodeValidator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /*
  * This file is part of the Akeneo PIM Enterprise Edition.
  *
- * (c) 2018 Akeneo SAS (http://www.akeneo.com)
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -15,13 +15,8 @@ namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\Common;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Validation;
 
-/**
- * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
- * @copyright 2018 Akeneo SAS (https://www.akeneo.com)
- */
 class CodeValidator extends ConstraintValidator
 {
     private const MAX_CODE_LENGTH = 255;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/LabelCollection.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/LabelCollection.php
@@ -1,11 +1,10 @@
 <?php
-
 declare(strict_types=1);
 
 /*
  * This file is part of the Akeneo PIM Enterprise Edition.
  *
- * (c) 2018 Akeneo SAS (http://www.akeneo.com)
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -15,10 +14,6 @@ namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\Common;
 
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
- * @copyright 2018 Akeneo SAS (https://www.akeneo.com)
- */
 class LabelCollection extends Constraint
 {
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/LabelCollectionValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/LabelCollectionValidator.php
@@ -1,11 +1,10 @@
 <?php
-
 declare(strict_types=1);
 
 /*
  * This file is part of the Akeneo PIM Enterprise Edition.
  *
- * (c) 2018 Akeneo SAS (http://www.akeneo.com)
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -16,18 +15,13 @@ namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\Common;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-/**
- * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
- * @copyright 2018 Akeneo SAS (https://www.akeneo.com)
- */
 class LabelCollectionValidator extends ConstraintValidator
 {
     /**
-     * @param mixed      $labels     The value that should be validated
+     * @param mixed $labels The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      */
     public function validate($labels, Constraint $constraint)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/Count.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/Count.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+
+class Count extends Constraint
+{
+    public $maxMessage = 'pim_measurements.validation.measurement_family.should_contain_max_elements';
+
+    public function validatedBy()
+    {
+        return 'akeneo_measure.validation.measurement_family.count';
+    }
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CountValidator.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class CountValidator extends ConstraintValidator
+{
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+    /** @var int */
+    private $max;
+
+    public function __construct(
+        MeasurementFamilyRepositoryInterface $measurementFamilyRepository,
+        int $max
+    )
+    {
+        $this->measurementFamilyRepository = $measurementFamilyRepository;
+        $this->max = $max;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($saveMeasurementFamilyCommand, Constraint $constraint)
+    {
+        if (!$constraint instanceof Count) {
+            throw new UnexpectedTypeException($constraint, Count::class);
+        }
+
+        if (!$saveMeasurementFamilyCommand instanceof SaveMeasurementFamilyCommand) {
+            throw new UnexpectedTypeException($saveMeasurementFamilyCommand, SaveMeasurementFamilyCommand::class);
+        }
+
+        try {
+            $excludedMeasurementFamilyCode = MeasurementFamilyCode::fromString($saveMeasurementFamilyCommand->code);
+        } catch (\Throwable $ex) {
+            return;
+        }
+
+        $count = $this->measurementFamilyRepository->countAllOthers($excludedMeasurementFamilyCode);
+
+        if ($count >= $this->max) {
+            $this->context->buildViolation($constraint->maxMessage)
+                ->setParameter('{{ limit }}', $this->max)
+                ->setInvalidValue($saveMeasurementFamilyCommand)
+                ->setPlural((int)$this->max)
+                ->addViolation();
+        }
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CountValidator.php
@@ -29,8 +29,7 @@ class CountValidator extends ConstraintValidator
     public function __construct(
         MeasurementFamilyRepositoryInterface $measurementFamilyRepository,
         int $max
-    )
-    {
+    ) {
         $this->measurementFamilyRepository = $measurementFamilyRepository;
         $this->max = $max;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CountValidator.php
@@ -47,11 +47,7 @@ class CountValidator extends ConstraintValidator
             throw new UnexpectedTypeException($saveMeasurementFamilyCommand, SaveMeasurementFamilyCommand::class);
         }
 
-        try {
-            $excludedMeasurementFamilyCode = MeasurementFamilyCode::fromString($saveMeasurementFamilyCommand->code);
-        } catch (\Throwable $ex) {
-            return;
-        }
+        $excludedMeasurementFamilyCode = MeasurementFamilyCode::fromString($saveMeasurementFamilyCommand->code);
 
         $count = $this->measurementFamilyRepository->countAllOthers($excludedMeasurementFamilyCode);
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCount.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCount.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+
+use Symfony\Component\Validator\Constraints\Count;
+
+class OperationCount extends Count
+{
+    public $minMessage = 'pim_measurements.validation.measurement_family.convert.should_contain_min_elements';
+    public $maxMessage = 'pim_measurements.validation.measurement_family.convert.should_contain_max_elements';
+    public $min = 1;
+
+    public function validatedBy()
+    {
+        return 'akeneo_measure.validation.measurement_family.operation_count';
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCountValidator.php
@@ -48,7 +48,6 @@ class OperationCountValidator extends ConstraintValidator
 
         if ($count > $this->max) {
             $this->context->buildViolation($constraint->maxMessage)
-                ->setParameter('{{ count }}', $count)
                 ->setParameter('{{ limit }}', $this->max)
                 ->setInvalidValue($value)
                 ->setPlural((int)$this->max)
@@ -59,7 +58,6 @@ class OperationCountValidator extends ConstraintValidator
 
         if ($count < $this->min) {
             $this->context->buildViolation($constraint->minMessage)
-                ->setParameter('{{ count }}', $count)
                 ->setParameter('{{ limit }}', $this->min)
                 ->setInvalidValue($value)
                 ->setPlural((int)$this->min)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCountValidator.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\CountValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class OperationCountValidator extends CountValidator
+{
+    private $max;
+
+    public function __construct(int $max)
+    {
+        $this->max = $max;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof OperationCount) {
+            throw new UnexpectedTypeException($constraint, OperationCount::class);
+        }
+
+        $constraint->min = 1;
+        $constraint->max = $this->max;
+
+        return parent::validate($value, $constraint);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCountValidator.php
@@ -19,7 +19,9 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 class OperationCountValidator extends ConstraintValidator
 {
+    /** @var int */
     private $min = 1;
+    /** @var int */
     private $max;
 
     public function __construct(int $max)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValue.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValue.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /*
  * This file is part of the Akeneo PIM Enterprise Edition.
  *
- * (c) 2018 Akeneo SAS (http://www.akeneo.com)
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -14,10 +14,6 @@ namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
 
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
- * @copyright 2018 Akeneo SAS (https://www.akeneo.com)
- */
 class OperationValue extends Constraint
 {
     const VALUE_SHOULD_BE_A_NUMBER_IN_A_STRING = 'pim_measurements.validation.measurement_family.convert.value_should_be_a_number_in_a_string';

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValueValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValueValidator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /*
  * This file is part of the Akeneo PIM Enterprise Edition.
  *
- * (c) 2018 Akeneo SAS (http://www.akeneo.com)
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -19,10 +19,6 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Validation;
 
-/**
- * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
- * @copyright 2018 Akeneo SAS (https://www.akeneo.com)
- */
 class OperationValueValidator extends ConstraintValidator
 {
     public function validate($convertValue, Constraint $constraint)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCode.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /*
  * This file is part of the Akeneo PIM Enterprise Edition.
  *
- * (c) 2018 Akeneo SAS (http://www.akeneo.com)
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -14,10 +14,6 @@ namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
 
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
- * @copyright 2018 Akeneo SAS (https://www.akeneo.com)
- */
 class StandardUnitCode extends Constraint
 {
     public const STANDARD_UNIT_CODE_SHOULD_EXIST = 'pim_measurements.validation.measurement_family.standard_unit_code_should_exist';

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeValidator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /*
  * This file is part of the Akeneo PIM Enterprise Edition.
  *
- * (c) 2018 Akeneo SAS (http://www.akeneo.com)
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -19,10 +19,6 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Validation;
 
-/**
- * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
- * @copyright 2018 Akeneo SAS (https://www.akeneo.com)
- */
 class StandardUnitCodeValidator extends ConstraintValidator
 {
     public function validate($saveMeasurementFamilyCommand, Constraint $constraint)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitCount.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitCount.php
@@ -14,13 +14,12 @@ namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
 
 use Symfony\Component\Validator\Constraint;
 
-class OperationCount extends Constraint
+class UnitCount extends Constraint
 {
-    public $minMessage = 'pim_measurements.validation.measurement_family.convert.should_contain_min_elements';
-    public $maxMessage = 'pim_measurements.validation.measurement_family.convert.should_contain_max_elements';
+    public $maxMessage = 'pim_measurements.validation.measurement_family.units.should_contain_max_elements';
 
     public function validatedBy()
     {
-        return 'akeneo_measure.validation.measurement_family.operation_count';
+        return 'akeneo_measure.validation.measurement_family.unit_count';
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitCountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitCountValidator.php
@@ -47,7 +47,6 @@ class UnitCountValidator extends ConstraintValidator
 
         if ($count > $this->max) {
             $this->context->buildViolation($constraint->maxMessage)
-                ->setParameter('{{ count }}', $count)
                 ->setParameter('{{ limit }}', $this->max)
                 ->setInvalidValue($value)
                 ->setPlural((int)$this->max)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitCountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitCountValidator.php
@@ -19,6 +19,7 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 class UnitCountValidator extends ConstraintValidator
 {
+    /** @var int */
     private $max;
 
     public function __construct(int $max)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitCountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitCountValidator.php
@@ -17,9 +17,8 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
-class OperationCountValidator extends ConstraintValidator
+class UnitCountValidator extends ConstraintValidator
 {
-    private $min = 1;
     private $max;
 
     public function __construct(int $max)
@@ -32,8 +31,8 @@ class OperationCountValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (!$constraint instanceof OperationCount) {
-            throw new UnexpectedTypeException($constraint, OperationCount::class);
+        if (!$constraint instanceof UnitCount) {
+            throw new UnexpectedTypeException($constraint, UnitCount::class);
         }
 
         if (null === $value) {
@@ -52,17 +51,6 @@ class OperationCountValidator extends ConstraintValidator
                 ->setParameter('{{ limit }}', $this->max)
                 ->setInvalidValue($value)
                 ->setPlural((int)$this->max)
-                ->addViolation();
-
-            return;
-        }
-
-        if ($count < $this->min) {
-            $this->context->buildViolation($constraint->minMessage)
-                ->setParameter('{{ count }}', $count)
-                ->setParameter('{{ limit }}', $this->min)
-                ->setInvalidValue($value)
-                ->setPlural((int)$this->min)
                 ->addViolation();
         }
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/AcceptanceTestCase.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/AcceptanceTestCase.php
@@ -37,7 +37,7 @@ abstract class AcceptanceTestCase extends KernelTestCase
      */
     protected function setUp(): void
     {
-        static::bootKernel(['debug' => false, 'env' => 'test_fake']);
+        static::bootKernel(['debug' => false, 'environment' => 'test_fake']);
         $this->connection = $this->get('doctrine.dbal.default_connection');
     }
 
@@ -51,9 +51,6 @@ abstract class AcceptanceTestCase extends KernelTestCase
      */
     protected function tearDown(): void
     {
-        $connectionCloser = $this->get('akeneo_integration_tests.doctrine.connection.connection_closer');
-        $connectionCloser->closeConnections();
-
         $this->ensureKernelShutdown();
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\tests\Acceptance;
 
+use Akeneo\Test\Acceptance\MeasurementFamily\InMemoryMeasurementFamilyRepository;
 use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
@@ -11,7 +12,6 @@ use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
-use Akeneo\Test\Acceptance\MeasurementFamily\InMemoryMeasurementFamilyRepository;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class SaveMeasurementFamilyTest extends AcceptanceTestCase

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
@@ -5,7 +5,13 @@ declare(strict_types=1);
 namespace Akeneo\Tool\Bundle\MeasureBundle\tests\Acceptance;
 
 use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
-use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Akeneo\Test\Acceptance\MeasurementFamily\InMemoryMeasurementFamilyRepository;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class SaveMeasurementFamilyTest extends AcceptanceTestCase
@@ -13,7 +19,7 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
     /** * @var ValidatorInterface */
     private $validator;
 
-    /** @var MeasurementFamilyRepositoryInterface */
+    /** @var InMemoryMeasurementFamilyRepository */
     private $measurementFamilyRepository;
 
     public function setUp(): void
@@ -21,6 +27,7 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
         parent::setUp();
         $this->validator = $this->get('validator');
         $this->measurementFamilyRepository = $this->get('akeneo_measure.persistence.measurement_family_repository');
+        $this->measurementFamilyRepository->clear();
     }
 
     /**
@@ -34,8 +41,8 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
         $saveFamilyCommand->standardUnitCode = 'kilogram';
         $saveFamilyCommand->units = [
             [
-                'code'                  => 'kilogram',
-                'labels'                => [],
+                'code' => 'kilogram',
+                'labels' => [],
                 'convert_from_standard' => [['operator' => 'mul', 'value' => '153']],
                 'symbol' => 'Km'
             ]
@@ -60,8 +67,8 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
         $saveFamilyCommand->standardUnitCode = 'kilogram';
         $saveFamilyCommand->units = [
             [
-                'code'                  => 'kilogram',
-                'labels'                => [],
+                'code' => 'kilogram',
+                'labels' => [],
                 'convert_from_standard' => [['operator' => 'mul', 'value' => '153']],
                 'symbol' => 'Km'
             ]
@@ -85,8 +92,8 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
         $saveFamilyCommand->standardUnitCode = 'invalid_standard_unit_code';
         $saveFamilyCommand->units = [
             [
-                'code'                  => 'kilogram',
-                'labels'                => [],
+                'code' => 'kilogram',
+                'labels' => [],
                 'convert_from_standard' => [['operator' => 'mul', 'value' => '153']],
                 'symbol' => 'Km'
             ]
@@ -114,8 +121,8 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
         $saveFamilyCommand->standardUnitCode = $invalidCodes;
         $saveFamilyCommand->units = [
             [
-                'code'                  => $invalidCodes,
-                'labels'                => [],
+                'code' => $invalidCodes,
+                'labels' => [],
                 'convert_from_standard' => [['operator' => 'mul', 'value' => '153']],
                 'symbol' => 'Km'
             ]
@@ -140,8 +147,8 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
         $saveFamilyCommand->standardUnitCode = 'kilogram';
         $saveFamilyCommand->units = [
             [
-                'code'                  => 'kilogram',
-                'labels'                => $invalidLabels,
+                'code' => 'kilogram',
+                'labels' => $invalidLabels,
                 'convert_from_standard' => [['operator' => 'mul', 'value' => '153']],
                 'symbol' => 'Km'
             ]
@@ -166,8 +173,8 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
         $saveFamilyCommand->standardUnitCode = 'kilogram';
         $saveFamilyCommand->units = [
             [
-                'code'                  => 'kilogram',
-                'labels'                => [],
+                'code' => 'kilogram',
+                'labels' => [],
                 'convert_from_standard' => [['operator' => $invalidOperator, 'value' => '251']],
                 'symbol' => 'Km'
             ]
@@ -192,8 +199,8 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
         $saveFamilyCommand->standardUnitCode = 'kilogram';
         $saveFamilyCommand->units = [
             [
-                'code'                  => 'kilogram',
-                'labels'                => [],
+                'code' => 'kilogram',
+                'labels' => [],
                 'convert_from_standard' => [['operator' => 'mul', 'value' => $invalidConvertValue]],
                 'symbol' => 'Km'
             ]
@@ -218,8 +225,8 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
         $saveFamilyCommand->standardUnitCode = 'kilogram';
         $saveFamilyCommand->units = [
             [
-                'code'                  => 'kilogram',
-                'labels'                => [],
+                'code' => 'kilogram',
+                'labels' => [],
                 'convert_from_standard' => [['operator' => 'mul', 'value' => '255']],
                 'symbol' => $invalidUnitSymbol
             ]
@@ -284,6 +291,49 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
         self::assertEquals($errorMessage, $violation->getMessage());
     }
 
+    /**
+     * @test
+     */
+    public function is_cannot_create_too_many_measurement_families(): void
+    {
+        for ($i = 0; $i < 100; $i++) {
+            $measurementFamily = MeasurementFamily::create(
+                MeasurementFamilyCode::fromString(sprintf('unit_%d', $i)),
+                LabelCollection::fromArray(['en_US' => 'Custom measurement']),
+                UnitCode::fromString(sprintf('UNIT_%d', $i)),
+                [
+                    Unit::create(
+                        UnitCode::fromString(sprintf('UNIT_%d', $i)),
+                        LabelCollection::fromArray(['en_US' => 'Custom unit']),
+                        [Operation::create('mul', '1')],
+                        'mm²',
+                    ),
+                ]
+            );
+
+            $this->measurementFamilyRepository->save($measurementFamily);
+        }
+
+        $saveFamilyCommand = new SaveMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = 'kilogram';
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '1']],
+                'symbol' => 'Kg',
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals('You’ve reached the limit of 100 measurement families.', $violation->getMessage());
+    }
+
     public function invalidCodes(): array
     {
         return [
@@ -301,14 +351,14 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
     {
         return [
             'Locale code should be a string' => [[123 => 'my label'], 'This value should be of type string.'],
-            'Label should be a string'       => [['fr_FR' => 12], 'This value should be of type string.']
+            'Label should be a string' => [['fr_FR' => 12], 'This value should be of type string.']
         ];
     }
 
     public function invalidOperator(): array
     {
         return [
-            'Operator cannot be blank'  => [null, 'This value should not be blank.'],
+            'Operator cannot be blank' => [null, 'This value should not be blank.'],
             'Operator is not supported' => ['invalid_operator', 'The value you selected is not a valid choice.'],
         ];
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/Persistence/MeasurementFamilyRepositoryIntegration.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/Persistence/MeasurementFamilyRepositoryIntegration.php
@@ -60,6 +60,22 @@ class MeasurementFamilyRepositoryIntegration extends SqlIntegrationTestCase
     /**
      * @test
      */
+    public function it_returns_the_amount_of_measurement_families_if_the_code_does_not_exists(): void
+    {
+        $this->assertEquals(2, $this->repository->countAllOthers(MeasurementFamilyCode::fromString('NOT_EXISTING')));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_amount_of_others_measurement_families_if_the_code_exists(): void
+    {
+        $this->assertEquals(1, $this->repository->countAllOthers(MeasurementFamilyCode::fromString('Area')));
+    }
+
+    /**
+     * @test
+     */
     public function it_throws_when_the_measurement_family_does_not_exists(): void
     {
         $this->expectException(MeasurementFamilyNotFoundException::class);

--- a/tests/back/Acceptance/MeasurementFamily/InMemoryMeasurementFamilyRepository.php
+++ b/tests/back/Acceptance/MeasurementFamily/InMemoryMeasurementFamilyRepository.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AkeneoTest\Acceptance\MeasurementFamily;
+namespace Akeneo\Test\Acceptance\MeasurementFamily;
 
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
@@ -66,5 +66,21 @@ class InMemoryMeasurementFamilyRepository implements MeasurementFamilyRepository
     public function save(MeasurementFamily $measurementFamily)
     {
         $this->measurementFamilies[$measurementFamily->normalize()['code']] = $measurementFamily;
+    }
+
+    public function countAllOthers(MeasurementFamilyCode $excludedMeasurementFamilyCode): int
+    {
+        if (empty($this->measurementFamilies)) {
+            $this->measurementFamilies = $this->loadMeasurementFamilies();
+        }
+
+        return isset($this->measurementFamilies[$excludedMeasurementFamilyCode->normalize()])
+            ? count($this->measurementFamilies) - 1
+            : count($this->measurementFamilies);
+    }
+
+    public function clear(): void
+    {
+        $this->measurementFamilies = [];
     }
 }

--- a/tests/back/Acceptance/Resources/config/pim/repositories.yml
+++ b/tests/back/Acceptance/Resources/config/pim/repositories.yml
@@ -39,7 +39,7 @@ services:
         class: 'Akeneo\Test\Acceptance\AssociationType\InMemoryAssociationTypeRepository'
 
     akeneo_measure.persistence.measurement_family_repository:
-        class: AkeneoTest\Acceptance\MeasurementFamily\InMemoryMeasurementFamilyRepository
+        class: 'Akeneo\Test\Acceptance\MeasurementFamily\InMemoryMeasurementFamilyRepository'
 
     ### Structure
     pim_catalog.repository.family:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The limits are:
- At least one mandatory operation per unit.
- 5 operations max per unit.
- The max number of measurement family is 100.
- The max number of units per measurement family is 50.

 This limits are configurable with the following parameters:
```
parameters:
    akeneo_measure.validation.measurement_family.operations_max: 5
    akeneo_measure.validation.measurement_family.units_max: 50
    akeneo_measure.validation.measurement_family.families_max: 100
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | yes
| Added integration tests           | yes
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
