### PR TITLE
TIP-1395: Adds a webpack option to run typescript without type checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,9 @@ jobs:
               name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
               command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
         - run:
+              name: Front type checking
+              command: make javascript-dev-strict
+        - run:
               name: Front linter
               command: make lint-front
         - run:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ javascript-dev:
 	$(YARN_RUN) run webpack-dev
 
 .PHONY: javascript-dev-strict
-javascript-dev:
+javascript-dev-strict:
 	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf public/dist
 	$(YARN_RUN) run webpack-dev --strict
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ javascript-dev:
 	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf public/dist
 	$(YARN_RUN) run webpack-dev
 
+.PHONY: javascript-dev-strict
+javascript-dev:
+	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf public/dist
+	$(YARN_RUN) run webpack-dev --strict
+
 .PHONY: javascript-test
 javascript-test:
 	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf public/dist

--- a/Makefile
+++ b/Makefile
@@ -36,22 +36,22 @@ css:
 
 .PHONY: javascript-prod
 javascript-prod:
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf public/dist
+	$(NODE_RUN) rm -rf public/dist
 	$(YARN_RUN) run webpack
 
 .PHONY: javascript-dev
 javascript-dev:
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf public/dist
+	$(NODE_RUN) rm -rf public/dist
 	$(YARN_RUN) run webpack-dev
 
 .PHONY: javascript-dev-strict
 javascript-dev-strict:
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf public/dist
+	$(NODE_RUN) rm -rf public/dist
 	$(YARN_RUN) run webpack-dev --strict
 
 .PHONY: javascript-test
 javascript-test:
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf public/dist
+	$(NODE_RUN) rm -rf public/dist
 	$(YARN_RUN) run webpack-test
 
 .PHONY: front

--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ https://docs.akeneo.com/master/migrate_pim/index.html
 
 To run the tests of Akeneo PIM, please follow:
 https://github.com/akeneo/pim-community-dev/blob/master/internal_doc/tests/running_the_tests.md
+
+CI

--- a/README.md
+++ b/README.md
@@ -32,5 +32,3 @@ https://docs.akeneo.com/master/migrate_pim/index.html
 
 To run the tests of Akeneo PIM, please follow:
 https://github.com/akeneo/pim-community-dev/blob/master/internal_doc/tests/running_the_tests.md
-
-CI

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "requirements": "node $npm_package_config_source/frontend/build/check-requirements.js",
     "webpack": "yarn requirements && NODE_PATH=node_modules webpack --config $npm_package_config_source/webpack.config.js --env=prod",
     "webpack-dev": "yarn requirements && NODE_PATH=node_modules webpack --config $npm_package_config_source/webpack.config.js",
-    "webpack-watch": "yarn requirements && NODE_PATH=node_modules webpack --progress --config $npm_package_config_source/webpack.config.js --watch",
+    "webpack-watch": "yarn requirements && NODE_PATH=node_modules webpack --progress --config $npm_package_config_source/webpack.config.js --watch --strict",
     "prettier": "prettier --config .prettierrc.json --parser typescript --write \"./src/**/*.ts\";",
     "before-commit": "yarn prettier && yarn lint && yarn test",
     "test": "yarn unit && yarn webpack-test --env=prod && yarn integration && yarn acceptance tests/features",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -190,7 +190,6 @@ const webpackConfig = {
             loader: 'ts-loader',
             options: {
               transpileOnly: !isStrict,
-              experimentalWatchApi: true,
               configFile: path.resolve(rootDir, 'tsconfig.json'),
               context: path.resolve(rootDir),
             },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const WebpackShellPlugin = require('webpack-shell-plugin');
 const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const isProd = process.argv && process.argv.indexOf('--env=prod') > -1;
+const isStrict = process.argv && process.argv.indexOf('--strict') > -1;
 const {getModulePaths, createModuleRegistry} = require('./frontend/webpack/requirejs-utils');
 const {aliases, config} = getModulePaths(rootDir, __dirname);
 
@@ -188,6 +189,8 @@ const webpackConfig = {
           {
             loader: 'ts-loader',
             options: {
+              transpileOnly: !isStrict,
+              experimentalWatchApi: true,
               configFile: path.resolve(rootDir, 'tsconfig.json'),
               context: path.resolve(rootDir),
             },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ const {aliases, config} = getModulePaths(rootDir, __dirname);
 
 createModuleRegistry(Object.keys(aliases), rootDir);
 
-console.log('Starting webpack from', rootDir, 'in', isProd ? 'prod' : 'dev', 'mode');
+console.log('Starting webpack from', rootDir, 'in', isProd ? 'prod' : 'dev', 'mode', isStrict ? 'with typechecking' : '');
 
 const webpackConfig = {
   stats: {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This is an attempt to improve webpack build times.

The **webpack build time is increasing** and the main culprit is `typescript` with its `ts-loader`, 
mostly on the **type-checking** part.

For a lot of daily tasks, when we are building the PIM, we don't need to run the type-checking. It should only be executed when needed and on the CI, as we already do for the back with `make lint-back`.

This PR introduces a new option for our webpack config: `--strict`. When enabled, webpack will run as before, with the type-checking.  When omitted, typescript will only transpile from `ts` to `js`.

#### What are the performances changes (CE) ? (TL;DR: -30%)

For the benchmark, I've used a small script to cleanup the cache between builds, to check the performances on a "cold" webpack:
```
#!/bin/bash

rm -rf node_modules/.cache public/cache
yarn run webpack
```

Webpack **before**:
```
$ perf stat -r 10 -B ./perf.sh

 Performance counter stats for './perf.sh' (10 runs):
      32,897314634 seconds time elapsed                                          ( +-  1,35% )
```

Webpack **after**, without `--strict`:
```
perf stat -r 10 -B ./perf.sh

 Performance counter stats for './perf.sh' (10 runs):
      22,984510380 seconds time elapsed                                          ( +-  2,01% )
```

#### What about the CI ?

For the CI, I introduced a new make command: `make javascript-dev-strict` and a new step `Front type checking` inside `test_front_static_acceptance_and_integration`.

#### And if I want the type-checking ?

You can keep the previous behavior by running `yarn run webpack-dev --strict`.

Also, `yarn run webpack-watch` is unaffected, `--strict` is enabled by default when using watch, as we usually want type-checking when working actively on the frontend code.

#### Overall benefits

This commands are **slightly faster**:

- `make pim-dev`
- `make pim-behat`
- `make javascript-dev`
- `make front`
- `yarn run webpack`
- `yarn run webpack-dev`
- `yarn run webpack-test`

And the CI differences (approximatly, I don't want to run a lot of jobs for this):

| step | before | after | diff |
|---|---:|---:|---:|
| build_dev | 4m 4s | 3m 51s | **-13s** |
| test_front_static_acceptance_and_integration | 3m 8s | 3m 46s | **+38s** | 

Note: The differences are insignificant regarding the CI for the CE but are more valuable in EE.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
