### PR TITLE
MET-64: Add validation to prevent removing units when measurement family is locked

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily.php
@@ -22,7 +22,7 @@ class IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily
         $this->connection = $connection;
     }
 
-    public function execute(string $metricFamily): bool
+    public function execute(string $metricFamilyCode): bool
     {
         $query = <<<SQL
 SELECT 1
@@ -30,7 +30,7 @@ FROM pim_catalog_attribute
 WHERE metric_family = :metric_family
 AND attribute_type = 'pim_catalog_metric';
 SQL;
-        $stmt = $this->connection->executeQuery($query, ['metric_family' => $metricFamily]);
+        $stmt = $this->connection->executeQuery($query, ['metric_family' => $metricFamilyCode]);
         $result = $this->connection->convertToPHPValue($stmt->fetch(\PDO::FETCH_COLUMN), Type::BOOLEAN);
 
         return $result;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyCommand.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyCommand.php
@@ -21,5 +21,5 @@ class SaveMeasurementFamilyCommand
     public $standardUnitCode;
 
     /** @var array */
-    public $units = [];
+    public $units;
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidator.php
@@ -38,7 +38,7 @@ class MeasurementFamilyValidator
                 '_links'             => ['type' => 'object'],
                 'code'               => ['type' => ['string'],],
                 'labels'             => [
-                    'type'              => 'object',
+                    'type'              => ['object', 'array'],
                     'patternProperties' => [
                         '.+' => ['type' => 'string'],
                     ],
@@ -53,7 +53,7 @@ class MeasurementFamilyValidator
                         'properties' => [
                             'code'                  => ['type' => 'string'],
                             'labels'                => [
-                                'type'              => 'object',
+                                'type'              => ['object', 'array'],
                                 'patternProperties' => [
                                     '.+' => ['type' => 'string'],
                                 ],

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -75,8 +75,8 @@ SQL;
             ]
         );
 
-        // 1 if INSERT, 2 if UPDATE
-        if ($affectedRows !== 1 && $affectedRows !== 2) {
+        // 0 if SAME, 1 if INSERT, 2 if UPDATE
+        if ($affectedRows !== 0 && $affectedRows !== 1 && $affectedRows !== 2) {
             throw new \RuntimeException(
                 sprintf('Expected to create/update one measurement family, but %d were affected', $affectedRows)
             );

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
@@ -65,7 +65,7 @@ services:
             - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validation.measurement_family.count' }
 
     # Validation
-    akeneo_measure.validation.measure_family.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units:
+    akeneo_measure.validation.measurement_family.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units:
         class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
@@ -63,3 +63,12 @@ services:
             - '%akeneo_measure.validation.measurement_family.families_max%'
         tags:
             - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validation.measurement_family.count' }
+
+    # Validation
+    akeneo_measure.validation.measure_family.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator
+        arguments:
+            - '@akeneo_measure.persistence.measurement_family_repository'
+            - '@akeneo.pim.structure.query.is_there_at_least_one_attribute_configured_with_measurement_family'
+        tags:
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validator.asset.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units' }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
@@ -32,5 +32,6 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasureme
                                         value:
                                             - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationValue: ~
     constraints:
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCode: ~
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeShouldExist: ~
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits: { groups: [other_constraints] }
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\Count: { groups: [other_constraints] }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
@@ -28,7 +28,9 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasureme
                                         operator:
                                             - NotBlank: ~
                                             - Type: string
-                                            - Choice: [mul, div, add, sub]
+                                            - Choice:
+                                                choices: [mul, div, add, sub]
+                                                message: pim_measurements.validation.measurement_family.units.operation.invalid_operator
                                         value:
                                             - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationValue: ~
     constraints:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -11,8 +11,9 @@ pim_measurements:
                 value_should_be_a_number_in_a_string: 'The conversion value should be a number represented in a string (example: "0.2561")'
                 should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'
                 should_contain_max_elements: 'You’ve reached the limit of {{ limit }} conversion operations per unit.'
-                measurement_family_standard_unit_code_is_locked_for_updates: 'The update of the "%measurement_family_code%" measurement family standard unit code is not allowed because it is linked to a product attribute.'
-                measurement_family_units_is_locked_for_updates: 'The removal of the %unit_code% unit(s) in the "%measurement_family_code%" measurement family is not allowed because it is linked to a product attribute.'
+            measurement_family_standard_unit_code_is_locked_for_updates: 'The update of the "%measurement_family_code%" measurement family standard unit code is not allowed because it is linked to a product attribute.'
+            measurement_family_units_is_locked_for_updates: 'The removal of the %unit_code% unit(s) in the "%measurement_family_code%" measurement family is not allowed because it is linked to a product attribute.'
+            measurement_family_unit_operations_locked_for_updates: 'The update of the convert operations for the %unit_code% unit(s) in the "%measurement_family_code%" measurement family is not allowed because it is linked to a product attribute.'
             units:
                 should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'
                 should_contain_max_elements: 'You’ve reached the limit of {{ limit }} conversion operations per unit.'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -5,15 +5,17 @@ pim_measurements:
                 pattern: 'This field can only contain letters, numbers, and underscores.'
                 limit_reached: 'You cannot create the "%measurement_family_code%" measurement family because you have reached the limit of %limit% measurement families'
         measurement_family:
-            standard_unit_code_should_exist: 'The "%standard_unit_code%" standard unit code does not exist in the list of units for the measurement family.'
+            standard_unit_code:
+                is_required: 'The standard unit is required.'
+                should_be_in_the_list_of_units: 'The "%standard_unit_code%" standard unit code does not exist in the list of units for the measurement family.'
             should_contain_max_elements: 'You’ve reached the limit of {{ limit }} measurement families.'
             convert:
                 value_should_be_a_number_in_a_string: 'The conversion value should be a number represented in a string (example: "0.2561")'
                 should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'
                 should_contain_max_elements: 'You’ve reached the limit of {{ limit }} conversion operations per unit.'
-            measurement_family_standard_unit_code_is_locked_for_updates: 'The update of the "%measurement_family_code%" measurement family standard unit code is not allowed because it is linked to a product attribute.'
-            measurement_family_units_is_locked_for_updates: 'The removal of the %unit_code% unit(s) in the "%measurement_family_code%" measurement family is not allowed because it is linked to a product attribute.'
-            measurement_family_unit_operations_locked_for_updates: 'The update of the convert operations for the %unit_code% unit(s) in the "%measurement_family_code%" measurement family is not allowed because it is linked to a product attribute.'
+            measurement_family_standard_unit_code_is_locked_for_updates: 'A product attribute is linked to this measurement family, you can only edit its translated labels.'
+            measurement_family_units_is_locked_for_updates: 'A product attribute is linked to this measurement family, you can only edit the translated labels and symbol of a unit'
+            measurement_family_unit_operations_locked_for_updates: 'A product attribute is linked to this measurement family, you can only edit the translated labels and symbol of a unit'
             units:
                 should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'
                 should_contain_max_elements: 'You’ve reached the limit of {{ limit }} conversion operations per unit.'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -11,6 +11,8 @@ pim_measurements:
                 value_should_be_a_number_in_a_string: 'The conversion value should be a number represented in a string (example: "0.2561")'
                 should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'
                 should_contain_max_elements: 'You’ve reached the limit of {{ limit }} conversion operations per unit.'
+                measurement_family_standard_unit_code_is_locked_for_updates: 'The update of the "%measurement_family_code%" measurement family standard unit code is not allowed because it is linked to a product attribute.'
+                measurement_family_units_is_locked_for_updates: 'The removal of the %unit_code% unit(s) in the "%measurement_family_code%" measurement family is not allowed because it is linked to a product attribute.'
             units:
                 should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'
                 should_contain_max_elements: 'You’ve reached the limit of {{ limit }} conversion operations per unit.'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -7,7 +7,7 @@ pim_measurements:
         measurement_family:
             standard_unit_code:
                 is_required: 'The standard unit is required.'
-                should_be_in_the_list_of_units: 'The "%standard_unit_code%" standard unit code does not exist in the list of units for the measurement family.'
+                should_be_in_the_list_of_units: 'The "%standard_unit_code%" standard unit code does not exist in the list of units for the "%measurement_family_code%" measurement family.'
             should_contain_max_elements: 'You’ve reached the limit of {{ limit }} measurement families.'
             convert:
                 value_should_be_a_number_in_a_string: 'The conversion value should be a number represented in a string (example: "0.2561")'
@@ -19,3 +19,5 @@ pim_measurements:
             units:
                 should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'
                 should_contain_max_elements: 'You’ve reached the limit of {{ limit }} conversion operations per unit.'
+                operation:
+                    invalid_operator: 'The {{ value }} operator is invalid, please use {{ choices }} instead.'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CountValidator.php
@@ -23,6 +23,7 @@ class CountValidator extends ConstraintValidator
 {
     /** @var MeasurementFamilyRepositoryInterface */
     private $measurementFamilyRepository;
+
     /** @var int */
     private $max;
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCountValidator.php
@@ -21,6 +21,7 @@ class OperationCountValidator extends ConstraintValidator
 {
     /** @var int */
     private $min = 1;
+
     /** @var int */
     private $max;
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValue.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValue.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraint;
 
 class OperationValue extends Constraint
 {
-    const VALUE_SHOULD_BE_A_NUMBER_IN_A_STRING = 'pim_measurements.validation.measurement_family.convert.value_should_be_a_number_in_a_string';
+    public const VALUE_SHOULD_BE_A_NUMBER_IN_A_STRING = 'pim_measurements.validation.measurement_family.convert.value_should_be_a_number_in_a_string';
 
     public function getTargets()
     {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExist.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExist.php
@@ -14,7 +14,7 @@ namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
 
 use Symfony\Component\Validator\Constraint;
 
-class StandardUnitCode extends Constraint
+class StandardUnitCodeShouldExist extends Constraint
 {
     public const STANDARD_UNIT_CODE_SHOULD_EXIST = 'pim_measurements.validation.measurement_family.standard_unit_code_should_exist';
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExist.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExist.php
@@ -16,7 +16,8 @@ use Symfony\Component\Validator\Constraint;
 
 class StandardUnitCodeShouldExist extends Constraint
 {
-    public const STANDARD_UNIT_CODE_SHOULD_EXIST = 'pim_measurements.validation.measurement_family.standard_unit_code_should_exist';
+    public const STANDARD_UNIT_CODE_SHOULD_EXIST_IN_THE_LIST_OF_UNITS = 'pim_measurements.validation.measurement_family.standard_unit_code.should_be_in_the_list_of_units';
+    public const STANDARD_UNIT_CODE_IS_REQUIRED = 'pim_measurements.validation.measurement_family.standard_unit_code.is_required';
 
     public function getTargets()
     {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExistValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExistValidator.php
@@ -41,11 +41,14 @@ class StandardUnitCodeShouldExistValidator extends ConstraintValidator
         }
 
         $validator = Validation::createValidator();
+        $measurementFamilyCode = $saveMeasurementFamilyCommand->code;
         $violations = $validator->validate(
             $saveMeasurementFamilyCommand->units,
             [
                 new Callback(
-                    function (array $units, ExecutionContextInterface $context) use ($standardUnitCode) {
+                    function (array $units, ExecutionContextInterface $context)
+                    use ($standardUnitCode, $measurementFamilyCode)
+                    {
                         foreach ($units as $unit) {
                             if ($standardUnitCode === $unit['code']) {
                                 return;
@@ -53,7 +56,7 @@ class StandardUnitCodeShouldExistValidator extends ConstraintValidator
                         }
                         $context->buildViolation(
                             StandardUnitCodeShouldExist::STANDARD_UNIT_CODE_SHOULD_EXIST_IN_THE_LIST_OF_UNITS,
-                            ['%standard_unit_code%' => $standardUnitCode]
+                            ['%standard_unit_code%' => $standardUnitCode, '%measurement_family_code%' => $measurementFamilyCode]
                         )->addViolation();
                     }
                 )

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExistValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExistValidator.php
@@ -33,6 +33,12 @@ class StandardUnitCodeShouldExistValidator extends ConstraintValidator
             );
         }
         $standardUnitCode = $saveMeasurementFamilyCommand->standardUnitCode;
+        if (empty($standardUnitCode)) {
+            $this->context->buildViolation(StandardUnitCodeShouldExist::STANDARD_UNIT_CODE_IS_REQUIRED)
+                ->addViolation();
+
+            return;
+        }
 
         $validator = Validation::createValidator();
         $violations = $validator->validate(
@@ -46,7 +52,7 @@ class StandardUnitCodeShouldExistValidator extends ConstraintValidator
                             }
                         }
                         $context->buildViolation(
-                            StandardUnitCodeShouldExist::STANDARD_UNIT_CODE_SHOULD_EXIST,
+                            StandardUnitCodeShouldExist::STANDARD_UNIT_CODE_SHOULD_EXIST_IN_THE_LIST_OF_UNITS,
                             ['%standard_unit_code%' => $standardUnitCode]
                         )->addViolation();
                     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExistValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExistValidator.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Validation;
 
-class StandardUnitCodeValidator extends ConstraintValidator
+class StandardUnitCodeShouldExistValidator extends ConstraintValidator
 {
     public function validate($saveMeasurementFamilyCommand, Constraint $constraint)
     {
@@ -46,7 +46,7 @@ class StandardUnitCodeValidator extends ConstraintValidator
                             }
                         }
                         $context->buildViolation(
-                            StandardUnitCode::STANDARD_UNIT_CODE_SHOULD_EXIST,
+                            StandardUnitCodeShouldExist::STANDARD_UNIT_CODE_SHOULD_EXIST,
                             ['%standard_unit_code%' => $standardUnitCode]
                         )->addViolation();
                     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExistValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/StandardUnitCodeShouldExistValidator.php
@@ -46,9 +46,7 @@ class StandardUnitCodeShouldExistValidator extends ConstraintValidator
             $saveMeasurementFamilyCommand->units,
             [
                 new Callback(
-                    function (array $units, ExecutionContextInterface $context)
-                    use ($standardUnitCode, $measurementFamilyCode)
-                    {
+                    function (array $units, ExecutionContextInterface $context) use ($standardUnitCode, $measurementFamilyCode) {
                         foreach ($units as $unit) {
                             if ($standardUnitCode === $unit['code']) {
                                 return;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits extends Constraint
+{
+    public const MEASUREMENT_FAMILY_STANDARD_UNIT_CODE_IS_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.convert.measurement_family_standard_unit_code_is_locked_for_updates';
+    public const MEASUREMENT_FAMILY_UNIT_REMOVAL_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.convert.measurement_family_units_is_locked_for_updates';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    public function validatedBy(): string
+    {
+        return 'akeneo_measure.validator.asset.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units';
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
@@ -13,8 +13,9 @@ use Symfony\Component\Validator\Constraint;
  */
 class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits extends Constraint
 {
-    public const MEASUREMENT_FAMILY_STANDARD_UNIT_CODE_IS_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.convert.measurement_family_standard_unit_code_is_locked_for_updates';
-    public const MEASUREMENT_FAMILY_UNIT_REMOVAL_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.convert.measurement_family_units_is_locked_for_updates';
+    public const MEASUREMENT_FAMILY_STANDARD_UNIT_CODE_IS_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.measurement_family_standard_unit_code_is_locked_for_updates';
+    public const MEASUREMENT_FAMILY_UNIT_REMOVAL_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.measurement_family_units_is_locked_for_updates';
+    public const MEASUREMENT_FAMILY_OPERATION_UPDATE_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.measurement_family_unit_operations_locked_for_updates';
 
     public function getTargets()
     {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator.php
@@ -110,12 +110,7 @@ class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUn
             return $unit['code'];
         }, $saveMeasurementFamily->units);
 
-        return array_unique(
-            array_merge(
-                array_diff($actualUnitCodes, $unitCodesToUpdate),
-                array_diff($unitCodesToUpdate, $actualUnitCodes)
-            )
-        );
+        return array_diff($actualUnitCodes, $unitCodesToUpdate);
     }
 
     private function isTryingToUpdateTheConvertionOperations(

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+
+use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator extends ConstraintValidator
+{
+    /** @var IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily */
+    private $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+
+    public function __construct(
+        MeasurementFamilyRepositoryInterface $measurementFamilyRepository,
+        IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily
+    ) {
+        $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily = $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+        $this->measurementFamilyRepository = $measurementFamilyRepository;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate($saveMeasurementFamily, Constraint $constraint)
+    {
+        $isMeasureFamilyLockedForUpdates = $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily
+            ->execute($saveMeasurementFamily->code);
+
+        if (!$isMeasureFamilyLockedForUpdates) {
+            return;
+        }
+
+        try {
+            $measurementFamily = $this->measurementFamilyRepository->getByCode(MeasurementFamilyCode::fromString($saveMeasurementFamily->code));
+        } catch (MeasurementFamilyNotFoundException $exception) {
+            return;
+        }
+
+        if ($this->isTryingToUpdateStandardUnitCode($measurementFamily, $saveMeasurementFamily)) {
+            $this->context->buildViolation(
+                WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits::MEASUREMENT_FAMILY_STANDARD_UNIT_CODE_IS_NOT_ALLOWED,
+                ['%measurement_family_code%' => $saveMeasurementFamily->code]
+            )->addViolation();
+        }
+
+        $removedUnits = $this->isTryingToRemoveAUnit($measurementFamily, $saveMeasurementFamily);
+        if (0 !== \count($removedUnits)) {
+            $this->context->buildViolation(
+                WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits::MEASUREMENT_FAMILY_UNIT_REMOVAL_NOT_ALLOWED,
+                [
+                    '%unit_code%'               => implode(',', $removedUnits),
+                    '%measurement_family_code%' => $saveMeasurementFamily->code
+                ]
+            )->addViolation();
+        }
+
+    }
+
+    private function isTryingToUpdateStandardUnitCode(
+        MeasurementFamily $measurementFamily,
+        SaveMeasurementFamilyCommand $saveMeasurementFamilyCommand
+    ): bool {
+        $normalizedMeasurementFamily = $measurementFamily->normalize();
+
+        return $normalizedMeasurementFamily['standard_unit_code'] !== $saveMeasurementFamilyCommand->standardUnitCode;
+    }
+
+    private function isTryingToRemoveAUnit(MeasurementFamily $measurementFamily, SaveMeasurementFamilyCommand $saveMeasurementFamily): array
+    {
+        $normalizedMeasurementFamily = $measurementFamily->normalize();
+        $actualUnitCodes = array_map(
+            function (array $unit) {
+                return $unit['code'];
+            },
+            $normalizedMeasurementFamily['units']
+        );
+        $unitCodesToUpdate = array_map(function (array $unit) {
+            return $unit['code'];
+        }, $saveMeasurementFamily->units);
+
+        return array_unique(
+            array_merge(
+                array_diff($actualUnitCodes, $unitCodesToUpdate),
+                array_diff($unitCodesToUpdate, $actualUnitCodes)
+            )
+        );
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator.php
@@ -157,7 +157,7 @@ class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUn
             $serializedOperations = array_map(
                 function (array $unit) {
                     return json_encode($unit);
-                },$unit['convert_from_standard']);
+                }, $unit['convert_from_standard']);
             $operationsPerUnit[$unitCode] = $serializedOperations;
         }
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
@@ -244,6 +244,30 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
     /**
      * @test
      */
+    public function it_does_not_specify_a_standard_unit_code(): void
+    {
+        $saveFamilyCommand = new SaveMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '153']],
+                'symbol' => 'Km'
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals('The standard unit is required.', $violation->getMessage());
+    }
+
+    /**
+     * @test
+     */
     public function it_has_a_standard_unit_which_is_not_a_unit_of_the_measurement_family(): void
     {
         $saveFamilyCommand = new SaveMeasurementFamilyCommand();

--- a/tests/back/Acceptance/Attribute/InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub.php
+++ b/tests/back/Acceptance/Attribute/InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\Acceptance\Attribute;
+
+use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub extends IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily
+{
+    private $result = false;
+
+    public function __construct(Connection $connection = null)
+    {
+    }
+
+    public function execute(string $metricFamilyCode): bool
+    {
+        return $this->result;
+    }
+
+    public function setStub(bool $result): void
+    {
+        $this->result = $result;
+    }
+}

--- a/tests/back/Acceptance/MeasurementFamily/InMemoryMeasurementFamilyRepository.php
+++ b/tests/back/Acceptance/MeasurementFamily/InMemoryMeasurementFamilyRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Test\Acceptance\MeasurementFamily;
 
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
@@ -35,6 +36,11 @@ class InMemoryMeasurementFamilyRepository implements MeasurementFamilyRepository
     {
         if (empty($this->measurementFamilies)) {
             $this->measurementFamilies = $this->loadMeasurementFamilies();
+        }
+
+        $measurementFamily = $this->measurementFamilies[$measurementFamilyCode->normalize()] ?? null;
+        if (null === $measurementFamily) {
+            throw new MeasurementFamilyNotFoundException();
         }
 
         return $this->measurementFamilies[$measurementFamilyCode->normalize()];

--- a/tests/back/Acceptance/Resources/config/pim/queries.yml
+++ b/tests/back/Acceptance/Resources/config/pim/queries.yml
@@ -4,7 +4,11 @@ services:
         class: 'Akeneo\Test\Acceptance\Attribute\InMemoryGetAttributes'
         arguments:
             - '@pim_catalog.repository.attribute'
+
     akeneo.pim.structure.query.get_existing_attribute_option_codes_from_option_codes:
         class: 'Akeneo\Test\Acceptance\AttributeOption\InMemoryGetExistingAttributeOptionCodes'
         arguments:
             - '@pim_catalog.repository.attribute_option'
+
+    akeneo.pim.structure.query.is_there_at_least_one_attribute_configured_with_measurement_family:
+        class: Akeneo\Test\Acceptance\Attribute\InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add update validation on update of a locked measurement family.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | Ok
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
