### PR TITLE
PIM-9133: Fix product save when the user has no permission on some attribute groups

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.0
 
+## Bug fixes
+
+- PIM-9133: Fix product save when the user has no permission on some attribute groups
+
 ## New features
 
 - MET-14: Measurements (or metrics) are now stored in database

--- a/src/Akeneo/Pim/Enrichment/Bundle/Filter/ProductEditDataFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Filter/ProductEditDataFilter.php
@@ -52,7 +52,7 @@ class ProductEditDataFilter implements CollectionFilterInterface
 
         foreach ($collection as $type => $data) {
             if ($this->isAllowed($product, $type)) {
-                $newProductData[$type] = $data;
+                $newProductData[$type] = $this->filterData($type, $data);
             }
         }
 
@@ -65,6 +65,15 @@ class ProductEditDataFilter implements CollectionFilterInterface
     public function supportsCollection($collection, $type, array $options = [])
     {
         return false;
+    }
+
+    private function filterData(string $type, $data)
+    {
+        if ('values' === $type) {
+            $data = $this->productValuesFilter->filterCollection($data, 'pim.internal_api.product_values_data.edit');
+        }
+
+        return $data;
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This PR fixes a regression that can prevent a user from saving a product in a very specific usercase : 
Users `A` and `B` both open the same product page.
A user `A` update an attribute `A1` of an attribute group `Marketing` for example, and save a product. 
The user `B`, who still has the "old" version of the product, doesn't have edit rights on the attribute group `Marketing`, updates another attribute `A2` and try to save the product : there is an error.

This error occurs because the user send ALL the product data to the back when the form is sent, and the back doesn't filter the attributes the user can't edit. So for the backend point of view, the attribute `A1` that the user `A` sent to the back was updated. So in this PR, I now filter the attributes that the user can't edit so the updated won't even know that they were updated and only saves the attribute that the user can actually edit.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
