### PR TITLE
PIM-9135: Currency is not set by default on price filter

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-9135: Currency is not set by default on price filter on datagrid
+
 # 3.0.68 (2020-02-19)
 
 # 3.0.67 (2020-02-10)

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
@@ -191,9 +191,6 @@ define(
                 e.preventDefault();
             },
 
-            /**
-             * {@inheritdoc}
-             */
             _firstCurrency() {
                 return _.first(_.keys(this.currencies));
             },

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/price-filter.js
@@ -52,7 +52,7 @@ define(
                 NumberFilter.prototype.initialize.apply(this, arguments);
 
                 this.emptyValue = {
-                    currency: _.first(_.keys(this.currencies)),
+                    currency: this._firstCurrency(),
                     type: _.findWhere(this.choices, { label: '=' }).data,
                     value: ''
                 };
@@ -80,7 +80,7 @@ define(
                         updateLabel: __('pim_common.update'),
                         currencies: this.currencies,
                         currencyLabel: __('pim_datagrid.filters.price_filter.label'),
-                        selectedCurrency: this._getDisplayValue().currency,
+                        selectedCurrency: this._getDisplayValue().currency || this._firstCurrency(),
                         value: this._getDisplayValue().value
                     })
                 );
@@ -189,6 +189,13 @@ define(
                 this._highlightDropdown(value, '.currency');
 
                 e.preventDefault();
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            _firstCurrency() {
+                return _.first(_.keys(this.currencies));
             },
 
             /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
On version 3.0.68 currency is not set by default on price filter on the datagrid.
Now the first currency is selected by default.
This is a cherry pick from [this](https://github.com/akeneo/pim-community-dev/commit/01a2a71a7943231d1436a6a7486668d6042fcf17#diff-61c9320a11738f809f9d1123c0a05a15) ans [this](https://github.com/akeneo/pim-community-dev/commit/a17ccb59337d833551e4ebac2e5d62ef2b18c3f4#diff-61c9320a11738f809f9d1123c0a05a15) prs.


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       |-
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
