### PR TITLE
PIM-9110: remove completeness fk

### DIFF
--- a/upgrades/schema/Version_5_0_20200309165300_remove_product_foreign_key_pim_catalog_completeness.php
+++ b/upgrades/schema/Version_5_0_20200309165300_remove_product_foreign_key_pim_catalog_completeness.php
@@ -18,7 +18,7 @@ FROM information_schema.INNODB_FOREIGN AS fk
   JOIN information_schema.INNODB_FOREIGN_COLS AS fk_cols
     ON fk.id = fk_cols.id
 WHERE
-  fk.for_name = 'akeneo_pim/pim_catalog_completeness'
+  fk.for_name = '{db_name}/pim_catalog_completeness'
   AND fk.ref_name = '{db_name}/pim_catalog_product'
   AND fk_cols.for_col_name = 'product_id'
   AND fk_cols.ref_col_name = 'id'

--- a/upgrades/schema/Version_5_0_20200309165300_remove_product_foreign_key_pim_catalog_completeness.php
+++ b/upgrades/schema/Version_5_0_20200309165300_remove_product_foreign_key_pim_catalog_completeness.php
@@ -19,11 +19,12 @@ FROM information_schema.INNODB_FOREIGN AS fk
     ON fk.id = fk_cols.id
 WHERE
   fk.for_name = 'akeneo_pim/pim_catalog_completeness'
-  AND fk.ref_name = 'akeneo_pim/pim_catalog_product'
+  AND fk.ref_name = '{db_name}/pim_catalog_product'
   AND fk_cols.for_col_name = 'product_id'
   AND fk_cols.ref_col_name = 'id'
 SQL;
 
+        $sql = strtr($sql, ['{db_name}' => $this->connection->getDatabase()]);
         return $this->connection->executeQuery($sql)->fetchAll(\PDO::FETCH_COLUMN);
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This PR makes the migration script able to guess the database name in order to retrieve the name of the foreign key to drop. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | OK
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
