### PR TITLE
MET-79: Add InternalApi endpoint for creating measurement families

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/CreateMeasurementFamilyAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/CreateMeasurementFamilyAction.php
@@ -53,8 +53,8 @@ class CreateMeasurementFamilyAction
             return new RedirectResponse('/');
         }
 
-        $normalizedRequest = $this->normalizeRequest($request);
-        $structureErrors = $this->validateNormalizedRequest($normalizedRequest);
+        $decodedRequest = $this->decodeRequest($request);
+        $structureErrors = $this->validateDecodedRequest($decodedRequest);
 
         if (!empty($structureErrors)) {
             return new JsonResponse(
@@ -67,7 +67,7 @@ class CreateMeasurementFamilyAction
             );
         }
 
-        $saveMeasurementFamilyCommand = $this->createSaveMeasurementFamilyCommand($normalizedRequest);
+        $saveMeasurementFamilyCommand = $this->createSaveMeasurementFamilyCommand($decodedRequest);
 
         try {
             $this->validateSaveMeasurementFamilyCommand($saveMeasurementFamilyCommand);
@@ -90,7 +90,7 @@ class CreateMeasurementFamilyAction
         return new Response(null, Response::HTTP_CREATED);
     }
 
-    private function normalizeRequest(Request $request): array
+    private function decodeRequest(Request $request): array
     {
         $normalizedRequest = json_decode($request->getContent(), true);
 
@@ -101,9 +101,9 @@ class CreateMeasurementFamilyAction
         return $normalizedRequest;
     }
 
-    private function validateNormalizedRequest(array $normalizedRequest): array
+    private function validateDecodedRequest(array $decodedRequest): array
     {
-        return $this->measurementFamilyStructureValidator->validate($normalizedRequest);
+        return $this->measurementFamilyStructureValidator->validate($decodedRequest);
     }
 
     private function createSaveMeasurementFamilyCommand(

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/CreateMeasurementFamilyAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/CreateMeasurementFamilyAction.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyHandler;
+use Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchemaErrorsFormatter;
+use Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi\JsonSchema\MeasurementFamilyStructureValidator;
+use Akeneo\Tool\Component\Api\Exception\ViolationHttpException;
+use Akeneo\Tool\Component\Api\Normalizer\Exception\ViolationNormalizer;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CreateMeasurementFamilyAction
+{
+    /** @var MeasurementFamilyStructureValidator */
+    private $measurementFamilyStructureValidator;
+
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /** @var ViolationNormalizer */
+    private $violationNormalizer;
+
+    /** @var SaveMeasurementFamilyHandler */
+    private $saveMeasurementFamilyHandler;
+
+    public function __construct(
+        MeasurementFamilyStructureValidator $measurementFamilyStructureValidator,
+        ValidatorInterface $validator,
+        ViolationNormalizer $violationNormalizer,
+        SaveMeasurementFamilyHandler $saveMeasurementFamilyHandler
+    ) {
+        $this->measurementFamilyStructureValidator = $measurementFamilyStructureValidator;
+        $this->validator = $validator;
+        $this->violationNormalizer = $violationNormalizer;
+        $this->saveMeasurementFamilyHandler = $saveMeasurementFamilyHandler;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
+        $normalizedRequest = $this->normalizeRequest($request);
+        $structureErrors = $this->validateNormalizedRequest($normalizedRequest);
+
+        if (!empty($structureErrors)) {
+            return new JsonResponse(
+                [
+                    'code' => Response::HTTP_BAD_REQUEST,
+                    'message' => 'The measurement family has an invalid format.',
+                    'errors' => JsonSchemaErrorsFormatter::format($structureErrors),
+                ],
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+
+        $saveMeasurementFamilyCommand = $this->createSaveMeasurementFamilyCommand($normalizedRequest);
+
+        try {
+            $this->validateSaveMeasurementFamilyCommand($saveMeasurementFamilyCommand);
+            $this->handleSaveMeasurementFamilyCommand($saveMeasurementFamilyCommand);
+        } catch (\InvalidArgumentException $ex) {
+            return new JsonResponse(
+                [
+                    'code' => Response::HTTP_UNPROCESSABLE_ENTITY,
+                    'message' => $ex->getMessage(),
+                ],
+                Response::HTTP_UNPROCESSABLE_ENTITY
+            );
+        } catch (ViolationHttpException $ex) {
+            return new JsonResponse(
+                $this->violationNormalizer->normalize($ex),
+                Response::HTTP_UNPROCESSABLE_ENTITY
+            );
+        }
+
+        return new Response(null, Response::HTTP_CREATED);
+    }
+
+    private function normalizeRequest(Request $request): array
+    {
+        $normalizedRequest = json_decode($request->getContent(), true);
+
+        if (null === $normalizedRequest) {
+            throw new BadRequestHttpException('Invalid json message received');
+        }
+
+        return $normalizedRequest;
+    }
+
+    private function validateNormalizedRequest(array $normalizedRequest): array
+    {
+        return $this->measurementFamilyStructureValidator->validate($normalizedRequest);
+    }
+
+    private function createSaveMeasurementFamilyCommand(
+        array $normalizedMeasurementFamily
+    ): SaveMeasurementFamilyCommand {
+        $saveMeasurementFamilyCommand = new SaveMeasurementFamilyCommand();
+        $saveMeasurementFamilyCommand->code = $normalizedMeasurementFamily['code'];
+        $saveMeasurementFamilyCommand->standardUnitCode = $normalizedMeasurementFamily['standard_unit_code'];
+        $saveMeasurementFamilyCommand->labels = $normalizedMeasurementFamily['labels'];
+        $saveMeasurementFamilyCommand->units = $normalizedMeasurementFamily['units'];
+
+        return $saveMeasurementFamilyCommand;
+    }
+
+    private function validateSaveMeasurementFamilyCommand(SaveMeasurementFamilyCommand $saveMeasurementFamilyCommand)
+    {
+        $violations = $this->validator->validate($saveMeasurementFamilyCommand);
+
+        if (count($violations) > 0) {
+            throw new ViolationHttpException(
+                $violations,
+                'The measurement family has data that does not comply with the business rules.'
+            );
+        }
+    }
+
+    private function handleSaveMeasurementFamilyCommand(SaveMeasurementFamilyCommand $saveMeasurementFamilyCommand)
+    {
+        $this->saveMeasurementFamilyHandler->handle($saveMeasurementFamilyCommand);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/JsonSchema/MeasurementFamilyStructureValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/JsonSchema/MeasurementFamilyStructureValidator.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi\JsonSchema;
+
+use JsonSchema\Validator;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MeasurementFamilyStructureValidator
+{
+    public function validate(array $normalizedMeasurementFamily): array
+    {
+        $validator = new Validator();
+        $normalizedMeasurementFamilyObject = Validator::arrayToObjectRecursive($normalizedMeasurementFamily);
+        $validator->validate($normalizedMeasurementFamilyObject, $this->getJsonSchema());
+
+        return $validator->getErrors();
+    }
+
+    private function getJsonSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                '_links' => ['type' => 'object'],
+                'code' => ['type' => ['string'],],
+                'labels' => [
+                    'type' => 'object',
+                    'patternProperties' => [
+                        '.+' => ['type' => 'string'],
+                    ],
+                ],
+                'standard_unit_code' => ['type' => 'string'],
+                'units' => [
+                    'type' => 'array',
+                    'minItems' => 1,
+                    'items' => [
+                        'type' => 'object',
+                        'required' => ['code', 'labels', 'convert_from_standard', 'symbol'],
+                        'properties' => [
+                            'code' => ['type' => 'string'],
+                            'labels' => [
+                                'type' => 'object',
+                                'patternProperties' => [
+                                    '.+' => ['type' => 'string'],
+                                ],
+                            ],
+                            'convert_from_standard' => [
+                                'minItems' => 1,
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'operator' => ['type' => 'string'],
+                                        'value' => ['type' => 'string']
+                                    ],
+                                    'required' => ['operator', 'value'],
+                                ]
+                            ],
+                            'symbol' => ['type' => 'string']
+                        ]
+                    ]
+                ]
+            ],
+            'required' => ['code', 'labels', 'units', 'standard_unit_code'],
+            'additionalProperties' => false,
+        ];
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/JsonSchemaErrorsFormatter.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/JsonSchemaErrorsFormatter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi;
+
+/**
+ * Format errors from the json-schema validator for the API connector.
+ *
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class JsonSchemaErrorsFormatter
+{
+    public static function format(array $errors): array
+    {
+        return array_map(function (array $error) {
+            return [
+                'property' => $error['property'] ?? '',
+                'message' => $error['message'] ?? '',
+            ];
+        }, $errors);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/DependencyInjection/AkeneoMeasureExtension.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/DependencyInjection/AkeneoMeasureExtension.php
@@ -25,6 +25,7 @@ class AkeneoMeasureExtension extends Extension
         // load service
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('api.yml');
+        $loader->load('internal_api.yml');
         $loader->load('limits.yml');
         $loader->load('services.yml');
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/internal_api.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/internal_api.yml
@@ -1,0 +1,14 @@
+services:
+    # controllers
+    pim_api.controller.internal_api.create_measurement_family:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi\CreateMeasurementFamilyAction
+        public: true
+        arguments:
+            - '@pim_api.controller.internal_api.json_schema.measurement_family_structure_validator'
+            - '@validator'
+            - '@pim_api.normalizer.exception.violation'
+            - '@akeneo_measure.application.save_measurement_family_handler'
+
+    # Json schema
+    pim_api.controller.internal_api.json_schema.measurement_family_structure_validator:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi\JsonSchema\MeasurementFamilyStructureValidator

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/routing.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/routing.yml
@@ -1,2 +1,8 @@
 akeneo_measurements_settings_index:
     path: '/configuration/measurement'
+
+# Internal API
+akeneo_measurements_measurement_family_create_rest:
+    path: '/rest/measurement-families'
+    defaults: { _controller: pim_api.controller.internal_api.create_measurement_family }
+    methods: [POST]

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyEndToEnd.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\tests\EndToEnd\ExternalApi;
+
+use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class CreateMeasurementFamilyEndToEnd extends ApiTestCase
+{
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->measurementFamilyRepository = $this->get('akeneo_measure.persistence.measurement_family_repository');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_measurement_family()
+    {
+        $measurementFamily = self::createMeasurementFamily('custom_metric_1');
+        $normalizedMeasurementFamily = $measurementFamily->normalize();
+
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(
+            'POST',
+            'rest/measurement-families',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ],
+            json_encode($normalizedMeasurementFamily)
+        );
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertMeasurementFamilyHasBeenCreated($measurementFamily);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_when_the_measurement_family_does_not_have_the_right_structure()
+    {
+        $invalidMeasurementFamily = ['values' => null];
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(
+            'POST',
+            'rest/measurement-families',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ],
+            json_encode($invalidMeasurementFamily)
+        );
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $responseBody = json_decode($response->getContent(), true);
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $responseBody['code']);
+        $this->assertEquals('The measurement family has an invalid format.', $responseBody['message']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_when_the_measurement_family_is_not_valid()
+    {
+        $measurementFamily = self::createMeasurementFamily('custom_metric_1');
+        $normalizedMeasurementFamily = $measurementFamily->normalize();
+        $normalizedMeasurementFamily['code'] = 'INVALID CODE WITH SPACES';
+
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(
+            'POST',
+            'rest/measurement-families',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ],
+            json_encode($normalizedMeasurementFamily)
+        );
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $responseBody = json_decode($response->getContent(), true);
+        $this->assertEquals(Response::HTTP_UNPROCESSABLE_ENTITY, $responseBody['code']);
+        $this->assertEquals(
+            'The measurement family has data that does not comply with the business rules.',
+            $responseBody['message']
+        );
+    }
+
+    private static function createMeasurementFamily(string $code): MeasurementFamily
+    {
+        return MeasurementFamily::create(
+            MeasurementFamilyCode::fromString($code),
+
+            LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
+            UnitCode::fromString('CUSTOM_UNIT_1_1'),
+            [
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
+                    [Operation::create('mul', '0.000001')],
+                    'mm²'
+                ),
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_2_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
+                    [Operation::create('mul', '0.0001')],
+                    'cm²'
+                )
+            ]
+        );
+    }
+
+    private function assertMeasurementFamilyHasBeenCreated(MeasurementFamily $expected): void
+    {
+        $measurementFamilyCode = MeasurementFamilyCode::fromString($expected->normalize()['code']);
+        $actual = $this->measurementFamilyRepository->getByCode($measurementFamilyCode);
+
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

New endpoint for the internal API for creating a new MeasurementFamily:
`POST /rest/measurement-families`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | yes
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
