### PR TITLE
PIM-9137: do not export headers if no data to export and attribute used as filters

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9135: Currency is not set by default on price filter on datagrid
+- PIM-9137: do not export headers if no data to export and attribute used as filters
 
 # 3.0.68 (2020-02-19)
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
@@ -40,6 +40,8 @@ class ProductWriter extends AbstractItemMediaWriter implements
     /** @var GenerateFlatHeadersFromAttributeCodesInterface */
     protected $generateHeadersFromAttributeCodes;
 
+    private $hasItems;
+
     public function __construct(
         ArrayConverterInterface $arrayConverter,
         BufferFactory $bufferFactory,
@@ -71,6 +73,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
     public function initialize()
     {
         $this->familyCodes = [];
+        $this->hasItems = false;
 
         parent::initialize();
     }
@@ -80,6 +83,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
      */
     public function write(array $items)
     {
+        $this->hasItems = true;
         foreach ($items as $item) {
             if (isset($item['family']) && !in_array($item['family'], $this->familyCodes)) {
                 $this->familyCodes[] = $item['family'];
@@ -118,7 +122,8 @@ class ProductWriter extends AbstractItemMediaWriter implements
         $attributeCodes = [];
 
         if (isset($filters['structure']['attributes'])
-            && !empty($filters['structure']['attributes'])) {
+            && !empty($filters['structure']['attributes'])
+            && $this->hasItems === true) {
             $attributeCodes = $filters['structure']['attributes'];
         } elseif ($parameters->has('selected_properties')) {
             $attributeCodes = $parameters->get('selected_properties');

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
@@ -40,6 +40,8 @@ class ProductWriter extends AbstractItemMediaWriter implements
     /** @var GenerateFlatHeadersFromAttributeCodesInterface */
     protected $generateHeadersFromAttributeCodes;
 
+    private $hasItems;
+
     public function __construct(
         ArrayConverterInterface $arrayConverter,
         BufferFactory $bufferFactory,
@@ -71,6 +73,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
     public function initialize()
     {
         $this->familyCodes = [];
+        $this->hasItems = false;
 
         parent::initialize();
     }
@@ -80,6 +83,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
      */
     public function write(array $items)
     {
+        $this->hasItems = true;
         foreach ($items as $item) {
             if (isset($item['family']) && !in_array($item['family'], $this->familyCodes)) {
                 $this->familyCodes[] = $item['family'];
@@ -119,7 +123,8 @@ class ProductWriter extends AbstractItemMediaWriter implements
         $attributeCodes = [];
 
         if (isset($filters['structure']['attributes'])
-            && !empty($filters['structure']['attributes'])) {
+            && !empty($filters['structure']['attributes'])
+            && $this->hasItems === true) {
             $attributeCodes = $filters['structure']['attributes'];
         } elseif ($parameters->has('selected_properties')) {
             $attributeCodes = $parameters->get('selected_properties');


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This PR fixes a regression in 3.0 in a very specific use case : if a product export has no data and one or several attributes are used as filters, the expected behavior is to NOT export the headers (so the file should be empty).

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
