### PR TITLE
Fix for broken pagination using search_locale

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -706,6 +706,9 @@ class ProductController
         if (null !== $query->searchChannelCode) {
             $queryParameters['search_scope'] = $query->searchChannelCode;
         }
+        if (null !== $query->searchLocaleCode) {
+            $queryParameters['search_locale'] = $query->searchLocaleCode;
+        } 
         if (null !== $query->localeCodes) {
             $queryParameters['locales'] = join(',', $query->localeCodes);
         }


### PR DESCRIPTION
https://github.com/akeneo/pim-community-dev/issues/11722

This fixes the pagination links for the products search/list external API.

Should probably be applied to the 3.2 branch but since https://docs.akeneo.com/master/contributing/contribution_guide.html is 404 I don't know the procedure for that.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
