### PR TITLE
FIX-PIM-9134: Remove error notif when a user saves a product and they have no view rights on the attribute used as label

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,7 @@
 # 4.0.x
 
+- PIM-9134: Remove error notif when a user saves a product and they have no view rights on the attribute used as label 
+
 # 4.0.8 (2020-03-05)
 
 - PIM-9129: Fix missing brightness measure translations

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-label.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-label.js
@@ -49,9 +49,10 @@ define(
                 if (values) {
                     return values.find(value => {
                         return (false === scopable || value.scope === scope)
-                        && (false === localizable || value.locale === locale);
+                            && (false === localizable || value.locale === locale);
                     }).data;
                 }
+
                 return '';
             },
 
@@ -65,7 +66,7 @@ define(
                 return null;
             },
 
-            fetchFamily: function(code) {
+            fetchFamily: function (code) {
                 if (!code) {
                     return;
                 }
@@ -76,11 +77,11 @@ define(
 
                 FetcherRegistry.getFetcher('family')
                     .fetch(code)
-                    .then(function(family) {
-                      this.family = family;
-                      this.render();
+                    .then(function (family) {
+                        this.family = family;
+                        this.render();
                     }.bind(this));
-            },
+            }
         });
     }
 );

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-label.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-label.js
@@ -46,11 +46,13 @@ define(
                 var locale = UserContext.get('catalogLocale');
 
                 var values = this.getFormData().values[attributeAsLabelIdentifier];
-
-                return values.find(value => {
-                    return (false === scopable || value.scope === scope)
-                      && (false === localizable || value.locale === locale);
-                }).data;
+                if (values) {
+                    return values.find(value => {
+                        return (false === scopable || value.scope === scope)
+                        && (false === localizable || value.locale === locale);
+                    }).data;
+                }
+                return '';
             },
 
             getLabelFromMeta: function () {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/save.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/save.js
@@ -76,6 +76,7 @@ define(
 
                 return ProductSaver
                     .save(productId, product)
+                    .fail(this.fail.bind(this))
                     .then(function (data) {
                         this.postSave();
 
@@ -83,7 +84,6 @@ define(
 
                         this.getRoot().trigger('pim_enrich:form:entity:post_fetch', data);
                     }.bind(this))
-                    .fail(this.fail.bind(this))
                     .always(this.hideLoadingMask.bind(this));
             }
         });


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
When a user saves a product with a label on which he have no view rights, two notifications shows up, a success one (200 from server) and an error.
![image](https://user-images.githubusercontent.com/4653573/76408374-26294980-638d-11ea-8751-3edea716e01f.png)

The error one is trigger by two things :
-[here](https://github.com/akeneo/pim-community-dev/pull/11724/files#diff-e882e90a45781908d099227dfb7f540dR49), values is undefined so the find method crash.
-[here](https://github.com/akeneo/pim-community-dev/pull/11724/files#diff-0c84f61c4586733ded5138a47a03638cL86) the .fail from the ajax api is apply on all the transformation / side effect and not only on the http call.

Also this bug on EE rise some questions.
On the product grid user with no right can see the label
![image](https://user-images.githubusercontent.com/4653573/76409032-2249f700-638e-11ea-8426-9d013630e27b.png)
But the label is hidden in the product edit page
![image](https://user-images.githubusercontent.com/4653573/76409132-44437980-638e-11ea-84b6-9910b092f0b4.png)
 It seems that we have a consistency problem on this use case.

The proposal in this pr is : 
- put the ajax fail only on the http call response
- return an empty string if the [values is empty](https://github.com/akeneo/pim-community-dev/pull/11724/files#diff-e882e90a45781908d099227dfb7f540dR55)




<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
