### PR TITLE
Filter on product model to avoid loading all of them from the DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9133: Fix product save when the user has no permission on some attribute groups
+- Fixes memory leak when indexing product models with a lot of product models in the same family
 - PIM-9119: Fix missing warning when using mass edit with parent filter set to empty
 - PIM-9114: fix errors on mass action when the parent filter is set to empty
 - PIM-9110: avoid deadlock error when loading product and product models in parallel with the API

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
@@ -344,6 +344,7 @@ FROM pim_catalog_product_model product_model
 INNER JOIN pim_catalog_family_variant family_variant ON family_variant.id = product_model.family_variant_id
 INNER JOIN family_attributes ON family_attributes.family_id = family_variant.family_id
 INNER JOIN family_variant_attributes_per_level ON family_variant_attributes_per_level.family_variant_id = product_model.family_variant_id
+WHERE product_model.code IN (:productModelCodes)
 SQL;
 
         $rows = $this->connection->fetchAll(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This fix avoid loading all product model of the same families than the one being indexed in memory.

The previous SQL query was missing the filter on product model codes, so it was erroneously loading all product models from the same family than the ones identified by the provided product model codes.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
