### PR TITLE
PIM-9148: Fix UI attribute group display in association panel

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9148: Fix UI attribute group display in association panel
+
 # 3.2.43 (2020-03-11)
 
 # 3.2.42 (2020-03-04)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.multiselect.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.multiselect.less
@@ -111,6 +111,9 @@
     text-transform: uppercase;
     padding: 0;
     margin: -12px 0 -4px 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   .ui-multiselect-checkboxes li.ui-multiselect-optgroup-label {
@@ -315,13 +318,5 @@
         height: 30px;
       }
     }
-  }
-}
-
-.filters-column {
-  .ui-multiselect-optgroup-label a {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
   }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
before: 
![image](https://user-images.githubusercontent.com/1978756/76629525-ae9b1c00-653e-11ea-98a5-296d3482ef3d.png)

after: 
![image](https://user-images.githubusercontent.com/1978756/76629443-90352080-653e-11ea-91fd-1189c538b3d1.png)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
