### PR TITLE
MET-105: Fix CreateMeasurementFamily validation

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/CreateMeasurementFamily/CreateMeasurementFamilyCommand.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/CreateMeasurementFamily/CreateMeasurementFamilyCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily;
+
+/**
+ * @copyright 2020 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class CreateMeasurementFamilyCommand
+{
+    /** @var string */
+    public $code;
+
+    /** @var array */
+    public $labels;
+
+    /** @var string */
+    public $standardUnitCode;
+
+    /** @var array */
+    public $units = [];
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/CreateMeasurementFamily/CreateMeasurementFamilyHandler.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/CreateMeasurementFamily/CreateMeasurementFamilyHandler.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class CreateMeasurementFamilyHandler
+{
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+
+    public function __construct(MeasurementFamilyRepositoryInterface $measurementFamilyRepository)
+    {
+        $this->measurementFamilyRepository = $measurementFamilyRepository;
+    }
+
+    public function handle(CreateMeasurementFamilyCommand $saveMeasurementFamilyCommand): void
+    {
+        $units = $this->units($saveMeasurementFamilyCommand);
+        $measurementFamily = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString($saveMeasurementFamilyCommand->code),
+            LabelCollection::fromArray($saveMeasurementFamilyCommand->labels),
+            UnitCode::fromString($saveMeasurementFamilyCommand->standardUnitCode),
+            $units
+        );
+
+        $this->measurementFamilyRepository->save($measurementFamily);
+    }
+
+    private function units(CreateMeasurementFamilyCommand $saveMeasurementFamilyCommand): array
+    {
+        return array_map(
+            function (array $unit) {
+                $operations = array_map(
+                    function (array $operation) {
+                        return Operation::create(
+                            $operation['operator'],
+                            $operation['value']
+                        );
+                    },
+                    $unit['convert_from_standard']
+                );
+
+                return Unit::create(
+                    UnitCode::fromString($unit['code']),
+                    LabelCollection::fromArray($unit['labels']),
+                    $operations,
+                    $unit['symbol']
+                );
+            },
+            $saveMeasurementFamilyCommand->units
+        );
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/CreateMeasurementFamilyAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/CreateMeasurementFamilyAction.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi;
 
-use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
-use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyHandler;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyHandler;
 use Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchemaErrorsFormatter;
 use Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi\JsonSchema\MeasurementFamilyStructureValidator;
 use Akeneo\Tool\Component\Api\Exception\ViolationHttpException;
@@ -32,19 +32,19 @@ class CreateMeasurementFamilyAction
     /** @var ViolationNormalizer */
     private $violationNormalizer;
 
-    /** @var SaveMeasurementFamilyHandler */
-    private $saveMeasurementFamilyHandler;
+    /** @var CreateMeasurementFamilyHandler */
+    private $createMeasurementFamilyHandler;
 
     public function __construct(
         MeasurementFamilyStructureValidator $measurementFamilyStructureValidator,
         ValidatorInterface $validator,
         ViolationNormalizer $violationNormalizer,
-        SaveMeasurementFamilyHandler $saveMeasurementFamilyHandler
+        CreateMeasurementFamilyHandler $createMeasurementFamilyHandler
     ) {
         $this->measurementFamilyStructureValidator = $measurementFamilyStructureValidator;
         $this->validator = $validator;
         $this->violationNormalizer = $violationNormalizer;
-        $this->saveMeasurementFamilyHandler = $saveMeasurementFamilyHandler;
+        $this->createMeasurementFamilyHandler = $createMeasurementFamilyHandler;
     }
 
     public function __invoke(Request $request): Response
@@ -67,11 +67,11 @@ class CreateMeasurementFamilyAction
             );
         }
 
-        $saveMeasurementFamilyCommand = $this->createSaveMeasurementFamilyCommand($decodedRequest);
+        $createMeasurementFamilyCommand = $this->createCreateMeasurementFamilyCommand($decodedRequest);
 
         try {
-            $this->validateSaveMeasurementFamilyCommand($saveMeasurementFamilyCommand);
-            $this->handleSaveMeasurementFamilyCommand($saveMeasurementFamilyCommand);
+            $this->validateCreateMeasurementFamilyCommand($createMeasurementFamilyCommand);
+            $this->handleCreateMeasurementFamilyCommand($createMeasurementFamilyCommand);
         } catch (\InvalidArgumentException $ex) {
             return new JsonResponse(
                 [
@@ -106,21 +106,21 @@ class CreateMeasurementFamilyAction
         return $this->measurementFamilyStructureValidator->validate($decodedRequest);
     }
 
-    private function createSaveMeasurementFamilyCommand(
+    private function createCreateMeasurementFamilyCommand(
         array $normalizedMeasurementFamily
-    ): SaveMeasurementFamilyCommand {
-        $saveMeasurementFamilyCommand = new SaveMeasurementFamilyCommand();
-        $saveMeasurementFamilyCommand->code = $normalizedMeasurementFamily['code'];
-        $saveMeasurementFamilyCommand->standardUnitCode = $normalizedMeasurementFamily['standard_unit_code'];
-        $saveMeasurementFamilyCommand->labels = $normalizedMeasurementFamily['labels'];
-        $saveMeasurementFamilyCommand->units = $normalizedMeasurementFamily['units'];
+    ): CreateMeasurementFamilyCommand {
+        $createMeasurementFamilyCommand = new CreateMeasurementFamilyCommand();
+        $createMeasurementFamilyCommand->code = $normalizedMeasurementFamily['code'];
+        $createMeasurementFamilyCommand->standardUnitCode = $normalizedMeasurementFamily['standard_unit_code'];
+        $createMeasurementFamilyCommand->labels = $normalizedMeasurementFamily['labels'];
+        $createMeasurementFamilyCommand->units = $normalizedMeasurementFamily['units'];
 
-        return $saveMeasurementFamilyCommand;
+        return $createMeasurementFamilyCommand;
     }
 
-    private function validateSaveMeasurementFamilyCommand(SaveMeasurementFamilyCommand $saveMeasurementFamilyCommand)
+    private function validateCreateMeasurementFamilyCommand(CreateMeasurementFamilyCommand $createMeasurementFamilyCommand)
     {
-        $violations = $this->validator->validate($saveMeasurementFamilyCommand);
+        $violations = $this->validator->validate($createMeasurementFamilyCommand);
 
         if (count($violations) > 0) {
             throw new ViolationHttpException(
@@ -130,8 +130,8 @@ class CreateMeasurementFamilyAction
         }
     }
 
-    private function handleSaveMeasurementFamilyCommand(SaveMeasurementFamilyCommand $saveMeasurementFamilyCommand)
+    private function handleCreateMeasurementFamilyCommand(CreateMeasurementFamilyCommand $createMeasurementFamilyCommand)
     {
-        $this->saveMeasurementFamilyHandler->handle($saveMeasurementFamilyCommand);
+        $this->createMeasurementFamilyHandler->handle($createMeasurementFamilyCommand);
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Model/MeasurementFamilyCode.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Model/MeasurementFamilyCode.php
@@ -27,7 +27,7 @@ final class MeasurementFamilyCode
         Assert::regex(
             $code,
             '/^[a-zA-Z0-9_]+$/',
-            sprintf('Asset code may contain only letters, numbers and underscores. "%s" given', $code)
+            sprintf('Measurement family code may contain only letters, numbers and underscores. "%s" given', $code)
         );
 
         $this->code = $code;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Model/UnitCode.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Model/UnitCode.php
@@ -27,7 +27,7 @@ final class UnitCode
         Assert::regex(
             $code,
             '/^[a-zA-Z0-9_]+$/',
-            sprintf('Asset code may contain only letters, numbers and underscores. "%s" given', $code)
+            sprintf('Unit code may contain only letters, numbers and underscores. "%s" given', $code)
         );
         $this->code = $code;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepositoryInterface.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepositoryInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Persistence;
 
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
 
@@ -11,6 +12,9 @@ interface MeasurementFamilyRepositoryInterface
 {
     public function all(): array;
 
+    /**
+     * @throws MeasurementFamilyNotFoundException
+     */
     public function getByCode(MeasurementFamilyCode $measurementFamilyCode): MeasurementFamily;
 
     public function save(MeasurementFamily $measurementFamily);

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/internal_api.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/internal_api.yml
@@ -7,7 +7,7 @@ services:
             - '@pim_api.controller.internal_api.json_schema.measurement_family_structure_validator'
             - '@validator'
             - '@pim_api.normalizer.exception.violation'
-            - '@akeneo_measure.application.save_measurement_family_handler'
+            - '@akeneo_measure.application.create_measurement_family_handler'
 
     # Json schema
     pim_api.controller.internal_api.json_schema.measurement_family_structure_validator:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
@@ -42,6 +42,18 @@ services:
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'
 
+    akeneo_measure.application.create_measurement_family_handler:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyHandler
+        arguments:
+            - '@akeneo_measure.persistence.measurement_family_repository'
+
+    akeneo_measure.validation.create_measurement_family.code_must_be_unique:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\CodeMustBeUniqueValidator
+        arguments:
+            - '@akeneo_measure.persistence.measurement_family_repository'
+        tags:
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validation.create_measurement_family.code_must_be_unique' }
+
     akeneo_measurement.validation.measurement_family.operation_count:
         class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationCountValidator
         arguments:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
@@ -54,6 +54,14 @@ services:
         tags:
             - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validation.create_measurement_family.code_must_be_unique' }
 
+    akeneo_measurement.validation.create_measurement_family.count:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\CountValidator
+        arguments:
+            - '@akeneo_measure.persistence.measurement_family_repository'
+            - '%akeneo_measurement.validation.measurement_family.families_max%'
+        tags:
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.create_measurement_family.count' }
+
     akeneo_measurement.validation.measurement_family.operation_count:
         class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationCountValidator
         arguments:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
@@ -40,3 +40,47 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasureme
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeOperationShouldBeMultiplyByOne: { groups: [other_constraints] }
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits: { groups: [other_constraints] }
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\Count: { groups: [other_constraints] }
+
+Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand:
+    group_sequence:
+        - SaveMeasurementFamilyCommand
+        - other_constraints
+    properties:
+        code:
+            - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\Code: ~
+            - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\CodeMustBeUnique: ~
+        labels:
+            - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\LabelCollection: ~
+        units:
+            - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\UnitCount: ~
+            - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\ShouldNotContainDuplicatedUnits: ~
+            - All:
+                - Collection:
+                    fields:
+                        code:
+                            - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\Code: ~
+                        labels:
+                            - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\LabelCollection: ~
+                        symbol:
+                            - Type: string
+                            - Length:
+                                  max: 255
+                        convert_from_standard:
+                            - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationCount: ~
+                            - All:
+                                - Collection:
+                                    fields:
+                                        operator:
+                                            - NotBlank: ~
+                                            - Type: string
+                                            - Choice:
+                                                choices: [mul, div, add, sub]
+                                                message: pim_measurements.validation.measurement_family.units.operation.invalid_operator
+                                        value:
+                                            - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationValue: ~
+    constraints:
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeShouldExist: ~
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeCannotBeChanged: { groups: [other_constraints] }
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeOperationShouldBeMultiplyByOne: { groups: [other_constraints] }
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits: { groups: [other_constraints] }
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\Count: { groups: [other_constraints] }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
@@ -43,12 +43,12 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasureme
 
 Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand:
     group_sequence:
-        - SaveMeasurementFamilyCommand
+        - CreateMeasurementFamilyCommand
         - other_constraints
     properties:
         code:
             - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\Code: ~
-            - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\CodeMustBeUnique: ~
+            - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\CodeMustBeUnique: { groups: [other_constraints] }
         labels:
             - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\LabelCollection: ~
         units:
@@ -79,8 +79,8 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasu
                                         value:
                                             - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationValue: ~
     constraints:
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeShouldExist: ~
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\StandardUnitCodeShouldExist: ~
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeCannotBeChanged: { groups: [other_constraints] }
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeOperationShouldBeMultiplyByOne: { groups: [other_constraints] }
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits: { groups: [other_constraints] }
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\Count: { groups: [other_constraints] }
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\Count: { groups: [other_constraints] }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -11,6 +11,8 @@ pim_measurements:
                 cannot_be_changed: 'The standard unit code of the "%measurement_family_code%" measurement family cannot be changed'
                 operation_should_be_multiply_by_one: 'The standard unit code of the "%measurement_family_code%" measurement family should be a multiply by 1 operation'
             should_contain_max_elements: 'You’ve reached the limit of %limit% measurement families.'
+            code:
+                must_be_unique: 'This measurement family code is already used.'
             convert:
                 value_should_be_a_number_in_a_string: 'The conversion value should be a number represented in a string (example: "0.2561")'
                 should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -12,7 +12,7 @@ pim_measurements:
                 operation_should_be_multiply_by_one: 'The standard unit code of the "%measurement_family_code%" measurement family should be a multiply by 1 operation'
             should_contain_max_elements: 'You’ve reached the limit of %limit% measurement families.'
             code:
-                must_be_unique: 'This measurement family code is already used.'
+                must_be_unique: 'This measurement family code already exists.'
             convert:
                 value_should_be_a_number_in_a_string: 'The conversion value should be a number represented in a string (example: "0.2561")'
                 should_contain_min_elements: 'A minimum of one conversion operation per unit is required.'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/CodeValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/CodeValidator.php
@@ -27,7 +27,7 @@ class CodeValidator extends ConstraintValidator
         $violations = $validator->validate($code, [
                 new Constraints\NotBlank(),
                 new Constraints\Type(['type' => 'string']),
-                new Constraints\Length(['max' => self::MAX_CODE_LENGTH, 'min' => 1]),
+                new Constraints\Length(['max' => self::MAX_CODE_LENGTH]),
                 new Constraints\Regex([
                         'pattern' => '/^[a-zA-Z0-9_]+$/',
                         'message' => 'pim_measurements.validation.common.code.pattern',

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/CodeMustBeUnique.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/CodeMustBeUnique.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CodeMustBeUnique extends Constraint
+{
+    public $message = 'pim_measurements.validation.measurement_family.code.must_be_unique';
+
+    public function validatedBy()
+    {
+        return 'akeneo_measure.validation.create_measurement_family.code_must_be_unique';
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/CodeMustBeUniqueValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/CodeMustBeUniqueValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CodeMustBeUniqueValidator extends ConstraintValidator
+{
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+
+    public function __construct(MeasurementFamilyRepositoryInterface $measurementFamilyRepository)
+    {
+        $this->measurementFamilyRepository = $measurementFamilyRepository;
+    }
+
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof CodeMustBeUnique) {
+            throw new UnexpectedTypeException($constraint, CodeMustBeUnique::class);
+        }
+
+        if ($this->isCodeAlreadyUsed($value)) {
+            $this->context->buildViolation($constraint->message)
+                ->setInvalidValue($value)
+                ->addViolation();
+        }
+    }
+
+    private function isCodeAlreadyUsed(string $code)
+    {
+        try {
+            $this->measurementFamilyRepository->getByCode(MeasurementFamilyCode::fromString($code));
+            return true;
+        } catch (MeasurementFamilyNotFoundException $ex) {
+            return false;
+        }
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/Count.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/Count.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Count extends Constraint
+{
+    public const MAX_MESSAGE = 'pim_measurements.validation.measurement_family.should_contain_max_elements';
+
+    public function validatedBy()
+    {
+        return 'akeneo_measurement.validation.create_measurement_family.count';
+    }
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/CountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/CountValidator.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class CountValidator extends ConstraintValidator
+{
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+
+    /** @var int */
+    private $max;
+
+    public function __construct(
+        MeasurementFamilyRepositoryInterface $measurementFamilyRepository,
+        int $max
+    ) {
+        $this->measurementFamilyRepository = $measurementFamilyRepository;
+        $this->max = $max;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($saveMeasurementFamilyCommand, Constraint $constraint)
+    {
+        if (!$constraint instanceof Count) {
+            throw new UnexpectedTypeException($constraint, Count::class);
+        }
+
+        if (!$saveMeasurementFamilyCommand instanceof CreateMeasurementFamilyCommand) {
+            throw new UnexpectedTypeException($saveMeasurementFamilyCommand, CreateMeasurementFamilyCommand::class);
+        }
+
+        $excludedMeasurementFamilyCode = MeasurementFamilyCode::fromString($saveMeasurementFamilyCommand->code);
+
+        $count = $this->measurementFamilyRepository->countAllOthers($excludedMeasurementFamilyCode);
+
+        if ($count >= $this->max) {
+            $this->context->buildViolation(Count::MAX_MESSAGE)
+                ->setParameter('%limit%', $this->max)
+                ->setInvalidValue($saveMeasurementFamilyCommand)
+                ->setPlural((int)$this->max)
+                ->addViolation();
+        }
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeShouldExist.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeShouldExist.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class StandardUnitCodeShouldExist extends Constraint
+{
+    public const STANDARD_UNIT_CODE_SHOULD_EXIST_IN_THE_LIST_OF_UNITS = 'pim_measurements.validation.measurement_family.standard_unit_code.should_be_in_the_list_of_units';
+    public const STANDARD_UNIT_CODE_IS_REQUIRED = 'pim_measurements.validation.measurement_family.standard_unit_code.is_required';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeShouldExistValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeShouldExistValidator.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeShouldExist;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class StandardUnitCodeShouldExistValidator extends ConstraintValidator
+{
+    private const PROPERTY_PATH = 'standard_unit_code';
+
+    public function validate($saveMeasurementFamilyCommand, Constraint $constraint)
+    {
+        if (!$saveMeasurementFamilyCommand instanceof CreateMeasurementFamilyCommand) {
+            throw new \LogicException(
+                sprintf(
+                    'Expect an instance of class "%s", "%s" given',
+                    CreateMeasurementFamilyCommand::class,
+                    get_class($saveMeasurementFamilyCommand)
+                )
+            );
+        }
+        $standardUnitCode = $saveMeasurementFamilyCommand->standardUnitCode;
+        if (empty($standardUnitCode)) {
+            $this->context
+                ->buildViolation(StandardUnitCodeShouldExist::STANDARD_UNIT_CODE_IS_REQUIRED)
+                ->atPath(self::PROPERTY_PATH)
+                ->addViolation();
+
+            return;
+        }
+
+        $validator = Validation::createValidator();
+        $measurementFamilyCode = $saveMeasurementFamilyCommand->code;
+        $violations = $validator->validate(
+            $saveMeasurementFamilyCommand->units,
+            [
+                new Callback(
+                    function (array $units, ExecutionContextInterface $context) use ($standardUnitCode, $measurementFamilyCode) {
+                        foreach ($units as $unit) {
+                            if ($standardUnitCode === $unit['code']) {
+                                return;
+                            }
+                        }
+                        $context->buildViolation(
+                            StandardUnitCodeShouldExist::STANDARD_UNIT_CODE_SHOULD_EXIST_IN_THE_LIST_OF_UNITS,
+                            ['%standard_unit_code%' => $standardUnitCode, '%measurement_family_code%' => $measurementFamilyCode]
+                        )->addViolation();
+                    }
+                )
+            ]
+        );
+
+        if ($violations->count() > 0) {
+            foreach ($violations as $violation) {
+                $this->context->buildViolation($violation->getMessage())
+                    ->setParameters($violation->getParameters())
+                    ->atPath(self::PROPERTY_PATH)
+                    ->setCode($violation->getCode())
+                    ->setPlural($violation->getPlural())
+                    ->setInvalidValue($violation->getInvalidValue())
+                    ->addViolation();
+            }
+        }
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyEndToEnd.php
@@ -165,13 +165,13 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
                 Unit::create(
                     UnitCode::fromString('CUSTOM_UNIT_1_1'),
                     LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
-                    [Operation::create('mul', '0.000001')],
+                    [Operation::create('mul', '1')],
                     'mm²'
                 ),
                 Unit::create(
                     UnitCode::fromString('CUSTOM_UNIT_2_1'),
                     LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
-                    [Operation::create('mul', '0.0001')],
+                    [Operation::create('mul', '0.1')],
                     'cm²'
                 )
             ]

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyEndToEnd.php
@@ -116,6 +116,44 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function it_returns_an_error_when_the_measurement_family_code_already_exists()
+    {
+        $measurementFamily = self::createMeasurementFamily('custom_metric_1');
+        $normalizedMeasurementFamily = $measurementFamily->normalize();
+
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(
+            'POST',
+            'rest/measurement-families',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ],
+            json_encode($normalizedMeasurementFamily)
+        );
+
+        $client->restart();
+
+        $client->request(
+            'POST',
+            'rest/measurement-families',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ],
+            json_encode($normalizedMeasurementFamily)
+        );
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
     private static function createMeasurementFamily(string $code): MeasurementFamily
     {
         return MeasurementFamily::create(

--- a/tests/back/Acceptance/MeasurementFamily/InMemoryMeasurementFamilyRepository.php
+++ b/tests/back/Acceptance/MeasurementFamily/InMemoryMeasurementFamilyRepository.php
@@ -43,7 +43,7 @@ class InMemoryMeasurementFamilyRepository implements MeasurementFamilyRepository
             throw new MeasurementFamilyNotFoundException();
         }
 
-        return $this->measurementFamilies[$measurementFamilyCode->normalize()];
+        return $measurementFamily;
     }
 
     private function loadMeasurementFamilies(): array


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

2 issues fixed:
- The constraints `NotBlank` and `Length(min=1)` on the code are doing the same thing, when the field is empty, 2 validation errors are returned. It was useless.
- the `Create` endpoint should not use the `SaveMeasurementFamilyCommand` because it's an upsert. I added a `CreateMeasurementFamilyCommand` with proper validation and the new `CodeMustBeUnique`.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
