### PR TITLE
MET-102: Unify export use

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/context/notify-context.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/context/notify-context.ts
@@ -1,12 +1,14 @@
 import {createContext} from 'react';
 
-export enum NotificationLevel {
-    INFO = 'info',
-    SUCCESS = 'success',
-    WARNING = 'warning',
-    ERROR = 'error',
+enum NotificationLevel {
+  INFO = 'info',
+  SUCCESS = 'success',
+  WARNING = 'warning',
+  ERROR = 'error',
 }
 
-export type NotifyContextValue = (level: NotificationLevel, message: string) => void;
+type NotifyContextValue = (level: NotificationLevel, message: string) => void;
 
-export const NotifyContext = createContext<NotifyContextValue>(() => undefined);
+const NotifyContext = createContext<NotifyContextValue>(() => undefined);
+
+export {NotificationLevel, NotifyContextValue, NotifyContext};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/hooks/use-toggle-state.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/hooks/use-toggle-state.tsx
@@ -1,6 +1,6 @@
 import {EffectCallback, useCallback, useState} from 'react';
 
-export const useToggleState = (defaultValue: boolean): [boolean, EffectCallback, EffectCallback] => {
+const useToggleState = (defaultValue: boolean): [boolean, EffectCallback, EffectCallback] => {
   const [value, setValue] = useState<boolean>(defaultValue);
 
   const setTrue = useCallback(() => {
@@ -13,3 +13,5 @@ export const useToggleState = (defaultValue: boolean): [boolean, EffectCallback,
 
   return [value, setTrue, setFalse];
 };
+
+export {useToggleState};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/measurement-family.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/measurement-family.ts
@@ -2,12 +2,12 @@ import {getLabel} from 'pimui/js/i18n';
 
 type LocaleCode = string;
 
-export enum Direction {
+enum Direction {
   Ascending = 'Ascending',
   Descending = 'Descending',
 }
 
-export enum Operator {
+enum Operator {
   MUL = 'mul',
   DIV = 'div',
   ADD = 'add',
@@ -85,6 +85,8 @@ const sortMeasurementFamily = (sortDirection: Direction, locale: LocaleCode, sor
 };
 
 export {
+  Direction,
+  Operator,
   MeasurementFamily,
   getMeasurementFamilyLabel,
   getStandardUnitLabel,

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/validation-error.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/validation-error.ts
@@ -1,4 +1,6 @@
-export type ValidationError = {
+type ValidationError = {
   property: string;
   message: string;
 };
+
+export {ValidationError};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/CreateMeasurementFamily.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/CreateMeasurementFamily.tsx
@@ -3,7 +3,7 @@ import {Modal, ModalBodyWithIllustration, ModalCloseButton, ModalTitle} from 'ak
 import {TranslateContext} from 'akeneomeasure/context/translate-context';
 import {NotificationLevel, NotifyContext} from 'akeneomeasure/context/notify-context';
 import {UserContext} from 'akeneomeasure/context/user-context';
-import {MeasurementFamily as MeasurementFamilyIllustration} from 'akeneomeasure/shared/illustrations/MeasurementFamily';
+import {MeasurementFamilyIllustration} from 'akeneomeasure/shared/illustrations/MeasurementFamilyIllustration';
 import {Subsection, SubsectionHeader} from 'akeneomeasure/shared/components/Subsection';
 import {HELPER_LEVEL_WARNING, SubsectionHelper} from 'akeneomeasure/shared/components/SubsectionHelper';
 import {TextField} from 'akeneomeasure/shared/components/TextField';
@@ -13,12 +13,14 @@ import {useCreateMeasurementFamilyState} from 'akeneomeasure/pages/create-measur
 import {useCreateMeasurementFamilySaver} from 'akeneomeasure/pages/create-measurement-family/hooks/use-create-measurement-family-saver';
 import {createMeasurementFamilyFromFormState} from 'akeneomeasure/pages/create-measurement-family/form/create-measurement-family-form';
 import {ValidationError} from 'akeneomeasure/model/validation-error';
+import {useShortcut} from 'akeneomeasure/shared/hooks/use-shortcut';
+import {Key} from 'akeneomeasure/shared/key';
 
 type CreateMeasurementFamilyProps = {
   onClose: () => void;
 };
 
-export const CreateMeasurementFamily = ({onClose}: CreateMeasurementFamilyProps) => {
+const CreateMeasurementFamily = ({onClose}: CreateMeasurementFamilyProps) => {
   const __ = useContext(TranslateContext);
   const notify = useContext(NotifyContext);
   const locale = useContext(UserContext)('uiLocale');
@@ -27,16 +29,16 @@ export const CreateMeasurementFamily = ({onClose}: CreateMeasurementFamilyProps)
   const saveMeasurementFamily = useCreateMeasurementFamilySaver();
   const [errors, setErrors] = useState<ValidationError[]>([]);
 
-  const handleClose = useCallback(() => {
-    onClose();
-  }, [onClose]);
+  const handleClose = useCallback(onClose, [onClose]);
+
+  useShortcut(Key.Escape, handleClose);
 
   const handleSave = useCallback(async () => {
     try {
       const measurementFamily = createMeasurementFamilyFromFormState(form, locale);
       const response = await saveMeasurementFamily(measurementFamily);
 
-      switch(response.success){
+      switch (response.success) {
         case true:
           notify(NotificationLevel.SUCCESS, __('measurements.create_family.flash.success'));
           handleClose();
@@ -55,8 +57,8 @@ export const CreateMeasurementFamily = ({onClose}: CreateMeasurementFamilyProps)
 
   return (
     <Modal>
-      <ModalCloseButton title={__('close')} onClick={handleClose}/>
-      <ModalBodyWithIllustration illustration={<MeasurementFamilyIllustration/>}>
+      <ModalCloseButton title={__('close')} onClick={handleClose} />
+      <ModalBodyWithIllustration illustration={<MeasurementFamilyIllustration />}>
         <ModalTitle
           title={__('measurements.family.add_new_measurement_family')}
           subtitle={__('measurements.title.measurement')}
@@ -118,3 +120,5 @@ export const CreateMeasurementFamily = ({onClose}: CreateMeasurementFamilyProps)
     </Modal>
   );
 };
+
+export {CreateMeasurementFamily};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/form/create-measurement-family-form.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/form/create-measurement-family-form.ts
@@ -2,7 +2,7 @@ import {MeasurementFamily, Operator} from 'akeneomeasure/model/measurement-famil
 
 type LocaleCode = string;
 
-export type FormState = {
+type FormState = {
   family_code: string;
   family_label: string;
   standard_unit_code: string;
@@ -10,7 +10,7 @@ export type FormState = {
   standard_unit_symbol: string;
 };
 
-export const createFormState = () => {
+const createFormState = () => {
   return Object.freeze({
     family_code: '',
     family_label: '',
@@ -20,7 +20,7 @@ export const createFormState = () => {
   });
 };
 
-export const createMeasurementFamilyFromFormState = (data: FormState, locale: LocaleCode): MeasurementFamily => {
+const createMeasurementFamilyFromFormState = (data: FormState, locale: LocaleCode): MeasurementFamily => {
   return {
     code: data.family_code,
     labels: {
@@ -44,3 +44,5 @@ export const createMeasurementFamilyFromFormState = (data: FormState, locale: Lo
     ],
   };
 };
+
+export {FormState, createFormState, createMeasurementFamilyFromFormState};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/hooks/use-create-measurement-family-saver.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/hooks/use-create-measurement-family-saver.ts
@@ -10,7 +10,7 @@ type SaverResult = {
 
 type Saver = (data: MeasurementFamily) => Promise<SaverResult>;
 
-export const useCreateMeasurementFamilySaver = (): Saver => {
+const useCreateMeasurementFamilySaver = (): Saver => {
   const router = useContext(RouterContext);
 
   return async (data: MeasurementFamily) => {
@@ -36,3 +36,5 @@ export const useCreateMeasurementFamilySaver = (): Saver => {
     };
   };
 };
+
+export {useCreateMeasurementFamilySaver};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/hooks/use-create-measurement-family-state.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/hooks/use-create-measurement-family-state.ts
@@ -1,10 +1,13 @@
 import {useCallback, useState} from 'react';
-import {FormState, createFormState} from 'akeneomeasure/pages/create-measurement-family/form/create-measurement-family-form';
+import {
+  FormState,
+  createFormState,
+} from 'akeneomeasure/pages/create-measurement-family/form/create-measurement-family-form';
 
 type SetValue = (path: string, value: string) => void;
 type ClearValues = () => void;
 
-export const useCreateMeasurementFamilyState = (): [FormState, SetValue, ClearValues] => {
+const useCreateMeasurementFamilyState = (): [FormState, SetValue, ClearValues] => {
   const [state, setState] = useState<FormState>(createFormState());
 
   const setValue = useCallback(
@@ -27,3 +30,5 @@ export const useCreateMeasurementFamilyState = (): [FormState, SetValue, ClearVa
 
   return [state, setValue, clear];
 };
+
+export {useCreateMeasurementFamilyState};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/list/List.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/list/List.tsx
@@ -97,7 +97,7 @@ const List = () => {
             viewName="pim-measurements-user-navigation"
           />
         }
-        buttons={[<Button onClick={openCreateModal}>Create</Button>]}
+        buttons={[<Button onClick={openCreateModal}>{__('measurements.family.create')}</Button>]}
         breadcrumb={
           <Breadcrumb>
             <BreadcrumbItem>{__('pim_menu.tab.settings')}</BreadcrumbItem>

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/list/List.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/list/List.tsx
@@ -5,7 +5,7 @@ import {PimView} from 'akeneomeasure/bridge/legacy/pim-view/PimView';
 import {Breadcrumb} from 'akeneomeasure/shared/components/Breadcrumb';
 import {BreadcrumbItem} from 'akeneomeasure/shared/components/BreadcrumbItem';
 import {TranslateContext} from 'akeneomeasure/context/translate-context';
-import {MeasurementFamily as MeasurementFamilyIllustration} from 'akeneomeasure/shared/illustrations/MeasurementFamily';
+import {MeasurementFamilyIllustration} from 'akeneomeasure/shared/illustrations/MeasurementFamilyIllustration';
 import {HelperTitle, HelperText, Helper} from 'akeneomeasure/shared/components/Helper';
 import {Link} from 'akeneomeasure/shared/components/Link';
 import {NoDataSection, NoDataTitle, NoDataText} from 'akeneomeasure/shared/components/NoData';
@@ -97,11 +97,7 @@ const List = () => {
             viewName="pim-measurements-user-navigation"
           />
         }
-        buttons={[
-          <Button onClick={openCreateModal}>
-            Create
-          </Button>,
-        ]}
+        buttons={[<Button onClick={openCreateModal}>Create</Button>]}
         breadcrumb={
           <Breadcrumb>
             <BreadcrumbItem>{__('pim_menu.tab.settings')}</BreadcrumbItem>

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/Flag.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/Flag.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 type FlagProps = {
   localeCode: string;
-}
+};
 
-export const Flag = ({localeCode}: FlagProps) => {
+const Flag = ({localeCode}: FlagProps) => {
   const region = localeCode.split('_')[localeCode.split('_').length - 1];
 
-  return (
-    <i className={`flag flag-${region.toLowerCase()}`}/>
-  );
+  return <i className={`flag flag-${region.toLowerCase()}`} />;
 };
+
+export {Flag};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/FormGroup.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/FormGroup.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
-export const FormGroup = styled.div.attrs(() => ({className: 'AknFormContainer'}))`
+const FormGroup = styled.div.attrs(() => ({className: 'AknFormContainer'}))`
   margin-top: 18px;
 `;
+
+export {FormGroup};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/InputErrors.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/InputErrors.tsx
@@ -3,18 +3,16 @@ import {ValidationError} from 'akeneomeasure/model/validation-error';
 
 type InputErrorsProps = {
   errors: ValidationError[];
-}
-
-export const InputErrors = ({errors}: InputErrorsProps) => {
-  return (
-    <div className="AknFieldContainer-footer AknFieldContainer-validationErrors">
-      {errors.map((error: ValidationError, key: number) => {
-        return (
-          <span className="AknFieldContainer-validationError error-message" key={key}>
-            {error.message}
-          </span>
-        );
-      })}
-    </div>
-  );
 };
+
+const InputErrors = ({errors}: InputErrorsProps) => (
+  <div className="AknFieldContainer-footer AknFieldContainer-validationErrors">
+    {errors.map((error: ValidationError, key: number) => (
+      <span className="AknFieldContainer-validationError error-message" key={key}>
+        {error.message}
+      </span>
+    ))}
+  </div>
+);
+
+export {InputErrors};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/Modal.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/Modal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import {akeneoTheme} from 'akeneomeasure/shared/theme';
 import {CloseIcon} from 'akeneomeasure/shared/icons/CloseIcon';
 
-export const Modal = styled.div.attrs(() => ({className: 'AknFullPage'}))``;
+const Modal = styled.div.attrs(() => ({className: 'AknFullPage'}))``;
 
 const ModalCloseButtonContainer = styled.button`
   background: none;
@@ -21,7 +21,7 @@ const ModalCloseButtonContainer = styled.button`
   }
 `;
 
-export const ModalCloseButton = ({title, ...props}: {title: string} & any) => (
+const ModalCloseButton = ({title, ...props}: {title: string} & any) => (
   <ModalCloseButtonContainer title={title} tabIndex={0} aria-label={title} {...props}>
     <CloseIcon color={akeneoTheme.color.grey100} title={title} size={24} />
   </ModalCloseButtonContainer>
@@ -29,19 +29,14 @@ export const ModalCloseButton = ({title, ...props}: {title: string} & any) => (
 
 type ModalWithIllustationProps = {
   illustration: ReactElement;
-}
-
-export const ModalBodyWithIllustration = ({
-  illustration,
-  children,
-}: PropsWithChildren<ModalWithIllustationProps>) => {
-  return (
-    <div className="AknFullPage-content AknFullPage-content--withIllustration">
-      <div>{illustration}</div>
-      <div>{children}</div>
-    </div>
-  );
 };
+
+const ModalBodyWithIllustration = ({illustration, children}: PropsWithChildren<ModalWithIllustationProps>) => (
+  <div className="AknFullPage-content AknFullPage-content--withIllustration">
+    <div>{illustration}</div>
+    <div>{children}</div>
+  </div>
+);
 
 const ModalTitleContainer = styled.div.attrs(() => ({className: 'AknFullPage-titleContainer'}))`
   margin-bottom: 16px;
@@ -50,13 +45,13 @@ const ModalTitleContainer = styled.div.attrs(() => ({className: 'AknFullPage-tit
 type ModalTitleProps = {
   title: string;
   subtitle?: string;
-}
-
-export const ModalTitle = ({title, subtitle}: ModalTitleProps) => {
-  return (
-    <ModalTitleContainer>
-      {subtitle && <div className="AknFullPage-subTitle">{subtitle}</div>}
-      <div className="AknFullPage-title">{title}</div>
-    </ModalTitleContainer>
-  )
 };
+
+const ModalTitle = ({title, subtitle}: ModalTitleProps) => (
+  <ModalTitleContainer>
+    {subtitle && <div className="AknFullPage-subTitle">{subtitle}</div>}
+    <div className="AknFullPage-title">{title}</div>
+  </ModalTitleContainer>
+);
+
+export {Modal, ModalCloseButton, ModalBodyWithIllustration, ModalTitle};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/PageContent.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/PageContent.tsx
@@ -1,9 +1,11 @@
 import React, {PropsWithChildren} from 'react';
 
-export const PageContent = ({children}: PropsWithChildren<{}>) => (
+const PageContent = ({children}: PropsWithChildren<{}>) => (
   <div className="AknDefault-contentWithColumn">
     <div className="AknDefault-contentWithBottom">
       <div className="AknDefault-mainContent">{children}</div>
     </div>
   </div>
 );
+
+export {PageContent};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/ResultCount.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/ResultCount.tsx
@@ -15,7 +15,9 @@ type ResultCountProps = {
   labelKey?: string;
 };
 
-export const ResultCount = ({count = null, labelKey = 'measurements.list.result_count'}: ResultCountProps) =>
+const ResultCount = ({count = null, labelKey = 'measurements.list.result_count'}: ResultCountProps) =>
   count === null ? null : (
     <Container>{useContext(TranslateContext)(labelKey, {itemsCount: count.toString()}, count)}</Container>
   );
+
+export {ResultCount};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/SearchBar.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 import React, {useContext, ChangeEvent} from 'react';
 import styled from 'styled-components';
-import {Search as SearchIcon} from 'akeneomeasure/shared/icons/Search';
+import {SearchIcon} from 'akeneomeasure/shared/icons/SearchIcon';
 import {ResultCount} from 'akeneomeasure/shared/components/ResultCount';
 import {TranslateContext} from 'akeneomeasure/context/translate-context';
 import {useFocus} from 'akeneomeasure/shared/hooks/use-focus';

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/Subsection.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/Subsection.tsx
@@ -1,8 +1,8 @@
 import styled, {css} from 'styled-components';
 
-export const Subsection = styled.div.attrs(() => ({className: 'AknSubsection'}))``;
+const Subsection = styled.div.attrs(() => ({className: 'AknSubsection'}))``;
 
-export const SubsectionHeader = styled.header<{top?: number}>`
+const SubsectionHeader = styled.header<{top?: number}>`
   border-bottom: 1px solid ${props => props.theme.color.grey140};
   color: ${props => props.theme.color.grey140};
   display: flex;
@@ -22,3 +22,4 @@ export const SubsectionHeader = styled.header<{top?: number}>`
     `}
 `;
 
+export {Subsection, SubsectionHeader};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/SubsectionHelper.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/SubsectionHelper.tsx
@@ -3,13 +3,13 @@ import React, {PropsWithChildren} from 'react';
 import {WarningIcon} from 'akeneomeasure/shared/icons/WarningIcon';
 import {akeneoTheme} from 'akeneomeasure/shared/theme';
 
-export const HELPER_LEVEL_WARNING = 'warning';
-export const HELPER_LEVEL_INFO = 'info'; // @todo
+const HELPER_LEVEL_WARNING = 'warning';
+const HELPER_LEVEL_INFO = 'info'; // @todo
 
 type Level = typeof HELPER_LEVEL_WARNING | typeof HELPER_LEVEL_INFO;
 
 const getBackgroundColor = (level: Level): string => {
-  switch(level){
+  switch (level) {
     case HELPER_LEVEL_WARNING:
     default:
       return akeneoTheme.color.yellow10;
@@ -17,7 +17,7 @@ const getBackgroundColor = (level: Level): string => {
 };
 
 const getForegroundColor = (level: Level): string => {
-  switch(level){
+  switch (level) {
     case HELPER_LEVEL_WARNING:
     default:
       return akeneoTheme.color.yellow120;
@@ -25,10 +25,10 @@ const getForegroundColor = (level: Level): string => {
 };
 
 const getIcon = (level: Level): JSX.Element => {
-  switch(level){
+  switch (level) {
     case HELPER_LEVEL_WARNING:
     default:
-      return <WarningIcon color={akeneoTheme.color.yellow120}/>;
+      return <WarningIcon color={akeneoTheme.color.yellow120} />;
   }
 };
 
@@ -46,7 +46,7 @@ const SubsectionHelperIconContainer = styled.div<{level: Level}>`
   position: relative;
   display: flex;
   margin: 0 15px 0 0;
-  
+
   &:after {
     background-color: ${props => getForegroundColor(props.level)};
     content: '';
@@ -60,23 +60,19 @@ const SubsectionHelperIconContainer = styled.div<{level: Level}>`
   }
 `;
 
-const SubsectionHelperIcon = ({level}: {level: Level}) => {
-  return (
-    <SubsectionHelperIconContainer level={level}>
-      {getIcon(level)}
-    </SubsectionHelperIconContainer>
-  );
-};
+const SubsectionHelperIcon = ({level}: {level: Level}) => (
+  <SubsectionHelperIconContainer level={level}>{getIcon(level)}</SubsectionHelperIconContainer>
+);
 
 type SubsectionHelperProps = {
   level: Level;
-}
-
-export const SubsectionHelper = ({level, children}: PropsWithChildren<SubsectionHelperProps>) => {
-  return (
-    <SubsectionHelperContainer level={level}>
-      <SubsectionHelperIcon level={level}/>
-      {children}
-    </SubsectionHelperContainer>
-  );
 };
+
+const SubsectionHelper = ({level, children}: PropsWithChildren<SubsectionHelperProps>) => (
+  <SubsectionHelperContainer level={level}>
+    <SubsectionHelperIcon level={level} />
+    {children}
+  </SubsectionHelperContainer>
+);
+
+export {HELPER_LEVEL_INFO, HELPER_LEVEL_WARNING, SubsectionHelper};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/TextField.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/TextField.tsx
@@ -1,9 +1,9 @@
 import React, {ChangeEventHandler, useContext} from 'react';
+import styled, {css} from 'styled-components';
 import {ValidationError} from 'akeneomeasure/model/validation-error';
 import {InputErrors} from 'akeneomeasure/shared/components/InputErrors';
 import {TranslateContext} from 'akeneomeasure/context/translate-context';
 import {Flag} from 'akeneomeasure/shared/components/Flag';
-import styled, {css} from 'styled-components';
 
 const Input = styled.input.attrs(() => ({className: 'AknTextField'}))<{invalid: boolean}>`
   ${props =>
@@ -25,17 +25,9 @@ type TextFieldProps = {
   onChange: ChangeEventHandler<Element>;
 
   errors?: ValidationError[];
-}
+};
 
-export const TextField = ({
-  id,
-  label,
-  errors,
-  propertyPath,
-  required = false,
-  flag,
-  ...props
-}: TextFieldProps & any) => {
+const TextField = ({id, label, errors, propertyPath, required = false, flag, ...props}: TextFieldProps & any) => {
   const __ = useContext(TranslateContext);
 
   return (
@@ -44,17 +36,14 @@ export const TextField = ({
         <label className="AknFieldContainer-label" htmlFor={id}>
           {label} {required && __('measurements.form.required_suffix')}
         </label>
-        {flag && <Flag localeCode={flag}/>}
+        {flag && <Flag localeCode={flag} />}
       </div>
       <div className="AknFieldContainer-inputContainer">
-        <Input
-          type="text"
-          autoComplete="off"
-          invalid={errors && errors.length > 0}
-          {...props}
-        />
+        <Input type="text" autoComplete="off" invalid={errors && errors.length > 0} {...props} />
       </div>
-      {errors && <InputErrors errors={errors}/>}
+      {errors && <InputErrors errors={errors} />}
     </div>
-  )
+  );
 };
+
+export {TextField};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/icons/CloseIcon.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/icons/CloseIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const CloseIcon = ({
+const CloseIcon = ({
   color = '#67768A',
   title,
   size = 24,
@@ -8,7 +8,7 @@ export const CloseIcon = ({
 }: {
   color: string;
   title?: string;
-  size: number
+  size: number;
 } & any) => (
   <svg viewBox="0 0 24 24" width={size} height={size} {...props}>
     <g fillRule="nonzero" stroke={color} fill="none" strokeLinecap="round">
@@ -17,3 +17,5 @@ export const CloseIcon = ({
     <title>{title}</title>
   </svg>
 );
+
+export {CloseIcon};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/icons/SearchIcon.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/icons/SearchIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Search = ({
+const SearchIcon = ({
   title = 'Search',
   color = '#67768A',
   size = 24,
@@ -15,4 +15,4 @@ const Search = ({
   </svg>
 );
 
-export {Search};
+export {SearchIcon};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/icons/WarningIcon.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/icons/WarningIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const WarningIcon = ({
+const WarningIcon = ({
   color = '#A1A9B7',
   title,
   size = 24,
@@ -19,3 +19,5 @@ export const WarningIcon = ({
     </g>
   </svg>
 );
+
+export {WarningIcon};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/illustrations/MeasurementFamilyIllustration.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/illustrations/MeasurementFamilyIllustration.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const MeasurementFamily = ({
+const MeasurementFamilyIllustration = ({
   title = 'Measurement Family icon',
   size = 256,
   ...props
@@ -2602,4 +2602,4 @@ const MeasurementFamily = ({
   </svg>
 );
 
-export {MeasurementFamily};
+export {MeasurementFamilyIllustration};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/jsmessages.en_US.yml
@@ -22,6 +22,7 @@ measurements:
         standard_unit: Standard Unit
         standard_unit_is_not_editable_after_creation: This standard unit is set once and for all. It will be used to convert the other units.
         add_new_measurement_family: Add a new measurement family
+        create: Create
     list:
         result_count: "{0}0 results|{1}1 result|]1, Inf[{{ itemsCount }} results"
         header:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Unifying coding style by using `export` only once at the end of each module.
Also boy-scout-adding Escape key shortcut to close the Create Measurement Family modal.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
