### PR TITLE
PIM-9146: Fix select2-choice-filter fetch for cached&missing data

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9140: Translate error message from backend in dialogs
+- PIM-9146: Fix product grid choice-filter data fetching
 
 # 3.0.69 (2020-03-11)
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js
@@ -221,7 +221,7 @@ define(
                 }, this);
 
                 if (missingResults.length) {
-                    var params = { options: { ids: missingResults } };
+                    var params = { options: { identifiers: missingResults } };
 
                     $.ajax({
                         url: Routing.generate(this.choiceUrl, this.choiceUrlParams) + '&' + $.param(params),


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix the data loading of the product grid select2 choice filter.

Only fetch the selected asset ids:
![Screenshot from 2020-03-16 16-35-52](https://user-images.githubusercontent.com/1671213/76777176-16a06b00-67a8-11ea-92b4-502d5cad7948.png)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
