### PR TITLE
MET-116: Fix the EE tests

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyEndToEnd.php
@@ -22,7 +22,6 @@ class CreateMeasurementFamilyEndToEnd extends WebTestCase
         parent::setUp();
 
         $this->measurementFamilyRepository = $this->get('akeneo_measure.persistence.measurement_family_repository');
-        $this->authenticateAsAdmin();
     }
 
     /**
@@ -41,6 +40,7 @@ class CreateMeasurementFamilyEndToEnd extends WebTestCase
         $measurementFamily = self::createMeasurementFamily('custom_metric_1');
         $normalizedMeasurementFamily = $measurementFamily->normalize();
 
+        $this->authenticateAsAdmin();
         $this->client->request(
             'POST',
             'rest/measurement-families',
@@ -64,6 +64,7 @@ class CreateMeasurementFamilyEndToEnd extends WebTestCase
     {
         $invalidMeasurementFamily = ['values' => null];
 
+        $this->authenticateAsAdmin();
         $this->client->request(
             'POST',
             'rest/measurement-families',
@@ -91,6 +92,7 @@ class CreateMeasurementFamilyEndToEnd extends WebTestCase
         $normalizedMeasurementFamily = $measurementFamily->normalize();
         $normalizedMeasurementFamily['code'] = 'INVALID CODE WITH SPACES';
 
+        $this->authenticateAsAdmin();
         $this->client->request(
             'POST',
             'rest/measurement-families',
@@ -120,6 +122,7 @@ class CreateMeasurementFamilyEndToEnd extends WebTestCase
         $measurementFamily = self::createMeasurementFamily('custom_metric_1');
         $normalizedMeasurementFamily = $measurementFamily->normalize();
 
+        $this->authenticateAsAdmin();
         $this->client->request(
             'POST',
             'rest/measurement-families',
@@ -133,6 +136,7 @@ class CreateMeasurementFamilyEndToEnd extends WebTestCase
 
         $this->client->restart();
 
+        $this->authenticateAsAdmin();
         $this->client->request(
             'POST',
             'rest/measurement-families',

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyEndToEnd.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\tests\EndToEnd\InternalApi;
 
-use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
@@ -10,9 +9,10 @@ use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
 use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Akeneo\Tool\Bundle\MeasureBundle\tests\EndToEnd\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class CreateMeasurementFamilyEndToEnd extends ApiTestCase
+class CreateMeasurementFamilyEndToEnd extends WebTestCase
 {
     /** @var MeasurementFamilyRepositoryInterface */
     private $measurementFamilyRepository;
@@ -22,6 +22,7 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
         parent::setUp();
 
         $this->measurementFamilyRepository = $this->get('akeneo_measure.persistence.measurement_family_repository');
+        $this->authenticateAsAdmin();
     }
 
     /**
@@ -29,7 +30,7 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
      */
     protected function getConfiguration()
     {
-        return $this->catalog->useTechnicalCatalog();
+        return $this->catalog->useMinimalCatalog();
     }
 
     /**
@@ -40,9 +41,7 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
         $measurementFamily = self::createMeasurementFamily('custom_metric_1');
         $normalizedMeasurementFamily = $measurementFamily->normalize();
 
-        $client = $this->createAuthenticatedClient();
-
-        $client->request(
+        $this->client->request(
             'POST',
             'rest/measurement-families',
             [],
@@ -53,7 +52,7 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
             json_encode($normalizedMeasurementFamily)
         );
 
-        $response = $client->getResponse();
+        $response = $this->client->getResponse();
         $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
         $this->assertMeasurementFamilyHasBeenCreated($measurementFamily);
     }
@@ -64,9 +63,8 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
     public function it_returns_an_error_when_the_measurement_family_does_not_have_the_right_structure()
     {
         $invalidMeasurementFamily = ['values' => null];
-        $client = $this->createAuthenticatedClient();
 
-        $client->request(
+        $this->client->request(
             'POST',
             'rest/measurement-families',
             [],
@@ -77,7 +75,7 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
             json_encode($invalidMeasurementFamily)
         );
 
-        $response = $client->getResponse();
+        $response = $this->client->getResponse();
         $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
         $responseBody = json_decode($response->getContent(), true);
         $this->assertEquals(Response::HTTP_BAD_REQUEST, $responseBody['code']);
@@ -93,9 +91,7 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
         $normalizedMeasurementFamily = $measurementFamily->normalize();
         $normalizedMeasurementFamily['code'] = 'INVALID CODE WITH SPACES';
 
-        $client = $this->createAuthenticatedClient();
-
-        $client->request(
+        $this->client->request(
             'POST',
             'rest/measurement-families',
             [],
@@ -106,7 +102,7 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
             json_encode($normalizedMeasurementFamily)
         );
 
-        $response = $client->getResponse();
+        $response = $this->client->getResponse();
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
         $responseBody = json_decode($response->getContent(), true);
         $this->assertEquals(Response::HTTP_UNPROCESSABLE_ENTITY, $responseBody['code']);
@@ -124,9 +120,7 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
         $measurementFamily = self::createMeasurementFamily('custom_metric_1');
         $normalizedMeasurementFamily = $measurementFamily->normalize();
 
-        $client = $this->createAuthenticatedClient();
-
-        $client->request(
+        $this->client->request(
             'POST',
             'rest/measurement-families',
             [],
@@ -137,9 +131,9 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
             json_encode($normalizedMeasurementFamily)
         );
 
-        $client->restart();
+        $this->client->restart();
 
-        $client->request(
+        $this->client->request(
             'POST',
             'rest/measurement-families',
             [],
@@ -150,7 +144,7 @@ class CreateMeasurementFamilyEndToEnd extends ApiTestCase
             json_encode($normalizedMeasurementFamily)
         );
 
-        $response = $client->getResponse();
+        $response = $this->client->getResponse();
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/WebTestCase.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/WebTestCase.php
@@ -20,17 +20,33 @@ abstract class WebTestCase extends TestCase
     /** @var KernelBrowser */
     protected $client;
 
+    /** @var UserInterface */
+    protected $user;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->client = self::$container->get('test.client');
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->user = null;
+    }
+
     protected function authenticateAsAdmin()
     {
-        $user = $this->createAdminUser();
+        $this->authenticate($this->getAdminUser());
+    }
 
-        $this->authenticate($user);
+    protected function getAdminUser(): UserInterface
+    {
+        if (!$this->user) {
+            $this->user = $this->createAdminUser();
+        }
+
+        return $this->user;
     }
 
     private function authenticate(UserInterface $user)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/WebTestCase.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/WebTestCase.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\tests\EndToEnd;
+
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+/**
+ * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+abstract class WebTestCase extends TestCase
+{
+    /** @var KernelBrowser */
+    protected $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client = self::$container->get('test.client');
+    }
+
+    protected function authenticateAsAdmin()
+    {
+        $user = $this->createAdminUser();
+
+        $this->authenticate($user);
+    }
+
+    private function authenticate(UserInterface $user)
+    {
+        $firewallName = 'main';
+        $firewallContext = 'main';
+
+        $token = new UsernamePasswordToken($user, null, $firewallName, $user->getRoles());
+        $session = $this->getSession();
+        $session->set('_security_' . $firewallContext, serialize($token));
+        $session->save();
+
+        $cookie = new Cookie($session->getName(), $session->getId());
+        $this->client->getCookieJar()->set($cookie);
+    }
+
+    private function getSession(): SessionInterface
+    {
+        return $this->client->getContainer()->get('session');
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

By mistake, I've used `Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase` for the End-to-End tests of this internal api endpoint. The tests are good when runned from a CE env but are failing on the auth when runned from EE.

This PR fix it by using the appropriate auth method.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -