### PR TITLE
MET-90: Add DELETE endpoint for measurement families

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/DeleteMeasurementFamily/DeleteMeasurementFamilyCommand.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/DeleteMeasurementFamily/DeleteMeasurementFamilyCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily;
+
+/**
+ * @copyright 2020 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class DeleteMeasurementFamilyCommand
+{
+    /** @var string */
+    public $code;
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/DeleteMeasurementFamily/DeleteMeasurementFamilyHandler.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/DeleteMeasurementFamily/DeleteMeasurementFamilyHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class DeleteMeasurementFamilyHandler
+{
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+
+    public function __construct(MeasurementFamilyRepositoryInterface $measurementFamilyRepository)
+    {
+        $this->measurementFamilyRepository = $measurementFamilyRepository;
+    }
+
+    /**
+     * @throws MeasurementFamilyNotFoundException
+     */
+    public function handle(DeleteMeasurementFamilyCommand $deleteMeasurementFamilyCommand): void
+    {
+        $this->measurementFamilyRepository->deleteByCode(MeasurementFamilyCode::fromString($deleteMeasurementFamilyCommand->code));
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/DeleteMeasurementFamilyAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/DeleteMeasurementFamilyAction.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily\DeleteMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily\DeleteMeasurementFamilyHandler;
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
+use Akeneo\Tool\Component\Api\Exception\ViolationHttpException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DeleteMeasurementFamilyAction
+{
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /** @var DeleteMeasurementFamilyHandler */
+    private $deleteMeasurementFamilyHandler;
+
+    public function __construct(
+        ValidatorInterface $validator,
+        DeleteMeasurementFamilyHandler $deleteMeasurementFamilyHandler
+    ) {
+        $this->validator = $validator;
+        $this->deleteMeasurementFamilyHandler = $deleteMeasurementFamilyHandler;
+    }
+
+    public function __invoke(Request $request, string $code): Response
+    {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
+        try {
+            $deleteMeasurementFamilyCommand = $this->createDeleteMeasurementFamilyCommand($code);
+            $this->validateDeleteMeasurementFamilyCommand($deleteMeasurementFamilyCommand);
+            $this->handleDeleteMeasurementFamilyCommand($deleteMeasurementFamilyCommand);
+        } catch (MeasurementFamilyNotFoundException $ex) {
+            return new Response(null, Response::HTTP_NOT_FOUND);
+        } catch (ViolationHttpException $ex) {
+            return new JsonResponse(
+                [
+                    'code' => Response::HTTP_UNPROCESSABLE_ENTITY,
+                    'message' => 'The measurement family cannot be removed.',
+                ],
+                Response::HTTP_UNPROCESSABLE_ENTITY
+            );
+        }
+
+        return new Response(null, Response::HTTP_NO_CONTENT);
+    }
+
+    private function createDeleteMeasurementFamilyCommand(string $code)
+    {
+        $deleteMeasurementFamilyCommand = new DeleteMeasurementFamilyCommand();
+        $deleteMeasurementFamilyCommand->code = $code;
+
+        return $deleteMeasurementFamilyCommand;
+    }
+
+    private function validateDeleteMeasurementFamilyCommand(
+        DeleteMeasurementFamilyCommand $deleteMeasurementFamilyCommand
+    ) {
+        $violations = $this->validator->validate($deleteMeasurementFamilyCommand);
+
+        if (count($violations) > 0) {
+            throw new ViolationHttpException($violations);
+        }
+    }
+
+    /**
+     * @throws MeasurementFamilyNotFoundException
+     */
+    private function handleDeleteMeasurementFamilyCommand(
+        DeleteMeasurementFamilyCommand $deleteMeasurementFamilyCommand
+    ) {
+        $this->deleteMeasurementFamilyHandler->handle($deleteMeasurementFamilyCommand);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -101,6 +101,32 @@ SQL;
         return (int) $statement->fetch(\PDO::FETCH_COLUMN);
     }
 
+    public function deleteByCode(MeasurementFamilyCode $measurementFamilyCode)
+    {
+        $sql = <<<SQL
+    DELETE FROM akeneo_measurement
+    WHERE code = :code
+SQL;
+
+        $affectedRows = $this->sqlConnection->executeUpdate(
+            $sql,
+            [
+                'code' => $measurementFamilyCode->normalize(),
+            ]
+        );
+
+        if (1 !== $affectedRows) {
+            throw new MeasurementFamilyNotFoundException();
+        }
+
+        if (isset($this->measurementFamilyCache[$measurementFamilyCode->normalize()])) {
+            unset($this->measurementFamilyCache[$measurementFamilyCode->normalize()]);
+        }
+        if (isset($this->allMeasurementFamiliesCache[$measurementFamilyCode->normalize()])) {
+            unset($this->allMeasurementFamiliesCache[$measurementFamilyCode->normalize()]);
+        }
+    }
+
     private function hydrateMeasurementFamily(
         string $code,
         string $normalizedLabels,

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepositoryInterface.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepositoryInterface.php
@@ -20,4 +20,9 @@ interface MeasurementFamilyRepositoryInterface
     public function save(MeasurementFamily $measurementFamily);
 
     public function countAllOthers(MeasurementFamilyCode $excludedMeasurementFamilyCode): int;
+
+    /**
+     * @throws MeasurementFamilyNotFoundException
+     */
+    public function deleteByCode(MeasurementFamilyCode $measurementFamilyCode);
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/internal_api.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/internal_api.yml
@@ -9,6 +9,13 @@ services:
             - '@pim_api.normalizer.exception.violation'
             - '@akeneo_measure.application.create_measurement_family_handler'
 
+    pim_api.controller.internal_api.delete_measurement_family:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi\DeleteMeasurementFamilyAction
+        public: true
+        arguments:
+            - '@validator'
+            - '@akeneo_measure.application.delete_measurement_family_handler'
+
     # Json schema
     pim_api.controller.internal_api.json_schema.measurement_family_structure_validator:
         class: Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi\JsonSchema\MeasurementFamilyStructureValidator

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/routing.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/routing.yml
@@ -6,3 +6,8 @@ akeneo_measurements_measurement_family_create_rest:
     path: '/rest/measurement-families'
     defaults: { _controller: pim_api.controller.internal_api.create_measurement_family }
     methods: [POST]
+
+akeneo_measurements_measurement_family_delete_rest:
+    path: '/rest/measurement-families/{code}'
+    defaults: { _controller: pim_api.controller.internal_api.delete_measurement_family }
+    methods: [DELETE]

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
@@ -47,6 +47,11 @@ services:
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'
 
+    akeneo_measure.application.delete_measurement_family_handler:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily\DeleteMeasurementFamilyHandler
+        arguments:
+            - '@akeneo_measure.persistence.measurement_family_repository'
+
     akeneo_measure.validation.create_measurement_family.code_must_be_unique:
         class: Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\CodeMustBeUniqueValidator
         arguments:
@@ -99,3 +104,10 @@ services:
             - '@akeneo.pim.structure.query.is_there_at_least_one_attribute_configured_with_measurement_family'
         tags:
             - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validator.asset.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units' }
+
+    akeneo_measurement.validation.delete_measurement_family.should_not_be_used_by_product_attribute:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\DeleteMeasurementFamily\ShouldNotBeUsedByProductAttributeValidator
+        arguments:
+            - '@akeneo.pim.structure.query.is_there_at_least_one_attribute_configured_with_measurement_family'
+        tags:
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.delete_measurement_family.should_not_be_used_by_product_attribute' }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
@@ -84,3 +84,7 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasu
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeOperationShouldBeMultiplyByOne: { groups: [other_constraints] }
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits: { groups: [other_constraints] }
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\Count: { groups: [other_constraints] }
+
+Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily\DeleteMeasurementFamilyCommand:
+    constraints:
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\DeleteMeasurementFamily\ShouldNotBeUsedByProductAttribute: ~

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/DeleteMeasurementFamily/ShouldNotBeUsedByProductAttribute.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/DeleteMeasurementFamily/ShouldNotBeUsedByProductAttribute.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\DeleteMeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ShouldNotBeUsedByProductAttribute extends Constraint
+{
+    public const MEASUREMENT_FAMILY_REMOVAL_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.measurement_family_cannot_be_removed';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    public function validatedBy(): string
+    {
+        return 'akeneo_measurement.validation.delete_measurement_family.should_not_be_used_by_product_attribute';
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/DeleteMeasurementFamily/ShouldNotBeUsedByProductAttributeValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/DeleteMeasurementFamily/ShouldNotBeUsedByProductAttributeValidator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\DeleteMeasurementFamily;
+
+use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily\DeleteMeasurementFamilyCommand;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class ShouldNotBeUsedByProductAttributeValidator extends ConstraintValidator
+{
+    /** @var IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily */
+    private $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+
+    public function __construct(
+        IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily
+    ) {
+        $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily = $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate($deleteMeasurementFamily, Constraint $constraint)
+    {
+        if (!$constraint instanceof ShouldNotBeUsedByProductAttribute) {
+            throw new UnexpectedTypeException($constraint, ShouldNotBeUsedByProductAttribute::class);
+        }
+
+        if (!$deleteMeasurementFamily instanceof DeleteMeasurementFamilyCommand) {
+            throw new UnexpectedTypeException($deleteMeasurementFamily, DeleteMeasurementFamilyCommand::class);
+        }
+
+        $isMeasureFamilyLockedForUpdates = $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily
+            ->execute($deleteMeasurementFamily->code);
+
+        if ($isMeasureFamilyLockedForUpdates) {
+            $this->context
+                ->buildViolation(ShouldNotBeUsedByProductAttribute::MEASUREMENT_FAMILY_REMOVAL_NOT_ALLOWED)
+                ->addViolation();
+        }
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/DeleteMeasurementFamilyEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/DeleteMeasurementFamilyEndToEnd.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\tests\EndToEnd\InternalApi;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Akeneo\Tool\Bundle\MeasureBundle\tests\EndToEnd\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class DeleteMeasurementFamilyEndToEnd extends WebTestCase
+{
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->measurementFamilyRepository = $this->get('akeneo_measure.persistence.measurement_family_repository');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @test
+     */
+    public function it_deletes_a_measurement_family()
+    {
+        $measurementFamilyCode = 'custom_metric_1';
+        $measurementFamily = self::createMeasurementFamily($measurementFamilyCode);
+        $this->insertMeasurementFamily($measurementFamily);
+
+        $this->assertMeasurementFamilyExists($measurementFamily);
+
+        $this->authenticateAsAdmin();
+        $this->client->request(
+            'DELETE',
+            sprintf('rest/measurement-families/%s', $measurementFamilyCode),
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertMeasurementFamilyHasBeenDeleted($measurementFamily);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_when_the_measurement_family_does_not_exists()
+    {
+        $measurementFamilyCode = 'custom_metric_1';
+
+        $this->authenticateAsAdmin();
+        $this->client->request(
+            'DELETE',
+            sprintf('rest/measurement-families/%s', $measurementFamilyCode),
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_when_the_measurement_family_is_used_by_attributes()
+    {
+        $measurementFamilyCode = 'Power';
+
+        $this->authenticateAsAdmin();
+        $this->client->request(
+            'DELETE',
+            sprintf('rest/measurement-families/%s', $measurementFamilyCode),
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    private static function createMeasurementFamily(string $code): MeasurementFamily
+    {
+        return MeasurementFamily::create(
+            MeasurementFamilyCode::fromString($code),
+
+            LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
+            UnitCode::fromString('CUSTOM_UNIT_1_1'),
+            [
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
+                    [Operation::create('mul', '1')],
+                    'mm²'
+                ),
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_2_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
+                    [Operation::create('mul', '0.1')],
+                    'cm²'
+                )
+            ]
+        );
+    }
+
+    private function insertMeasurementFamily(MeasurementFamily $measurementFamily)
+    {
+        $this->measurementFamilyRepository->save($measurementFamily);
+    }
+
+    private function assertMeasurementFamilyExists(MeasurementFamily $expected): void
+    {
+        $measurementFamilyCode = MeasurementFamilyCode::fromString($expected->normalize()['code']);
+        $actual = $this->measurementFamilyRepository->getByCode($measurementFamilyCode);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    private function assertMeasurementFamilyHasBeenDeleted(MeasurementFamily $expected): void
+    {
+        $measurementFamilyCode = MeasurementFamilyCode::fromString($expected->normalize()['code']);
+
+        $this->expectException(MeasurementFamilyNotFoundException::class);
+        $this->measurementFamilyRepository->getByCode($measurementFamilyCode);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/DeleteMeasurementFamilyEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/DeleteMeasurementFamilyEndToEnd.php
@@ -39,23 +39,14 @@ class DeleteMeasurementFamilyEndToEnd extends WebTestCase
     public function it_deletes_a_measurement_family()
     {
         $measurementFamilyCode = 'custom_metric_1';
-        $measurementFamily = self::createMeasurementFamily($measurementFamilyCode);
+        $measurementFamily = $this->createMeasurementFamily($measurementFamilyCode);
         $this->insertMeasurementFamily($measurementFamily);
 
         $this->assertMeasurementFamilyExists($measurementFamily);
 
         $this->authenticateAsAdmin();
-        $this->client->request(
-            'DELETE',
-            sprintf('rest/measurement-families/%s', $measurementFamilyCode),
-            [],
-            [],
-            [
-                'HTTP_X-Requested-With' => 'XMLHttpRequest',
-            ]
-        );
+        $response = $this->requestDeleteEndpoint($measurementFamilyCode);
 
-        $response = $this->client->getResponse();
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertMeasurementFamilyHasBeenDeleted($measurementFamily);
     }
@@ -63,22 +54,13 @@ class DeleteMeasurementFamilyEndToEnd extends WebTestCase
     /**
      * @test
      */
-    public function it_returns_an_error_when_the_measurement_family_does_not_exists()
+    public function it_returns_an_error_when_the_measurement_family_does_not_exist()
     {
         $measurementFamilyCode = 'custom_metric_1';
 
         $this->authenticateAsAdmin();
-        $this->client->request(
-            'DELETE',
-            sprintf('rest/measurement-families/%s', $measurementFamilyCode),
-            [],
-            [],
-            [
-                'HTTP_X-Requested-With' => 'XMLHttpRequest',
-            ]
-        );
+        $response = $this->requestDeleteEndpoint($measurementFamilyCode);
 
-        $response = $this->client->getResponse();
         $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
     }
 
@@ -90,21 +72,12 @@ class DeleteMeasurementFamilyEndToEnd extends WebTestCase
         $measurementFamilyCode = 'Power';
 
         $this->authenticateAsAdmin();
-        $this->client->request(
-            'DELETE',
-            sprintf('rest/measurement-families/%s', $measurementFamilyCode),
-            [],
-            [],
-            [
-                'HTTP_X-Requested-With' => 'XMLHttpRequest',
-            ]
-        );
+        $response = $this->requestDeleteEndpoint($measurementFamilyCode);
 
-        $response = $this->client->getResponse();
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
-    private static function createMeasurementFamily(string $code): MeasurementFamily
+    private function createMeasurementFamily(string $code): MeasurementFamily
     {
         return MeasurementFamily::create(
             MeasurementFamilyCode::fromString($code),
@@ -126,6 +99,21 @@ class DeleteMeasurementFamilyEndToEnd extends WebTestCase
                 )
             ]
         );
+    }
+
+    private function requestDeleteEndpoint(string $measurementFamilyCode): Response
+    {
+        $this->client->request(
+            'DELETE',
+            sprintf('rest/measurement-families/%s', $measurementFamilyCode),
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+
+        return $this->client->getResponse();
     }
 
     private function insertMeasurementFamily(MeasurementFamily $measurementFamily)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/WebTestCase.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/WebTestCase.php
@@ -43,7 +43,7 @@ abstract class WebTestCase extends TestCase
     protected function getAdminUser(): UserInterface
     {
         if (!$this->user) {
-            $this->user = $this->createAdminUser();
+            $this->user = self::$container->get('pim_user.manager')->findUserByUsername('admin') ?? $this->createAdminUser();
         }
 
         return $this->user;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/Persistence/MeasurementFamilyRepositoryIntegration.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/Persistence/MeasurementFamilyRepositoryIntegration.php
@@ -113,6 +113,40 @@ class MeasurementFamilyRepositoryIntegration extends SqlIntegrationTestCase
         $this->assertCount(3, $measurementFamilies);
     }
 
+    /**
+     * @test
+     */
+    public function it_deletes_a_measurement_family(): void
+    {
+        $measurementFamilies = $this->repository->all();
+        $this->assertEquals(
+            ['Area', 'Binary'],
+            array_map(function (MeasurementFamily $measurementFamily) {
+                return $measurementFamily->normalize()['code'];
+            }, $measurementFamilies)
+        );
+
+        $this->repository->deleteByCode(MeasurementFamilyCode::fromString('Area'));
+
+        $measurementFamilies = $this->repository->all();
+        $this->assertEquals(
+            ['Binary'],
+            array_map(function (MeasurementFamily $measurementFamily) {
+                return $measurementFamily->normalize()['code'];
+            }, $measurementFamilies)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_the_measurement_family_being_removed_does_not_exists(): void
+    {
+        $this->expectException(MeasurementFamilyNotFoundException::class);
+
+        $this->repository->deleteByCode(MeasurementFamilyCode::fromString('NOT_EXISTING'));
+    }
+
     private function createMeasurementFamily(string $code = 'Area', array $labels = ["en_US" => "Area", "fr_FR" => "Surface"]): MeasurementFamily
     {
         return MeasurementFamily::create(

--- a/tests/back/Acceptance/MeasurementFamily/InMemoryMeasurementFamilyRepository.php
+++ b/tests/back/Acceptance/MeasurementFamily/InMemoryMeasurementFamilyRepository.php
@@ -85,6 +85,15 @@ class InMemoryMeasurementFamilyRepository implements MeasurementFamilyRepository
             : count($this->measurementFamilies);
     }
 
+    public function deleteByCode(MeasurementFamilyCode $measurementFamilyCode)
+    {
+        if (!isset($this->measurementFamilies[$measurementFamilyCode->normalize()])) {
+            throw new MeasurementFamilyNotFoundException();
+        }
+
+        unset($this->measurementFamilies[$measurementFamilyCode->normalize()]);
+    }
+
     public function clear(): void
     {
         $this->measurementFamilies = [];


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

New internal endpoint:
```
DELETE /rest/measurement-families/{code}
```

3 responses possibles:
```
204 - Deleted
404 - Cannot be found
422 - Cannot be deleted
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

