### PR TITLE
PIM-9152: Handle old versioning date format

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9152: Handle old versioning date format
+
 # 3.2.44 (2020-03-13)
 
 ## Bug fixes


### PR DESCRIPTION
Fixes issues when products saved with 'date' are modified to 'datetime'. The PIM recognizes those fields as being updated (even if the date remains the same) and creates versions in the product history.