### PR TITLE
MET-91: Remove Measurement Family frontend (remover hook & confirm modal)

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/hooks/use-measurement-family-remover.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/hooks/use-measurement-family-remover.ts
@@ -1,0 +1,41 @@
+import {useContext} from 'react';
+import {RouterContext} from 'akeneomeasure/context/router-context';
+
+enum MeasurementFamilyRemoverResult {
+  Success = 'Success',
+  Unprocessable = 'Unprocessable',
+  NotFound = 'NotFound',
+}
+
+type Remover = (measurementFamilyCode: string) => Promise<MeasurementFamilyRemoverResult>;
+
+const useMeasurementFamilyRemover = (): Remover => {
+  const router = useContext(RouterContext);
+
+  return async (measurementFamilyCode: string) => {
+    const response = await fetch(router.generate('akeneo_measurements_measurement_family_delete_rest', {
+      code: measurementFamilyCode,
+    }), {
+      method: 'DELETE',
+      headers: [
+        ['X-Requested-With', 'XMLHttpRequest'],
+      ],
+    });
+
+    switch (response.status) {
+      case 204:
+        return MeasurementFamilyRemoverResult.Success;
+      case 404:
+        return MeasurementFamilyRemoverResult.NotFound;
+      case 422:
+        return MeasurementFamilyRemoverResult.Unprocessable;
+      default:
+        throw Error('The DELETE endpoint returned an unexpected response');
+    }
+  };
+};
+
+export {
+  useMeasurementFamilyRemover,
+  MeasurementFamilyRemoverResult
+};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/edit/UnitTab.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/edit/UnitTab.tsx
@@ -124,7 +124,7 @@ const UnitTab = ({
   const selectedUnitIndex = getUnitIndex(measurementFamily, selectedUnitCode);
   const filteredUnits = measurementFamily.units.filter(filterOnLabelOrCode(searchValue, locale));
 
-  const removeUnitHandler = useCallback(() => {
+  const handleRemoveUnit = useCallback(() => {
     onMeasurementFamilyChange(removeUnit(measurementFamily, selectedUnitCode));
     selectUnitCode(measurementFamily.standard_unit_code);
     closeConfirmDeleteUnitModal();
@@ -137,7 +137,7 @@ const UnitTab = ({
       {isConfirmDeleteUnitModalOpen && (
         <ConfirmDeleteModal
           description={__('measurements.unit.delete.confirm')}
-          onConfirm={removeUnitHandler}
+          onConfirm={handleRemoveUnit}
           onCancel={closeConfirmDeleteUnitModal}
         />
       )}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/jsmessages.en_US.yml
@@ -26,7 +26,12 @@ measurements:
         tab:
             units: Units
             properties: Properties
-        delete: Delete measurement family
+        delete:
+            button: Delete measurement family
+            confirm: Are you sure you want to delete this measurement family?
+            flash:
+                success: Measurement family successfully deleted.
+                error: Sorry, an error occured while deleting the measurement family.
         save:
             flash:
                 success: Measurement family successfully saved.

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/front/unit/hooks/use-measurement-family-remover.unit.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/front/unit/hooks/use-measurement-family-remover.unit.ts
@@ -1,0 +1,59 @@
+'use strict';
+
+import '@testing-library/jest-dom/extend-expect';
+import {renderHook} from '@testing-library/react-hooks';
+import {useMeasurementFamilyRemover, MeasurementFamilyRemoverResult} from 'akeneomeasure/hooks/use-measurement-family-remover';
+
+afterEach(() => {
+  global.fetch && global.fetch.mockClear();
+  delete global.fetch;
+});
+
+test('It returns a success response when removing', async () => {
+  const fetchMock = jest.fn().mockImplementation(() => ({
+    status: 204,
+  }));
+  global.fetch = fetchMock;
+
+  const {result} = renderHook(() => useMeasurementFamilyRemover());
+  const remove = result.current;
+
+  expect(await remove('custom_metric')).toEqual(MeasurementFamilyRemoverResult.Success);
+  expect(fetchMock).toHaveBeenCalledWith(
+    'akeneo_measurements_measurement_family_delete_rest?code=custom_metric',
+    {"headers": [["X-Requested-With", "XMLHttpRequest"]], "method": "DELETE"}
+  );
+});
+
+test('It returns a not found response when removing an unknown measurement family', async () => {
+  global.fetch = jest.fn().mockImplementation(() => ({
+    status: 404,
+  }));
+
+  const {result} = renderHook(() => useMeasurementFamilyRemover());
+  const remove = result.current;
+
+  expect(await remove('custom_metric')).toEqual(MeasurementFamilyRemoverResult.NotFound);
+});
+
+test('It returns a not allowed response when removing a read-only measurement family', async () => {
+  global.fetch = jest.fn().mockImplementation(() => ({
+    status: 422,
+  }));
+
+  const {result} = renderHook(() => useMeasurementFamilyRemover());
+  const remove = result.current;
+
+  expect(await remove('custom_metric')).toEqual(MeasurementFamilyRemoverResult.Unprocessable);
+});
+
+test('An error is thrown if the server does not respond correctly', async () => {
+  global.fetch = jest.fn().mockImplementation(() => ({
+    status: 500,
+  }));
+
+  const {result} = renderHook(() => useMeasurementFamilyRemover());
+  const remove = result.current;
+
+  expect(remove('custom_metric')).rejects.toThrow();
+});


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR:
- Adds the remove measurement family hook
- Adds the remove measurement family modal

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
