### PR TITLE
Pim 9147 create completeness clean command

### DIFF
--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -58,7 +58,7 @@ integration-back: var/tests/phpunit connectivity-connection-integration-back
 ifeq ($(CI),true)
 	.circleci/run_phpunit.sh . .circleci/find_phpunit.php PIM_Integration_Test
 else
-	@echo Run integration test locally is too long, please use the target defined for your bounded context (ex: bounded-context-integration-back)
+	@echo "Run integration test locally is too long, please use the target defined for your bounded context (ex: bounded-context-integration-back)"
 endif
 
 ### Migration tests

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanCompletenessForNonExistingProducts.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanCompletenessForNonExistingProducts.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 
 class CleanCompletenessForNonExistingProducts extends Command
-{ 
+{
     protected static $defaultName = 'pim:completeness:clean';
 
     /** @var Connection */
@@ -56,4 +56,3 @@ SQL;
         return 0;
     }
 }
-

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanCompletenessForNonExistingProducts.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanCompletenessForNonExistingProducts.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Command;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * This command deletes entries from the completeness table which are related
+ * of products that do not exist anymore in the product or product model table.
+ *
+ * @author    Grégoire HUBERT <gregoire.hubert@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+class CleanCompletenessForNonExistingProducts extends Command
+{ 
+    protected static $defaultName = 'pim:completeness:clean';
+
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        parent::__construct();
+        $this->connection = $connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setDescription('Clean orphan completeness entries.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $sql = <<<SQL
+DELETE FROM pim_catalog_completeness AS pcc
+WHERE pcc.product_id NOT IN (SELECT id FROM pim_catalog_product AS pcp)
+SQL;
+        $output->writeln('<info>Cleaning orphans from completenesses table...</info>');
+        $stmt = $this->connection->query($sql);
+        $output->writeln(sprintf('<fg=white;options=bold>%d rows</> deleted from table "%s.pim_catalog_completeness".', $stmt->rowCount(), $this->connection->getDatabase()));
+
+        return 0;
+    }
+}
+

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
@@ -25,3 +25,10 @@ services:
             - '@database_connection'
         tags:
             - { name: 'console.command' }
+
+    akeneo.pim.enrichment.command.clean_completeness:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Command\CleanCompletenessForNonExistingProducts'
+        arguments:
+            - '@database_connection'
+        tags:
+            - { name: 'console.command' }

--- a/tests/back/Pim/Enrichment/Integration/Completeness/CleanCompletenessForNonExistingProductsCommandIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/CleanCompletenessForNonExistingProductsCommandIntegration.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Completeness;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Test\IntegrationTestsBundle\Launcher\CommandLauncher;
+use PHPUnit\Framework\Assert;
+
+class CleanCompletenessForNonExistingProductsCommandIntegration extends TestCase
+{
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function countCompleteness(): int
+    {
+        $sql = "select count(*) as line_count from pim_catalog_completeness";
+        $lines = $this->get('database_connection')
+            ->executeQuery($sql)
+            ->fetch();
+
+        return $lines['line_count'] + 0;
+    }
+
+    private function getProductLinesNumber(int $productId): int
+    {
+        $sql = "select count(*) as line_count from pim_catalog_completeness where product_id = :product_id";
+        $lines = $this->get('database_connection')
+            ->executeQuery($sql, ['product_id' => $product_id])
+            ->fetch();
+
+        return $lines['line_count'] + 0;
+    }
+
+    private function deleteProduct(string $identifier): int
+    {
+        $sql = "delete from pim_product_catalog where identifier = :id";
+
+        return $this->get('database_connection')
+            ->executeUpdate($sql, ['id' => $identifier]);
+    }
+
+    private function createProduct(string $identifier, array $data): int
+    {
+        $product = $this->get('pim_catalog.builder.product')
+            ->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')
+            ->update($product, $data);
+        $this->get('pim_catalog.saver.product')
+            ->save($product);
+
+        return $product->getId();
+    }
+
+    public function test_with_no_product()
+    {
+        $commandLauncher = new CommandLauncher(static::$kernel);
+        $initial_rows_nb = $this->countCompleteness();
+        $commandLauncher->execute('pim:completeness:clean');
+        Assert::assertTrue($initial_rows_nb == $this->countCompleteness());
+    }
+
+    public function test_with_products()
+    {
+        $id1 = $this->createProduct('AAA1', ['values' => [ "a_yes_no" => [['scope' => null, 'locale' => null, 'data' => true]]]]);
+        $this->get('pim_catalog.completeness.product.compute_and_persist')
+            ->fromProductIdentifier('AAA1');
+        $commandLauncher = new CommandLauncher(static::$kernel);
+        $commandLauncher->execute('pim:completeness:clean');
+        Assert::assertEquals(1, $this->countCompleteness());
+        $this->deleteProduct('AAA1');
+        Assert::assertEquals(1, $this->countCompleteness());
+        $commandLauncher->execute('pim:completeness:clean');
+        Assert::assertEquals(0, $this->countCompleteness());
+    }
+}


### PR DESCRIPTION
**Description**
Since the foreign key between completeness and product has been removed, the delete of products does not cascade to completeness. This PR introduces the job that removes the completeness records of products that do not exist anymore.

See [JIRA ticket](https://akeneo.atlassian.net/browse/PIM-9147)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | yes
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
