### PR TITLE
PIM-9090: Optimize variant navigation dropdown

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Enhancements
+
+- PIM-9090: Improve performance of the variant navigation dropdown in the product model edit form
+
 # 3.0.70 (2020-03-17)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductModelController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductModelController.php
@@ -291,10 +291,14 @@ class ProductModelController
     public function childrenAction(Request $request): JsonResponse
     {
         $parent = $this->findProductModelOr404($request->get('id'));
-        $children = $this->productModelRepository->findChildrenProductModels($parent);
-        if (empty($children)) {
-            $children = $this->productModelRepository->findChildrenProducts($parent);
+        if ($parent->isRoot() && 2 === $parent->getFamilyVariant()->getNumberOfLevel()) {
+            $children = $parent->getProductModels();
+        } else {
+            $children = $parent->getProducts();
         }
+
+        $localeCode = $request->get('locale', $this->userContext->getCurrentLocaleCode());
+        $channelCode = $request->get('scope', $this->userContext->getUserChannelCode());
 
         $normalizedChildren = [];
         foreach ($children as $child) {
@@ -310,7 +314,10 @@ class ProductModelController
             $normalizedChildren[] = $this->entityWithFamilyVariantNormalizer->normalize(
                 $child,
                 'internal_api',
-                ['locale' => $this->userContext->getCurrentLocaleCode()]
+                [
+                    'locale' => $localeCode,
+                    'channel' => $channelCode,
+                ]
             );
         }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Query/SqlGetProductCompletenessRatio.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Query/SqlGetProductCompletenessRatio.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query;
+
+use Akeneo\Pim\Enrichment\Component\Product\Completeness\Query\GetProductCompletenessRatio;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SqlGetProductCompletenessRatio implements GetProductCompletenessRatio
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function forChannelCodeAndLocaleCode(int $productId, string $channelCode, string $localeCode): ?int
+    {
+        $sql = <<<SQL
+SELECT completeness.ratio from pim_catalog_completeness completeness
+INNER JOIN pim_catalog_channel channel on completeness.channel_id = channel.id
+INNER JOIN pim_catalog_locale locale on completeness.locale_id = locale.id
+WHERE completeness.product_id = :productId
+AND channel.code = :channelCode
+AND locale.code = :localeCode
+SQL;
+        $ratio = $this->connection->executeQuery(
+            $sql,
+            [
+                'productId' => $productId,
+                'channelCode' => $channelCode,
+                'localeCode' => $localeCode,
+            ]
+        )->fetchColumn();
+
+        return false === $ratio ? null : (int) $ratio;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -170,7 +170,7 @@ services:
             - '@pim_catalog.validator.product'
             - '@pim_catalog.saver.product_model'
             - '@pim_enrich.normalizer.product_violation'
-            - '@pim_enrich.normalizer.entity_with_family_variant'
+            - '@pim_enrich.normalizer.entity_with_family_variant.light'
             - '@pim_catalog.factory.product_model'
             - '@pim_enrich.normalizer.violation'
             - '@pim_catalog.repository.family_variant'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -59,6 +59,17 @@ services:
             - '@pim_catalog.context.catalog'
             - '@pim_catalog.repository.cached_attribute_option'
 
+    pim_enrich.normalizer.entity_with_family_variant.light:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\LightEntityWithFamilyVariantNormalizer'
+        arguments:
+            - '@pim_enrich.normalizer.image'
+            - '@pim_catalog.product_models.image_as_label'
+            - '@pim_catalog.family_variant.provider.entity_with_family_variant_attributes'
+            - '@pim_catalog.repository.cached_attribute_option'
+            - '@akeneo.pim.enrichment.product.query.product_completeness_ratio'
+            - '@pim_catalog.doctrine.query.find_variant_product_completeness'
+            - !tagged pim_axis_value_label_normalizer
+
     pim_enrich.normalizer.entity_with_family_variant.simple_select.label.normalizer:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer\SimpleSelectOptionNormalizer'
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -156,3 +156,8 @@ services:
         class: 'Akeneo\Channel\Bundle\Doctrine\Query\GetChannelActiveLocaleCodes'
         arguments:
             - '@database_connection'
+
+    akeneo.pim.enrichment.product.query.product_completeness_ratio:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\SqlGetProductCompletenessRatio'
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/Query/GetProductCompletenessRatio.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/Query/GetProductCompletenessRatio.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Completeness\Query;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetProductCompletenessRatio
+{
+    public function forChannelCodeAndLocaleCode(int $productId, string $channelCode, string $localeCode): ?int;
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/LightEntityWithFamilyVariantNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/LightEntityWithFamilyVariantNormalizer.php
@@ -23,8 +23,8 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * - only the current locale
  * - for completeness: only the ratio for the current locale and channel
  *
- * This normalizer exists for performance reasons, as normalizing a completeness collection in internalè_api format is
- * very costly, especially if there are a lot of channels and locales in the catalog
+ * This normalizer exists for performance reasons, as normalizing a completeness collection in
+ * internal_api format is very costly, especially if there are a lot of channels and locales in the catalog
  *
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/LightEntityWithFamilyVariantNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/LightEntityWithFamilyVariantNormalizer.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi;
+
+use Akeneo\Pim\Enrichment\Component\Product\Completeness\Query\GetProductCompletenessRatio;
+use Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\EntityWithFamilyVariantAttributesProvider;
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyVariantInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer\AxisValueLabelsNormalizer;
+use Akeneo\Pim\Enrichment\Component\Product\ProductModel\ImageAsLabel;
+use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\VariantProductRatioInterface;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * "Light" version of the EntityWithFamilyVariantNormalizer, it only returns the needed information
+ * for the "variant navigation" drop down in a product model edit form:
+ * - only the current locale
+ * - for completeness: only the ratio for the current locale and channel
+ *
+ * This normalizer exists for performance reasons, as normalizing a completeness collection in internalè_api format is
+ * very costly, especially if there are a lot of channels and locales in the catalog
+ *
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class LightEntityWithFamilyVariantNormalizer implements NormalizerInterface
+{
+    /** @var ImageNormalizer */
+    private $imageNormalizer;
+
+    /** @var ImageAsLabel */
+    private $imageAsLabel;
+
+    /** @var EntityWithFamilyVariantAttributesProvider */
+    private $attributesProvider;
+
+    /** @var IdentifiableObjectRepositoryInterface */
+    private $attributeOptionRepository;
+
+    /** @var GetProductCompletenessRatio */
+    private $getCompletenessRatio;
+
+    /** @var VariantProductRatioInterface */
+    private $variantProductRatioQuery;
+
+    /** @var iterable */
+    private $axisLabelsNormalizers;
+
+    public function __construct(
+        ImageNormalizer $imageNormalizer,
+        ImageAsLabel $imageAsLabel,
+        EntityWithFamilyVariantAttributesProvider $attributesProvider,
+        IdentifiableObjectRepositoryInterface $attributeOptionRepository,
+        GetProductCompletenessRatio $getCompletenessRatio,
+        VariantProductRatioInterface $variantProductRatioQuery,
+        iterable $axisLabelsNormalizers
+    ) {
+        $this->imageNormalizer = $imageNormalizer;
+        $this->imageAsLabel = $imageAsLabel;
+        $this->attributesProvider = $attributesProvider;
+        $this->attributeOptionRepository = $attributeOptionRepository;
+        $this->getCompletenessRatio = $getCompletenessRatio;
+        $this->variantProductRatioQuery = $variantProductRatioQuery;
+        $this->axisLabelsNormalizers = $axisLabelsNormalizers;
+    }
+
+    public function normalize($entity, $format = null, array $context = []): array
+    {
+        $channelCode = $context['channel'] ?? null;
+        $localeCode = $context['locale'] ?? null;
+
+        if (!is_string($channelCode) || !is_string($localeCode)) {
+            throw new \LogicException('channel and locale have to be defined in the $context argument');
+        }
+
+        if ($entity instanceof ProductModelInterface) {
+            $image = $this->imageAsLabel->value($entity);
+            $completeness = $this->getProductModelCompleteness($entity, $channelCode, $localeCode);
+        } else {
+            $image = $entity->getImage();
+            $completeness = $this->getProductCompleteness($entity, $channelCode, $localeCode);
+        }
+
+        return [
+            'id' => $entity->getId(),
+            'identifier' => $this->getIdentifier($entity),
+            'labels' => [$localeCode => $entity->getLabel($localeCode, $channelCode)],
+            'axes_values_labels' => $this->getAxesLabel($entity, $localeCode),
+            'order' => $this->getOrder($entity),
+            'image' => $this->imageNormalizer->normalize($image),
+            'model_type' => $entity instanceof ProductModelInterface ? 'product_model' : 'product',
+            'completeness' => $completeness,
+        ];
+    }
+
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return 'internal_api' === $format && $data instanceof EntityWithFamilyVariantInterface;
+    }
+
+    /**
+     * Get axes label for the $entity on the given $localeCode for all axes values.
+     */
+    private function getAxesLabel(EntityWithFamilyVariantInterface $entity, string $localeCode): array
+    {
+        $valuesForLocale = [];
+        foreach ($this->attributesProvider->getAxes($entity) as $axisAttribute) {
+            $value = $entity->getValue($axisAttribute->getCode());
+            $normalizedValue = (string)$value;
+
+            $attributeNormalizer = $this->getAttributeLabelsNormalizer($axisAttribute);
+            if ($attributeNormalizer instanceof AxisValueLabelsNormalizer) {
+                $normalizedValue = $attributeNormalizer->normalize($value, $localeCode);
+            }
+
+            $valuesForLocale[] = $normalizedValue;
+        }
+
+        return [$localeCode => implode(', ', $valuesForLocale)];
+    }
+
+    private function getAttributeLabelsNormalizer(AttributeInterface $attribute): ?AxisValueLabelsNormalizer
+    {
+        foreach ($this->axisLabelsNormalizers as $normalizer) {
+            if ($normalizer->supports($attribute->getType())) {
+                return $normalizer;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Generate an array for the given $entity to represent its order among all its axes values.
+     *
+     * For example, if its axes values are "Blue, 10 CENTIMETER" and Blue is an option with a sort order equals to 4,
+     * it will return [4, "blue", "CENTIMETER", 10].
+     *
+     * It allows to sort on front-end to respect sort orders of attribute options.
+     *
+     * @param EntityWithFamilyVariantInterface $entity
+     *
+     * @return array
+     */
+    private function getOrder(EntityWithFamilyVariantInterface $entity): array
+    {
+        $orderArray = [];
+
+        foreach ($this->attributesProvider->getAxes($entity) as $axisAttribute) {
+            $value = $entity->getValue($axisAttribute->getCode());
+
+            if (AttributeTypes::OPTION_SIMPLE_SELECT === $axisAttribute->getType()) {
+                $optionCode = $value->getData();
+                $option = $this->attributeOptionRepository->findOneByIdentifier(
+                    $value->getAttributeCode() . '.' . $optionCode
+                );
+                $orderArray[] = $option->getSortOrder();
+                $orderArray[] = $option->getCode();
+            } elseif (AttributeTypes::METRIC === $axisAttribute->getType()) {
+                $data = $value->getData();
+                $orderArray[] = $data->getUnit();
+                $orderArray[] = floatval($data->getData());
+            } elseif (AttributeTypes::BOOLEAN === $axisAttribute->getType()) {
+                $orderArray[] = (true === $value->getData() ? '1' : '0');
+            } else {
+                $orderArray[] = (string)$value;
+            }
+        }
+
+        return $orderArray;
+    }
+
+    private function getIdentifier(EntityWithFamilyVariantInterface $entity): string
+    {
+        return $entity instanceof ProductModelInterface ? $entity->getCode() : $entity->getIdentifier();
+    }
+
+    private function getProductModelCompleteness(ProductModelInterface $entity, string $channelCode, string $localeCode): array
+    {
+        $completeness = $this->variantProductRatioQuery->findComplete($entity)->value($channelCode, $localeCode);
+
+        return [
+            'completenesses' => [
+                $channelCode => [
+                    $localeCode => $completeness['complete'],
+                ],
+            ],
+            'total' => $completeness['total'],
+        ];
+    }
+
+    private function getProductCompleteness(ProductInterface $entity, string $channelCode, string $localeCode): array
+    {
+        return [
+            [
+                'channel' => $channelCode,
+                'locales' => [
+                    $localeCode => [
+                        'completeness' => [
+                            'ratio' => $this->getCompletenessRatio->forChannelCodeAndLocaleCode(
+                                $entity->getId(),
+                                $channelCode,
+                                $localeCode
+                            ),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/fetcher/product-model-fetcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/fetcher/product-model-fetcher.js
@@ -12,6 +12,7 @@ define(
         'jquery',
         'underscore',
         'pim/product-fetcher',
+        'pim/user-context',
         'oro/mediator',
         'routing'
     ],
@@ -19,6 +20,7 @@ define(
         $,
         _,
         ProductFetcher,
+        UserContext,
         mediator,
         Routing
     ) {
@@ -50,7 +52,11 @@ define(
                 }
 
                 return $.getJSON(
-                    Routing.generate(this.options.urls.children), {id: parentId}
+                    Routing.generate(this.options.urls.children), {
+                        id: parentId,
+                        scope: UserContext.get('catalogScope'),
+                        locale: UserContext.get('catalogLocale')
+                    }
                 ).then(_.identity).promise();
             }
         });

--- a/tests/back/Pim/Enrichment/Integration/Completeness/SqlGetProductCompletenessRatioIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/SqlGetProductCompletenessRatioIntegration.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Completeness;
+
+use Akeneo\Pim\Enrichment\Component\Product\Completeness\Query\GetProductCompletenessRatio;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SqlGetProductCompletenessRatioIntegration extends TestCase
+{
+    /** @var GetProductCompletenessRatio */
+    private $getProductCompletenessRatio;
+
+    /**
+     * @test
+     */
+    public function it_returns_the_completeness_ratio_of_a_product_for_a_given_channel_and_locale()
+    {
+        $product = $this->createProduct();
+        $completenesses = $product->getCompletenesses();
+        Assert::assertNotEmpty($completenesses);
+
+        foreach ($completenesses as $completeness) {
+            $ratio = $this->getProductCompletenessRatio->forChannelCodeAndLocaleCode(
+                $product->getId(),
+                $completeness->getChannel()->getCode(),
+                $completeness->getLocale()->getCode()
+            );
+            Assert::assertNotNull($ratio);
+            Assert::assertSame($completeness->getRatio(), $ratio);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_if_the_completeness_is_not_calculated_yet()
+    {
+        $product = $this->createProduct();
+        $this->get('database_connection')->executeUpdate(
+            'DELETE FROM pim_catalog_completeness WHERE product_id = :productId',
+            [
+                'productId' => $product->getId(),
+            ]
+        );
+
+        Assert::assertNull(
+            $this->getProductCompletenessRatio->forChannelCodeAndLocaleCode($product->getId(), 'ecommerce', 'en_US')
+        );
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->getProductCompletenessRatio = $this->get(
+            'akeneo.pim.enrichment.product.query.product_completeness_ratio'
+        );
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function createProduct(): ProductInterface
+    {
+        $product = new Product();
+        $this->get('pim_catalog.updater.product')->update(
+            $product,
+            [
+                'family' => 'familyA',
+                'values' => [
+                    'sku' => [
+                        [
+                            'scope' => null,
+                            'locale' => null,
+                            'data' => 'test_completeness',
+                        ],
+                    ],
+                    'a_date' => [
+                        [
+                            'scope' => null,
+                            'locale' => null,
+                            'data' => '2020-03-18T00:00:00+00:00',
+                        ],
+                    ],
+                    'a_text' => [
+                        [
+                            'scope' => null,
+                            'locale' => null,
+                            'data' => 'lorem ipsum',
+                        ],
+                    ],
+                    'a_yes_no' => [
+                        [
+                            'scope' => null,
+                            'locale' => null,
+                            'data' => false,
+                        ],
+                    ],
+                    'a_scopable_price' => [
+                        [
+                            'scope' => 'ecommerce',
+                            'locale' => null,
+                            'data' => [
+                                ['amount' => '10.00', 'currency' => 'EUR'],
+                                ['amount' => '12.00', 'currency' => 'USD'],
+                            ],
+                        ],
+                    ],
+                    'a_localized_and_scopable_text_area' => [
+                        [
+                            'scope' => 'ecommerce',
+                            'locale' => 'en_US',
+                            'data' => 'Lorem ipsum dolor sit amet',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        return $product;
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/LightEntityWithFamilyVariantNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/LightEntityWithFamilyVariantNormalizerSpec.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi;
+
+use Akeneo\Pim\Enrichment\Component\Product\Completeness\Query\GetProductCompletenessRatio;
+use Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\EntityWithFamilyVariantAttributesProvider;
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyVariantInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer\AxisValueLabelsNormalizer;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\ImageNormalizer;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\LightEntityWithFamilyVariantNormalizer;
+use Akeneo\Pim\Enrichment\Component\Product\ProductModel\ImageAsLabel;
+use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\CompleteVariantProducts;
+use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\VariantProductRatioInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Value\MediaValue;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\Attribute;
+use Akeneo\Pim\Structure\Component\Model\AttributeOption;
+use Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class LightEntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
+{
+    function let(
+        ImageNormalizer $imageNormalizer,
+        ImageAsLabel $imageAsLabel,
+        EntityWithFamilyVariantAttributesProvider $attributesProvider,
+        IdentifiableObjectRepositoryInterface $attributeOptionRepository,
+        GetProductCompletenessRatio $getCompletenessRatio,
+        VariantProductRatioInterface $variantProductRatioQuery,
+        AxisValueLabelsNormalizer $axisValueLabelsNormalizer
+    ) {
+        $color = (new Attribute())->setCode('color')->setType(AttributeTypes::OPTION_SIMPLE_SELECT);
+        $attributesProvider->getAxes(Argument::type(EntityWithFamilyVariantInterface::class))
+                           ->willReturn([$color]);
+
+        $green = (new AttributeOption())->setCode('green')->setSortOrder(5)->setAttribute($color);
+        $attributeOptionRepository->findOneByIdentifier('color.green')->willReturn($green);
+
+        $axisValueLabelsNormalizer->supports(AttributeTypes::OPTION_SIMPLE_SELECT)->willReturn(true);
+        $axisValueLabelsNormalizer->normalize(Argument::type(ValueInterface::class), 'en_US')->willReturn('Green');
+
+        $this->beConstructedWith(
+            $imageNormalizer,
+            $imageAsLabel,
+            $attributesProvider,
+            $attributeOptionRepository,
+            $getCompletenessRatio,
+            $variantProductRatioQuery,
+            [$axisValueLabelsNormalizer]
+        );
+    }
+
+    function it_is_a_normalizer()
+    {
+        $this->shouldImplement(NormalizerInterface::class);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(LightEntityWithFamilyVariantNormalizer::class);
+    }
+
+    function it_only_suports_entities_with_family_variant_and_internal_api_format()
+    {
+        $this->supportsNormalization(new Product(), 'internal_api')->shouldReturn(true);
+        $this->supportsNormalization(new ProductModel(), 'internal_api')->shouldReturn(true);
+
+        $this->supportsNormalization(new Product(), 'standard')->shouldReturn(false);
+        $this->supportsNormalization(new AttributeOption(), 'internal_api')->shouldReturn(false);
+    }
+
+    function it_throws_an_exception_if_channel_is_not_provided_in_the_context()
+    {
+        $this->shouldThrow(new \LogicException('channel and locale have to be defined in the $context argument'))
+             ->during('normalize', [new ProductModel(), 'internal_api', ['locale' => 'en_US']]);
+    }
+
+    function it_throws_an_exception_if_locale_is_not_provided_in_the_context()
+    {
+        $this->shouldThrow(new \LogicException('channel and locale have to be defined in the $context argument'))
+             ->during('normalize', [new ProductModel(), 'internal_api', ['channel' => 'ecommerce']]);
+    }
+
+    function it_normalizes_a_variant_product(
+        ImageNormalizer $imageNormalizer,
+        GetProductCompletenessRatio $getCompletenessRatio,
+        ProductInterface $variantProduct,
+        FileInfoInterface $fileInfo
+    ) {
+        $variantProduct->getId()->willReturn(42);
+        $variantProduct->getIdentifier()->willReturn('tshirt_green');
+        $variantProduct->getLabel('en_US', 'ecommerce')->willReturn('Green t-shirt');
+
+        $imageValue = MediaValue::value('image', $fileInfo->getWrappedObject());
+        $imageNormalizer->normalize($imageValue)->willReturn(
+            [
+                'filePath' => '1/2/3/my_variant_product.png',
+                'originalFilename' => 'my_variant_product.png',
+            ]
+        );
+        $variantProduct->getImage()->willReturn($imageValue);
+        $variantProduct->getValue('color')->willReturn(OptionValue::value('color', 'green'));
+
+        $getCompletenessRatio->forChannelCodeAndLocaleCode(42, 'ecommerce', 'en_US')->willReturn(44);
+
+        $this->normalize($variantProduct, 'internal_api', ['channel' => 'ecommerce', 'locale' => 'en_US'])->shouldReturn(
+             [
+                 'id' => 42,
+                 'identifier' => 'tshirt_green',
+                 'labels' => ['en_US' => 'Green t-shirt'],
+                 'axes_values_labels' => ['en_US' => 'Green'],
+                 'order' => [5, 'green'],
+                 'image' => [
+                     'filePath' => '1/2/3/my_variant_product.png',
+                     'originalFilename' => 'my_variant_product.png',
+                 ],
+                 'model_type' => 'product',
+                 'completeness' => [
+                     [
+                         'channel' => 'ecommerce',
+                         'locales' => [
+                             'en_US' => [
+                                 'completeness' => [
+                                     'ratio' => 44,
+                                 ],
+                             ],
+                         ],
+                     ],
+                 ],
+             ]
+         );
+    }
+
+    function it_normalizes_a_sub_product_model(
+        ImageNormalizer $imageNormalizer,
+        ImageAsLabel $imageAsLabel,
+        VariantProductRatioInterface $variantProductRatioQuery,
+        ProductModelInterface $productModel,
+        FileInfoInterface $fileInfo
+    ) {
+        $productModel->getId()->willReturn(56);
+        $productModel->getCode()->willReturn('my_tshirt_model');
+        $productModel->getLabel('en_US', 'ecommerce')->willReturn('Green t-shirt model');
+        $productModel->getValue('color')->willReturn(OptionValue::value('color', 'green'));
+
+        $imageValue = MediaValue::value('model_picture', $fileInfo->getWrappedObject());
+        $imageNormalizer->normalize($imageValue)->willReturn([
+            'filePath' => 'a/b/c/my_model.jpg',
+            'originalFilename' => 'my_model.jpg',
+        ]);
+        $imageAsLabel->value($productModel)->willReturn($imageValue);
+
+        $variantProductRatioQuery->findComplete($productModel)->willReturn(new CompleteVariantProducts(
+            [
+                [
+                    'product_identifier' => 'tshirt_green_s',
+                    'channel_code' => 'ecommerce',
+                    'locale_code' => 'en_US',
+                    'complete' => 0,
+                ],
+                [
+                    'product_identifier' => 'tshirt_green_m',
+                    'channel_code' => 'ecommerce',
+                    'locale_code' => 'en_US',
+                    'complete' => 1,
+                ],
+                [
+                    'product_identifier' => 'tshirt_green_l',
+                    'channel_code' => 'ecommerce',
+                    'locale_code' => 'en_US',
+                    'complete' => 1,
+                ],
+            ]
+        ));
+
+        $this->normalize($productModel, 'internal_api', ['channel' => 'ecommerce', 'locale' => 'en_US'])->shouldReturn(
+            [
+                'id' => 56,
+                'identifier' => 'my_tshirt_model',
+                'labels' => ['en_US' => 'Green t-shirt model'],
+                'axes_values_labels' => ['en_US' => 'Green'],
+                'order' => [5, 'green'],
+                'image' => [
+                    'filePath' => 'a/b/c/my_model.jpg',
+                    'originalFilename' => 'my_model.jpg',
+                ],
+                'model_type' => 'product_model',
+                'completeness' => [
+                    'completenesses' => [
+                        'ecommerce' => [
+                            'en_US' => 2,
+                        ],
+                    ],
+                    'total' => 3,
+                ],
+
+            ]
+        );
+
+    }
+}

--- a/tests/legacy/features/Behat/Decorator/TabElement/ComparisonPanelDecorator.php
+++ b/tests/legacy/features/Behat/Decorator/TabElement/ComparisonPanelDecorator.php
@@ -85,7 +85,11 @@ class ComparisonPanelDecorator extends ElementDecorator
             return $toggle;
         }, 'Dropdown action menu was not found');
 
-        $toggle->click();
+        $this->spin(function () use ($toggle) {
+            $toggle->click();
+
+            return true;
+        }, 'Could not click on dropdown menu');
 
         $option = $this->spin(function () use ($dropdown, $source) {
             $option = $dropdown->find('css', sprintf('.AknDropdown-menuLink[data-source="%s"]', $source));


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When a product model has a large number (several hundreds) of children, the variant navigation dropdown in the product model edit form can be really slow. This is especially true when children are variant products.
For other dropdown components we usually add an infinite scroll in this case, but it proves extremely complicated in this case: 
- the sorting system is quite complex and is performed frontend-side, on already normalized data
- the search is also performed on the frontend (the search is on normalized labels for the axes values). 
 => Implementing this search / sorting with an SQL query would be extremely hard, and probably unreadable

I noticed that most of the request time was due to the completeness normalization, whereas the dropdown component only needs the ratio for the current locale and channel. I decided to improve the time by optimizing the normalization of the returned products/product models, only returning the relevant data:
- labels only in the selected locale
- completeness only for the selected channel/locale
- reduce usage of n+1 queries

a quick benchmark (icecat_demo_dev, 455 variant products for a product model) gives the following results:
- before: ~ 3.7s
- with this fix: ~650 ms

I believe the gain would be even higher with a catalog with a lot of channels and locales

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
