### PR TITLE
MET-121: Add endpoint for validating a new unit

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/ValidateUnit/ValidateUnitCommand.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/ValidateUnit/ValidateUnitCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Application\ValidateUnit;
+
+/**
+ * @copyright 2020 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ValidateUnitCommand
+{
+    /** @var string */
+    public $measurementFamilyCode;
+
+    /** @var string */
+    public $code;
+
+    /** @var array */
+    public $labels;
+
+    /** @var array */
+    public $convert_from_standard;
+
+    /** @var string */
+    public $symbol;
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/ValidateUnitAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/ValidateUnitAction.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Application\ValidateUnit\ValidateUnitCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
+use Akeneo\Tool\Component\Api\Exception\ViolationHttpException;
+use Akeneo\Tool\Component\Api\Normalizer\Exception\ViolationNormalizer;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ValidateUnitAction
+{
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /** @var ViolationNormalizer */
+    private $violationNormalizer;
+
+    public function __construct(
+        ValidatorInterface $validator,
+        ViolationNormalizer $violationNormalizer
+    )
+    {
+        $this->validator = $validator;
+        $this->violationNormalizer = $violationNormalizer;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
+        $measurementFamilyCode = $request->get('measurement_family_code');
+
+        $decodedRequest = $this->decodeRequest($request);
+        $validateUnitCommand = $this->createValidateUnitCommand($measurementFamilyCode, $decodedRequest);
+
+        try {
+            $this->validateValidateUnitCommand($validateUnitCommand);
+        } catch (MeasurementFamilyNotFoundException $ex) {
+            return new Response(null, Response::HTTP_NOT_FOUND);
+        } catch (ViolationHttpException $exception) {
+            return new JsonResponse(
+                $this->violationNormalizer->normalize($exception),
+                Response::HTTP_UNPROCESSABLE_ENTITY
+            );
+        }
+
+        return new Response(null, Response::HTTP_OK);
+    }
+
+    private function decodeRequest(Request $request): array
+    {
+        $decodedRequest = json_decode($request->getContent(), true);
+
+        if (null === $decodedRequest) {
+            throw new BadRequestHttpException('Invalid json message received');
+        }
+
+        return $decodedRequest;
+    }
+
+    private function createValidateUnitCommand(string $measurementFamilyCode, array $decodedRequest): ValidateUnitCommand
+    {
+        $command = new ValidateUnitCommand();
+        $command->measurementFamilyCode = $measurementFamilyCode;
+        $command->code = $decodedRequest['code'];
+        $command->labels = $decodedRequest['labels'];
+        $command->convert_from_standard = $decodedRequest['convert_from_standard'];
+        $command->symbol = $decodedRequest['symbol'];
+
+        return $command;
+    }
+
+    /**
+     * @throws MeasurementFamilyNotFoundException
+     */
+    private function validateValidateUnitCommand(ValidateUnitCommand $command)
+    {
+        $violations = $this->validator->validate($command);
+
+        if (count($violations) > 0) {
+            throw new ViolationHttpException(
+                $violations,
+                'The unit cannot be added to the measurement family.'
+            );
+        }
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/ValidateUnitAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/InternalApi/ValidateUnitAction.php
@@ -30,8 +30,7 @@ class ValidateUnitAction
     public function __construct(
         ValidatorInterface $validator,
         ViolationNormalizer $violationNormalizer
-    )
-    {
+    ) {
         $this->validator = $validator;
         $this->violationNormalizer = $violationNormalizer;
     }
@@ -72,8 +71,10 @@ class ValidateUnitAction
         return $decodedRequest;
     }
 
-    private function createValidateUnitCommand(string $measurementFamilyCode, array $decodedRequest): ValidateUnitCommand
-    {
+    private function createValidateUnitCommand(
+        string $measurementFamilyCode,
+        array $decodedRequest
+    ): ValidateUnitCommand {
         $command = new ValidateUnitCommand();
         $command->measurementFamilyCode = $measurementFamilyCode;
         $command->code = $decodedRequest['code'];

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/internal_api.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/internal_api.yml
@@ -22,3 +22,10 @@ services:
             - '@validator'
             - '@akeneo_measure.application.save_measurement_family_handler'
             - '@pim_api.normalizer.exception.violation'
+
+    pim_api.controller.internal_api.validate_unit:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Controller\InternalApi\ValidateUnitAction
+        public: true
+        arguments:
+            - '@validator'
+            - '@pim_api.normalizer.exception.violation'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/routing.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/routing.yml
@@ -16,3 +16,8 @@ akeneo_measurements_measurement_family_create_save:
     path: '/rest/measurement-families/{measurement_family_code}'
     defaults: { _controller: pim_api.controller.internal_api.save_measurement_family }
     methods: [POST]
+
+akeneo_measurements_validate_unit_rest:
+    path: '/rest/measurement-families/{measurement_family_code}/validate-unit'
+    defaults: { _controller: pim_api.controller.internal_api.validate_unit }
+    methods: [POST]

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
@@ -89,6 +89,13 @@ services:
         tags:
             - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.measurement_family.count' }
 
+    akeneo_measurement.validation.unit.code_must_be_unique:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\Unit\CodeMustBeUniqueValidator
+        arguments:
+            - '@akeneo_measure.persistence.measurement_family_repository'
+        tags:
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.unit.code_must_be_unique' }
+
     akeneo_measurement.validation.measurement_family.standard_unit_code_cannot_be_changed:
         class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeCannotBeChangedValidator
         arguments:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
@@ -88,3 +88,32 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasu
 Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily\DeleteMeasurementFamilyCommand:
     constraints:
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\DeleteMeasurementFamily\ShouldNotBeUsedByProductAttribute: ~
+
+Akeneo\Tool\Bundle\MeasureBundle\Application\ValidateUnit\ValidateUnitCommand:
+    group_sequence:
+        - ValidateUnitCommand
+        - other_constraints
+    constraints:
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\Unit\CodeMustBeUnique: { groups: [other_constraints] }
+    properties:
+        code:
+            - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\Code: ~
+        labels:
+            - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\LabelCollection: ~
+        symbol:
+            - Type: string
+            - Length:
+                  max: 255
+        convert_from_standard:
+            - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationCount: ~
+            - All:
+                - Collection:
+                    fields:
+                        operator:
+                            - NotBlank: ~
+                            - Type: string
+                            - Choice:
+                                choices: [mul, div, add, sub]
+                                message: pim_measurements.validation.measurement_family.units.operation.invalid_operator
+                        value:
+                            - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationValue: ~

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -26,3 +26,6 @@ pim_measurements:
                     invalid_operator: 'The {{ value }} operator is invalid, please use {{ choices }} instead.'
                 should_contain_at_least_one_unit: 'There should be at least %limit% unit in the measurement family.'
                 should_not_contain_duplicates: 'We found some duplicated units in the measurement family. The measurement family requires unique units.'
+        unit:
+            code:
+                must_be_unique: 'This unit code already exists.'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Unit/CodeMustBeUnique.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Unit/CodeMustBeUnique.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\Unit;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CodeMustBeUnique extends Constraint
+{
+    public $message = 'pim_measurements.validation.unit.code.must_be_unique';
+
+    public function validatedBy()
+    {
+        return 'akeneo_measurement.validation.unit.code_must_be_unique';
+    }
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Unit/CodeMustBeUniqueValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Unit/CodeMustBeUniqueValidator.php
@@ -3,7 +3,6 @@
 namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\Unit;
 
 use Akeneo\Tool\Bundle\MeasureBundle\Application\ValidateUnit\ValidateUnitCommand;
-use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
 use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
@@ -30,7 +29,7 @@ class CodeMustBeUniqueValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, CodeMustBeUnique::class);
         }
 
-        if(!$value instanceof ValidateUnitCommand){
+        if (!$value instanceof ValidateUnitCommand) {
             throw new UnexpectedTypeException($value, ValidateUnitCommand::class);
         }
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Unit/CodeMustBeUniqueValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Unit/CodeMustBeUniqueValidator.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\Unit;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Application\ValidateUnit\ValidateUnitCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CodeMustBeUniqueValidator extends ConstraintValidator
+{
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+
+    public function __construct(MeasurementFamilyRepositoryInterface $measurementFamilyRepository)
+    {
+        $this->measurementFamilyRepository = $measurementFamilyRepository;
+    }
+
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof CodeMustBeUnique) {
+            throw new UnexpectedTypeException($constraint, CodeMustBeUnique::class);
+        }
+
+        if(!$value instanceof ValidateUnitCommand){
+            throw new UnexpectedTypeException($value, ValidateUnitCommand::class);
+        }
+
+        if ($this->measurementFamilyAlreadyHasUnitWithCode($value->measurementFamilyCode, $value->code)) {
+            $this->context->buildViolation($constraint->message)
+                ->atPath('code')
+                ->setInvalidValue($value->code)
+                ->addViolation();
+        }
+    }
+
+    private function measurementFamilyAlreadyHasUnitWithCode(string $measurementFamilyCode, string $code)
+    {
+        $measurementFamily = $this->measurementFamilyRepository->getByCode(MeasurementFamilyCode::fromString($measurementFamilyCode));
+
+        foreach ($measurementFamily->normalize()['units'] as $unit) {
+            if ($unit['code'] === $code) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/ValidateUnitActionEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/ValidateUnitActionEndToEnd.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\tests\EndToEnd\InternalApi;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Akeneo\Tool\Bundle\MeasureBundle\tests\EndToEnd\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class ValidateUnitActionEndToEnd extends WebTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->authenticateAsAdmin();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_ok_if_the_new_unit_is_valid()
+    {
+        $measurementFamilyCode = MeasurementFamilyCode::fromString('Power');
+        $unit = Unit::create(
+            UnitCode::fromString('CUSTOM_UNIT'),
+            LabelCollection::fromArray(['en_US' => 'Custom unit', 'fr_FR' => 'Unité personalisée']),
+            [Operation::create('mul', '0.1')],
+            'cu'
+        );
+
+        $response = $this->requestValidationEndpoint($measurementFamilyCode, $unit);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_validation_errors_if_the_new_unit_is_not_valid()
+    {
+        $measurementFamilyCode = MeasurementFamilyCode::fromString('Power');
+        $unit = Unit::create(
+            UnitCode::fromString('WATT'), // "WATT" already exists in Power
+            LabelCollection::fromArray(['en_US' => 'Custom unit', 'fr_FR' => 'Unité personalisée']),
+            [Operation::create('mul', '0.1')],
+            'cu'
+        );
+
+        $response = $this->requestValidationEndpoint($measurementFamilyCode, $unit);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame([
+            'code' => 422,
+            'message' => 'The unit cannot be added to the measurement family.',
+            'errors' => [
+                [
+                    'property' => 'code',
+                    'message' => 'This unit code already exists.',
+                ],
+            ],
+        ], json_decode($response->getContent(), true));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_if_the_measurement_family_does_not_exist()
+    {
+        $measurementFamilyCode = MeasurementFamilyCode::fromString('NotFound');
+        $unit = Unit::create(
+            UnitCode::fromString('CUSTOM_UNIT'),
+            LabelCollection::fromArray(['en_US' => 'Custom unit', 'fr_FR' => 'Unité personalisée']),
+            [Operation::create('mul', '0.1')],
+            'cu'
+        );
+
+        $response = $this->requestValidationEndpoint($measurementFamilyCode, $unit);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    private function requestValidationEndpoint(MeasurementFamilyCode $measurementFamilyCode, Unit $unit)
+    {
+        $this->client->request(
+            'POST',
+            sprintf('rest/measurement-families/%s/validate-unit', $measurementFamilyCode->normalize()),
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ],
+            json_encode($unit->normalize())
+        );
+
+        return $this->client->getResponse();
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

New internal endpoint:
```
POST /rest/measurement-families/{code}/validate-unit
```

3 responses possibles:
```
200 - Valid
404 - Measurement family cannot be found
422 - Not valid
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -