### PR TITLE
MET-124: Split models

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/direction.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/direction.ts
@@ -1,0 +1,6 @@
+enum Direction {
+  Ascending = 'Ascending',
+  Descending = 'Descending',
+}
+
+export {Direction};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/label-collection.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/label-collection.ts
@@ -1,0 +1,5 @@
+type LabelCollection = {
+  [locale: string]: string;
+};
+
+export {LabelCollection};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/measurement-family.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/measurement-family.ts
@@ -1,37 +1,9 @@
 import {getLabel} from 'pimui/js/i18n';
 import {LocaleCode} from 'akeneomeasure/model/locale';
-
-enum Direction {
-  Ascending = 'Ascending',
-  Descending = 'Descending',
-}
-
-const MAX_OPERATION_COUNT = 5;
-
-enum Operator {
-  MUL = 'mul',
-  DIV = 'div',
-  ADD = 'add',
-  SUB = 'sub',
-}
-
-type LabelCollection = {
-  [locale: string]: string;
-};
-
-type Operation = {
-  operator: string;
-  value: string;
-};
-
-type UnitCode = string;
-
-type Unit = {
-  code: UnitCode;
-  labels: LabelCollection;
-  symbol: string;
-  convert_from_standard: Operation[];
-};
+import {LabelCollection} from 'akeneomeasure/model/label-collection';
+import {Unit, UnitCode, getUnitLabel} from 'akeneomeasure/model/unit';
+import {Operation} from 'akeneomeasure/model/operation';
+import {Direction} from 'akeneomeasure/model/direction';
 
 type MeasurementFamilyCode = string;
 
@@ -44,8 +16,6 @@ type MeasurementFamily = {
 
 const getMeasurementFamilyLabel = (measurementFamily: MeasurementFamily, locale: LocaleCode) =>
   getLabel(measurementFamily.labels, locale, measurementFamily.code);
-
-const getUnitLabel = (unit: Unit, locale: LocaleCode) => getLabel(unit.labels, locale, unit.code);
 
 const setMeasurementFamilyLabel = (
   measurementFamily: MeasurementFamily,
@@ -87,11 +57,6 @@ const setUnitOperations = (measurementFamily: MeasurementFamily, unitCode: UnitC
 
   return {...measurementFamily, units: units};
 };
-
-const emptyOperation = (): Operation => ({
-  value: '1',
-  operator: Operator.MUL,
-});
 
 const removeUnit = (measurementFamily: MeasurementFamily, unitCode: UnitCode): MeasurementFamily => ({
   ...measurementFamily,
@@ -161,23 +126,15 @@ const sortMeasurementFamily = (sortDirection: Direction, locale: LocaleCode, sor
 };
 
 export {
-  Direction,
   MeasurementFamily,
   MeasurementFamilyCode,
-  Operation,
-  Operator,
-  Unit,
-  UnitCode,
   getMeasurementFamilyLabel,
   setMeasurementFamilyLabel,
   getUnit,
-  getUnitLabel,
   setUnitLabel,
   setUnitSymbol,
   setUnitOperations,
-  emptyOperation,
   removeUnit,
-  MAX_OPERATION_COUNT,
   getStandardUnit,
   getStandardUnitLabel,
   filterOnLabelOrCode,

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/operation.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/operation.ts
@@ -1,0 +1,20 @@
+const MAX_OPERATION_COUNT = 5;
+
+enum Operator {
+  MUL = 'mul',
+  DIV = 'div',
+  ADD = 'add',
+  SUB = 'sub',
+}
+
+type Operation = {
+  operator: string;
+  value: string;
+};
+
+const emptyOperation = (): Operation => ({
+  value: '1',
+  operator: Operator.MUL,
+});
+
+export {MAX_OPERATION_COUNT, Operation, Operator, emptyOperation};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/unit.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/model/unit.ts
@@ -1,0 +1,17 @@
+import {LocaleCode} from 'akeneomeasure/model/locale';
+import {LabelCollection} from 'akeneomeasure/model/label-collection';
+import {Operation} from 'akeneomeasure/model/operation';
+import {getLabel} from 'pimui/js/i18n';
+
+type UnitCode = string;
+
+type Unit = {
+  code: UnitCode;
+  labels: LabelCollection;
+  symbol: string;
+  convert_from_standard: Operation[];
+};
+
+const getUnitLabel = (unit: Unit, locale: LocaleCode) => getLabel(unit.labels, locale, unit.code);
+
+export {Unit, UnitCode, getUnitLabel};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/common/OperationCollection.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/common/OperationCollection.tsx
@@ -2,13 +2,13 @@ import React, {useState, useContext, useCallback} from 'react';
 import styled, {css} from 'styled-components';
 import {TranslateContext} from 'akeneomeasure/context/translate-context';
 import {Button, TransparentButton} from 'akeneomeasure/shared/components/Button';
-import {Operation, Operator, emptyOperation, MAX_OPERATION_COUNT} from 'akeneomeasure/model/measurement-family';
 import {DownIcon} from 'akeneomeasure/shared/icons/DownIcon';
 import {akeneoTheme} from 'akeneomeasure/shared/theme';
 import {CloseIcon} from 'akeneomeasure/shared/icons/CloseIcon';
 import {SubArrowRightIcon} from 'akeneomeasure/shared/icons/SubArrowRightIcon';
 import {useShortcut} from 'akeneomeasure/shared/hooks/use-shortcut';
 import {Key} from 'akeneomeasure/shared/key';
+import {Operation, Operator, emptyOperation, MAX_OPERATION_COUNT} from 'akeneomeasure/model/operation';
 
 const Container = styled.div<{level: number}>`
   display: flex;
@@ -188,13 +188,16 @@ const OperationCollection = ({operations, onOperationsChange}: OperationCollecti
           )}
         </Container>
       ))}
-      {MAX_OPERATION_COUNT > operations.length && (
-        <Footer>
-          <Button color="grey" outline onClick={() => onOperationsChange([...operations, emptyOperation()])}>
-            {__('measurements.unit.operation.add')}
-          </Button>
-        </Footer>
-      )}
+      <Footer>
+        <Button
+          color="grey"
+          outline={true}
+          disabled={MAX_OPERATION_COUNT <= operations.length}
+          onClick={() => onOperationsChange([...operations, emptyOperation()])}
+        >
+          {__('measurements.unit.operation.add')}
+        </Button>
+      </Footer>
     </>
   );
 };

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/form/create-measurement-family-form.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/form/create-measurement-family-form.ts
@@ -1,4 +1,5 @@
-import {MeasurementFamily, Operator} from 'akeneomeasure/model/measurement-family';
+import {MeasurementFamily} from 'akeneomeasure/model/measurement-family';
+import {Operator} from 'akeneomeasure/model/operation';
 
 type LocaleCode = string;
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/edit/PropertyTab.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/edit/PropertyTab.tsx
@@ -6,7 +6,6 @@ import {SubsectionHeader} from 'akeneomeasure/shared/components/Subsection';
 import {TextField} from 'akeneomeasure/shared/components/TextField';
 import {useUiLocales} from 'akeneomeasure/shared/hooks/use-ui-locales';
 import {FormGroup} from 'akeneomeasure/shared/components/FormGroup';
-import {useFocus} from 'akeneomeasure/shared/hooks/use-focus';
 
 const Container = styled.div`
   display: flex;
@@ -24,7 +23,6 @@ const PropertyTab = ({
 }) => {
   const __ = useContext(TranslateContext);
   const locales = useUiLocales();
-  const [ref] = useFocus();
 
   return (
     <Container>
@@ -43,7 +41,7 @@ const PropertyTab = ({
         {null !== locales &&
           locales.map((locale, index) => (
             <TextField
-              ref={0 === index ? ref : undefined}
+              autofocus={0 === index}
               id={`measurements.family.properties.label.${locale.code}`}
               label={locale.label}
               key={locale.code}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/edit/UnitTab.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/edit/UnitTab.tsx
@@ -2,14 +2,10 @@ import React, {useState, useContext, FormEvent} from 'react';
 import styled from 'styled-components';
 import {
   MeasurementFamily,
-  Unit,
-  getUnitLabel,
   getUnit,
   filterOnLabelOrCode,
   setUnitSymbol,
-  UnitCode,
   setUnitLabel,
-  Operation,
   setUnitOperations,
   removeUnit,
 } from 'akeneomeasure/model/measurement-family';
@@ -25,6 +21,8 @@ import {useUiLocales} from 'akeneomeasure/shared/hooks/use-ui-locales';
 import {OperationCollection} from 'akeneomeasure/pages/common/OperationCollection';
 import {Button} from 'akeneomeasure/shared/components/Button';
 import {Table, HeaderCell, Row, LabelCell} from 'akeneomeasure/pages/common/Table';
+import {Unit, UnitCode, getUnitLabel} from 'akeneomeasure/model/unit';
+import {Operation} from 'akeneomeasure/model/operation';
 
 const UnitList = styled.div`
   flex: 1;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/list/List.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/list/List.tsx
@@ -10,7 +10,7 @@ import {Link} from 'akeneomeasure/shared/components/Link';
 import {NoDataSection, NoDataTitle, NoDataText} from 'akeneomeasure/shared/components/NoData';
 import {useMeasurementFamilies} from 'akeneomeasure/hooks/use-measurement-families';
 import {SearchBar} from 'akeneomeasure/shared/components/SearchBar';
-import {sortMeasurementFamily, Direction, filterOnLabelOrCode} from 'akeneomeasure/model/measurement-family';
+import {sortMeasurementFamily, filterOnLabelOrCode} from 'akeneomeasure/model/measurement-family';
 import {UserContext} from 'akeneomeasure/context/user-context';
 import {MeasurementFamilyTable} from 'akeneomeasure/pages/list/MeasurementFamilyTable';
 import {Button} from 'akeneomeasure/shared/components/Button';
@@ -18,6 +18,7 @@ import {CreateMeasurementFamily} from 'akeneomeasure/pages/create-measurement-fa
 import {useToggleState} from 'akeneomeasure/hooks/use-toggle-state';
 import {PageContent} from 'akeneomeasure/shared/components/PageContent';
 import {TablePlaceholder} from 'akeneomeasure/pages/common/Table';
+import {Direction} from 'akeneomeasure/model/direction';
 
 const useSorting = (
   defaultColumn: string

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/list/MeasurementFamilyTable.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/list/MeasurementFamilyTable.tsx
@@ -2,9 +2,10 @@ import React, {useContext} from 'react';
 import styled from 'styled-components';
 import {MeasurementFamilyRow} from 'akeneomeasure/pages/list/MeasurementFamilyRow';
 import {MeasurementFamily} from 'akeneomeasure/model/measurement-family';
-import {Caret, Direction} from 'akeneomeasure/shared/components/Caret';
+import {Caret} from 'akeneomeasure/shared/components/Caret';
 import {TranslateContext} from 'akeneomeasure/context/translate-context';
 import {Table, HeaderCell} from 'akeneomeasure/pages/common/Table';
+import {Direction} from 'akeneomeasure/model/direction';
 
 const SortableHeaderCell = styled(HeaderCell)`
   &:hover {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/Caret.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/Caret.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import {Direction} from 'akeneomeasure/model/measurement-family';
+import {Direction} from 'akeneomeasure/model/direction';
 
 const CaretContainer = styled.span`
   display: inline-block;
@@ -28,4 +28,4 @@ type CaretProps = {
 const Caret = ({direction}: CaretProps) =>
   direction === Direction.Ascending ? <AscendingCaret /> : <DescendingCaret />;
 
-export {Direction, Caret};
+export {Caret};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/TextField.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/TextField.tsx
@@ -1,9 +1,10 @@
-import React, {ChangeEventHandler, useContext, forwardRef} from 'react';
+import React, {ChangeEventHandler, useContext} from 'react';
 import styled, {css} from 'styled-components';
 import {ValidationError} from 'akeneomeasure/model/validation-error';
 import {InputErrors} from 'akeneomeasure/shared/components/InputErrors';
 import {TranslateContext} from 'akeneomeasure/context/translate-context';
 import {Flag} from 'akeneomeasure/shared/components/Flag';
+import {useFocus} from 'akeneomeasure/shared/hooks/use-focus';
 
 const Input = styled.input.attrs(() => ({className: 'AknTextField'}))<{invalid: boolean}>`
   border: 1px solid ${props => props.theme.color.grey80};
@@ -23,6 +24,7 @@ type TextFieldProps = {
   locale?: string;
   required?: boolean;
   flag?: string;
+  autofocus?: boolean;
 
   value: string;
   onChange: ChangeEventHandler<Element>;
@@ -30,25 +32,40 @@ type TextFieldProps = {
   errors?: ValidationError[];
 };
 
-const TextField = forwardRef<HTMLInputElement, TextFieldProps & any>(
-  ({id, label, errors, propertyPath, required = false, flag, ...props}, ref) => {
-    const __ = useContext(TranslateContext);
+const TextField = ({
+  id,
+  label,
+  errors,
+  propertyPath,
+  required = false,
+  flag,
+  autofocus = false,
+  ...props
+}: TextFieldProps & any) => {
+  const __ = useContext(TranslateContext);
+  const [focusRef] = useFocus();
 
-    return (
-      <div className="AknFieldContainer">
-        <div className="AknFieldContainer-header">
-          <label className="AknFieldContainer-label" htmlFor={id}>
-            {label} {required && __('pim_common.required_label')}
-          </label>
-          {flag && <Flag localeCode={flag} />}
-        </div>
-        <div className="AknFieldContainer-inputContainer">
-          <Input ref={ref} id={id} type="text" autoComplete="off" invalid={errors && errors.length > 0} {...props} />
-        </div>
-        {errors && <InputErrors errors={errors} />}
+  return (
+    <div className="AknFieldContainer">
+      <div className="AknFieldContainer-header">
+        <label className="AknFieldContainer-label" htmlFor={id}>
+          {label} {required && __('pim_common.required_label')}
+        </label>
+        {flag && <Flag localeCode={flag} />}
       </div>
-    );
-  }
-);
+      <div className="AknFieldContainer-inputContainer">
+        <Input
+          ref={autofocus ? focusRef : undefined}
+          id={id}
+          type="text"
+          autoComplete="off"
+          invalid={errors && errors.length > 0}
+          {...props}
+        />
+      </div>
+      {errors && <InputErrors errors={errors} />}
+    </div>
+  );
+};
 
 export {TextField};

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/jsmessages.en_US.yml
@@ -27,6 +27,10 @@ measurements:
             units: Units
             properties: Properties
         delete: Delete measurement family
+        save:
+            flash:
+                success: Measurement family successfully saved.
+                error: Sorry, an error occured while saving the measurement family.
     unit:
         title: Edit {{ unitLabel }}
         symbol: Symbol

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/front/unit/model/measurement-family.unit.ts
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/front/unit/model/measurement-family.unit.ts
@@ -83,10 +83,6 @@ describe('measurement family', () => {
     expect(newMeasurementFamily.units[0].convert_from_standard).toEqual([{operator: 'div', value: '3'}]);
   });
 
-  it('should create an empty Operation', () => {
-    expect(emptyOperation()).toEqual({value: '1', operator: 'mul'});
-  });
-
   it('should remove the provided unit (using the unit code) from the measurement family', () => {
     expect(measurementFamily.units.length).toEqual(2);
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR:
- Splits model in dedicated files
- Add a `autofocus` prop in TextField component
- Disables the add operation button instead of hiding it

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
