### PR TITLE
DAPI-931: Keep the same tab when switching from a variant to a model (and vice versa)

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
@@ -443,9 +443,7 @@ define(
                 const entity = this.getFormData();
                 const level = $(event.target).data('level');
 
-                this.getRoot().trigger('pim:product:variant-navigation:navigate-to-level:before');
                 this.redirectToEntity(entity.meta.variant_navigation[level].selected);
-                this.getRoot().trigger('pim:product:variant-navigation:navigate-to-level:after');
             },
 
             /**
@@ -464,6 +462,7 @@ define(
                     : 'pim_enrich_product_edit'
                 ;
 
+                this.getRoot().trigger('pim:product:variant-navigation:navigate-to-level:before');
                 router.redirectToRoute(route, params);
             }
         });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
@@ -462,7 +462,7 @@ define(
                     : 'pim_enrich_product_edit'
                 ;
 
-                this.getRoot().trigger('pim:product:variant-navigation:navigate-to-level:before');
+                this.getRoot().trigger('pim:product:variant-navigation:navigate-to-level:before', entity);
                 router.redirectToRoute(route, params);
             }
         });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
@@ -443,7 +443,9 @@ define(
                 const entity = this.getFormData();
                 const level = $(event.target).data('level');
 
+                this.getRoot().trigger('pim:product:variant-navigation:navigate-to-level:before');
                 this.redirectToEntity(entity.meta.variant_navigation[level].selected);
+                this.getRoot().trigger('pim:product:variant-navigation:navigate-to-level:after');
             },
 
             /**


### PR DESCRIPTION

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Trigger events before and after handling navigation in product model breadcrumb

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
