### PR TITLE
API-1009: Change Audit message when no connection exist

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -144,9 +144,10 @@ akeneo_connectivity.connection:
                 during_the_last_seven_days: During the last seven days
                 today: Today
         no_connection:
-            title: No source connection declared yet.
+            title: Want to see some fancy charts about your connections?
             message_with_permission:
-                link: Create one here!
+                message: Create and start tracking your first connection right
+                link: here.
             message_without_permission:
                 message: Ask your administrator to create one.
                 link: Learn more about connections here...

--- a/src/Akeneo/Connectivity/Connection/front/src/audit/components/NoConnection.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/components/NoConnection.tsx
@@ -23,6 +23,8 @@ export const NoConnection = () => {
                     </>
                 }
             >
+                <Translate id='akeneo_connectivity.connection.dashboard.no_connection.message_with_permission.message' />
+                &nbsp;
                 <Link onClick={() => redirect('/connections')}>
                     <Translate id='akeneo_connectivity.connection.dashboard.no_connection.message_with_permission.link' />
                 </Link>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

![no-connection](https://user-images.githubusercontent.com/1671213/77312964-40571600-6d03-11ea-8906-75fe798ca114.png)

![no-connection_no-permission](https://user-images.githubusercontent.com/1671213/77312966-40efac80-6d03-11ea-85aa-110918bd14eb.png)
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

