### PR TITLE
PIM-9157: Fix performance issue when loading the data of a product group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - PIM-9114: fix errors on mass action when the parent filter is set to empty
 - PIM-9110: avoid deadlock error when loading product and product models in parallel with the API
 - PIM-9113: Locale Specific attribute breaks product grid
+- PIM-9157: Fix performance issue when loading the data of a product group
 
 ## New features
 
@@ -47,6 +48,8 @@
     - add `Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface $measurementFamilyRepository`
     - add `Akeneo\Tool\Component\StorageUtils\Repository\BaseCachedObjectRepository $baseCachedObjectRepository`
     - add `Psr\Log\LoggerInterface $logger`
+- Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\GroupNormalizer` to
+    - add `Akeneo\Pim\Enrichment\Component\Product\Query\GetGroupProductIdentifiers`
 - Change `Akeneo\Tool\Bundle\MeasureBundle\Manager\MeasureManager` to remove method `setMeasureConfig(array $config)`
 - Remove `Akeneo\Tool\Bundle\MeasureBundle\DependencyInjection\Configuration`
 - Remove `Akeneo\Tool\Bundle\MeasureBundle\Family\AreaFamilyInterface`

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -61,6 +61,7 @@ services:
             - '@pim_structure_version.provider.structure_version.group'
             - '@pim_versioning.manager.version'
             - '@pim_enrich.normalizer.version'
+            - '@akeneo.pim.enrichment.group.query.get_group_product_identifiers'
         tags:
             - { name: pim_internal_api_serializer.normalizer }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -261,3 +261,8 @@ services:
         class: 'Akeneo\Channel\Bundle\Doctrine\Query\GetChannelActiveLocaleCodes'
         arguments:
             - '@database_connection'
+
+    akeneo.pim.enrichment.group.query.get_group_product_identifiers:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Group\SqlGetGroupProductIdentifiers'
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Group/SqlGetGroupProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Group/SqlGetGroupProductIdentifiers.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Group;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetGroupProductIdentifiers;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SqlGetGroupProductIdentifiers implements GetGroupProductIdentifiers
+{
+    /** @var Connection */
+    private $dbConnection;
+
+    public function __construct(Connection $dbConnection)
+    {
+        $this->dbConnection = $dbConnection;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function byGroupId(int $groupId): array
+    {
+        $query = <<<SQL
+SELECT product.identifier 
+FROM pim_catalog_group_product AS group_product
+INNER JOIN pim_catalog_product AS product ON group_product.product_id = product.id
+WHERE group_product.group_id = :groupId
+SQL;
+
+        $stmt = $this->dbConnection->executeQuery(
+            $query,
+            ['groupId' => $groupId],
+            ['groupId' => \PDO::PARAM_INT]
+        );
+
+        return $stmt->fetchAll(\PDO::FETCH_COLUMN);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/GroupNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/GroupNormalizer.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\GroupInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetGroupProductIdentifiers;
 use Akeneo\Platform\Bundle\UIBundle\Provider\StructureVersion\StructureVersionProviderInterface;
 use Akeneo\Tool\Bundle\VersioningBundle\Manager\VersionManager;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
@@ -32,22 +33,21 @@ class GroupNormalizer implements NormalizerInterface, CacheableSupportsMethodInt
     /** @var NormalizerInterface */
     protected $versionNormalizer;
 
-    /**
-     * @param NormalizerInterface               $groupNormalizer
-     * @param StructureVersionProviderInterface $structureVersionProvider
-     * @param VersionManager                    $versionManager
-     * @param NormalizerInterface               $versionNormalizer
-     */
+    /** @var GetGroupProductIdentifiers */
+    private $getGroupProductIdentifiers;
+
     public function __construct(
         NormalizerInterface $groupNormalizer,
         StructureVersionProviderInterface $structureVersionProvider,
         VersionManager $versionManager,
-        NormalizerInterface $versionNormalizer
+        NormalizerInterface $versionNormalizer,
+        GetGroupProductIdentifiers $getGroupProductIdentifiers
     ) {
         $this->groupNormalizer = $groupNormalizer;
         $this->structureVersionProvider = $structureVersionProvider;
         $this->versionManager = $versionManager;
         $this->versionNormalizer = $versionNormalizer;
+        $this->getGroupProductIdentifiers = $getGroupProductIdentifiers;
     }
 
     /**
@@ -57,10 +57,7 @@ class GroupNormalizer implements NormalizerInterface, CacheableSupportsMethodInt
     {
         $normalizedGroup = $this->groupNormalizer->normalize($group, 'standard', $context);
 
-        $normalizedGroup['products'] = [];
-        foreach ($group->getProducts() as $product) {
-            $normalizedGroup['products'][] = $product->getIdentifier();
-        }
+        $normalizedGroup['products'] = $this->getGroupProductIdentifiers->byGroupId($group->getId());
 
         $firstVersion = $this->versionManager->getOldestLogEntry($group);
         $lastVersion = $this->versionManager->getNewestLogEntry($group);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetGroupProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetGroupProductIdentifiers.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Query;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetGroupProductIdentifiers
+{
+    /**
+     * @param int $groupId
+     *
+     * @return string[] list of product identifiers of the given group.
+     */
+    public function byGroupId(int $groupId): array;
+}

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Group/SqlGetGroupProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Group/SqlGetGroupProductIdentifiersIntegration.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\Group;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\GroupInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetGroupProductIdentifiers;
+use Akeneo\Test\Integration\TestCase;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SqlGetGroupProductIdentifiersIntegration extends TestCase
+{
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_it_returns_the_identifiers_of_the_products_of_a_given_group()
+    {
+        $groupA = $this->givenAGroup('groupA');
+        $groupB = $this->givenAGroup('groupB');
+
+        $this->givenProductsWithGroup(['product_1', 'product_2'], 'groupA');
+        $this->givenAProductWithoutGroup();
+
+        $this->assertEmpty($this->getQuery()->byGroupId($groupB->getId()));
+
+        $productIdentifiers = $this->getQuery()->byGroupId($groupA->getId());
+        $this->assertEqualsCanonicalizing(['product_1', 'product_2'], $productIdentifiers);
+    }
+
+    private function getQuery(): GetGroupProductIdentifiers
+    {
+        return $this->get('akeneo.pim.enrichment.group.query.get_group_product_identifiers');
+    }
+
+    private function givenAGroup(string $groupCode): GroupInterface
+    {
+        $group = $this->get('pim_catalog.factory.group')->createGroup('RELATED');
+        $this->get('pim_catalog.updater.group')->update($group, [
+            'code' => $groupCode
+        ]);
+
+        $errors = $this->get('validator')->validate($group);
+        Assert::count($errors, 0);
+
+        $this->get('pim_catalog.saver.group')->save($group);
+
+        return $group;
+    }
+
+    private function givenProductsWithGroup(array $productIdentifiers, string $groupCode): void
+    {
+        foreach ($productIdentifiers as $productIdentifier) {
+            $this->createProduct($productIdentifier, ['groups' => [$groupCode]]);
+        }
+    }
+
+    private function givenAProductWithoutGroup(): void
+    {
+        $this->createProduct('whatever');
+    }
+
+    private function createProduct(string $identifier, array $data = []): void
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+
+        $errors = $this->get('pim_catalog.validator.product')->validate($product);
+        Assert::count($errors, 0);
+
+        $this->get('pim_catalog.saver.product')->save($product);
+    }
+}


### PR DESCRIPTION
There's a performance issue when displaying the edit page of a group that has a lot of products.

The problem comes from the `GroupNormalizer` that iterate on all the products of a group to retrieve the product identifiers. It makes Doctrine loads and hydrates all the products and it's very costly.

The list of product identifiers is necessary for the frontend, and it would be complicated to change that. So the simplest and cheapest solution to fix this problem is to add a SQL query to retrieve the product identifiers.

Execution time of the end-point that loads a group with 1000 products (on a PIM installed locally with dev env and Icecat catalog)

- before: ~900ms
- after: ~200ms (same time with only one product)