### PR TITLE
RUL-106: Allow to add any combination of products, product models or …

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Adder/AssociationFieldAdder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Adder/AssociationFieldAdder.php
@@ -97,9 +97,9 @@ class AssociationFieldAdder extends AbstractFieldAdder
                     $typeCode
                 );
             }
-            $this->addAssociatedProducts($association, $items['products']);
-            $this->addAssociatedGroups($association, $items['groups']);
-            $this->addAssociatedProductModels($association, $items['product_models']);
+            $this->addAssociatedProducts($association, $items['products'] ?? []);
+            $this->addAssociatedGroups($association, $items['groups'] ?? []);
+            $this->addAssociatedProductModels($association, $items['product_models'] ?? []);
         }
     }
 
@@ -206,7 +206,8 @@ class AssociationFieldAdder extends AbstractFieldAdder
      */
     protected function checkAssociationData($field, array $data, $assocTypeCode, $items)
     {
-        if (!is_array($items) || !is_string($assocTypeCode) || !isset($items['products']) || !isset($items['groups']) || !isset($items['product_models'])) {
+        if (!is_array($items) || !is_string($assocTypeCode) ||
+            (!isset($items['products']) && !isset($items['groups']) && !isset($items['product_models']))) {
             throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $field,
                 sprintf('association format is not valid for the association type "%s".', $assocTypeCode),


### PR DESCRIPTION
…groups in AssociationFieldAdder

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The `AssociationFieldAdder` was expecting all of `products`, `product_models` and `groups` keys for every association type (whereas only one of the keys is required for AssociationFieldSetter).
You can now use only one of these keys if you wish, in order to only add associated products (or product models, or groups)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
