### PR TITLE
RUL-89: add clearers for associations, categories and groups

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/updaters.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/updaters.yml
@@ -567,3 +567,18 @@ services:
             - '@akeneo.pim.structure.query.get_attributes'
         tags:
             - { name: 'pim_catalog.updater.clearer' }
+
+    pim_catalog.updater.clearer.association_field:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field\AssociationFieldClearer'
+        tags:
+            - { name: 'pim_catalog.updater.clearer' }
+
+    pim_catalog.updater.clearer.category_field:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field\CategoryFieldClearer'
+        tags:
+            - { name: 'pim_catalog.updater.clearer' }
+
+    pim_catalog.updater.clearer.group_field:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field\GroupFieldClearer'
+        tags:
+            - { name: 'pim_catalog.updater.clearer' }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/AssociationFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/AssociationFieldClearer.php
@@ -4,36 +4,36 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
 
-use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\FieldClearerInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\ClearerInterface;
 use Doctrine\Common\Collections\ArrayCollection;
+use Webmozart\Assert\Assert;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class AssociationFieldClearer implements FieldClearerInterface
+final class AssociationFieldClearer implements ClearerInterface
 {
     private const SUPPORTED_FIELD = 'associations';
 
     /**
      * {@inheritDoc}
      */
-    public function supportsField(string $field): bool
+    public function supportsProperty(string $property): bool
     {
-        return static::SUPPORTED_FIELD === $field;
+        return static::SUPPORTED_FIELD === $property;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function clear($entity, string $field, array $options = []): void
+    public function clear($entity, string $property, array $options = []): void
     {
-        if (!$this->supportsField($field)) {
-            throw new \InvalidArgumentException(
-                sprintf('Field must be "%s", "%s" given', static::SUPPORTED_FIELD, $field)
-            );
-        }
+        Assert::true(
+            $this->supportsProperty($property),
+            sprintf('The clearer does not handle the "%s" property.', $property)
+        );
 
         // getAssociations() can return an array or a Collection. We handle both.
         $entity->setAssociations(new ArrayCollection());

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/AssociationFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/AssociationFieldClearer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
+
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\FieldClearerInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class AssociationFieldClearer implements FieldClearerInterface
+{
+    private const SUPPORTED_FIELD = 'associations';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsField(string $field): bool
+    {
+        return static::SUPPORTED_FIELD === $field;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clear($entity, string $field, array $options = []): void
+    {
+        if (!$this->supportsField($field)) {
+            throw new \InvalidArgumentException(
+                sprintf('Field must be "%s", "%s" given', static::SUPPORTED_FIELD, $field)
+            );
+        }
+
+        // getAssociations() can return an array or a Collection. We handle both.
+        $entity->setAssociations(new ArrayCollection());
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/AssociationFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/AssociationFieldClearer.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithAssociationsInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\ClearerInterface;
-use Doctrine\Common\Collections\ArrayCollection;
 use Webmozart\Assert\Assert;
 
 /**
@@ -35,7 +35,15 @@ final class AssociationFieldClearer implements ClearerInterface
             sprintf('The clearer does not handle the "%s" property.', $property)
         );
 
-        // getAssociations() can return an array or a Collection. We handle both.
-        $entity->setAssociations(new ArrayCollection());
+        if ($entity instanceof EntityWithAssociationsInterface) {
+            // getAssociations() can return an array or a Collection. We handle both.
+            // We cannot clear the association directly, doctrine does not understand. We have to clear the
+            // products,m product models and groups of each assocations.
+            foreach ($entity->getAssociations() as $association) {
+                $association->getProducts()->clear();
+                $association->getProductModels()->clear();
+                $association->getGroups()->clear();
+            }
+        }
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/CategoryFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/CategoryFieldClearer.php
@@ -4,36 +4,36 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
 
-use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\FieldClearerInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\ClearerInterface;
 use Doctrine\Common\Collections\ArrayCollection;
+use Webmozart\Assert\Assert;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class CategoryFieldClearer implements FieldClearerInterface
+final class CategoryFieldClearer implements ClearerInterface
 {
     private const SUPPORTED_FIELD = 'categories';
 
     /**
      * {@inheritDoc}
      */
-    public function supportsField(string $field): bool
+    public function supportsProperty(string $property): bool
     {
-        return static::SUPPORTED_FIELD === $field;
+        return static::SUPPORTED_FIELD === $property;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function clear($entity, string $field, array $options = []): void
+    public function clear($entity, string $property, array $options = []): void
     {
-        if (!$this->supportsField($field)) {
-            throw new \InvalidArgumentException(
-                sprintf('Field must be "%s", "%s" given', static::SUPPORTED_FIELD, $field)
-            );
-        }
+        Assert::true(
+            $this->supportsProperty($property),
+            sprintf('The clearer does not handle the "%s" property.', $property)
+        );
 
         $entity->setCategories(new ArrayCollection());
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/CategoryFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/CategoryFieldClearer.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
+
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\FieldClearerInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class CategoryFieldClearer implements FieldClearerInterface
+{
+    private const SUPPORTED_FIELD = 'categories';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsField(string $field): bool
+    {
+        return static::SUPPORTED_FIELD === $field;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clear($entity, string $field, array $options = []): void
+    {
+        if (!$this->supportsField($field)) {
+            throw new \InvalidArgumentException(
+                sprintf('Field must be "%s", "%s" given', static::SUPPORTED_FIELD, $field)
+            );
+        }
+
+        $entity->setCategories(new ArrayCollection());
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/CategoryFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/CategoryFieldClearer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
 
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\ClearerInterface;
+use Akeneo\Tool\Component\Classification\CategoryAwareInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Webmozart\Assert\Assert;
 
@@ -35,6 +36,11 @@ final class CategoryFieldClearer implements ClearerInterface
             sprintf('The clearer does not handle the "%s" property.', $property)
         );
 
-        $entity->setCategories(new ArrayCollection());
+        if ($entity instanceof CategoryAwareInterface) {
+            // The `$entity->getCategories()->clear();` does not work on ProductModel. We have to remove one by one.
+            foreach ($entity->getCategories() as $category) {
+                $entity->removeCategory($category);
+            }
+        }
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/GroupFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/GroupFieldClearer.php
@@ -5,35 +5,35 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\FieldClearerInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\ClearerInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class GroupFieldClearer implements FieldClearerInterface
+final class GroupFieldClearer implements ClearerInterface
 {
     private const SUPPORTED_FIELD = 'groups';
 
     /**
      * {@inheritDoc}
      */
-    public function supportsField(string $field): bool
+    public function supportsProperty(string $property): bool
     {
-        return static::SUPPORTED_FIELD === $field;
+        return static::SUPPORTED_FIELD === $property;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function clear($entity, string $field, array $options = []): void
+    public function clear($entity, string $property, array $options = []): void
     {
-        if (!$this->supportsField($field)) {
-            throw new \InvalidArgumentException(
-                sprintf('Field must be "%s", "%s" given', static::SUPPORTED_FIELD, $field)
-            );
-        }
+        Assert::true(
+            $this->supportsProperty($property),
+            sprintf('The clearer does not handle the "%s" property.', $property)
+        );
 
         // Groups are only available for products, not product models.
         if ($entity instanceof ProductInterface) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/GroupFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/GroupFieldClearer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\FieldClearerInterface;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GroupFieldClearer implements FieldClearerInterface
+{
+    private const SUPPORTED_FIELD = 'groups';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsField(string $field): bool
+    {
+        return static::SUPPORTED_FIELD === $field;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clear($entity, string $field, array $options = []): void
+    {
+        if (!$this->supportsField($field)) {
+            throw new \InvalidArgumentException(
+                sprintf('Field must be "%s", "%s" given', static::SUPPORTED_FIELD, $field)
+            );
+        }
+
+        // Groups are only available for products, not product models.
+        if ($entity instanceof ProductInterface) {
+            $entity->getGroups()->clear();
+        }
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Updater;
 
+use Akeneo\Pim\Enrichment\Bundle\Doctrine\Common\Saver\ProductSaver;
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithAssociationsInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\PropertyClearer;
 use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
@@ -18,10 +22,22 @@ class PropertyClearerIntegration extends TestCase
     /** @var PropertyClearer */
     private $propertyClearer;
 
+    /** @var ProductSaver */
+    private $productSaver;
+
+    /** @var ProductRepositoryInterface */
+    private $productRepository;
+
+    /** @var EntityManagerClearerInterface */
+    private $cacheClearer;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->propertyClearer = $this->get('pim_catalog.updater.property_clearer');
+        $this->productSaver = $this->get('pim_catalog.saver.product');
+        $this->productRepository = $this->get('pim_catalog.repository.product');
+        $this->cacheClearer = $this->get('pim_connector.doctrine.cache_clearer');
     }
 
     public function test_it_clears_attribute_values(): void
@@ -93,10 +109,17 @@ class PropertyClearerIntegration extends TestCase
             ],
         ];
         $product = $this->createProduct('a_product_with_association', $parameters);
-        $this->assertGreaterThan(0, $product->getAssociations()->count());
+
+        $this->assertGreaterThan(0, $this->getAssociationsCount($product));
 
         $this->propertyClearer->clear($product, 'associations');
-        $this->assertCount(0, $product->getAssociations());
+        $this->assertSame(0, $this->getAssociationsCount($product));
+
+        // Save the product, clear the doctrine cache, reload the product and test the change is still good.
+        $this->productSaver->save($product);
+        $this->cacheClearer->clear();
+        $product = $this->productRepository->findOneByIdentifier('a_product_with_association');
+        $this->assertSame(0, $this->getAssociationsCount($product));
     }
 
     public function test_it_clears_categories(): void
@@ -109,6 +132,12 @@ class PropertyClearerIntegration extends TestCase
 
         $this->propertyClearer->clear($product, 'categories');
         $this->assertCount(0, $product->getCategories());
+
+        // Save the product, clear the doctrine cache, reload the product and test the change is still good.
+        $this->productSaver->save($product);
+        $this->cacheClearer->clear();
+        $product = $this->productRepository->findOneByIdentifier('a_product_with_categories');
+        $this->assertCount(0, $product->getCategories());
     }
 
     public function test_it_clears_groups(): void
@@ -116,10 +145,16 @@ class PropertyClearerIntegration extends TestCase
         $parameters = [
             'groups' => ['groupA', 'groupB'],
         ];
-        $product = $this->createProduct('a_product_with_categories', $parameters);
+        $product = $this->createProduct('a_product_with_groups', $parameters);
         $this->assertGreaterThan(0, $product->getGroups()->count());
 
         $this->propertyClearer->clear($product, 'groups');
+        $this->assertCount(0, $product->getGroups());
+
+        // Save the product, clear the doctrine cache, reload the product and test the change is still good.
+        $this->productSaver->save($product);
+        $this->cacheClearer->clear();
+        $product = $this->productRepository->findOneByIdentifier('a_product_with_groups');
         $this->assertCount(0, $product->getGroups());
     }
 
@@ -146,5 +181,17 @@ class PropertyClearerIntegration extends TestCase
         $this->get('pim_catalog.validator.unique_value_set')->reset();
 
         return $product;
+    }
+
+    private function getAssociationsCount(EntityWithAssociationsInterface $entity): int
+    {
+        $count = 0;
+        foreach ($entity->getAssociations() as $association) {
+            $count += $association->getProducts()->count();
+            $count += $association->getProductModels()->count();
+            $count += $association->getGroups()->count();
+        };
+
+        return $count;
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
@@ -7,7 +7,6 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Updater;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\PropertyClearer;
 use Akeneo\Test\Integration\TestCase;
-use Webmozart\Assert\Assert;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
@@ -94,10 +93,10 @@ class PropertyClearerIntegration extends TestCase
             ],
         ];
         $product = $this->createProduct('a_product_with_association', $parameters);
-        Assert::greaterThan($product->getAssociations()->count(), 0);
+        $this->assertGreaterThan(0, $product->getAssociations()->count());
 
         $this->propertyClearer->clear($product, 'associations');
-        Assert::count($product->getAssociations(), 0);
+        $this->assertCount(0, $product->getAssociations());
     }
 
     public function test_it_clears_categories(): void
@@ -106,10 +105,10 @@ class PropertyClearerIntegration extends TestCase
             'categories' => ['categoryA', 'categoryB'],
         ];
         $product = $this->createProduct('a_product_with_categories', $parameters);
-        Assert::greaterThan($product->getCategories()->count(), 0);
+        $this->assertGreaterThan(0, $product->getCategories()->count());
 
         $this->propertyClearer->clear($product, 'categories');
-        Assert::count($product->getCategories(), 0);
+        $this->assertCount(0, $product->getCategories());
     }
 
     public function test_it_clears_groups(): void
@@ -118,10 +117,10 @@ class PropertyClearerIntegration extends TestCase
             'groups' => ['groupA', 'groupB'],
         ];
         $product = $this->createProduct('a_product_with_categories', $parameters);
-        Assert::greaterThan($product->getGroups()->count(), 0);
+        $this->assertGreaterThan(0, $product->getGroups()->count());
 
         $this->propertyClearer->clear($product, 'groups');
-        Assert::count($product->getGroups(), 0);
+        $this->assertCount(0, $product->getGroups());
     }
 
     public function getConfiguration()

--- a/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
@@ -7,6 +7,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Updater;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\PropertyClearer;
 use Akeneo\Test\Integration\TestCase;
+use Webmozart\Assert\Assert;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
@@ -76,6 +77,51 @@ class PropertyClearerIntegration extends TestCase
         $this->propertyClearer->clear($product, 'a_metric');
         $this->assertNotNull($product->getValue('a_text'));
         $this->assertNotNull($product->getValue('a_localized_and_scopable_text_area', 'en_US', 'ecommerce'));
+    }
+
+    public function test_it_clears_associations(): void
+    {
+        $this->createProduct('a_product', []);
+        $this->createProduct('another_product', []);
+
+        $parameters = [
+            'associations' => [
+                'X_SELL' => [
+                    'products' => ['a_product', 'another_product'],
+                    'product_models' => [],
+                    'groups' => [],
+                ],
+            ],
+        ];
+        $product = $this->createProduct('a_product_with_association', $parameters);
+        Assert::greaterThan($product->getAssociations()->count(), 0);
+
+        $this->propertyClearer->clear($product, 'associations');
+        Assert::count($product->getAssociations(), 0);
+    }
+
+    public function test_it_clears_categories(): void
+    {
+        $parameters = [
+            'categories' => ['categoryA', 'categoryB'],
+        ];
+        $product = $this->createProduct('a_product_with_categories', $parameters);
+        Assert::greaterThan($product->getCategories()->count(), 0);
+
+        $this->propertyClearer->clear($product, 'categories');
+        Assert::count($product->getCategories(), 0);
+    }
+
+    public function test_it_clears_groups(): void
+    {
+        $parameters = [
+            'groups' => ['groupA', 'groupB'],
+        ];
+        $product = $this->createProduct('a_product_with_categories', $parameters);
+        Assert::greaterThan($product->getGroups()->count(), 0);
+
+        $this->propertyClearer->clear($product, 'groups');
+        Assert::count($product->getGroups(), 0);
     }
 
     public function getConfiguration()

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/AssociationFieldClearerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/AssociationFieldClearerSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductAssociation;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelAssociation;
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AssociationFieldClearerSpec extends ObjectBehavior
+{
+    function it_supports_only_associations_field()
+    {
+        $this->supportsField('categories')->shouldReturn(false);
+        $this->supportsField('associations')->shouldReturn(true);
+        $this->supportsField('other')->shouldReturn(false);
+    }
+
+    function it_removes_all_association_of_a_product()
+    {
+
+        $product = new Product();
+        $associations = new ArrayCollection();
+        $associations->add(new ProductAssociation());
+        $associations->add(new ProductAssociation());
+        $product->setAssociations($associations);
+
+        $this->clear($product, 'associations');
+        Assert::count($product->getAssociations(), 0);
+    }
+
+    function it_removes_all_association_of_a_product_model()
+    {
+
+        $productModel = new ProductModel();
+        $associations = new ArrayCollection();
+        $associations->add(new ProductModelAssociation());
+        $associations->add(new ProductModelAssociation());
+        $productModel->setAssociations($associations);
+
+        $this->clear($productModel, 'associations');
+        Assert::count($productModel->getAssociations(), 0);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/AssociationFieldClearerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/AssociationFieldClearerSpec.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductAssociation;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelAssociation;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\ClearerInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Webmozart\Assert\Assert;
@@ -18,11 +19,16 @@ use Webmozart\Assert\Assert;
  */
 class AssociationFieldClearerSpec extends ObjectBehavior
 {
+    function it_is_a_clearer()
+    {
+        $this->shouldImplement(ClearerInterface::class);
+    }
+
     function it_supports_only_associations_field()
     {
-        $this->supportsField('categories')->shouldReturn(false);
-        $this->supportsField('associations')->shouldReturn(true);
-        $this->supportsField('other')->shouldReturn(false);
+        $this->supportsProperty('categories')->shouldReturn(false);
+        $this->supportsProperty('associations')->shouldReturn(true);
+        $this->supportsProperty('other')->shouldReturn(false);
     }
 
     function it_removes_all_association_of_a_product()

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/AssociationFieldClearerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/AssociationFieldClearerSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithAssociationsInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductAssociation;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
@@ -33,7 +34,6 @@ class AssociationFieldClearerSpec extends ObjectBehavior
 
     function it_removes_all_association_of_a_product()
     {
-
         $product = new Product();
         $associations = new ArrayCollection();
         $associations->add(new ProductAssociation());
@@ -41,12 +41,11 @@ class AssociationFieldClearerSpec extends ObjectBehavior
         $product->setAssociations($associations);
 
         $this->clear($product, 'associations');
-        Assert::count($product->getAssociations(), 0);
+        Assert::same($this->getAssociationsCount($product), 0);
     }
 
     function it_removes_all_association_of_a_product_model()
     {
-
         $productModel = new ProductModel();
         $associations = new ArrayCollection();
         $associations->add(new ProductModelAssociation());
@@ -54,6 +53,18 @@ class AssociationFieldClearerSpec extends ObjectBehavior
         $productModel->setAssociations($associations);
 
         $this->clear($productModel, 'associations');
-        Assert::count($productModel->getAssociations(), 0);
+        Assert::same($this->getAssociationsCount($productModel), 0);
+    }
+
+    private function getAssociationsCount(EntityWithAssociationsInterface $entity): int
+    {
+        $count = 0;
+        foreach ($entity->getAssociations() as $association) {
+            $count += $association->getProducts()->count();
+            $count += $association->getProductModels()->count();
+            $count += $association->getGroups()->count();
+        };
+
+        return $count;
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/CategoryFieldClearerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/CategoryFieldClearerSpec.php
@@ -7,6 +7,7 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\
 use Akeneo\Pim\Enrichment\Component\Category\Model\Category;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\ClearerInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Webmozart\Assert\Assert;
@@ -17,11 +18,16 @@ use Webmozart\Assert\Assert;
  */
 class CategoryFieldClearerSpec extends ObjectBehavior
 {
+    function it_is_a_clearer()
+    {
+        $this->shouldImplement(ClearerInterface::class);
+    }
+
     function it_supports_only_categories_field()
     {
-        $this->supportsField('categories')->shouldReturn(true);
-        $this->supportsField('groups')->shouldReturn(false);
-        $this->supportsField('other')->shouldReturn(false);
+        $this->supportsProperty('categories')->shouldReturn(true);
+        $this->supportsProperty('groups')->shouldReturn(false);
+        $this->supportsProperty('other')->shouldReturn(false);
     }
 
     function it_removes_all_categories_of_a_product()

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/CategoryFieldClearerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/CategoryFieldClearerSpec.php
@@ -32,7 +32,6 @@ class CategoryFieldClearerSpec extends ObjectBehavior
 
     function it_removes_all_categories_of_a_product()
     {
-
         $product = new Product();
         $categories = new ArrayCollection();
         $categories->add(new Category());
@@ -45,7 +44,6 @@ class CategoryFieldClearerSpec extends ObjectBehavior
 
     function it_removes_all_categories_of_a_product_model()
     {
-
         $productModel = new ProductModel();
         $categories = new ArrayCollection();
         $categories->add(new Category());

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/CategoryFieldClearerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/CategoryFieldClearerSpec.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
+
+use Akeneo\Pim\Enrichment\Component\Category\Model\Category;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CategoryFieldClearerSpec extends ObjectBehavior
+{
+    function it_supports_only_categories_field()
+    {
+        $this->supportsField('categories')->shouldReturn(true);
+        $this->supportsField('groups')->shouldReturn(false);
+        $this->supportsField('other')->shouldReturn(false);
+    }
+
+    function it_removes_all_categories_of_a_product()
+    {
+
+        $product = new Product();
+        $categories = new ArrayCollection();
+        $categories->add(new Category());
+        $categories->add(new Category());
+        $product->setCategories($categories);
+
+        $this->clear($product, 'categories');
+        Assert::count($product->getCategories(), 0);
+    }
+
+    function it_removes_all_categories_of_a_product_model()
+    {
+
+        $productModel = new ProductModel();
+        $categories = new ArrayCollection();
+        $categories->add(new Category());
+        $categories->add(new Category());
+        $productModel->setCategories($categories);
+
+        $this->clear($productModel, 'categories');
+        Assert::count($productModel->getCategories(), 0);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/GroupFieldClearerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/GroupFieldClearerSpec.php
@@ -6,6 +6,7 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\Group;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\ClearerInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Webmozart\Assert\Assert;
@@ -16,11 +17,16 @@ use Webmozart\Assert\Assert;
  */
 class GroupFieldClearerSpec extends ObjectBehavior
 {
+    function it_is_a_clearer()
+    {
+        $this->shouldImplement(ClearerInterface::class);
+    }
+
     function it_supports_only_groups_field()
     {
-        $this->supportsField('categories')->shouldReturn(false);
-        $this->supportsField('groups')->shouldReturn(true);
-        $this->supportsField('other')->shouldReturn(false);
+        $this->supportsProperty('categories')->shouldReturn(false);
+        $this->supportsProperty('groups')->shouldReturn(true);
+        $this->supportsProperty('other')->shouldReturn(false);
     }
 
     function it_removes_all_groups_of_a_product()

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/GroupFieldClearerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/GroupFieldClearerSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\Group;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GroupFieldClearerSpec extends ObjectBehavior
+{
+    function it_supports_only_groups_field()
+    {
+        $this->supportsField('categories')->shouldReturn(false);
+        $this->supportsField('groups')->shouldReturn(true);
+        $this->supportsField('other')->shouldReturn(false);
+    }
+
+    function it_removes_all_groups_of_a_product()
+    {
+
+        $product = new Product();
+        $groups = new ArrayCollection();
+        $groups->add(new Group());
+        $groups->add(new Group());
+        $product->setGroups($groups);
+
+        $this->clear($product, 'groups');
+        Assert::count($product->getGroups(), 0);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/GroupFieldClearerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/GroupFieldClearerSpec.php
@@ -31,7 +31,6 @@ class GroupFieldClearerSpec extends ObjectBehavior
 
     function it_removes_all_groups_of_a_product()
     {
-
         $product = new Product();
         $groups = new ArrayCollection();
         $groups->add(new Group());


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Add clearers to clear associations, categories and groups from a product / product model.  


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
