### PR TITLE
PIM-9163: total_fields limit of elasticsearch should be configurable

### DIFF
--- a/.env
+++ b/.env
@@ -11,4 +11,4 @@ APP_INDEX_HOSTS=elasticsearch:9200
 APP_PRODUCT_AND_PRODUCT_MODEL_INDEX_NAME=akeneo_pim_product_and_product_model
 MAILER_URL=null://localhost?encryption=tls&auth_mode=login&username=foo&password=bar&sender_address=no-reply@example.com
 AKENEO_PIM_URL=http://localhost:8080
-APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT=1000
+APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT=10000

--- a/.env
+++ b/.env
@@ -11,3 +11,4 @@ APP_INDEX_HOSTS=elasticsearch:9200
 APP_PRODUCT_AND_PRODUCT_MODEL_INDEX_NAME=akeneo_pim_product_and_product_model
 MAILER_URL=null://localhost?encryption=tls&auth_mode=login&username=foo&password=bar&sender_address=no-reply@example.com
 AKENEO_PIM_URL=http://localhost:8080
+APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT=1000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PIM-9110: avoid deadlock error when loading product and product models in parallel with the API
 - PIM-9113: Locale Specific attribute breaks product grid
 - PIM-9157: Fix performance issue when loading the data of a product group
+- PIM-9163: total_fields limit of elasticsearch should be configurable
 
 ## New features
 
@@ -24,6 +25,8 @@
 
 ### Codebase
 
+- Change constructor of `Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\Loader` to
+    - add `Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface $parameterBag`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ProductModelController` to
     - add `Akeneo\Pim\Enrichment\Bundle\Filter\CollectionFilterInterface $productEditDataFilter`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ProductController` to

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -31,8 +31,6 @@ parameters:
     # Maximum number of resources when updating a list of resources
     api_input_max_resources_number: 100
 
-    # Default value if env var is not defined
-    env(APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT): 10000
     elasticsearch_total_fields_limit: '%env(APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT)%'
 
     # Files used as configuration for the Elasticsearch index

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -31,9 +31,7 @@ parameters:
     # Maximum number of resources when updating a list of resources
     api_input_max_resources_number: 100
 
-    # Default value if env var is not defined
-    env(APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT): 1000
-    elasticsearch_total_fields_limit: '%env(APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT)%'
+    elasticsearch_total_fields_limit: '%env(default:10000:APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT)%'
 
     # Files used as configuration for the Elasticsearch index
     elasticsearch_index_configuration_files:

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -31,6 +31,10 @@ parameters:
     # Maximum number of resources when updating a list of resources
     api_input_max_resources_number: 100
 
+    # Default value if env var is not defined
+    env(APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT): 1000
+    elasticsearch_total_fields_limit: '%env(APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT)%'
+
     # Files used as configuration for the Elasticsearch index
     elasticsearch_index_configuration_files:
         - '%pim_ce_dev_src_folder_location%/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/settings.yml'

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -31,7 +31,9 @@ parameters:
     # Maximum number of resources when updating a list of resources
     api_input_max_resources_number: 100
 
-    elasticsearch_total_fields_limit: '%env(default:10000:APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT)%'
+    # Default value if env var is not defined
+    env(APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT): 10000
+    elasticsearch_total_fields_limit: '%env(APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT)%'
 
     # Files used as configuration for the Elasticsearch index
     elasticsearch_index_configuration_files:

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -32,7 +32,7 @@ ifeq ($(CI),true)
 	$(DOCKER_COMPOSE) run -T -u www-data --rm php php vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
 	.circleci/find_non_executed_phpspec.sh
 else
-	${PHP_RUN} vendor/bin/phpspec run
+	${PHP_RUN} vendor/bin/phpspec run -v
 endif
 
 .PHONY: unit-front

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -32,7 +32,7 @@ ifeq ($(CI),true)
 	$(DOCKER_COMPOSE) run -T -u www-data --rm php php vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
 	.circleci/find_non_executed_phpspec.sh
 else
-	${PHP_RUN} vendor/bin/phpspec run -v
+	${PHP_RUN} vendor/bin/phpspec run
 endif
 
 .PHONY: unit-front

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/settings.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/settings.yml
@@ -33,4 +33,4 @@ settings:
         # ES default value is 1000. This value can be too low for big catalogs.
         # For more information see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html#mapping-limit-settings
         total_fields:
-            limit: 10000
+            limit: %elasticsearch_total_fields_limit%

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/settings.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/settings.yml
@@ -33,4 +33,4 @@ settings:
         # ES default value is 1000. This value can be too low for big catalogs.
         # For more information see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html#mapping-limit-settings
         total_fields:
-            limit: %elasticsearch_total_fields_limit%
+            limit: '%elasticsearch_total_fields_limit%'

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/DependencyInjection/AkeneoElasticsearchExtension.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/DependencyInjection/AkeneoElasticsearchExtension.php
@@ -7,6 +7,7 @@ use Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\Loader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
@@ -54,7 +55,10 @@ class AkeneoElasticsearchExtension extends Extension
                 $index['service_name']
             );
             $container->register($configurationLoaderServiceName, Loader::class)
-                ->setArguments([$index['configuration_files']]);
+                ->setArguments([
+                    $index['configuration_files'],
+                    new Reference(ParameterBagInterface::class)
+                ]);
 
             $container->register($index['service_name'], Client::class)
                 ->setArguments([

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration;
 
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Yaml\Parser;
 
 /**
@@ -20,12 +22,16 @@ class Loader
     /** @var array */
     private $configurationFiles;
 
+    /** @var ParameterBag */
+    private $parameterBag;
+
     /**
      * @param array $configurationFiles
      */
-    public function __construct(array $configurationFiles)
+    public function __construct(array $configurationFiles, ParameterBagInterface $parameterBag)
     {
         $this->configurationFiles = $configurationFiles;
+        $this->parameterBag = $parameterBag;
     }
 
     /**
@@ -49,6 +55,10 @@ class Loader
             }
 
             $configuration = $yaml->parse(file_get_contents($configurationFile));
+
+            array_walk_recursive($configuration, function (&$value) {
+                $value = $this->parameterBag->resolveValue($value);
+            });
 
             if (isset($configuration['settings'])) {
                 $settings = array_replace_recursive($settings, $configuration['settings']);

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration;
 
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Yaml\Parser;
 
@@ -22,7 +21,7 @@ class Loader
     /** @var array */
     private $configurationFiles;
 
-    /** @var ParameterBag */
+    /** @var ParameterBagInterface */
     private $parameterBag;
 
     /**

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/LoaderSpec.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/LoaderSpec.php
@@ -3,12 +3,19 @@
 namespace spec\Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class LoaderSpec extends ObjectBehavior
 {
-    function it_loads_the_configuration_from_a_single_file()
+    function let(ParameterBagInterface $parameterBag)
     {
-        $this->beConstructedWith([__DIR__ . '/conf1.yml']);
+        $parameterBag->resolveValue(Argument::any())->willReturnArgument();
+    }
+
+    function it_loads_the_configuration_from_a_single_file(ParameterBagInterface $parameterBag)
+    {
+        $this->beConstructedWith([__DIR__ . '/conf1.yml'], $parameterBag);
 
         $indexConfiguration = $this->load();
         $indexConfiguration->getSettings()->shouldReturn(
@@ -68,14 +75,15 @@ class LoaderSpec extends ObjectBehavior
         $indexConfiguration->getAliases()->shouldReturn([]);
     }
 
-    function it_loads_the_configuration_from_multiple_files()
+    function it_loads_the_configuration_from_multiple_files(ParameterBagInterface $parameterBag)
     {
         $this->beConstructedWith(
             [
                 __DIR__ . '/conf1.yml',
                 __DIR__ . '/conf2.yml',
                 __DIR__ . '/conf3.yml',
-            ]
+            ],
+            $parameterBag
         );
 
         $indexConfiguration = $this->load();
@@ -167,14 +175,15 @@ class LoaderSpec extends ObjectBehavior
         );
     }
 
-    function it_loads_the_compiled_configuration_from_multiple_files()
+    function it_loads_the_compiled_configuration_from_multiple_files(ParameterBagInterface $parameterBag)
     {
         $this->beConstructedWith(
             [
                 __DIR__ . '/conf1.yml',
                 __DIR__ . '/conf2.yml',
                 __DIR__ . '/conf3.yml',
-            ]
+            ],
+            $parameterBag
         );
 
         $indexConfiguration = $this->load();
@@ -267,14 +276,46 @@ class LoaderSpec extends ObjectBehavior
         ]);
     }
 
-    function it_throws_an_exception_when_a_file_is_not_readable()
+    function it_replaces_parameters_in_the_configuration(ParameterBagInterface $parameterBag)
+    {
+        $this->beConstructedWith(
+            [
+                __DIR__ . '/conf4.yml',
+            ],
+            $parameterBag
+        );
+        $parameterBag->resolveValue('%elasticsearch_total_fields_limit%')->willReturn(10000);
+
+        $indexConfiguration = $this->load();
+        $indexConfiguration->getSettings()->shouldReturn(
+            [
+                'analysis' => [
+                    'char_filter' => [
+                        'newline_pattern' => [
+                            'type' => 'pattern_replace',
+                            'pattern' => '\\n',
+                            'replacement' => '',
+                        ],
+                    ],
+                ],
+                'mapping' => [
+                    'total_fields' => [
+                        'limit' => 10000
+                    ]
+                ]
+            ]
+        );
+    }
+
+    function it_throws_an_exception_when_a_file_is_not_readable(ParameterBagInterface $parameterBag)
     {
         $this->beConstructedWith(
             [
                 __DIR__ . '/conf1.yml',
                 __DIR__ . '/do_not_exists.yml',
                 __DIR__ . '/conf2.yml',
-            ]
+            ],
+            $parameterBag
         );
 
         $this->shouldThrow('\Exception')->during('load');

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf4.yml
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf4.yml
@@ -1,0 +1,10 @@
+settings:
+    analysis:
+        char_filter:
+            newline_pattern:
+                type: "pattern_replace"
+                pattern: "\\n"
+                replacement: ""
+    mapping:
+        total_fields:
+            limit: '%elasticsearch_total_fields_limit%'


### PR DESCRIPTION
Total_fields limit of elasticsearch should be configurable on serenity instances

As per this documentation, this is something that can be needed by some clients:

https://docs.akeneo.com/4.0/maintain_pim/common_issues/index.html#the-limit-of-total-fields-is-reached-in-elasticsearch
