### PR TITLE
PIM-9164: Fix build property path for localized attributes validation

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9164: Fix build property path for localized attributes validation
+
 # 4.0.12 (2020-03-24)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Localization/Localizer/AttributeConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Localization/Localizer/AttributeConverter.php
@@ -175,23 +175,16 @@ class AttributeConverter implements AttributeConverterInterface
      * Build the property path of the attribute
      *
      * @param array  $data
-     * @param string $code
+     * @param string $attributeCode
      *
      * @return string
      */
-    protected function buildPropertyPath(array $data, $code)
+    protected function buildPropertyPath(array $data, $attributeCode)
     {
-        $path = $code;
+        $channelCode = isset($data['scope']) && '' !== $data['scope'] ? $data['scope'] : '<all_channels>';
+        $localeCode = isset($data['locale']) && '' !== $data['locale'] ? $data['locale'] : '<all_locales>';
 
-        if (isset($data['scope']) && '' !== $data['scope']) {
-            $path .= sprintf('-%s', $data['scope']);
-        }
-
-        if (isset($data['locale']) && '' !== $data['locale']) {
-            $path .= sprintf('-%s', $data['locale']);
-        }
-
-        return sprintf('values[%s]', $path);
+        return sprintf('values[%s-%s-%s]', $attributeCode, $channelCode, $localeCode);
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Localization/Localizer/AttributeConverterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Localization/Localizer/AttributeConverterSpec.php
@@ -28,7 +28,7 @@ class AttributeConverterSpec extends ObjectBehavior
         $attributeRepository->getAttributeTypeByCodes(['number'])->willReturn(['number' => 'pim_number']);
         $localizerRegistry->getLocalizer('pim_number')->willReturn($localizer);
         $localizer->supports('pim_number')->willReturn(true);
-        $localizer->validate('10,45', 'values[number]', $options)->willReturn(null);
+        $localizer->validate('10,45', 'values[number-<all_channels>-<all_locales>]', $options)->willReturn(null);
         $localizer->delocalize('10,45', $options)->willReturn('10.45');
 
         $this->convertToDefaultFormats(['number' => [['data' => '10,45']]], $options)
@@ -58,10 +58,10 @@ class AttributeConverterSpec extends ObjectBehavior
         $attributeRepository->getAttributeTypeByCodes(['number'])->willReturn(['number' => 'pim_number']);
         $localizerRegistry->getLocalizer('pim_number')->willReturn($localizer);
 
-        $constraint = new ConstraintViolation('Error with attribute', '', [], '', 'values[number]', '10,45');
+        $constraint = new ConstraintViolation('Error with attribute', '', [], '', 'values[number-<all_channels>-<all_locales>]', '10,45');
         $constraints = new ConstraintViolationList([$constraint]);
         $localizer->supports('pim_number')->willReturn(true);
-        $localizer->validate('10,45', 'values[number]', $options)->willReturn($constraints);
+        $localizer->validate('10,45', 'values[number-<all_channels>-<all_locales>]', $options)->willReturn($constraints);
         $localizer->delocalize('10,45', $options)->willReturn('10.45');
 
         $this->convertToDefaultFormats(['number' => [['data' => '10,45']]], $options)


### PR DESCRIPTION
A client encountered this problem:
When attempting to save a product with a comma-separated decimal value (i.e 13,24) inside of a localized price attribute, the PIM fails leaving in a blank page. It should display an error message on the price field.

The blank page is due to a Javascript error because the locale is defined instead of the channel in the JSON response of the product edition.
The reason is that Backend side, the property path set in the validation constraint is malformed. It contains only the attribute code and the locale code separated by a dash. There is no channel because the attribute is not scopable, but it should replace the channel by "<all_channels>" to have the right format : "attribute-channel-locale". By having a property path like "attribute-locale", the violation normalizer interprets the locale as the channel.

The problem concerns only the localizable but not scopable attributes, and only with two constraints specific to the PIM: https://github.com/akeneo/pim-community-dev/blob/4.0/src/Akeneo/Tool/Component/Localization/Validator/Constraints/NumberFormat.php and https://github.com/akeneo/pim-community-dev/blob/4.0/src/Akeneo/Tool/Component/Localization/Validator/Constraints/DateFormatValidator.php because they set the property path of the violation themselves. For the native Symfony constraints, the path is defined differently.

There's maybe a better solution that would involve changing the way we define the property path of a constraint violation, but it would need a lot of rework. And anyways, the property path built in https://github.com/akeneo/pim-community-dev/blob/4.0/src/Akeneo/Pim/Enrichment/Component/Product/Localization/Localizer/AttributeConverter.php is wrong, because it cannot be interpreted for the attributes that are only localizable or scopable.