### PR TITLE
MET-137: move constraint validation into respective directory

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyCommonStructureValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyCommonStructureValidator.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchema;
+
+use JsonSchema\Validator;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MeasurementFamilyCommonStructureValidator
+{
+    public function validate(array $normalizedMeasurementFamily): array
+    {
+        $validator = new Validator();
+        $normalizedMeasurementFamilyObject = Validator::arrayToObjectRecursive($normalizedMeasurementFamily);
+        $validator->validate($normalizedMeasurementFamilyObject, $this->getJsonSchema());
+
+        return $validator->getErrors();
+    }
+
+    private function getJsonSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'code' => ['type' => 'string'],
+            ],
+            'required' => [
+                'code',
+            ],
+            'additionalProperties' => true,
+        ];
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyListValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyListValidator.php
@@ -27,8 +27,8 @@ class MeasurementFamilyListValidator
         return [
             'type' => 'array',
             'items' => [
-                'type' => 'object'
-            ]
+                'type' => 'object',
+            ],
         ];
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidator.php
@@ -45,31 +45,33 @@ class MeasurementFamilyValidator
                 ],
                 'standard_unit_code' => ['type' => 'string'],
                 'units'              => [
-                    'type'  => 'array',
-                    'items' => [
-                        'type'       => 'object',
-                        'required'   => ['code', 'labels', 'convert_from_standard', 'symbol'],
-                        'properties' => [
-                            'code'                  => ['type' => 'string'],
-                            'labels'                => [
-                                'type'              => ['object', 'array'],
-                                'patternProperties' => [
-                                    '.+' => ['type' => 'string'],
-                                ],
-                            ],
-                            'convert_from_standard' => [
-                                'type'  => 'array',
-                                'items' => [
-                                    'type'       => 'object',
-                                    'properties' => [
-                                        'operator' => ['type' => 'string'],
-                                        'value'    => ['type' => 'string']
+                    'type'  => 'object',
+                    'patternProperties' => [
+                        '.+' => [
+                            'type'       => 'object',
+                            'required'   => ['code', 'labels', 'convert_from_standard', 'symbol'],
+                            'properties' => [
+                                'code'                  => ['type' => 'string'],
+                                'labels'                => [
+                                    'type'              => ['object', 'array'],
+                                    'patternProperties' => [
+                                        '.+' => ['type' => 'string'],
                                     ],
-                                    'required'   => ['operator', 'value'],
-                                ]
-                            ],
-                            'symbol'                => ['type' => 'string']
-                        ]
+                                ],
+                                'convert_from_standard' => [
+                                    'type'  => 'array',
+                                    'items' => [
+                                        'type'       => 'object',
+                                        'properties' => [
+                                            'operator' => ['type' => 'string'],
+                                            'value'    => ['type' => 'string']
+                                        ],
+                                        'required'   => ['operator', 'value'],
+                                    ]
+                                ],
+                                'symbol'                => ['type' => 'string']
+                            ]
+                        ],
                     ]
                 ]
             ],

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/SaveMeasurementFamiliesAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/SaveMeasurementFamiliesAction.php
@@ -22,8 +22,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @author    Samir Boulil <samir.boulil@akeneo.com>

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/SaveMeasurementFamiliesAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/SaveMeasurementFamiliesAction.php
@@ -14,7 +14,7 @@ use Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchema\Measureme
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
-use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepository;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
 use Akeneo\Tool\Component\Api\Exception\ViolationHttpException;
 use Akeneo\Tool\Component\Api\Normalizer\Exception\ViolationNormalizer;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -51,7 +51,7 @@ class SaveMeasurementFamiliesAction
     /** @var CreateMeasurementFamilyHandler */
     private $createMeasurementFamilyHandler;
 
-    /** @var MeasurementFamilyRepository */
+    /** @var MeasurementFamilyRepositoryInterface */
     private $measurementFamilyRepository;
 
     public function __construct(
@@ -62,7 +62,7 @@ class SaveMeasurementFamiliesAction
         ViolationNormalizer $violationNormalizer,
         SaveMeasurementFamilyHandler $saveMeasurementFamilyHandler,
         CreateMeasurementFamilyHandler $createMeasurementFamilyHandler,
-        MeasurementFamilyRepository $measurementFamilyRepository
+        MeasurementFamilyRepositoryInterface $measurementFamilyRepository
     ) {
         $this->measurementFamilyListValidator = $measurementFamilyListValidator;
         $this->measurementFamilyCommonStructureValidator = $measurementFamilyCommonStructureValidator;
@@ -113,13 +113,13 @@ class SaveMeasurementFamiliesAction
                 }
             } catch (\InvalidArgumentException $exception) {
                 $responses[] = [
-                    'code'        => $normalizedMeasurementFamily['code'],
+                    'code' => $normalizedMeasurementFamily['code'],
                     'status_code' => Response::HTTP_UNPROCESSABLE_ENTITY,
-                    'message'     => $exception->getMessage()
+                    'message' => $exception->getMessage()
                 ];
             } catch (ViolationHttpException $exception) {
                 $response = [
-                    'code'        => $normalizedMeasurementFamily['code'],
+                    'code' => $normalizedMeasurementFamily['code'],
                     'status_code' => Response::HTTP_UNPROCESSABLE_ENTITY
                 ];
                 $response += $this->violationNormalizer->normalize($exception);
@@ -169,8 +169,10 @@ class SaveMeasurementFamiliesAction
         ];
     }
 
-    private function updateMeasurementFamily(array $normalizedMeasurementFamily, MeasurementFamily $measurementFamily): array
-    {
+    private function updateMeasurementFamily(
+        array $normalizedMeasurementFamily,
+        MeasurementFamily $measurementFamily
+    ): array {
         $normalizedMeasurementFamily = array_replace_recursive(
             $measurementFamily->normalizeWithIndexedUnits(),
             $normalizedMeasurementFamily

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Model/MeasurementFamily.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Model/MeasurementFamily.php
@@ -62,6 +62,20 @@ class MeasurementFamily
         ];
     }
 
+    public function normalizeWithIndexedUnits(): array
+    {
+        return [
+            'code' => $this->code->normalize(),
+            'labels' => $this->labels->normalize(),
+            'standard_unit_code' => $this->standardUnitCode->normalize(),
+            'units' => array_reduce($this->units, function (array $units, Unit $unit) {
+                $normalizedUnit = $unit->normalize();
+                $units[$normalizedUnit['code']] = $normalizedUnit;
+                return $units;
+            }, []),
+        ];
+    }
+
     private function assertStandardUnitExists(UnitCode $standardUnitCode, array $units): void
     {
         $isStandardUnitCodePresentInUnits = !empty($this->getUnit($standardUnitCode, $units));

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -101,6 +101,12 @@ SQL;
         return (int) $statement->fetch(\PDO::FETCH_COLUMN);
     }
 
+    public function clear(): void
+    {
+        $this->allMeasurementFamiliesCache = [];
+        $this->measurementFamilyCache = [];
+    }
+
     private function hydrateMeasurementFamily(
         string $code,
         string $normalizedLabels,

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepositoryInterface.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepositoryInterface.php
@@ -20,4 +20,6 @@ interface MeasurementFamilyRepositoryInterface
     public function save(MeasurementFamily $measurementFamily);
 
     public function countAllOthers(MeasurementFamilyCode $excludedMeasurementFamilyCode): int;
+
+    public function clear(): void;
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/api.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/api.yml
@@ -32,14 +32,20 @@ services:
         public: true
         arguments:
             - '@pim_api.controller.external_api.json_schema.measurement_family_list_validator'
+            - '@pim_api.controller.external_api.json_schema.measurement_family_common_structure_validator'
             - '@pim_api.controller.external_api.json_schema.measurement_family_validator'
             - '@validator'
             - '@pim_api.normalizer.exception.violation'
             - '@akeneo_measure.application.save_measurement_family_handler'
+            - '@akeneo_measure.application.create_measurement_family_handler'
+            - '@akeneo_measure.persistence.measurement_family_repository'
 
     # Json schema
     pim_api.controller.external_api.json_schema.measurement_family_list_validator:
         class: Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchema\MeasurementFamilyListValidator
+
+    pim_api.controller.external_api.json_schema.measurement_family_common_structure_validator:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchema\MeasurementFamilyCommonStructureValidator
 
     pim_api.controller.external_api.json_schema.measurement_family_validator:
         class: Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchema\MeasurementFamilyValidator

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
@@ -47,12 +47,12 @@ services:
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'
 
-    akeneo_measure.validation.create_measurement_family.code_must_be_unique:
-        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\CodeMustBeUniqueValidator
+    akeneo_measure.validation.measurement_family.code_must_be_unique:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\CodeMustBeUniqueValidator
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'
         tags:
-            - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validation.create_measurement_family.code_must_be_unique' }
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validation.measurement_family.code_must_be_unique' }
 
     akeneo_measurement.validation.create_measurement_family.count:
         class: Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\CountValidator
@@ -76,26 +76,43 @@ services:
         tags:
             - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.measurement_family.unit_count' }
 
-    akeneo_measurement.validation.measurement_family.count:
-        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\CountValidator
-        arguments:
-            - '@akeneo_measure.persistence.measurement_family_repository'
-            - '%akeneo_measurement.validation.measurement_family.families_max%'
-        tags:
-            - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.measurement_family.count' }
-
-    akeneo_measurement.validation.measurement_family.standard_unit_code_cannot_be_changed:
-        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeCannotBeChangedValidator
+    akeneo_measurement.validation.create_measurement_family.standard_unit_code_cannot_be_changed:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\StandardUnitCodeCannotBeChangedValidator
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'
         tags:
-            - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.measurement_family.standard_unit_code_cannot_be_changed' }
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.create_measurement_family.standard_unit_code_cannot_be_changed' }
 
     # Validation
-    akeneo_measurement.validation.measurement_family.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units:
-        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator
+    akeneo_measurement.validation.create_measurement_family.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'
             - '@akeneo.pim.structure.query.is_there_at_least_one_attribute_configured_with_measurement_family'
         tags:
-            - { name: 'validator.constraint_validator', alias: 'akeneo_measure.validator.asset.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units' }
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.create_measurement_family.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units' }
+
+
+    akeneo_measurement.validation.save_measurement_family.count:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily\CountValidator
+        arguments:
+            - '@akeneo_measure.persistence.measurement_family_repository'
+            - '%akeneo_measurement.validation.measurement_family.families_max%'
+        tags:
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.save_measurement_family.count' }
+
+    akeneo_measurement.validation.save_measurement_family.standard_unit_code_cannot_be_changed:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily\StandardUnitCodeCannotBeChangedValidator
+        arguments:
+            - '@akeneo_measure.persistence.measurement_family_repository'
+        tags:
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.save_measurement_family.standard_unit_code_cannot_be_changed' }
+
+    # Validation
+    akeneo_measurement.validation.save_measurement_family.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator
+        arguments:
+            - '@akeneo_measure.persistence.measurement_family_repository'
+            - '@akeneo.pim.structure.query.is_there_at_least_one_attribute_configured_with_measurement_family'
+        tags:
+            - { name: 'validator.constraint_validator', alias: 'akeneo_measurement.validation.save_measurement_family.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units' }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/validation.yml
@@ -35,11 +35,11 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasureme
                                         value:
                                             - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationValue: ~
     constraints:
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeShouldExist: ~
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeCannotBeChanged: { groups: [other_constraints] }
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeOperationShouldBeMultiplyByOne: { groups: [other_constraints] }
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits: { groups: [other_constraints] }
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\Count: { groups: [other_constraints] }
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily\StandardUnitCodeShouldExist: ~
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily\StandardUnitCodeCannotBeChanged: { groups: [other_constraints] }
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily\StandardUnitCodeOperationShouldBeMultiplyByOne: { groups: [other_constraints] }
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits: { groups: [other_constraints] }
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily\Count: { groups: [other_constraints] }
 
 Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand:
     group_sequence:
@@ -48,7 +48,7 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasu
     properties:
         code:
             - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\Code: ~
-            - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\CodeMustBeUnique: { groups: [other_constraints] }
+            - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\CodeMustBeUnique: { groups: [other_constraints] }
         labels:
             - Akeneo\Tool\Bundle\MeasureBundle\Validation\Common\LabelCollection: ~
         units:
@@ -80,7 +80,7 @@ Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasu
                                             - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationValue: ~
     constraints:
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\StandardUnitCodeShouldExist: ~
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeCannotBeChanged: { groups: [other_constraints] }
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeOperationShouldBeMultiplyByOne: { groups: [other_constraints] }
-        - Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits: { groups: [other_constraints] }
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\StandardUnitCodeCannotBeChanged: { groups: [other_constraints] }
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\StandardUnitCodeOperationShouldBeMultiplyByOne: { groups: [other_constraints] }
+        - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits: { groups: [other_constraints] }
         - Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily\Count: { groups: [other_constraints] }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/translations/validators.en_US.yml
@@ -26,3 +26,4 @@ pim_measurements:
                     invalid_operator: 'The {{ value }} operator is invalid, please use {{ choices }} instead.'
                 should_contain_at_least_one_unit: 'There should be at least %limit% unit in the measurement family.'
                 should_not_contain_duplicates: 'We found some duplicated units in the measurement family. The measurement family requires unique units.'
+                must_be_indexed_by_code: 'The index does not match the unit code.'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/CountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/CountValidator.php
@@ -30,24 +30,24 @@ class CountValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($saveMeasurementFamilyCommand, Constraint $constraint)
+    public function validate($createMeasurementFamilyCommand, Constraint $constraint)
     {
         if (!$constraint instanceof Count) {
             throw new UnexpectedTypeException($constraint, Count::class);
         }
 
-        if (!$saveMeasurementFamilyCommand instanceof CreateMeasurementFamilyCommand) {
-            throw new UnexpectedTypeException($saveMeasurementFamilyCommand, CreateMeasurementFamilyCommand::class);
+        if (!$createMeasurementFamilyCommand instanceof CreateMeasurementFamilyCommand) {
+            throw new UnexpectedTypeException(createMeasurementFamilyCommand, CreateMeasurementFamilyCommand::class);
         }
 
-        $excludedMeasurementFamilyCode = MeasurementFamilyCode::fromString($saveMeasurementFamilyCommand->code);
+        $excludedMeasurementFamilyCode = MeasurementFamilyCode::fromString($createMeasurementFamilyCommand->code);
 
         $count = $this->measurementFamilyRepository->countAllOthers($excludedMeasurementFamilyCode);
 
         if ($count >= $this->max) {
             $this->context->buildViolation(Count::MAX_MESSAGE)
                 ->setParameter('%limit%', $this->max)
-                ->setInvalidValue($saveMeasurementFamilyCommand)
+                ->setInvalidValue($createMeasurementFamilyCommand)
                 ->setPlural((int)$this->max)
                 ->addViolation();
         }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeCannotBeChanged.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeCannotBeChanged.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class StandardUnitCodeCannotBeChanged extends Constraint
+{
+    public const ERROR_MESSAGE = 'pim_measurements.validation.measurement_family.standard_unit_code.cannot_be_changed';
+
+    public function validatedBy()
+    {
+        return 'akeneo_measurement.validation.create_measurement_family.standard_unit_code_cannot_be_changed';
+    }
+
+    public function getTargets()
+    {
+        return Constraint::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeCannotBeChangedValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeCannotBeChangedValidator.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class StandardUnitCodeCannotBeChangedValidator extends ConstraintValidator
+{
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+
+    public function __construct(MeasurementFamilyRepositoryInterface $measurementFamilyRepository)
+    {
+        $this->measurementFamilyRepository = $measurementFamilyRepository;
+    }
+
+    /**
+     * @param CreateMeasurementFamilyCommand $createMeasurementFamilyCommand
+     * @inheritDoc
+     */
+    public function validate($createMeasurementFamilyCommand, Constraint $constraint)
+    {
+        try {
+            $measurementFamily = $this->measurementFamilyRepository
+                ->getByCode(MeasurementFamilyCode::fromString($createMeasurementFamilyCommand->code));
+        } catch (MeasurementFamilyNotFoundException $e) {
+            return;
+        }
+
+        if ($createMeasurementFamilyCommand->standardUnitCode !== $this->standardUnitCode($measurementFamily)) {
+            $this->context->buildViolation(StandardUnitCodeCannotBeChanged::ERROR_MESSAGE)
+                ->setParameter('%measurement_family_code%', $createMeasurementFamilyCommand->code)
+                ->atPath('standard_unit_code')
+                ->setInvalidValue($createMeasurementFamilyCommand->standardUnitCode)
+                ->addViolation();
+        }
+    }
+
+    private function standardUnitCode(MeasurementFamily $measurementFamily): string
+    {
+        return $measurementFamily->normalize()['standard_unit_code'];
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOne.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOne.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class StandardUnitCodeOperationShouldBeMultiplyByOne extends Constraint
+{
+    public const ERROR_MESSAGE = 'pim_measurements.validation.measurement_family.standard_unit_code.operation_should_be_multiply_by_one';
+
+    public function getTargets()
+    {
+        return Constraint::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOneValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOneValidator.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
 
-use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 class StandardUnitCodeOperationShouldBeMultiplyByOneValidator extends ConstraintValidator
 {
     /**
-     * @param SaveMeasurementFamilyCommand $saveMeasurementFamily
+     * @param CreateMeasurementFamilyCommand $saveMeasurementFamily
      */
     public function validate($saveMeasurementFamily, Constraint $constraint)
     {
@@ -37,7 +37,7 @@ class StandardUnitCodeOperationShouldBeMultiplyByOneValidator extends Constraint
     }
 
     /**
-     * @param SaveMeasurementFamilyCommand $saveMeasurementFamily
+     * @param CreateMeasurementFamilyCommand $saveMeasurementFamily
      */
     private function standardUnit($saveMeasurementFamily): array
     {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeShouldExistValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeShouldExistValidator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
 
 use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand;
-use Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\StandardUnitCodeShouldExist;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -20,18 +19,18 @@ class StandardUnitCodeShouldExistValidator extends ConstraintValidator
 {
     private const PROPERTY_PATH = 'standard_unit_code';
 
-    public function validate($saveMeasurementFamilyCommand, Constraint $constraint)
+    public function validate($createMeasurementFamilyCommand, Constraint $constraint)
     {
-        if (!$saveMeasurementFamilyCommand instanceof CreateMeasurementFamilyCommand) {
+        if (!$createMeasurementFamilyCommand instanceof CreateMeasurementFamilyCommand) {
             throw new \LogicException(
                 sprintf(
                     'Expect an instance of class "%s", "%s" given',
                     CreateMeasurementFamilyCommand::class,
-                    get_class($saveMeasurementFamilyCommand)
+                    get_class($createMeasurementFamilyCommand)
                 )
             );
         }
-        $standardUnitCode = $saveMeasurementFamilyCommand->standardUnitCode;
+        $standardUnitCode = $createMeasurementFamilyCommand->standardUnitCode;
         if (empty($standardUnitCode)) {
             $this->context
                 ->buildViolation(StandardUnitCodeShouldExist::STANDARD_UNIT_CODE_IS_REQUIRED)
@@ -42,9 +41,9 @@ class StandardUnitCodeShouldExistValidator extends ConstraintValidator
         }
 
         $validator = Validation::createValidator();
-        $measurementFamilyCode = $saveMeasurementFamilyCommand->code;
+        $measurementFamilyCode = $createMeasurementFamilyCommand->code;
         $violations = $validator->validate(
-            $saveMeasurementFamilyCommand->units,
+            $createMeasurementFamilyCommand->units,
             [
                 new Callback(
                     function (array $units, ExecutionContextInterface $context) use ($standardUnitCode, $measurementFamilyCode) {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits extends Constraint
+{
+    public const MEASUREMENT_FAMILY_UNIT_REMOVAL_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.measurement_family_units_is_locked_for_updates';
+    public const MEASUREMENT_FAMILY_OPERATION_UPDATE_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.measurement_family_unit_operations_locked_for_updates';
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    public function validatedBy(): string
+    {
+        return 'akeneo_measurement.validation.create_measurement_family.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units';
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
 
 use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
-use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand;
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
@@ -84,7 +84,7 @@ class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUn
         }
     }
 
-    private function isTryingToRemoveAUnit(MeasurementFamily $measurementFamily, SaveMeasurementFamilyCommand $saveMeasurementFamily): array
+    private function isTryingToRemoveAUnit(MeasurementFamily $measurementFamily, CreateMeasurementFamilyCommand $saveMeasurementFamily): array
     {
         $normalizedMeasurementFamily = $measurementFamily->normalize();
         $actualUnitCodes = array_map(
@@ -102,7 +102,7 @@ class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUn
 
     private function isTryingToUpdateTheConvertionOperations(
         MeasurementFamily $measurementFamily,
-        SaveMeasurementFamilyCommand $saveMeasurementFamily
+        CreateMeasurementFamilyCommand $saveMeasurementFamily
     ): array {
         $serializedUpdatedOperationsPerUnit = $this->serializeUpdatedOperationsPerUnit($saveMeasurementFamily);
         $serializedActualOperationsPerUnit = $this->serializeActualOperationsPerUnit($measurementFamily);
@@ -118,7 +118,7 @@ class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUn
         return $unitsBeingUpdated;
     }
 
-    private function serializeUpdatedOperationsPerUnit(SaveMeasurementFamilyCommand $saveMeasurementFamily): array
+    private function serializeUpdatedOperationsPerUnit(CreateMeasurementFamilyCommand $saveMeasurementFamily): array
     {
         $operationsPerUnit = [];
         foreach ($saveMeasurementFamily->units as $unit) {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CodeMustBeUnique.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CodeMustBeUnique.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
 
 use Symfony\Component\Validator\Constraint;
 
@@ -16,6 +16,6 @@ class CodeMustBeUnique extends Constraint
 
     public function validatedBy()
     {
-        return 'akeneo_measure.validation.create_measurement_family.code_must_be_unique';
+        return 'akeneo_measure.validation.measurement_family.code_must_be_unique';
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CodeMustBeUniqueValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CodeMustBeUniqueValidator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\CreateMeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
 
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitsMustBeIndexedByCode.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitsMustBeIndexedByCode.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UnitsMustBeIndexedByCode extends Constraint
+{
+    public $message = 'pim_measurements.validation.measurement_family.units.must_be_indexed_by_code';
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitsMustBeIndexedByCodeValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitsMustBeIndexedByCodeValidator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UnitsMustBeIndexedByCodeValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof UnitsMustBeIndexedByCode) {
+            throw new UnexpectedTypeException($constraint, UnitsMustBeIndexedByCode::class);
+        }
+
+        if (!is_array($value)) {
+            throw new UnexpectedTypeException($value, 'array');
+        }
+
+        foreach ($value as $key => $unit) {
+            if ($key !== $unit['code']) {
+                $path = sprintf('[%s]', $key);
+
+                // @see https://github.com/akeneo/pim-community-dev/blob/e166444691b7d63957cef3cac5277a74e4058ce9/src/Akeneo/Tool/Component/Api/Normalizer/Exception/ViolationNormalizer.php#L140
+                $constraint->payload['standardPropertyName'] = $this->context->getPropertyPath() . $path;
+
+                $this->context->buildViolation($constraint->message)
+                    ->atPath($path)
+                    ->setInvalidValue($value)
+                    ->addViolation();
+            }
+        }
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/Count.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/Count.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily;
 
 use Symfony\Component\Validator\Constraint;
 
@@ -20,7 +20,7 @@ class Count extends Constraint
 
     public function validatedBy()
     {
-        return 'akeneo_measurement.validation.measurement_family.count';
+        return 'akeneo_measurement.validation.save_measurement_family.count';
     }
 
     public function getTargets()

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/CountValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/CountValidator.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily;
 
 use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeCannotBeChanged.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeCannotBeChanged.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily;
 
 use Symfony\Component\Validator\Constraint;
 
@@ -17,7 +17,7 @@ class StandardUnitCodeCannotBeChanged extends Constraint
 
     public function validatedBy()
     {
-        return 'akeneo_measurement.validation.measurement_family.standard_unit_code_cannot_be_changed';
+        return 'akeneo_measurement.validation.save_measurement_family.standard_unit_code_cannot_be_changed';
     }
 
     public function getTargets()

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeCannotBeChangedValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeCannotBeChangedValidator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily;
 
 use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOne.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOne.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOneValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOneValidator.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class StandardUnitCodeOperationShouldBeMultiplyByOneValidator extends ConstraintValidator
+{
+    /**
+     * @param SaveMeasurementFamilyCommand $saveMeasurementFamily
+     */
+    public function validate($saveMeasurementFamily, Constraint $constraint)
+    {
+        $standardUnit = $this->standardUnit($saveMeasurementFamily);
+        $hasOneOperation = 1 === \count($standardUnit['convert_from_standard']);
+        if (!$hasOneOperation) {
+            return;
+        }
+        $hasOperationMultiply = 'mul' === $standardUnit['convert_from_standard'][0]['operator'];
+        $hasOperationValueOne = '1' === $standardUnit['convert_from_standard'][0]['value'];
+        if (!$hasOperationMultiply || !$hasOperationValueOne) {
+            $this->context
+                ->buildViolation(StandardUnitCodeOperationShouldBeMultiplyByOne::ERROR_MESSAGE)
+                ->setParameter('%measurement_family_code%', $saveMeasurementFamily->code)
+                ->atPath('units[0].convert_from_standard')
+                ->addViolation();
+        }
+    }
+
+    /**
+     * @param SaveMeasurementFamilyCommand $saveMeasurementFamily
+     */
+    private function standardUnit($saveMeasurementFamily): array
+    {
+        foreach ($saveMeasurementFamily->units as $unit) {
+            if ($saveMeasurementFamily->standardUnitCode === $unit['code']) {
+                return $unit;
+            }
+        }
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeShouldExist.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeShouldExist.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeShouldExistValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeShouldExistValidator.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily;
 
 use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
 use Symfony\Component\Validator\Constraint;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily;
 
 use Symfony\Component\Validator\Constraint;
 
@@ -23,6 +23,6 @@ class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUn
 
     public function validatedBy(): string
     {
-        return 'akeneo_measure.validator.asset.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units';
+        return 'akeneo_measurement.validation.save_measurement_family.when_used_in_a_product_attribute_should_be_able_to_update_only_labels_and_symbol_and_add_units';
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\SaveMeasurementFamily;
+
+use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnitsValidator extends ConstraintValidator
+{
+    /** @var IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily */
+    private $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+
+    /** @var MeasurementFamilyRepositoryInterface */
+    private $measurementFamilyRepository;
+
+    public function __construct(
+        MeasurementFamilyRepositoryInterface $measurementFamilyRepository,
+        IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily
+    ) {
+        $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily = $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+        $this->measurementFamilyRepository = $measurementFamilyRepository;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate($saveMeasurementFamily, Constraint $constraint)
+    {
+        $isMeasureFamilyLockedForUpdates = $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily
+            ->execute($saveMeasurementFamily->code);
+
+        if (!$isMeasureFamilyLockedForUpdates) {
+            return;
+        }
+
+        try {
+            $measurementFamily = $this->measurementFamilyRepository->getByCode(MeasurementFamilyCode::fromString($saveMeasurementFamily->code));
+        } catch (MeasurementFamilyNotFoundException $exception) {
+            return;
+        }
+
+        $removedUnits = $this->isTryingToRemoveAUnit($measurementFamily, $saveMeasurementFamily);
+        if (0 !== \count($removedUnits)) {
+            $this->context->buildViolation(
+                WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits::MEASUREMENT_FAMILY_UNIT_REMOVAL_NOT_ALLOWED,
+                [
+                    '%unit_code%'               => implode(',', $removedUnits),
+                    '%measurement_family_code%' => $saveMeasurementFamily->code
+                ]
+            )
+                ->atPath('units')
+                ->addViolation();
+        }
+
+        $unitsBeingUpdated = $this->isTryingToUpdateTheConvertionOperations(
+            $measurementFamily,
+            $saveMeasurementFamily
+        );
+        if ($unitsBeingUpdated) {
+            $this->context->buildViolation(
+                WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits::MEASUREMENT_FAMILY_OPERATION_UPDATE_NOT_ALLOWED,
+                [
+                    '%unit_code%'               => implode(',', $unitsBeingUpdated),
+                    '%measurement_family_code%' => $saveMeasurementFamily->code
+                ]
+            )
+                ->addViolation();
+        }
+    }
+
+    private function isTryingToRemoveAUnit(MeasurementFamily $measurementFamily, SaveMeasurementFamilyCommand $saveMeasurementFamily): array
+    {
+        $normalizedMeasurementFamily = $measurementFamily->normalize();
+        $actualUnitCodes = array_map(
+            function (array $unit) {
+                return $unit['code'];
+            },
+            $normalizedMeasurementFamily['units']
+        );
+        $unitCodesToUpdate = array_map(function (array $unit) {
+            return $unit['code'];
+        }, $saveMeasurementFamily->units);
+
+        return array_diff($actualUnitCodes, $unitCodesToUpdate);
+    }
+
+    private function isTryingToUpdateTheConvertionOperations(
+        MeasurementFamily $measurementFamily,
+        SaveMeasurementFamilyCommand $saveMeasurementFamily
+    ): array {
+        $serializedUpdatedOperationsPerUnit = $this->serializeUpdatedOperationsPerUnit($saveMeasurementFamily);
+        $serializedActualOperationsPerUnit = $this->serializeActualOperationsPerUnit($measurementFamily);
+
+        $unitsBeingUpdated = [];
+        foreach ($serializedActualOperationsPerUnit as $unitCode => $serializedActualUnitOperations) {
+            if (isset($serializedUpdatedOperationsPerUnit[$unitCode])
+                && $serializedUpdatedOperationsPerUnit[$unitCode] !== $serializedActualUnitOperations) {
+                $unitsBeingUpdated[] = $unitCode;
+            }
+        }
+
+        return $unitsBeingUpdated;
+    }
+
+    private function serializeUpdatedOperationsPerUnit(SaveMeasurementFamilyCommand $saveMeasurementFamily): array
+    {
+        $operationsPerUnit = [];
+        foreach ($saveMeasurementFamily->units as $unit) {
+            $unitCode = $unit['code'];
+            $serializedOperations = array_map(
+                function (array $unit) {
+                    return json_encode($unit);
+                },
+                $unit['convert_from_standard']
+            );
+            $operationsPerUnit[$unitCode] = $serializedOperations;
+        }
+
+        return $operationsPerUnit;
+    }
+
+    private function serializeActualOperationsPerUnit(MeasurementFamily $measurementFamily): array
+    {
+        $operationsPerUnit = [];
+        $normalizedUnits = $measurementFamily->normalize()['units'];
+        foreach ($normalizedUnits as $unit) {
+            $unitCode = $unit['code'];
+            $serializedOperations = array_map(
+                function (array $unit) {
+                    return json_encode($unit);
+                }, $unit['convert_from_standard']);
+            $operationsPerUnit[$unitCode] = $serializedOperations;
+        }
+
+        return $operationsPerUnit;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyCommonStructureValidatorSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyCommonStructureValidatorSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchema;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchema\MeasurementFamilyCommonStructureValidator;
+use PhpSpec\ObjectBehavior;
+
+class MeasurementFamilyCommonStructureValidatorSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MeasurementFamilyCommonStructureValidator::class);
+    }
+
+    function it_returns_all_the_errors_of_invalid_measurement_family_properties()
+    {
+        $asset = [
+            'values' => null,
+            'foo' => 'bar',
+        ];
+
+        $errors = $this->validate($asset);
+        $errors->shouldBeArray();
+        $errors->shouldHaveCount(1);
+    }
+
+    function it_returns_an_empty_array_if_all_the_required_measurement_family_properties_are_valid()
+    {
+        $measurementFamily = [
+            'code' => 'custom_metric_1',
+        ];
+
+        $this->validate($measurementFamily)->shouldReturn([]);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidatorSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidatorSpec.php
@@ -27,7 +27,7 @@ class MeasurementFamilyValidatorSpec extends ObjectBehavior
     {
         $asset = [
             'values' => null,
-            'foo'    => 'bar',
+            'foo' => 'bar',
         ];
 
         $errors = $this->validate($asset);
@@ -35,21 +35,21 @@ class MeasurementFamilyValidatorSpec extends ObjectBehavior
         $errors->shouldHaveCount(6);
     }
 
-    function it_returns_an_empty_array_if_all_the_asset_properties_are_valid()
+    function it_returns_an_empty_array_if_all_the_measurement_family_properties_are_valid()
     {
         $measurementFamily = [
-            'code'               => 'custom_metric_1',
-            'labels'             =>
+            'code' => 'custom_metric_1',
+            'labels' =>
                 [
                     'en_US' => 'Custom measurement 1',
                     'fr_FR' => 'Mesure personalisée 1',
                 ],
             'standard_unit_code' => 'CUSTOM_UNIT_1_1',
-            'units'              =>
+            'units' =>
                 [
-                    [
-                        'code'                  => 'CUSTOM_UNIT_1_1',
-                        'labels'                =>
+                    'CUSTOM_UNIT_1_1' => [
+                        'code' => 'CUSTOM_UNIT_1_1',
+                        'labels' =>
                             [
                                 'en_US' => 'Custom unit 1_1',
                                 'fr_FR' => 'Unité personalisée 1_1',
@@ -58,14 +58,14 @@ class MeasurementFamilyValidatorSpec extends ObjectBehavior
                             [
                                 [
                                     'operator' => 'mul',
-                                    'value'    => '0.000001',
+                                    'value' => '0.000001',
                                 ],
                             ],
-                        'symbol'                => 'mm²',
+                        'symbol' => 'mm²',
                     ],
                     [
-                        'code'                  => 'CUSTOM_UNIT_2_1',
-                        'labels'                =>
+                        'code' => 'CUSTOM_UNIT_2_1',
+                        'labels' =>
                             [
                                 'en_US' => 'Custom unit 2_1',
                                 'fr_FR' => 'Unité personalisée 2_1',
@@ -74,10 +74,10 @@ class MeasurementFamilyValidatorSpec extends ObjectBehavior
                             [
                                 [
                                     'operator' => 'mul',
-                                    'value'    => '0.0001',
+                                    'value' => '0.0001',
                                 ],
                             ],
-                        'symbol'                => 'cm²',
+                        'symbol' => 'cm²',
                     ],
                 ],
         ];

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/CreateMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/CreateMeasurementFamilyTest.php
@@ -1,0 +1,670 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\tests\Acceptance;
+
+use Akeneo\Test\Acceptance\Attribute\InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub;
+use Akeneo\Test\Acceptance\MeasurementFamily\InMemoryMeasurementFamilyRepository;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyHandler;
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class CreateMeasurementFamilyTest extends AcceptanceTestCase
+{
+    /** * @var ValidatorInterface */
+    private $validator;
+
+    /** @var InMemoryMeasurementFamilyRepository */
+    private $measurementFamilyRepository;
+
+    /** @var CreateMeasurementFamilyHandler */
+    private $createMeasurementFamilyHandler;
+
+    /** @var InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub */
+    private $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = $this->get('validator');
+        $this->measurementFamilyRepository = $this->get('akeneo_measure.persistence.measurement_family_repository');
+        $this->measurementFamilyRepository->clear();
+        $this->createMeasurementFamilyHandler = $this->get('akeneo_measure.application.create_measurement_family_handler');
+        $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily = $this->get('akeneo.pim.structure.query.is_there_at_least_one_attribute_configured_with_measurement_family');
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_measurement_family(): void
+    {
+        $measurementFamilyCode = 'weight';
+        $measurementFamilyLabels = ['fr_FR' => 'Poids', 'en_US' => 'Weight'];
+        // kilogram unit
+        $kilogramUnitCode = 'kilogram';
+        $kilogramLabels = ['fr_FR' => 'kilogramme', 'en_US' => 'Kilogram'];
+        $kilogramConversion = ['operator' => 'mul', 'value' => '1'];
+        $kilogramSymbol = 'Km';
+        // gram unit
+        $gramUnitCode = 'gram';
+        $gramLabels = ['fr_FR' => 'Gramme', 'en_US' => 'Gram'];
+        $gramConversion = ['operator' => 'mul', 'value' => '0.001'];
+        $gramSymbol = 'g';
+        //command
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = $measurementFamilyCode;
+        $saveFamilyCommand->labels = $measurementFamilyLabels;
+        $saveFamilyCommand->standardUnitCode = $kilogramUnitCode;
+        $saveFamilyCommand->units = [
+            [
+                'code' => $kilogramUnitCode,
+                'labels' => $kilogramLabels,
+                'convert_from_standard' => [$kilogramConversion],
+                'symbol' => $kilogramSymbol
+            ],
+            [
+                'code' => $gramUnitCode,
+                'labels' => $gramLabels,
+                'convert_from_standard' => [$gramConversion],
+                'symbol' => $gramSymbol
+            ]
+        ];
+        $this->assertMeasurementFamilyDoesNotExists($measurementFamilyCode);
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+        $this->createMeasurementFamilyHandler->handle($saveFamilyCommand);
+
+        self::assertEquals(0, $violations->count());
+        $expectedMeasurementFamily = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString($measurementFamilyCode),
+            LabelCollection::fromArray($measurementFamilyLabels),
+            UnitCode::fromString($kilogramUnitCode),
+            [
+                Unit::create(
+                    UnitCode::fromString($kilogramUnitCode),
+                    LabelCollection::fromArray($kilogramLabels),
+                    [Operation::create($kilogramConversion['operator'], $kilogramConversion['value'])],
+                    $kilogramSymbol
+                ),
+                Unit::create(
+                    UnitCode::fromString($gramUnitCode),
+                    LabelCollection::fromArray($gramLabels),
+                    [Operation::create($gramConversion['operator'], $gramConversion['value'])],
+                    $gramSymbol
+                )
+            ]
+        );
+        $actualMeasurementFamily = $this->measurementFamilyRepository->getByCode(
+            MeasurementFamilyCode::fromString($measurementFamilyCode)
+        );
+        $this->assertEquals($expectedMeasurementFamily, $actualMeasurementFamily);
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_update_an_existing_measurement_family(): void
+    {
+        $measurementFamilyCode = 'weight';
+        $standardUnitCode = 'KILOGRAM';
+        $this->createMeasurementFamilyWithUnitsAndStandardUnit(
+            $measurementFamilyCode,
+            [$standardUnitCode],
+            $standardUnitCode
+        );
+
+        // ton
+        $updatedMeasurementFamilyLabel = ['fr_FR' => 'Another LABEL'];
+        $tonUnitCode = 'ton';
+        $tonLabels = ['fr_FR' => 'Tonne', 'en_US' => 'Ton'];
+        $tonConversionOperator = ['operator' => 'mul', 'value' => '1'];
+        $tonSymbol = 'T';
+        //command
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = $measurementFamilyCode;
+        $saveFamilyCommand->labels = $updatedMeasurementFamilyLabel;
+        $saveFamilyCommand->standardUnitCode = $standardUnitCode;
+        $saveFamilyCommand->units = [
+            [
+                'code' => $standardUnitCode,
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '1']],
+                'symbol' => 'kg'
+            ],
+            [
+                'code' => $tonUnitCode,
+                'labels' => $tonLabels,
+                'convert_from_standard' => [$tonConversionOperator],
+                'symbol' => $tonSymbol
+            ],
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+        $this->createMeasurementFamilyHandler->handle($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_create_if_the_standard_unit_code_operation_is_not_mul_1(): void
+    {
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = 'KILOGRAM';
+        $saveFamilyCommand->units = [
+            [
+                'code'                  => 'KILOGRAM',
+                'labels'                => ['fr_FR' => 'Kilogrammes'],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '0.1']],
+                'symbol' => 'kg'
+            ]
+        ];
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals('The standard unit code of the "WEIGHT" measurement family should be a multiply-by-1 operation', $violation->getMessage());
+        self::assertEquals('units[0].convert_from_standard', $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidCodes
+     */
+    public function it_has_an_invalid_code($invalidCode, string $expectedErrorMessage): void
+    {
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = $invalidCode;
+        $saveFamilyCommand->standardUnitCode = 'kilogram';
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '153']],
+                'symbol' => 'Km'
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals($expectedErrorMessage, $violation->getMessage());
+        self::assertEquals('code', $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidLabels
+     */
+    public function it_has_an_invalid_label($invalidLabels, string $expectedErrorMessage): void
+    {
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = $invalidLabels;
+        $saveFamilyCommand->standardUnitCode = 'kilogram';
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '1']],
+                'symbol' => 'Km'
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals($expectedErrorMessage, $violation->getMessage());
+        self::assertEquals('labels', $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_specify_a_standard_unit_code(): void
+    {
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '153']],
+                'symbol' => 'Km'
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals('The standard unit is required.', $violation->getMessage());
+        self::assertEquals('standard_unit_code', $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_standard_unit_which_is_not_a_unit_of_the_measurement_family(): void
+    {
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = 'invalid_standard_unit_code';
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '153']],
+                'symbol' => 'Km'
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals(
+            'The "invalid_standard_unit_code" standard unit code does not exist in the list of units for the "WEIGHT" measurement family.',
+            $violation->getMessage()
+        );
+        self::assertEquals('standard_unit_code', $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidCodes
+     */
+    public function it_has_a_unit_with_an_invalid_code($invalidCode, string $expectedErrorMessage): void
+    {
+        $expectedPropertyPath = 'units[0][code]';
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = $invalidCode;
+        $saveFamilyCommand->units = [
+            [
+                'code' => $invalidCode,
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '153']],
+                'symbol' => 'Km'
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+        $actualViolation = null;
+        foreach ($violations as $violation) {
+            if ($violation->getMessage() === $expectedErrorMessage) {
+                $actualViolation = $violation;
+            }
+        }
+        self::assertNotNull(
+            $actualViolation,
+            sprintf('Expected to have a violation with message "%s" at path "%s"', $expectedErrorMessage, $expectedPropertyPath)
+        );
+        self::assertEquals($expectedErrorMessage, $violation->getMessage());
+        self::assertEquals($expectedPropertyPath, $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidLabels
+     */
+    public function it_has_a_unit_with_an_invalid_label($invalidLabels, string $expectedErrorMessage): void
+    {
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = 'kilogram';
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => $invalidLabels,
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '153']],
+                'symbol' => 'Km'
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals($expectedErrorMessage, $violation->getMessage());
+        self::assertEquals('units[0][labels]', $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidOperator
+     */
+    public function it_has_a_unit_with_an_invalid_convert_operator($invalidOperator, string $expectedErrorMessage): void
+    {
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = 'kilogram';
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => [],
+                'convert_from_standard' => [['operator' => $invalidOperator, 'value' => '251']],
+                'symbol' => 'Km'
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals($expectedErrorMessage, $violation->getMessage());
+        self::assertEquals('units[0][convert_from_standard][0][operator]', $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidConvertValue
+     */
+    public function it_has_a_unit_with_an_invalid_convert_value($invalidConvertValue, string $expectedErrorMessage): void
+    {
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = 'kilogram';
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => $invalidConvertValue]],
+                'symbol' => 'Km'
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals($expectedErrorMessage, $violation->getMessage());
+        self::assertEquals('units[0][convert_from_standard][0][value]', $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidUnitSymbol
+     */
+    public function it_has_a_unit_with_an_invalid_unit_symbol($invalidUnitSymbol, string $expectedErrorMessage): void
+    {
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = 'kilogram';
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '255']],
+                'symbol' => $invalidUnitSymbol
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals($expectedErrorMessage, $violation->getMessage());
+        self::assertEquals('units[0][symbol]', $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidOperationCount
+     */
+    public function it_has_an_invalid_amount_of_operations($invalidOperationCount, string $expectedErrorMessage): void
+    {
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = 'kilogram';
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => [],
+                'convert_from_standard' => array_fill(0, $invalidOperationCount, ['operator' => 'mul', 'value' => '1']),
+                'symbol' => 'Kg',
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals($expectedErrorMessage, $violation->getMessage());
+        self::assertEquals('units[0][convert_from_standard]', $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidUnitCount
+     */
+    public function it_has_an_invalid_amount_of_units($numberOfUnits, string $expectedErrorMessage): void
+    {
+        $expectedPropertyPath = 'units';
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = 0 === $numberOfUnits ? '' : 'unit_0';
+        $saveFamilyCommand->units = 0 === $numberOfUnits ? [] : array_map(function ($i) {
+            return [
+                'code' => sprintf('unit_%d', $i),
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '1']],
+                'symbol' => 'Kg',
+            ];
+        }, range(0, $numberOfUnits - 1));
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        $actualViolation = null;
+        foreach ($violations as $violation) {
+            if ($violation->getMessage() === $expectedErrorMessage) {
+                $actualViolation = $violation;
+            }
+        }
+        self::assertNotNull(
+            $actualViolation,
+            sprintf('Expected to have a violation with message "%s" at path "%s"', $expectedErrorMessage, $expectedPropertyPath)
+        );
+        self::assertEquals($expectedErrorMessage, $violation->getMessage());
+        self::assertEquals($expectedPropertyPath, $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_create_too_many_measurement_families(): void
+    {
+        for ($i = 0; $i < 100; $i++) {
+            $measurementFamily = MeasurementFamily::create(
+                MeasurementFamilyCode::fromString(sprintf('unit_%d', $i)),
+                LabelCollection::fromArray(['en_US' => 'Custom measurement']),
+                UnitCode::fromString(sprintf('UNIT_%d', $i)),
+                [
+                    Unit::create(
+                        UnitCode::fromString(sprintf('UNIT_%d', $i)),
+                        LabelCollection::fromArray(['en_US' => 'Custom unit']),
+                        [Operation::create('mul', '1')],
+                        'mm²',
+                    ),
+                ]
+            );
+
+            $this->measurementFamilyRepository->save($measurementFamily);
+        }
+
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = 'kilogram';
+        $saveFamilyCommand->units = [
+            [
+                'code' => 'kilogram',
+                'labels' => [],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '1']],
+                'symbol' => 'Kg',
+            ]
+        ];
+
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals('You’ve reached the limit of 100 measurement families.', $violation->getMessage());
+        self::assertEquals('', $violation->getPropertyPath());
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_have_the_same_unit_code_twice(): void
+    {
+        $saveFamilyCommand = new CreateMeasurementFamilyCommand();
+        $saveFamilyCommand->code = 'WEIGHT';
+        $saveFamilyCommand->labels = [];
+        $saveFamilyCommand->standardUnitCode = 'KILOGRAM';
+        $saveFamilyCommand->units = [
+            [
+                'code'                  => 'KILOGRAM',
+                'labels'                => ['fr_FR' => 'Kilogramme'],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '1']],
+                'symbol' => 'km'
+            ],
+            [
+                'code'                  => 'KILOGRAM',
+                'labels'                => ['fr_FR' => 'New Kilogramme'],
+                'convert_from_standard' => [['operator' => 'mul', 'value' => '0.000001']],
+                'symbol' => 'km'
+            ],
+        ];
+        $violations = $this->validator->validate($saveFamilyCommand);
+
+        self::assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        self::assertEquals('We found some duplicated units in the measurement family. The measurement family requires unique units.', $violation->getMessage());
+        self::assertEquals('units', $violation->getPropertyPath());
+    }
+
+    public function invalidCodes(): array
+    {
+        return [
+            'Should not be too long' => [
+                str_repeat('a', 256),
+                'This value is too long. It should have 255 characters or less.'
+            ],
+            'Should not blank' => [null, 'This value should not be blank.'],
+            'Should not a string' => [123, 'This value should be of type string.'],
+            'Should not have unsupported character' => ['--nice-', 'This field can only contain letters, numbers, and underscores.']
+        ];
+    }
+
+    public function invalidLabels(): array
+    {
+        return [
+            'Locale code should be a string' => [[123 => 'my label'], 'This value should be of type string.'],
+            'Locale code cannot be too long' => [[str_repeat('a', 101) => 'my label'], 'This value is too long. It should have 100 characters or less.'],
+            'Label should be a string' => [['fr_FR' => 12], 'This value should be of type string.'],
+            'Label cannot be too long' => [['fr_FR' => str_repeat('a', 101)], 'This value is too long. It should have 100 characters or less.']
+        ];
+    }
+
+    public function invalidOperator(): array
+    {
+        return [
+            'Operator cannot be blank' => [null, 'This value should not be blank.'],
+            'Operator is not supported' => ['invalid_operator', 'The "invalid_operator" operator is invalid, please use "mul", "div", "add", "sub" instead.'],
+        ];
+    }
+
+    public function invalidConvertValue(): array
+    {
+        return [
+            'The convert value is not a valid number represented as a string' => ['1.24adv', 'The conversion value should be a number represented in a string (example: "0.2561")']
+        ];
+    }
+
+    public function invalidUnitSymbol()
+    {
+        return [
+            'Should not be too long' => [str_repeat('a', 256), 'This value is too long. It should have 255 characters or less.'],
+            'Should be a string' => [123, 'This value should be of type string.'],
+        ];
+    }
+
+    private function assertThereIsAProductAttributeLinkedToThisMeasurementFamily(): void
+    {
+        $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily->setStub(true);
+    }
+
+    private function createMeasurementFamilyWithUnitsAndStandardUnit(string $measurementFamilyCode, array $unitCodes, string $standardUnitCode): void
+    {
+        $this->measurementFamilyRepository->save(
+            MeasurementFamily::create(
+                MeasurementFamilyCode::fromString($measurementFamilyCode),
+                LabelCollection::fromArray([]),
+                UnitCode::fromString($standardUnitCode),
+                array_map(function (string $unitCode) {
+                    return Unit::create(
+                        UnitCode::fromString($unitCode),
+                        LabelCollection::fromArray([]),
+                        [
+                            Operation::create("mul", "1"),
+                        ],
+                        "km",
+                        );
+                }, $unitCodes)
+            )
+        );
+    }
+
+    public function invalidOperationCount()
+    {
+        return [
+            'Should have at least one operation' => [0, 'A minimum of one conversion operation per unit is required.'],
+            'Should have max 5 operations' => [6, 'You’ve reached the limit of 5 conversion operations per unit.'],
+        ];
+    }
+
+    public function invalidUnitCount()
+    {
+        return [
+            'Should have at least one operation' => [0, 'There should be at least 1 unit in the measurement family.'],
+            'Cannot have more than 50 operations' => [51, 'You’ve reached the limit of 50 conversion operations per unit.'],
+        ];
+    }
+
+    private function assertMeasurementFamilyDoesNotExists(string $measurementFamilyCode): void
+    {
+        try {
+            $this->measurementFamilyRepository->getByCode(MeasurementFamilyCode::fromString($measurementFamilyCode));
+        } catch (MeasurementFamilyNotFoundException $e) {
+            return;
+        }
+
+        self::assertTrue(
+            false,
+            sprintf('Measurement family "%s" exists, expected not to exist', $measurementFamilyCode)
+        );
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/SaveMeasurementFamiliesActionEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/SaveMeasurementFamiliesActionEndToEnd.php
@@ -27,27 +27,318 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
     /**
      * @test
      */
-    public function it_creates_multiple_measurement_families()
+    public function it_create_a_measurement_family_when_it_does_not_exists()
     {
-        $multipleMeasurementFamilies = [
-            $this->measurementFamily1()->normalize(),
-            $this->measurementFamily2()->normalize()
-        ];
-        $client = $this->createAuthenticatedClient();
-
-        $client->request(
-            'PATCH',
-            'api/rest/v1/measurement-families',
-            [],
-            [],
-            [],
-            json_encode($multipleMeasurementFamilies)
+        $measurementFamily = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('custom_metric_1'),
+            LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
+            UnitCode::fromString('CUSTOM_UNIT_1_1'),
+            [
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
+                    [Operation::create('mul', '1')],
+                    'mm²'
+                ),
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_2_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
+                    [Operation::create('mul', '0.0001')],
+                    'cm²'
+                )
+            ]
         );
 
-        $response = $client->getResponse();
+        $response = $this->request([$this->normalizeExternal($measurementFamily)]);
+
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertMeasurementFamilyHasBeenCreated($this->measurementFamily1());
-        $this->assertMeasurementFamilyHasBeenCreated($this->measurementFamily2());
+        $this->assertSame([['code' => 'custom_metric_1', 'status_code' => 201]], json_decode($response->getContent(), true));
+        $this->assertMeasurementFamilyIsPersisted($measurementFamily);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_when_the_measurement_family_does_not_have_a_code()
+    {
+        $response = $this->request([
+            [
+                'labels' => [
+                    'es_ES' => 'Embalaje',
+                    'fi_FI' => 'Pakkaus',
+                    'fr_FR' => 'Emballage',
+                ],
+            ]
+        ]);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame([[
+            'code' => '',
+            'status_code' => 422,
+            'message' => 'The measurement family has an invalid format.',
+            'errors' => [[
+                'property' => 'code',
+                'message' => 'The property code is required',
+            ]],
+        ]], json_decode($response->getContent(), true));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_nothing_when_the_measurement_family_already_exists_and_is_exactly_the_same()
+    {
+        $measurementFamily = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('custom_metric_1'),
+            LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
+            UnitCode::fromString('CUSTOM_UNIT_1_1'),
+            [
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
+                    [Operation::create('mul', '1')],
+                    'mm²'
+                ),
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_2_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
+                    [Operation::create('mul', '0.0001')],
+                    'cm²'
+                )
+            ]
+        );
+
+        $this->measurementFamilyRepository->save($measurementFamily);
+
+        $response = $this->request([$this->normalizeExternal($measurementFamily)]);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame([['code' => 'custom_metric_1', 'status_code' => 204]], json_decode($response->getContent(), true));
+        $this->assertMeasurementFamilyIsPersisted($measurementFamily);
+    }
+
+    /**
+     * @test
+     */
+    public function it_add_an_unit_when_it_does_not_exist()
+    {
+        $measurementFamily = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('custom_metric_1'),
+            LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
+            UnitCode::fromString('CUSTOM_UNIT_1_1'),
+            [
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
+                    [Operation::create('mul', '1')],
+                    'mm²'
+                ),
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_2_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
+                    [Operation::create('mul', '0.0001')],
+                    'cm²'
+                )
+            ]
+        );
+
+        $this->measurementFamilyRepository->save($measurementFamily);
+
+        $response = $this->request([
+            [
+                'code' => 'custom_metric_1',
+                'units' => [
+                    'code' => 'CUSTOM_UNIT_3_1',
+                    'labels' => [
+                        'ca_ES' => 'Centímetre quadrat'
+                    ],
+                    'convert_from_standard' => [
+                        [
+                            'operator' => 'mul',
+                            'value' => '0.00001'
+                        ]
+                    ],
+                    'symbol' => 'km²'
+                ],
+            ]
+        ]);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame([['code' => 'custom_metric_1', 'status_code' => 204]], json_decode($response->getContent(), true));
+        $this->assertMeasurementFamilyIsPersisted(MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('custom_metric_1'),
+            LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
+            UnitCode::fromString('CUSTOM_UNIT_1_1'),
+            [
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
+                    [Operation::create('mul', '1')],
+                    'mm²'
+                ),
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_2_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
+                    [Operation::create('mul', '0.0001')],
+                    'cm²'
+                ),
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_3_1'),
+                    LabelCollection::fromArray(['ca_ES' => 'Centímetre quadrat']),
+                    [Operation::create('mul', '0.00001')],
+                    'km²'
+                )
+            ]
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_add_a_label_translation()
+    {
+        $measurementFamily = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('custom_metric_1'),
+            LabelCollection::fromArray(['en_US' => 'Custom measurement 1']),
+            UnitCode::fromString('CUSTOM_UNIT_1_1'),
+            [
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1']),
+                    [Operation::create('mul', '1')],
+                    'mm²'
+                ),
+            ]
+        );
+
+        $this->measurementFamilyRepository->save($measurementFamily);
+        $response = $this->request([
+            [
+                'code' => 'custom_metric_1',
+                'labels' => ['fr_FR' => 'Mesure personalisée 1'],
+            ]
+        ]);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame([['code' => 'custom_metric_1', 'status_code' => 204]], json_decode($response->getContent(), true));
+        $this->assertMeasurementFamilyIsPersisted(MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('custom_metric_1'),
+            LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
+            UnitCode::fromString('CUSTOM_UNIT_1_1'),
+            [
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1']),
+                    [Operation::create('mul', '1')],
+                    'mm²'
+                ),
+            ]
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_update_a_label_translation()
+    {
+        $measurementFamily = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('custom_metric_1'),
+            LabelCollection::fromArray(['en_US' => 'Custom measurement 1']),
+            UnitCode::fromString('CUSTOM_UNIT_1_1'),
+            [
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1']),
+                    [Operation::create('mul', '1')],
+                    'mm²'
+                ),
+            ]
+        );
+
+        $this->measurementFamilyRepository->save($measurementFamily);
+        $response = $this->request([
+            [
+                'code' => 'custom_metric_1',
+                'labels' => ['en_US' => 'Custom measurement 2'],
+            ]
+        ]);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame([['code' => 'custom_metric_1', 'status_code' => 204]], json_decode($response->getContent(), true));
+        $this->assertMeasurementFamilyIsPersisted(MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('custom_metric_1'),
+            LabelCollection::fromArray(['en_US' => 'Custom measurement 2']),
+            UnitCode::fromString('CUSTOM_UNIT_1_1'),
+            [
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1']),
+                    [Operation::create('mul', '1')],
+                    'mm²'
+                ),
+            ]
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_multiple_measurement_families()
+    {
+        $measurementFamilies = [
+            MeasurementFamily::create(
+                MeasurementFamilyCode::fromString('custom_metric_1'),
+                LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
+                UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                [
+                    Unit::create(
+                        UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                        LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
+                        [Operation::create('mul', '1')],
+                        'mm²'
+                    ),
+                    Unit::create(
+                        UnitCode::fromString('CUSTOM_UNIT_2_1'),
+                        LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
+                        [Operation::create('mul', '0.0001')],
+                        'cm²'
+                    )
+                ]
+            ),
+            MeasurementFamily::create(
+                MeasurementFamilyCode::fromString('custom_metric_2'),
+                LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
+                UnitCode::fromString('CUSTOM_UNIT_2_2'),
+                [
+                    Unit::create(
+                        UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                        LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
+                        [Operation::create('mul', '1')],
+                        'mm²'
+                    ),
+                    Unit::create(
+                        UnitCode::fromString('CUSTOM_UNIT_2_1'),
+                        LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
+                        [Operation::create('mul', '0.0001')],
+                        'cm²'
+                    )
+                ]
+            )
+        ];
+
+        $response = $this->request(array_map(function(MeasurementFamily $measurementFamily) {
+            return $measurementFamily->normalize();
+        }, $measurementFamilies));
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame([
+            ['code' => 'custom_metric_1', 'status_code' => 201],
+            ['code' => 'custom_metric_2', 'status_code' => 201]
+        ], json_decode($response->getContent(), true));
+
+        foreach ($measurementFamilies as $measurementFamily) {
+            $this->assertMeasurementFamilyIsPersisted($measurementFamily);
+        }
     }
 
     /**
@@ -55,106 +346,109 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
      */
     public function it_returns_an_error_when_the_measurement_family_list_does_not_have_the_right_structure()
     {
-        $invalidMeasurementFamilyStructure = [
-            'values' => null,
-        ];
-        $client = $this->createAuthenticatedClient();
+        $response = $this->request(['values' => null]);
 
-        $client->request(
-            'PATCH',
-            'api/rest/v1/measurement-families',
-            [],
-            [],
-            [],
-            json_encode($invalidMeasurementFamilyStructure)
-        );
-
-        $response = $client->getResponse();
         $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
-        $responseBody = json_decode($response->getContent(), true);
-        $this->assertEquals(400, $responseBody['code']);
-        $this->assertEquals('The list of measurement families has an invalid format.', $responseBody['message']);
+        $this->assertSame(
+            [
+                'code' => 400,
+                'message' => 'The list of measurement families has an invalid format.',
+                'errors' => [
+                    [
+                        'property' => '',
+                        'message' => 'Object value found, but an array is required',
+                    ],
+                ]
+            ], json_decode($response->getContent(), true)
+        );
     }
 
     /**
      * @test
      */
-    public function it_returns_an_error_when_the_measurement_family_measurement_does_not_have_the_right_structure()
+    public function it_returns_an_error_when_the_measurement_family_creation_does_not_have_the_right_structure()
     {
-        $invalidMeasurementFamilyStructure = [
+        $response = $this->request([
             [
-                'code'               => 'custom_metric_1',
-                'standard_unit_code' => 'CUSTOM_UNIT_1_1',
-                'units'              =>
-                    [
-                        [
-                            'code'                  => 'CUSTOM_UNIT_1_1',
-                            'labels'                =>
-                                [
-                                    'en_US' => 'Custom unit 1_1',
-                                    'fr_FR' => 'Unité personalisée 1_1',
-                                ],
-                            'convert_from_standard' =>
-                                [
-                                    [
-                                        'operator' => 'mul',
-                                        'value'    => '0.000001',
-                                    ],
-                                ],
-                            'symbol'                => 'mm²',
-                        ],
-                        [
-                            'code'                  => 'CUSTOM_UNIT_2_1',
-                            'labels'                =>
-                                [
-                                    'en_US' => 'Custom unit 2_1',
-                                    'fr_FR' => 'Unité personalisée 2_1',
-                                ],
-                            'convert_from_standard' =>
-                                [
-                                    [
-                                        'operator' => 'mul',
-                                        'value'    => '0.0001',
-                                    ],
-                                ],
-                            'symbol'                => 'cm²',
-                        ],
-                    ],
+                'code' => 'custom_metric_1',
             ]
-        ];
-        $client = $this->createAuthenticatedClient();
+        ]);
 
-        $client->request(
-            'PATCH',
-            'api/rest/v1/measurement-families',
-            [],
-            [],
-            [],
-            json_encode($invalidMeasurementFamilyStructure)
-        );
-
-        $response = $client->getResponse();
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $responseBody = json_decode($response->getContent(), true);
-        $this->assertSame(
+        $this->assertSame([
             [
-                'code'        => 'custom_metric_1',
+                'code' => 'custom_metric_1',
                 'status_code' => 422,
-                'message'     => 'The measurement family has an invalid format.',
-                'errors'      =>
+                'message' => 'The measurement family has an invalid format.',
+                'errors' =>
                     [
                         [
                             'property' => 'labels',
-                            'message'  => 'The property labels is required',
+                            'message' => 'The property labels is required',
+                        ],
+                        [
+                            'property' => 'units',
+                            'message' => 'The property units is required',
+                        ],
+                        [
+                            'property' => 'standard_unit_code',
+                            'message' => 'The property standard_unit_code is required',
                         ],
                     ],
-            ],
-            current($responseBody)
-        );
+            ]
+        ], json_decode($response->getContent(), true));
     }
 
-    // Add spec - Add check the maximum resources to process does not exceed the limit
-    // Add test - Add check if the validator throws a violation http exception
+    /**
+     * @test
+     */
+    public function it_returns_an_error_when_the_measurement_family_update_does_not_have_the_right_structure()
+    {
+        $measurementFamily = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('custom_metric_1'),
+            LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
+            UnitCode::fromString('CUSTOM_UNIT_1_1'),
+            [
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
+                    [Operation::create('mul', '1')],
+                    'mm²'
+                ),
+                Unit::create(
+                    UnitCode::fromString('CUSTOM_UNIT_2_1'),
+                    LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
+                    [Operation::create('mul', '0.0001')],
+                    'cm²'
+                )
+            ]
+        );
+
+        $this->measurementFamilyRepository->save($measurementFamily);
+
+        $response = $this->request([
+            [
+                'code' => 'custom_metric_1',
+                'foo' => 'bar'
+            ]
+        ]);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame([
+            [
+                'code' => 'custom_metric_1',
+                'status_code' => 422,
+                'message' => 'The measurement family has an invalid format.',
+                'errors' =>
+                    [
+                        [
+                            'property' => '',
+                            'message' => 'The property foo is not defined and the definition does not allow additional properties',
+                        ],
+                    ],
+            ]
+        ], json_decode($response->getContent(), true));
+    }
 
     /**
      * {@inheritdoc}
@@ -164,55 +458,34 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
         return $this->catalog->useTechnicalCatalog();
     }
 
-    private function measurementFamily1(): MeasurementFamily
+    private function normalizeExternal(MeasurementFamily $measurementFamily): array
     {
-        return MeasurementFamily::create(
-            MeasurementFamilyCode::fromString('custom_metric_1'),
+        $normalizedMeasurementFamily = $measurementFamily->normalize();
+        $normalizedMeasurementFamily['units'] = array_reduce($normalizedMeasurementFamily['units'], function ($indexedUnit, $unit) {
+            $indexedUnit[$unit['code']] = $unit;
+            return $indexedUnit;
+        }, []);
 
-            LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
-            UnitCode::fromString('CUSTOM_UNIT_1_1'),
-            [
-                Unit::create(
-                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
-                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
-                    [Operation::create('mul', '1')],
-                    'mm²',
-                    ),
-                Unit::create(
-                    UnitCode::fromString('CUSTOM_UNIT_2_1'),
-                    LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
-                    [Operation::create('mul', '0.0001')],
-                    'cm²',
-                    )
-            ],
-            );
+        return $normalizedMeasurementFamily;
     }
 
-    private function measurementFamily2(): MeasurementFamily
+    private function request(array $measurementFamilies): Response
     {
-        return MeasurementFamily::create(
-            MeasurementFamilyCode::fromString('custom_measurement_2'),
+        $client = $this->createAuthenticatedClient();
 
-            LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
-            UnitCode::fromString('CUSTOM_UNIT_1_1'),
-            [
-                Unit::create(
-                    UnitCode::fromString('CUSTOM_UNIT_1_1'),
-                    LabelCollection::fromArray(['en_US' => 'Custom unit 1_1', 'fr_FR' => 'Unité personalisée 1_1']),
-                    [Operation::create('mul', '1')],
-                    'mm²',
-                    ),
-                Unit::create(
-                    UnitCode::fromString('CUSTOM_UNIT_2_1'),
-                    LabelCollection::fromArray(['en_US' => 'Custom unit 2_1', 'fr_FR' => 'Unité personalisée 2_1']),
-                    [Operation::create('mul', '0.0001')],
-                    'cm²',
-                    )
-            ]
+        $client->request(
+            'PATCH',
+            'api/rest/v1/measurement-families',
+            [],
+            [],
+            [],
+            json_encode($measurementFamilies)
         );
+
+        return $client->getResponse();
     }
 
-    private function assertMeasurementFamilyHasBeenCreated(MeasurementFamily $expected): void
+    private function assertMeasurementFamilyIsPersisted(MeasurementFamily $expected): void
     {
         $measurementFamilyCode = MeasurementFamilyCode::fromString($expected->normalize()['code']);
         $actual = $this->measurementFamilyRepository->getByCode($measurementFamilyCode);

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/SaveMeasurementFamiliesActionEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/SaveMeasurementFamiliesActionEndToEnd.php
@@ -52,7 +52,9 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
         $response = $this->request([$this->normalizeExternal($measurementFamily)]);
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertSame([['code' => 'custom_metric_1', 'status_code' => 201]], json_decode($response->getContent(), true));
+        $this->assertSame([
+            ['code' => 'custom_metric_1', 'status_code' => 201],
+        ], json_decode($response->getContent(), true));
         $this->assertMeasurementFamilyIsPersisted($measurementFamily);
     }
 
@@ -72,15 +74,19 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
         ]);
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertSame([[
-            'code' => '',
-            'status_code' => 422,
-            'message' => 'The measurement family has an invalid format.',
-            'errors' => [[
-                'property' => 'code',
-                'message' => 'The property code is required',
-            ]],
-        ]], json_decode($response->getContent(), true));
+        $this->assertSame([
+            [
+                'code' => '',
+                'status_code' => 422,
+                'message' => 'The measurement family has an invalid format.',
+                'errors' => [
+                    [
+                        'property' => 'code',
+                        'message' => 'The property code is required',
+                    ]
+                ],
+            ]
+        ], json_decode($response->getContent(), true));
     }
 
     /**
@@ -113,7 +119,9 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
         $response = $this->request([$this->normalizeExternal($measurementFamily)]);
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertSame([['code' => 'custom_metric_1', 'status_code' => 204]], json_decode($response->getContent(), true));
+        $this->assertSame([
+            ['code' => 'custom_metric_1', 'status_code' => 204],
+        ], json_decode($response->getContent(), true));
         $this->assertMeasurementFamilyIsPersisted($measurementFamily);
     }
 
@@ -164,7 +172,9 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
         ]);
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertSame([['code' => 'custom_metric_1', 'status_code' => 204]], json_decode($response->getContent(), true));
+        $this->assertSame([
+            ['code' => 'custom_metric_1', 'status_code' => 204],
+        ], json_decode($response->getContent(), true));
         $this->assertMeasurementFamilyIsPersisted(MeasurementFamily::create(
             MeasurementFamilyCode::fromString('custom_metric_1'),
             LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
@@ -220,7 +230,9 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
         ]);
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertSame([['code' => 'custom_metric_1', 'status_code' => 204]], json_decode($response->getContent(), true));
+        $this->assertSame([
+            ['code' => 'custom_metric_1', 'status_code' => 204],
+        ], json_decode($response->getContent(), true));
         $this->assertMeasurementFamilyIsPersisted(MeasurementFamily::create(
             MeasurementFamilyCode::fromString('custom_metric_1'),
             LabelCollection::fromArray(['en_US' => 'Custom measurement 1', 'fr_FR' => 'Mesure personalisée 1']),
@@ -264,7 +276,9 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
         ]);
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertSame([['code' => 'custom_metric_1', 'status_code' => 204]], json_decode($response->getContent(), true));
+        $this->assertSame([
+            ['code' => 'custom_metric_1', 'status_code' => 204],
+        ], json_decode($response->getContent(), true));
         $this->assertMeasurementFamilyIsPersisted(MeasurementFamily::create(
             MeasurementFamilyCode::fromString('custom_metric_1'),
             LabelCollection::fromArray(['en_US' => 'Custom measurement 2']),
@@ -326,14 +340,14 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
             )
         ];
 
-        $response = $this->request(array_map(function(MeasurementFamily $measurementFamily) {
+        $response = $this->request(array_map(function (MeasurementFamily $measurementFamily) {
             return $measurementFamily->normalize();
         }, $measurementFamilies));
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $this->assertSame([
             ['code' => 'custom_metric_1', 'status_code' => 201],
-            ['code' => 'custom_metric_2', 'status_code' => 201]
+            ['code' => 'custom_metric_2', 'status_code' => 201],
         ], json_decode($response->getContent(), true));
 
         foreach ($measurementFamilies as $measurementFamily) {
@@ -461,10 +475,11 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
     private function normalizeExternal(MeasurementFamily $measurementFamily): array
     {
         $normalizedMeasurementFamily = $measurementFamily->normalize();
-        $normalizedMeasurementFamily['units'] = array_reduce($normalizedMeasurementFamily['units'], function ($indexedUnit, $unit) {
-            $indexedUnit[$unit['code']] = $unit;
-            return $indexedUnit;
-        }, []);
+        $normalizedMeasurementFamily['units'] = array_reduce($normalizedMeasurementFamily['units'],
+            function ($indexedUnit, $unit) {
+                $indexedUnit[$unit['code']] = $unit;
+                return $indexedUnit;
+            }, []);
 
         return $normalizedMeasurementFamily;
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- We splitted the Validators that were applied to the command classes in their respective directories : `Validation/CreateMeasurementFamily` and `Validation/SaveMeasurementFamily` instead of only `Validation/MeasurementFamily`.
- We added the method `MeasurementFamily::normalizeWithIndexedUnits` into the model.
- We updated the Save controller to switch between a `CreateMeasurementFamilyCommand` and `SaveMeasurementFamilyCommand` depending on the request.
- The Save controller supports partial updates
- We rewrited the tests for the External API Save endpoint with the following use cases:
  - it_create_a_measurement_family_when_it_does_not_exists
  - it_returns_an_error_when_the_measurement_family_does_not_have_a_code
  - it_returns_an_error_when_the_units_are_not_correctly_indexed
  - it_does_nothing_when_the_measurement_family_already_exists_and_is_exactly_the_same
  - it_add_an_unit_when_it_does_not_exist
  - it_add_a_label_translation
  - it_update_a_label_translation
  - it_update_an_unit_operations
  - it_creates_multiple_measurement_families
  - it_returns_an_error_when_the_measurement_family_list_does_not_have_the_right_structure
  - it_returns_an_error_when_the_measurement_family_creation_does_not_have_the_right_structure
  - it_returns_an_error_when_the_measurement_family_update_does_not_have_the_right_structure

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
