### PR TITLE
MET-171: Redirect to newly created Measurement Family after creation

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/CreateMeasurementFamily.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/CreateMeasurementFamily.tsx
@@ -19,9 +19,10 @@ import {ValidationError, getErrorsForPath} from 'akeneomeasure/model/validation-
 import {useShortcut} from 'akeneomeasure/shared/hooks/use-shortcut';
 import {Key} from 'akeneomeasure/shared/key';
 import {useForm} from 'akeneomeasure/hooks/use-form';
+import {MeasurementFamilyCode} from 'akeneomeasure/model/measurement-family';
 
 type CreateMeasurementFamilyProps = {
-  onClose: () => void;
+  onClose: (createdMeasurementFamilyCode?: MeasurementFamilyCode) => void;
 };
 
 const CreateMeasurementFamily = ({onClose}: CreateMeasurementFamilyProps) => {
@@ -45,7 +46,7 @@ const CreateMeasurementFamily = ({onClose}: CreateMeasurementFamilyProps) => {
       switch (response.success) {
         case true:
           notify(NotificationLevel.SUCCESS, __('measurements.create_family.flash.success'));
-          handleClose();
+          handleClose(measurementFamily.code);
           break;
 
         case false:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/list/List.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/list/List.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useContext, useState} from 'react';
+import {useHistory} from 'react-router-dom';
 import {PageHeader, PageHeaderPlaceholder} from 'akeneomeasure/shared/components/PageHeader';
 import {PimView} from 'akeneomeasure/bridge/legacy/pim-view/PimView';
 import {Breadcrumb} from 'akeneomeasure/shared/components/Breadcrumb';
@@ -10,7 +11,11 @@ import {Link} from 'akeneomeasure/shared/components/Link';
 import {NoDataSection, NoDataTitle, NoDataText} from 'akeneomeasure/shared/components/NoData';
 import {useMeasurementFamilies} from 'akeneomeasure/hooks/use-measurement-families';
 import {SearchBar} from 'akeneomeasure/shared/components/SearchBar';
-import {sortMeasurementFamily, filterOnLabelOrCode} from 'akeneomeasure/model/measurement-family';
+import {
+  sortMeasurementFamily,
+  filterOnLabelOrCode,
+  MeasurementFamilyCode,
+} from 'akeneomeasure/model/measurement-family';
 import {UserContext} from 'akeneomeasure/context/user-context';
 import {MeasurementFamilyTable} from 'akeneomeasure/pages/list/MeasurementFamilyTable';
 import {Button} from 'akeneomeasure/shared/components/Button';
@@ -42,18 +47,22 @@ const useSorting = (
 const List = () => {
   const __ = useContext(TranslateContext);
   const isGranted = useContext(SecurityContext);
+  const locale = useContext(UserContext)('uiLocale');
+  const history = useHistory();
   const [searchValue, setSearchValue] = useState('');
   const [sortColumn, getSortDirection, toggleSortDirection] = useSorting('label');
-
-  const [measurementFamilies, fetchMeasurementFamilies] = useMeasurementFamilies();
-  const locale = useContext(UserContext)('uiLocale');
-
+  const [measurementFamilies] = useMeasurementFamilies();
   const [isCreateModalOpen, openCreateModal, closeCreateModal] = useToggleState(false);
 
-  const handleModalClose = useCallback(() => {
-    closeCreateModal();
-    fetchMeasurementFamilies();
-  }, [closeCreateModal, fetchMeasurementFamilies]);
+  const handleModalClose = useCallback(
+    (createdMeasurementFamilyCode?: MeasurementFamilyCode) => {
+      closeCreateModal();
+      if (undefined !== createdMeasurementFamilyCode) {
+        history.push(`/${createdMeasurementFamilyCode}`);
+      }
+    },
+    [closeCreateModal, history]
+  );
 
   const filteredMeasurementFamilies =
     null === measurementFamilies


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

We now redirect to the newly created Measurement Family after creating it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
