### PR TITLE
MET-172: reuse MeasurementFamily::normalizeWithIndexedUnits

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/GetMeasurementFamiliesAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/GetMeasurementFamiliesAction.php
@@ -36,15 +36,9 @@ class GetMeasurementFamiliesAction
     {
         $normalizedMeasurementFamilies = [];
 
-        /** @var MeasurementFamily */
+        /** @var MeasurementFamily $measurementFamily */
         foreach ($measurementFamilies as $measurementFamily) {
-            $normalizedMeasurementFamily = $measurementFamily->normalize();
-            $normalizedMeasurementFamily['units'] = array_reduce($normalizedMeasurementFamily['units'], function ($indexedUnit, $unit) {
-                $indexedUnit[$unit['code']] = $unit;
-
-                return $indexedUnit;
-            }, []);
-            $normalizedMeasurementFamilies[] = $normalizedMeasurementFamily;
+            $normalizedMeasurementFamilies[] = $measurementFamily->normalizeWithIndexedUnits();
         }
 
         return $normalizedMeasurementFamilies;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/GetMeasurementFamiliesAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/GetMeasurementFamiliesAction.php
@@ -27,20 +27,10 @@ class GetMeasurementFamiliesAction
     public function __invoke(): JsonResponse
     {
         $measurementFamilies = $this->measurementFamilyRepository->all();
-        $normalizedMeasurementFamilies = $this->normalizeMeasurementFamilies($measurementFamilies);
+        $normalizedMeasurementFamilies = array_map(function (MeasurementFamily $measurementFamily) {
+            return $measurementFamily->normalizeWithIndexedUnits();
+        }, $measurementFamilies);
 
         return new JsonResponse($normalizedMeasurementFamilies);
-    }
-
-    private function normalizeMeasurementFamilies(array $measurementFamilies): array
-    {
-        $normalizedMeasurementFamilies = [];
-
-        /** @var MeasurementFamily $measurementFamily */
-        foreach ($measurementFamilies as $measurementFamily) {
-            $normalizedMeasurementFamilies[] = $measurementFamily->normalizeWithIndexedUnits();
-        }
-
-        return $normalizedMeasurementFamilies;
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Harmonize the GET controller with the new method added in MET-137.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

