### PR TITLE
MET-176: fix: do not allow scientific notation

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Model/Operation.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Model/Operation.php
@@ -26,7 +26,11 @@ final class Operation
     private function __construct(string $operator, string $value)
     {
         Assert::oneOf($operator, self::SUPPORTED_OPERATORS);
-        Assert::numeric($value);
+        Assert::regex(
+            $value,
+            '~^[0-9]*\.?[0-9]+$~',
+            sprintf('Expecting operation value to be a numeric, %s given', $value)
+        );
 
         $this->operator = $operator;
         $this->value = $value;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Model/Operation.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Model/Operation.php
@@ -29,7 +29,7 @@ final class Operation
         Assert::regex(
             $value,
             '~^[0-9]*\.?[0-9]+$~',
-            sprintf('Expecting operation value to be a numeric, %s given', $value)
+            sprintf('Expecting operation value to be a numeric, "%s" given', $value)
         );
 
         $this->operator = $operator;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Tool\Bundle\MeasureBundle\Persistence;
 
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValueValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValueValidator.php
@@ -20,7 +20,7 @@ class OperationValueValidator extends ConstraintValidator
             [
                 new NotBlank(),
                 new Callback(
-                    function ($value, ExecutionContextInterface $context, $payload) {
+                    function ($value, ExecutionContextInterface $context) {
                         if (null !== $value && '' !== $value && !$this->isStringNumericWithoutScientificNotation($value)) {
                             $context->buildViolation(OperationValue::VALUE_SHOULD_BE_A_NUMBER_IN_A_STRING)
                                 ->addViolation();

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValueValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValueValidator.php
@@ -20,8 +20,8 @@ class OperationValueValidator extends ConstraintValidator
             [
                 new NotBlank(),
                 new Callback(
-                    function ($value, ExecutionContextInterface $context) {
-                        if (null !== $value && '' !== $value && !is_numeric($value)) {
+                    function ($value, ExecutionContextInterface $context, $payload) {
+                        if (null !== $value && '' !== $value && !$this->isStringNumericWithoutScientificNotation($value)) {
                             $context->buildViolation(OperationValue::VALUE_SHOULD_BE_A_NUMBER_IN_A_STRING)
                                 ->addViolation();
                         }
@@ -39,5 +39,10 @@ class OperationValueValidator extends ConstraintValidator
                 );
             }
         }
+    }
+
+    private function isStringNumericWithoutScientificNotation($value)
+    {
+        return is_string($value) && preg_match('~^[0-9]*\.?[0-9]+$~', $value) === 1;
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Model/OperationSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Model/OperationSpec.php
@@ -43,4 +43,10 @@ class OperationSpec extends ObjectBehavior
             ->during('create', [self::OPERATOR, $invalidValue]);
 
     }
+
+    function it_cannot_be_constructed_with_a_scientific_annotation()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)
+            ->during('create', [self::OPERATOR, '7E-10']);
+    }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Model/OperationSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Model/OperationSpec.php
@@ -44,7 +44,7 @@ class OperationSpec extends ObjectBehavior
 
     }
 
-    function it_cannot_be_constructed_with_a_scientific_annotation()
+    function it_cannot_be_constructed_with_scientific_notation()
     {
         $this->shouldThrow(\InvalidArgumentException::class)
             ->during('create', [self::OPERATOR, '7E-10']);

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Validation/MeasurementFamily/OperationValueValidatorSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Validation/MeasurementFamily/OperationValueValidatorSpec.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\OperationValue;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+class OperationValueValidatorSpec extends ObjectBehavior
+{
+    public function let(ExecutionContextInterface $context)
+    {
+        $this->initialize($context);
+    }
+
+    public function it_should_validate_operation_value_int_in_string(
+        OperationValue $constraint,
+        ExecutionContextInterface $context
+    ) {
+        $context->addViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate('1', $constraint);
+    }
+
+    public function it_should_validate_operation_value_float_in_string(
+        OperationValue $constraint,
+        ExecutionContextInterface $context
+    ) {
+        $context->addViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate('0.00000006', $constraint);
+    }
+
+    public function it_add_violation_when_operation_value_is_null(
+        OperationValue $constraint,
+        ExecutionContextInterface $context
+    ) {
+        $context
+            ->addViolation('This value should not be blank.', ['{{ value }}' => 'null'])
+            ->shouldBeCalled();
+
+        $this->validate(null, $constraint);
+    }
+
+    public function it_add_violation_when_operation_value_is_empty(
+        OperationValue $constraint,
+        ExecutionContextInterface $context
+    ) {
+        $context
+            ->addViolation('This value should not be blank.', ['{{ value }}' => '""'])
+            ->shouldBeCalled();
+
+        $this->validate('', $constraint);
+    }
+
+    public function it_add_violation_when_operation_value_is_an_array(
+        OperationValue $constraint,
+        ExecutionContextInterface $context
+    ) {
+        $context
+            ->addViolation('pim_measurements.validation.measurement_family.convert.value_should_be_a_number_in_a_string', [])
+            ->shouldBeCalled();
+
+        $this->validate(['value' => '10'], $constraint);
+    }
+
+    public function it_add_violation_when_operation_value_is_a_number(
+        OperationValue $constraint,
+        ExecutionContextInterface $context
+    ) {
+        $context
+            ->addViolation('pim_measurements.validation.measurement_family.convert.value_should_be_a_number_in_a_string', [])
+            ->shouldBeCalled();
+
+        $this->validate(16.88888, $constraint);
+    }
+
+    public function it_add_violation_when_operation_value_is_a_scientific_notation(
+        OperationValue $constraint,
+        ExecutionContextInterface $context
+    ) {
+        $context
+            ->addViolation('pim_measurements.validation.measurement_family.convert.value_should_be_a_number_in_a_string', [])
+            ->shouldBeCalled();
+
+        $this->validate('10E-7', $constraint);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Currently the endpoint PATCH /api/rest/v1/measurement-families unit[convert_from_standard][value] field allow scientific annotation. To have consistency between UI (we allow only number in operation value) and API we decided to remove support of scientific notation in API and in Internal Controller (in case of UI validation is by passed)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
