### PR TITLE
MET-180: In Measurement Units, labels and symbol are not required

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidator.php
@@ -27,7 +27,7 @@ class MeasurementFamilyValidator
             'type'                 => 'object',
             'properties'           => [
                 '_links'             => ['type' => 'object'],
-                'code'               => ['type' => ['string'],],
+                'code'               => ['type' => 'string'],
                 'labels'             => [
                     'type'              => ['object', 'array'],
                     'patternProperties' => [
@@ -40,7 +40,6 @@ class MeasurementFamilyValidator
                     'patternProperties' => [
                         '.+' => [
                             'type'       => 'object',
-                            'required'   => ['code', 'labels', 'convert_from_standard', 'symbol'],
                             'properties' => [
                                 'code'                  => ['type' => 'string'],
                                 'labels'                => [
@@ -61,12 +60,14 @@ class MeasurementFamilyValidator
                                     ]
                                 ],
                                 'symbol'                => ['type' => 'string']
-                            ]
+                            ],
+                            'required' => ['code', 'convert_from_standard'],
+                            'additionalProperties' => false,
                         ],
                     ]
                 ]
             ],
-            'required'             => ['code', 'labels', 'units', 'standard_unit_code'],
+            'required'             => ['code', 'units', 'standard_unit_code'],
             'additionalProperties' => false,
         ];
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/SaveMeasurementFamiliesAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/SaveMeasurementFamiliesAction.php
@@ -265,8 +265,8 @@ class SaveMeasurementFamiliesAction
         $saveMeasurementFamilyCommand = new SaveMeasurementFamilyCommand;
         $saveMeasurementFamilyCommand->code = $normalizedMeasurementFamily['code'];
         $saveMeasurementFamilyCommand->standardUnitCode = $normalizedMeasurementFamily['standard_unit_code'];
-        $saveMeasurementFamilyCommand->labels = $normalizedMeasurementFamily['labels'];
-        $saveMeasurementFamilyCommand->units = array_values($normalizedMeasurementFamily['units']);
+        $saveMeasurementFamilyCommand->labels = $normalizedMeasurementFamily['labels'] ?? [];
+        $saveMeasurementFamilyCommand->units = $this->getNormalizedUnitsFromNormalizedMeasurementFamily($normalizedMeasurementFamily);
 
         return $saveMeasurementFamilyCommand;
     }
@@ -276,9 +276,24 @@ class SaveMeasurementFamiliesAction
         $createMeasurementFamilyCommand = new CreateMeasurementFamilyCommand();
         $createMeasurementFamilyCommand->code = $normalizedMeasurementFamily['code'];
         $createMeasurementFamilyCommand->standardUnitCode = $normalizedMeasurementFamily['standard_unit_code'];
-        $createMeasurementFamilyCommand->labels = $normalizedMeasurementFamily['labels'];
-        $createMeasurementFamilyCommand->units = array_values($normalizedMeasurementFamily['units']);
+        $createMeasurementFamilyCommand->labels = $normalizedMeasurementFamily['labels'] ?? [];
+        $createMeasurementFamilyCommand->units = $this->getNormalizedUnitsFromNormalizedMeasurementFamily($normalizedMeasurementFamily);
 
         return $createMeasurementFamilyCommand;
+    }
+
+    /**
+     * This method ensures that the units will have all the properties, even the optional ones.
+     */
+    private function getNormalizedUnitsFromNormalizedMeasurementFamily(array $normalizedMeasurementFamily): array
+    {
+        return array_map(function (array $unit) {
+            return [
+              'code' => $unit['code'],
+              'convert_from_standard' => $unit['convert_from_standard'],
+              'labels' => $unit['labels'] ?? [],
+              'symbol' => $unit['symbol'] ?? '',
+            ];
+        }, array_values($normalizedMeasurementFamily['units'] ?? []));
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidatorSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidatorSpec.php
@@ -23,7 +23,7 @@ class MeasurementFamilyValidatorSpec extends ObjectBehavior
 
         $errors = $this->validate($asset);
         $errors->shouldBeArray();
-        $errors->shouldHaveCount(6);
+        $errors->shouldHaveCount(5);
     }
 
     function it_returns_an_empty_array_if_all_the_measurement_family_properties_are_valid()
@@ -49,7 +49,7 @@ class MeasurementFamilyValidatorSpec extends ObjectBehavior
                             [
                                 [
                                     'operator' => 'mul',
-                                    'value' => '0.000001',
+                                    'value' => '1',
                                 ],
                             ],
                         'symbol' => 'mm²',
@@ -87,7 +87,7 @@ class MeasurementFamilyValidatorSpec extends ObjectBehavior
                     'convert_from_standard' => [
                         [
                             'operator' => 'mul',
-                            'value' => '0.000001',
+                            'value' => '1',
                         ],
                     ],
                 ]

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidatorSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidatorSpec.php
@@ -75,4 +75,25 @@ class MeasurementFamilyValidatorSpec extends ObjectBehavior
 
         $this->validate($measurementFamily)->shouldReturn([]);
     }
+
+    function it_returns_an_empty_array_if_only_the_required_properties_are_given()
+    {
+        $measurementFamily = [
+            'code' => 'custom_metric_1',
+            'standard_unit_code' => 'CUSTOM_UNIT_1_1',
+            'units' => [
+                'CUSTOM_UNIT_1_1' => [
+                    'code' => 'CUSTOM_UNIT_1_1',
+                    'convert_from_standard' => [
+                        [
+                            'operator' => 'mul',
+                            'value' => '0.000001',
+                        ],
+                    ],
+                ]
+            ],
+        ];
+
+        $this->validate($measurementFamily)->shouldReturn([]);
+    }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/SaveMeasurementFamiliesActionEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/SaveMeasurementFamiliesActionEndToEnd.php
@@ -537,10 +537,6 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
                 'errors' =>
                     [
                         [
-                            'property' => 'labels',
-                            'message' => 'The property labels is required',
-                        ],
-                        [
                             'property' => 'units',
                             'message' => 'The property units is required',
                         ],


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When creating a new Measurement Family, labels and symbols are not required.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

