### PR TITLE
MET-179: Fix locale flag being displayed on measurement attributes

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/metric-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/metric-field.js
@@ -38,7 +38,6 @@ define([
                     family.code === templateContext.attribute.metric_family);
                 templateContext.i18n = i18n;
                 templateContext.units = measurementFamily.units;
-                templateContext.locale = templateContext.locale || templateContext.context.locale;
                 templateContext.uiLocale = UserContext.get('uiLocale');
 
                 return templateContext;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The locale flag is displayed if either `locale` or `channel` is present in the context.
The UI locale was added a first time here (with a misleading variable name that triggered the bug):
https://github.com/akeneo/pim-community-dev/commit/f7bf1df71a044d09102de9d304b7986fda800798#diff-560f9f5174f27c976d1dc73643bcb030R40
and is now obsolete as the UI locale is injected there:
 https://github.com/akeneo/pim-community-dev/commit/948c8fc90d2e250af7d08079c641a4859b605492#diff-560f9f5174f27c976d1dc73643bcb030R42

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
