### PR TITLE
MET-195: Fix the close button of CreateMeasurementFamily modal

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/CreateMeasurementFamily.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/CreateMeasurementFamily.tsx
@@ -61,7 +61,7 @@ const CreateMeasurementFamily = ({onClose}: CreateMeasurementFamilyProps) => {
 
   return (
     <Modal>
-      <ModalCloseButton title={__('pim_common.close')} onClick={handleClose} />
+      <ModalCloseButton title={__('pim_common.close')} onClick={() => handleClose()} />
       <ModalBodyWithIllustration illustration={<MeasurementFamilyIllustration />}>
         <ModalTitle
           title={__('measurements.family.add_new_measurement_family')}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The function `handleClose` has a new signature: 
`(createdMeasurementFamilyCode?: MeasurementFamilyCode) => void;`
but when called from `onClick`, a click event is given, redirecting the url to `/#/configuration/measurement/[object Object]`.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
