### PR TITLE
RUL-60: Replace prices with same currency in PriceCollectionAttributeAdder

### DIFF
--- a/tests/back/Acceptance/Channel/ChannelContext.php
+++ b/tests/back/Acceptance/Channel/ChannelContext.php
@@ -77,7 +77,7 @@ final class ChannelContext implements Context
     }
 
     /**
-     * @Then the locale :localeCode is removed from the :channelCode channel
+     * @when the locale :localeCode is removed from the :channelCode channel
      */
     public function iRemoveTheLocaleFromTheChannel(string $localeCode, string $channelCode)
     {
@@ -108,6 +108,25 @@ final class ChannelContext implements Context
 
         $channel->addLocale($locale);
 
+        $this->channelRepository->save($channel);
+    }
+
+    /**
+     * @When the :currencyCode currency is added to the :channelCode channel
+     */
+    public function theCurrencyIsAddedToChannel(string $currencyCode, string $channelCode)
+    {
+        if (null === $channel = $this->channelRepository->findOneByIdentifier($channelCode)) {
+            throw new \Exception(sprintf('Channel "%s" cannot be found', $channelCode));
+        }
+
+        $currency = $this->currencyRepository->findOneByIdentifier($currencyCode);
+        if (null === $currency) {
+            $currency = $this->currencyBuilder->build(['code' => $currencyCode]);
+            $this->currencyRepository->save($currency);
+        }
+
+        $channel->addCurrency($currency);
         $this->channelRepository->save($channel);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Prior to v4.0, the PriceCollectionValueFactory used to filter duplicate prices (with the same currency), only keeping the newest one (see https://github.com/akeneo/pim-community-dev/blob/f328bf1059babb2db6a14fa6f230e7679da21a2e/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/PriceCollectionValueFactory.php#L237). This is not the case anymore, although the PriceCollectionAttributeAdder used to rely on this behavior.

I'll update the PriceCollectionValueFactory (to check that a currency is not used twice) in another PR.

I also took advantage of this PR to add allow to add a currency to a channel in acceptance context.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
