### PR TITLE
MET-181: add notion of bidirectional association type

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AssociationTypeRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AssociationTypeRepository.php
@@ -30,7 +30,6 @@ class AssociationTypeRepository extends EntityRepository implements DatagridRepo
     public function createDatagridQueryBuilder()
     {
         $qb = $this->createQueryBuilder('a')
-            ->select('a')
             ->addSelect('(CASE WHEN translation.label IS NULL THEN a.code ELSE translation.label END) AS label')
             ->addSelect('translation.label')
             ->addSelect('a.isBidirectional')

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AssociationTypeRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AssociationTypeRepository.php
@@ -32,7 +32,7 @@ class AssociationTypeRepository extends EntityRepository implements DatagridRepo
         $qb = $this->createQueryBuilder('a')
             ->addSelect('(CASE WHEN translation.label IS NULL THEN a.code ELSE translation.label END) AS label')
             ->addSelect('translation.label')
-            ->addSelect('a.isBidirectional')
+            ->addSelect('a.isTwoWay')
             ->leftJoin('a.translations', 'translation', 'WITH', 'translation.locale = :localeCode');
 
         return $qb;

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AssociationTypeRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AssociationTypeRepository.php
@@ -42,7 +42,6 @@ class AssociationTypeRepository extends EntityRepository implements DatagridRepo
             ->addSelect(sprintf("%s AS label", $labelExpr))
             ->addSelect('translation.label')
             ->addSelect('a.isBidirectional');
-        ;
 
         $qb->leftJoin($rootAlias .'.translations', 'translation', 'WITH', 'translation.locale = :localeCode');
 

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AssociationTypeRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AssociationTypeRepository.php
@@ -29,21 +29,12 @@ class AssociationTypeRepository extends EntityRepository implements DatagridRepo
      */
     public function createDatagridQueryBuilder()
     {
-        $qb = $this->createQueryBuilder('a');
-        $rootAlias = $qb->getRootAlias();
-
-        $labelExpr = sprintf(
-            "(CASE WHEN translation.label IS NULL THEN %s.code ELSE translation.label END)",
-            $rootAlias
-        );
-
-        $qb
-            ->select($rootAlias)
-            ->addSelect(sprintf("%s AS label", $labelExpr))
+        $qb = $this->createQueryBuilder('a')
+            ->select('a')
+            ->addSelect('(CASE WHEN translation.label IS NULL THEN a.code ELSE translation.label END) AS label')
             ->addSelect('translation.label')
-            ->addSelect('a.isBidirectional');
-
-        $qb->leftJoin($rootAlias .'.translations', 'translation', 'WITH', 'translation.locale = :localeCode');
+            ->addSelect('a.isBidirectional')
+            ->leftJoin('a.translations', 'translation', 'WITH', 'translation.locale = :localeCode');
 
         return $qb;
     }

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AssociationTypeRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AssociationTypeRepository.php
@@ -40,10 +40,11 @@ class AssociationTypeRepository extends EntityRepository implements DatagridRepo
         $qb
             ->select($rootAlias)
             ->addSelect(sprintf("%s AS label", $labelExpr))
-            ->addSelect('translation.label');
+            ->addSelect('translation.label')
+            ->addSelect('a.isBidirectional');
+        ;
 
-        $qb
-            ->leftJoin($rootAlias .'.translations', 'translation', 'WITH', 'translation.locale = :localeCode');
+        $qb->leftJoin($rootAlias .'.translations', 'translation', 'WITH', 'translation.locale = :localeCode');
 
         return $qb;
     }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
@@ -11,8 +11,8 @@ datagrid:
             label:
                 label: Label
                 frontend_type: label
-            isBidirectional:
-                label:         Two-way association
+            two_way:
+                label: Two-way association
                 frontend_type: boolean-status
         properties:
             id: ~

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
@@ -12,7 +12,7 @@ datagrid:
                 label: Label
                 frontend_type: label
             isBidirectional:
-                label:         Is bidirectional
+                label:         Two-way association
                 frontend_type: boolean-status
         properties:
             id: ~

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
@@ -11,7 +11,7 @@ datagrid:
             label:
                 label: Label
                 frontend_type: label
-            two_way:
+            is_two_way:
                 label: 2-way association
                 frontend_type: boolean-status
         properties:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
@@ -12,7 +12,7 @@ datagrid:
                 label: Label
                 frontend_type: label
             two_way:
-                label: Two-way association
+                label: 2-way association
                 frontend_type: boolean-status
         properties:
             id: ~

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
@@ -11,6 +11,9 @@ datagrid:
             label:
                 label: Label
                 frontend_type: label
+            isBidirectional:
+                label:         Is bidirectional
+                frontend_type: boolean-status
         properties:
             id: ~
             edit_link:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
@@ -11,7 +11,7 @@ datagrid:
             label:
                 label: Label
                 frontend_type: label
-            is_two_way:
+            isTwoWay:
                 label: 2-way association
                 frontend_type: boolean-status
         properties:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/model/doctrine/AssociationType.orm.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/model/doctrine/AssociationType.orm.yml
@@ -23,6 +23,10 @@ Akeneo\Pim\Structure\Component\Model\AssociationType:
             gedmo:
                 timestampable:
                     on: update
+        isBidirectional:
+            type: boolean
+            options:
+                default: false
     oneToMany:
         translations:
             targetEntity: Akeneo\Pim\Structure\Component\Model\AssociationTypeTranslationInterface

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/model/doctrine/AssociationType.orm.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/model/doctrine/AssociationType.orm.yml
@@ -23,8 +23,9 @@ Akeneo\Pim\Structure\Component\Model\AssociationType:
             gedmo:
                 timestampable:
                     on: update
-        isBidirectional:
+        isTwoWay:
             type: boolean
+            column: is_two_way
             options:
                 default: false
     oneToMany:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
@@ -14,7 +14,7 @@ Akeneo\Pim\Structure\Component\Model\AssociationType:
                 max: 100
         translations:
             - Valid: ~
-        isBidirectional:
+        is_bidirectional:
             - Type: bool
             - NotNull: ~
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
@@ -4,6 +4,7 @@ Akeneo\Pim\Structure\Component\Model\AssociationType:
         - Akeneo\Tool\Component\StorageUtils\Validator\Constraints\Immutable:
             properties:
                 - code
+                - isBidirectional
     properties:
         code:
             - NotBlank: ~

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
@@ -14,6 +14,9 @@ Akeneo\Pim\Structure\Component\Model\AssociationType:
                 max: 100
         translations:
             - Valid: ~
+        isBidirectional:
+            - Type: bool
+            - NotNull: ~
 
 Akeneo\Pim\Structure\Component\Model\AssociationTypeTranslation:
     properties:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
@@ -14,7 +14,7 @@ Akeneo\Pim\Structure\Component\Model\AssociationType:
                 max: 100
         translations:
             - Valid: ~
-        is_bidirectional:
+        isBidirectional:
             - Type: bool
             - NotNull: ~
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
@@ -4,7 +4,7 @@ Akeneo\Pim\Structure\Component\Model\AssociationType:
         - Akeneo\Tool\Component\StorageUtils\Validator\Constraints\Immutable:
             properties:
                 - code
-                - isBidirectional
+                - isTwoWay
     properties:
         code:
             - NotBlank: ~
@@ -15,7 +15,7 @@ Akeneo\Pim\Structure\Component\Model\AssociationType:
                 max: 100
         translations:
             - Valid: ~
-        isBidirectional:
+        isTwoWay:
             - Type: bool
             - NotNull: ~
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -84,7 +84,7 @@ pim_enrich.entity.attribute_option:
 pim_enrich.entity.association_type:
     label: association type
     property:
-        two_way: 2-way association
+        is_two_way: 2-way association
     flash:
         update:
             success: Association type successfully updated.

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -84,7 +84,7 @@ pim_enrich.entity.attribute_option:
 pim_enrich.entity.association_type:
     label: association type
     property:
-        is_bidirectional: Two-way association
+        two_way: Two-way association
     flash:
         update:
             success: Association type successfully updated.

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -83,6 +83,8 @@ pim_enrich.entity.attribute_option:
 
 pim_enrich.entity.association_type:
     label: association type
+    property:
+        is_bidirectional: Is bidirectionnal
     flash:
         update:
             success: Association type successfully updated.

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -84,7 +84,7 @@ pim_enrich.entity.attribute_option:
 pim_enrich.entity.association_type:
     label: association type
     property:
-        is_bidirectional: Is bidirectionnal
+        is_bidirectional: Two-way association
     flash:
         update:
             success: Association type successfully updated.

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -84,7 +84,7 @@ pim_enrich.entity.attribute_option:
 pim_enrich.entity.association_type:
     label: association type
     property:
-        two_way: Two-way association
+        two_way: 2-way association
     flash:
         update:
             success: Association type successfully updated.
@@ -99,9 +99,11 @@ pim_enrich.entity.association_type:
         index: "]-Inf, 1]{{ count }} association type|]1, Inf[{{ count }} association types"
     module:
         create:
+            title: Create a new association type
             button: Create association type
         delete:
             confirm: Are you sure you want to delete this association type?
+    hint: <a href="{{link}}" target="_blank">In this article</a>, you'll find everything you need to create your own association type.
 
 pim_enrich.entity.group_type:
     label: group type

--- a/src/Akeneo/Pim/Structure/Component/ArrayConverter/FlatToStandard/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/ArrayConverter/FlatToStandard/AssociationType.php
@@ -35,7 +35,7 @@ class AssociationType implements ArrayConverterInterface
      *      'code'        => 'mycode',
      *      'label-fr_FR' => 'XSELL',
      *      'label-en_US' => 'Vente croisée',
-     *      'is-bidirectional' => 1,
+     *      'is_bidirectional' => 1,
      * ]
      *
      * After:
@@ -45,7 +45,7 @@ class AssociationType implements ArrayConverterInterface
      *          'fr_FR' => 'XSELL',
      *          'en_US' => 'Vente croisée',
      *      ],
-     *      'isBidirectional' => true
+     *      'is_bidirectional' => true
      * ]
      */
     public function convert(array $item, array $options = [])
@@ -59,7 +59,7 @@ class AssociationType implements ArrayConverterInterface
                 $convertedItem = $this->convertField($convertedItem, $field, $data);
             }
         }
-        $convertedItem['isBidirectional'] = (bool) ($item['is-bidirectional'] ?? false);
+        $convertedItem['is_bidirectional'] = (bool) ($item['is_bidirectional'] ?? false);
 
         return $convertedItem;
     }

--- a/src/Akeneo/Pim/Structure/Component/ArrayConverter/FlatToStandard/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/ArrayConverter/FlatToStandard/AssociationType.php
@@ -35,7 +35,7 @@ class AssociationType implements ArrayConverterInterface
      *      'code'        => 'mycode',
      *      'label-fr_FR' => 'XSELL',
      *      'label-en_US' => 'Vente croisée',
-     *      'is_bidirectional' => 1,
+     *      'two_way' => 1,
      * ]
      *
      * After:
@@ -45,7 +45,7 @@ class AssociationType implements ArrayConverterInterface
      *          'fr_FR' => 'XSELL',
      *          'en_US' => 'Vente croisée',
      *      ],
-     *      'is_bidirectional' => true
+     *      'two_way' => true
      * ]
      */
     public function convert(array $item, array $options = [])
@@ -59,7 +59,7 @@ class AssociationType implements ArrayConverterInterface
                 $convertedItem = $this->convertField($convertedItem, $field, $data);
             }
         }
-        $convertedItem['is_bidirectional'] = (bool) ($item['is_bidirectional'] ?? false);
+        $convertedItem['two_way'] = (bool) ($item['two_way'] ?? false);
 
         return $convertedItem;
     }

--- a/src/Akeneo/Pim/Structure/Component/ArrayConverter/FlatToStandard/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/ArrayConverter/FlatToStandard/AssociationType.php
@@ -35,7 +35,7 @@ class AssociationType implements ArrayConverterInterface
      *      'code'        => 'mycode',
      *      'label-fr_FR' => 'XSELL',
      *      'label-en_US' => 'Vente croisée',
-     *      'two_way' => 1,
+     *      'is_two_way' => 1,
      * ]
      *
      * After:
@@ -45,7 +45,7 @@ class AssociationType implements ArrayConverterInterface
      *          'fr_FR' => 'XSELL',
      *          'en_US' => 'Vente croisée',
      *      ],
-     *      'two_way' => true
+     *      'is_two_way' => true
      * ]
      */
     public function convert(array $item, array $options = [])
@@ -59,7 +59,7 @@ class AssociationType implements ArrayConverterInterface
                 $convertedItem = $this->convertField($convertedItem, $field, $data);
             }
         }
-        $convertedItem['two_way'] = (bool) ($item['two_way'] ?? false);
+        $convertedItem['is_two_way'] = (bool) ($item['is_two_way'] ?? false);
 
         return $convertedItem;
     }

--- a/src/Akeneo/Pim/Structure/Component/ArrayConverter/FlatToStandard/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/ArrayConverter/FlatToStandard/AssociationType.php
@@ -35,6 +35,7 @@ class AssociationType implements ArrayConverterInterface
      *      'code'        => 'mycode',
      *      'label-fr_FR' => 'XSELL',
      *      'label-en_US' => 'Vente croisée',
+     *      'is-bidirectional' => 1,
      * ]
      *
      * After:
@@ -44,6 +45,7 @@ class AssociationType implements ArrayConverterInterface
      *          'fr_FR' => 'XSELL',
      *          'en_US' => 'Vente croisée',
      *      ],
+     *      'isBidirectional' => true
      * ]
      */
     public function convert(array $item, array $options = [])
@@ -57,6 +59,7 @@ class AssociationType implements ArrayConverterInterface
                 $convertedItem = $this->convertField($convertedItem, $field, $data);
             }
         }
+        $convertedItem['isBidirectional'] = (bool) ($item['is-bidirectional'] ?? false);
 
         return $convertedItem;
     }

--- a/src/Akeneo/Pim/Structure/Component/ArrayConverter/StandardToFlat/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/ArrayConverter/StandardToFlat/AssociationType.php
@@ -27,7 +27,7 @@ class AssociationType extends AbstractSimpleArrayConverter implements ArrayConve
                 }
                 break;
             case 'is_bidirectional':
-                $convertedItem['is_bidirectional'] = (int) $data['is_bidirectional'];
+                $convertedItem['is_bidirectional'] = (int) $data;
                 break;
             default:
                 $convertedItem[$property] = (string) $data;

--- a/src/Akeneo/Pim/Structure/Component/ArrayConverter/StandardToFlat/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/ArrayConverter/StandardToFlat/AssociationType.php
@@ -26,8 +26,8 @@ class AssociationType extends AbstractSimpleArrayConverter implements ArrayConve
                     $convertedItem[$labelKey] = $label;
                 }
                 break;
-            case 'is_bidirectional':
-                $convertedItem['is_bidirectional'] = (int) $data;
+            case 'two_way':
+                $convertedItem['two_way'] = (int) $data;
                 break;
             default:
                 $convertedItem[$property] = (string) $data;

--- a/src/Akeneo/Pim/Structure/Component/ArrayConverter/StandardToFlat/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/ArrayConverter/StandardToFlat/AssociationType.php
@@ -26,8 +26,8 @@ class AssociationType extends AbstractSimpleArrayConverter implements ArrayConve
                     $convertedItem[$labelKey] = $label;
                 }
                 break;
-            case 'isBidirectional':
-                $convertedItem['is-bidirectional'] = (int) $data['isBidirectional'];
+            case 'is_bidirectional':
+                $convertedItem['is_bidirectional'] = (int) $data['is_bidirectional'];
                 break;
             default:
                 $convertedItem[$property] = (string) $data;

--- a/src/Akeneo/Pim/Structure/Component/ArrayConverter/StandardToFlat/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/ArrayConverter/StandardToFlat/AssociationType.php
@@ -26,8 +26,8 @@ class AssociationType extends AbstractSimpleArrayConverter implements ArrayConve
                     $convertedItem[$labelKey] = $label;
                 }
                 break;
-            case 'two_way':
-                $convertedItem['two_way'] = (int) $data;
+            case 'is_two_way':
+                $convertedItem['is_two_way'] = (int) $data;
                 break;
             default:
                 $convertedItem[$property] = (string) $data;

--- a/src/Akeneo/Pim/Structure/Component/ArrayConverter/StandardToFlat/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/ArrayConverter/StandardToFlat/AssociationType.php
@@ -26,6 +26,9 @@ class AssociationType extends AbstractSimpleArrayConverter implements ArrayConve
                     $convertedItem[$labelKey] = $label;
                 }
                 break;
+            case 'isBidirectional':
+                $convertedItem['is-bidirectional'] = (int) $data['isBidirectional'];
+                break;
             default:
                 $convertedItem[$property] = (string) $data;
         }

--- a/src/Akeneo/Pim/Structure/Component/Model/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AssociationType.php
@@ -46,6 +46,7 @@ class AssociationType implements AssociationTypeInterface
     public function __construct()
     {
         $this->translations = new ArrayCollection();
+        $this->isBidirectional = false;
     }
 
     /**

--- a/src/Akeneo/Pim/Structure/Component/Model/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AssociationType.php
@@ -37,6 +37,9 @@ class AssociationType implements AssociationTypeInterface
     /** @var \DateTime */
     protected $updated;
 
+    /** @var bool */
+    protected $isBidirectional;
+
     /**
      * Constructor
      */
@@ -223,5 +226,21 @@ class AssociationType implements AssociationTypeInterface
     public function getReference()
     {
         return $this->code;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isBidirectional(): bool
+    {
+        return $this->isBidirectional;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setIsBidirectional(bool $isBidirectional): void
+    {
+        $this->isBidirectional = $isBidirectional;
     }
 }

--- a/src/Akeneo/Pim/Structure/Component/Model/AssociationType.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AssociationType.php
@@ -38,7 +38,7 @@ class AssociationType implements AssociationTypeInterface
     protected $updated;
 
     /** @var bool */
-    protected $isBidirectional;
+    protected $isTwoWay;
 
     /**
      * Constructor
@@ -46,7 +46,7 @@ class AssociationType implements AssociationTypeInterface
     public function __construct()
     {
         $this->translations = new ArrayCollection();
-        $this->isBidirectional = false;
+        $this->isTwoWay = false;
     }
 
     /**
@@ -232,16 +232,16 @@ class AssociationType implements AssociationTypeInterface
     /**
      * @inheritDoc
      */
-    public function isBidirectional(): bool
+    public function isTwoWay(): bool
     {
-        return $this->isBidirectional;
+        return $this->isTwoWay;
     }
 
     /**
      * @inheritDoc
      */
-    public function setIsBidirectional(bool $isBidirectional): void
+    public function setIsTwoWay(bool $isTwoWay): void
     {
-        $this->isBidirectional = $isBidirectional;
+        $this->isTwoWay = $isTwoWay;
     }
 }

--- a/src/Akeneo/Pim/Structure/Component/Model/AssociationTypeInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AssociationTypeInterface.php
@@ -71,12 +71,12 @@ interface AssociationTypeInterface extends
     /**
      * @return bool
      */
-    public function isBidirectional(): bool;
+    public function isTwoWay(): bool;
 
     /**
-     * @param bool $isBidirectional
+     * @param bool $isTwoWay
      */
-    public function setIsBidirectional(bool $isBidirectional): void;
+    public function setIsTwoWay(bool $isTwoWay): void;
 
     /**
      * Returns the label of the association type

--- a/src/Akeneo/Pim/Structure/Component/Model/AssociationTypeInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AssociationTypeInterface.php
@@ -69,6 +69,16 @@ interface AssociationTypeInterface extends
     public function setLabel($label);
 
     /**
+     * @return bool
+     */
+    public function isBidirectional(): bool;
+
+    /**
+     * @param bool $isBidirectional
+     */
+    public function setIsBidirectional(bool $isBidirectional): void;
+
+    /**
      * Returns the label of the association type
      *
      * @return string

--- a/src/Akeneo/Pim/Structure/Component/Normalizer/Standard/AssociationTypeNormalizer.php
+++ b/src/Akeneo/Pim/Structure/Component/Normalizer/Standard/AssociationTypeNormalizer.php
@@ -33,7 +33,7 @@ class AssociationTypeNormalizer implements NormalizerInterface, CacheableSupport
         return [
             'code'   => $associationType->getCode(),
             'labels' => $this->translationNormalizer->normalize($associationType, 'standard', $context),
-            'is_bidirectional' => $associationType->isBidirectional()
+            'two_way' => $associationType->isTwoWay()
         ];
     }
 

--- a/src/Akeneo/Pim/Structure/Component/Normalizer/Standard/AssociationTypeNormalizer.php
+++ b/src/Akeneo/Pim/Structure/Component/Normalizer/Standard/AssociationTypeNormalizer.php
@@ -26,12 +26,14 @@ class AssociationTypeNormalizer implements NormalizerInterface, CacheableSupport
 
     /**
      * {@inheritdoc}
+     * @param AssociationTypeInterface $associationType
      */
     public function normalize($associationType, $format = null, array $context = [])
     {
         return [
             'code'   => $associationType->getCode(),
             'labels' => $this->translationNormalizer->normalize($associationType, 'standard', $context),
+            'isBidirectional' => $associationType->isBidirectional()
         ];
     }
 

--- a/src/Akeneo/Pim/Structure/Component/Normalizer/Standard/AssociationTypeNormalizer.php
+++ b/src/Akeneo/Pim/Structure/Component/Normalizer/Standard/AssociationTypeNormalizer.php
@@ -33,7 +33,7 @@ class AssociationTypeNormalizer implements NormalizerInterface, CacheableSupport
         return [
             'code'   => $associationType->getCode(),
             'labels' => $this->translationNormalizer->normalize($associationType, 'standard', $context),
-            'two_way' => $associationType->isTwoWay()
+            'is_two_way' => $associationType->isTwoWay()
         ];
     }
 

--- a/src/Akeneo/Pim/Structure/Component/Normalizer/Standard/AssociationTypeNormalizer.php
+++ b/src/Akeneo/Pim/Structure/Component/Normalizer/Standard/AssociationTypeNormalizer.php
@@ -33,7 +33,7 @@ class AssociationTypeNormalizer implements NormalizerInterface, CacheableSupport
         return [
             'code'   => $associationType->getCode(),
             'labels' => $this->translationNormalizer->normalize($associationType, 'standard', $context),
-            'isBidirectional' => $associationType->isBidirectional()
+            'is_bidirectional' => $associationType->isBidirectional()
         ];
     }
 

--- a/src/Akeneo/Pim/Structure/Component/Updater/AssociationTypeUpdater.php
+++ b/src/Akeneo/Pim/Structure/Component/Updater/AssociationTypeUpdater.php
@@ -63,6 +63,8 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
             $associationType->setCode($data);
         } elseif ('labels' === $field) {
             $this->translatableUpdater->update($associationType, $data);
+        } elseif ('isBidirectional' === $field) {
+            $associationType->setIsBidirectional($data);
         }
     }
 
@@ -95,6 +97,10 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
         } elseif ('code' === $field) {
             if (null !== $data && !is_scalar($data)) {
                 throw InvalidPropertyTypeException::scalarExpected($field, static::class, $data);
+            }
+        } elseif ('isBidirectional') {
+            if (null !== $data && !is_bool($data)) {
+                throw InvalidPropertyTypeException::booleanExpected($field, static::class, $data);
             }
         } else {
             throw UnknownPropertyException::unknownProperty($field);

--- a/src/Akeneo/Pim/Structure/Component/Updater/AssociationTypeUpdater.php
+++ b/src/Akeneo/Pim/Structure/Component/Updater/AssociationTypeUpdater.php
@@ -63,7 +63,7 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
             $associationType->setCode($data);
         } elseif ('labels' === $field) {
             $this->translatableUpdater->update($associationType, $data);
-        } elseif ('isBidirectional' === $field) {
+        } elseif ('is_bidirectional' === $field) {
             $associationType->setIsBidirectional($data);
         }
     }
@@ -98,7 +98,7 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
             if (null !== $data && !is_scalar($data)) {
                 throw InvalidPropertyTypeException::scalarExpected($field, static::class, $data);
             }
-        } elseif ('isBidirectional' === $field) {
+        } elseif ('is_bidirectional' === $field) {
             if (null !== $data && !is_bool($data)) {
                 throw InvalidPropertyTypeException::booleanExpected($field, static::class, $data);
             }

--- a/src/Akeneo/Pim/Structure/Component/Updater/AssociationTypeUpdater.php
+++ b/src/Akeneo/Pim/Structure/Component/Updater/AssociationTypeUpdater.php
@@ -98,7 +98,7 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
             if (null !== $data && !is_scalar($data)) {
                 throw InvalidPropertyTypeException::scalarExpected($field, static::class, $data);
             }
-        } elseif ('isBidirectional') {
+        } elseif ('isBidirectional' === $field) {
             if (null !== $data && !is_bool($data)) {
                 throw InvalidPropertyTypeException::booleanExpected($field, static::class, $data);
             }

--- a/src/Akeneo/Pim/Structure/Component/Updater/AssociationTypeUpdater.php
+++ b/src/Akeneo/Pim/Structure/Component/Updater/AssociationTypeUpdater.php
@@ -63,7 +63,7 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
             $associationType->setCode($data);
         } elseif ('labels' === $field) {
             $this->translatableUpdater->update($associationType, $data);
-        } elseif ('two_way' === $field) {
+        } elseif ('is_two_way' === $field) {
             $associationType->setIsTwoWay($data);
         }
     }
@@ -98,7 +98,7 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
             if (null !== $data && !is_scalar($data)) {
                 throw InvalidPropertyTypeException::scalarExpected($field, static::class, $data);
             }
-        } elseif ('two_way' === $field) {
+        } elseif ('is_two_way' === $field) {
             if (null !== $data && !is_bool($data)) {
                 throw InvalidPropertyTypeException::booleanExpected($field, static::class, $data);
             }

--- a/src/Akeneo/Pim/Structure/Component/Updater/AssociationTypeUpdater.php
+++ b/src/Akeneo/Pim/Structure/Component/Updater/AssociationTypeUpdater.php
@@ -63,8 +63,8 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
             $associationType->setCode($data);
         } elseif ('labels' === $field) {
             $this->translatableUpdater->update($associationType, $data);
-        } elseif ('is_bidirectional' === $field) {
-            $associationType->setIsBidirectional($data);
+        } elseif ('two_way' === $field) {
+            $associationType->setIsTwoWay($data);
         }
     }
 
@@ -98,7 +98,7 @@ class AssociationTypeUpdater implements ObjectUpdaterInterface
             if (null !== $data && !is_scalar($data)) {
                 throw InvalidPropertyTypeException::scalarExpected($field, static::class, $data);
             }
-        } elseif ('is_bidirectional' === $field) {
+        } elseif ('two_way' === $field) {
             if (null !== $data && !is_bool($data)) {
                 throw InvalidPropertyTypeException::booleanExpected($field, static::class, $data);
             }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/create.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/create.yml
@@ -26,6 +26,6 @@ extensions:
         targetZone: fields
         position: 20
         config:
-            fieldName: isBidirectional
+            fieldName: is_bidirectional
             label: pim_enrich.entity.association_type.property.is_bidirectional
             defaultValue: false

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/create.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/create.yml
@@ -3,8 +3,11 @@ extensions:
         module: pim/form/common/creation/modal
         config:
             labels:
-                title: pim_common.create
+                title: pim_enrich.entity.association_type.module.create.title
                 subTitle: pim_menu.item.association_type
+            hint:
+                title: pim_enrich.entity.association_type.hint
+                link: https://help.akeneo.com/pim/articles/manage-your-association-types.html
             picture: illustrations/Association-types.svg
             successMessage: pim_enrich.entity.association_type.flash.create.success
             editRoute: pim_enrich_associationtype_edit

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/create.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/create.yml
@@ -20,12 +20,12 @@ extensions:
             identifier: code
             label: pim_common.code
 
-    pim-association-type-properties-bidirectional:
+    pim-association-type-properties-two-way:
         module: pim/form/common/fields/boolean
         parent: pim-association-type-create-modal
         targetZone: fields
         position: 20
         config:
-            fieldName: is_bidirectional
-            label: pim_enrich.entity.association_type.property.is_bidirectional
+            fieldName: two_way
+            label: pim_enrich.entity.association_type.property.two_way
             defaultValue: false

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/create.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/create.yml
@@ -23,12 +23,12 @@ extensions:
             identifier: code
             label: pim_common.code
 
-    pim-association-type-properties-two-way:
+    pim-association-type-properties-is-two-way:
         module: pim/form/common/fields/boolean
         parent: pim-association-type-create-modal
         targetZone: fields
         position: 20
         config:
-            fieldName: two_way
-            label: pim_enrich.entity.association_type.property.two_way
+            fieldName: is_two_way
+            label: pim_enrich.entity.association_type.property.is_two_way
             defaultValue: false

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/create.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/create.yml
@@ -15,6 +15,17 @@ extensions:
         module: pim/form/common/creation/field
         parent: pim-association-type-create-modal
         targetZone: fields
+        position: 10
         config:
             identifier: code
             label: pim_common.code
+
+    pim-association-type-properties-bidirectional:
+        module: pim/form/common/fields/boolean
+        parent: pim-association-type-create-modal
+        targetZone: fields
+        position: 20
+        config:
+            fieldName: isBidirectional
+            label: pim_enrich.entity.association_type.property.is_bidirectional
+            defaultValue: false

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
@@ -115,6 +115,7 @@ extensions:
         config:
             fieldName: isBidirectional
             label: pim_enrich.entity.association_type.property.is_bidirectional
+            readOnly: true
 
     pim-association-type-edit-form-properties-translation-section:
         module: pim/common/simple-view

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
@@ -107,6 +107,15 @@ extensions:
           formRequired: pim_common.required_label
           inputField: pim_enrich_association_type_form_code
 
+    pim-association-type-edit-form-properties-is-bidirectional:
+        module: pim/form/common/fields/boolean
+        parent: pim-association-type-edit-form-properties
+        targetZone: accordion
+        position: 110
+        config:
+            fieldName: isBidirectional
+            label: pim_enrich.entity.association_type.property.is_bidirectional
+
     pim-association-type-edit-form-properties-translation-section:
         module: pim/common/simple-view
         parent: pim-association-type-edit-form-properties

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
@@ -113,8 +113,8 @@ extensions:
         targetZone: accordion
         position: 110
         config:
-            fieldName: two_way
-            label: pim_enrich.entity.association_type.property.two_way
+            fieldName: is_two_way
+            label: pim_enrich.entity.association_type.property.is_two_way
             readOnly: true
 
     pim-association-type-edit-form-properties-translation-section:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
@@ -107,14 +107,14 @@ extensions:
           formRequired: pim_common.required_label
           inputField: pim_enrich_association_type_form_code
 
-    pim-association-type-edit-form-properties-is-bidirectional:
+    pim-association-type-edit-form-properties-is-two-way:
         module: pim/form/common/fields/boolean
         parent: pim-association-type-edit-form-properties
         targetZone: accordion
         position: 110
         config:
-            fieldName: is_bidirectional
-            label: pim_enrich.entity.association_type.property.is_bidirectional
+            fieldName: two_way
+            label: pim_enrich.entity.association_type.property.two_way
             readOnly: true
 
     pim-association-type-edit-form-properties-translation-section:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
@@ -113,7 +113,7 @@ extensions:
         targetZone: accordion
         position: 110
         config:
-            fieldName: isBidirectional
+            fieldName: is_bidirectional
             label: pim_enrich.entity.association_type.property.is_bidirectional
             readOnly: true
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/field.js
@@ -18,7 +18,7 @@ define([
         template: _.template(template),
         dialog: null,
         events: {
-            'change input': 'updateModel'
+            'keyup input': 'updateModel'
         },
 
         /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/modal.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/modal.js
@@ -51,7 +51,8 @@ define(
             render() {
                 this.$el.html(this.template({
                     innerDescription: __(this.config.labels.content),
-                    fields: null
+                    fields: null,
+                    hint: this.config.hint ? __(this.config.hint.title).replace('{{link}}', this.config.hint.link) : null,
                 }));
 
                 this.renderExtensions();

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/modal.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/modal.js
@@ -52,7 +52,9 @@ define(
                 this.$el.html(this.template({
                     innerDescription: __(this.config.labels.content),
                     fields: null,
-                    hint: this.config.hint ? __(this.config.hint.title).replace('{{link}}', this.config.hint.link) : null,
+                    hint: this.config.hint
+                        ? __(this.config.hint.title).replace('{{link}}', this.config.hint.link)
+                        : null,
                 }));
 
                 this.renderExtensions();

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ModalHint.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ModalHint.less
@@ -1,0 +1,23 @@
+.ModalHint {
+  align-items: center;
+  background: #F5F9FC;
+  color: @AknSlateGrey;
+  display: flex;
+  font-size: 13px;
+  margin: -22px 0 0;
+  max-width: 550px;
+  min-height: 44px;
+  padding: 5px;
+
+  &-title {
+    flex-grow: 1;
+  }
+
+  &-icon {
+    background-image: url("/bundles/pimui/images/icon-info.svg");
+    border-right: 1px @AknMediumGrey solid;
+    margin-right: 15px;
+    min-height: 30px;
+    min-width: 39px;
+  }
+}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/index.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/index.less
@@ -105,6 +105,7 @@
 @import "./public/bundles/pimui/less/components/Widget.less";
 @import "./public/bundles/pimui/less/components/FamilyVariant.less";
 @import "./public/bundles/pimui/less/components/CatalogVolume.less";
+@import "./public/bundles/pimui/less/components/ModalHint.less";
 
 @import "./public/bundles/pimui/less/pages/Default.less";
 @import "./public/bundles/pimui/less/pages/FullPage.less";

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/creation/modal.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/creation/modal.html
@@ -1,4 +1,4 @@
-<% if (hint) { %>
+<% if (typeof hint !== 'undefined' && hint) { %>
 <div class="ModalHint">
     <div class="ModalHint-icon AknIconButton AknIconButton--info"></div>
     <div class="ModalHint-title"> <%= hint %></div>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/creation/modal.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/creation/modal.html
@@ -1,3 +1,9 @@
+<% if (hint) { %>
+<div class="ModalHint">
+    <div class="ModalHint-icon AknIconButton AknIconButton--info"></div>
+    <div class="ModalHint-title"> <%= hint %></div>
+</div>
+<% } %>
 <div class="AknFormContainer AknFormContainer--withPadding">
     <div data-drop-zone="fields" class="AknFormContainer">
         <% if (null !== fields) { %>

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AssociationTypeIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AssociationTypeIntegration.php
@@ -17,6 +17,7 @@ class AssociationTypeIntegration extends AbstractNormalizerTestCase
                 'en_US' => 'Cross sell',
                 'fr_FR' => 'Vente croisée',
             ],
+            'isBidirectional' => false
         ];
 
         $repository = $this->get('pim_catalog.repository.association_type');

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AssociationTypeIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AssociationTypeIntegration.php
@@ -17,7 +17,7 @@ class AssociationTypeIntegration extends AbstractNormalizerTestCase
                 'en_US' => 'Cross sell',
                 'fr_FR' => 'Vente croisée',
             ],
-            'is_bidirectional' => false
+            'two_way' => false
         ];
 
         $repository = $this->get('pim_catalog.repository.association_type');

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AssociationTypeIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AssociationTypeIntegration.php
@@ -17,7 +17,7 @@ class AssociationTypeIntegration extends AbstractNormalizerTestCase
                 'en_US' => 'Cross sell',
                 'fr_FR' => 'Vente croisée',
             ],
-            'isBidirectional' => false
+            'is_bidirectional' => false
         ];
 
         $repository = $this->get('pim_catalog.repository.association_type');

--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AssociationTypeIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/AssociationTypeIntegration.php
@@ -17,7 +17,7 @@ class AssociationTypeIntegration extends AbstractNormalizerTestCase
                 'en_US' => 'Cross sell',
                 'fr_FR' => 'Vente croisée',
             ],
-            'two_way' => false
+            'is_two_way' => false
         ];
 
         $repository = $this->get('pim_catalog.repository.association_type');

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/CreateAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/CreateAssociationTypeEndToEnd.php
@@ -43,7 +43,7 @@ JSON;
         $associationTypeStandard = [
             'code'       => 'NEW_SELL',
             'labels'     => [],
-            'isBidirectional' => false
+            'is_bidirectional' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 
@@ -77,7 +77,7 @@ JSON;
                 'en_US' => 'New sell',
                 'fr_FR' => 'Nouvelle vente',
             ],
-            'isBidirectional' => false
+            'is_bidirectional' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 
@@ -108,7 +108,7 @@ JSON;
         $associationTypeStandard = [
             'code'       => 'NEW_SELL',
             'labels'     => [],
-            'isBidirectional' => false
+            'is_bidirectional' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/CreateAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/CreateAssociationTypeEndToEnd.php
@@ -43,7 +43,7 @@ JSON;
         $associationTypeStandard = [
             'code'       => 'NEW_SELL',
             'labels'     => [],
-            'is_bidirectional' => false
+            'two_way' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 
@@ -64,7 +64,7 @@ JSON;
             "en_US": "New sell",
             "fr_FR": "Nouvelle vente"
         },
-        "is_bidirectional": true
+        "two_way": true
     }
 JSON;
 
@@ -78,7 +78,7 @@ JSON;
                 'en_US' => 'New sell',
                 'fr_FR' => 'Nouvelle vente',
             ],
-            'is_bidirectional' => true
+            'two_way' => true
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 
@@ -109,7 +109,7 @@ JSON;
         $associationTypeStandard = [
             'code'       => 'NEW_SELL',
             'labels'     => [],
-            'is_bidirectional' => false
+            'two_way' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/CreateAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/CreateAssociationTypeEndToEnd.php
@@ -43,6 +43,7 @@ JSON;
         $associationTypeStandard = [
             'code'       => 'NEW_SELL',
             'labels'     => [],
+            'isBidirectional' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 
@@ -76,6 +77,7 @@ JSON;
                 'en_US' => 'New sell',
                 'fr_FR' => 'Nouvelle vente',
             ],
+            'isBidirectional' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 
@@ -106,6 +108,7 @@ JSON;
         $associationTypeStandard = [
             'code'       => 'NEW_SELL',
             'labels'     => [],
+            'isBidirectional' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/CreateAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/CreateAssociationTypeEndToEnd.php
@@ -43,7 +43,7 @@ JSON;
         $associationTypeStandard = [
             'code'       => 'NEW_SELL',
             'labels'     => [],
-            'two_way' => false
+            'is_two_way' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 
@@ -64,7 +64,7 @@ JSON;
             "en_US": "New sell",
             "fr_FR": "Nouvelle vente"
         },
-        "two_way": true
+        "is_two_way": true
     }
 JSON;
 
@@ -78,7 +78,7 @@ JSON;
                 'en_US' => 'New sell',
                 'fr_FR' => 'Nouvelle vente',
             ],
-            'two_way' => true
+            'is_two_way' => true
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 
@@ -109,7 +109,7 @@ JSON;
         $associationTypeStandard = [
             'code'       => 'NEW_SELL',
             'labels'     => [],
-            'two_way' => false
+            'is_two_way' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/CreateAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/CreateAssociationTypeEndToEnd.php
@@ -63,7 +63,8 @@ JSON;
         "labels": {
             "en_US": "New sell",
             "fr_FR": "Nouvelle vente"
-        }
+        },
+        "is_bidirectional": true
     }
 JSON;
 
@@ -77,7 +78,7 @@ JSON;
                 'en_US' => 'New sell',
                 'fr_FR' => 'Nouvelle vente',
             ],
-            'is_bidirectional' => false
+            'is_bidirectional' => true
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/GetAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/GetAssociationTypeEndToEnd.php
@@ -20,7 +20,7 @@ class GetAssociationTypeEndToEnd extends ApiTestCase
         "en_US": "Cross sell",
         "fr_FR": "Vente croisée"
     },
-    "two_way": false
+    "is_two_way": false
 }
 JSON;
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/GetAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/GetAssociationTypeEndToEnd.php
@@ -20,7 +20,7 @@ class GetAssociationTypeEndToEnd extends ApiTestCase
         "en_US": "Cross sell",
         "fr_FR": "Vente croisée"
     },
-    "is_bidirectional": false
+    "two_way": false
 }
 JSON;
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/GetAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/GetAssociationTypeEndToEnd.php
@@ -19,7 +19,8 @@ class GetAssociationTypeEndToEnd extends ApiTestCase
     "labels": {
         "en_US": "Cross sell",
         "fr_FR": "Vente croisée"
-    }
+    },
+    "isBidirectional": false
 }
 JSON;
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/GetAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/GetAssociationTypeEndToEnd.php
@@ -20,7 +20,7 @@ class GetAssociationTypeEndToEnd extends ApiTestCase
         "en_US": "Cross sell",
         "fr_FR": "Vente croisée"
     },
-    "isBidirectional": false
+    "is_bidirectional": false
 }
 JSON;
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/ListAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/ListAssociationTypeEndToEnd.php
@@ -201,7 +201,8 @@ JSON;
     "labels":{
         "en_US": "Cross sell",
         "fr_FR": "Vente croisée"
-    }
+    },
+    "isBidirectional": false
 }
 JSON;
 
@@ -216,7 +217,8 @@ JSON;
     "labels":{
         "en_US": "Upsell",
         "fr_FR": "Vente incitative"
-    }
+    },
+    "isBidirectional": false
 }
 JSON;
 
@@ -231,7 +233,8 @@ JSON;
     "labels":{
         "en_US": "Substitution",
         "fr_FR": "Remplacement"
-    }
+    },
+    "isBidirectional": false
 }
 JSON;
 
@@ -246,7 +249,8 @@ JSON;
     "labels":{
         "en_US": "Pack",
         "fr_FR": "Pack"
-    }
+    },
+    "isBidirectional": false
 }
 JSON;
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/ListAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/ListAssociationTypeEndToEnd.php
@@ -202,7 +202,7 @@ JSON;
         "en_US": "Cross sell",
         "fr_FR": "Vente croisée"
     },
-    "two_way": false
+    "is_two_way": false
 }
 JSON;
 
@@ -218,7 +218,7 @@ JSON;
         "en_US": "Upsell",
         "fr_FR": "Vente incitative"
     },
-    "two_way": false
+    "is_two_way": false
 }
 JSON;
 
@@ -234,7 +234,7 @@ JSON;
         "en_US": "Substitution",
         "fr_FR": "Remplacement"
     },
-    "two_way": false
+    "is_two_way": false
 }
 JSON;
 
@@ -250,7 +250,7 @@ JSON;
         "en_US": "Pack",
         "fr_FR": "Pack"
     },
-    "two_way": false
+    "is_two_way": false
 }
 JSON;
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/ListAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/ListAssociationTypeEndToEnd.php
@@ -202,7 +202,7 @@ JSON;
         "en_US": "Cross sell",
         "fr_FR": "Vente croisée"
     },
-    "isBidirectional": false
+    "is_bidirectional": false
 }
 JSON;
 
@@ -218,7 +218,7 @@ JSON;
         "en_US": "Upsell",
         "fr_FR": "Vente incitative"
     },
-    "isBidirectional": false
+    "is_bidirectional": false
 }
 JSON;
 
@@ -234,7 +234,7 @@ JSON;
         "en_US": "Substitution",
         "fr_FR": "Remplacement"
     },
-    "isBidirectional": false
+    "is_bidirectional": false
 }
 JSON;
 
@@ -250,7 +250,7 @@ JSON;
         "en_US": "Pack",
         "fr_FR": "Pack"
     },
-    "isBidirectional": false
+    "is_bidirectional": false
 }
 JSON;
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/ListAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/ListAssociationTypeEndToEnd.php
@@ -202,7 +202,7 @@ JSON;
         "en_US": "Cross sell",
         "fr_FR": "Vente croisée"
     },
-    "is_bidirectional": false
+    "two_way": false
 }
 JSON;
 
@@ -218,7 +218,7 @@ JSON;
         "en_US": "Upsell",
         "fr_FR": "Vente incitative"
     },
-    "is_bidirectional": false
+    "two_way": false
 }
 JSON;
 
@@ -234,7 +234,7 @@ JSON;
         "en_US": "Substitution",
         "fr_FR": "Remplacement"
     },
-    "is_bidirectional": false
+    "two_way": false
 }
 JSON;
 
@@ -250,7 +250,7 @@ JSON;
         "en_US": "Pack",
         "fr_FR": "Pack"
     },
-    "is_bidirectional": false
+    "two_way": false
 }
 JSON;
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
@@ -72,7 +72,8 @@ JSON;
         "labels": {
             "en_US": "Gift sell",
             "fr_FR": "Vente cadeau"
-        }
+        },
+        "is_bidirectional": true
     }
 JSON;
         $client->request('PATCH', '/api/rest/v1/association-types/GIFT_SELL', [], [], [], $data);
@@ -83,12 +84,42 @@ JSON;
                 'en_US' => 'Gift sell',
                 'fr_FR' => 'Vente cadeau',
             ],
-            'is_bidirectional' => false,
+            'is_bidirectional' => true,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
         $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
         $this->assertSame($associationTypeStandard, $normalizer->normalize($associationType));
+    }
+
+    public function testIsBidirectionalIsImmutable()
+    {
+        $client = $this->createAuthenticatedClient();
+        $data =
+<<<JSON
+    {
+        "code": "X_SELL",
+        "is_bidirectional": true
+    }
+JSON;
+        $expectedContent =
+<<<JSON
+{
+    "code": 422,
+    "message": "Validation failed.",
+    "errors": [
+        {
+            "property": "is_bidirectional",
+            "message": "This property cannot be changed."
+        }
+    ]
+}
+JSON;
+
+        $client->request('PATCH', '/api/rest/v1/association-types/X_SELL', [], [], [], $data);
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
     }
 
     public function testAssociationTypePartialUpdateWithAnEmptyContent()

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
@@ -55,7 +55,7 @@ JSON;
         $associationTypeStandard = [
             'code'             => 'YOLO_SELL',
             'labels'           => [],
-            'two_way' => false
+            'is_two_way' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -73,7 +73,7 @@ JSON;
             "en_US": "Gift sell",
             "fr_FR": "Vente cadeau"
         },
-        "two_way": true
+        "is_two_way": true
     }
 JSON;
         $client->request('PATCH', '/api/rest/v1/association-types/GIFT_SELL', [], [], [], $data);
@@ -84,7 +84,7 @@ JSON;
                 'en_US' => 'Gift sell',
                 'fr_FR' => 'Vente cadeau',
             ],
-            'two_way' => true,
+            'is_two_way' => true,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -92,14 +92,14 @@ JSON;
         $this->assertSame($associationTypeStandard, $normalizer->normalize($associationType));
     }
 
-    public function testTwoWayIsImmutable()
+    public function testIsTwoWayFieldIsImmutable()
     {
         $client = $this->createAuthenticatedClient();
         $data =
 <<<JSON
     {
         "code": "X_SELL",
-        "two_way": true
+        "is_two_way": true
     }
 JSON;
         $expectedContent =
@@ -134,7 +134,7 @@ JSON;
                 'en_US' => 'Cross sell',
                 'fr_FR' => 'Vente croisée',
             ],
-            'two_way' => false,
+            'is_two_way' => false,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -160,7 +160,7 @@ JSON;
             'labels'           => [
                 'fr_FR' => 'Vente croisée',
             ],
-            'two_way' => false,
+            'is_two_way' => false,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
@@ -55,7 +55,7 @@ JSON;
         $associationTypeStandard = [
             'code'             => 'YOLO_SELL',
             'labels'           => [],
-            'is_bidirectional' => false
+            'two_way' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -73,7 +73,7 @@ JSON;
             "en_US": "Gift sell",
             "fr_FR": "Vente cadeau"
         },
-        "is_bidirectional": true
+        "two_way": true
     }
 JSON;
         $client->request('PATCH', '/api/rest/v1/association-types/GIFT_SELL', [], [], [], $data);
@@ -84,7 +84,7 @@ JSON;
                 'en_US' => 'Gift sell',
                 'fr_FR' => 'Vente cadeau',
             ],
-            'is_bidirectional' => true,
+            'two_way' => true,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -92,14 +92,14 @@ JSON;
         $this->assertSame($associationTypeStandard, $normalizer->normalize($associationType));
     }
 
-    public function testIsBidirectionalIsImmutable()
+    public function testTwoWayIsImmutable()
     {
         $client = $this->createAuthenticatedClient();
         $data =
 <<<JSON
     {
         "code": "X_SELL",
-        "is_bidirectional": true
+        "two_way": true
     }
 JSON;
         $expectedContent =
@@ -109,7 +109,7 @@ JSON;
     "message": "Validation failed.",
     "errors": [
         {
-            "property": "is_bidirectional",
+            "property": "two_way",
             "message": "This property cannot be changed."
         }
     ]
@@ -134,7 +134,7 @@ JSON;
                 'en_US' => 'Cross sell',
                 'fr_FR' => 'Vente croisée',
             ],
-            'is_bidirectional' => false,
+            'two_way' => false,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -160,7 +160,7 @@ JSON;
             'labels'           => [
                 'fr_FR' => 'Vente croisée',
             ],
-            'is_bidirectional' => false,
+            'two_way' => false,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
@@ -55,7 +55,7 @@ JSON;
         $associationTypeStandard = [
             'code'             => 'YOLO_SELL',
             'labels'           => [],
-            'isBidirectional' => false
+            'is_bidirectional' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -83,7 +83,7 @@ JSON;
                 'en_US' => 'Gift sell',
                 'fr_FR' => 'Vente cadeau',
             ],
-            'isBidirectional' => false,
+            'is_bidirectional' => false,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -103,7 +103,7 @@ JSON;
                 'en_US' => 'Cross sell',
                 'fr_FR' => 'Vente croisée',
             ],
-            'isBidirectional' => false,
+            'is_bidirectional' => false,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -129,7 +129,7 @@ JSON;
             'labels'           => [
                 'fr_FR' => 'Vente croisée',
             ],
-            'isBidirectional' => false,
+            'is_bidirectional' => false,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
@@ -55,6 +55,7 @@ JSON;
         $associationTypeStandard = [
             'code'             => 'YOLO_SELL',
             'labels'           => [],
+            'isBidirectional' => false
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -82,6 +83,7 @@ JSON;
                 'en_US' => 'Gift sell',
                 'fr_FR' => 'Vente cadeau',
             ],
+            'isBidirectional' => false,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -101,6 +103,7 @@ JSON;
                 'en_US' => 'Cross sell',
                 'fr_FR' => 'Vente croisée',
             ],
+            'isBidirectional' => false,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();
@@ -126,6 +129,7 @@ JSON;
             'labels'           => [
                 'fr_FR' => 'Vente croisée',
             ],
+            'isBidirectional' => false,
         ];
         $normalizer = $this->get('pim_catalog.normalizer.standard.association_type');
         $response = $client->getResponse();

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateAssociationTypeEndToEnd.php
@@ -109,7 +109,7 @@ JSON;
     "message": "Validation failed.",
     "errors": [
         {
-            "property": "two_way",
+            "property": "is_two_way",
             "message": "This property cannot be changed."
         }
     ]

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateListAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateListAssociationTypeEndToEnd.php
@@ -36,12 +36,12 @@ JSON;
                     'en_US' => 'Cross sell',
                     'fr_FR' => 'Vente croisée',
                 ],
-                'is_bidirectional' => false,
+                'two_way' => false,
             ],
             'NEW_SELL' => [
                 'code'   => 'NEW_SELL',
                 'labels' => [],
-                'is_bidirectional' => false,
+                'two_way' => false,
             ],
         ];
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateListAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateListAssociationTypeEndToEnd.php
@@ -36,10 +36,12 @@ JSON;
                     'en_US' => 'Cross sell',
                     'fr_FR' => 'Vente croisée',
                 ],
+                'isBidirectional' => false,
             ],
             'NEW_SELL' => [
                 'code'   => 'NEW_SELL',
                 'labels' => [],
+                'isBidirectional' => false,
             ],
         ];
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateListAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateListAssociationTypeEndToEnd.php
@@ -36,12 +36,12 @@ JSON;
                     'en_US' => 'Cross sell',
                     'fr_FR' => 'Vente croisée',
                 ],
-                'isBidirectional' => false,
+                'is_bidirectional' => false,
             ],
             'NEW_SELL' => [
                 'code'   => 'NEW_SELL',
                 'labels' => [],
-                'isBidirectional' => false,
+                'is_bidirectional' => false,
             ],
         ];
 

--- a/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateListAssociationTypeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AssociationType/ExternalApi/PartialUpdateListAssociationTypeEndToEnd.php
@@ -36,12 +36,12 @@ JSON;
                     'en_US' => 'Cross sell',
                     'fr_FR' => 'Vente croisée',
                 ],
-                'two_way' => false,
+                'is_two_way' => false,
             ],
             'NEW_SELL' => [
                 'code'   => 'NEW_SELL',
                 'labels' => [],
-                'two_way' => false,
+                'is_two_way' => false,
             ],
         ];
 

--- a/tests/back/Pim/Structure/Integration/Normalizer/Standard/AssociationTypeIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Normalizer/Standard/AssociationTypeIntegration.php
@@ -18,7 +18,8 @@ class AssociationTypeIntegration extends TestCase
             'labels' => [
                 'en_US' => 'Substitution',
                 'fr_FR' => 'Remplacement'
-            ]
+            ],
+            'is_bidirectional' => false,
         ];
 
         $repository = $this->get('pim_catalog.repository.association_type');

--- a/tests/back/Pim/Structure/Integration/Normalizer/Standard/AssociationTypeIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Normalizer/Standard/AssociationTypeIntegration.php
@@ -19,7 +19,7 @@ class AssociationTypeIntegration extends TestCase
                 'en_US' => 'Substitution',
                 'fr_FR' => 'Remplacement'
             ],
-            'two_way' => false,
+            'is_two_way' => false,
         ];
 
         $repository = $this->get('pim_catalog.repository.association_type');

--- a/tests/back/Pim/Structure/Integration/Normalizer/Standard/AssociationTypeIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Normalizer/Standard/AssociationTypeIntegration.php
@@ -19,7 +19,7 @@ class AssociationTypeIntegration extends TestCase
                 'en_US' => 'Substitution',
                 'fr_FR' => 'Remplacement'
             ],
-            'is_bidirectional' => false,
+            'two_way' => false,
         ];
 
         $repository = $this->get('pim_catalog.repository.association_type');

--- a/tests/back/Pim/Structure/Integration/Normalizer/Versioning/AssociationTypeIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Normalizer/Versioning/AssociationTypeIntegration.php
@@ -18,7 +18,7 @@ class AssociationTypeIntegration extends TestCase
 
         $this->assertSame($flatAssociationType, [
             'code'        => 'X_SELL',
-            'is_bidirectional' => false,
+            'two_way' => false,
             'label-en_US' => 'Cross sell',
             'label-fr_FR' => 'Vente croisée',
         ]);

--- a/tests/back/Pim/Structure/Integration/Normalizer/Versioning/AssociationTypeIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Normalizer/Versioning/AssociationTypeIntegration.php
@@ -18,6 +18,7 @@ class AssociationTypeIntegration extends TestCase
 
         $this->assertSame($flatAssociationType, [
             'code'        => 'X_SELL',
+            'isBidirectional' => false,
             'label-en_US' => 'Cross sell',
             'label-fr_FR' => 'Vente croisée',
         ]);

--- a/tests/back/Pim/Structure/Integration/Normalizer/Versioning/AssociationTypeIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Normalizer/Versioning/AssociationTypeIntegration.php
@@ -18,7 +18,7 @@ class AssociationTypeIntegration extends TestCase
 
         $this->assertSame($flatAssociationType, [
             'code'        => 'X_SELL',
-            'two_way' => false,
+            'is_two_way' => false,
             'label-en_US' => 'Cross sell',
             'label-fr_FR' => 'Vente croisée',
         ]);

--- a/tests/back/Pim/Structure/Integration/Normalizer/Versioning/AssociationTypeIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Normalizer/Versioning/AssociationTypeIntegration.php
@@ -18,7 +18,7 @@ class AssociationTypeIntegration extends TestCase
 
         $this->assertSame($flatAssociationType, [
             'code'        => 'X_SELL',
-            'isBidirectional' => false,
+            'is_bidirectional' => false,
             'label-en_US' => 'Cross sell',
             'label-fr_FR' => 'Vente croisée',
         ]);

--- a/tests/back/Pim/Structure/Specification/Component/ArrayConverter/FlatToStandard/AssociationTypeSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/ArrayConverter/FlatToStandard/AssociationTypeSpec.php
@@ -18,7 +18,7 @@ class AssociationTypeSpec extends ObjectBehavior
             'code'        => 'mycode',
             'label-fr_FR' => 'Vente croisée',
             'label-en_US' => 'Cross sell',
-            'two_way'   => true,
+            'is_two_way' => true,
         ];
 
         $this->convert($fields)->shouldReturn(
@@ -28,7 +28,7 @@ class AssociationTypeSpec extends ObjectBehavior
                     'en_US' => 'Cross sell',
                 ],
                 'code'   => 'mycode',
-                'two_way'   => true,
+                'is_two_way' => true,
             ]
         );
     }
@@ -48,7 +48,7 @@ class AssociationTypeSpec extends ObjectBehavior
                     'en_US' => 'Cross sell',
                 ],
                 'code'   => 'mycode',
-                'two_way'   => false,
+                'is_two_way' => false,
             ]
         );
     }

--- a/tests/back/Pim/Structure/Specification/Component/ArrayConverter/FlatToStandard/AssociationTypeSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/ArrayConverter/FlatToStandard/AssociationTypeSpec.php
@@ -27,7 +27,7 @@ class AssociationTypeSpec extends ObjectBehavior
                     'en_US' => 'Cross sell',
                 ],
                 'code'   => 'mycode',
-                'isBidirectional'   => false,
+                'is_bidirectional'   => false,
             ]
         );
     }

--- a/tests/back/Pim/Structure/Specification/Component/ArrayConverter/FlatToStandard/AssociationTypeSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/ArrayConverter/FlatToStandard/AssociationTypeSpec.php
@@ -18,6 +18,27 @@ class AssociationTypeSpec extends ObjectBehavior
             'code'        => 'mycode',
             'label-fr_FR' => 'Vente croisée',
             'label-en_US' => 'Cross sell',
+            'is_bidirectional'   => true,
+        ];
+
+        $this->convert($fields)->shouldReturn(
+            [
+                'labels' => [
+                    'fr_FR' => 'Vente croisée',
+                    'en_US' => 'Cross sell',
+                ],
+                'code'   => 'mycode',
+                'is_bidirectional'   => true,
+            ]
+        );
+    }
+
+    function it_converts_is_bidirectional_to_false_by_default()
+    {
+        $fields = [
+            'code'        => 'mycode',
+            'label-fr_FR' => 'Vente croisée',
+            'label-en_US' => 'Cross sell',
         ];
 
         $this->convert($fields)->shouldReturn(

--- a/tests/back/Pim/Structure/Specification/Component/ArrayConverter/FlatToStandard/AssociationTypeSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/ArrayConverter/FlatToStandard/AssociationTypeSpec.php
@@ -18,7 +18,7 @@ class AssociationTypeSpec extends ObjectBehavior
             'code'        => 'mycode',
             'label-fr_FR' => 'Vente croisée',
             'label-en_US' => 'Cross sell',
-            'is_bidirectional'   => true,
+            'two_way'   => true,
         ];
 
         $this->convert($fields)->shouldReturn(
@@ -28,12 +28,12 @@ class AssociationTypeSpec extends ObjectBehavior
                     'en_US' => 'Cross sell',
                 ],
                 'code'   => 'mycode',
-                'is_bidirectional'   => true,
+                'two_way'   => true,
             ]
         );
     }
 
-    function it_converts_is_bidirectional_to_false_by_default()
+    function it_converts_is_not_two_way_by_default()
     {
         $fields = [
             'code'        => 'mycode',
@@ -48,7 +48,7 @@ class AssociationTypeSpec extends ObjectBehavior
                     'en_US' => 'Cross sell',
                 ],
                 'code'   => 'mycode',
-                'is_bidirectional'   => false,
+                'two_way'   => false,
             ]
         );
     }

--- a/tests/back/Pim/Structure/Specification/Component/ArrayConverter/FlatToStandard/AssociationTypeSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/ArrayConverter/FlatToStandard/AssociationTypeSpec.php
@@ -27,6 +27,7 @@ class AssociationTypeSpec extends ObjectBehavior
                     'en_US' => 'Cross sell',
                 ],
                 'code'   => 'mycode',
+                'isBidirectional'   => false,
             ]
         );
     }

--- a/tests/back/Pim/Structure/Specification/Component/ArrayConverter/StandardToFlat/AssociationTypeSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/ArrayConverter/StandardToFlat/AssociationTypeSpec.php
@@ -12,7 +12,7 @@ class AssociationTypeSpec extends ObjectBehavior
             'code'        => 'long_sword',
             'label-fr_FR' => 'Épée longue',
             'label-en_US' => 'Long sword',
-            'two_way' => 1
+            'is_two_way' => 1
         ];
 
         $item = [
@@ -21,7 +21,7 @@ class AssociationTypeSpec extends ObjectBehavior
                 'fr_FR' => 'Épée longue',
                 'en_US' => 'Long sword'
             ],
-            'two_way' => true
+            'is_two_way' => true
         ];
 
         $this->convert($item)->shouldReturn($expected);

--- a/tests/back/Pim/Structure/Specification/Component/ArrayConverter/StandardToFlat/AssociationTypeSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/ArrayConverter/StandardToFlat/AssociationTypeSpec.php
@@ -12,7 +12,7 @@ class AssociationTypeSpec extends ObjectBehavior
             'code'        => 'long_sword',
             'label-fr_FR' => 'Épée longue',
             'label-en_US' => 'Long sword',
-            'is_bidirectional' => 1
+            'two_way' => 1
         ];
 
         $item = [
@@ -21,7 +21,7 @@ class AssociationTypeSpec extends ObjectBehavior
                 'fr_FR' => 'Épée longue',
                 'en_US' => 'Long sword'
             ],
-            'is_bidirectional' => true
+            'two_way' => true
         ];
 
         $this->convert($item)->shouldReturn($expected);

--- a/tests/back/Pim/Structure/Specification/Component/ArrayConverter/StandardToFlat/AssociationTypeSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/ArrayConverter/StandardToFlat/AssociationTypeSpec.php
@@ -11,7 +11,8 @@ class AssociationTypeSpec extends ObjectBehavior
         $expected = [
             'code'        => 'long_sword',
             'label-fr_FR' => 'Épée longue',
-            'label-en_US' => 'Long sword'
+            'label-en_US' => 'Long sword',
+            'is_bidirectional' => 1
         ];
 
         $item = [
@@ -19,7 +20,8 @@ class AssociationTypeSpec extends ObjectBehavior
             'labels' => [
                 'fr_FR' => 'Épée longue',
                 'en_US' => 'Long sword'
-            ]
+            ],
+            'is_bidirectional' => true
         ];
 
         $this->convert($item)->shouldReturn($expected);

--- a/tests/back/Pim/Structure/Specification/Component/Normalizer/Standard/AssociationTypeNormalizerSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Normalizer/Standard/AssociationTypeNormalizerSpec.php
@@ -39,10 +39,12 @@ class AssociationTypeNormalizerSpec extends ObjectBehavior
         $translationNormalizer->normalize($associationType, 'standard', [])->willReturn([]);
 
         $associationType->getCode()->willReturn('my_code');
+        $associationType->isBidirectional()->willReturn(true);
 
         $this->normalize($associationType)->shouldReturn([
             'code'   => 'my_code',
-            'labels' => []
+            'labels' => [],
+            'isBidirectional' => true
         ]);
     }
 }

--- a/tests/back/Pim/Structure/Specification/Component/Normalizer/Standard/AssociationTypeNormalizerSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Normalizer/Standard/AssociationTypeNormalizerSpec.php
@@ -44,7 +44,7 @@ class AssociationTypeNormalizerSpec extends ObjectBehavior
         $this->normalize($associationType)->shouldReturn([
             'code'   => 'my_code',
             'labels' => [],
-            'two_way' => true
+            'is_two_way' => true
         ]);
     }
 }

--- a/tests/back/Pim/Structure/Specification/Component/Normalizer/Standard/AssociationTypeNormalizerSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Normalizer/Standard/AssociationTypeNormalizerSpec.php
@@ -44,7 +44,7 @@ class AssociationTypeNormalizerSpec extends ObjectBehavior
         $this->normalize($associationType)->shouldReturn([
             'code'   => 'my_code',
             'labels' => [],
-            'isBidirectional' => true
+            'is_bidirectional' => true
         ]);
     }
 }

--- a/tests/back/Pim/Structure/Specification/Component/Normalizer/Standard/AssociationTypeNormalizerSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Normalizer/Standard/AssociationTypeNormalizerSpec.php
@@ -39,12 +39,12 @@ class AssociationTypeNormalizerSpec extends ObjectBehavior
         $translationNormalizer->normalize($associationType, 'standard', [])->willReturn([]);
 
         $associationType->getCode()->willReturn('my_code');
-        $associationType->isBidirectional()->willReturn(true);
+        $associationType->isTwoWay()->willReturn(true);
 
         $this->normalize($associationType)->shouldReturn([
             'code'   => 'my_code',
             'labels' => [],
-            'is_bidirectional' => true
+            'two_way' => true
         ]);
     }
 }

--- a/tests/back/Pim/Structure/Specification/Component/Updater/AssociationTypeUpdaterSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Updater/AssociationTypeUpdaterSpec.php
@@ -51,9 +51,11 @@ class AssociationTypeUpdaterSpec extends ObjectBehavior
             'labels' => [
                 'fr_FR' => 'Vente croisée',
             ],
+            'is_bidirectional' => true
         ];
 
         $associationType->setCode('mycode')->shouldBeCalled();
+        $associationType->setIsBidirectional(true)->shouldBeCalled();
         $translatableUpdater->update($associationType, $values['labels'])->shouldBeCalled();
 
         $this->update($associationType, $values, []);
@@ -108,6 +110,21 @@ class AssociationTypeUpdaterSpec extends ObjectBehavior
                     'one of the "labels" values is not a scalar',
                     AssociationTypeUpdater::class,
                     ['fr_FR' => []]
+                )
+            )
+            ->during('update', [$associationType, $data, []]);
+    }
+
+    function it_throws_an_exception_when_is_bidirectional_is_not_boolean(AssociationTypeInterface $associationType)
+    {
+        $data = ['is_bidirectional' => 'foo'];
+
+        $this
+            ->shouldThrow(
+                InvalidPropertyTypeException::booleanExpected(
+                    'is_bidirectional',
+                    AssociationTypeUpdater::class,
+                    'foo'
                 )
             )
             ->during('update', [$associationType, $data, []]);

--- a/tests/back/Pim/Structure/Specification/Component/Updater/AssociationTypeUpdaterSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Updater/AssociationTypeUpdaterSpec.php
@@ -51,11 +51,11 @@ class AssociationTypeUpdaterSpec extends ObjectBehavior
             'labels' => [
                 'fr_FR' => 'Vente croisée',
             ],
-            'is_bidirectional' => true
+            'two_way' => true
         ];
 
         $associationType->setCode('mycode')->shouldBeCalled();
-        $associationType->setIsBidirectional(true)->shouldBeCalled();
+        $associationType->setIsTwoWay(true)->shouldBeCalled();
         $translatableUpdater->update($associationType, $values['labels'])->shouldBeCalled();
 
         $this->update($associationType, $values, []);
@@ -115,14 +115,14 @@ class AssociationTypeUpdaterSpec extends ObjectBehavior
             ->during('update', [$associationType, $data, []]);
     }
 
-    function it_throws_an_exception_when_is_bidirectional_is_not_boolean(AssociationTypeInterface $associationType)
+    function it_throws_an_exception_when_value_two_way_is_not_boolean(AssociationTypeInterface $associationType)
     {
-        $data = ['is_bidirectional' => 'foo'];
+        $data = ['two_way' => 'foo'];
 
         $this
             ->shouldThrow(
                 InvalidPropertyTypeException::booleanExpected(
-                    'is_bidirectional',
+                    'two_way',
                     AssociationTypeUpdater::class,
                     'foo'
                 )

--- a/tests/back/Pim/Structure/Specification/Component/Updater/AssociationTypeUpdaterSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Updater/AssociationTypeUpdaterSpec.php
@@ -51,7 +51,7 @@ class AssociationTypeUpdaterSpec extends ObjectBehavior
             'labels' => [
                 'fr_FR' => 'Vente croisée',
             ],
-            'two_way' => true
+            'is_two_way' => true
         ];
 
         $associationType->setCode('mycode')->shouldBeCalled();
@@ -115,14 +115,14 @@ class AssociationTypeUpdaterSpec extends ObjectBehavior
             ->during('update', [$associationType, $data, []]);
     }
 
-    function it_throws_an_exception_when_value_two_way_is_not_boolean(AssociationTypeInterface $associationType)
+    function it_throws_an_exception_when_value_is_two_way_is_not_boolean(AssociationTypeInterface $associationType)
     {
-        $data = ['two_way' => 'foo'];
+        $data = ['is_two_way' => 'foo'];
 
         $this
             ->shouldThrow(
                 InvalidPropertyTypeException::booleanExpected(
-                    'two_way',
+                    'is_two_way',
                     AssociationTypeUpdater::class,
                     'foo'
                 )

--- a/tests/legacy/features/Context/FixturesContext.php
+++ b/tests/legacy/features/Context/FixturesContext.php
@@ -978,6 +978,8 @@ class FixturesContext extends BaseFixturesContext
                 $matches = null;
                 if (preg_match('/^label-(?P<locale>.*)$/', $key, $matches)) {
                     Assert::assertEquals($value, $associationType->getTranslation($matches['locale'])->getLabel());
+                } elseif ('is_bidirectional' === $key) {
+                    Assert::assertEquals($value, $associationType->isBidirectionnal());
                 } else {
                     throw new \InvalidArgumentException(
                         sprintf('Cannot check "%s" attribute of the association type', $key)

--- a/tests/legacy/features/Context/FixturesContext.php
+++ b/tests/legacy/features/Context/FixturesContext.php
@@ -978,7 +978,7 @@ class FixturesContext extends BaseFixturesContext
                 $matches = null;
                 if (preg_match('/^label-(?P<locale>.*)$/', $key, $matches)) {
                     Assert::assertEquals($value, $associationType->getTranslation($matches['locale'])->getLabel());
-                } elseif ('two_way' === $key) {
+                } elseif ('is_two_way' === $key) {
                     Assert::assertEquals($value === 'false' ? false : true, $associationType->isTwoWay());
                 } else {
                     throw new \InvalidArgumentException(

--- a/tests/legacy/features/Context/FixturesContext.php
+++ b/tests/legacy/features/Context/FixturesContext.php
@@ -978,8 +978,8 @@ class FixturesContext extends BaseFixturesContext
                 $matches = null;
                 if (preg_match('/^label-(?P<locale>.*)$/', $key, $matches)) {
                     Assert::assertEquals($value, $associationType->getTranslation($matches['locale'])->getLabel());
-                } elseif ('is_bidirectional' === $key) {
-                    Assert::assertEquals($value === 'false' ? false : true, $associationType->isBidirectional());
+                } elseif ('two_way' === $key) {
+                    Assert::assertEquals($value === 'false' ? false : true, $associationType->isTwoWay());
                 } else {
                     throw new \InvalidArgumentException(
                         sprintf('Cannot check "%s" attribute of the association type', $key)

--- a/tests/legacy/features/Context/FixturesContext.php
+++ b/tests/legacy/features/Context/FixturesContext.php
@@ -979,7 +979,7 @@ class FixturesContext extends BaseFixturesContext
                 if (preg_match('/^label-(?P<locale>.*)$/', $key, $matches)) {
                     Assert::assertEquals($value, $associationType->getTranslation($matches['locale'])->getLabel());
                 } elseif ('is_bidirectional' === $key) {
-                    Assert::assertEquals($value, $associationType->isBidirectional());
+                    Assert::assertEquals($value === 'false' ? false : true, $associationType->isBidirectional());
                 } else {
                     throw new \InvalidArgumentException(
                         sprintf('Cannot check "%s" attribute of the association type', $key)

--- a/tests/legacy/features/Context/FixturesContext.php
+++ b/tests/legacy/features/Context/FixturesContext.php
@@ -979,7 +979,7 @@ class FixturesContext extends BaseFixturesContext
                 if (preg_match('/^label-(?P<locale>.*)$/', $key, $matches)) {
                     Assert::assertEquals($value, $associationType->getTranslation($matches['locale'])->getLabel());
                 } elseif ('is_bidirectional' === $key) {
-                    Assert::assertEquals($value, $associationType->isBidirectionnal());
+                    Assert::assertEquals($value, $associationType->isBidirectional());
                 } else {
                     throw new \InvalidArgumentException(
                         sprintf('Cannot check "%s" attribute of the association type', $key)

--- a/tests/legacy/features/Context/catalog/apparel/association_types.csv
+++ b/tests/legacy/features/Context/catalog/apparel/association_types.csv
@@ -1,4 +1,4 @@
-code;two_way;label-en_US;label-en_GB;label-fr_FR;label-de_DE
+code;is_two_way;label-en_US;label-en_GB;label-fr_FR;label-de_DE
 variant;0;Variant;Variant;Variante;Variante
 similar;0;Similar;Similar;Similaire;Ähnlich
 related;0;Related;Related;Connexe;Verbunden

--- a/tests/legacy/features/Context/catalog/apparel/association_types.csv
+++ b/tests/legacy/features/Context/catalog/apparel/association_types.csv
@@ -1,8 +1,8 @@
 code;is_bidirectional;label-en_US;label-en_GB;label-fr_FR;label-de_DE
-variant;false;Variant;Variant;Variante;Variante
-similar;false;Similar;Similar;Similaire;Ähnlich
-related;false;Related;Related;Connexe;Verbunden
-cross_sell;false;Cross sell;Cross sell;Vente croisée;Cross-Selling
-upsell;false;Upsell;Upsell;Vente incitative;Upsell
-substitute;false;Substitute;Substitute;Substitut;Ersatz
-pack;false;Pack;Pack;Paquet;Pack
+variant;0;Variant;Variant;Variante;Variante
+similar;0;Similar;Similar;Similaire;Ähnlich
+related;0;Related;Related;Connexe;Verbunden
+cross_sell;0;Cross sell;Cross sell;Vente croisée;Cross-Selling
+upsell;0;Upsell;Upsell;Vente incitative;Upsell
+substitute;0;Substitute;Substitute;Substitut;Ersatz
+pack;0;Pack;Pack;Paquet;Pack

--- a/tests/legacy/features/Context/catalog/apparel/association_types.csv
+++ b/tests/legacy/features/Context/catalog/apparel/association_types.csv
@@ -1,4 +1,4 @@
-code;is-bidirectional;label-en_US;label-en_GB;label-fr_FR;label-de_DE
+code;is_bidirectional;label-en_US;label-en_GB;label-fr_FR;label-de_DE
 variant;false;Variant;Variant;Variante;Variante
 similar;false;Similar;Similar;Similaire;Ähnlich
 related;false;Related;Related;Connexe;Verbunden

--- a/tests/legacy/features/Context/catalog/apparel/association_types.csv
+++ b/tests/legacy/features/Context/catalog/apparel/association_types.csv
@@ -1,8 +1,8 @@
-code;label-en_US;label-en_GB;label-fr_FR;label-de_DE
-variant;Variant;Variant;Variante;Variante
-similar;Similar;Similar;Similaire;Ähnlich
-related;Related;Related;Connexe;Verbunden
-cross_sell;Cross sell;Cross sell;Vente croisée;Cross-Selling
-upsell;Upsell;Upsell;Vente incitative;Upsell
-substitute;Substitute;Substitute;Substitut;Ersatz
-pack;Pack;Pack;Paquet;Pack
+code;is-bidirectional;label-en_US;label-en_GB;label-fr_FR;label-de_DE
+variant;false;Variant;Variant;Variante;Variante
+similar;false;Similar;Similar;Similaire;Ähnlich
+related;false;Related;Related;Connexe;Verbunden
+cross_sell;false;Cross sell;Cross sell;Vente croisée;Cross-Selling
+upsell;false;Upsell;Upsell;Vente incitative;Upsell
+substitute;false;Substitute;Substitute;Substitut;Ersatz
+pack;false;Pack;Pack;Paquet;Pack

--- a/tests/legacy/features/Context/catalog/apparel/association_types.csv
+++ b/tests/legacy/features/Context/catalog/apparel/association_types.csv
@@ -1,4 +1,4 @@
-code;is_bidirectional;label-en_US;label-en_GB;label-fr_FR;label-de_DE
+code;two_way;label-en_US;label-en_GB;label-fr_FR;label-de_DE
 variant;0;Variant;Variant;Variante;Variante
 similar;0;Similar;Similar;Similaire;Ähnlich
 related;0;Related;Related;Connexe;Verbunden

--- a/tests/legacy/features/Context/catalog/catalog_modeling/association_types.csv
+++ b/tests/legacy/features/Context/catalog/catalog_modeling/association_types.csv
@@ -1,4 +1,4 @@
-code;is_bidirectional;label-en_US;label-fr_FR;label-de_DE
+code;two_way;label-en_US;label-fr_FR;label-de_DE
 X_SELL;0;Cross sell;Vente croisée;
 UPSELL;0;Upsell;Vente incitative;
 SUBSTITUTION;0;Substitution;Remplacement;Ersatz

--- a/tests/legacy/features/Context/catalog/catalog_modeling/association_types.csv
+++ b/tests/legacy/features/Context/catalog/catalog_modeling/association_types.csv
@@ -1,4 +1,4 @@
-code;two_way;label-en_US;label-fr_FR;label-de_DE
+code;is_two_way;label-en_US;label-fr_FR;label-de_DE
 X_SELL;0;Cross sell;Vente croisée;
 UPSELL;0;Upsell;Vente incitative;
 SUBSTITUTION;0;Substitution;Remplacement;Ersatz

--- a/tests/legacy/features/Context/catalog/catalog_modeling/association_types.csv
+++ b/tests/legacy/features/Context/catalog/catalog_modeling/association_types.csv
@@ -1,5 +1,5 @@
-code;label-en_US;label-fr_FR;label-de_DE
-X_SELL;Cross sell;Vente croisée;
-UPSELL;Upsell;Vente incitative;
-SUBSTITUTION;Substitution;Remplacement;Ersatz
-PACK;Pack;Pack;Pack
+code;is-bidirectional;label-en_US;label-fr_FR;label-de_DE
+X_SELL;false;Cross sell;Vente croisée;
+UPSELL;false;Upsell;Vente incitative;
+SUBSTITUTION;false;Substitution;Remplacement;Ersatz
+PACK;false;Pack;Pack;Pack

--- a/tests/legacy/features/Context/catalog/catalog_modeling/association_types.csv
+++ b/tests/legacy/features/Context/catalog/catalog_modeling/association_types.csv
@@ -1,5 +1,5 @@
 code;is_bidirectional;label-en_US;label-fr_FR;label-de_DE
-X_SELL;false;Cross sell;Vente croisée;
-UPSELL;false;Upsell;Vente incitative;
-SUBSTITUTION;false;Substitution;Remplacement;Ersatz
-PACK;false;Pack;Pack;Pack
+X_SELL;0;Cross sell;Vente croisée;
+UPSELL;0;Upsell;Vente incitative;
+SUBSTITUTION;0;Substitution;Remplacement;Ersatz
+PACK;0;Pack;Pack;Pack

--- a/tests/legacy/features/Context/catalog/catalog_modeling/association_types.csv
+++ b/tests/legacy/features/Context/catalog/catalog_modeling/association_types.csv
@@ -1,4 +1,4 @@
-code;is-bidirectional;label-en_US;label-fr_FR;label-de_DE
+code;is_bidirectional;label-en_US;label-fr_FR;label-de_DE
 X_SELL;false;Cross sell;Vente croisée;
 UPSELL;false;Upsell;Vente incitative;
 SUBSTITUTION;false;Substitution;Remplacement;Ersatz

--- a/tests/legacy/features/Context/catalog/default/association_types.csv
+++ b/tests/legacy/features/Context/catalog/default/association_types.csv
@@ -1,5 +1,5 @@
-code;label-en_US;label-fr_FR
-X_SELL;Cross sell;Vente croisée
-UPSELL;Upsell;Vente incitative
-SUBSTITUTION;Substitution;Remplacement
-PACK;Pack;Pack
+code;is-bidirectional;label-en_US;label-fr_FR
+X_SELL;false;Cross sell;Vente croisée
+UPSELL;false;Upsell;Vente incitative
+SUBSTITUTION;false;Substitution;Remplacement
+PACK;false;Pack;Pack

--- a/tests/legacy/features/Context/catalog/default/association_types.csv
+++ b/tests/legacy/features/Context/catalog/default/association_types.csv
@@ -1,4 +1,4 @@
-code;is-bidirectional;label-en_US;label-fr_FR
+code;is_bidirectional;label-en_US;label-fr_FR
 X_SELL;false;Cross sell;Vente croisée
 UPSELL;false;Upsell;Vente incitative
 SUBSTITUTION;false;Substitution;Remplacement

--- a/tests/legacy/features/Context/catalog/default/association_types.csv
+++ b/tests/legacy/features/Context/catalog/default/association_types.csv
@@ -1,4 +1,4 @@
-code;two_way;label-en_US;label-fr_FR
+code;is_two_way;label-en_US;label-fr_FR
 X_SELL;0;Cross sell;Vente croisée
 UPSELL;0;Upsell;Vente incitative
 SUBSTITUTION;0;Substitution;Remplacement

--- a/tests/legacy/features/Context/catalog/default/association_types.csv
+++ b/tests/legacy/features/Context/catalog/default/association_types.csv
@@ -1,5 +1,5 @@
 code;is_bidirectional;label-en_US;label-fr_FR
-X_SELL;false;Cross sell;Vente croisée
-UPSELL;false;Upsell;Vente incitative
-SUBSTITUTION;false;Substitution;Remplacement
-PACK;false;Pack;Pack
+X_SELL;0;Cross sell;Vente croisée
+UPSELL;0;Upsell;Vente incitative
+SUBSTITUTION;0;Substitution;Remplacement
+PACK;0;Pack;Pack

--- a/tests/legacy/features/Context/catalog/default/association_types.csv
+++ b/tests/legacy/features/Context/catalog/default/association_types.csv
@@ -1,4 +1,4 @@
-code;is_bidirectional;label-en_US;label-fr_FR
+code;two_way;label-en_US;label-fr_FR
 X_SELL;0;Cross sell;Vente croisée
 UPSELL;0;Upsell;Vente incitative
 SUBSTITUTION;0;Substitution;Remplacement

--- a/tests/legacy/features/Context/catalog/footwear/association_types.csv
+++ b/tests/legacy/features/Context/catalog/footwear/association_types.csv
@@ -1,4 +1,4 @@
-code;is_bidirectional;label-en_US
+code;two_way;label-en_US
 X_SELL;0;Cross sell
 UPSELL;0;Upsell
 SUBSTITUTION;0;Substitution

--- a/tests/legacy/features/Context/catalog/footwear/association_types.csv
+++ b/tests/legacy/features/Context/catalog/footwear/association_types.csv
@@ -1,5 +1,5 @@
 code;is_bidirectional;label-en_US
-X_SELL;false;Cross sell
-UPSELL;false;Upsell
-SUBSTITUTION;false;Substitution
-PACK;false;Pack
+X_SELL;0;Cross sell
+UPSELL;0;Upsell
+SUBSTITUTION;0;Substitution
+PACK;0;Pack

--- a/tests/legacy/features/Context/catalog/footwear/association_types.csv
+++ b/tests/legacy/features/Context/catalog/footwear/association_types.csv
@@ -1,4 +1,4 @@
-code;two_way;label-en_US
+code;is_two_way;label-en_US
 X_SELL;0;Cross sell
 UPSELL;0;Upsell
 SUBSTITUTION;0;Substitution

--- a/tests/legacy/features/Context/catalog/footwear/association_types.csv
+++ b/tests/legacy/features/Context/catalog/footwear/association_types.csv
@@ -1,5 +1,5 @@
-code;label-en_US
-X_SELL;Cross sell
-UPSELL;Upsell
-SUBSTITUTION;Substitution
-PACK;Pack
+code;is-bidirectional;label-en_US
+X_SELL;false;Cross sell
+UPSELL;false;Upsell
+SUBSTITUTION;false;Substitution
+PACK;false;Pack

--- a/tests/legacy/features/Context/catalog/footwear/association_types.csv
+++ b/tests/legacy/features/Context/catalog/footwear/association_types.csv
@@ -1,4 +1,4 @@
-code;is-bidirectional;label-en_US
+code;is_bidirectional;label-en_US
 X_SELL;false;Cross sell
 UPSELL;false;Upsell
 SUBSTITUTION;false;Substitution

--- a/tests/legacy/features/pim/structure/association-type/export_association_types_csv.feature
+++ b/tests/legacy/features/pim/structure/association-type/export_association_types_csv.feature
@@ -13,4 +13,4 @@ Feature: Export association types
     And I am on the "csv_footwear_association_type_export" export job page
     When I launch the export job
     And I wait for the "csv_footwear_association_type_export" job to finish
-    Then file "%tmp%/association_type_export/association_type_export.csv" should contain 5 rows
+    Then file "%tmp%/association_type_export/association_type_export.csv" should contain 6 rows

--- a/tests/legacy/features/pim/structure/association-type/export_association_types_csv.feature
+++ b/tests/legacy/features/pim/structure/association-type/export_association_types_csv.feature
@@ -13,4 +13,4 @@ Feature: Export association types
     And I am on the "csv_footwear_association_type_export" export job page
     When I launch the export job
     And I wait for the "csv_footwear_association_type_export" job to finish
-    Then file "%tmp%/association_type_export/association_type_export.csv" should contain 6 rows
+    Then file "%tmp%/association_type_export/association_type_export.csv" should contain 5 rows

--- a/tests/legacy/features/pim/structure/association-type/import_association_types.feature
+++ b/tests/legacy/features/pim/structure/association-type/import_association_types.feature
@@ -7,10 +7,10 @@ Feature: Import association types
     Given the "footwear" catalog configuration
     And the following CSV file to import:
       """
-      code;label-en_US;label-fr_FR
-      default;;
-      X_SELL_footwear;Cross Sell footwear;Vente croisée footwear
-      UPSELL_footwear;Upsell footwear;Vente incitative footwear
+      code;isBidirectional;label-en_US;label-fr_FR
+      default;false;;
+      X_SELL_footwear;false;Cross Sell footwear;Vente croisée footwear
+      UPSELL_footwear;false;Upsell footwear;Vente incitative footwear
       """
     When the associations types are imported via the job csv_footwear_association_type_import
     Then there should be the following association types:

--- a/tests/legacy/features/pim/structure/association-type/import_association_types.feature
+++ b/tests/legacy/features/pim/structure/association-type/import_association_types.feature
@@ -7,14 +7,14 @@ Feature: Import association types
     Given the "footwear" catalog configuration
     And the following CSV file to import:
       """
-      code;is_two_way;label-en_US;label-fr_FR
+      code;two_way;label-en_US;label-fr_FR
       default;0;;
       X_SELL_footwear;1;Cross Sell footwear;Vente croisée footwear
       UPSELL_footwear;0;Upsell footwear;Vente incitative footwear
       """
     When the associations types are imported via the job csv_footwear_association_type_import
     Then there should be the following association types:
-      | code            | label-en_US         | label-fr_FR               | is_two_way       |
+      | code            | label-en_US         | label-fr_FR               | two_way          |
       | default         |                     |                           | false            |
       | X_SELL_footwear | Cross Sell footwear | Vente croisée footwear    | true             |
       | UPSELL_footwear | Upsell footwear     | Vente incitative footwear | false            |

--- a/tests/legacy/features/pim/structure/association-type/import_association_types.feature
+++ b/tests/legacy/features/pim/structure/association-type/import_association_types.feature
@@ -9,12 +9,12 @@ Feature: Import association types
       """
       code;is_bidirectional;label-en_US;label-fr_FR
       default;false;;
-      X_SELL_footwear;false;Cross Sell footwear;Vente croisée footwear
+      X_SELL_footwear;true;Cross Sell footwear;Vente croisée footwear
       UPSELL_footwear;false;Upsell footwear;Vente incitative footwear
       """
     When the associations types are imported via the job csv_footwear_association_type_import
     Then there should be the following association types:
-      | code            | label-en_US         | label-fr_FR               |
-      | default         |                     |                           |
-      | X_SELL_footwear | Cross Sell footwear | Vente croisée footwear    |
-      | UPSELL_footwear | Upsell footwear     | Vente incitative footwear |
+      | code            | label-en_US         | label-fr_FR               | is_bidirectional |
+      | default         |                     |                           | false            |
+      | X_SELL_footwear | Cross Sell footwear | Vente croisée footwear    | true             |
+      | UPSELL_footwear | Upsell footwear     | Vente incitative footwear | false            |

--- a/tests/legacy/features/pim/structure/association-type/import_association_types.feature
+++ b/tests/legacy/features/pim/structure/association-type/import_association_types.feature
@@ -7,14 +7,14 @@ Feature: Import association types
     Given the "footwear" catalog configuration
     And the following CSV file to import:
       """
-      code;is_bidirectional;label-en_US;label-fr_FR
+      code;is_two_way;label-en_US;label-fr_FR
       default;0;;
       X_SELL_footwear;1;Cross Sell footwear;Vente croisée footwear
       UPSELL_footwear;0;Upsell footwear;Vente incitative footwear
       """
     When the associations types are imported via the job csv_footwear_association_type_import
     Then there should be the following association types:
-      | code            | label-en_US         | label-fr_FR               | is_bidirectional |
+      | code            | label-en_US         | label-fr_FR               | is_two_way       |
       | default         |                     |                           | false            |
       | X_SELL_footwear | Cross Sell footwear | Vente croisée footwear    | true             |
       | UPSELL_footwear | Upsell footwear     | Vente incitative footwear | false            |

--- a/tests/legacy/features/pim/structure/association-type/import_association_types.feature
+++ b/tests/legacy/features/pim/structure/association-type/import_association_types.feature
@@ -7,7 +7,7 @@ Feature: Import association types
     Given the "footwear" catalog configuration
     And the following CSV file to import:
       """
-      code;isBidirectional;label-en_US;label-fr_FR
+      code;is_bidirectional;label-en_US;label-fr_FR
       default;false;;
       X_SELL_footwear;false;Cross Sell footwear;Vente croisée footwear
       UPSELL_footwear;false;Upsell footwear;Vente incitative footwear

--- a/tests/legacy/features/pim/structure/association-type/import_association_types.feature
+++ b/tests/legacy/features/pim/structure/association-type/import_association_types.feature
@@ -8,9 +8,9 @@ Feature: Import association types
     And the following CSV file to import:
       """
       code;is_bidirectional;label-en_US;label-fr_FR
-      default;false;;
-      X_SELL_footwear;true;Cross Sell footwear;Vente croisée footwear
-      UPSELL_footwear;false;Upsell footwear;Vente incitative footwear
+      default;0;;
+      X_SELL_footwear;1;Cross Sell footwear;Vente croisée footwear
+      UPSELL_footwear;0;Upsell footwear;Vente incitative footwear
       """
     When the associations types are imported via the job csv_footwear_association_type_import
     Then there should be the following association types:

--- a/tests/legacy/features/pim/structure/association-type/import_association_types.feature
+++ b/tests/legacy/features/pim/structure/association-type/import_association_types.feature
@@ -7,14 +7,14 @@ Feature: Import association types
     Given the "footwear" catalog configuration
     And the following CSV file to import:
       """
-      code;two_way;label-en_US;label-fr_FR
+      code;is_two_way;label-en_US;label-fr_FR
       default;0;;
       X_SELL_footwear;1;Cross Sell footwear;Vente croisée footwear
       UPSELL_footwear;0;Upsell footwear;Vente incitative footwear
       """
     When the associations types are imported via the job csv_footwear_association_type_import
     Then there should be the following association types:
-      | code            | label-en_US         | label-fr_FR               | two_way          |
+      | code            | label-en_US         | label-fr_FR               | is_two_way       |
       | default         |                     |                           | false            |
       | X_SELL_footwear | Cross Sell footwear | Vente croisée footwear    | true             |
       | UPSELL_footwear | Upsell footwear     | Vente incitative footwear | false            |

--- a/upgrades/schema/Version_5_0_20200320095430_add_is_bidirectional_col_to_associations.php
+++ b/upgrades/schema/Version_5_0_20200320095430_add_is_bidirectional_col_to_associations.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version_5_0_20200320095430_add_is_bidirectional_col_to_associations extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->addSql('ALTER TABLE pim_catalog_association_type ADD isBidirectional TINYINT(1) DEFAULT \'0\' NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/upgrades/schema/Version_5_0_20200320095430_add_is_two_way_col_to_associations.php
+++ b/upgrades/schema/Version_5_0_20200320095430_add_is_two_way_col_to_associations.php
@@ -8,11 +8,11 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version_5_0_20200320095430_add_is_bidirectional_col_to_associations extends AbstractMigration
+final class Version_5_0_20200320095430_add_is_two_way_col_to_associations extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {
-        $this->addSql('ALTER TABLE pim_catalog_association_type ADD isBidirectional TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('ALTER TABLE pim_catalog_association_type ADD is_two_way TINYINT(1) DEFAULT \'0\' NOT NULL');
     }
 
     public function down(Schema $schema) : void


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
The goal of this PR is to add possibility to define an two way association type on creation association type interface. 

The user can show this configuration on edit association type interface and datagrind view.

We also add this information on consult/create/list/upsert API and on import and export file.

Functional rule associated : 
An two way association type cannot be changed to one way association type and vice versa

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Done
| Added legacy Behats               | -
| Added acceptance tests            | Done
| Added integration tests           | Done
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
