### PR TITLE
Fix the boolean field cancelling other events

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/field.js
@@ -18,7 +18,7 @@ define([
         template: _.template(template),
         dialog: null,
         events: {
-            'change input': 'updateModel'
+            'keyup input': 'updateModel'
         },
 
         /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/boolean.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/boolean.js
@@ -25,7 +25,7 @@ function (
             'change input': function (event) {
                 this.errors = [];
                 this.updateModel(this.getFieldValue(event.target));
-                this.render();
+                this.getRoot().render();
             }
         },
         template: _.template(template),

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/boolean.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/boolean.js
@@ -25,7 +25,7 @@ function (
             'change input': function (event) {
                 this.errors = [];
                 this.updateModel(this.getFieldValue(event.target));
-                this.getRoot().render();
+                this.render();
             }
         },
         template: _.template(template),


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In one form, if you have a text field & boolean field:

![Screenshot_2020-04-07_17-08-04](https://user-images.githubusercontent.com/1421130/78685673-5fa09680-78f2-11ea-9516-ff06ac7f7c1e.png)

If you want to reproduce locally, add the following lines:
```
# src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/create.yml
extensions:
    # ...
    pim-association-type-properties-foo:
        module: pim/form/common/fields/boolean
        parent: pim-association-type-create-modal
        targetZone: fields
        position: 20
        config:
            fieldName: foo
            label: foo
            defaultValue: false
```
rebuild the front & try to create a new association type.

You can reproduce the bug with the following steps:
- fill the text field
- click directly on the boolean

The text field is emptied.

**Why ?**

In the creation field for the code, the input will update only on change (when the field lose the focus):
```js
// src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/field.js
events: {
    'change input': 'updateModel'
},
```
But the boolean field re-render the root, unregistering the events of all the other fields:
```js
// src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/boolean.js
events: {
    'change input': function (event) {
        this.errors = [];
        this.updateModel(this.getFieldValue(event.target));
        this.getRoot().render();
    }
},
```
And since **the 2 events are happening at the same time** (text field lose the focus & boolean field change), there is a conflict and the text field lose its value.

**Proposed solutions**

1) We can replace, in boolean field, `this.getRoot().render();` by `this.render();` (IMHO, a boolean change shouldn't re-render the full form but maybe I'm missing something)
2) Replace `change input` by `keyup input` in the text field.

I'm going for n°2 in this PR.

Thanks to @StevenVAIDIE for doing most of the work on this.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
