### PR TITLE
PIM-9164: Improve the display of the validation error message

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9164: Improve the display of the validation error message
+
 # 4.0.15 (2020-04-07)
 
 ## Technical Improvements

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/tab/attributes/validation-error.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/tab/attributes/validation-error.html
@@ -4,7 +4,7 @@
             <span class="field-context change-context" data-locale="<%- error.locale %>" data-scope="<%- error.scope %>">
                 <% if (error.scope) { %> <span><%- error.scope %></span> <% } %>
                 <% if (error.locale) { %> <span><%= i18n.getFlag(error.locale) %></span> <% } %>
-            </span>
+            </span> &nbsp;
         <% } %>
         <span class="error-message"><%- error.message %></span>
     </span>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Before: A white space missed between the locale and the error message.
![Screenshot from 2020-04-06 18-19-48](https://user-images.githubusercontent.com/57708349/78687790-d6d72a00-78f4-11ea-864e-b2b40dc05f59.png)

After: 
![validation-error](https://user-images.githubusercontent.com/57708349/78687855-e5254600-78f4-11ea-9ef8-0a44b942da7d.png)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
