### PR TITLE
PIM-9177: Fix showing/updating attributes in attribute group when too many attributes

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,10 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9177: Handle the display of a large number of attributes within an attribute group
+- PIM-9176: Fix the permission update of attribute groups having a lot of attributes
+
 # 3.2.46 (2020-03-30)
 
 # 3.2.45 (2020-03-20)

--- a/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/AttributeGroup/Sql/FindAttributeCodesForAttributeGroup.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/AttributeGroup/Sql/FindAttributeCodesForAttributeGroup.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Bundle\Query\InternalAPI\AttributeGroup\Sql;
+
+use Doctrine\DBAL\Driver\Connection;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FindAttributeCodesForAttributeGroup
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function execute(string $attributeGroupCode): array
+    {
+        $query = <<<SQL
+SELECT a.code
+FROM pim_catalog_attribute_group g INNER JOIN pim_catalog_attribute a ON g.id = a.group_id WHERE g.code=:group_code;
+SQL;
+
+        return $this->connection
+            ->executeQuery($query, [
+                'group_code' => $attributeGroupCode
+            ])
+            ->fetchAll(\PDO::FETCH_COLUMN);
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/AttributeGroup/Sql/FindAttributeCodesForAttributeGroup.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/AttributeGroup/Sql/FindAttributeCodesForAttributeGroup.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Structure\Bundle\Query\InternalAPI\AttributeGroup\Sql;
+namespace Akeneo\Pim\Structure\Bundle\Query\InternalApi\AttributeGroup\Sql;
 
 use Doctrine\DBAL\Driver\Connection;
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
@@ -132,6 +132,7 @@ services:
             - '@pim_catalog.factory.attribute_group'
             - '@event_dispatcher'
             - '@pim_catalog.filter.chained'
+            - '@akeneo.pim.structure.query.find_attribute_codes_for_attribute_groups'
 
     pim_enrich.controller.rest.family:
         class: 'Akeneo\Pim\Structure\Bundle\Controller\InternalApi\FamilyController'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
@@ -13,3 +13,8 @@ services:
         class: 'Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache\LRUCachedGetAttributes'
         arguments:
             $getAttributes: '@akeneo.pim.structure.query.sql_get_attributes'
+
+    akeneo.pim.structure.query.find_attribute_codes_for_attribute_groups:
+        class: Akeneo\Pim\Structure\Bundle\Query\InternalAPI\AttributeGroup\Sql\FindAttributeCodesForAttributeGroup
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
@@ -15,6 +15,6 @@ services:
             $getAttributes: '@akeneo.pim.structure.query.sql_get_attributes'
 
     akeneo.pim.structure.query.find_attribute_codes_for_attribute_groups:
-        class: Akeneo\Pim\Structure\Bundle\Query\InternalAPI\AttributeGroup\Sql\FindAttributeCodesForAttributeGroup
+        class: Akeneo\Pim\Structure\Bundle\Query\InternalApi\AttributeGroup\Sql\FindAttributeCodesForAttributeGroup
         arguments:
             - '@database_connection'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -208,6 +208,10 @@ pim_enrich.entity.attribute_group:
     label: attribute group
     uppercase_label: Attribute group
     plural_label: Attribute groups
+    show_more_attribute:
+        title: It's a bit crowded around here, we show you {{ attributeCount }}/{{ totalAttributeCount }} attributes.
+        subtitle: To discover all the attributes of this group, just click below!
+        button: View all attributes
     flash:
         update:
             success: Attribute group successfully updated
@@ -223,7 +227,6 @@ pim_enrich.entity.attribute_group:
             attributes_groups_selected: '{{ itemsCount }} group(s) selected'
         delete:
             confirm: Are you sure you want to delete this attribute group?
-
 
 pim_enrich.mass_edit.family:
     title: Families bulk action

--- a/src/Akeneo/Pim/Structure/Component/Normalizer/InternalApi/AttributeGroupNormalizer.php
+++ b/src/Akeneo/Pim/Structure/Component/Normalizer/InternalApi/AttributeGroupNormalizer.php
@@ -13,6 +13,8 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class AttributeGroupNormalizer implements NormalizerInterface
 {
+    private const MAX_ATTRIBUTES_SHOWN = 500;
+
     /** @var array $supportedFormats */
     protected $supportedFormats = ['internal_api'];
 
@@ -38,17 +40,21 @@ class AttributeGroupNormalizer implements NormalizerInterface
     public function normalize($attributeGroup, $format = null, array $context = [])
     {
         $standardAttributeGroup = $this->normalizer->normalize($attributeGroup, 'standard', $context);
+        $totalCount = \count($standardAttributeGroup['attributes']);
+        $standardAttributeGroup = $this->showOnlyMaximumAttributes($standardAttributeGroup);
 
-        $attributes = $this->attributeRepository->findBy(
-            ['code' => $standardAttributeGroup['attributes']]
-        );
+        $attributes = $this->attributeRepository->findBy(['code' => $standardAttributeGroup['attributes']]);
+        $count = \count($attributes);
+
         $sortOrder = [];
         foreach ($attributes as $attribute) {
             $sortOrder[$attribute->getCode()] = $attribute->getSortOrder();
         }
         $standardAttributeGroup['attributes_sort_order'] = $sortOrder;
         $standardAttributeGroup['meta'] = [
-            'id' => $attributeGroup->getId()
+            'id' => $attributeGroup->getId(),
+            'attribute_count' => $count,
+            'total_attribute_count' => $totalCount
         ];
 
         return $standardAttributeGroup;
@@ -60,5 +66,12 @@ class AttributeGroupNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return $data instanceof AttributeGroupInterface && in_array($format, $this->supportedFormats);
+    }
+
+    private function showOnlyMaximumAttributes(array $standardAttributeGroup): array
+    {
+        $standardAttributeGroup['attributes'] = array_splice($standardAttributeGroup['attributes'], 0, self::MAX_ATTRIBUTES_SHOWN);
+
+        return $standardAttributeGroup;
     }
 }

--- a/src/Akeneo/Pim/Structure/Component/Normalizer/InternalApi/AttributeGroupNormalizer.php
+++ b/src/Akeneo/Pim/Structure/Component/Normalizer/InternalApi/AttributeGroupNormalizer.php
@@ -13,8 +13,6 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class AttributeGroupNormalizer implements NormalizerInterface
 {
-    private const MAX_ATTRIBUTES_SHOWN = 500;
-
     /** @var array $supportedFormats */
     protected $supportedFormats = ['internal_api'];
 
@@ -40,21 +38,17 @@ class AttributeGroupNormalizer implements NormalizerInterface
     public function normalize($attributeGroup, $format = null, array $context = [])
     {
         $standardAttributeGroup = $this->normalizer->normalize($attributeGroup, 'standard', $context);
-        $totalCount = \count($standardAttributeGroup['attributes']);
-        $standardAttributeGroup = $this->showOnlyMaximumAttributes($standardAttributeGroup);
 
-        $attributes = $this->attributeRepository->findBy(['code' => $standardAttributeGroup['attributes']]);
-        $count = \count($attributes);
-
+        $attributes = $this->attributeRepository->findBy(
+            ['code' => $standardAttributeGroup['attributes']]
+        );
         $sortOrder = [];
         foreach ($attributes as $attribute) {
             $sortOrder[$attribute->getCode()] = $attribute->getSortOrder();
         }
         $standardAttributeGroup['attributes_sort_order'] = $sortOrder;
         $standardAttributeGroup['meta'] = [
-            'id' => $attributeGroup->getId(),
-            'attribute_count' => $count,
-            'total_attribute_count' => $totalCount
+            'id' => $attributeGroup->getId()
         ];
 
         return $standardAttributeGroup;
@@ -66,12 +60,5 @@ class AttributeGroupNormalizer implements NormalizerInterface
     public function supportsNormalization($data, $format = null)
     {
         return $data instanceof AttributeGroupInterface && in_array($format, $this->supportedFormats);
-    }
-
-    private function showOnlyMaximumAttributes(array $standardAttributeGroup): array
-    {
-        $standardAttributeGroup['attributes'] = array_splice($standardAttributeGroup['attributes'], 0, self::MAX_ATTRIBUTES_SHOWN);
-
-        return $standardAttributeGroup;
     }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/attribute.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/attribute.js
@@ -12,6 +12,7 @@ define(
         'jquery',
         'underscore',
         'oro/translator',
+        'pim/router',
         'pim/form',
         'pim/i18n',
         'pim/user-context',
@@ -19,19 +20,23 @@ define(
         'pim/security-context',
         'pim/dialog',
         'pim/template/form/attribute-group/tab/attribute',
-        'jquery-ui'
-    ],
+        'jquery-ui',
+        'pim/datagrid/state'
+],
     function (
         $,
         _,
         __,
+        Router,
         BaseForm,
         i18n,
         UserContext,
         FetcherRegistry,
         SecurityContext,
         Dialog,
-        template
+        template,
+        jqueryUi, // TODO: remove if not used
+        DatagridState
     ) {
         return BaseForm.extend({
             className: 'tabbable tabs-left',
@@ -40,7 +45,8 @@ define(
             attributeSortOrderKey: 'attributes_sort_order',
 
             events: {
-                'click .remove-attribute': 'removeAttributeRequest'
+                'click .remove-attribute': 'removeAttributeRequest',
+                'click .redirect-attribute-list': 'redirectAttributeList'
             },
 
             /**
@@ -98,7 +104,9 @@ define(
                             UserContext: UserContext,
                             __: __,
                             hasRightToRemove: this.hasRightToRemove(),
-                            canSortAttributes: SecurityContext.isGranted(this.config.sortAttributesACL)
+                            canSortAttributes: SecurityContext.isGranted(this.config.sortAttributesACL),
+                            attributeCount: this.getFormData().meta.attribute_count,
+                            totalAttributeCount: this.getFormData().meta.total_attribute_count,
                         }));
 
                         this.$('.attribute-list').sortable({
@@ -228,6 +236,14 @@ define(
 
                 return currentAttributeGroupIsNotOther &&
                     SecurityContext.isGranted(this.config.addAttributeACL)
+            },
+
+            redirectAttributeList: function (event) {
+                const groupFilters = `f[group][value][]=${this.getFormData().code}`;
+
+                DatagridState.set('attribute-grid', {filters: groupFilters});
+
+                Router.redirectToRoute('pim_enrich_attribute_index');
             }
         });
     });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/attribute.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/attribute.js
@@ -83,7 +83,8 @@ define(
              * {@inheritdoc}
              */
             render: function () {
-                const attributeCodesToFetch = this.getFormData().attributes.slice(0, this.config.number_of_attributes_displayed);
+                const attributeCodesToFetch = this.getFormData().attributes
+                    .slice(0, this.config.number_of_attributes_displayed);
                 FetcherRegistry.getFetcher('attribute')
                     .fetchByIdentifiers(attributeCodesToFetch, {rights: 0})
                     .then(function (attributes) {
@@ -139,26 +140,16 @@ define(
              * Update the sort order of attributes
              */
             updateAttributeOrders: function () {
-                var updatedSortOrder = _.reduce(this.$('.attribute'), function (previous, current, order) {
-                    var next = _.extend({}, previous);
-                    next[current.dataset.attributeCode] = order;
-
-                    return next;
-                }, {});
-                const notUpdateSortOrder = this.getFormData().attributes
-                    .slice(this.config.number_of_attributes_displayed)
-                    .reduce(
-                        function (previous, current, order) {
-                            var next = _.extend({}, previous);
-                            next[current] = this.getFormData().attributes_sort_order[current];
-
-                            return next;
-                        }.bind(this),
-                        {});
-                const attributeWithSortOrder = _.extend(updatedSortOrder, notUpdateSortOrder);
-
                 var attributeGroup = _.extend({}, this.getFormData());
-                attributeGroup.attributes_sort_order = attributeWithSortOrder;
+                attributeGroup.attributes_sort_order = _.reduce(
+                    this.$('.attribute'),
+                    function (previous, current, order) {
+                        var next = _.extend({}, previous);
+                        next[current.dataset.attributeCode] = order;
+
+                        return next;
+                    },
+                    {});
 
                 this.setData(attributeGroup);
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/attribute.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/attribute.js
@@ -238,7 +238,7 @@ define(
                     SecurityContext.isGranted(this.config.addAttributeACL)
             },
 
-            redirectAttributeList: function (event) {
+            redirectAttributeList: function () {
                 const groupFilters = `f[group][value][]=${this.getFormData().code}`;
 
                 DatagridState.set('attribute-grid', {filters: groupFilters});

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-group/tab/attribute.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/attribute-group/tab/attribute.html
@@ -48,6 +48,12 @@
                     <% }) %>
                 </tbody>
             </table>
+            <% if (totalAttributeCount !== attributeCount) { %>
+                <div class="AknGridContainer-notEnoughDataTitle"><%- __('pim_enrich.entity.attribute_group.show_more_attribute.title', {attributeCount: attributeCount, totalAttributeCount: totalAttributeCount}) %></div>
+                <div class="AknGridContainer-notEnoughDataSubtitle"><%- __('pim_enrich.entity.attribute_group.show_more_attribute.subtitle') %></div>
+                <button class="AknButton AknButton--big AknButton--apply AknButton--centered redirect-attribute-list"><%- __('pim_enrich.entity.attribute_group.show_more_attribute.button') %></button>
+                <img class="AknImage--centeredWithMargin" src="/bundles/pimui/images/illustration_scroll.svg"/>
+            <% } %>
         </div>
     </div>
 </div>

--- a/tests/back/Pim/Structure/Integration/AttributeGroup/Query/SqlFindAttributeCodesForAttributeGroupIntegration.php
+++ b/tests/back/Pim/Structure/Integration/AttributeGroup/Query/SqlFindAttributeCodesForAttributeGroupIntegration.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Structure\Integration\AttributeGroup\Query;
+
+use Akeneo\Pim\Structure\Bundle\Query\InternalAPI\AttributeGroup\Sql\FindAttributeCodesForAttributeGroup;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+
+class SqlFindAttributeCodesForAttributeGroupIntegration extends TestCase
+{
+    /** @var Connection */
+    private $connection;
+
+    /** @var FindAttributeCodesForAttributeGroup */
+    private $findAttributeCodesForAttributeGroup;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = $this->get('database_connection');
+        $this->findAttributeCodesForAttributeGroup = $this->get('akeneo.pim.structure.query.find_attribute_codes_for_attribute_groups');
+    }
+
+    public function testQueryToGetAssociatedProductCodes()
+    {
+        $attributeGroupCode = 'Marketing';
+        $this->loadAttributesForAttributeGroup($attributeGroupCode);
+
+        $actual = $this->findAttributeCodesForAttributeGroup->execute($attributeGroupCode);
+
+        $this->assertAttributeCodesAreCorrect($actual);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function loadAttributesForAttributeGroup(string $attributeCode): void
+    {
+        $insertAttributeGroup = <<<SQL
+INSERT INTO `pim_catalog_attribute_group` (`id`, `code`, `sort_order`, `created`, `updated`)
+VALUES
+	(29, :attribute_group_code, 0, '2017-10-09 12:23:59', '2017-12-14 11:36:48');
+SQL;
+        $insertAttributesForGroup = <<<SQL
+        INSERT INTO `pim_catalog_attribute` (`id`, `group_id`, `sort_order`, `useable_as_grid_filter`, `max_characters`, `validation_rule`, `validation_regexp`, `wysiwyg_enabled`, `number_min`, `number_max`, `decimals_allowed`, `negative_allowed`, `date_min`, `date_max`, `metric_family`, `default_metric_unit`, `max_file_size`, `allowed_extensions`, `minimumInputLength`, `is_required`, `is_unique`, `is_localizable`, `is_scopable`, `code`, `entity_type`, `attribute_type`, `backend_type`, `properties`, `created`, `updated`)
+VALUES
+	(662, 29, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, 'ValidationAchat', 'Pim\\Component\\Catalog\\Model\\Product', 'pim_catalog_boolean', 'boolean', 'a:0:{}', '2019-03-07 16:39:40', '2019-03-07 16:39:40'),
+	(1, 29, 1, 1, NULL, 'regexp', '/^(EAN\\|[0-9]{13})|(UPC\\|[0-9]{12})|(ISBN\\|(97(8|9))?\\d{9}(\\d|X))|(SKU\\|[A-Z0-9a-z\\._-]{1,25}?)|(MPN\\|[A-Z0-9a-z]+)/', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '', NULL, 1, 1, 0, 0, 'sku', 'Pim\\Component\\Catalog\\Model\\Product', 'pim_catalog_identifier', 'text', 'a:3:{s:19:\"reference_data_name\";N;s:12:\"is_read_only\";b:1;s:19:\"auto_option_sorting\";N;}', '2017-06-27 10:10:23', '2019-03-07 16:40:48'),
+	(565, 29, 2, 1, NULL, 'regexp', '/^[0-9]{8}/', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '', NULL, 0, 1, 0, 0, 'Reference', 'Pim\\Component\\Catalog\\Model\\Product', 'pim_catalog_text', 'text', 'a:3:{s:12:\"is_read_only\";b:1;s:19:\"reference_data_name\";N;s:19:\"auto_option_sorting\";N;}', '2017-10-09 12:24:29', '2019-09-18 13:34:37'),
+	(604, 29, 3, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '', NULL, 0, 0, 1, 0, 'Libelle', 'Pim\\Component\\Catalog\\Model\\Product', 'pim_catalog_text', 'text', 'a:3:{s:12:\"is_read_only\";b:1;s:19:\"reference_data_name\";N;s:19:\"auto_option_sorting\";N;}', '2017-10-09 12:24:29', '2019-03-07 16:40:48'),
+	(574, 29, 4, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '', NULL, 0, 0, 0, 0, 'IsInternet', 'Pim\\Component\\Catalog\\Model\\Product', 'pim_catalog_multiselect', 'options', 'a:3:{s:12:\"is_read_only\";b:0;s:19:\"reference_data_name\";N;s:19:\"auto_option_sorting\";N;}', '2017-10-09 12:24:29', '2017-12-23 09:40:09'),
+	(603, 29, 5, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '', NULL, 0, 0, 0, 0, 'VentilationNonOk', 'Pim\\Component\\Catalog\\Model\\Product', 'pim_catalog_boolean', 'boolean', 'a:3:{s:12:\"is_read_only\";b:0;s:19:\"reference_data_name\";N;s:19:\"auto_option_sorting\";N;}', '2017-10-09 12:24:29', '2017-12-19 13:02:01'),
+	(637, 29, 6, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, 'InterditAuxMineurs', 'Pim\\Component\\Catalog\\Model\\Product', 'pim_catalog_boolean', 'boolean', 'a:0:{}', '2018-03-02 12:35:05', '2018-03-02 12:38:26'),
+	(656, 29, 7, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, 'PieceDetachee', 'Pim\\Component\\Catalog\\Model\\Product', 'pim_catalog_boolean', 'boolean', 'a:0:{}', '2018-09-21 07:23:25', '2018-09-26 12:57:53');
+SQL;
+
+        $res = $this->connection->executeUpdate($insertAttributeGroup, ['attribute_group_code' => $attributeCode]);
+        self::assertEquals(1, $res, 'Attribute group has not been inserted in DB correctly');
+        $res = $this->connection->executeUpdate($insertAttributesForGroup);
+        self::assertEquals(8, $res, 'Attributes have not been inserted in DB correctly');
+    }
+
+    private function assertAttributeCodesAreCorrect(array $actual): void
+    {
+        self::assertSame(
+            [
+                'sku',
+                'Reference',
+                'IsInternet',
+                'VentilationNonOk',
+                'Libelle',
+                'InterditAuxMineurs',
+                'PieceDetachee',
+                'ValidationAchat'
+            ],
+            $actual
+        );
+    }
+}

--- a/tests/back/Pim/Structure/Specification/Component/Normalizer/InternalApi/AttributeGroupNormalizerSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Normalizer/InternalApi/AttributeGroupNormalizerSpec.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Structure\Component\Normalizer\InternalApi;
+
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Doctrine\Common\Persistence\ObjectRepository;
+use PhpSpec\ObjectBehavior;
+use Akeneo\Pim\Structure\Component\Normalizer\InternalApi\AttributeGroupNormalizer;
+use Akeneo\Pim\Structure\Component\Model\AttributeGroupInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class AttributeGroupNormalizerSpec extends ObjectBehavior
+{
+    const MAX_ATTRIBUTES_SHOWN = 500;
+    const TOTAL_ATTRIBUTES_IN_GROUP = 501;
+
+    function let(NormalizerInterface $stdNormalizer, ObjectRepository $attributeRepository)
+    {
+        $this->beConstructedWith($stdNormalizer, $attributeRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AttributeGroupNormalizer::class);
+    }
+
+    function it_supports_an_attribute_group(AttributeGroupInterface $attributeGroup)
+    {
+        $this->supportsNormalization(new \stdClass(), 'whatever')->shouldReturn(false);
+        $this->supportsNormalization(new \stdClass(), 'internal_api')->shouldReturn(false);
+        $this->supportsNormalization($attributeGroup, 'whatever')->shouldReturn(false);
+        $this->supportsNormalization($attributeGroup, 'internal_api')->shouldReturn(true);
+    }
+
+    function it_normalizes_an_attribute_group(
+        $stdNormalizer,
+        AttributeGroupInterface $attributeGroup,
+        ObjectRepository $attributeRepository,
+        AttributeInterface $sku,
+        AttributeInterface $name
+    ) {
+        $sku->getCode()->willReturn('sku');
+        $sku->getSortOrder()->willReturn(1);
+        $name->getCode()->willReturn('name');
+        $name->getSortOrder()->willReturn(2);
+        $attributeGroup->getId()->willReturn(1);
+
+        $data = ['code' => 'my_attribute_group', 'labels' => [], 'attributes' => ['sku', 'name']];
+
+        $stdNormalizer->normalize($attributeGroup, 'standard', [])->willReturn($data);
+        $attributeRepository->findBy(['code'=> ['sku', 'name']])->willReturn([$sku, $name]);
+
+        $this->normalize($attributeGroup, 'internal_api', [])->shouldReturn(
+            [
+                'code'       => 'my_attribute_group',
+                'labels'     => [
+                ],
+                'attributes' => ['sku', 'name'],
+                'attributes_sort_order' => [
+                    'sku' => 1,
+                    'name' => 2
+                ],
+                'meta' => [
+                    'id' => 1,
+                    'attribute_count' => 2,
+                    'total_attribute_count' => 2,
+                ]
+            ]
+        );
+    }
+
+    function it_normalizes_an_attribute_group_with_a_maximum_of_attributes(
+        $stdNormalizer,
+        AttributeGroupInterface $attributeGroup,
+        ObjectRepository $attributeRepository,
+        AttributeInterface $attribute
+    ) {
+        $attribute->getCode()->willReturn('attribute');
+        $attribute->getSortOrder()->willReturn(1);
+        $attributeGroup->getId()->willReturn(1);
+
+        $allAttributeCodes = array_fill(0, self::TOTAL_ATTRIBUTES_IN_GROUP, 'attribute');
+        $onlyShownAttributeCodes = array_fill(0, self::MAX_ATTRIBUTES_SHOWN, 'attribute');
+        $onlyShownAttributes = array_fill(0, self::MAX_ATTRIBUTES_SHOWN, $attribute);
+
+        $stdNormalizer->normalize($attributeGroup, 'standard', [])->willReturn(
+            ['code' => 'my_attribute_group', 'labels' => [], 'attributes' => $allAttributeCodes]
+        );
+        $attributeRepository->findBy(['code' => $onlyShownAttributeCodes])->willReturn($onlyShownAttributes);
+
+        $actual = $this->normalize($attributeGroup, 'internal_api', []);
+        $actual['meta']['attribute_count']->shouldBe(self::MAX_ATTRIBUTES_SHOWN);
+        $actual['meta']['total_attribute_count']->shouldBe(self::TOTAL_ATTRIBUTES_IN_GROUP);
+        $actual['attributes']->shouldHaveCount(self::MAX_ATTRIBUTES_SHOWN);
+    }
+}

--- a/tests/back/Pim/Structure/Specification/Component/Normalizer/InternalApi/AttributeGroupNormalizerSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Normalizer/InternalApi/AttributeGroupNormalizerSpec.php
@@ -5,15 +5,12 @@ namespace Specification\Akeneo\Pim\Structure\Component\Normalizer\InternalApi;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Doctrine\Common\Persistence\ObjectRepository;
 use PhpSpec\ObjectBehavior;
-use Akeneo\Pim\Structure\Component\Normalizer\InternalApi\AttributeGroupNormalizer;
+use Akeneo\Pim\Structure\Component\Normalizer\InternalAPI\AttributeGroupNormalizer;
 use Akeneo\Pim\Structure\Component\Model\AttributeGroupInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class AttributeGroupNormalizerSpec extends ObjectBehavior
 {
-    const MAX_ATTRIBUTES_SHOWN = 500;
-    const TOTAL_ATTRIBUTES_IN_GROUP = 501;
-
     function let(NormalizerInterface $stdNormalizer, ObjectRepository $attributeRepository)
     {
         $this->beConstructedWith($stdNormalizer, $attributeRepository);
@@ -62,35 +59,8 @@ class AttributeGroupNormalizerSpec extends ObjectBehavior
                 ],
                 'meta' => [
                     'id' => 1,
-                    'attribute_count' => 2,
-                    'total_attribute_count' => 2,
                 ]
             ]
         );
-    }
-
-    function it_normalizes_an_attribute_group_with_a_maximum_of_attributes(
-        $stdNormalizer,
-        AttributeGroupInterface $attributeGroup,
-        ObjectRepository $attributeRepository,
-        AttributeInterface $attribute
-    ) {
-        $attribute->getCode()->willReturn('attribute');
-        $attribute->getSortOrder()->willReturn(1);
-        $attributeGroup->getId()->willReturn(1);
-
-        $allAttributeCodes = array_fill(0, self::TOTAL_ATTRIBUTES_IN_GROUP, 'attribute');
-        $onlyShownAttributeCodes = array_fill(0, self::MAX_ATTRIBUTES_SHOWN, 'attribute');
-        $onlyShownAttributes = array_fill(0, self::MAX_ATTRIBUTES_SHOWN, $attribute);
-
-        $stdNormalizer->normalize($attributeGroup, 'standard', [])->willReturn(
-            ['code' => 'my_attribute_group', 'labels' => [], 'attributes' => $allAttributeCodes]
-        );
-        $attributeRepository->findBy(['code' => $onlyShownAttributeCodes])->willReturn($onlyShownAttributes);
-
-        $actual = $this->normalize($attributeGroup, 'internal_api', []);
-        $actual['meta']['attribute_count']->shouldBe(self::MAX_ATTRIBUTES_SHOWN);
-        $actual['meta']['total_attribute_count']->shouldBe(self::TOTAL_ATTRIBUTES_IN_GROUP);
-        $actual['attributes']->shouldHaveCount(self::MAX_ATTRIBUTES_SHOWN);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When there is too many attributes within a group, and a user tries to list all the attributes for this group. The UI freezes.

Solution:

We only display the first 500 attributes of this group, when the number of attributes exceeds 500. We display a helper message at the end of the link and a link to the attribute list screen pre-filtered with the current attribute group code.

<img width="1587" alt="Screen Shot 2020-04-08 at 11 29 19" src="https://user-images.githubusercontent.com/1826473/78768438-37657600-798c-11ea-9a5a-7071749e9461.png">


EDIT 10/04/2020:

In this new version, we filter the 500 attributes to show in the front-end (before we did this in the back-end). This way, we avoid updating the attribute with only 500 attributes instead of the whole attribute group entity.

I introduced a query function to speed things up during the update in the attribute group controller to avoid falling into a php maximum execution time error.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
