### PR TITLE
API-1075: Use int value for user id instead of value object

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Settings/Command/CreateConnectionHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Settings/Command/CreateConnectionHandler.php
@@ -10,7 +10,6 @@ use Akeneo\Connectivity\Connection\Application\Settings\Service\CreateClientInte
 use Akeneo\Connectivity\Connection\Application\Settings\Service\CreateUserInterface;
 use Akeneo\Connectivity\Connection\Domain\Settings\Exception\ConstraintViolationListException;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\ConnectionWithCredentials;
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\UserId;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\Write\Connection;
 use Akeneo\Connectivity\Connection\Domain\Settings\Persistence\Repository\ConnectionRepository;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -66,7 +65,7 @@ final class CreateConnectionHandler
             $command->label(),
             $command->flowType(),
             $client->id(),
-            new UserId($user->id()),
+            $user->id(),
             null,
             $command->auditable()
         );

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Settings/Model/Write/Connection.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Settings/Model/Write/Connection.php
@@ -44,7 +44,7 @@ class Connection
         string $label,
         string $flowType,
         int $clientId,
-        UserId $userId,
+        int $userId,
         ?string $image = null,
         bool $auditable = false
     ) {
@@ -52,7 +52,7 @@ class Connection
         $this->label = new ConnectionLabel($label);
         $this->flowType = new FlowType($flowType);
         $this->clientId = new ClientId($clientId);
-        $this->userId = $userId;
+        $this->userId = new UserId($userId);
         $this->image = null !== $image ? new ConnectionImage($image) : null;
         $this->auditable = $auditable;
     }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Dbal/Repository/DbalConnectionRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Dbal/Repository/DbalConnectionRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\Persistence\Dbal\Repository;
 
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\UserId;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\Write\Connection;
 use Akeneo\Connectivity\Connection\Domain\Settings\Persistence\Repository\ConnectionRepository;
 use Doctrine\DBAL\Connection as DbalConnection;
@@ -64,7 +63,7 @@ SQL;
                 $dataRow['label'],
                 $dataRow['flow_type'],
                 (int) $dataRow['client_id'],
-                new UserId((int) $dataRow['user_id']),
+                (int) $dataRow['user_id'],
                 $dataRow['image'],
                 (bool) $dataRow['auditable']
             ) : null;

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/InMemory/Repository/InMemoryConnectionRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/InMemory/Repository/InMemoryConnectionRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\Persistence\InMemory\Repository;
 
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\UserId;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\Write\Connection;
 use Akeneo\Connectivity\Connection\Domain\Settings\Persistence\Repository\ConnectionRepository;
 
@@ -46,7 +45,7 @@ class InMemoryConnectionRepository implements ConnectionRepository
             $dataRow['label'],
             $dataRow['flow_type'],
             $dataRow['client_id'],
-            new UserId($dataRow['user_id']),
+            $dataRow['user_id'],
             $dataRow['image'],
             $dataRow['auditable']
         );

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Settings/Command/DeleteConnectionHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Settings/Command/DeleteConnectionHandlerSpec.php
@@ -46,8 +46,8 @@ class DeleteConnectionHandlerSpec extends ObjectBehavior
             'magento',
             'Magento',
             FlowType::OTHER,
-            1,
-            $magentoUserId,
+            $magentoClientId->id(),
+            $magentoUserId->id(),
             null,
             false
         );

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Settings/Command/RegenerateConnectionPasswordHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Settings/Command/RegenerateConnectionPasswordHandlerSpec.php
@@ -41,7 +41,7 @@ class RegenerateConnectionPasswordHandlerSpec extends ObjectBehavior
             'Magento Connector',
             FlowType::DATA_DESTINATION,
             42,
-            $userId,
+            $userId->id(),
             null,
             false,
         );

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Settings/Command/RegenerateConnectionSecretHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Settings/Command/RegenerateConnectionSecretHandlerSpec.php
@@ -37,7 +37,7 @@ class RegenerateConnectionSecretHandlerSpec extends ObjectBehavior
             'Magento Connector',
             FlowType::DATA_DESTINATION,
             42,
-            $userId,
+            $userId->id(),
             null,
             false
         );

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Settings/Command/UpdateConnectionHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Settings/Command/UpdateConnectionHandlerSpec.php
@@ -9,7 +9,6 @@ use Akeneo\Connectivity\Connection\Application\Settings\Command\UpdateConnection
 use Akeneo\Connectivity\Connection\Application\Settings\Service\UpdateUserPermissionsInterface;
 use Akeneo\Connectivity\Connection\Domain\Settings\Exception\ConstraintViolationListException;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\UserId;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\Write\Connection;
 use Akeneo\Connectivity\Connection\Domain\Settings\Persistence\Repository\ConnectionRepository;
 use PhpSpec\ObjectBehavior;
@@ -55,7 +54,7 @@ class UpdateConnectionHandlerSpec extends ObjectBehavior
             'Magento Connector',
             FlowType::OTHER,
             42,
-            new UserId(50),
+            50,
             null,
             false
         );

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Settings/Validation/Connection/CodeMustBeUniqueValidatorSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Settings/Validation/Connection/CodeMustBeUniqueValidatorSpec.php
@@ -58,7 +58,7 @@ class CodeMustBeUniqueValidatorSpec extends ObjectBehavior
                     'Magento connector',
                     FlowType::DATA_DESTINATION,
                     42,
-                    new UserId(50),
+                    50,
                     null,
                     true
                 )

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Settings/Model/Write/ConnectionSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Settings/Model/Write/ConnectionSpec.php
@@ -27,7 +27,7 @@ class ConnectionSpec extends ObjectBehavior
             'Magento Connector',
             FlowType::DATA_DESTINATION,
             42,
-            new UserId(24),
+            24,
             null,
             true
         );
@@ -76,7 +76,7 @@ class ConnectionSpec extends ObjectBehavior
             'Magento Connector',
             FlowType::DATA_DESTINATION,
             42,
-            new UserId(24),
+            24,
             'a/b/c/image_path.jpg',
             false
         );


### PR DESCRIPTION


<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
