### PR TITLE
PIM-9160: Fix product association display

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9160: Fix the display of the associations list on the product edit form
+
 # 4.0.16 (2020-04-08)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductNormalizer.php
@@ -163,7 +163,11 @@ class ProductNormalizer implements NormalizerInterface, NormalizerAwareInterface
      */
     protected function normalizeImage(?ValueInterface $data, array $context = [])
     {
-        return $this->imageNormalizer->normalize($data, $context['data_locale'], $context['data_channel']);
+        return $this->imageNormalizer->normalize(
+            $data,
+            $context['data_locale'] ?? null,
+            $context['data_channel'] ?? null
+        );
     }
 
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix https://akeneo.atlassian.net/browse/PIM-9160 

The association list on the PEF was broken because of missing channel. As the request is done with locale but without channel, we have to handle this case. The fix is done in the product normalizer (datagrid one).  

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
