### PR TITLE
PIM-9175: Fix the import of all price values

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Technical Improvements
+
+- PIM-9175: Fix the import of all price values
+
 # 4.0.15 (2020-04-07)
 
 ## Technical Improvements

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,6 +1,6 @@
 # 4.0.x
 
-## Technical Improvements
+## Bug fixes
 
 - PIM-9175: Fix the import of all price values
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMerger.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMerger.php
@@ -151,9 +151,11 @@ class ColumnsMerger
     protected function collectPriceData(array $collectedPrices, array $attributeInfos, $fieldValue)
     {
         $cleanField = $this->getCleanFieldName($attributeInfos);
-        if (null !== $attributeInfos['price_currency'] && trim($fieldValue) !== '') {
+        if (null !== $attributeInfos['price_currency']) {
             $collectedPrices[$cleanField] = $collectedPrices[$cleanField] ?? [];
-
+            if (trim($fieldValue) === '') {
+                return $collectedPrices;
+            }
             $collectedPrices[$cleanField][] = sprintf(
                 '%s%s%s',
                 $fieldValue,
@@ -163,7 +165,6 @@ class ColumnsMerger
         } else {
             $collectedPrices[$cleanField] = explode(AttributeColumnInfoExtractor::ARRAY_SEPARATOR, $fieldValue);
         }
-
         return $collectedPrices;
     }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMerger.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMerger.php
@@ -154,7 +154,6 @@ class ColumnsMerger
         if (null !== $attributeInfos['price_currency']) {
             $collectedPrices[$cleanField] = $collectedPrices[$cleanField] ?? [];
             if (trim($fieldValue) === '') {
-
                 return $collectedPrices;
             }
             $collectedPrices[$cleanField][] = sprintf(

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMerger.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMerger.php
@@ -154,6 +154,7 @@ class ColumnsMerger
         if (null !== $attributeInfos['price_currency']) {
             $collectedPrices[$cleanField] = $collectedPrices[$cleanField] ?? [];
             if (trim($fieldValue) === '') {
+
                 return $collectedPrices;
             }
             $collectedPrices[$cleanField][] = sprintf(
@@ -165,6 +166,7 @@ class ColumnsMerger
         } else {
             $collectedPrices[$cleanField] = explode(AttributeColumnInfoExtractor::ARRAY_SEPARATOR, $fieldValue);
         }
+
         return $collectedPrices;
     }
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMergerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMergerSpec.php
@@ -90,6 +90,42 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
+    function it_merges_columns_which_represents_metric_attribute_value_in_severals_columns(
+        $fieldExtractor,
+        AttributeInterface $price
+    ) {
+        $row = [
+            'price-EUR' => '10',
+            'price-USD' => '',
+            'price-CHF' => '14',
+        ];
+        $attributeInfoEur = [
+            'attribute' => $price,
+            'locale_code' => null,
+            'scope_code' => null,
+            'price_currency' => 'EUR'
+        ];
+        $fieldExtractor->extractColumnInfo('price-EUR')->willReturn($attributeInfoEur);
+        $attributeInfoUsd = [
+            'attribute' => $price,
+            'locale_code' => null,
+            'scope_code' => null,
+            'price_currency' => 'USD'
+        ];
+        $fieldExtractor->extractColumnInfo('price-USD')->willReturn($attributeInfoUsd);
+        $attributeInfoChf = [
+            'attribute' => $price,
+            'locale_code' => null,
+            'scope_code' => null,
+            'price_currency' => 'CHF'
+        ];
+        $fieldExtractor->extractColumnInfo('price-CHF')->willReturn($attributeInfoChf);
+        $price->getCode()->willReturn('price');
+        $price->getBackendType()->willReturn('prices');
+        $mergedRow = ['price' => '10 EUR,14 CHF'];
+        $this->merge($row)->shouldReturn($mergedRow);
+    }
+
     function it_merges_columns_which_represents_metric_attribute_value_in_two_columns(
         $fieldExtractor,
         AttributeInterface $weight

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMergerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMergerSpec.php
@@ -90,7 +90,7 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
-    function it_merges_columns_which_represents_metric_attribute_value_in_severals_columns(
+    function it_merges_price_attribute_value_columns(
         $fieldExtractor,
         AttributeInterface $price
     ) {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Imagine that you have activated but unused currencies on your PIM:
1- You export a product : the columns with the unused currencies are in the csv/xlsx file.
2- You complete the columns where the currencies that are interresting you (activated and used currencies)
3- You import your product on your PIM

Issue: The values completed in the csv/xlsx file didn't appear on the concerned PEF.

So, I fixed this issue by modifying the condition in the collectPriceData() function.

Now, all the values that you have completed on your csv/xlsx file appear on the concerned PEF, after importing it.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
