### PR TITLE
PIM-9193: DatePresenter presents null if date can not be formatted

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9179: Fix product grid freezing when using ENTER on filter
+- PIM-9193: DatePresenter presents null if date can not be formatted
 
 # 3.0.72 (2020-04-03)
 

--- a/src/Akeneo/Tool/Component/Localization/Presenter/DatePresenter.php
+++ b/src/Akeneo/Tool/Component/Localization/Presenter/DatePresenter.php
@@ -43,7 +43,11 @@ class DatePresenter implements PresenterInterface
         }
 
         if (!($value instanceof \DateTime)) {
-            $value = new \DateTime($value);
+            try {
+                $value = new \DateTime($value);
+            } catch (\Exception $e) {
+                return null;
+            }
         }
 
         $formatter = $this->dateFactory->create($options);

--- a/src/Akeneo/Tool/Component/Localization/spec/Presenter/DatePresenterSpec.php
+++ b/src/Akeneo/Tool/Component/Localization/spec/Presenter/DatePresenterSpec.php
@@ -44,4 +44,19 @@ class DatePresenterSpec extends ObjectBehavior
 
         $this->present($date, $options)->shouldReturn('31/01/2015');
     }
+
+    function it_does_not_present_a_date_if_the_date_can_not_be_formatted()
+    {
+        $date = '-001-11-30T00:00:00+00:00';
+        $options = [
+            'locale' => 'fr_FR',
+            'date_format' => 'dd/MM/yyyy',
+            'datetype'    => \IntlDateFormatter::SHORT,
+            'timetype'    => \IntlDateFormatter::NONE,
+            'timezone'    => null,
+            'calendar'    => null,
+        ];
+
+        $this->present($date, $options)->shouldReturn(null);
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

So that the PEF is not broken if a weird date is in the version (among all other problems we could encounter in pages where the date presenter is used).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
