### PR TITLE
PIM-9197: make the InMemoryGetAttributes case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PIM-9113: Locale Specific attribute breaks product grid
 - PIM-9157: Fix performance issue when loading the data of a product group
 - PIM-9163: total_fields limit of elasticsearch should be configurable
+- PIM-9197: Make queries in InMemoryGetAttributes case insensitive
 
 ## New features
 

--- a/tests/back/Acceptance/Attribute/InMemoryAttributeRepository.php
+++ b/tests/back/Acceptance/Attribute/InMemoryAttributeRepository.php
@@ -102,7 +102,7 @@ class InMemoryAttributeRepository implements AttributeRepositoryInterface, Saver
      */
     public function findAll()
     {
-        throw new NotImplementedException(__METHOD__);
+        return $this->attributes->toArray();
     }
 
     /**

--- a/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
+++ b/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
@@ -24,13 +24,18 @@ class InMemoryGetAttributes implements GetAttributes
 
     public function forCodes(array $attributeCodes): array
     {
+        $attributesIndexedByCode = [];
+        foreach ($this->attributeRepository->findAll() as $attribute) {
+            $attributesIndexedByCode[strtolower($attribute->getCode())] = $attribute;
+        }
+
         $attributes = [];
         foreach ($attributeCodes as $attributeCode) {
             /** @var $attribute AttributeInterface*/
-            $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
+            $attribute = $attributesIndexedByCode[strtolower($attributeCode)] ?? null;
             if (null !== $attribute) {
                 $attributes[$attributeCode] = new Attribute(
-                    $attributeCode,
+                    $attribute->getCode(),
                     $attribute->getType(),
                     $attribute->getProperties(),
                     (bool) $attribute->isLocalizable(),

--- a/tests/back/Acceptance/spec/Attribute/InMemoryAttributeRepositorySpec.php
+++ b/tests/back/Acceptance/spec/Attribute/InMemoryAttributeRepositorySpec.php
@@ -154,6 +154,28 @@ class InMemoryAttributeRepositorySpec extends ObjectBehavior
         $this->findMediaAttributeCodes()->shouldReturn(['attribute_2', 'attribute_4']);
     }
 
+    function it_finds_all_attributes()
+    {
+        $attribute1 = $this->createAttribute('attribute_1', null, AttributeTypes::BACKEND_TYPE_BOOLEAN);
+        $attribute2 = $this->createAttribute('attribute_2', null, AttributeTypes::BACKEND_TYPE_MEDIA);
+        $attribute3 = $this->createAttribute('attribute_3', null, AttributeTypes::BACKEND_TYPE_INTEGER);
+        $attribute4 = $this->createAttribute('attribute_4', null, AttributeTypes::BACKEND_TYPE_MEDIA);
+
+        $this->beConstructedWith([
+            $attribute1->getCode() => $attribute1,
+            $attribute2->getCode() => $attribute2,
+            $attribute3->getCode() => $attribute3,
+            $attribute4->getCode() => $attribute4,
+        ]);
+
+        $this->findAll()->shouldReturn([
+            'attribute_1' => $attribute1,
+            'attribute_2' => $attribute2,
+            'attribute_3' => $attribute3,
+            'attribute_4' => $attribute4,
+        ]);
+    }
+
     private function createAttribute(string $code, string $type = null, string $backendType = null): AttributeInterface
     {
         $attribute = new Attribute();

--- a/tests/back/Acceptance/spec/Attribute/InMemoryGetAttributesSpec.php
+++ b/tests/back/Acceptance/spec/Attribute/InMemoryGetAttributesSpec.php
@@ -59,4 +59,32 @@ class InMemoryGetAttributesSpec extends ObjectBehavior
             ),
         ]);
     }
+
+    function it_returns_attributes_case_insensitive()
+    {
+        $this->forCodes(['sKu', 'SKU_2', 'foo'])->shouldBeLike([
+            'sKu' => new Attribute(
+                'sku',
+                AttributeTypes::IDENTIFIER,
+                [],
+                false,
+                false,
+                null,
+                false,
+                AttributeTypes::BACKEND_TYPE_TEXT,
+                []
+            ),
+            'SKU_2' => new Attribute(
+                'sku_2',
+                AttributeTypes::IDENTIFIER,
+                [],
+                false,
+                false,
+                null,
+                false,
+                AttributeTypes::BACKEND_TYPE_TEXT,
+                []
+            ),
+        ]);
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The SQL implementation of GetAttributes is case insensitive. To reflect this in our tests, we have to do the same in InMemory one.  

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
