### PR TITLE
PIM-9195: Add extra ImageMagick library to handle SVG files

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -7,6 +7,10 @@
 - PIM-9160: Fix the display of the associations list on the product edit form
 - PIM-9175: Fix the import of all price values
 
+## Technical Improvements
+
+- PIM-9195: Add extra ImageMagick library to handle SVG files
+
 # 4.0.16 (2020-04-08)
 
 ## Bug fixes

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
     echo 'path-exclude=/usr/share/man/*' > /etc/dpkg/dpkg.cfg.d/path_exclusions && \
     echo 'path-exclude=/usr/share/doc/*' >> /etc/dpkg/dpkg.cfg.d/path_exclusions && \
     apt-get update && \
-    apt-get --yes install imagemagick \
+    apt-get --yes install imagemagick libmagickcore-6.q16-2-extra \
         ghostscript \
         php7.3-fpm \
         php7.3-cli \


### PR DESCRIPTION
This lib allows us to generate preview for SVG files