### PR TITLE
PIM-9204: Avoid error with ACL restricitions on axis attribute

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9204: Fix error when the user does not have the permission to view the axis attribute
+
 # 3.2.48 (2020-04-21)
 
 # 3.2.47 (2020-04-14)

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
@@ -178,8 +178,12 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
 
                 $normalizedValue = (string) $value;
 
+                if (null === $value) {
+                    $normalizedValue = '[PERMISSION ERROR]';
+                }
+
                 $attributeNormalizer = $this->getAttributeLabelsNormalizer($axisAttribute);
-                if ($attributeNormalizer instanceof AxisValueLabelsNormalizer) {
+                if (null !== $value && $attributeNormalizer instanceof AxisValueLabelsNormalizer) {
                     $normalizedValue = $attributeNormalizer->normalize($value, $localeCode);
                 }
 
@@ -249,6 +253,11 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
 
         foreach ($this->attributesProvider->getAxes($entity) as $axisAttribute) {
             $value = $entity->getValue($axisAttribute->getCode());
+
+            if (null === $value) {
+                $orderArray[] = '[PERMISSION ERROR]';
+                continue;
+            }
 
             if (AttributeTypes::OPTION_SIMPLE_SELECT === $axisAttribute->getType()) {
                 $optionCode = $value->getData();

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
@@ -178,10 +178,6 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
 
                 $normalizedValue = (string) $value;
 
-                if (null === $value) {
-                    $normalizedValue = '[PERMISSION ERROR]';
-                }
-
                 $attributeNormalizer = $this->getAttributeLabelsNormalizer($axisAttribute);
                 if (null !== $value && $attributeNormalizer instanceof AxisValueLabelsNormalizer) {
                     $normalizedValue = $attributeNormalizer->normalize($value, $localeCode);
@@ -255,7 +251,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface
             $value = $entity->getValue($axisAttribute->getCode());
 
             if (null === $value) {
-                $orderArray[] = '[PERMISSION ERROR]';
+                $orderArray[] = '';
                 continue;
             }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When the user does not have the right to view the attribute used as an axis on product model variant, the UI display a 500 error because the axis attribute cannot be normalized (since it has been excluded) in the API response.

There has been an error page designed for this specific error but I don't know how to link this error from the back to the front.

The proposed solution is to at least catch the error and let the front fallback on its default behavior without crashing.

On the product model common PEF:
![Screenshot_2020-04-22_10-32-41](https://user-images.githubusercontent.com/1421130/79959721-be364a80-8484-11ea-9cf3-87487b67fcbb.png)

When I select the variant color:
![Screenshot_2020-04-23_11-07-26](https://user-images.githubusercontent.com/1421130/80080977-a0cfb200-8552-11ea-98b2-4abe77298d98.png)




**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
