### PR TITLE
Fix PDF export of product to expose all attributes

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
@@ -120,7 +120,7 @@ class ProductPdfRenderer implements RendererInterface
 
     protected function getAttributeCodes(ProductInterface $product): array
     {
-        return $product->getUsedAttributeCodes();
+        return $product->getValues()->getAttributeCodes();
     }
 
     /**


### PR DESCRIPTION
as per PIM-8427 on 3.0 branch - this worked fine on 3.1 too but reverted in 3.2 after I upgraded.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
