### PR TITLE
PIM-9205: PDF doesn't export Product Model values

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9205: PDF doesn't export Poduct Model values
+
 # 3.2.48 (2020-04-21)
 
 # 3.2.47 (2020-04-14)

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-9205: PDF doesn't export Poduct Model values
+- PIM-9205: Fix PDF not exporting Product Model values
 
 # 3.2.48 (2020-04-21)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
@@ -240,7 +240,7 @@ class ProductPdfRenderer implements RendererInterface
         return $options;
     }
 
-    protected function getOptionLabel($attributeCode, $optionCode, $localeCode)
+    protected function getOptionLabel($attributeCode, $optionCode, $localeCode): string
     {
         $option = $this->attributeOptionRepository->findOneByIdentifier($attributeCode . '.' . $optionCode);
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
@@ -64,7 +64,7 @@ class ProductPdfRenderer implements RendererInterface
     /** @var EntityWithFamilyValuesFillerInterface|null */
     private $productValuesFiller;
 
-    // TODO: on master we must remove null for the $attributeOptionRepository and change the order with $customFont
+    // TODO: on master we must remove null for the $attributeOptionRepository and $productValuesFiller and change the order with $customFont
     public function __construct(
         EngineInterface $templating,
         PdfBuilderInterface $pdfBuilder,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/renderers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/renderers.yml
@@ -16,6 +16,7 @@ services:
             - '%upload_dir%'
             - '%pim_pdf_generator_font%'
             - '@pim_catalog.repository.cached_attribute_option'
+            - '@pim_catalog.values_filler.product'
         tags:
             - { name: pim_pdf_generator.renderer, priority: 80 }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Issue: When exporting a Product as PDF, we only had the values from the product itself, not the ones inherited from the Product Model.

Solution: We added the productValuesFiller to the productPDFRenderer.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | Yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
