### PR TITLE
PIM-9208 Uses HTTP instead of Yarn buggy HTTPs server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ jobs:
       - run:
             name: Install back and front dependencies
             command: make dependencies
+            environment:
+                YARN_REGISTRY: "http://registry.yarnpkg.com"
       - run:
             name: Install asset
             command: make assets

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER_COMPOSE = docker-compose
-NODE_RUN = $(DOCKER_COMPOSE) run -u node --rm node
+NODE_RUN = $(DOCKER_COMPOSE) run -u node --rm -e YARN_REGISTRY node
 YARN_RUN = $(NODE_RUN) yarn
 PHP_RUN = $(DOCKER_COMPOSE) run -u www-data --rm php php
 PHP_EXEC = $(DOCKER_COMPOSE) exec -u www-data fpm php

--- a/std-build/Makefile
+++ b/std-build/Makefile
@@ -4,7 +4,7 @@
 #
 CMD_ON_PROJECT = docker-compose run -u www-data --rm php
 PHP_RUN = $(CMD_ON_PROJECT) php
-YARN_RUN = docker-compose run -u node --rm node yarn
+YARN_RUN = docker-compose run -u node --rm -e YARN_REGISTRY -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD node yarn
 
 ifdef NO_DOCKER
   CMD_ON_PROJECT =
@@ -15,10 +15,10 @@ endif
 .DEFAULT_GOAL := dev
 
 yarn.lock: package.json
-	$(YARN_RUN) install
+	PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 $(YARN_RUN) install
 
 node_modules: yarn.lock
-	$(YARN_RUN) install
+	PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 $(YARN_RUN) install
 
 .PHONY: assets
 assets:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

PIM-9208 Uses HTTP instead of Yarn buggy HTTPs server

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
