### PR TITLE
PIM-9192: Fix error being printed in the response of partial update of products API

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-9192: Fix deadlock error being printed in the response of partial update of products API
+- PIM-9192: Fix error being printed in the response of partial update of products API
 
 # 4.0.18 (2020-04-23)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9192: Fix deadlock error being printed in the response of partial update of products API
+
 # 4.0.18 (2020-04-23)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -432,7 +432,7 @@ class ProductController
         $response = $this->partialUpdateStreamResource->streamResponse($resource, [], function () {
             try {
                 $this->apiAggregatorForProductPostSave->dispatchAllEvents();
-            } catch (\Exception $exception) {
+            } catch (\Throwable $exception) {
                 // TODO @merge master Remove this condition
                 if (null !== $this->logger) {
                     $this->logger->critical('An exception has been thrown in the post-save events', [

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -39,6 +39,7 @@ use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use Elasticsearch\Common\Exceptions\BadRequest400Exception;
 use Elasticsearch\Common\Exceptions\ServerErrorResponseException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -145,6 +146,9 @@ class ProductController
     /** @var DuplicateValueChecker */
     protected $duplicateValueChecker;
 
+    /** @var LoggerInterface */
+    private $logger;
+
     public function __construct(
         NormalizerInterface $normalizer,
         IdentifiableObjectRepositoryInterface $channelRepository,
@@ -173,7 +177,8 @@ class ProductController
         GetConnectorProducts $getConnectorProducts,
         ApiAggregatorForProductPostSaveEventSubscriber $apiAggregatorForProductPostSave,
         WarmupQueryCache $warmupQueryCache,
-        DuplicateValueChecker $duplicateValueChecker = null // TODO @merge master Remove this null parameter and the conditions
+        DuplicateValueChecker $duplicateValueChecker = null, // TODO @merge master Remove this null parameter and the conditions
+        ?LoggerInterface $logger = null // TODO @merge master Remove this null parameter and the conditions
     ) {
         $this->normalizer = $normalizer;
         $this->channelRepository = $channelRepository;
@@ -203,6 +208,7 @@ class ProductController
         $this->apiAggregatorForProductPostSave = $apiAggregatorForProductPostSave;
         $this->warmupQueryCache = $warmupQueryCache;
         $this->duplicateValueChecker = $duplicateValueChecker;
+        $this->logger = $logger;
     }
 
     /**
@@ -424,7 +430,16 @@ class ProductController
         $resource = $request->getContent(true);
         $this->apiAggregatorForProductPostSave->activate();
         $response = $this->partialUpdateStreamResource->streamResponse($resource, [], function () {
-            $this->apiAggregatorForProductPostSave->dispatchAllEvents();
+            try {
+                $this->apiAggregatorForProductPostSave->dispatchAllEvents();
+            } catch (\Exception $exception) {
+                // TODO @merge master Remove this condition
+                if (null !== $this->logger) {
+                    $this->logger->critical('An exception has been thrown in the post-save events', [
+                        'exception' => $exception,
+                    ]);
+                }
+            }
             $this->apiAggregatorForProductPostSave->deactivate();
         });
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -67,6 +67,7 @@ services:
             - '@pim_catalog.event_subscriber.product.on_save.api_aggregator_event_subscriber'
             - '@pim_api.warmup_query_cache.dummy'
             - '@pim_api.checker.duplicate_value'
+            - '@logger'
 
     pim_api.controller.product_model:
         public: true


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

A deadlock can occurs during the completeness calculation, on the `postSave` event in partial update of products.

This produce the following output:
```
...
{"line":93,"identifier":"1111111204","status_code":204}
{"line":94,"identifier":"1111111205","status_code":204}
{"line":95,"identifier":"1111111206","status_code":204}
{"line":96,"identifier":"1111111207","status_code":204}
{"line":97,"identifier":"1111111208","status_code":204}
{"line":98,"identifier":"1111111209","status_code":204}
{"line":99,"identifier":"1111111210","status_code":204}
{"line":100,"identifier":"1111111211","status_code":204}{"code":500,"message":"Internal Server Error"}
```

The proposed solution is to log the error instead of breaking the API response because it's already too late to change the response status, and also because, from a functional point of view, a completeness error should not block the product update.

This has been confirmed by our dear Performance Director @ahocquard 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -