### PR TITLE
RULE-ENGINE: Add eslintignore for rule directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ src/Oro/**/**/*.js
 src/Akeneo/ReferenceEntity/tests/front
 src/Akeneo/Pim/Enrichment/AssetManager/tests/front
 src/Akeneo/Connectivity/Connection
+src/Akeneo/Pim/Automation/RuleEngine/front


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

Adding the Rule directory as ignore in eslintignore file.
We are using a yarn workspace and specific linter rules on our project.
The global yarn lint failed on our project due to a dependency on @typescript/parser.
Didn't find a way to fix it for now, this is a quicker solution for the moment.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
