### PR TITLE
PIM-9219: Fix duplicated categories in the product API when present in both Product Model and Variant

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9219: Fix duplicated categories in the product API when present in both Product Model and Variant
+
 # 3.2.49 (2020-04-23)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/GetCategoryCodesByProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/GetCategoryCodesByProductIdentifiers.php
@@ -74,6 +74,7 @@ SQL;
         foreach ($queryResults as $queryResult) {
             $categoryCodes = json_decode($queryResult['category_codes']);
             sort($categoryCodes);
+            $categoryCodes = array_unique($categoryCodes);
             $results[$queryResult['product_identifier']] = $categoryCodes;
         }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/GetCategoryCodesByProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/Query/Sql/GetCategoryCodesByProductIdentifiers.php
@@ -74,7 +74,8 @@ SQL;
         foreach ($queryResults as $queryResult) {
             $categoryCodes = json_decode($queryResult['category_codes']);
             sort($categoryCodes);
-            $categoryCodes = array_unique($categoryCodes);
+            // @todo https://akeneo.atlassian.net/browse/PIM-9220
+            $categoryCodes = array_values(array_unique($categoryCodes));
             $results[$queryResult['product_identifier']] = $categoryCodes;
         }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

If one category is assigned first to a variant, then to the product model, in the product external API, this category is returned twice.

Instead of trying to search and update the database for this case, we simply hide the duplicates from the product API response. The reasons are:

- checking/removing duplicate categories from children while saving a product model would induce a huge performance impact
- it’s not that important/bad to have a category for both the product and the parent product model in BDD, because functionally speaking the child does have the category (it inherits it from its parent)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
