### PR TITLE
PIM-9212: Keep vertical scroll position of the attribute form after editing values

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9212: Keep vertical scroll position of the attribute form after editing values
+
 # 3.2.50 (2020-04-24)
 
 ## Bug fixes:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/edit-form.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/edit-form.js
@@ -89,12 +89,14 @@ define(
                     return this;
                 }
                 this.getRoot().trigger('pim_enrich:form:render:before');
+                this.getRoot().trigger('pim_enrich:form:extension:render:before');
 
                 this.$el.html(this.template());
 
                 this.renderExtensions();
 
                 this.getRoot().trigger('pim_enrich:form:render:after');
+                this.getRoot().trigger('pim_enrich:form:extension:render:after');
             },
 
             /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- Now saving the scroll position on the common edit form before re-rendering, all credit goes to @mmetayer https://github.com/akeneo/pim-community-dev/pull/11600.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
