### PR TITLE
AOB-925: Fix front-end override capabilities

### DIFF
--- a/frontend/webpack/requirejs-utils.js
+++ b/frontend/webpack/requirejs-utils.js
@@ -72,7 +72,7 @@ const utils = {
     getModulePaths(baseDir, sourceDir) {
         const pathSourceFile = require(path.join(baseDir, 'public/js/require-paths.js'));
         const { config, paths } = utils.getRequireConfig(pathSourceFile, baseDir);
-        const aliases = Object.assign(paths, getFrontModules(process.cwd(), './public/bundles')(), {
+        const aliases = Object.assign(getFrontModules(process.cwd(), './public/bundles')(), paths, {
           'require-polyfill': path.resolve(sourceDir, './frontend/webpack/require-polyfill.js'),
           'require-context': path.resolve(sourceDir, './frontend/webpack/require-context.js'),
           'module-registry': path.resolve(baseDir, './public/js/module-registry.js'),


### PR DESCRIPTION
**Description**

This PR fixes a bug preventing the override of any requirejs module if the file path and the module name are identical.

For instance:
```yaml
config:
    paths:
        acme/controller/index: 'acme/controller/index'
```

That was never an issue until now as the real file path and the module name are different most of the time, so the override work in this case. But we recently had the issue on the Onboarder with an Asset Manager module which name and real file path are identical.

The root cause is that `frontend/webpack/requirejs-utils.js` is merging all requirejs module paths together, but real file paths were taking precedence over them.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
