### PR TITLE
PIM-9221: Performance issue on update product model through API

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9221: Fix performance issue when saving a variant product/product model with a lot of siblings
+
 # 3.2.53 (2020-05-05)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Query/SqlGetValuesOfSiblings.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Query/SqlGetValuesOfSiblings.php
@@ -30,7 +30,7 @@ final class SqlGetValuesOfSiblings implements GetValuesOfSiblings
         $this->valueCollectionFactory = $valueCollectionFactory;
     }
 
-    public function for(EntityWithFamilyVariantInterface $entity): array
+    public function for(EntityWithFamilyVariantInterface $entity, array $attributeCodesToFilter = []): array
     {
         if (null === $entity->getParent()) {
             return [];
@@ -64,9 +64,18 @@ SQL;
                 'identifier' => $identifier
             ]
         );
+
         foreach ($rows as $row) {
+            $rawValues = json_decode($row['raw_values'], true) ?? [];
+
+            if (!empty($attributeCodesToFilter)) {
+                $rawValues = array_filter($rawValues, function (string $attributeCode) use ($attributeCodesToFilter) {
+                    return in_array($attributeCode, $attributeCodesToFilter);
+                }, ARRAY_FILTER_USE_KEY);
+            }
+
             $valuesOfSiblings[$row['identifier']] = $this->valueCollectionFactory->createFromStorageFormat(
-                json_decode($row['raw_values'], true)
+                $rawValues
             );
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/ProductModel/Query/GetValuesOfSiblings.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/ProductModel/Query/GetValuesOfSiblings.php
@@ -14,9 +14,12 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyVariantInterfa
 interface GetValuesOfSiblings
 {
     /**
-     * Returns the values of the siblings of an EntityWithVariantInterface, indexed by identifier
+     * Returns the values of the siblings of an EntityWithFamilyVariantInterface, indexed by identifier,
+     * optionally filtered by attribute code
      *
+     * @param EntityWithFamilyVariantInterface $entity
+     * @param string[] $attributeCodesToFilter
      * @return WriteValueCollectionFactory[]
      */
-    public function for(EntityWithFamilyVariantInterface $entity): array;
+    public function for(EntityWithFamilyVariantInterface $entity, array $attributeCodesToFilter = []): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/UniqueVariantAxisValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/UniqueVariantAxisValidator.php
@@ -99,7 +99,11 @@ class UniqueVariantAxisValidator extends ConstraintValidator
 
         // TODO merge master/4.0: remove the test, and the whole 'else' statement
         if (null !== $this->getValuesOfSiblings) {
-            $siblingValues = $this->getValuesOfSiblings->for($entity);
+            $axesAttributesCodesToFilter = array_map(function (AttributeInterface $axisAttribute) {
+                return $axisAttribute->getCode();
+            }, $axes);
+
+            $siblingValues = $this->getValuesOfSiblings->for($entity, $axesAttributesCodesToFilter);
         } else {
             $siblingValues = $this->getSiblingValues($entity);
         }

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptions.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptions.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Bundle\Query\PublicApi\AttributeOption\Cache;
+
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAttributeOptionCodes;
+use Akeneo\Tool\Component\StorageUtils\Cache\LRUCache;
+
+/**
+ * Cached version of Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAttributeOptionCodes
+ * It uses a LRUCache which stores existing attribute options with `true`, and unexisting ones with `false`
+ *
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LRUCachedGetExistingAttributeOptions implements GetExistingAttributeOptionCodes
+{
+    /** @var GetExistingAttributeOptionCodes */
+    private $getExistingOptionCodes;
+
+    /** @var LRUCache */
+    private $cache;
+
+    public function __construct(GetExistingAttributeOptionCodes $getExistingOptionCodes)
+    {
+        $this->getExistingOptionCodes = $getExistingOptionCodes;
+        $this->cache = new LRUCache(10000);
+    }
+
+    public function fromOptionCodesByAttributeCode(array $optionCodesIndexedByAttributeCodes): array
+    {
+        if (empty($optionCodesIndexedByAttributeCodes)) {
+            return [];
+        }
+
+        $fetchNonCachedAttributeOptions = function (array $nonCachedAttributeOptionKeys): array {
+            if ([] === $nonCachedAttributeOptionKeys) {
+                return [];
+            }
+
+            $results = array_fill_keys($nonCachedAttributeOptionKeys, false);
+            $existingAttributeOptionCodes = $this->getExistingOptionCodes->fromOptionCodesByAttributeCode(
+                $this->fromCacheKeys($nonCachedAttributeOptionKeys)
+            );
+            $existingKeys = array_fill_keys($this->toCacheKeys($existingAttributeOptionCodes), true);
+
+            return array_replace($results, $existingKeys);
+        };
+
+        $keys = $this->cache->getForKeys(
+            $this->toCacheKeys($optionCodesIndexedByAttributeCodes),
+            $fetchNonCachedAttributeOptions
+        );
+
+        return $this->fromCacheKeys(array_keys(array_filter($keys)));
+    }
+
+    /**
+     * Converts an array of option codes indexed by attribute code to an array of keys usable by the LRUCache
+     * e.g:
+     * [
+     *    'color' => ['blue', 'green'],
+     *    'size' => ['xs'],
+     * ]
+     * will be converted to ['color.blue', 'color.green', 'size.xs']
+     */
+    private function toCacheKeys(array $optionCodesIndexedByAttributeCode): array
+    {
+        $keys = [];
+        foreach ($optionCodesIndexedByAttributeCode as $attributeCode => $optionCodes) {
+            foreach ($optionCodes as $optionCode) {
+                $keys[] = sprintf('%s.%s', $attributeCode, $optionCode);
+            }
+        }
+
+        return $keys;
+    }
+
+    /**
+     * Performs the reverse operation from `toCacheKeys()` method
+     */
+    private function fromCacheKeys(array $cacheKeys): array
+    {
+        $optionsIndexedByAttributeCode = [];
+        foreach ($cacheKeys as $cacheKey) {
+            [$attributeCode, $optionCode] = explode('.', $cacheKey);
+            $optionsIndexedByAttributeCode[$attributeCode][] = $optionCode;
+        }
+
+        return $optionsIndexedByAttributeCode;
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
@@ -4,6 +4,13 @@ services:
         arguments:
             $connection: '@database_connection'
 
+    akeneo.pim.structure.query.cache.get_existing_attribute_option_codes_from_option_codes:
+        class: 'Akeneo\Pim\Structure\Bundle\Query\PublicApi\AttributeOption\Cache\LRUCachedGetExistingAttributeOptions'
+        decorates: akeneo.pim.structure.query.get_existing_attribute_option_codes_from_option_codes
+        decoration_inner_name: akeneo.pim.structure.query.get_existing_attribute_option_codes_from_option_codes.sql
+        arguments:
+            - '@akeneo.pim.structure.query.get_existing_attribute_option_codes_from_option_codes.sql'
+
     akeneo.pim.structure.query.sql_get_attributes:
         class: 'Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\SqlGetAttributes'
         arguments:

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Query/SqlGetValuesOfSiblingsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Query/SqlGetValuesOfSiblingsIntegration.php
@@ -70,6 +70,20 @@ class SqlGetValuesOfSiblingsIntegration extends TestCase
         Assert::assertArrayHasKey('apollon_optiona_false', $valuesOfSiblings);
     }
 
+    public function test_that_it_can_filter_values_by_attribute_codes()
+    {
+        $subSweatA = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('sub_sweat_option_a');
+
+        $valuesOfSiblings = $this->getValuesOfSiblings($subSweatA, ['a_simple_select']);
+        Assert::assertCount(1, $valuesOfSiblings);
+        Assert::assertArrayHasKey('sub_sweat_option_b', $valuesOfSiblings);
+        Assert::assertNull($valuesOfSiblings['sub_sweat_option_b']->getByCodes('a_text'));
+        Assert::assertInstanceOf(
+            ValueInterface::class,
+            $valuesOfSiblings['sub_sweat_option_b']->getByCodes('a_simple_select')
+        );
+    }
+
     // - sweat
     //     - sub_sweat_option_a
     //         - apollon_optiona_true
@@ -216,8 +230,9 @@ class SqlGetValuesOfSiblingsIntegration extends TestCase
         return $productModel;
     }
 
-    private function getValuesOfSiblings(EntityWithFamilyVariantInterface $entity): array
+    private function getValuesOfSiblings(EntityWithFamilyVariantInterface $entity, array $attributeCodes = []): array
     {
-        return $this->get('akeneo.pim.enrichment.product_model.query.get_values_of_siblings')->for($entity);
+        return $this->get('akeneo.pim.enrichment.product_model.query.get_values_of_siblings')
+                    ->for($entity, $attributeCodes);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
@@ -2,21 +2,21 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints;
 
-use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
-use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\GetValuesOfSiblings;
-use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueVariantAxisValidator;
-use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Repository\EntityWithFamilyVariantRepository;
-use Akeneo\Pim\Enrichment\Component\Product\Exception\AlreadyExistingAxisValueCombinationException;
 use Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\EntityWithFamilyVariantAttributesProvider;
-use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\AlreadyExistingAxisValueCombinationException;
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyVariantInterface;
-use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
+use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\GetValuesOfSiblings;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueVariantAxis;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueVariantAxisValidator;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\UniqueAxesCombinationSet;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
+use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
@@ -107,10 +107,11 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         EntityWithFamilyVariantInterface $entity,
         UniqueVariantAxis $constraint
     ) {
+        $axes = [];
         $entity->getParent()->willReturn($parent);
-        $axesProvider->getAxes($entity)->willReturn([]);
+        $axesProvider->getAxes($entity)->willReturn($axes);
         $entity->getFamilyVariant()->willReturn($familyVariant);
-        $getValuesOfSiblings->for($entity)->willReturn([]);
+        $getValuesOfSiblings->for($entity, [])->willReturn([]);
 
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
 
@@ -162,9 +163,11 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         ValueInterface $yellow,
         UniqueVariantAxis $constraint
     ) {
+        $axes = [$color];
+
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
-        $axesProvider->getAxes($entity)->willReturn([$color]);
+        $axesProvider->getAxes($entity)->willReturn($axes);
         $color->getCode()->willReturn('color');
 
         $values->getByCodes('color')->willReturn($blue);
@@ -174,7 +177,7 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $red->__toString()->willReturn('[red]');
         $yellow->__toString()->willReturn('[yellow]');
 
-        $getValuesOfSiblings->for($entity)->willReturn([
+        $getValuesOfSiblings->for($entity, ['color'])->willReturn([
             'sibling1' => $valuesOfFirstSibling,
             'sibling2' => $valuesOfSecondSibling,
         ]);
@@ -203,18 +206,20 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         ValueInterface $red,
         UniqueVariantAxis $constraint
     ) {
+        $axes = [$color];
+
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
         $entity->getValuesForVariation()->willReturn($values);
         $values->getByCodes('color')->willReturn($blue);
 
-        $axesProvider->getAxes($entity)->willReturn([$color]);
+        $axesProvider->getAxes($entity)->willReturn($axes);
         $color->getCode()->willReturn('color');
 
         $blue->__toString()->willReturn('[blue]');
         $red->__toString()->willReturn('[red]');
 
-        $getValuesOfSiblings->for($entity)->willReturn(
+        $getValuesOfSiblings->for($entity, ['color'])->willReturn(
             [
                 'sibbling_identifier' => $valuesOfSibling,
             ]
@@ -244,14 +249,17 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         UniqueVariantAxis $constraint,
         ConstraintViolationBuilderInterface $violation
     ) {
+        $axes = [$color];
+
         $entity->getCode()->willReturn('entity_code');
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
         $entity->getValuesForVariation()->willReturn($values);
-        $axesProvider->getAxes($entity)->willReturn([$color]);
+
+        $axesProvider->getAxes($entity)->willReturn($axes);
         $color->getCode()->willReturn('color');
 
-        $getValuesOfSiblings->for($entity)->willReturn(
+        $getValuesOfSiblings->for($entity, ['color'])->willReturn(
             [
                 'sibling1' => $valuesOfFirstSibling,
                 'sibling2' => $valuesOfSecondSibling,
@@ -301,14 +309,16 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         UniqueVariantAxis $constraint,
         ConstraintViolationBuilderInterface $violation
     ) {
+        $axes = [$color];
+
         $entity->getIdentifier()->willReturn('my_identifier');
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
         $entity->getValuesForVariation()->willReturn($values);
-        $axesProvider->getAxes($entity)->willReturn([$color]);
+        $axesProvider->getAxes($entity)->willReturn($axes);
         $color->getCode()->willReturn('color');
 
-        $getValuesOfSiblings->for($entity)->willReturn(
+        $getValuesOfSiblings->for($entity, ['color'])->willReturn(
             [
                 'sibling1' => $valuesOfFirstSibling,
                 'sibling2' => $valuesOfSecondSibling,
@@ -360,12 +370,14 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         ConstraintViolationBuilderInterface $violation,
         ValueInterface $xl
     ) {
+        $axes = [$color, $size];
+
         $entity->getCode()->willReturn('entity_code');
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
         $entity->getValuesForVariation()->willReturn($values);
 
-        $axesProvider->getAxes($entity)->willReturn([$color, $size]);
+        $axesProvider->getAxes($entity)->willReturn($axes);
         $color->getCode()->willReturn('color');
         $size->getCode()->willReturn('size');
 
@@ -378,7 +390,7 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $valuesOfSecondSibling->getByCodes('color')->willReturn($blue);
         $valuesOfSecondSibling->getByCodes('size')->willReturn($xl);
 
-        $getValuesOfSiblings->for($entity)->willReturn(
+        $getValuesOfSiblings->for($entity, ['color', 'size'])->willReturn(
             [
                 'sibling1' => $valuesOfFirstSibling,
                 'sibling2' => $valuesOfSecondSibling,
@@ -427,12 +439,14 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         ConstraintViolationBuilderInterface $violation,
         ValueInterface $xl
     ) {
+        $axes = [$color, $size];
+
         $entity->getIdentifier()->willReturn('entity_code');
         $entity->getParent()->willReturn($parent);
         $entity->getFamilyVariant()->willReturn($familyVariant);
         $entity->getValuesForVariation()->willReturn($values);
 
-        $axesProvider->getAxes($entity)->willReturn([$color, $size]);
+        $axesProvider->getAxes($entity)->willReturn($axes);
         $color->getCode()->willReturn('color');
         $size->getCode()->willReturn('size');
 
@@ -445,7 +459,7 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $valuesOfSecondSibling->getByCodes('color')->willReturn($blue);
         $valuesOfSecondSibling->getByCodes('size')->willReturn($xl);
 
-        $getValuesOfSiblings->for($entity)->willReturn(
+        $getValuesOfSiblings->for($entity, ['color', 'size'])->willReturn(
             [
                 'sibling1' => $valuesOfFirstSibling,
                 'sibling2' => $valuesOfSecondSibling,
@@ -491,17 +505,18 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         UniqueVariantAxis $constraint,
         ConstraintViolationBuilderInterface $violation
     ) {
+        $axes = [$color];
         $entity1->getParent()->willReturn($parent);
         $entity1->getFamilyVariant()->willReturn($familyVariant);
-        $axesProvider->getAxes($entity1)->willReturn([$color]);
+        $axesProvider->getAxes($entity1)->willReturn($axes);
         $color->getCode()->willReturn('color');
-        $getValuesOfSiblings->for($entity1)->willReturn([]);
+        $getValuesOfSiblings->for($entity1, ['color'])->willReturn([]);
 
         $entity2->getCode()->willReturn('entity_2');
         $entity2->getParent()->willReturn($parent);
         $entity2->getFamilyVariant()->willReturn($familyVariant);
-        $getValuesOfSiblings->for($entity2)->willReturn([]);
-        $axesProvider->getAxes($entity2)->willReturn([$color]);
+        $getValuesOfSiblings->for($entity2, ['color'])->willReturn([]);
+        $axesProvider->getAxes($entity2)->willReturn($axes);
 
         $values->getByCodes('color')->willReturn($blue);
         $entity1->getValuesForVariation()->willReturn($values);
@@ -545,17 +560,19 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         UniqueVariantAxis $constraint,
         ConstraintViolationBuilderInterface $violation
     ) {
+        $axes = [$color];
+
         $entity1->getParent()->willReturn($parent);
         $entity1->getFamilyVariant()->willReturn($familyVariant);
-        $axesProvider->getAxes($entity1)->willReturn([$color]);
+        $axesProvider->getAxes($entity1)->willReturn($axes);
         $color->getCode()->willReturn('color');
-        $getValuesOfSiblings->for($entity1)->willReturn([]);
+        $getValuesOfSiblings->for($entity1, ['color'])->willReturn([]);
 
         $entity2->getIdentifier()->willReturn('entity_2');
         $entity2->getParent()->willReturn($parent);
         $entity2->getFamilyVariant()->willReturn($familyVariant);
-        $getValuesOfSiblings->for($entity2)->willReturn([]);
-        $axesProvider->getAxes($entity2)->willReturn([$color]);
+        $getValuesOfSiblings->for($entity2, ['color'])->willReturn([]);
+        $axesProvider->getAxes($entity2)->willReturn($axes);
 
         $values->getByCodes('color')->willReturn($blue);
         $entity1->getValuesForVariation()->willReturn($values);

--- a/tests/back/Pim/Structure/Specification/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptionsSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptionsSpec.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Structure\Bundle\Query\PublicApi\AttributeOption\Cache;
+
+use Akeneo\Pim\Structure\Bundle\Query\PublicApi\AttributeOption\Cache\LRUCachedGetExistingAttributeOptions;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAttributeOptionCodes;
+use Akeneo\Tool\Component\StorageUtils\Cache\LRUCache;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class LRUCachedGetExistingAttributeOptionsSpec extends ObjectBehavior
+{
+    function let(GetExistingAttributeOptionCodes $sqlQuery)
+    {
+        $this->beConstructedWith($sqlQuery, new LRUCache(4));
+    }
+
+    function it_is_a_get_existing_attribute_options_query()
+    {
+        $this->shouldImplement(GetExistingAttributeOptionCodes::class);
+    }
+
+    function it_is_a_cached_version_of_the_query()
+    {
+        $this->shouldHaveType(LRUCachedGetExistingAttributeOptions::class);
+    }
+
+    function it_gets_existing_options_by_performing_an_sql_query_if_the_cache_is_not_hit(
+        GetExistingAttributeOptionCodes $sqlQuery
+    ) {
+        $sqlQuery->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2']])
+                 ->shouldBeCalledOnce()
+                 ->willReturn(['attribute_1' => ['option2']]);
+
+        $this->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2']])
+             ->shouldReturn(['attribute_1' => ['option2']]);
+    }
+
+    function it_does_not_perform_an_sql_query_when_the_cache_is_hit(GetExistingAttributeOptionCodes $sqlQuery)
+    {
+        $sqlQuery->fromOptionCodesByAttributeCode(Argument::type('array'))
+                 ->shouldBeCalledOnce()
+                 ->willReturn(['attribute_1' => ['option2', 'option3']]);
+
+        $this->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2', 'option3', 'option4']])
+             ->shouldReturn(['attribute_1' => ['option2', 'option3']]);
+        $this->fromOptionCodesByAttributeCode(['attribute_1' => ['option4', 'option3', 'option1', 'option2']])
+            ->shouldReturn(['attribute_1' => ['option3', 'option2']]);
+    }
+
+    function it_mixes_calls_between_the_cached_and_the_non_cached(GetExistingAttributeOptionCodes $sqlQuery)
+    {
+        $sqlQuery->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2']])
+                 ->shouldBeCalledOnce()
+                 ->willReturn(['attribute_1' => ['option2']]);
+        $sqlQuery->fromOptionCodesByAttributeCode(['attribute_1' => ['option3'], 'attribute_2' => ['other_option']])
+                 ->shouldBeCalledOnce()
+                 ->willReturn(['attribute_1' => ['option3'], 'attribute_2' => ['other_option']]);
+
+        $this->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2']])
+             ->shouldReturn(['attribute_1' => ['option2']]);
+        $this->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2', 'option3'], 'attribute_2' => ['other_option']])
+             ->shouldReturn([
+                 'attribute_1' => ['option3', 'option2'],
+                 'attribute_2' => ['other_option'],
+             ]);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When saving a variant product or product model, the `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueVariantAxisValidator` validates that its variant axes are unique. In order to do so, it fetches the values of the siblings of the saved entity from DB and creates a ValueCollection.
However, creating a ValueCollection is costly, as there are a lot of checks performed (e.g, check that the stored attribute options still exist...), so creating a ValueCollection for each sibling can prove **very** costly

This PR:
- only fetches values corresponding to the variant axes to compare them
- stores the existing/unexisting attribute options into an LRU cache in order to avoid performing the same SQL query for each entity

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
