### PR TITLE
TIP-1406: Add a tag to configure a DIC service based on a feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- TIP-1406: Add a tag to configure a DIC service based on a feature flag
 - PIM-9133: Fix product save when the user has no permission on some attribute groups
 - Fixes memory leak when indexing product models with a lot of product models in the same family
 - PIM-9119: Fix missing warning when using mass edit with parent filter set to empty

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/AkeneoFeatureFlagBundle.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/AkeneoFeatureFlagBundle.php
@@ -2,6 +2,9 @@
 
 namespace Akeneo\Platform\Bundle\FeatureFlagBundle;
 
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -11,6 +14,49 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AkeneoFeatureFlagBundle extends Bundle
+class AkeneoFeatureFlagBundle extends Bundle implements CompilerPassInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        $configs = [];
+        foreach ($container->findTaggedServiceIds('feature_flags.is_enabled') as $id => $tags) {
+            $definition = $container->getDefinition($id);
+            $definition->setPublic(true);
+            $container->setDefinition("$id.real", $definition);
+            $container->setDefinition($id, (new Definition())->setSynthetic(true));
+
+            $configs[$id] = current($tags);
+
+            if (!empty($configs[$id]['otherwise'])) {
+                $container->getDefinition($configs[$id]['otherwise'])->setPublic(true);
+            }
+        }
+        $container->setParameter('feature_flagged.services', $configs);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boot(): void
+    {
+        foreach ($this->container->getParameter('feature_flagged.services') as $id => $config) {
+            $isEnabled = $this->container->get('feature_flags')->isEnabled($config['feature']);
+            if ($isEnabled) {
+                $this->container->set($id, $this->container->get("$id.real"));
+            } elseif (!empty($config['otherwise'])) {
+                $this->container->set($id, $this->container->get($config['otherwise']));
+            }
+        }
+    }
 }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/README.md
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/README.md
@@ -20,7 +20,7 @@ Feature flags are defined by a _key_, representing the feature, and a _service_ 
 
 akeneo_feature_flag:
     feature_flags:
-        - { feature: 'onboarder', service: '@service_that_defines_if_onboarder_feature_is_enabled' }
+        - { feature: 'myCoolFeature', service: '@service_that_defines_if_myCoolFeature_feature_is_enabled' }
         - { feature: 'foo', service: '@service_that_defines_if_foo_feature_is_enabled' }
         - ...
 ```
@@ -44,10 +44,10 @@ Let's take a very simple example: we want to (de)activate the _Onboarder_ featur
 
 ```yaml
 services:
-    service_that_defines_if_onboarder_feature_is_enabled:
+    service_that_defines_if_myCoolFeature_feature_is_enabled:
         class: 'Akeneo\Platform\Bundle\FeatureFlagBundle\Configuration\EnvVarFeatureFlag'
         arguments:
-            - '%env(bool:FLAG_ONBOARDER_ENABLED)%'
+            - '%env(bool:FLAG_MYCOOLFEATURE_ENABLED)%'
 ```
 
 Behind the scenes, the very simple `EnvVarFeatureFlag` class is called:
@@ -118,19 +118,6 @@ Flags are of course also available for frontend. Behind the scenes, a backend ro
 
 ## Using feature flags in your code
 
-### Switching DIC services based on a feature flag
-
-You can replace a specific DIC service by an alternative one based on a feature flag:
-
-```yaml
-services:
-    My\Service:
-        tags:
-            - { name: feature_flags.is_enabled, feature: onboarder, otherwise: 'My\NullService' }
-
-    My\NullService: ~
-```
-
 ### Knowing if a feature is enabled
 
 #### Backend
@@ -149,6 +136,19 @@ You can easily disable a route if your feature is disabled by using the `_featur
 pim_analytics_system_info_index:
     path: /system_info
     defaults: { _controller: 'pim_analytics.controller.system_info:indexAction', _format: html, _feature: 'myCoolFeature' }
+```
+
+### Switching DIC services based on a feature flag
+
+You can replace a specific DIC service by an alternative one based on a feature flag:
+
+```yaml
+services:
+    My\Service:
+        tags:
+            - { name: feature_flags.is_enabled, feature: myCoolFeature, otherwise: 'My\NullService' }
+
+    My\NullService: ~
 ```
 
 #### Frontend

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/README.md
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/README.md
@@ -118,6 +118,19 @@ Flags are of course also available for frontend. Behind the scenes, a backend ro
 
 ## Using feature flags in your code
 
+### Switching DIC services based on a feature flag
+
+You can replace a specific DIC service by an alternative one based on a feature flag:
+
+```yaml
+services:
+    My\Service:
+        tags:
+            - { name: feature_flags.is_enabled, feature: onboarder, otherwise: 'My\NullService' }
+
+    My\NullService: ~
+```
+
 ### Knowing if a feature is enabled
 
 #### Backend

--- a/tests/back/Platform/Specification/Bundle/FeatureFlagBundle/AkeneoFeatureFlagBundleSpec.php
+++ b/tests/back/Platform/Specification/Bundle/FeatureFlagBundle/AkeneoFeatureFlagBundleSpec.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Specification\Akeneo\Platform\Bundle\FeatureFlagBundle;
+
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\Internal\Registry;
+use InvalidArgumentException;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags;
+
+class AkeneoFeatureFlagBundleSpec extends ObjectBehavior
+{
+    function it_replaces_with_alternative_if_feature_disabled(FeatureFlags $flags)
+    {
+        $dic = new ContainerBuilder();
+        $dic->set('feature_flags', $flags->getWrappedObject());
+
+        $dic->setDefinition('service', (new Definition(Service::class))->addTag('feature_flags.is_enabled', [
+            'feature' => 'feature_a',
+            'otherwise' => 'alternative',
+        ]));
+        $dic->setDefinition('alternative', (new Definition(Alternative::class)));
+
+        $this->process($dic);
+        $this->setContainer($dic);
+
+        $flags->isEnabled('feature_a')->willReturn(false);
+        $this->boot();
+
+        if (!$dic->get('service') instanceof Alternative) {
+            throw new \Exception('service should be an instance of Alternative');
+        }
+    }
+
+    function it_replaces_with_real_service_if_feature_enabled(FeatureFlags $flags)
+    {
+        $dic = new ContainerBuilder();
+        $dic->set('feature_flags', $flags->getWrappedObject());
+
+        $dic->setDefinition('service', (new Definition(Service::class))->addTag('feature_flags.is_enabled', [
+            'feature' => 'feature_a',
+            'otherwise' => 'alternative',
+        ]));
+        $dic->setDefinition('alternative', (new Definition(Alternative::class)));
+
+        $this->process($dic);
+        $this->setContainer($dic);
+
+        $flags->isEnabled('feature_a')->willReturn(true);
+        $this->boot();
+
+        if (!$dic->get('service') instanceof Service) {
+            throw new \Exception('service should be an instance of Service');
+        }
+    }
+
+    function it_keeps_service_synthetic_if_disabled_and_no_alternative(FeatureFlags $flags)
+    {
+        $dic = new ContainerBuilder();
+        $dic->set('feature_flags', $flags->getWrappedObject());
+
+        $dic->setDefinition('service', (new Definition(Service::class))->addTag('feature_flags.is_enabled', [
+            'feature' => 'feature_a',
+        ]));
+        $dic->setDefinition('alternative', (new Definition(Alternative::class)));
+
+        $this->process($dic);
+        $this->setContainer($dic);
+
+        $flags->isEnabled('feature_a')->willReturn(false);
+        $this->boot();
+
+        if (!$dic->getDefinition('service')->isSynthetic()) {
+            throw new \Exception('service should be synthetic');
+        }
+    }
+}
+
+class Service {}
+class Alternative {}


### PR DESCRIPTION
This introduces a new compiler pass along with a boot hook in the kernel.

The compiler pass replaces each service tagged `feature_flags.is_enabled`
by a synthetic service (i.e: a service that needs to be defined at runtime).
The original service is renamed to `$id.real` and an alternative service is provided using a tag attribute named `otherwise`.

The alternative service must be a drop-in replacement of the original service (by implementing the same interface for example).

If no alternative is proposed, the service is kept synthetic, and accessing it would blow up with a runtime exception.

All in all, no change has to be made in your code and/or service definitions, except for adding the tag on the services you want:

```yaml
services:
    My\Service:
        tags:
            - { name: feature_flags.is_enabled, feature: onboarder, otherwise: 'My\NullService' }

    My\NullService: ~
```

The `boot` method hooks into the kernel startup, and decides which service (either the real one or the alternative one) will replace the synthetic service, based on the state of the feature flag.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -