### PR TITLE
Fix the README in FeatureFlagBundle about services declaration

### DIFF
--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/README.md
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/README.md
@@ -20,8 +20,8 @@ Feature flags are defined by a _key_, representing the feature, and a _service_ 
 
 akeneo_feature_flag:
     feature_flags:
-        - { feature: 'onboarder', service: '@service_that_defines_if_onboarder_feature_is_enabled' }
-        - { feature: 'foo', service: '@service_that_defines_if_foo_feature_is_enabled' }
+        - { feature: 'onboarder', service: 'service_that_defines_if_onboarder_feature_is_enabled' }
+        - { feature: 'foo', service: 'service_that_defines_if_foo_feature_is_enabled' }
         - ...
 ```
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Since the `service` value is used by the DI as a `Reference`, it should not be prefixed by `@`.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
