### PR TITLE
PIM-9222: Error 500 when attempting bulk change with parent=empty filter

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9222: Fix errors on mass action when the parent filter is set to empty
+
 # 3.2.51 (2020-04-28)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
@@ -303,7 +303,7 @@ class MassActionDispatcher
     {
         if ($this->areAllRowsSelected($filters)) {
             foreach ($filters as &$filter) {
-                if ('parent' === $filter['field']) {
+                if ('parent' === $filter['field'] && 'EMPTY' !== $filter['operator']) {
                     $filter['field'] = 'ancestor.code';
                 }
             }

--- a/src/Oro/Bundle/PimDataGridBundle/spec/Extension/MassAction/MassActionDispatcherSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/Extension/MassAction/MassActionDispatcherSpec.php
@@ -269,4 +269,62 @@ class MassActionDispatcherSpec extends ObjectBehavior
             ],
         ]);
     }
+
+    function it_does_not_convert_empty_parent_filter_when_all_rows_are_selected(
+        DatagridInterface $grid,
+        Acceptor $acceptor,
+        MassActionExtension $massActionExtension,
+        MassActionInterface $massActionInterface,
+        QueryBuilder $queryBuilder,
+        ProductDatasource $datasource,
+        ProductMassActionRepositoryInterface $massActionRepository,
+        MassActionParametersParser $parametersParser,
+        ProductQueryBuilderInterface $productQueryBuilder
+    ) {
+        $massActionName = 'mass_edit_action';
+        $request = new Request([
+            'inset'      => 'inset',
+            'values'     => [1],
+            'gridName'   => 'grid',
+            'massAction' => $massActionInterface,
+            'actionName' => 'mass_edit_action',
+        ]);
+
+        $parametersParser->parse($request)->willReturn([
+            'inset' => 'inset',
+            'values' => [1],
+            'gridName'   => 'grid',
+            'massAction' => $massActionInterface,
+            'actionName' => 'mass_edit_action',
+        ]);
+        $datasource->getMassActionRepository()->willReturn($massActionRepository);
+        $massActionRepository->applyMassActionParameters($queryBuilder, '', [1])->willReturn(null);
+        $massActionExtension->getMassAction('mass_edit_action', $grid)->willReturn($massActionInterface);
+        $acceptor->getExtensions()->willReturn([$massActionExtension]);
+
+        $datasource->getProductQueryBuilder()->willReturn($productQueryBuilder);
+        $productQueryBuilder->getRawFilters()->willReturn([
+            [
+                'field' => 'parent',
+                'operator' => 'EMPTY',
+                'values' => "",
+            ],
+        ]);
+        $datasource->getParameters()->willReturn(null);
+
+        $this->getRawFilters([
+            'inset'      => '',
+            'values'     => [1],
+            'gridName'   => 'grid',
+            'massAction' => $massActionInterface,
+            'actionName' => $massActionName
+        ])->shouldReturn([
+            [
+                'field' => 'parent',
+                'operator' => 'EMPTY',
+                'values' => "",
+                'context' => [],
+            ],
+        ]);
+    }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/AncestorCodeFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/AncestorCodeFilterSpec.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\AncestorCodeFilter;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductModelRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+
+class AncestorCodeFilterSpec extends ObjectBehavior
+{
+    function let(
+        ProductModelRepositoryInterface $productModelRepository
+    )
+    {
+        $this->beConstructedWith($productModelRepository, ['ancestor.code'], [Operators::EQUALS, Operators::IN_LIST, Operators::NOT_IN_LIST]);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AncestorCodeFilter::class);
+    }
+
+    function it_is_a_filter()
+    {
+        $this->shouldImplement(FieldFilterInterface::class);
+    }
+
+    function it_supports_operators()
+    {
+        $this->supportsOperator(Operators::EQUALS)->shouldReturn(true);
+        $this->supportsOperator(Operators::IN_LIST)->shouldReturn(true);
+        $this->supportsOperator(Operators::NOT_IN_LIST)->shouldReturn(true);
+        $this->supportsOperator(Operators::IS_EMPTY)->shouldReturn(false);
+        $this->supportsOperator(Operators::IS_NOT_EMPTY)->shouldReturn(false);
+    }
+
+    function it_supports_ancestor_code_field()
+    {
+        $this->supportsField('ancestor.id')->shouldReturn(false);
+        $this->supportsField('ancestor.code')->shouldReturn(true);
+        $this->supportsField('wrong_field')->shouldReturn(false);
+    }
+
+    function it_adds_a_filter_with_operator_equals(
+        SearchQueryBuilder $sqb
+    )
+    {
+        $sqb->addFilter(
+            [
+                'terms' => ['ancestors.codes' => ['product_model_1', 'product_model_2']],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter(
+            'ancestor.code',
+            Operators::EQUALS,
+            ['product_model_1', 'product_model_2'],
+            null,
+            null,
+            []
+        );
+    }
+
+    function it_adds_a_filter_with_operator_in_list(
+        SearchQueryBuilder $sqb
+    )
+    {
+        $sqb->addFilter(
+            [
+                'terms' => ['ancestors.codes' => ['product_model_1', 'product_model_2']],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter(
+            'ancestor.code',
+            Operators::IN_LIST,
+            ['product_model_1', 'product_model_2'],
+            null,
+            null,
+            []
+        );
+    }
+
+    function it_adds_a_filter_with_operator_not_in_list(
+        SearchQueryBuilder $sqb
+    )
+    {
+        $sqb->addMustNot(
+            [
+                'terms' => ['ancestors.codes' => ['product_model_1', 'product_model_2']],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter(
+            'ancestor.code',
+            Operators::NOT_IN_LIST,
+            ['product_model_1', 'product_model_2'],
+            null,
+            null,
+            []
+        );
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Backports fix from #11638 to 3.2 branch. It fixes errors on mass action when the parent filter is set to empty

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
