### PR TITLE
TIP-1456: require correct EE branch if it exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,12 @@ jobs:
               export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa_1f25f8bb595295f6e2f2972f30d4e966 -o UserKnownHostsFile=~/.ssh/known_hosts -o IdentitiesOnly=Yes'
               git clone git@github.com:akeneo/pim-enterprise-dev.git /home/circleci/project
       - run:
-          name: Require proper CE dev branch
+          name: Checkout EE branch if it exists, or master otherwise
+          command: |
+            cd /home/circleci/project
+            git checkout ${CIRCLE_BRANCH} || git checkout master
+      - run:
+          name: Require proper dev CE branch
           command: |
             sed -i "s|\"akeneo/pim-community-dev\": \"dev-master|\"akeneo/pim-community-dev\": \"dev-${CIRCLE_BRANCH}|" composer.json
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,16 +308,6 @@ jobs:
           - attach_workspace:
                 at: ~/
           - set_gcloud_config_dev
-          - when:
-                condition: << parameters.is_pull_request >>
-                steps:
-                    - run:
-                          name: Update composer.json if same branch exists in CE
-                          command: >
-                              curl --output /dev/null --silent --head --fail
-                              https://github.com/akeneo/pim-community-dev/tree/${CIRCLE_BRANCH} &&
-                              sed -i "s|\"akeneo/pim-community-dev\": \"dev-master|\"akeneo/pim-community-dev\": \"dev-${CIRCLE_BRANCH}|" composer.json ||
-                              echo "No CE branch $CIRCLE_BRANCH found. I don't touch the composer.json file."
           - run:
               name: Build PROD PIM docker image
               command: IMAGE_TAG=$CIRCLE_SHA1 IMAGE_TAG_DATE=$(date +%Y%m%d%H%M%S) make php-image-prod

--- a/.circleci/detect_structure_changes.sh
+++ b/.circleci/detect_structure_changes.sh
@@ -82,12 +82,12 @@ echo "Restore Git repository as how it was at the beginning..."
 git clean -f
 git checkout -- .
 
-echo "Checkout EE PR branch..."
-(curl --output /dev/null --silent --head --fail https://github.com/akeneo/pim-entrerprise-dev/tree/${PR_BRANCH} && git checkout $PR_BRANCH) || git checkout master
+echo "Checkout EE PR branch (or master if it does not exist)..."
+git checkout $PR_BRANCH || git checkout master
 
-echo "Checkout CE PR branch..."
+echo "Checkout CE PR branch (or master if it does not exist)..."
 pushd vendor/akeneo/pim-community-dev
-(curl --output /dev/null --silent --head --fail https://github.com/akeneo/pim-community-dev/tree/${PR_BRANCH} && git checkout $PR_BRANCH) || git checkout master
+git checkout $PR_BRANCH || git checkout master
 popd
 
 echo "Copy CE migrations into EE to launch branch migrations..."


### PR DESCRIPTION
JM reported me a problem. Imagine you have both a CE and an EE branch.
Currently, the CE build will install a master EE with your CE branch. But your EE branch is not taken into account. This PR fixes the problem.

It also lead me to :
- fix the wrong checkout of the EE branch in the `detect_structure_changes.sh` script. The URL was not accessible at all! And as we now always clone an EE, it's much easier to do a  `git checkout MYBRANCH || git checkout master`. And this exactly what we want. Checkout MYBRANCH if it exists, master otherwise.
- remove a useless hack of the `composer.json` in the `build_prod` job. This change is already performed in `checkout_ee`.
