### PR TITLE
PIM-9224: Refresh command broken in 4.0

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9224: Fix versioning refresh command
+
 # 4.0.21 (2020-04-29)
 
 ## Technical Improvements

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Command/RefreshCommand.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Command/RefreshCommand.php
@@ -154,4 +154,12 @@ class RefreshCommand extends Command
             $this->entityManager->flush($version);
         }
     }
+
+    /**
+     * @return ObjectManager
+     */
+    protected function getObjectManager()
+    {
+        return $this->getContainer()->get('doctrine.orm.default_entity_manager');
+    }
 }

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Command/RefreshCommand.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Command/RefreshCommand.php
@@ -100,8 +100,6 @@ class RefreshCommand extends Command
 
         $batchSize = $input->getOption('batch-size');
 
-        $om = $this->getObjectManager();
-
         $pendingVersions = $this->versionManager
             ->getVersionRepository()
             ->getPendingVersions($batchSize);
@@ -122,7 +120,7 @@ class RefreshCommand extends Command
 
                 $progress->advance();
             }
-            $om->flush();
+            $this->entityManager->flush();
             $this->bulkObjectDetacher->detachAll($pendingVersions);
 
             $pendingVersions = $this->versionManager
@@ -153,13 +151,5 @@ class RefreshCommand extends Command
             $this->entityManager->remove($version);
             $this->entityManager->flush($version);
         }
-    }
-
-    /**
-     * @return ObjectManager
-     */
-    protected function getObjectManager()
-    {
-        return $this->getContainer()->get('doctrine.orm.default_entity_manager');
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The refresh command was not working with the following error message : 
```
In RefreshCommand.php line 103:
Attempted to call an undefined method named "getObjectManager" of class 
"Akeneo\Tool\Bundle\VersioningBundle\Command\RefreshCommand". 
```
Checking on 3.2, that definition was properly done.

**Solution:** 

The RefreshCommand class doesn't extend ContainerAwareCommand class anymore.
So, the method getObjectManager must now be called via the entityManager object (EntityManagerInterface extends ObjectManager).






<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
