### PR TITLE
TIP-1291: launch migrations in prod mode, as it will be done on Serenity

### DIFF
--- a/config/services/test/test_services.yml
+++ b/config/services/test/test_services.yml
@@ -16,6 +16,13 @@ services:
     _defaults:
         public: true
 
+    akeneo_integration_tests.migration_command_launcher:
+        class: 'Akeneo\Tool\Component\Console\CommandLauncher'
+        arguments:
+            - '%kernel.root_dir%'
+            - 'prod'
+            - '%kernel.logs_dir%'
+
     akeneo_integration_tests.loader.reference_data_loader:
         class: '%akeneo_integration_tests.loader.reference_data_loader.class%'
         arguments:

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/repositories.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/repositories.yml
@@ -5,6 +5,7 @@ parameters:
 
 services:
     pim_user.repository.role:
+        public: true
         class: '%pim_user.repository.role.class%'
         factory: 'doctrine.orm.entity_manager:getRepository'
         arguments: ['%pim_user.entity.role.class%']

--- a/src/Oro/Bundle/SecurityBundle/Resources/config/services.yml
+++ b/src/Oro/Bundle/SecurityBundle/Resources/config/services.yml
@@ -49,6 +49,7 @@ services:
 
     oro_security.acl.manager:
         class: '%oro_security.acl.manager.class%'
+        public: true
         arguments:
             - '@oro_security.acl.object_identity_factory'
             - '@oro_security.acl.extension_selector'

--- a/upgrades/test_schema/ExecuteMigrationTrait.php
+++ b/upgrades/test_schema/ExecuteMigrationTrait.php
@@ -22,7 +22,7 @@ trait ExecuteMigrationTrait
 
     private function getCommandLauncher(): CommandLauncher
     {
-        return $this->get('pim_catalog.command_launcher');
+        return $this->get('akeneo_integration_tests.migration_command_launcher');
     }
 
     private function reExecuteMigration(string $migrationLabel): void


### PR DESCRIPTION
**What's done today**

When we launch the command `make migration-back` in the CI job `test_back_data_migrations`, all PhpUnit tests of the suite `PIM_Migration_Test` are launched.

Those PhpUnit are launched in `test` mode, which is what we want as a lot of services we use for those tests are defined only in `test` mode. Each of this tests launches a migration in a subprocess via the [command_launcher service](https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/console.yml#L4-L10). This service uses the current environment (in our case, `test`).

**The problem**

The migration [Version_4_1_20200127171059_unauthorized_view_all_jobs_permission](https://github.com/akeneo/pim-community-dev/blob/master/upgrades/schema/Version_4_1_20200127171059_unauthorized_view_all_jobs_permission.php) fails when launched on a Serenity instance, telling the service `oro_security.acl.manager` [does not exist](https://akeneo.slack.com/archives/CAXJK7SH2/p1588237738049000). Indeed, this service is private. The PR that has introduced this migration has been merged with a green CI.

On the CI, as stated above, this migration is executed with the `test` environment, [where all services are made public](https://github.com/akeneo/pim-community-dev/blob/master/tests/back/Integration/IntegrationTestsBundle/DependencyInjection/MakeServicesPublicForTestEnv.php). On the Serenity, this migration is executed with the `prod` environment, where this service remains private.

_The CI should have been red._

**What's done in this PR**

The subprocess that launches the migration now uses the `prod` environment. The test remains launched with the `test` environment, as this is really what we need.

Which means, the PR that introduced this migration would have been red.
