### PR TITLE
PIM-9227: Fix performance issue on product grid for product model images

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes:
+
+- PIM-9227: Fix performance issue on product grid for product model images
+
 # 4.0.21 (2020-04-29)
 
 ## Technical Improvements


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Optimizes the SQL query fetching product model images at the product level for the product datagrid. MySQL could sometimes wrongly optimize it (maybe bacause of the COALESCE in the ON CLAUSE). On a duplicated env with ~1 million products (but only 2 product models and 5 variant products):
- former query: ~ 1min40s
- new query: ~10 ms

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
