### PR TITLE
Poc: Does not start with identifier filter

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilter.php
@@ -111,6 +111,16 @@ class IdentifierFilter extends AbstractAttributeFilter implements AttributeFilte
                 $this->searchQueryBuilder->addFilter($clause);
                 break;
 
+            case Operators::DOES_NOT_START_WITH:
+                $clause = [
+                    'query_string' => [
+                        'default_field' => $attributePath,
+                        'query'         => QueryString::escapeValue($value) . '*',
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+                break;
+
             case Operators::CONTAINS:
                 $clause = [
                     'query_string' => [

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/IdentifierFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/IdentifierFilter.php
@@ -85,6 +85,16 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
                 $this->searchQueryBuilder->addFilter($clause);
                 break;
 
+            case Operators::DOES_NOT_START_WITH:
+                $clause = [
+                    'query_string' => [
+                        'default_field' => $field,
+                        'query'         => QueryString::escapeValue($value) . '*',
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+                break;
+
             case Operators::CONTAINS:
                 $clause = [
                     'query_string' => [

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -242,7 +242,7 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.identifier_field.class%'
         arguments:
             - ['identifier']
-            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN']
+            - ['STARTS WITH', 'DOES NOT START WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
@@ -476,7 +476,7 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.identifier_attribute.class%'
         arguments:
             - ['pim_catalog_identifier']
-            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN']
+            - ['STARTS WITH', 'DOES NOT START WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/Filter/Operators.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/Filter/Operators.php
@@ -12,6 +12,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Query\Filter;
 class Operators
 {
     public const STARTS_WITH = 'STARTS WITH';
+    public const DOES_NOT_START_WITH = 'DOES NOT START WITH';
     public const ENDS_WITH = 'ENDS WITH';
     public const CONTAINS = 'CONTAINS';
     public const DOES_NOT_CONTAIN = 'DOES NOT CONTAIN';

--- a/src/Oro/Bundle/FilterBundle/Filter/StringFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/StringFilter.php
@@ -95,14 +95,15 @@ class StringFilter extends AbstractFilter
     protected function getOperator($type)
     {
         $operatorTypes = [
-            TextFilterType::TYPE_CONTAINS     => Operators::IS_LIKE,
-            TextFilterType::TYPE_NOT_CONTAINS => Operators::IS_NOT_LIKE,
-            TextFilterType::TYPE_EQUAL        => Operators::EQUALS,
-            TextFilterType::TYPE_STARTS_WITH  => Operators::IS_LIKE,
-            TextFilterType::TYPE_ENDS_WITH    => Operators::IS_LIKE,
-            FilterType::TYPE_EMPTY            => Operators::IS_EMPTY,
-            FilterType::TYPE_NOT_EMPTY        => Operators::IS_NOT_EMPTY,
-            FilterType::TYPE_IN_LIST          => Operators::IN_LIST,
+            TextFilterType::TYPE_CONTAINS            => Operators::IS_LIKE,
+            TextFilterType::TYPE_NOT_CONTAINS        => Operators::IS_NOT_LIKE,
+            TextFilterType::TYPE_EQUAL               => Operators::EQUALS,
+            TextFilterType::TYPE_STARTS_WITH         => Operators::IS_LIKE,
+            TextFilterType::TYPE_DOES_NOT_START_WITH => Operators::IS_NOT_LIKE,
+            TextFilterType::TYPE_ENDS_WITH           => Operators::IS_LIKE,
+            FilterType::TYPE_EMPTY                   => Operators::IS_EMPTY,
+            FilterType::TYPE_NOT_EMPTY               => Operators::IS_NOT_EMPTY,
+            FilterType::TYPE_IN_LIST                 => Operators::IN_LIST,
         ];
 
         return isset($operatorTypes[$type]) ? $operatorTypes[$type] : 'LIKE';
@@ -120,7 +121,8 @@ class StringFilter extends AbstractFilter
         // for other than listed comparison types - use default format
         switch ($comparisonType) {
             case TextFilterType::TYPE_STARTS_WITH:
-                $format = '%s%%';
+            case TextFilterType::TYPE_DOES_NOT_START_WITH:
+            $format = '%s%%';
                 break;
             case TextFilterType::TYPE_ENDS_WITH:
                 $format = '%%%s';

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/TextFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/TextFilterType.php
@@ -14,6 +14,7 @@ class TextFilterType extends AbstractType
     const TYPE_EQUAL = 3;
     const TYPE_STARTS_WITH = 4;
     const TYPE_ENDS_WITH = 5;
+    const TYPE_DOES_NOT_START_WITH = 'does_not_start_with';
     const TYPE_EMPTY = 'empty';
     const NAME = 'oro_type_text_filter';
 
@@ -52,11 +53,12 @@ class TextFilterType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $choices = [
-            self::TYPE_CONTAINS     => $this->translator->trans('oro.filter.form.label_type_contains'),
-            self::TYPE_NOT_CONTAINS => $this->translator->trans('oro.filter.form.label_type_not_contains'),
-            self::TYPE_EQUAL        => $this->translator->trans('oro.filter.form.label_type_equals'),
-            self::TYPE_STARTS_WITH  => $this->translator->trans('oro.filter.form.label_type_start_with'),
-            self::TYPE_EMPTY        => $this->translator->trans('oro.filter.form.label_type_empty'),
+            self::TYPE_CONTAINS            => $this->translator->trans('oro.filter.form.label_type_contains'),
+            self::TYPE_NOT_CONTAINS        => $this->translator->trans('oro.filter.form.label_type_not_contains'),
+            self::TYPE_EQUAL               => $this->translator->trans('oro.filter.form.label_type_equals'),
+            self::TYPE_STARTS_WITH         => $this->translator->trans('oro.filter.form.label_type_start_with'),
+            self::TYPE_DOES_NOT_START_WITH => $this->translator->trans('oro.filter.form.label_type_does_not_start_with'),
+            self::TYPE_EMPTY               => $this->translator->trans('oro.filter.form.label_type_empty'),
         ];
 
         $resolver->setDefaults(

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/identifier-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/identifier-filter.js
@@ -15,6 +15,7 @@ define(['underscore', 'oro/translator', 'oro/datafilter/choice-filter'],
           {'label': __('pim_datagrid.filters.common.does_not_contain'), 'value': '2'},
           {'label': __('pim_datagrid.filters.common.equal'), 'value': '3'},
           {'label': __('pim_datagrid.filters.common.start_with'), 'value': '4'},
+          {'label': __('pim_datagrid.filters.common.does_not_start_with'), 'value': 'does_not_start_with'},
           {'label': __('pim_datagrid.filters.common.in_list'), 'value': 'in'},
         ];
         this.emptyValue = { 'type': 'in', 'value': ''};
@@ -31,6 +32,7 @@ define(['underscore', 'oro/translator', 'oro/datafilter/choice-filter'],
           '2': __('pim_datagrid.filters.common.does_not_contain'),
           '3': __('pim_datagrid.filters.common.equal'),
           '4': __('pim_datagrid.filters.common.start_with'),
+          'does_not_start_with': __('pim_datagrid.filters.common.does_not_start_with'),
           'in': __('pim_datagrid.filters.common.in_list'),
         };
       },

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/translations/jsmessages.en_US.yml
@@ -83,6 +83,7 @@ pim_datagrid:
       does_not_contain: does not contain
       equal: is equal to
       start_with: starts with
+      does_not_start_with: does not start with
       operator: Operator
     price_filter:
       label: Currency

--- a/src/Oro/Bundle/PimFilterBundle/Filter/ProductValue/StringFilter.php
+++ b/src/Oro/Bundle/PimFilterBundle/Filter/ProductValue/StringFilter.php
@@ -20,14 +20,15 @@ class StringFilter extends OroStringFilter
 {
     /** @var array */
     protected $operatorTypes = [
-        TextFilterType::TYPE_CONTAINS     => Operators::CONTAINS,
-        TextFilterType::TYPE_NOT_CONTAINS => Operators::DOES_NOT_CONTAIN,
-        TextFilterType::TYPE_EQUAL        => Operators::EQUALS,
-        TextFilterType::TYPE_STARTS_WITH  => Operators::STARTS_WITH,
-        TextFilterType::TYPE_ENDS_WITH    => Operators::ENDS_WITH,
-        FilterType::TYPE_EMPTY            => Operators::IS_EMPTY,
-        FilterType::TYPE_NOT_EMPTY        => Operators::IS_NOT_EMPTY,
-        FilterType::TYPE_IN_LIST          => Operators::IN_LIST,
+        TextFilterType::TYPE_CONTAINS            => Operators::CONTAINS,
+        TextFilterType::TYPE_NOT_CONTAINS        => Operators::DOES_NOT_CONTAIN,
+        TextFilterType::TYPE_EQUAL               => Operators::EQUALS,
+        TextFilterType::TYPE_STARTS_WITH         => Operators::STARTS_WITH,
+        TextFilterType::TYPE_DOES_NOT_START_WITH => Operators::DOES_NOT_START_WITH,
+        TextFilterType::TYPE_ENDS_WITH           => Operators::ENDS_WITH,
+        FilterType::TYPE_EMPTY                   => Operators::IS_EMPTY,
+        FilterType::TYPE_NOT_EMPTY               => Operators::IS_NOT_EMPTY,
+        FilterType::TYPE_IN_LIST                 => Operators::IN_LIST,
     ];
 
     /**

--- a/src/Oro/Bundle/PimFilterBundle/Resources/translations/messages.en_US.yml
+++ b/src/Oro/Bundle/PimFilterBundle/Resources/translations/messages.en_US.yml
@@ -9,6 +9,7 @@ oro.filter.form.label_type_contains: contains
 oro.filter.form.label_type_not_contains: does not contain
 oro.filter.form.label_type_equals: is equal to
 oro.filter.form.label_type_start_with: starts with
+oro.filter.form.label_type_does_not_start_with: does not start with
 oro.filter.form.label_type_end_with: ends with
 oro.filter.form.label_type_empty: is empty
 oro.filter.form.label_type_not_empty: is not empty


### PR DESCRIPTION
**Notes**
![Kapture 2020-05-06 at 13 34 24](https://user-images.githubusercontent.com/1826473/81173015-a04a0900-8f9f-11ea-9eb3-943c636608b0.gif)



Apparently providing this new operator to the sku automatically adds it to text filters too. (since they both use the `\Oro\Bundle\FilterBundle\Form\Type\Filter\TextFilterType` form type.

Hence, the easiest is to add this operator to the text & text area attributes too.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
