### PR TITLE
Fix for #12049 - null pointer exception on Product::getVariationLevel

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -805,7 +805,7 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getVariationLevel(): int
     {
-        return $this->getParent()->getVariationLevel() + 1;
+        return $this->getParent() !== null ? $this->getParent()->getVariationLevel() + 1 : self::ROOT_VARIATION_LEVEL;
     }
 
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

See #12049 for bug description. It's mostly triggered by custom code, but some services fail where they shouldn't due to an unexpected error.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
