### PR TITLE
PIM-9242: Fix API product model list when filtering with SINCE LAST N DAYS operator

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,5 +1,9 @@
 # 3.0.x
 
+## Bug fixes
+
+- PIM-9242: Fix API product model list when filtering with SINCE LAST N DAYS operator 
+
 # 3.0.76 (2020-04-27)
 
 # 3.0.75 (2020-04-21)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
@@ -627,7 +627,7 @@ class ProductModelController
                             $values[] = \DateTime::createFromFormat('Y-m-d H:i:s', $date);
                         }
                         $value = $values;
-                    } else {
+                    } elseif (Operators::SINCE_LAST_N_DAYS !== $filter['operator']) {
                         //PIM-7541 Create the date with the server timezone configuration. Do not force it to UTC timezone.
                         $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
                     }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/ListUpdatedOrCreatedSinceNDaysProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/ListUpdatedOrCreatedSinceNDaysProductModelEndToEnd.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+
+class ListUpdatedOrCreatedSinceNDaysProductModelEndToEnd extends AbstractProductModelTestCase
+{
+    /**
+     * @group ce
+     */
+    public function testListUpdatedSinceNDays()
+    {
+        $search = sprintf('{"updated":[{"operator":"%s","value":2}]}', Operators::SINCE_LAST_N_DAYS);
+        $this->assertOperatorSinceNDays($search);
+    }
+
+    /**
+     * @group ce
+     */
+    public function testListCreatedSinceNDays()
+    {
+        $search = sprintf('{"created":[{"operator":"%s","value":2}]}', Operators::SINCE_LAST_N_DAYS);
+        $this->assertOperatorSinceNDays($search);
+    }
+
+    private function assertOperatorSinceNDays(string $search): void
+    {
+        $standardizedProducts = $this->getStandardizedProductModels();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/product-models?search=' . $search);
+        $searchEncoded = rawurlencode($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=false&pagination_type=page&limit=10&search=$searchEncoded"},
+        "first" : {"href": "http://localhost/api/rest/v1/product-models?page=1&with_count=false&pagination_type=page&limit=10&search=$searchEncoded"}
+    },
+    "current_page" : 1,
+    "_embedded" : {
+        "items" : [
+            {$standardizedProducts['sweat']},
+            {$standardizedProducts['shoes']},
+            {$standardizedProducts['tshirt']},
+            {$standardizedProducts['trousers']},
+            {$standardizedProducts['hat']},
+            {$standardizedProducts['handbag']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Basically the same fix as the one for the product : https://github.com/akeneo/pim-community-dev/pull/8885

There must not be no formatting on date filter for the operators SINCE_LAST_N_DAYS, since it's an integer

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
