### PR TITLE
PIM-9216: Allow search on variant and product models when using the label or identifier search field

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9242: Fix API product model list when filtering with SINCE LAST N DAYS operator 
+- PIM-9216: Allow search on variant and product models when using the label or identifier search field
 
 # 3.0.76 (2020-04-27)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -130,6 +130,7 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
         $hasEntityTypeFilter = $this->hasRawFilter('field', 'entity_type');
         $hasAncestorsIdsFilter = $this->hasRawFilter('field', 'ancestor.id');
         $hasSelfAndAncestorsIdsFilter = $this->hasRawFilter('field', 'self_and_ancestor.id');
+        $hasLabelOrIdentifierFilter = $this->hasRawFilter('field', 'label_or_identifier');
         $hasSelfAndAncestorsLabelOrIdentifierFilter = $this->hasRawFilter(
             'field',
             'self_and_ancestor.label_or_identifier'
@@ -144,6 +145,7 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
             !$hasEntityTypeFilter &&
             !$hasAncestorsIdsFilter &&
             !$hasSelfAndAncestorsIdsFilter &&
+            !$hasLabelOrIdentifierFilter &&
             !$hasSelfAndAncestorsLabelOrIdentifierFilter &&
             !$hasGroupsFilter &&
             !$hasCategoryFilter;

--- a/tests/back/Pim/Enrichment/Specification/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
@@ -489,4 +489,29 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
         $this->execute()->shouldReturn($cursor);
     }
+
+    function it_does_not_add_a_default_filter_on_parents_when_there_is_a_filter_on_label_or_identifier(
+        $pqb,
+        $searchAggregator,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb
+    ) {
+        $rawFilters = [
+            [
+                'field'    => 'label_or_identifier',
+                'operator' => 'EQUALS',
+                'value'    => 'toto',
+                'context'  => [],
+                'type'     => 'field'
+            ],
+        ];
+        $pqb->getRawFilters()->willReturn($rawFilters);
+
+        $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
+        $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldBeCalled();
+
+        $this->execute()->shouldReturn($cursor);
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
The variant and product models were deliberately ignored when a user searched a product via the "label or identifier" search field. I simply added this filter to the "white list" to allow the variants and product models to be searched.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
