### PR TITLE
AOB-683: Add an extension point in family variant attribute-set

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family-variant/form/attribute-set.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family-variant/form/attribute-set.js
@@ -111,14 +111,7 @@ define(
                             .map(set => set.axes)
                             .reduce((allAxes, axes) => allAxes.concat(axes));
 
-                        const lockedAttributes = family.attributes
-                            .filter(attribute => {
-                                const isUnique = attribute.unique;
-                                const isAxis = axesAttributes.includes(attribute.code);
-
-                                return isAxis || isUnique;
-                            })
-                            .map(attribute => attribute.code);
+                        const lockedAttributes = this.getLockedAttributes(family, axesAttributes);
 
                         this.$el.empty().append(this.template({
                             lockedAttributes,
@@ -313,6 +306,17 @@ define(
                     null,
                     null,
                     'families');
+            },
+
+            getLockedAttributes(family, axesAttributes) {
+                return family.attributes
+                    .filter(attribute => {
+                        const isUnique = attribute.unique;
+                        const isAxis = axesAttributes.includes(attribute.code);
+
+                        return isAxis || isUnique;
+                    })
+                    .map(attribute => attribute.code);
             }
         });
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

For the Onboarder needs, we have to update the `family_variant/form/attribute-set.js` in order to lock our `supplier` and `supplier_reference` attributes to the latest level of family variant.
This PR extracts the logic of locking attributes in a function so we can override it easily.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
