### PR TITLE
PIM-9245: Fix relative JS files path for less compilation

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9245: Fix relative JS files path for less compilation
+
 # 3.2.54 (2020-05-06)
 
 ## Bug fixes

--- a/frontend/build/compile-less.js
+++ b/frontend/build/compile-less.js
@@ -45,9 +45,14 @@ function getFileContents(filePath) {
  */
 function collectBundleImports(bundlePaths) {
     // Make each path relative
+    /*
+    * regex explanation: remove everything before the FIRST 'src' that is after the LAST 'vendor' occurrence
+    * /srv/pim/vendor/my-domain/my-bundle/src/foo/bundle/resources => src/foo/bundle/resources
+    * /srv/subfolder/src/pim/vendor/my-domain/my-bundle/src/bar/bundle/resources => src/bar/bundle/resources
+    */
     const indexFiles = bundlePaths.map(bundlePath => {
         return `${bundlePath}/${BUNDLE_LESS_INDEX_PATH}`
-                .replace(/(^.+)[^vendor](?=\/src|\/vendor)\//gm, '')
+                .replace(/^(.+)(?=vendor).*?(?=src)\//gm, '');
     })
 
     const bundleImports = []

--- a/frontend/build/compile-less.js
+++ b/frontend/build/compile-less.js
@@ -52,7 +52,7 @@ function collectBundleImports(bundlePaths) {
     */
     const indexFiles = bundlePaths.map(bundlePath => {
         return `${bundlePath}/${BUNDLE_LESS_INDEX_PATH}`
-                .replace(/^(.+)(?=vendor).*?(?=src)\//gm, '');
+                .replace(/^.+(?=vendor).*?(?=src)\//gm, '');
     })
 
     const bundleImports = []

--- a/frontend/build/update-extensions.js
+++ b/frontend/build/update-extensions.js
@@ -27,7 +27,7 @@ const EXTENSION_DEFAULTS = {
  * @param {string} path
  */
 function getRelativeBundlePath(path) {
-    return path.replace(/(^.+)[^vendor](?=\/src|\/vendor)\//gm, '')
+    return path.replace(/^.+(?=vendor).*?(?=src)\//gm, '')
 }
 
 /**


### PR DESCRIPTION
Seen here in action: https://regex101.com/r/4A6zOF/5 (you can open the substitution panel to see the result)

It respect and improve the two previous examples:
https://regex101.com/r/4A6zOF/2
https://regex101.com/r/vdDaWy/5

One big error was the use of `[^vendor]` instead of `(?!=vendor)`

Regex explanation of `^.+(?=vendor).*?(?=src)\/`

`^` : easy, the string start
`.+(?=vendor)` : everything that is not followed by "vendor". Greedy mode, will go the the last _vendor_ occurrence
`.*?(?=src)` : everything that is not followed by "src". Non greedy mode, will go to the first _src_ occurrence
`\/` : require a slash behind _src_, not needed IMHO but i wanted to stay in the same line than previous code.

To sum up:
> remove everything before the FIRST 'src/' that is after the LAST 'vendor' occurrence