### PR TITLE
PIM-9245: Fix relative JS files path for less compilation

### DIFF
--- a/frontend/build/compile-less.js
+++ b/frontend/build/compile-less.js
@@ -51,7 +51,6 @@ function collectBundleImports(bundlePaths) {
     * /srv/subfolder/src/pim/vendor/my-domain/my-bundle/src/bar/bundle/resources => src/bar/bundle/resources
     */
     const indexFiles = bundlePaths.map(bundlePath => {
-        console.log(`${bundlePath}/${BUNDLE_LESS_INDEX_PATH}`)
         return `${bundlePath}/${BUNDLE_LESS_INDEX_PATH}`
                 .replace(/^(.+?(?=\/vendor\/)|.+(?=\/src\/))\//gm, '');
     })

--- a/frontend/build/compile-less.js
+++ b/frontend/build/compile-less.js
@@ -51,8 +51,9 @@ function collectBundleImports(bundlePaths) {
     * /srv/subfolder/src/pim/vendor/my-domain/my-bundle/src/bar/bundle/resources => src/bar/bundle/resources
     */
     const indexFiles = bundlePaths.map(bundlePath => {
+        console.log(`${bundlePath}/${BUNDLE_LESS_INDEX_PATH}`)
         return `${bundlePath}/${BUNDLE_LESS_INDEX_PATH}`
-                .replace(/^(.+?(?=\/vendor\/)|.+(?=\/src\/))/gm, '');
+                .replace(/^(.+?(?=\/vendor\/)|.+(?=\/src\/))\//gm, '');
     })
 
     const bundleImports = []

--- a/frontend/build/compile-less.js
+++ b/frontend/build/compile-less.js
@@ -52,7 +52,7 @@ function collectBundleImports(bundlePaths) {
     */
     const indexFiles = bundlePaths.map(bundlePath => {
         return `${bundlePath}/${BUNDLE_LESS_INDEX_PATH}`
-                .replace(/^.+\/vendor\/.+?\/src\//gm, 'src/');
+                .replace(/^(.+?(?=\/vendor\/)|.+(?=\/src\/))/gm, '');
     })
 
     const bundleImports = []

--- a/frontend/build/compile-less.js
+++ b/frontend/build/compile-less.js
@@ -52,7 +52,7 @@ function collectBundleImports(bundlePaths) {
     */
     const indexFiles = bundlePaths.map(bundlePath => {
         return `${bundlePath}/${BUNDLE_LESS_INDEX_PATH}`
-                .replace(/^.+(?=vendor).*?(?=src)\//gm, '');
+                .replace(/^.+\/vendor\/.+?\/src\//gm, 'src/');
     })
 
     const bundleImports = []

--- a/frontend/build/update-extensions.js
+++ b/frontend/build/update-extensions.js
@@ -27,7 +27,7 @@ const EXTENSION_DEFAULTS = {
  * @param {string} path
  */
 function getRelativeBundlePath(path) {
-    return path.replace(/^.+\/vendor\/.+?\/src\//gm, 'src/');
+    return path.replace(/^(.+?(?=\/vendor\/)|.+(?=\/src\/))/gm, 'src/');
 }
 
 /**

--- a/frontend/build/update-extensions.js
+++ b/frontend/build/update-extensions.js
@@ -27,7 +27,7 @@ const EXTENSION_DEFAULTS = {
  * @param {string} path
  */
 function getRelativeBundlePath(path) {
-    return path.replace(/^(.+?(?=\/vendor\/)|.+(?=\/src\/))/gm, 'src/');
+    return path.replace(/^(.+?(?=\/vendor\/)|.+(?=\/src\/))\//gm, 'src/');
 }
 
 /**

--- a/frontend/build/update-extensions.js
+++ b/frontend/build/update-extensions.js
@@ -27,7 +27,7 @@ const EXTENSION_DEFAULTS = {
  * @param {string} path
  */
 function getRelativeBundlePath(path) {
-    return path.replace(/^(.+?(?=\/vendor\/)|.+(?=\/src\/))\//gm, 'src/');
+    return path.replace(/^(.+?(?=\/vendor\/)|.+(?=\/src\/))\//gm, '')
 }
 
 /**
@@ -55,7 +55,6 @@ function getExtensionsFromRequiredBundles() {
     )
 
     const formExtensions = []
-
     bundleDirectories.forEach(dir => {
         formExtensions.push(glob.sync(`${dir}/Resources/config/{form_extensions/**/*.yml,form_extensions.yml}`))
     })

--- a/frontend/build/update-extensions.js
+++ b/frontend/build/update-extensions.js
@@ -27,7 +27,7 @@ const EXTENSION_DEFAULTS = {
  * @param {string} path
  */
 function getRelativeBundlePath(path) {
-    return path.replace(/^.+(?=vendor).*?(?=src)\//gm, '')
+    return path.replace(/^.+\/vendor\/.+?\/src\//gm, 'src/');
 }
 
 /**


### PR DESCRIPTION
**EDIT: this description is not right anymore. See https://github.com/akeneo/pim-community-dev/pull/12068#issuecomment-628094055 comment below for the correction.**

A simpler version of #12062 , thanks to @ahocquard .

The replace is slightly different, but simpler: instead of removing a string, it cleans and replaces it.
The search is also simpler to understand because positive lookahead can sometimes disturb people.

So now, the description of the regex is:

**Replace everything until and including the FIRST 'src/ that is after the LAST 'vendor' occurrence by `src/`**

The new regex behavior can be tested here: https://regex101.com/r/4A6zOF/9


Note from Alex: it fixes a bug also, if a directory is named "foo-vendor" or "foo-src" for example.