### PR TITLE
PIM-9246: Add a validation on locale codes

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9246: Add a validation on locale codes
+
 # 4.0.24 (2020-05-07)
 
 # 4.0.23 (2020-05-06)

--- a/src/Akeneo/Channel/Bundle/Resources/config/validation/locale.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/validation/locale.yml
@@ -4,3 +4,6 @@ Akeneo\Channel\Component\Model\Locale:
         - Akeneo\Tool\Component\StorageUtils\Validator\Constraints\Immutable:
             properties:
                 - code
+    properties:
+        code:
+            - Akeneo\Channel\Component\Validator\Constraint\LocaleCode: ~

--- a/src/Akeneo/Channel/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/validators.yml
@@ -30,3 +30,8 @@ services:
             - '@pim_catalog.repository.cached_locale'
         tags:
             - { name: validator.constraint_validator, alias: pim_locale_validator }
+
+    pim_catalog.validator.constraints.locale.locale_code_validator:
+        class: Akeneo\Channel\Component\Validator\Constraint\LocaleCodeValidator
+        tags:
+            - { name: validator.constraint_validator, alias: pim_locale_code_validator }

--- a/src/Akeneo/Channel/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/translations/validators.en_US.yml
@@ -1,0 +1,3 @@
+pim_enrich.entity.locale:
+    constraint:
+        invalid_locale_code: This locale code does not match the expected format

--- a/src/Akeneo/Channel/Component/Validator/Constraint/LocaleCode.php
+++ b/src/Akeneo/Channel/Component/Validator/Constraint/LocaleCode.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Channel\Component\Validator\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+final class LocaleCode extends Constraint
+{
+    public $message = 'pim_enrich.entity.locale.constraint.invalid_locale_code';
+
+    public function getTargets()
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
+
+    public function validatedBy()
+    {
+        return 'pim_locale_code_validator';
+    }
+}

--- a/src/Akeneo/Channel/Component/Validator/Constraint/LocaleCodeValidator.php
+++ b/src/Akeneo/Channel/Component/Validator/Constraint/LocaleCodeValidator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Akeneo\Channel\Component\Validator\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class LocaleCodeValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint): void
+    {
+        if (! preg_match('#[a-z]{2,3}_[a-z0-9_]{2,}#i', $value)) {
+            $this->context->buildViolation($constraint->message)->addViolation();
+        }
+    }
+}

--- a/tests/back/Channel/Specification/Component/Validator/Constraint/LocaleCodeValidatorSpec.php
+++ b/tests/back/Channel/Specification/Component/Validator/Constraint/LocaleCodeValidatorSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Specification\Akeneo\Channel\Component\Validator\Constraint;
+
+use Akeneo\Channel\Component\Validator\Constraint\LocaleCode;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class LocaleCodeValidatorSpec extends ObjectBehavior
+{
+    function let(ExecutionContextInterface $context)
+    {
+        $this->initialize($context);
+    }
+
+    function it_validates_a_valid_locale_code($context) {
+        $constraint = new LocaleCode();
+
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate('aa_AA', $constraint);
+        $this->validate('aaa_AAA', $constraint);
+        $this->validate('aaa_AAAA_AA', $constraint);
+        $this->validate('aaa_aaa', $constraint);
+        $this->validate('aaa_aaaa_aa', $constraint);
+        $this->validate('aaa_aaaa_aa', $constraint);
+        $this->validate('en_029', $constraint);
+    }
+
+    function it_add_a_violation_with_an_invalid_locale_code(ConstraintViolationBuilderInterface $violation, $context) {
+        $constraint = new LocaleCode();
+        $context->buildViolation($constraint->message)->willReturn($violation);
+
+        $violation->addViolation()->shouldBeCalledTimes(8);
+
+        $this->validate('aa', $constraint);
+        $this->validate('aa_', $constraint);
+        $this->validate('aa_a', $constraint);
+        $this->validate('a_aa', $constraint);
+        $this->validate('aA', $constraint);
+        $this->validate('AA_', $constraint);
+        $this->validate('aA_A', $constraint);
+        $this->validate('A_AA', $constraint);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This PR adds a validation rule on locale codes. A locale must at least start with 2 or 3 letters, followed by an underscore and at least 2 characters (numbers, letters or underscores).
So this means that locale codes with only 2 letters are now forbidden (for example `en`)

FYI This is all the locale code formats I found in the PIM : 
```
af_ZA
arn_CL
en_029
az_Cyrl_AZ
tzm_Latn_DZ
```

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
