### PR TITLE
RAC-21: Add quantified associations updater and setter

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -190,6 +190,7 @@ acceptance:
                 - test.catalog.product_creation.context
                 - test.catalog.product_validation.context
                 - test.enrichment.enrichment_follow_up_context
+                - test.enrichment.quantified_associations_context
                 - test.attribute.context
                 - test.attribute_option.context
                 - test.locale.context

--- a/src/Akeneo/Pim/Enrichment/Bundle/DependencyInjection/AkeneoPimEnrichmentExtension.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/DependencyInjection/AkeneoPimEnrichmentExtension.php
@@ -107,6 +107,7 @@ class AkeneoPimEnrichmentExtension extends Extension
         $loader->load('view_elements/category.yml');
         $loader->load('command.yml');
         $loader->load('cli_command.yml');
+        $loader->load('quantified_associations.yml');
 
         if (!$container->hasParameter('pim_pdf_generator_font')) {
             $container->setParameter('pim_pdf_generator_font', null);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/quantified_associations.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/quantified_associations.yml
@@ -1,0 +1,8 @@
+services:
+    pim_catalog.quantified_associations.quantified_associations_merger:
+        class: Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation\QuantifiedAssociationsMerger
+
+    pim_catalog.quantified_associations.quantified_associations_from_ancestors_filter:
+        class: Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation\QuantifiedAssociationsFromAncestorsFilter
+        arguments:
+            - '@pim_catalog.quantified_associations.quantified_associations_merger'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
@@ -54,6 +54,8 @@ services:
 
     pim_catalog.normalizer.standard.product.quantified_associations:
         class: '%pim_catalog.normalizer.standard.product.quantified_associations.class%'
+        arguments:
+            - '@pim_catalog.quantified_associations.quantified_associations_merger'
         tags:
             - { name: pim_standard_format_serializer.normalizer, priority: 40 }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/updaters.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/updaters.yml
@@ -17,6 +17,7 @@ parameters:
     pim_catalog.updater.setter.association_field.class:       Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\AssociationFieldSetter
     pim_catalog.updater.setter.enabled_field.class:           Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\EnabledFieldSetter
     pim_catalog.updater.setter.media_value.class:             Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\MediaAttributeSetter
+    pim_catalog.updater.setter.quantified_associations_field.class: Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\QuantifiedAssociationsFieldSetter
 
     pim_catalog.updater.copier.registry.class:                Akeneo\Pim\Enrichment\Component\Product\Updater\Copier\CopierRegistry
     pim_catalog.updater.copier.abstract.class:                Akeneo\Pim\Enrichment\Component\Product\Updater\Copier\AbstractAttributeCopier
@@ -48,6 +49,7 @@ services:
             - '@pim_catalog.updater.property_setter'
             - '@pim_catalog.updater.entity_with_values'
             - '@pim_catalog.association.filter.parent_associations'
+            - '@pim_catalog.quantified_associations.quantified_associations_from_ancestors_filter'
             - ['identifier', 'created', 'updated', 'parent_associations', 'metadata']
 
     pim_catalog.updater.product_model:
@@ -58,6 +60,7 @@ services:
             - '@pim_catalog.repository.family_variant'
             - '@pim_catalog.repository.product_model'
             - '@pim_catalog.association.filter.parent_associations'
+            - '@pim_catalog.quantified_associations.quantified_associations_from_ancestors_filter'
             - ['identifier', 'created', 'updated', 'parent_associations', 'metadata']
 
     pim_catalog.updater.entity_with_values:
@@ -172,6 +175,11 @@ services:
         parent: pim_catalog.updater.setter.abstract
         arguments:
             - ['pim_catalog_number']
+        tags:
+            - { name: 'pim_catalog.updater.setter' }
+
+    pim_catalog.updater.setter.quantified_associations_field:
+        class: '%pim_catalog.updater.setter.quantified_associations_field.class%'
         tags:
             - { name: 'pim_catalog.updater.setter' }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithQuantifiedAssociationsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithQuantifiedAssociationsInterface.php
@@ -1,9 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Model;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\IdMapping;
+use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\QuantifiedAssociations;
 
 /**
  * Interface to implement for any entity that should be aware of any quantified associations it is holding.
@@ -14,6 +16,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\IdMappin
  */
 interface EntityWithQuantifiedAssociationsInterface
 {
+    /**
+     * Set the quantified associations
+     */
+    public function setQuantifiedAssociations(QuantifiedAssociations $quantifiedAssociations): void;
+
     /**
      * Get all associated product ids
      *
@@ -56,7 +63,10 @@ interface EntityWithQuantifiedAssociationsInterface
      * @param IdMapping $mappedProductIdentifiers
      * @param IdMapping $mappedProductModelIdentifiers
      */
-    public function updateRawQuantifiedAssociations(IdMapping $mappedProductIdentifiers, IdMapping $mappedProductModelIdentifiers): void;
+    public function updateRawQuantifiedAssociations(
+        IdMapping $mappedProductIdentifiers,
+        IdMapping $mappedProductModelIdentifiers
+    ): void;
 
     /**
      * Normalize the quantified associations

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
@@ -24,6 +24,14 @@ trait EntityWithQuantifiedAssociationTrait
     /**
      * @inheritDoc
      */
+    public function setQuantifiedAssociations(QuantifiedAssociations $quantifiedAssociations): void
+    {
+        $this->quantifiedAssociations = $quantifiedAssociations;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function getQuantifiedAssociationsProductIds(): array
     {
         if (null === $this->rawQuantifiedAssociations) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Standard/Product/QuantifiedAssociationsNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Standard/Product/QuantifiedAssociationsNormalizer.php
@@ -17,12 +17,12 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class QuantifiedAssociationsNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     /** @var QuantifiedAssociationsMerger */
-    private $quantifedAssociationMerger;
+    private $quantifiedAssociationsMerger;
 
     public function __construct(
         QuantifiedAssociationsMerger $quantifiedAssociationMerger
     ) {
-        $this->quantifedAssociationMerger = $quantifiedAssociationMerger;
+        $this->quantifiedAssociationsMerger = $quantifiedAssociationMerger;
     }
 
     /**
@@ -70,7 +70,7 @@ class QuantifiedAssociationsNormalizer implements NormalizerInterface, Cacheable
         $entities = $this->getAncestors($entity);
         $entities[] = $entity;
 
-        return $this->quantifedAssociationMerger->normalizeAndMergeQuantifiedAssociationsFrom($entities);
+        return $this->quantifiedAssociationsMerger->normalizeAndMergeQuantifiedAssociationsFrom($entities);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/QuantifiedAssociation/QuantifiedAssociationsFromAncestorsFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/QuantifiedAssociation/QuantifiedAssociationsFromAncestorsFilter.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyVariantInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithQuantifiedAssociationsInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class QuantifiedAssociationsFromAncestorsFilter
+{
+    /** @var QuantifiedAssociationsMerger */
+    private $quantifiedAssociationMerger;
+
+    public function __construct(
+        QuantifiedAssociationsMerger $quantifiedAssociationMerger
+    ) {
+        $this->quantifiedAssociationMerger = $quantifiedAssociationMerger;
+    }
+
+    public function filter(array $data, EntityWithQuantifiedAssociationsInterface $entity)
+    {
+        if (!$entity instanceof EntityWithFamilyVariantInterface) {
+            return $data;
+        }
+
+        $ancestors = $this->getAncestors($entity);
+
+        if (empty($ancestors)) {
+            return $data;
+        }
+
+        $ancestorsQuantifiedAssociations = $this->quantifiedAssociationMerger->normalizeAndMergeQuantifiedAssociationsFrom($ancestors);
+
+        if (empty($ancestorsQuantifiedAssociations)) {
+            return $data;
+        }
+
+        $filteredData = [];
+
+        foreach ($data as $associationTypeCode => $associationTypeValues) {
+            foreach ($associationTypeValues['products'] as $quantifiedLink) {
+                $ancestorsQuantifiedLinks = $ancestorsQuantifiedAssociations[$associationTypeCode]['products'] ?? [];
+
+                if (!in_array($quantifiedLink, $ancestorsQuantifiedLinks)) {
+                    $filteredData[$associationTypeCode]['products'][] = $quantifiedLink;
+                }
+            }
+
+            foreach ($associationTypeValues['product_models'] as $quantifiedLink) {
+                $ancestorsQuantifiedLinks = $ancestorsQuantifiedAssociations[$associationTypeCode]['product_models'] ?? [];
+
+                if (!in_array($quantifiedLink, $ancestorsQuantifiedLinks)) {
+                    $filteredData[$associationTypeCode]['product_models'][] = $quantifiedLink;
+                }
+            }
+        }
+
+        return $filteredData;
+    }
+
+    /**
+     * This function returns an array with the ancestors in the following order:
+     * [product_model, product_variant_level_1, product_variant_level_2]
+     * It will only returns the parents, not the current entity.
+     *
+     * @param EntityWithFamilyVariantInterface $entity
+     * @return array
+     */
+    private function getAncestors(EntityWithFamilyVariantInterface $entity): array
+    {
+        $ancestors = [];
+        $current = $entity;
+
+        while (null !== $parent = $current->getParent()) {
+            $current = $parent;
+            $ancestors[] = $current;
+        }
+
+        return array_reverse($ancestors);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/QuantifiedAssociation/QuantifiedAssociationsFromAncestorsFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/QuantifiedAssociation/QuantifiedAssociationsFromAncestorsFilter.php
@@ -10,16 +10,24 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithQuantifiedAssociatio
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * This class filter quantified associations that are existing in one of the parent of this entity.
+ *
+ * This is needed because we merge all the quantified associations from a product variant with
+ * the quantified associations of its parents.
+ * When this collection is then submitted to the product updater, it will contains both quantified associations from
+ * the parents and from the current entity.
+ * This filter make sure we are not persisting inherited quantified associations.
  */
 class QuantifiedAssociationsFromAncestorsFilter
 {
     /** @var QuantifiedAssociationsMerger */
-    private $quantifiedAssociationMerger;
+    private $quantifiedAssociationsMerger;
 
     public function __construct(
-        QuantifiedAssociationsMerger $quantifiedAssociationMerger
+        QuantifiedAssociationsMerger $quantifiedAssociationsMerger
     ) {
-        $this->quantifiedAssociationMerger = $quantifiedAssociationMerger;
+        $this->quantifiedAssociationsMerger = $quantifiedAssociationsMerger;
     }
 
     public function filter(array $data, EntityWithQuantifiedAssociationsInterface $entity)
@@ -34,7 +42,7 @@ class QuantifiedAssociationsFromAncestorsFilter
             return $data;
         }
 
-        $ancestorsQuantifiedAssociations = $this->quantifiedAssociationMerger->normalizeAndMergeQuantifiedAssociationsFrom($ancestors);
+        $ancestorsQuantifiedAssociations = $this->quantifiedAssociationsMerger->normalizeAndMergeQuantifiedAssociationsFrom($ancestors);
 
         if (empty($ancestorsQuantifiedAssociations)) {
             return $data;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/QuantifiedAssociation/QuantifiedAssociationsFromAncestorsFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/QuantifiedAssociation/QuantifiedAssociationsFromAncestorsFilter.php
@@ -21,6 +21,9 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithQuantifiedAssociatio
  */
 class QuantifiedAssociationsFromAncestorsFilter
 {
+    private const PRODUCTS_QUANTIFIED_LINKS_KEY = 'products';
+    private const PRODUCT_MODELS_QUANTIFIED_LINKS_KEY = 'product_models';
+
     /** @var QuantifiedAssociationsMerger */
     private $quantifiedAssociationsMerger;
 
@@ -51,19 +54,19 @@ class QuantifiedAssociationsFromAncestorsFilter
         $filteredData = [];
 
         foreach ($data as $associationTypeCode => $associationTypeValues) {
-            foreach ($associationTypeValues['products'] as $quantifiedLink) {
-                $ancestorsQuantifiedLinks = $ancestorsQuantifiedAssociations[$associationTypeCode]['products'] ?? [];
+            foreach ($associationTypeValues[self::PRODUCTS_QUANTIFIED_LINKS_KEY] as $quantifiedLink) {
+                $ancestorsQuantifiedLinks = $ancestorsQuantifiedAssociations[$associationTypeCode][self::PRODUCTS_QUANTIFIED_LINKS_KEY] ?? [];
 
                 if (!in_array($quantifiedLink, $ancestorsQuantifiedLinks)) {
-                    $filteredData[$associationTypeCode]['products'][] = $quantifiedLink;
+                    $filteredData[$associationTypeCode][self::PRODUCTS_QUANTIFIED_LINKS_KEY][] = $quantifiedLink;
                 }
             }
 
-            foreach ($associationTypeValues['product_models'] as $quantifiedLink) {
-                $ancestorsQuantifiedLinks = $ancestorsQuantifiedAssociations[$associationTypeCode]['product_models'] ?? [];
+            foreach ($associationTypeValues[self::PRODUCT_MODELS_QUANTIFIED_LINKS_KEY] as $quantifiedLink) {
+                $ancestorsQuantifiedLinks = $ancestorsQuantifiedAssociations[$associationTypeCode][self::PRODUCT_MODELS_QUANTIFIED_LINKS_KEY] ?? [];
 
                 if (!in_array($quantifiedLink, $ancestorsQuantifiedLinks)) {
-                    $filteredData[$associationTypeCode]['product_models'][] = $quantifiedLink;
+                    $filteredData[$associationTypeCode][self::PRODUCT_MODELS_QUANTIFIED_LINKS_KEY][] = $quantifiedLink;
                 }
             }
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/QuantifiedAssociation/QuantifiedAssociationsMerger.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/QuantifiedAssociation/QuantifiedAssociationsMerger.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithQuantifiedAssociationsInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class QuantifiedAssociationsMerger
+{
+    public function normalizeAndMergeQuantifiedAssociationsFrom(array $entitiesWithQuantifiedAssociations): array
+    {
+        $associations = [];
+
+        foreach ($entitiesWithQuantifiedAssociations as $entity) {
+            if (!$entity instanceof EntityWithQuantifiedAssociationsInterface) {
+                continue;
+            }
+
+            $associations = $this->mergeQuantifiedAssociations(
+                $associations,
+                $entity->normalizeQuantifiedAssociations()
+            );
+        }
+
+        return $associations;
+    }
+
+    /**
+     * This method merge into $array_1 the associations from $array_2.
+     * If an identifier is found in both, the quantity in $array_2 will overwrite the existing one in $array_1.
+     */
+    private function mergeQuantifiedAssociations(array $quantifiedAssociations1, array $quantifiedAssociations2): array
+    {
+        foreach ($quantifiedAssociations2 as $associationTypeCode => $association) {
+            foreach ($association as $associationEntityType => $rows) {
+                if (!isset($quantifiedAssociations1[$associationTypeCode][$associationEntityType])) {
+                    $quantifiedAssociations1[$associationTypeCode][$associationEntityType] = [];
+                }
+
+                foreach ($rows as $row) {
+                    $key = $this->searchKeyOfDuplicatedQuantifiedAssociation(
+                        $quantifiedAssociations1,
+                        $associationTypeCode,
+                        $associationEntityType,
+                        $row
+                    );
+
+                    if (null !== $key) {
+                        $quantifiedAssociations1[$associationTypeCode][$associationEntityType][$key]['quantity'] = $row['quantity'];
+                        continue;
+                    }
+
+                    $quantifiedAssociations1[$associationTypeCode][$associationEntityType][] = $row;
+                }
+            }
+        }
+
+        return $quantifiedAssociations1;
+    }
+
+    /**
+     * Since we are using an unindexed array for the quantified associations,
+     * we need to find if there is a row with the same identifier as the one we have.
+     * With its key, we will be able to overwrite the quantity.
+     *
+     * For context, this is the structure:
+     * [
+     *      'PACK' => [
+     *          'products' => [
+     *              ['identifier' => 'foo', 'quantity' => 2],
+     *              ['identifier' => 'bar', 'quantity' => 4],
+     *          ]
+     *      ]
+     * ]
+     *
+     */
+    private function searchKeyOfDuplicatedQuantifiedAssociation(
+        array $source,
+        string $associationTypeCode,
+        string $associationEntityType,
+        array $quantifiedAssociation
+    ): ?int {
+        $matchingSourceQuantifiedAssociations = array_filter(
+            $source[$associationTypeCode][$associationEntityType] ?? [],
+            function ($sourceQuantifiedAssociation) use ($quantifiedAssociation) {
+                return $sourceQuantifiedAssociation['identifier'] === $quantifiedAssociation['identifier'];
+            }
+        );
+
+        if (empty($matchingSourceQuantifiedAssociations)) {
+            return null;
+        }
+
+        return array_keys($matchingSourceQuantifiedAssociations)[0];
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ProductUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ProductUpdater.php
@@ -6,6 +6,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Updater;
 
 use Akeneo\Pim\Enrichment\Component\Product\Association\ParentAssociationsFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation\QuantifiedAssociationsFromAncestorsFilter;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
@@ -34,22 +35,28 @@ class ProductUpdater implements ObjectUpdaterInterface
     /** @var ParentAssociationsFilter */
     private $parentAssociationsFilter;
 
+    /** @var QuantifiedAssociationsFromAncestorsFilter */
+    private $quantifiedAssociationsFromAncestorsFilter;
+
     /**
      * @param PropertySetterInterface  $propertySetter
      * @param ObjectUpdaterInterface   $valuesUpdater
      * @param ParentAssociationsFilter $parentAssociationsFilter
+     * @param QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter
      * @param array                    $ignoredFields
      */
     public function __construct(
         PropertySetterInterface $propertySetter,
         ObjectUpdaterInterface $valuesUpdater,
         ParentAssociationsFilter $parentAssociationsFilter,
+        QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter,
         array $ignoredFields
     ) {
         $this->propertySetter = $propertySetter;
         $this->valuesUpdater = $valuesUpdater;
         $this->ignoredFields = $ignoredFields;
         $this->parentAssociationsFilter = $parentAssociationsFilter;
+        $this->quantifiedAssociationsFromAncestorsFilter = $quantifiedAssociationsFromAncestorsFilter;
     }
 
     /**
@@ -149,14 +156,14 @@ class ProductUpdater implements ObjectUpdaterInterface
         }
 
         foreach ($data as $code => $value) {
-            $filteredValue = $this->filterData($code, $value, $data);
+            $filteredValue = $this->filterData($product, $code, $value, $data);
             $this->setData($product, $code, $filteredValue, $options);
         }
 
         return $this;
     }
 
-    protected function filterData(string $field, $data, array $context = [])
+    protected function filterData(ProductInterface $product, string $field, $data, array $context = [])
     {
         switch ($field) {
             case 'associations':
@@ -166,7 +173,7 @@ class ProductUpdater implements ObjectUpdaterInterface
                 }
                 break;
             case 'quantified_associations':
-                // @todo RAC-19
+                $data = $this->filterQuantifiedAssociationsFromAncestors($product, $data);
                 break;
         }
 
@@ -188,10 +195,8 @@ class ProductUpdater implements ObjectUpdaterInterface
                 $this->updateProductFields($product, $field, $data);
                 break;
             case 'associations':
-                $this->updateProductFields($product, $field, $data);
-                break;
             case 'quantified_associations':
-                // @todo RAC-19
+                $this->updateProductFields($product, $field, $data);
                 break;
             case 'values':
                 $this->valuesUpdater->update($product, $data, $options);
@@ -242,6 +247,16 @@ class ProductUpdater implements ObjectUpdaterInterface
         );
 
         return $associations;
+    }
+
+    protected function filterQuantifiedAssociationsFromAncestors(
+        ProductInterface $product,
+        array $data
+    ): array {
+        return $this->quantifiedAssociationsFromAncestorsFilter->filter(
+            $data,
+            $product
+        );
     }
 
     protected function validateScalar(string $field, $data): void

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Setter;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\QuantifiedAssociations;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class QuantifiedAssociationsFieldSetter extends AbstractFieldSetter
+{
+    /**
+     * {@inheritdoc}
+     *
+     * Expected data input format :
+     * {
+     *     "PACK": {
+     *         "products": [
+     *              {"identifier": "AKN_TS1", "quantity": 2},
+     *              {"identifier": "AKN_TSH2", "quantity": 3},
+     *         ],
+     *         "product_models": [
+     *              {"identifier": "MODEL_AKN_TS1", "quantity": 2},
+     *              {"identifier": "MODEL_AKN_TSH2", "quantity": 3},
+     *         ],
+     *     },
+     * }
+     */
+    public function setFieldData($entity, $field, $data, array $options = [])
+    {
+        $entity->setQuantifiedAssociations(QuantifiedAssociations::createFromNormalized($data));
+    }
+
+    public function supportsField($field)
+    {
+        return 'quantified_associations' === $field;
+    }
+}

--- a/tests/back/Pim/Enrichment/Acceptance/Context/QuantifiedAssociationsContext.php
+++ b/tests/back/Pim/Enrichment/Acceptance/Context/QuantifiedAssociationsContext.php
@@ -1,0 +1,420 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Acceptance\Context;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\ProductNormalizer;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\Family;
+use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyVariant;
+use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
+use Akeneo\Pim\Structure\Component\Model\VariantAttributeSet;
+use Akeneo\Test\Common\Structure\Attribute;
+use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Behat\Behat\Context\Context;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Webmozart\Assert\Assert;
+
+final class QuantifiedAssociationsContext implements Context
+{
+    /** @var Product|null */
+    private $product;
+
+    /** @var ProductModel|null */
+    private $productModel;
+
+    /** @var FamilyInterface|null */
+    private $family;
+
+    /** @var FamilyVariantInterface|null */
+    private $familyVariant;
+
+    /** @var AttributeInterface|null */
+    private $attribute;
+
+    /** @var ConstraintViolationListInterface|null */
+    private $violations;
+
+    /* --- */
+
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /** @var ObjectUpdaterInterface */
+    private $productUpdater;
+
+    /** @var ObjectUpdaterInterface */
+    private $productModelUpdater;
+
+    /** @var ProductNormalizer */
+    private $standardProductNormalizer;
+
+    public function __construct(
+        ValidatorInterface $validator,
+        ObjectUpdaterInterface $productUpdater,
+        ObjectUpdaterInterface $productModelUpdater,
+        ProductNormalizer $standardProductNormalizer
+    ) {
+        $this->validator = $validator;
+        $this->productUpdater = $productUpdater;
+        $this->productModelUpdater = $productModelUpdater;
+        $this->standardProductNormalizer = $standardProductNormalizer;
+    }
+
+    private function createProduct(array $fields): Product
+    {
+        $product = new Product();
+        $this->updateProduct($product, $fields);
+
+        return $product;
+    }
+
+    private function createProductVariant(array $fields): Product
+    {
+        $product = new Product();
+        $this->updateProduct($product, $fields);
+
+        $product->setFamily($this->getFamily());
+        $product->setFamilyVariant($this->getFamilyVariant());
+
+        return $product;
+    }
+
+    private function updateProduct(Product $product, array $fields): void
+    {
+        $this->productUpdater->update($product, $fields);
+    }
+
+    private function validateEntityWithValues(EntityWithValuesInterface $entity): ConstraintViolationListInterface
+    {
+        return $this->validator->validate($entity);
+    }
+
+    private function createProductModel(array $fields): ProductModel
+    {
+        $productModel = new ProductModel();
+        $this->updateProductModel($productModel, $fields);
+
+        $productModel->setFamilyVariant($this->getFamilyVariant());
+
+        return $productModel;
+    }
+
+    private function updateProductModel(ProductModel $productModel, array $fields): void
+    {
+        $this->productModelUpdater->update($productModel, $fields);
+    }
+
+    private function getAttribute(): AttributeInterface
+    {
+        if (null === $this->attribute) {
+            $this->attribute = (new Attribute\Builder())->aIdentifier()
+                ->withCode('sku')
+                ->build();
+        }
+
+        return $this->attribute;
+    }
+
+    private function getFamily(): FamilyInterface
+    {
+        if (null === $this->family) {
+            $this->family = new Family();
+            $this->family->setCode('furniture');
+            $this->family->addAttribute($this->getAttribute());
+        }
+
+        return $this->family;
+    }
+
+    private function getFamilyVariant(): FamilyVariantInterface
+    {
+        if (null === $this->familyVariant) {
+            $this->familyVariant = new FamilyVariant();
+            $this->familyVariant->setFamily($this->getFamily());
+
+            $variantAttributeSet = new VariantAttributeSet();
+            $variantAttributeSet->setLevel(1);
+            $variantAttributeSet->addAttribute($this->getAttribute());
+            $this->familyVariant->addVariantAttributeSet($variantAttributeSet);
+        }
+
+        return $this->familyVariant;
+    }
+
+    /**
+     * @Given a product with an invalid quantified association
+     */
+    public function aProductWithAnInvalidQuantifiedAssociation(): void
+    {
+        $this->product = $this->createProduct([
+            'values' => [
+                'sku' => [
+                    [
+                        'scope' => null,
+                        'locale' => null,
+                        'data' => 'yellow_chair',
+                    ],
+                ],
+            ],
+            'quantified_associations' => [
+                'INVALID_ASSOCIATION_TYPE' => [
+                    'products' => [],
+                    'product_models' => [],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @When I try to save this product
+     */
+    public function iTryToSaveThisProduct(): void
+    {
+        $this->violations = $this->validator->validate($this->product);
+    }
+
+    /**
+     * @Then there is a validation error on this quantified association
+     */
+    public function thereIsAValidationErrorOnThisQuantifiedAssociation()
+    {
+//        dump($this->violations);
+    }
+
+    /**
+     * @Given /^a product without quantified associations$/
+     */
+    public function aProductWithoutQuantifiedAssociations()
+    {
+        $this->product = $this->createProduct([
+            'values' => [
+                'sku' => [
+                    [
+                        'scope' => null,
+                        'locale' => null,
+                        'data' => 'yellow_chair',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @Given /^a product variant without quantified associations$/
+     */
+    public function aProductVariantWithoutQuantifiedAssociations()
+    {
+        $this->product = $this->createProductVariant([
+            'values' => [
+                'sku' => [
+                    [
+                        'scope' => null,
+                        'locale' => null,
+                        'data' => 'yellow_chair',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @Then /^this product should be associated to this other product$/
+     */
+    public function thisProductShouldBeAssociatedToThisOtherProduct()
+    {
+        $actualQuantifiedAssociations = $this->product->normalizeQuantifiedAssociations();
+        $expectedQuantifiedAssociations = [
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'accessory', 'quantity' => 42],
+                ],
+                'product_models' => [],
+            ],
+        ];
+
+        Assert::same($actualQuantifiedAssociations, $expectedQuantifiedAssociations);
+    }
+
+    /**
+     * @When /^I associate a product to this product with a quantity$/
+     */
+    public function iAssociateAProductToThisProductWithAQuantity()
+    {
+        $fields = [
+            'quantified_associations' => [
+                'PACK' => [
+                    'products' => [
+                        ['identifier' => 'accessory', 'quantity' => 42],
+                    ],
+                    'product_models' => [],
+                ],
+            ],
+        ];
+
+        $this->updateProduct($this->product, $fields);
+        Assert::count($this->validateEntityWithValues($this->product), 0);
+    }
+
+    /**
+     * @Given /^a product model without quantified associations$/
+     */
+    public function aProductModelWithoutQuantifiedAssociations()
+    {
+        $this->productModel = $this->createProductModel([
+            'code' => 'standard_chair',
+        ]);
+    }
+
+    /**
+     * @When /^I associate a product to this product model with a quantity$/
+     */
+    public function iAssociateAProductToThisProductModelWithAQuantity()
+    {
+        $fields = [
+            'quantified_associations' => [
+                'PACK' => [
+                    'products' => [
+                        ['identifier' => 'accessory', 'quantity' => 42],
+                    ],
+                    'product_models' => [],
+                ],
+            ],
+        ];
+
+        $this->updateProductModel($this->productModel, $fields);
+        Assert::count($this->validateEntityWithValues($this->productModel), 0);
+    }
+
+    /**
+     * @Then /^this product model should be associated to this other product$/
+     */
+    public function thisProductModelShouldBeAssociatedToThisOtherProduct()
+    {
+        $actualQuantifiedAssociations = $this->productModel->normalizeQuantifiedAssociations();
+        $expectedQuantifiedAssociations = [
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'accessory', 'quantity' => 42],
+                ],
+                'product_models' => [],
+            ],
+        ];
+
+        Assert::same($actualQuantifiedAssociations, $expectedQuantifiedAssociations);
+    }
+
+    /**
+     * @Given /^this product has a parent with a quantified associations$/
+     */
+    public function thisProductHasAParentWithAQuantifiedAssociations()
+    {
+        $productModel = $this->createProductModel([
+            'values' => [
+                'sku' => [
+                    [
+                        'scope' => null,
+                        'locale' => null,
+                        'data' => 'standard_chair',
+                    ],
+                ],
+            ],
+            'quantified_associations' => [
+                'PACK' => [
+                    'products' => [
+                        ['identifier' => 'accessory', 'quantity' => 66],
+                        ['identifier' => 'something_else', 'quantity' => 2],
+                    ],
+                    'product_models' => [],
+                ],
+            ],
+        ]);
+
+        $this->product->setParent($productModel);
+    }
+
+    /**
+     * @When /^I add the same quantified association with a different quantity$/
+     */
+    public function iAddTheSameQuantifiedAssociationWithADifferentQuantity()
+    {
+        $fields = [
+            'quantified_associations' => [
+                'PACK' => [
+                    'products' => [
+                        ['identifier' => 'accessory', 'quantity' => 42],
+                    ],
+                    'product_models' => [],
+                ],
+            ],
+        ];
+
+        $this->updateProduct($this->product, $fields);
+        Assert::count($this->validateEntityWithValues($this->product), 0);
+    }
+
+    /**
+     * @Then /^this product should have this quantified association and all the other parent quantified associations$/
+     */
+    public function thisProductShouldHaveThisQuantifiedAssociationAndAllTheOtherParentQuantifiedAssociations()
+    {
+        $normalizedProduct = $this->standardProductNormalizer->normalize($this->product, 'standard');
+
+        $actualQuantifiedAssociations = $normalizedProduct['quantified_associations'];
+        $expectedQuantifiedAssociations = [
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'accessory', 'quantity' => 42],
+                    ['identifier' => 'something_else', 'quantity' => 2],
+                ],
+                'product_models' => [],
+            ],
+        ];
+
+        Assert::same($actualQuantifiedAssociations, $expectedQuantifiedAssociations);
+    }
+
+    /**
+     * @When /^I associate a product model to this product model with a quantity$/
+     */
+    public function iAssociateAProductModelToThisProductModelWithAQuantity()
+    {
+        $fields = [
+            'quantified_associations' => [
+                'PACK' => [
+                    'products' => [],
+                    'product_models' => [
+                        ['identifier' => 'accessory', 'quantity' => 42],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->updateProductModel($this->productModel, $fields);
+        Assert::count($this->validateEntityWithValues($this->productModel), 0);
+    }
+
+    /**
+     * @Then /^this product model should be associated to this other product model$/
+     */
+    public function thisProductModelShouldBeAssociatedToThisOtherProductModel()
+    {
+        $actualQuantifiedAssociations = $this->productModel->normalizeQuantifiedAssociations();
+        $expectedQuantifiedAssociations = [
+            'PACK' => [
+                'products' => [],
+                'product_models' => [
+                    ['identifier' => 'accessory', 'quantity' => 42],
+                ],
+            ],
+        ];
+
+        Assert::same($actualQuantifiedAssociations, $expectedQuantifiedAssociations);
+    }
+}

--- a/tests/back/Pim/Enrichment/Acceptance/Resources/config/behat/services.yml
+++ b/tests/back/Pim/Enrichment/Acceptance/Resources/config/behat/services.yml
@@ -3,3 +3,11 @@ services:
         public: true
         class: 'AkeneoTest\Pim\Enrichment\Acceptance\Context\EnrichmentFollowUpContext'
 
+    test.enrichment.quantified_associations_context:
+        class: AkeneoTest\Pim\Enrichment\Acceptance\Context\QuantifiedAssociationsContext
+        arguments:
+            - '@pim_catalog.validator.product'
+            - '@pim_catalog.updater.product'
+            - '@pim_catalog.updater.product_model'
+            - '@pim_catalog.normalizer.standard.product'
+        public: true

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/QuantifiedAssociation/QuantifiedAssociationMergerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/QuantifiedAssociation/QuantifiedAssociationMergerSpec.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use PhpSpec\ObjectBehavior;
+
+class QuantifiedAssociationMergerSpec extends ObjectBehavior
+{
+    public function it_merge_quantified_associations(
+        ProductInterface $product_1,
+        ProductInterface $product_2
+    ) {
+        $product_1->normalizeQuantifiedAssociations()->willReturn([
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'A', 'quantity' => 2],
+                    ['identifier' => 'B', 'quantity' => 3],
+                ],
+            ],
+        ]);
+        $product_2->normalizeQuantifiedAssociations()->willReturn([
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'C', 'quantity' => 4],
+                    ['identifier' => 'D', 'quantity' => 5],
+                ],
+            ],
+        ]);
+
+        $this->normalizeAndMergeQuantifiedAssociationsFrom([
+            $product_1,
+            $product_2,
+        ])->willReturn([
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'A', 'quantity' => 2],
+                    ['identifier' => 'B', 'quantity' => 3],
+                    ['identifier' => 'C', 'quantity' => 4],
+                    ['identifier' => 'D', 'quantity' => 5],
+                ],
+            ],
+        ]);
+    }
+
+    public function it_merge_quantified_associations_and_overwrite_quantities_from_duplicated_identifiers(
+        ProductInterface $product_1,
+        ProductInterface $product_2
+    ) {
+        $product_1->normalizeQuantifiedAssociations()->willReturn([
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'A', 'quantity' => 2],
+                    ['identifier' => 'B', 'quantity' => 3],
+                    ['identifier' => 'C', 'quantity' => 4],
+                ],
+            ],
+        ]);
+        $product_2->normalizeQuantifiedAssociations()->willReturn([
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'C', 'quantity' => 42],
+                    ['identifier' => 'D', 'quantity' => 5],
+                ],
+            ],
+        ]);
+
+        $this->normalizeAndMergeQuantifiedAssociationsFrom([
+            $product_1,
+            $product_2,
+        ])->willReturn([
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'A', 'quantity' => 2],
+                    ['identifier' => 'B', 'quantity' => 3],
+                    ['identifier' => 'C', 'quantity' => 42],
+                    ['identifier' => 'D', 'quantity' => 4],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/QuantifiedAssociation/QuantifiedAssociationsFromAncestorsFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/QuantifiedAssociation/QuantifiedAssociationsFromAncestorsFilterSpec.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class QuantifiedAssociationsFromAncestorsFilterSpec extends ObjectBehavior
+{
+    public function it_remove_quantified_associations_on_products_belonging_to_an_ancestor(
+        ProductModelInterface $product_model,
+        ProductModelInterface $variant_level_1,
+        ProductInterface $variant_level_2
+    ) {
+        $product_model->getParent()->willReturn(null);
+        $variant_level_1->getParent()->willReturn($product_model);
+        $variant_level_2->getParent()->willReturn($variant_level_1);
+
+        $product_model->normalizeQuantifiedAssociations()->willReturn([
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'product_A', 'quantity' => 2],
+                ],
+            ],
+        ]);
+        $variant_level_1->normalizeQuantifiedAssociations()->willReturn([
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'product_B', 'quantity' => 3],
+                ],
+            ],
+        ]);
+
+        $mergedQuantifiedAssociations = [
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'product_A', 'quantity' => 2],
+                    ['identifier' => 'product_B', 'quantity' => 3],
+                    ['identifier' => 'product_C', 'quantity' => 4],
+                ],
+            ],
+        ];
+
+        $expectedQuantifiedAssociations = [
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'product_C', 'quantity' => 4],
+                ],
+            ],
+        ];
+
+        $this->filter($mergedQuantifiedAssociations, $variant_level_2)->shouldReturn($expectedQuantifiedAssociations);
+    }
+
+    public function it_remove_quantified_associations_on_product_models_belonging_to_an_ancestor(
+        ProductModelInterface $product_model,
+        ProductModelInterface $variant_level_1,
+        ProductInterface $variant_level_2
+    ) {
+        $product_model->getParent()->willReturn(null);
+        $variant_level_1->getParent()->willReturn($product_model);
+        $variant_level_2->getParent()->willReturn($variant_level_1);
+
+        $product_model->normalizeQuantifiedAssociations()->willReturn([
+            'PACK' => [
+                'product_models' => [
+                    ['identifier' => 'productmodel_A', 'quantity' => 2],
+                ],
+            ],
+        ]);
+        $variant_level_1->normalizeQuantifiedAssociations()->willReturn([
+            'PACK' => [
+                'product_models' => [
+                    ['identifier' => 'productmodel_B', 'quantity' => 3],
+                ],
+            ],
+        ]);
+
+        $mergedQuantifiedAssociations = [
+            'PACK' => [
+                'product_models' => [
+                    ['identifier' => 'productmodel_A', 'quantity' => 2],
+                    ['identifier' => 'productmodel_B', 'quantity' => 3],
+                    ['identifier' => 'productmodel_C', 'quantity' => 4],
+                ],
+            ],
+        ];
+
+        $expectedQuantifiedAssociations = [
+            'PACK' => [
+                'product_models' => [
+                    ['identifier' => 'productmodel_C', 'quantity' => 4],
+                ],
+            ],
+        ];
+
+        $this->filter($mergedQuantifiedAssociations, $variant_level_2)->shouldReturn($expectedQuantifiedAssociations);
+    }
+
+    public function it_preserve_quantified_associations_on_products_when_quantity_has_been_overwrited(
+        ProductModelInterface $product_model,
+        ProductModelInterface $variant_level_1
+    ) {
+        $product_model->getParent()->willReturn(null);
+        $variant_level_1->getParent()->willReturn($product_model);
+
+        $product_model->normalizeQuantifiedAssociations()->willReturn([
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'product_A', 'quantity' => 2],
+                ],
+            ],
+        ]);
+
+        $mergedQuantifiedAssociations = [
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'product_A', 'quantity' => 42],
+                ],
+            ],
+        ];
+
+        $expectedQuantifiedAssociations = [
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'product_A', 'quantity' => 42],
+                ],
+            ],
+        ];
+
+        $this->filter($mergedQuantifiedAssociations, $variant_level_1)->shouldReturn($expectedQuantifiedAssociations);
+    }
+
+    public function it_preserve_quantified_associations_on_product_models_when_quantity_has_been_overwrited(
+        ProductModelInterface $product_model,
+        ProductModelInterface $variant_level_1
+    ) {
+        $product_model->getParent()->willReturn(null);
+        $variant_level_1->getParent()->willReturn($product_model);
+
+        $product_model->normalizeQuantifiedAssociations()->willReturn([
+            'PACK' => [
+                'product_models' => [
+                    ['identifier' => 'productmodel_A', 'quantity' => 2],
+                ],
+            ],
+        ]);
+
+        $mergedQuantifiedAssociations = [
+            'PACK' => [
+                'product_models' => [
+                    ['identifier' => 'productmodel_A', 'quantity' => 42],
+                ],
+            ],
+        ];
+
+        $expectedQuantifiedAssociations = [
+            'PACK' => [
+                'product_models' => [
+                    ['identifier' => 'productmodel_A', 'quantity' => 42],
+                ],
+            ],
+        ];
+
+        $this->filter($mergedQuantifiedAssociations, $variant_level_1)->shouldReturn($expectedQuantifiedAssociations);
+    }
+}

--- a/tests/features/pim/enrichment/entity-with-quantified-associations/update_quantified_associations.feature
+++ b/tests/features/pim/enrichment/entity-with-quantified-associations/update_quantified_associations.feature
@@ -1,0 +1,42 @@
+Feature: Update the quantified associations of an entity
+  In order to associate products and product models with quantities
+  As a regular user
+  I need to be able to update the quantified associations
+
+  Background:
+    Given a catalog with the attribute "sku" as product identifier
+
+  @acceptance-back
+  Scenario: Associate a product to another product with quantity
+    Given a product without quantified associations
+    When I associate a product to this product with a quantity
+    Then this product should be associated to this other product
+
+  @acceptance-back
+  Scenario: Associate a product to another product model with quantity
+    Given a product model without quantified associations
+    When I associate a product to this product model with a quantity
+    Then this product model should be associated to this other product
+
+  @acceptance-back
+  Scenario: Associate a product model to another product model with quantity
+    Given a product model without quantified associations
+    When I associate a product model to this product model with a quantity
+    Then this product model should be associated to this other product model
+
+  @acceptance-back
+  Scenario: Change the quantity in a quantified association defined in the parent of a product variant
+    Given a product variant without quantified associations
+    And this product has a parent with a quantified associations
+    When I add the same quantified association with a different quantity
+    Then this product should have this quantified association and all the other parent quantified associations
+
+  # TODO:
+  # association type does not exist
+  # target type is invalid
+  # association quantity is an integer
+  # association quantity is at least 1
+  # association quantity is at max 9999
+  # product does not exist
+  # product models does not exist
+  # maximum 100 associations


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- Update ProductUpdater & ProductModelUpdater to filter quantified associations inherited from the parents
- Update ProductUpdater & ProductModelUpdater to call the property setter
- Update the Standard normalizer to call the quantified associations merger
- Acceptance tests 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
