### PR TITLE
PIM-9165: Improve message of akeneo:elasticsearch:reset-indexes command

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Improvement
+
+- PIM-9165: Improve message of `akeneo:elasticsearch:reset-indexes` command. Now, all commands available to re-index entities are shown.
+
 # 3.2.55 (2020-05-14)
 
 ## Bug fixes

--- a/app/config/pim_parameters.yml
+++ b/app/config/pim_parameters.yml
@@ -56,6 +56,10 @@ parameters:
         - '%pim_ce_dev_src_folder_location%/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/settings.yml'
         - '%pim_ce_dev_src_folder_location%/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/product_mapping.yml'
 
+    elasticsearch_indexing_commands:
+        - Akeneo\Pim\Enrichment\Bundle\Command\IndexProductCommand
+        - Akeneo\Pim\Enrichment\Bundle\Command\IndexProductModelCommand
+
     # these parameters indicate the advisable limitations of the PIM in term of volume
     # if your volume of data exceeds these limits, it can impact the performance
     average_max_attributes_per_family_limit: 125

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Command/ResetIndexesCommand.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Command/ResetIndexesCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\ElasticsearchBundle\Command;
 
-use Akeneo\Pim\Enrichment\Bundle\Command\IndexProductCommand;
-use Akeneo\Pim\Enrichment\Bundle\Command\IndexProductModelCommand;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -179,12 +177,10 @@ class ResetIndexesCommand extends ContainerAwareCommand
         $output->writeln('');
         $output->writeln('<info>All the indexes have been successfully reset!</info>');
         $output->writeln('');
-        $output->writeln(
-            sprintf(
-                '<info>You can now use the command %s and %s to start re-indexing your product and product models.</info>',
-                IndexProductCommand::NAME,
-                IndexProductModelCommand::NAME
-            )
-        );
+        $output->writeln('<info>You can now use the following commands to manually re-index the entities you want:</info>');
+        $commands = $this->getContainer()->getParameter('elasticsearch_indexing_commands');
+        foreach ($commands as $command) {
+            $output->writeln(sprintf('    <info>- %s</info>', $command::NAME));
+        }
     }
 }

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/Command/ResetIndexesCommandSpec.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/Command/ResetIndexesCommandSpec.php
@@ -47,6 +47,10 @@ class ResetIndexesCommandSpec extends ObjectBehavior
         QuestionHelper $questionHelper
     ) {
         $container->get('akeneo_elasticsearch.registry.clients')->willReturn($clientRegistry);
+        $container->getParameter('elasticsearch_indexing_commands')->willReturn([
+            'Akeneo\Pim\Enrichment\Bundle\Command\IndexProductCommand',
+            'Akeneo\Pim\Enrichment\Bundle\Command\IndexProductModelCommand'
+        ]);
         $clientRegistry->getClients()->willReturn([$client1, $client2]);
 
         $input->getOption('index')->willReturn([]);
@@ -75,8 +79,11 @@ class ResetIndexesCommandSpec extends ObjectBehavior
         $output->writeln('<info>All the indexes have been successfully reset!</info>')
             ->shouldBeCalled();
         $output->writeln('')->shouldBeCalled();
-        $output->writeln('<info>You can now use the command pim:product:index and pim:product-model:index to start re-indexing your product and product models.</info>')
+        $output
+            ->writeln('<info>You can now use the following commands to manually re-index the entities you want:</info>')
             ->shouldBeCalled();
+        $output->writeln('    <info>- pim:product:index</info>')->shouldBeCalled();
+        $output->writeln('    <info>- pim:product-model:index</info>')->shouldBeCalled();
 
         $commandInput = new ArrayInput([
             'command'    => 'pim:indexes:reset',
@@ -112,6 +119,10 @@ class ResetIndexesCommandSpec extends ObjectBehavior
         QuestionHelper $questionHelper
     ) {
         $container->get('akeneo_elasticsearch.registry.clients')->willReturn($clientRegistry);
+        $container->getParameter('elasticsearch_indexing_commands')->willReturn([
+            'Akeneo\Pim\Enrichment\Bundle\Command\IndexProductCommand',
+            'Akeneo\Pim\Enrichment\Bundle\Command\IndexProductModelCommand'
+        ]);
         $clientRegistry->getClients()->willReturn([$client1, $client2]);
 
         $input->getOption('index')->willReturn(['index_1']);
@@ -138,8 +149,11 @@ class ResetIndexesCommandSpec extends ObjectBehavior
         $output->writeln('<info>All the indexes have been successfully reset!</info>')
             ->shouldBeCalled();
         $output->writeln('')->shouldBeCalled();
-        $output->writeln('<info>You can now use the command pim:product:index and pim:product-model:index to start re-indexing your product and product models.</info>')
+        $output
+            ->writeln('<info>You can now use the following commands to manually re-index the entities you want:</info>')
             ->shouldBeCalled();
+        $output->writeln('    <info>- pim:product:index</info>')->shouldBeCalled();
+        $output->writeln('    <info>- pim:product-model:index</info>')->shouldBeCalled();
 
         $commandInput = new ArrayInput([
             'command'    => 'pim:indexes:reset',


### PR DESCRIPTION
PIM indexes were hardcoded and the message at the end of the command was wrong in EE.