### PR TITLE
Minor improvements on CI PR workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ jobs:
           - store_artifacts:
                 path: var/logs
 
-  back_behat_legacy:
+  test_back_behat_legacy:
     machine:
         image: ubuntu-1604:201903-01
     parallelism: 20
@@ -550,7 +550,7 @@ workflows:
                 requires:
                     - test_back_static_and_acceptance
                     - test_front_static_acceptance_and_integration
-          - back_behat_legacy:
+          - test_back_behat_legacy:
                 requires:
                     - test_back_data_migrations
                     - test_back_missing_structure_migrations
@@ -564,7 +564,7 @@ workflows:
                     - test_onboarder_bundle
           - pull_request_success:
                 requires:
-                    - back_behat_legacy
+                    - test_back_behat_legacy
                     - test_back_performance
                     - deploy_upgrade_oldest_prod_environment
   nightly:
@@ -591,7 +591,7 @@ workflows:
           - test_back_phpunit:
                 requires:
                     - build_dev
-          - back_behat_legacy:
+          - test_back_behat_legacy:
                 requires:
                     - build_dev
           - test_back_data_migrations:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,14 @@ jobs:
       - store_artifacts:
           path: var/tests/screenshots
 
+  pull_request_success:
+      docker:
+          - image: alpine/git
+      steps:
+          - run:
+                name: Success
+                command: echo "The build has run with success! Let's merge :)"
+
   test_front_static_acceptance_and_integration:
       machine:
           image: ubuntu-1604:201903-01
@@ -554,7 +562,10 @@ workflows:
                     - test_back_missing_structure_migrations
                     - test_back_phpunit
                     - test_onboarder_bundle
-
+          - pull_request_success:
+                requires:
+                    - back_behat_legacy
+                    - test_back_performance
   nightly:
       triggers:
           - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,6 +566,7 @@ workflows:
                 requires:
                     - back_behat_legacy
                     - test_back_performance
+                    - deploy_upgrade_oldest_prod_environment
   nightly:
       triggers:
           - schedule:

--- a/.circleci/run_behat.sh
+++ b/.circleci/run_behat.sh
@@ -5,13 +5,14 @@ set -eo pipefail
 TEST_SUITE=$1
 
 TEST_FILES=$(docker-compose run --rm -T php vendor/bin/behat --list-scenarios -p legacy -s $TEST_SUITE | circleci tests split --split-by=timings)
+echo "TEST FILES ON THIS CONTAINER: $TEST_FILES"
 
 fail=0
 counter=1
 total=$(($(echo $TEST_FILES | grep -o ' ' | wc -l) + 1))
 
 for TEST_FILE in $TEST_FILES; do
-    echo "$TEST_FILE ($counter/$total):"
+    echo "\nLAUNCHING $TEST_FILE ($counter/$total):"
     output=$(basename $TEST_FILE)_$(uuidgen)
 
     set +e


### PR DESCRIPTION
Currently, a PR is merge-able if the step `back_behat_legacy` is green. This configuration must be identical for all PIM branches. 
As we want to have more flexibility on our master workflow (for instance, a PR can be merged if `back_behat_legacy` and `foo` are green), we introduce here a final step `pull_request_success`. This one should always be green. And we can put whatever we want before it.

Also, `deploy_upgrade_oldest_prod_environment` now is a requirement to merge a PR.

Finally, we display behats lauched on each container for debug purposes. Indeed, we have sometimes problems with the split of the behats by timing. We hope that displaying the output of circle's command will help us to debug when the problem will occur again.