### PR TITLE
PIM-9055: Allow not to drop an existing database during install

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -14,6 +14,10 @@
 - PIM-9445: Fix boolean attribute is broken on compare/translate when the attribute is localisable or scopable
 - PIM-9439: Fix PEF shakes on product with lot of simple/multi select
 
+## Technical Improvements
+
+- PIM-9055: Allow not to drop an existing database during the install proces
+
 # 4.0.56 (2020-09-09)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -180,7 +180,9 @@ class DatabaseCommand extends Command
         );
 
         // TODO: Should be in an event subscriber
-        $this->createNotMappedTables($output);
+        if (!$input->getOption('doNotDropDatabase')) {
+            $this->createNotMappedTables($output);
+        }
 
         if (false === $input->getOption('withoutFixtures')) {
             $this->eventDispatcher->dispatch(


### PR DESCRIPTION
This PR adds an option in the pim:installer:db command in order to allow the user not to drop an existing database, but rather empty it.

For PaaS hosts such as Platform.sh, the database is provided by the host and we cannot delete it.