### PR TITLE
PIM-9260: do not use FPM memory_limit for CommandLauncher

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9260: do not use FPM memory_limit for CommandLauncher
+
 # 4.0.27 (2020-05-18)
 
 # 4.0.26 (2020-05-15)

--- a/src/Akeneo/Tool/Component/Console/CommandLauncher.php
+++ b/src/Akeneo/Tool/Component/Console/CommandLauncher.php
@@ -53,9 +53,14 @@ class CommandLauncher
      */
     protected function buildCommandString($command)
     {
-        $memoryLimit = ini_get('memory_limit');
+        $phpCommand = $this->getPhp();
 
-        return "{$this->getPhp()} -d memory_limit={$memoryLimit} {$this->rootDir}/../bin/console --env={$this->environment} {$command}";
+        if ('cli' === php_sapi_name()) {
+            $memoryLimit = ini_get('memory_limit');
+            $phpCommand = "{$this->getPhp()} -d memory_limit={$memoryLimit}";
+        }
+
+        return "{$phpCommand} {$this->rootDir}/../bin/console --env={$this->environment} {$command}";
     }
 
     /**


### PR DESCRIPTION
We should not fix the memory limit of a batch command FROM the web context because they may not have the same memory_limit setting.