### PR TITLE
AOB-953: Fix `ComputeFamilyVariantStructureChanges` constraint

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- AOB-953: Fix `ComputeFamilyVariantStructureChanges` constraint by accepting array of several elements
+
 ## Improvement
 
 - PIM-9165: Improve message of `akeneo:elasticsearch:reset-indexes` command. Now, all commands available to re-index entities are shown.

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Job/JobParameters/ConstraintCollectionProvider/ComputeFamilyVariantStructureChanges.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Job/JobParameters/ConstraintCollectionProvider/ComputeFamilyVariantStructureChanges.php
@@ -6,6 +6,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Job\JobParameters\ConstraintCo
 
 use Akeneo\Tool\Component\Batch\Job\JobInterface;
 use Akeneo\Tool\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface;
+use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -35,7 +36,7 @@ class ComputeFamilyVariantStructureChanges implements ConstraintCollectionProvid
         return new Collection(
             [
                 'fields' => [
-                    'family_variant_codes' => new Collection(['fields' => [new NotBlank()]]),
+                    'family_variant_codes' => new All(new NotBlank()),
                 ],
             ]
         );


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

This PR updates the `ComputeFamilyVariantStructureChanges` in order to allow several elements in the `family_variant_codes` array.

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
