### PR TITLE
HOTFIX: do not require deploy_upgrade_oldest_prod_environment as we h…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,7 +566,7 @@ workflows:
                 requires:
                     - test_back_behat_legacy
                     - test_back_performance
-                    - deploy_upgrade_oldest_prod_environment
+
   nightly:
       triggers:
           - schedule:


### PR DESCRIPTION
HOTFIX: do not require deploy_upgrade_oldest_prod_environment as we have permissions problems on CI