### PR TITLE
Fix an annotation of EntityWithValuesInterface::getValue return type to allow null

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithValuesInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithValuesInterface.php
@@ -47,7 +47,7 @@ interface EntityWithValuesInterface
      * @param string $localeCode
      * @param string $scopeCode
      *
-     * @return ValueInterface
+     * @return ValueInterface|null
      */
     public function getValue($attributeCode, $localeCode = null, $scopeCode = null);
 


### PR DESCRIPTION
### Description (for Contributor and Core Developer)

This PR doesn't change code but an annotation of the method `EntityWithValuesInterface`.

Classes that implement `EntityWithValuesInterface` allow null as a return value. 

E.g. `\Akeneo\Pim\Enrichment\Component\Product\Model\AbstractProduct::getValue`

```php
        if (null === $this->getParent()) {
            return null;
        }
```

It means that interface should also provide correct information about all possible return types:

```
@return ValueInterface|null
```

#### Alternative Solution

Another and better approach would be to introduce explicit return types:

```php

public function getValue(string $attributeCode, string $localeCode = null, string $scopeCode = null): ?ValueInterface;
```
but this approach needs consistent re-work of multiple files.


### Definition Of Done (for Core Developer only)

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
