### PR TITLE
PIM-9184: Fix error count

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Domain/Audit/Model/Read/ErrorCountPerConnection.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Audit/Model/Read/ErrorCountPerConnection.php
@@ -19,6 +19,7 @@ final class ErrorCountPerConnection
      */
     public function __construct(array $errorCounts)
     {
+        $this->errorCounts = [];
         foreach ($errorCounts as $errorCount) {
             if (!$errorCount instanceof ErrorCount) {
                 throw new \InvalidArgumentException('One of the given element is not an ErrorCount object.');

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Audit/Model/Read/ErrorCountPerConnectionSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Audit/Model/Read/ErrorCountPerConnectionSpec.php
@@ -37,4 +37,10 @@ class ErrorCountPerConnectionSpec extends ObjectBehavior
             'ecommerce' => 8,
         ]);
     }
+
+    public function it_normalizes_when_zero_error_count_per_connection(): void
+    {
+        $this->beConstructedWith([]);
+        $this->normalize()->shouldReturn([]);
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When no error are found on the connection, the `errorCounts` property was not initialized as an array. So we had the error `Invalid argument supplied for foreach() in...` and a 500.  

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
