### PR TITLE
DAPI-1008: Add versioning on attribute options

### DIFF
--- a/src/Akeneo/Pim/Structure/Component/Model/AttributeOptionInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AttributeOptionInterface.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Structure\Component\Model;
 
 use Akeneo\Tool\Component\StorageUtils\Model\ReferableInterface;
+use Akeneo\Tool\Component\Versioning\Model\VersionableInterface;
 
 /**
  * Attribute options
@@ -11,7 +12,7 @@ use Akeneo\Tool\Component\StorageUtils\Model\ReferableInterface;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-interface AttributeOptionInterface extends ReferableInterface
+interface AttributeOptionInterface extends ReferableInterface, VersionableInterface
 {
     /**
      * Get id

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/UpdateGuesser/AttributeOptionUpdateGuesser.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/UpdateGuesser/AttributeOptionUpdateGuesser.php
@@ -35,8 +35,8 @@ class AttributeOptionUpdateGuesser implements UpdateGuesserInterface
 
         if ($entity instanceof AttributeOptionInterface) {
             $pendings[] = $entity->getAttribute();
-        } elseif ($entity instanceof AttributeOptionValueInterface) {
-            $pendings[] = $entity->getOption()->getAttribute();
+        } elseif ($entity instanceof AttributeOptionValueInterface && $action === UpdateGuesserInterface::ACTION_UPDATE_ENTITY) {
+            $pendings[] = $entity->getOption();
         }
 
         return $pendings;

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/spec/UpdateGuesser/AttributeOptionUpdateGuesserSpec.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/spec/UpdateGuesser/AttributeOptionUpdateGuesserSpec.php
@@ -40,12 +40,12 @@ class AttributeOptionUpdateGuesserSpec extends ObjectBehavior
         $this->guessUpdates($em, $option, UpdateGuesserInterface::ACTION_DELETE)->shouldReturn([$attribute]);
     }
 
-    function it_marks_attributes_as_updated_when_an_attribute_option_value_is_removed_or_updated(
+    function it_marks_attribute_options_as_updated_when_an_attribute_option_value_is_updated(
         $em,
-        $attribute,
+        $option,
         $optionValue
     ) {
-        $this->guessUpdates($em, $optionValue, UpdateGuesserInterface::ACTION_UPDATE_ENTITY)->shouldReturn([$attribute]);
-        $this->guessUpdates($em, $optionValue, UpdateGuesserInterface::ACTION_DELETE)->shouldReturn([$attribute]);
+        $this->guessUpdates($em, $optionValue, UpdateGuesserInterface::ACTION_UPDATE_ENTITY)->shouldReturn([$option]);
+        $this->guessUpdates($em, $optionValue, UpdateGuesserInterface::ACTION_DELETE)->shouldReturn([]);
     }
 }


### PR DESCRIPTION
As part of the Data-quality-insight features, we need to determine when an attribute option has been modified (to check the spelling). 

To do so, the chosen solution is to add versioning on the attribute options. It will be imperceptible for the users because the current history of the attributes will be unchanged. It will add entries in the versioning table when an option is created, deleted, sorted, and when a value is updated (for the entity `Akeneo\Pim\Structure\Component\Model\AttributeOption`)