### PR TITLE
 PIM-9262: Keep exif rotations when generating thumbnails 

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -5,6 +5,7 @@
 ## Bug fixes
 
 - AOB-953: Fix `ComputeFamilyVariantStructureChanges` constraint by accepting array of several elements
+- PIM-9262: Keep image rotation on images and assets thumbnails
 
 ## Improvement
 

--- a/src/Akeneo/Platform/config/bundles/liip_imagine.yml
+++ b/src/Akeneo/Platform/config/bundles/liip_imagine.yml
@@ -7,6 +7,7 @@ liip_imagine:
             filters:
                 thumbnail:    { size: [58, 58], mode: outbound }
                 strip:        ~
+
         preview:
             quality:          95
             format:           jpg
@@ -14,18 +15,23 @@ liip_imagine:
                 background:
                     color: "#ffffff"
                 strip:        ~
+
         thumbnail:
             quality:          95
             format:           png
             filters:
                 thumbnail:    { size: [320, 320], mode: outbound }
                 strip:        ~
+                auto_rotate: ~
+
         thumbnail_small:
             quality:          95
             format:           png
             filters:
+                auto_rotate: ~
                 thumbnail:    { size: [280, 280], mode: outbound }
                 strip:        ~
+
         pdf_thumbnail:
             quality:          95
             format:           png


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Keep the rotation on thumbnails generated images We do it using the liip filter "auto_rotate" which tells imagick to keep the rotation in place.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | Ok
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
