### PR TITLE
Add Group to UserManagement resolved entities

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/DependencyInjection/Compiler/ResolveDoctrineTargetModelPass.php
+++ b/src/Akeneo/UserManagement/Bundle/DependencyInjection/Compiler/ResolveDoctrineTargetModelPass.php
@@ -3,6 +3,7 @@
 namespace Akeneo\UserManagement\Bundle\DependencyInjection\Compiler;
 
 use Akeneo\Tool\Bundle\StorageUtilsBundle\DependencyInjection\Compiler\AbstractResolveDoctrineTargetModelPass;
+use Akeneo\UserManagement\Component\Model\GroupInterface;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 
 /**
@@ -21,6 +22,7 @@ class ResolveDoctrineTargetModelPass extends AbstractResolveDoctrineTargetModelP
     {
         return [
             UserInterface::class => 'pim_user.entity.user.class',
+            GroupInterface::class => 'pim_user.entity.group.class',
         ];
     }
 }


### PR DESCRIPTION
I had to introduce a relation between an entity of mine and the Group entity from UserManagement.
But this entity is not resolved as the other : you cannot reference it using its interface within your mapping.

**Description (for Contributor and Core Developer)**

Add `Group` to resolved entities of UserManagement.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
