### PR TITLE
PIM-9255: Reload completeness on associated product when channel is switched on association view

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9255: Refresh completeness of associated products in grid when channel is switched
+
 # 3.2.56 (2020-05-25)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/associations.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/associations.js
@@ -82,6 +82,7 @@ define([
             };
             params[this.datagrids.products.paramName] = this.datagrids.products.getParamValue(associationType);
             params.dataLocale = UserContext.get('catalogLocale');
+            params.dataScope = UserContext.get('catalogScope');
 
             return params;
           }.bind(this),
@@ -152,7 +153,7 @@ define([
 
       this.listenTo(
         this.getRoot(),
-        'pim_enrich:form:locale_switcher:change',
+        'pim_enrich:form:locale_switcher:change pim_enrich:form:scope_switcher:change',
         function(localeEvent) {
           if ('base_product' === localeEvent.context) {
             this.render();
@@ -393,6 +394,9 @@ define([
       let urlParams = params;
       urlParams.alias = gridName;
       urlParams.params = _.clone(params);
+      if (params.dataScope) {
+        urlParams.filters = {scope: {value: params.dataScope}};
+      }
 
       const datagridState = DatagridState.get(gridName, ['filters']);
       if (null !== datagridState.filters) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/associations.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/associations.js
@@ -394,9 +394,7 @@ define([
       let urlParams = params;
       urlParams.alias = gridName;
       urlParams.params = _.clone(params);
-      if (params.dataScope) {
-        urlParams.filters = {scope: {value: params.dataScope}};
-      }
+      urlParams.filters = {scope: {value: params.dataScope}};
 
       const datagridState = DatagridState.get(gridName, ['filters']);
       if (null !== datagridState.filters) {

--- a/src/Oro/Bundle/PimDataGridBundle/Datagrid/Configuration/Product/ContextConfigurator.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datagrid/Configuration/Product/ContextConfigurator.php
@@ -273,6 +273,10 @@ class ContextConfigurator implements ConfiguratorInterface
         }
 
         if (null === $currentScopeCode) {
+            $currentScopeCode = $this->requestParams->get('dataScope', null);
+        }
+
+        if (null === $currentScopeCode) {
             $channel = $this->userContext->getUser()->getCatalogScope();
             $currentScopeCode = $channel->getCode();
         }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**Issue:**
When the channel was changed on a product, the associated products grid was not reloaded.
The completeness value could be wrong.

**Solution:**
We have made the associated products reloaded when the user changes the channel in the association view.

![PIM-9255](https://user-images.githubusercontent.com/57708349/82906408-7ca62d00-9f65-11ea-95f7-b638f30aa679.gif)
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            |
| Added integration tests           | 
Changelog updated                 | Yes
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
