### PR TITLE
PIM-9269: Add a key "tree.create" and its associated message in the translation file for Crowdin

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+-PIM-9269: Add the key "tree.create" and its associated message in the translation file for Crowdin
+
 # 4.0.29 (2020-05-26)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/messages.en_US.yml
@@ -94,3 +94,4 @@ tree:
   edit: Edit tree
   remove:
       error_linked: This category tree cannot be deleted, it is linked to a channel
+  create: Create a category tree


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

_**Issue:**_
On the header, while creating a new category, the terms "Tree.create" were not translated and not translatable (unable to find it) on Crowdin.

_**Solution:**_ 
I added the key "tree.create" and its associated message on the translation file.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | Ok
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
