### PR TITLE
AOB-956: No more Onboarder specific configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,7 @@ jobs:
           steps:
               - run:
                   name: Activate Onboarder bundle
-                  command: |
-                      docker-compose run -u www-data --rm php sed -i "s~];~    Akeneo\\\Onboarder\\\Bundle\\\PimOnboarderBundle::class => ['all' => true],\n];~g" ./config/bundles.php
-                      docker-compose run -u www-data --rm php cp vendor/akeneo/pim-onboarder/src/Bundle/Resources/config/onboarder_configuration.yml  config/packages/onboarder.yml
+                  command: docker-compose run -u www-data --rm php sed -i "s~];~    Akeneo\\\Onboarder\\\Bundle\\\PimOnboarderBundle::class => ['all' => true],\n];~g" ./config/bundles.php
       - run:
           name: Check PIM requirements
           command: |

--- a/.circleci/detect_structure_changes.sh
+++ b/.circleci/detect_structure_changes.sh
@@ -50,7 +50,6 @@ cp -R vendor/akeneo/pim-community-dev/upgrades/schema/* upgrades/schema
 
 echo "Enable Onboarder bundle on 4.0 branch..."
 if [ -d "vendor/akeneo/pim-onboarder" ]; then
-    cp vendor/akeneo/pim-onboarder/src/Bundle/Resources/config/onboarder_configuration.yml  config/packages/onboarder.yml
     sed -i "s~];~    Akeneo\\\Onboarder\\\Bundle\\\PimOnboarderBundle::class => ['all' => true],\n];~g" ./config/bundles.php
     # on the branch 4.0, the env var and the emulator are not present
     echo "PUBSUB_EMULATOR_HOST=pubsub-emulator:8085" >> .env
@@ -95,7 +94,6 @@ cp -R vendor/akeneo/pim-community-dev/upgrades/schema/* upgrades/schema
 
 echo "Enable Onboarder bundle on PR branch..."
 if [ -d "vendor/akeneo/pim-onboarder" ]; then
-    cp vendor/akeneo/pim-onboarder/src/Bundle/Resources/config/onboarder_configuration.yml  config/packages/onboarder.yml
     sed -i "s~];~    Akeneo\\\Onboarder\\\Bundle\\\PimOnboarderBundle::class => ['all' => true],\n];~g" ./config/bundles.php
 fi
 


### PR DESCRIPTION
**Description**

The Onboarder bundle contains all its configuration, so there is no need anymore to copy anything. Activating the bundle and setting the correct environment variables (not needed for the tests) is enough.

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
