### PR TITLE
CXP-297: Display documentation in connection monitoring

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Normalizer/DocumentedNormalizer.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Normalizer/DocumentedNormalizer.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Normalizer;
+
+use Akeneo\Pim\Enrichment\Component\DocumentedExceptionInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnknownAttributeException;
+use Akeneo\Tool\Component\Api\Exception\DocumentedHttpException;
+use Akeneo\Tool\Component\Api\Hal\Link;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DocumentedNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($exception, $format = null, array $context = []): array
+    {
+        $this->checkArgumentValidity($exception, $format);
+
+        $data = [
+            'code'    => $exception->getStatusCode(),
+            'message' => $exception->getMessage()
+        ];
+
+        $link = new Link('documentation', $exception->getHref());
+        $data['_links'] = $link->toArray();
+
+        /** @var DocumentedExceptionInterface $documented */
+        $documented = $exception->getPrevious();
+        $data['documentation'] = $documented->getDocumentation();
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($exception, $format = null): bool
+    {
+        return $exception instanceof DocumentedHttpException &&
+            $exception->getPrevious() instanceof DocumentedExceptionInterface;
+    }
+
+    private function checkArgumentValidity($exception, $format = null): void
+    {
+        if (!$this->supportsNormalization($exception, $format)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    '"%s" does not support normalization of "%s".',
+                    self::class,
+                    get_class($exception)
+                )
+            );
+        }
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/normalizers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/normalizers.yml
@@ -5,16 +5,21 @@ services:
             - '@akeneo_connectivity.connection.serializer'
 
     akeneo_connectivity.connection.serializer:
-        class: 'Symfony\Component\Serializer\Serializer'
+        class: Symfony\Component\Serializer\Serializer
 
     akeneo_connectivity.connection.normalizer.exception.violation:
-        class: 'Akeneo\Connectivity\Connection\Infrastructure\Normalizer\ViolationNormalizer'
+        class: Akeneo\Connectivity\Connection\Infrastructure\Normalizer\ViolationNormalizer
         arguments:
             - '@pim_catalog.repository.cached_attribute'
         tags:
             - { name:  akeneo_connectivity.connection.serializer.normalizer, priority: 100 }
 
     akeneo_connectivity.connection.encoder.exception.violation:
-        class: 'Symfony\Component\Serializer\Encoder\JsonEncoder'
+        class: Symfony\Component\Serializer\Encoder\JsonEncoder
         tags:
             - { name:  akeneo_connectivity.connection.serializer.encoder, priority: 100 }
+
+    akeneo_connectivity.connection.normalizer.exception.documented:
+        class: Akeneo\Connectivity\Connection\Infrastructure\Normalizer\DocumentedNormalizer
+        tags:
+            - { name:  akeneo_connectivity.connection.serializer.normalizer, priority: 100 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Normalizer/DocumentedNormalizerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Normalizer/DocumentedNormalizerSpec.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Normalizer;
+
+use Akeneo\Connectivity\Connection\Infrastructure\Normalizer\DocumentedNormalizer;
+use Akeneo\Pim\Enrichment\Component\DocumentedExceptionInterface;
+use Akeneo\Tool\Component\Api\Exception\DocumentedHttpException;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class DocumentedNormalizerSpec extends ObjectBehavior
+{
+    public function it_is_a_normalizer(): void
+    {
+        $this->shouldHaveType(DocumentedNormalizer::class);
+        $this->shouldImplement(NormalizerInterface::class);
+        $this->shouldImplement(CacheableSupportsMethodInterface::class);
+    }
+
+    public function it_is_cacheable(): void
+    {
+        $this->hasCacheableSupportsMethod()->shouldReturn(true);
+    }
+
+    public function it_supports_documented_exception(): void
+    {
+        $previousException = new DocumentedException();
+        $exception = new DocumentedHttpException('_link', 'message', $previousException, 422);
+
+        $this->supportsNormalization($exception)->shouldReturn(true);
+    }
+
+    public function it_normalizes_a_documented_exception(): void
+    {
+
+        $previousException = new DocumentedException();
+        $exception = new DocumentedHttpException('_link', 'message', $previousException, 422);
+
+        $this->normalize($exception)->shouldReturn(
+            [
+                'code' => 422,
+                'message' => 'message',
+                '_links' =>  [
+                    'documentation' => ['href' => '_link']
+                ],
+                'documentation' => $previousException->getDocumentation()
+            ]
+        );
+    }
+
+    public function it_supports_only_documented_exception(): void
+    {
+        $previousException = new \Exception();
+        $exception = new \Exception('message', 422, $previousException);
+
+        $this->supportsNormalization($exception)->shouldReturn(false);
+    }
+
+    public function it_is_able_to_normalize_only_supported_data(): void
+    {
+        $previousException = new \Exception();
+        $exception = new \Exception('message', 422, $previousException);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during('normalize', [$exception]);
+    }
+
+}
+
+class DocumentedException extends \Exception implements DocumentedExceptionInterface
+{
+    public function getDocumentation(): array
+    {
+        return [
+            [
+                'message' => 'my message %s',
+                'params' => [
+                    [
+                        'route' => 'pim_enrich_attribute_index',
+                        'params' => [],
+                        'title' => 'Attributes settings',
+                        'type' => 'route',
+                    ],
+                ],
+            ]
+        ];
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/front/src/error-management/components/Documentation/DocumentationList.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/error-management/components/Documentation/DocumentationList.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {Documentation} from '../../model/ConnectionError';
+import {DocumentationMessage} from './DocumentationMessage';
+
+type Props = {
+    documentations: Array<Documentation>;
+};
+
+export const DocumentationList = ({documentations}: Props) => {
+    const list = documentations.map((documentation, i) => (
+        <div key={i}>
+            <DocumentationMessage documentation={documentation} />
+        </div>
+    ));
+
+    return <>{list}</>;
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/error-management/components/Documentation/DocumentationMessage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/error-management/components/Documentation/DocumentationMessage.tsx
@@ -1,0 +1,37 @@
+import {Documentation, HrefType, RouteType} from '../../model/ConnectionError';
+import {Typography} from '../../../common';
+import React from 'react';
+import {RouteDocumentationMessageParameter} from './RouteDocumentationMessageParameter';
+import styled from '../../../common/styled-with-theme';
+
+type Props = {
+    documentation: Documentation;
+};
+
+export const DocumentationMessage = ({documentation}: Props) => {
+    const constructedMessage = documentation.message.split(/(%s)/).map((messagePart, i) => {
+        if (messagePart !== '%s') {
+            return <Message key={i}>{messagePart}</Message>;
+        }
+        const param = documentation.params.shift();
+        if (undefined === param) {
+            return;
+        }
+
+        switch (param.type) {
+            case HrefType:
+                return (
+                    <Typography.Link key={i} href={param.href} target='_blank'>
+                        {param.title}
+                    </Typography.Link>
+                );
+            case RouteType:
+                return <RouteDocumentationMessageParameter key={i} routeParam={param} />;
+        }
+    });
+
+    return <>{constructedMessage}</>;
+};
+const Message = styled.span`
+    color: ${({theme}) => theme.color.grey140};
+`;

--- a/src/Akeneo/Connectivity/Connection/front/src/error-management/components/Documentation/RouteDocumentationMessageParameter.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/error-management/components/Documentation/RouteDocumentationMessageParameter.tsx
@@ -1,0 +1,28 @@
+import styled from '../../../common/styled-with-theme';
+import React, {FC, useContext} from 'react';
+import {RouteParameter} from '../../model/ConnectionError';
+import {RouterContext} from '../../../shared/router';
+
+type Props = {
+    routeParam: RouteParameter;
+};
+
+export const RouteDocumentationMessageParameter: FC<Props> = ({routeParam}) => {
+    const router = useContext(RouterContext);
+
+    return (
+        <InternalLink onClick={() => router.redirect(router.generate(routeParam.route, routeParam.params))}>
+            {routeParam.title}
+        </InternalLink>
+    );
+};
+
+const InternalLink = styled.span`
+    color: ${({theme}) => theme.color.purple100};
+    font-size: ${({theme}) => theme.fontSize.default};
+    text-decoration: underline;
+    cursor: pointer;
+    :hover {
+        text-decoration: none;
+    }
+`;

--- a/src/Akeneo/Connectivity/Connection/front/src/error-management/components/ErrorList/ErrorList.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/error-management/components/ErrorList/ErrorList.tsx
@@ -3,10 +3,11 @@ import {Table, TableCell, TableHeaderCell, TableHeaderRow, TableRow} from '../..
 import styled from '../../../common/styled-with-theme';
 import {useDateFormatter} from '../../../shared/formatter/use-date-formatter';
 import {Translate} from '../../../shared/translate';
-import {ConnectionError} from '../../hooks/api/use-connection-errors';
 import {NoError} from './NoError';
 import {SearchFilter} from './SearchFilter';
 import {Order, SortButton} from './SortButton';
+import {ConnectionError} from '../../model/ConnectionError';
+import {DocumentationList} from '../Documentation/DocumentationList';
 
 const useFormatTimestamp = () => {
     const formatDateTime = useDateFormatter();
@@ -75,7 +76,7 @@ const ErrorList: FC<Props> = ({errors}) => {
                                     <table>
                                         <tbody>
                                             {Object.entries(error.content)
-                                                .filter(([key]) => 'message' !== key)
+                                                .filter(([key]) => 'message' !== key && 'documentation' !== key)
                                                 .map(([key, value], i) => {
                                                     return (
                                                         <ErrorContentRow key={i}>
@@ -86,6 +87,9 @@ const ErrorList: FC<Props> = ({errors}) => {
                                                 })}
                                         </tbody>
                                     </table>
+                                    {error.content.documentation !== undefined && (
+                                        <DocumentationList documentations={error.content.documentation} />
+                                    )}
                                 </ErrorMessageCell>
                             </TableRow>
                         ))}
@@ -103,7 +107,7 @@ const DateTimeCell = styled(TableCell)`
 `;
 
 const ErrorMessageCell = styled(TableCell)`
-    color: ${({theme}) => theme.color.red100};
+    color: ${({theme}) => theme.color.grey140};
     white-space: pre-wrap;
 `;
 

--- a/src/Akeneo/Connectivity/Connection/front/src/error-management/hooks/api/use-connection-errors.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/error-management/hooks/api/use-connection-errors.ts
@@ -1,7 +1,6 @@
 import {useMemo} from 'react';
 import {useQuery} from '../../../shared/fetch';
-
-type ConnectionError = {id: number; timestamp: number; content: {message: string; property?: string}};
+import {ConnectionError} from '../../model/ConnectionError';
 
 const useConnectionErrors = (connectionCode: string) => {
     const {loading, data} = useQuery<Array<{date_time: string; content: {message: string}}>>(

--- a/src/Akeneo/Connectivity/Connection/front/src/error-management/model/ConnectionError.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/error-management/model/ConnectionError.ts
@@ -1,0 +1,32 @@
+export const HrefType = 'href';
+export const RouteType = 'route';
+
+export type HrefParameter = {
+    type: typeof HrefType;
+    title: string;
+    href: string;
+};
+
+export type RouteParameter = {
+    type: typeof RouteType;
+    title: string;
+    route: string;
+    params: {
+        [parameterName: string]: string;
+    };
+};
+
+export type Documentation = {
+    message: string;
+    params: Array<HrefParameter | RouteParameter>;
+};
+
+export type ConnectionError = {
+    id: number;
+    timestamp: number;
+    content: {
+        message: string;
+        property?: string;
+        documentation?: Array<Documentation>;
+    };
+};


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
