### PR TITLE
PIM-9276: fix values merge during indexation

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9276: Fix product computing when moving an attribute in family variant
+
 # 4.0.30 (2020-05-28)
 
 ## Bug fixes

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-9276: Fix product computing when moving an attribute in family variant
+- PIM-9277: Fix product computing when moving an attribute in family variant
 
 # 4.0.30 (2020-05-28)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
@@ -107,7 +107,7 @@ WITH
             product_model.created,
             root_product_model.code AS parent_code,
             GREATEST(product_model.updated, COALESCE(root_product_model.updated, 0)) as updated,
-            JSON_MERGE_PRESERVE(COALESCE(root_product_model.raw_values, '{}'), COALESCE(product_model.raw_values, '{}')) AS raw_values,
+            JSON_MERGE_PATCH(COALESCE(root_product_model.raw_values, '{}'), COALESCE(product_model.raw_values, '{}')) AS raw_values,
             family.code AS family_code,
             family_variant.code AS family_variant_code,
             product_model.parent_id,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
@@ -133,7 +133,7 @@ WITH
             product.created AS created_date,
             GREATEST(product.updated, COALESCE(sub_product_model.updated, 0), COALESCE(root_product_model.updated, 0)) AS updated_date,
             JSON_KEYS(product.raw_values) AS attribute_codes_in_product_raw_values,
-            JSON_MERGE_PRESERVE(
+            JSON_MERGE_PATCH(
                 product.raw_values,
                 COALESCE(sub_product_model.raw_values, JSON_OBJECT()), 
                 COALESCE(root_product_model.raw_values, JSON_OBJECT())

--- a/tests/back/Pim/Enrichment/Integration/Product/Job/ComputeFamilyVariantStructureChangesTaskletIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Job/ComputeFamilyVariantStructureChangesTaskletIntegration.php
@@ -1,0 +1,145 @@
+<?php
+
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Product\Job;
+
+use Akeneo\Pim\Enrichment\Component\Product\Job\ComputeFamilyVariantStructureChangesTasklet;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyVariant;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\Batch\Job\JobParameters;
+use Akeneo\Tool\Component\Batch\Model\JobExecution;
+use Akeneo\Tool\Component\Batch\Model\StepExecution;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ */
+final class ComputeFamilyVariantStructureChangesTaskletIntegration extends TestCase
+{
+    /** @var ComputeFamilyVariantStructureChangesTasklet */
+    private $computeFamilyVariantStructureChangesTasklet;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        static::bootKernel();
+        $this->authenticateUserAdmin();
+
+        $jobParameters = new JobParameters(['family_variant_codes' => ['familyVariantA1']]);
+        $jobExecution = new JobExecution();
+        $jobExecution->setJobParameters($jobParameters);
+        $stepExecution = new StepExecution('a_step', $jobExecution);
+        $this->computeFamilyVariantStructureChangesTasklet = $this->get('pim_catalog.tasklet.compute_family_variant_structure_changes');
+        $this->computeFamilyVariantStructureChangesTasklet->setStepExecution($stepExecution);
+    }
+
+    /**
+     * @test
+     */
+    public function it_compute_product_values_when_family_variant_structure_changes()
+    {
+        $rootProductModel = $this->createRootProductModel('familyVariantA1');
+        $subProductModel = $this->createSubProductModel();
+        $this->moveAttributeAtLevel1InFamilyVariant('familyVariantA1', 'a_number_float');
+
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+        $this->computeFamilyVariantStructureChangesTasklet->execute();
+
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+        $rootProductModel = $this->getProductModel($rootProductModel->getCode());
+        $subProductModel = $this->getProductModel($subProductModel->getCode());
+
+        $this->assertNull($rootProductModel->getValue('a_number_float'));
+        $this->assertNotNull($value = $subProductModel->getValue('a_number_float'));
+        $this->assertEqualsCanonicalizing(5.5, $value->getData());
+    }
+
+    private function moveAttributeAtLevel1InFamilyVariant(string $familyVariantCode, string $attributeCode): void
+    {
+        $familyVariant = $this->getFamilyVariant($familyVariantCode);
+        $content = $this->get('pim_enrich.normalizer.family_variant')->normalize($familyVariant);
+        $content['variant_attribute_sets'][0]['attributes'][] = $attributeCode;
+        unset($content['meta']);
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, $content);
+        $this->assertCount(0, $this->get('validator')->validate($familyVariant));
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+    }
+
+    private function createRootProductModel(string $familyVariantCode): ProductModelInterface
+    {
+        return $this->createProductModel([
+            'code' => 'root_product_model_code',
+            'family_variant' => $familyVariantCode,
+            'values' => [
+                'a_number_float' => [['locale' => null, 'scope'  => null, 'data' => 5.5]],
+            ],
+            'categories' => ['categoryA1'],
+        ]);
+    }
+
+    private function createSubProductModel(): ProductModelInterface
+    {
+        return $this->createProductModel([
+            'code' => 'sub_product_model_code',
+            'family_variant' => 'familyVariantA1',
+            'parent' => 'root_product_model_code',
+            'values' => [
+                'a_simple_select' => [['locale' => null, 'scope'  => null, 'data' => 'optionB']],
+            ],
+            'categories' => ['categoryA2'],
+        ]);
+    }
+
+    private function createProductModel(array $data): ProductModelInterface
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        $errors = $this->get('pim_catalog.validator.product')->validate($productModel);
+
+        foreach ($errors as $error) {
+            print_r($error->__toString() . "\n");
+        }
+        Assert::assertCount(0, $errors);
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+
+        return $productModel;
+    }
+
+    private function getProductModel(string $code): ?ProductModelInterface
+    {
+        return $this->get('pim_api.repository.product_model')->findOneByIdentifier($code);
+    }
+
+    private function getFamilyVariant(string $code): ?FamilyVariant
+    {
+        return $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier($code);
+    }
+
+    private function authenticateUserAdmin(): void
+    {
+        $user = $this->get('pim_user.provider.user')->loadUserByUsername('admin');
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Product/Job/ComputeFamilyVariantStructureChangesTaskletIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Job/ComputeFamilyVariantStructureChangesTaskletIntegration.php
@@ -78,9 +78,8 @@ final class ComputeFamilyVariantStructureChangesTaskletIntegration extends TestC
     private function moveAttributeAtLevel1InFamilyVariant(string $familyVariantCode, string $attributeCode): void
     {
         $familyVariant = $this->getFamilyVariant($familyVariantCode);
-        $content = $this->get('pim_enrich.normalizer.family_variant')->normalize($familyVariant);
+        $content = $this->get('pim_catalog.normalizer.standard.family_variant')->normalize($familyVariant);
         $content['variant_attribute_sets'][0]['attributes'][] = $attributeCode;
-        unset($content['meta']);
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, $content);
         $this->assertCount(0, $this->get('validator')->validate($familyVariant));
         $this->get('pim_catalog.saver.family_variant')->save($familyVariant);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/PIM-9276  

A problem occurred when we change the level of an attribute in a family variant. A cron is launched to move the values from a product/product model to another product/product model, but during this operation there is a time where the value is at 2 levels (for example the value is in the root product model and the sub product model). That is because we cannot save product models and products at same time.  
In the indexation process, we merge all the values of root product model, sub product model and variant products, and this operation does not make it right because of the `JSON_MERGE_PRESERVE`.

For example a date value is present in the root PM and the sub PM. When we merge the value becomes an array of string date. When we hydrate object just after, the process crashes because it tries to hydrate an array instead of a string.

```sql
SELECT JSON_MERGE_PRESERVE('{"my_date": {"<all_channels>": {"<all_locales>": "2020-05-28T00:00:00+00:00"}}}', '{"my_date": {"<all_channels>": {"<all_locales>": "2020-05-28T00:00:00+00:00"}}}');
-- Result: {"my_date": {"<all_channels>": {"<all_locales>": ["2020-05-28T00:00:00+00:00", "2020-05-28T00:00:00+00:00"]}}}
```

The solution here is to replace `JSON_MERGE_PRESERVE` by `JSON_MERGE_PATCH`. The last one does not convert string in array. It just keep the value in the last parameter.  

```sql
SELECT JSON_MERGE_PATCH('{"my_date": {"<all_channels>": {"<all_locales>": "2020-05-28T00:00:00+00:00"}}}', '{"my_date": {"<all_channels>": {"<all_locales>": "2020-05-28T00:00:00+00:00"}}}');
-- Result: {"my_date": {"<all_channels>": {"<all_locales>": "2020-05-28T00:00:00+00:00"}}}
```

After discusion with Chipmunks team, we think this solution is not very risky because:

- The value must be at one level only. This case does not appear often
- The `JSON_MERGE_PRESERVE` modifies the value formats that it worst

Others solutions are discussed but more complicated:
- Do not dispatch events just after each product save. Dispatch when all product and product models are saved
- Dispatch events but block the indexation and keep in mind the product/product model to index. At the end of the job when all products and product models are saved, launch the indexation


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
