### PR TITLE
GITHUB-APD-130: Update help menu link to redirect to the right version on the help center

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -1,5 +1,9 @@
 # 2.3.x
 
+## Bug fixes
+
+- GITHUB-APD-130: Update help menu link to redirect to the right version on the help center
+
 # 2.3.78 (2020-03-24)
 
 # 2.3.77 (2020-01-22)

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/help.js
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/js/menu/help.js
@@ -44,11 +44,18 @@ define(
              * {@inheritdoc}
              */
             getUrl() {
-                return DataCollector.collect(this.analyticsUrl).then((data) => {
-                    const { pim_version, pim_edition } = data;
+              return DataCollector.collect(this.analyticsUrl).then(data => {
+                const {pim_version, pim_edition} = data;
+                let version = `v${pim_version.split('.')[0]}`;
+                let campaign = `${pim_edition}${pim_version}`;
 
-                    return `${pim_edition}${pim_version}`;
-                });
+                const url = new URL(`https://help.akeneo.com/pim/${version}/index.html`);
+                url.searchParams.append('utm_source', 'akeneo-app');
+                url.searchParams.append('utm_medium', 'interrogation-icon');
+                url.searchParams.append('utm_campaign', campaign);
+
+                return url.href;
+              });
             }
         });
     });

--- a/src/Pim/Bundle/EnrichBundle/Resources/public/templates/menu/help.html
+++ b/src/Pim/Bundle/EnrichBundle/Resources/public/templates/menu/help.html
@@ -1,4 +1,4 @@
-<a class="AknHeader-menuItem" title="<%= helper %>" href="https://help.akeneo.com/?utm_source=akeneo-app&utm_medium=interrogation-icon&utm_campaign=<%= url %>" target="_blank">
+<<a class="AknHeader-menuItem" title="<%= helper %>" href="<%= url %>" target="_blank">
     <div>
         <span class="AknHeader-menuItemImage AknHeader-menuItemImage--iconHelp"></span>
         <span class="AknHeader-menuItemImage AknHeader-menuItemImage--iconHelp"></span>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Same things than the https://github.com/akeneo/pim-community-dev/pull/12155 PR but in 2.3.

Ticket : https://github.com/akeneo/actionable-product-data/issues/130 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
