### PR TITLE
PIM-9274: Fix Yaml reader to display the number of lines read for incorrectly formatted files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ jobs:
           - run:
               name: Remove env on kubernetes
               command: ENV_NAME=dev INSTANCE_NAME_PREFIX=pimci-pr INSTANCE_NAME=pimci-pr-${CIRCLE_PULL_REQUEST##*/} IMAGE_TAG=${CIRCLE_SHA1} make delete
-              when: always
+              when: on_fail
 
   test_back_missing_structure_migrations:
       machine:

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -2,6 +2,8 @@
 
 ## Bug fixes
 
+- PIM-9274: Fix Yaml reader to display the number of lines read for incorrectly formatted files
+
 ## Improvements
 
 - AOB-277: Add an acl to allow a role member to view all job executions in last job execution grids, job tracker and last operations widget.

--- a/src/Akeneo/Tool/Component/Connector/Reader/File/Yaml/Reader.php
+++ b/src/Akeneo/Tool/Component/Connector/Reader/File/Yaml/Reader.php
@@ -125,7 +125,13 @@ class Reader implements FileReaderInterface
     {
         $jobParameters = $this->stepExecution->getJobParameters();
         $filePath = $jobParameters->get('filePath');
-        $fileData = current(Yaml::parse(file_get_contents($filePath)));
+        $fileContent = file_get_contents($filePath);
+        if (false !== $fileContent) {
+            if (null !== $this->stepExecution) {
+                $this->stepExecution->setSummary(['item_position' => 0]);
+            }
+        }
+        $fileData = current(Yaml::parse($fileContent));
         if (null === $fileData) {
             return null;
         }

--- a/src/Akeneo/Tool/Component/Connector/spec/Reader/File/Yaml/ReaderSpec.php
+++ b/src/Akeneo/Tool/Component/Connector/spec/Reader/File/Yaml/ReaderSpec.php
@@ -29,6 +29,21 @@ class ReaderSpec extends ObjectBehavior
         $this->shouldImplement('\Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface');
     }
 
+    function it_initializes_the_summary_info_if_the_yaml_file_is_not_correctly_formatted(
+        ArrayConverterInterface $converter,
+        StepExecution $stepExecution,
+        JobParameters $jobParameters
+    ) {
+        $this->beConstructedWith($converter, false, false);
+        $this->setStepExecution($stepExecution);
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $incorrectlyFormattedFilePath = realpath(__DIR__ . '/../../../fixtures/fake_incorrectly_formatted_yml_file.yml');
+        $jobParameters->get('filePath')->willReturn($incorrectlyFormattedFilePath);
+
+        $stepExecution->setSummary(['item_position' => 0])->shouldBeCalledTimes(1);
+        $this->read()->shouldReturn(null);
+    }
+
     function it_reads_entities_from_a_yml_file_one_by_one_incrementing_summary_info_for_each_one(
         ArrayConverterInterface $converter,
         StepExecution $stepExecution,
@@ -40,6 +55,7 @@ class ReaderSpec extends ObjectBehavior
         $jobParameters->get('filePath')->willReturn(realpath(__DIR__ . '/../../../fixtures/fake_products_with_code.yml'));
 
 
+        $stepExecution->setSummary(['item_position' => 0])->shouldBeCalledTimes(1);
         $stepExecution->incrementSummaryInfo('item_position')->shouldBeCalledTimes(3);
 
         $converter->convert(['sku' => 'mug_akeneo'])->willReturn(['sku' => 'mug_akeneo']);
@@ -74,6 +90,7 @@ class ReaderSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn(realpath(__DIR__ . '/../../../fixtures/fake_products_with_code.yml'));
 
+        $stepExecution->setSummary(['item_position' => 0])->shouldBeCalledTimes(1);
         $stepExecution->incrementSummaryInfo('item_position')->shouldBeCalled();
         $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
 
@@ -99,6 +116,7 @@ class ReaderSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn(realpath(__DIR__ . '/../../../fixtures/fake_products_with_code.yml'));
 
+        $stepExecution->setSummary(['item_position' => 0])->shouldBeCalledTimes(1);
         $stepExecution->incrementSummaryInfo(Argument::any())->shouldBeCalled();
 
         $converter->convert(['sku' => 'mug_akeneo'])->willReturn(['sku' => 'mug_akeneo']);
@@ -133,6 +151,7 @@ class ReaderSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filePath')->willReturn(realpath(__DIR__ . '/../../../fixtures/fake_products_with_code.yml'));
 
+        $stepExecution->setSummary(['item_position' => 0])->shouldBeCalledTimes(1);
         $stepExecution->incrementSummaryInfo('item_position')->shouldBeCalled();
 
         $result = [
@@ -164,6 +183,7 @@ class ReaderSpec extends ObjectBehavior
         $jobParameters->get('filePath')
             ->willReturn(realpath(__DIR__ . '/../../../fixtures/fake_products_without_code.yml'));
 
+        $stepExecution->setSummary(['item_position' => 0])->shouldBeCalledTimes(1);
         $stepExecution->incrementSummaryInfo('item_position')->shouldBeCalled();
 
         $result = [
@@ -197,6 +217,7 @@ class ReaderSpec extends ObjectBehavior
         $jobParameters->get('filePath')
             ->willReturn(realpath(__DIR__ . '/../../../fixtures/fake_products_with_code.yml'));
 
+        $stepExecution->setSummary(['item_position' => 0])->shouldBeCalledTimes(1);
         $stepExecution->incrementSummaryInfo('item_position')->shouldBeCalled();
 
         $converter->convert(['sku' => 'mug_akeneo'])->willReturn(['sku' => 'mug_akeneo']);

--- a/src/Akeneo/Tool/Component/Connector/spec/fixtures/fake_incorrectly_formatted_yml_file.yml
+++ b/src/Akeneo/Tool/Component/Connector/spec/fixtures/fake_incorrectly_formatted_yml_file.yml
@@ -1,0 +1,20 @@
+rules:
+copy_description_befr:
+        priority: 0
+        conditions:
+            - field: description
+              locale: en_US
+              scope: ecommerce
+              operator: EMPTY
+            - field: description
+              locale: en_US
+              scope: print
+              operator: NOT EMPTY
+        actions:
+            - type: copy
+              from_field: description
+              to_field: description
+              from_locale: en_US
+              from_scope: print
+              to_locale: en_US
+              to_scope: ecommerce


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Process tracker when incorrect file is read:
<img width="743" alt="Screen Shot 2020-05-29 at 12 10 39" src="https://user-images.githubusercontent.com/1826473/83274051-8a5deb80-a1cd-11ea-970a-8361c2d5f2fb.png">


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
