### PR TITLE
PIM-9106: Improve error message when editing an attribute when it's due to a regular expression

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Improvement
+
+-PIM-9106: Improve error message when editing an attribute when it's due to a regular expression
+
 ## Bug fixes
 
 - PIM-9277: Fix product computing when moving an attribute in family variant

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/RegexGuesser.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/RegexGuesser.php
@@ -38,7 +38,7 @@ class RegexGuesser implements ConstraintGuesserInterface
         $constraints = [];
 
         if ('regexp' === $attribute->getValidationRule() && $pattern = $attribute->getValidationRegexp()) {
-            $constraints[] = new Assert\Regex(['pattern' => $pattern]);
+            $constraints[] = new Assert\Regex(['pattern' => $pattern, 'message' => 'This value is not valid due to regular expression defined in the attribute.']);
         }
 
         return $constraints;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/RegexGuesser.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/RegexGuesser.php
@@ -38,7 +38,7 @@ class RegexGuesser implements ConstraintGuesserInterface
         $constraints = [];
 
         if ('regexp' === $attribute->getValidationRule() && $pattern = $attribute->getValidationRegexp()) {
-            $constraints[] = new Assert\Regex(['pattern' => $pattern, 'message' => 'This value is not valid due to regular expression defined in the attribute.']);
+            $constraints[] = new Assert\Regex(['pattern' => $pattern, 'message' => 'This value is not valid due to regular expression defined in the attribute']);
         }
 
         return $constraints;

--- a/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
@@ -65,7 +65,7 @@ class ProductIdentifierValidationIntegration extends TestCase
         $this->assertCount(1, $violations);
         $this->assertSame(
             $violations->get(0)->getMessage(),
-            'This value is not valid.'
+            'This value is not valid due to regular expression defined in the attribute.'
         );
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
@@ -65,7 +65,7 @@ class ProductIdentifierValidationIntegration extends TestCase
         $this->assertCount(1, $violations);
         $this->assertSame(
             $violations->get(0)->getMessage(),
-            'This value is not valid due to regular expression defined in the attribute.'
+            'This value is not valid due to regular expression defined in the attribute'
         );
     }
 

--- a/tests/legacy/features/pim/enrichment/product/validation/validate_identifier_attribute.feature
+++ b/tests/legacy/features/pim/enrichment/product/validation/validate_identifier_attribute.feature
@@ -30,7 +30,7 @@ Feature: Validate identifier attribute of a product
     When I am on the "foo" product page
     And I change the SKU to "001"
     And I save the product
-    Then I should see validation tooltip "This value is not valid."
+    Then I should see validation tooltip "This value is not valid due to regular expression defined in the attribute"
     And there should be 1 error in the "Other" tab
 
   @jira https://akeneo.atlassian.net/browse/PIM-3447

--- a/tests/legacy/features/pim/enrichment/product/validation/validate_text_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/validation/validate_text_attributes.feature
@@ -76,14 +76,14 @@ Feature: Validate text attributes of a product
   Scenario: Validate the regexp validation rule constraint of text attribute
     Given I change the Barcode to "111111"
     And I save the product
-    Then I should see validation tooltip "This value is not valid."
+    Then I should see validation tooltip "This value is not valid due to regular expression defined in the attribute"
     And there should be 1 error in the "Other" tab
 
   Scenario: Validate the regexp validation rule constraint of scopable text attribute
     Given I switch the scope to "ecommerce"
     Given I change the "Manufacturer number" to "111111"
     And I save the product
-    Then I should see validation tooltip "This value is not valid."
+    Then I should see validation tooltip "This value is not valid due to regular expression defined in the attribute"
     And there should be 1 error in the "Other" tab
 
   @jira https://akeneo.atlassian.net/browse/PIM-3447


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When you tried to edit an attribute (define with a regular expression) with a value not allowed you got a generic error message.

So, I modified this message in the RegexGuesser.php file.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | OK
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
