### PR TITLE
Make EntityWithValuesInterface::getValue to match ProductModel::getValue

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithValuesInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithValuesInterface.php
@@ -47,7 +47,7 @@ interface EntityWithValuesInterface
      * @param string $localeCode
      * @param string $scopeCode
      *
-     * @return ValueInterface
+     * @return ValueInterface|null
      */
     public function getValue($attributeCode, $localeCode = null, $scopeCode = null);
 


### PR DESCRIPTION
Add null return type to EntityWithValuesInterface match ProductModel.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

Make \Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface::getValue() 
 return type in PHPDoc match \Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel::getValue() return type. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
