### PR TITLE
RAC-45: Create/update quantified associations in the External API

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/updaters.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/updaters.yml
@@ -50,6 +50,7 @@ services:
             - '@pim_catalog.updater.entity_with_values'
             - '@pim_catalog.association.filter.parent_associations'
             - '@pim_catalog.quantified_associations.quantified_associations_from_ancestors_filter'
+            - '@pim_catalog.updater.validator.quantified_associations_structure_validator'
             - ['identifier', 'created', 'updated', 'parent_associations', 'metadata']
 
     pim_catalog.updater.product_model:
@@ -61,6 +62,7 @@ services:
             - '@pim_catalog.repository.product_model'
             - '@pim_catalog.association.filter.parent_associations'
             - '@pim_catalog.quantified_associations.quantified_associations_from_ancestors_filter'
+            - '@pim_catalog.updater.validator.quantified_associations_structure_validator'
             - ['identifier', 'created', 'updated', 'parent_associations', 'metadata']
 
     pim_catalog.updater.entity_with_values:
@@ -591,3 +593,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field\GroupFieldClearer'
         tags:
             - { name: 'pim_catalog.updater.clearer' }
+
+    # Validators
+    pim_catalog.updater.validator.quantified_associations_structure_validator:
+        class: Akeneo\Pim\Enrichment\Component\Product\Updater\Validator\QuantifiedAssociationsStructureValidator

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ProductModelUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ProductModelUpdater.php
@@ -7,6 +7,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Updater;
 use Akeneo\Pim\Enrichment\Component\Product\Association\ParentAssociationsFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation\QuantifiedAssociationsFromAncestorsFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Validator\QuantifiedAssociationsStructureValidatorInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\ImmutablePropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -45,14 +46,18 @@ class ProductModelUpdater implements ObjectUpdaterInterface
     /** @var QuantifiedAssociationsFromAncestorsFilter */
     private $quantifiedAssociationsFromAncestorsFilter;
 
+    /** @var QuantifiedAssociationsStructureValidatorInterface */
+    private $quantifiedAssociationsStructureValidator;
+
     /**
-     * @param PropertySetterInterface               $propertySetter
-     * @param ObjectUpdaterInterface                $valuesUpdater
+     * @param PropertySetterInterface $propertySetter
+     * @param ObjectUpdaterInterface $valuesUpdater
      * @param IdentifiableObjectRepositoryInterface $familyVariantRepository
      * @param IdentifiableObjectRepositoryInterface $productModelRepository
-     * @param ParentAssociationsFilter              $parentAssociationsFilter
+     * @param ParentAssociationsFilter $parentAssociationsFilter
      * @param QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter
-     * @param array                                 $ignoredFields
+     * @param QuantifiedAssociationsStructureValidatorInterface $quantifiedAssociationsStructureValidator
+     * @param array $ignoredFields
      */
     public function __construct(
         PropertySetterInterface $propertySetter,
@@ -61,6 +66,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
         IdentifiableObjectRepositoryInterface $productModelRepository,
         ParentAssociationsFilter $parentAssociationsFilter,
         QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter,
+        QuantifiedAssociationsStructureValidatorInterface $quantifiedAssociationsStructureValidator,
         array $ignoredFields
     ) {
         $this->propertySetter = $propertySetter;
@@ -70,6 +76,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
         $this->ignoredFields = $ignoredFields;
         $this->parentAssociationsFilter = $parentAssociationsFilter;
         $this->quantifiedAssociationsFromAncestorsFilter = $quantifiedAssociationsFromAncestorsFilter;
+        $this->quantifiedAssociationsStructureValidator = $quantifiedAssociationsStructureValidator;
     }
 
     /**
@@ -107,6 +114,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
                 }
                 break;
             case 'quantified_associations':
+                $this->quantifiedAssociationsStructureValidator->validate('quantified_associations', $data);
                 $data = $this->filterQuantifiedAssociationsFromAncestors($productModel, $data);
                 break;
         }
@@ -202,7 +210,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
      * already one and if the product model has a parent.
      *
      * @param ProductModelInterface $productModel
-     * @param array                 $data
+     * @param array $data
      */
     private function updateParentAndFamily(ProductModelInterface $productModel, array $data): void
     {
@@ -224,7 +232,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
      * exception will be thrown.
      *
      * @param ProductModelInterface $productModel
-     * @param string|null           $parentCode
+     * @param string|null $parentCode
      *
      * @throws ImmutablePropertyException
      * @throws InvalidPropertyException
@@ -283,7 +291,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
      * Updates the family variant of the family variant of the product model.
      *
      * @param ProductModelInterface $productModel
-     * @param string                $familyVariantCode
+     * @param string $familyVariantCode
      *
      * @throws ImmutablePropertyException
      * @throws InvalidPropertyException
@@ -367,8 +375,8 @@ class ProductModelUpdater implements ObjectUpdaterInterface
      * Sets the field
      *
      * @param ProductModelInterface $productModel
-     * @param string                $field
-     * @param mixed                 $value
+     * @param string $field
+     * @param mixed $value
      */
     protected function updateProductModelFields(ProductModelInterface $productModel, string $field, $value): void
     {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ProductUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ProductUpdater.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Association\ParentAssociationsFilter
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnknownAttributeException;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation\QuantifiedAssociationsFromAncestorsFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Validator\QuantifiedAssociationsStructureValidatorInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
@@ -39,18 +40,23 @@ class ProductUpdater implements ObjectUpdaterInterface
     /** @var QuantifiedAssociationsFromAncestorsFilter */
     private $quantifiedAssociationsFromAncestorsFilter;
 
+    /** @var QuantifiedAssociationsStructureValidatorInterface */
+    private $quantifiedAssociationsStructureValidator;
+
     /**
-     * @param PropertySetterInterface  $propertySetter
-     * @param ObjectUpdaterInterface   $valuesUpdater
+     * @param PropertySetterInterface $propertySetter
+     * @param ObjectUpdaterInterface $valuesUpdater
      * @param ParentAssociationsFilter $parentAssociationsFilter
      * @param QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter
-     * @param array                    $ignoredFields
+     * @param QuantifiedAssociationsStructureValidatorInterface $quantifiedAssociationsStructureValidator
+     * @param array $ignoredFields
      */
     public function __construct(
         PropertySetterInterface $propertySetter,
         ObjectUpdaterInterface $valuesUpdater,
         ParentAssociationsFilter $parentAssociationsFilter,
         QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter,
+        QuantifiedAssociationsStructureValidatorInterface $quantifiedAssociationsStructureValidator,
         array $ignoredFields
     ) {
         $this->propertySetter = $propertySetter;
@@ -58,6 +64,7 @@ class ProductUpdater implements ObjectUpdaterInterface
         $this->ignoredFields = $ignoredFields;
         $this->parentAssociationsFilter = $parentAssociationsFilter;
         $this->quantifiedAssociationsFromAncestorsFilter = $quantifiedAssociationsFromAncestorsFilter;
+        $this->quantifiedAssociationsStructureValidator = $quantifiedAssociationsStructureValidator;
     }
 
     /**
@@ -174,6 +181,7 @@ class ProductUpdater implements ObjectUpdaterInterface
                 }
                 break;
             case 'quantified_associations':
+                $this->quantifiedAssociationsStructureValidator->validate('quantified_associations', $data);
                 $data = $this->filterQuantifiedAssociationsFromAncestors($product, $data);
                 break;
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetter.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Setter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithQuantifiedAssociationsInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\QuantifiedAssociations;
 
 /**
@@ -26,14 +27,81 @@ class QuantifiedAssociationsFieldSetter extends AbstractFieldSetter
      *         ],
      *     },
      * }
+     *
+     * @param EntityWithQuantifiedAssociationsInterface $entity
      */
     public function setFieldData($entity, $field, $data, array $options = [])
     {
-        $entity->setQuantifiedAssociations(QuantifiedAssociations::createFromNormalized($data));
+        $normalizedQuantifiedAssociations = $entity->normalizeQuantifiedAssociations();
+        $mergedQuantifiedAssociations = $this->mergeByKeys($normalizedQuantifiedAssociations, $data);
+
+        $entity->setQuantifiedAssociations(QuantifiedAssociations::createFromNormalized($mergedQuantifiedAssociations));
     }
 
     public function supportsField($field)
     {
         return 'quantified_associations' === $field;
+    }
+
+    /**
+     * Merge 2 arrays of QuantifiedAssociations by keys, this is the expected behavior for PATCH partial updates.
+     *
+     * Given:
+     * {
+     *     "PRODUCTSET_A": {
+     *         "products": [
+     *              {"identifier": "AKN_TS1", "quantity": 2}
+     *         ],
+     *         "product_models": [
+     *              {"identifier": "MODEL_AKN_TS1", "quantity": 2}
+     *         ],
+     *     },
+     *     "PRODUCTSET_B": {
+     *         "products": [
+     *              {"identifier": "AKN_TS1", "quantity": 2}
+     *         ],
+     *         "product_models": [],
+     *     },
+     * }
+     * When merging:
+     * {
+     *     "PRODUCTSET_A": {
+     *         "products": [
+     *              {"identifier": "AKN_TS1_ALT", "quantity": 200}
+     *         ],
+     *     }
+     * }
+     * This will result in:
+     * {
+     *     "PRODUCTSET_A": {
+     *         "products": [
+     *              {"identifier": "AKN_TS1_ALT", "quantity": 200}
+     *         ],
+     *         "product_models": [
+     *              {"identifier": "MODEL_AKN_TS1", "quantity": 2}
+     *         ],
+     *     },
+     *     "PRODUCTSET_B": {
+     *         "products": [
+     *              {"identifier": "AKN_TS1", "quantity": 2}
+     *         ],
+     *         "product_models": [],
+     *     },
+     * }
+     */
+    private function mergeByKeys(array $quantifiedAssociations1, array $quantifiedAssociations2): array
+    {
+        foreach ($quantifiedAssociations2 as $associationTypeCode => $association) {
+            if (!isset($quantifiedAssociations1[$associationTypeCode])) {
+                $quantifiedAssociations1[$associationTypeCode] = $association;
+                continue;
+            }
+
+            foreach ($association as $quantifiedLinkType => $quantifiedLinks) {
+                $quantifiedAssociations1[$associationTypeCode][$quantifiedLinkType] = $quantifiedLinks;
+            }
+        }
+
+        return $quantifiedAssociations1;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Validator;
 
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidator.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Validator;
+
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+
+class QuantifiedAssociationsStructureValidator implements QuantifiedAssociationsStructureValidatorInterface
+{
+    public function validate(string $field, $data): void
+    {
+        if (!is_array($data)) {
+            throw InvalidPropertyTypeException::arrayExpected(
+                $field,
+                static::class,
+                $data
+            );
+        }
+
+        foreach ($data as $associationTypeCode => $associationTypeValues) {
+            if (!is_string($associationTypeCode)) {
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
+                    $field,
+                    'association type code should be a string',
+                    static::class,
+                    $data
+                );
+            }
+
+            if (!is_array($associationTypeValues)) {
+                throw InvalidPropertyTypeException::validArrayStructureExpected(
+                    $field,
+                    sprintf('"%s" should contain an array', $associationTypeCode),
+                    static::class,
+                    $data
+                );
+            }
+
+            foreach ($associationTypeValues as $quantifiedLinkType => $quantifiedLinks) {
+                if (!is_string($quantifiedLinkType)) {
+                    throw InvalidPropertyTypeException::validArrayStructureExpected(
+                        $field,
+                        sprintf('entity type in "%s" should be a string', $associationTypeCode),
+                        static::class,
+                        $data
+                    );
+                }
+
+                if (!is_array($quantifiedLinks) || !$this->isArraySequential($quantifiedLinks)) {
+                    throw InvalidPropertyTypeException::validArrayStructureExpected(
+                        $field,
+                        sprintf('"%s[%s]" should contain an array', $associationTypeCode, $quantifiedLinkType),
+                        static::class,
+                        $data
+                    );
+                }
+
+                foreach ($quantifiedLinks as $quantifiedLink) {
+                    foreach (['identifier', 'quantity'] as $requiredKey) {
+                        if (!isset($quantifiedLink[$requiredKey])) {
+                            throw InvalidPropertyTypeException::validArrayStructureExpected(
+                                $field,
+                                sprintf('a quantified association should contain the key "%s"', $requiredKey),
+                                static::class,
+                                $data
+                            );
+                        }
+                    }
+
+                    if (!is_string($quantifiedLink['identifier'])) {
+                        throw InvalidPropertyTypeException::validArrayStructureExpected(
+                            $field,
+                            'a quantified association should contain a valid identifier',
+                            static::class,
+                            $data
+                        );
+                    }
+
+                    if (!is_int($quantifiedLink['quantity'])) {
+                        throw InvalidPropertyTypeException::validArrayStructureExpected(
+                            $field,
+                            'a quantified association should contain a valid quantity',
+                            static::class,
+                            $data
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    private function isArraySequential(array $data): bool
+    {
+        return array_keys($data) === range(0, count($data) - 1);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidator.php
@@ -90,6 +90,6 @@ class QuantifiedAssociationsStructureValidator implements QuantifiedAssociations
 
     private function isArraySequential(array $data): bool
     {
-        return array_keys($data) === range(0, count($data) - 1);
+        return empty($data) || array_keys($data) === range(0, count($data) - 1);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidatorInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidatorInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Validator;
+
+interface QuantifiedAssociationsStructureValidatorInterface
+{
+    public function validate(string $field, $data): void;
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidatorInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidatorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Validator;
 
 interface QuantifiedAssociationsStructureValidatorInterface

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/EntityWithQuantifiedAssociations/AbstractQuantifiedAssociationsTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/EntityWithQuantifiedAssociations/AbstractQuantifiedAssociationsTestCase.php
@@ -7,6 +7,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 abstract class AbstractQuantifiedAssociationsTestCase extends InternalApiTestCase
 {
+    use QuantifiedAssociationsTestCaseTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -24,27 +26,6 @@ abstract class AbstractQuantifiedAssociationsTestCase extends InternalApiTestCas
     protected function getConfiguration()
     {
         return $this->catalog->useFunctionalCatalog('catalog_modeling');
-    }
-
-    protected function createQuantifiedAssociationType(string $code): void
-    {
-        $data =
-            <<<JSON
-    {
-        "code": "$code",
-        "is_quantified": true
-    }
-JSON;
-        $this->client->request(
-            'POST',
-            '/configuration/association-type/rest',
-            [],
-            [],
-            [
-                'HTTP_X-Requested-With' => 'XMLHttpRequest',
-            ],
-            $data
-        );
     }
 
     protected function getAdminUser(): UserInterface

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/EntityWithQuantifiedAssociations/QuantifiedAssociationsTestCaseTrait.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/EntityWithQuantifiedAssociations/QuantifiedAssociationsTestCaseTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations;
+
+use Akeneo\Pim\Structure\Component\Model\AssociationType;
+
+trait QuantifiedAssociationsTestCaseTrait
+{
+    protected function createQuantifiedAssociationType(string $code): AssociationType
+    {
+        $associationType = new AssociationType();
+        $associationType->setCode($code);
+        $associationType->setIsQuantified(true);
+
+        $this->get('pim_catalog.saver.association_type')->save($associationType);
+
+        return $associationType;
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/EntityWithQuantifiedAssociations/QuantifiedAssociationsTestCaseTrait.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/EntityWithQuantifiedAssociations/QuantifiedAssociationsTestCaseTrait.php
@@ -8,11 +8,13 @@ trait QuantifiedAssociationsTestCaseTrait
 {
     protected function createQuantifiedAssociationType(string $code): AssociationType
     {
-        $associationType = new AssociationType();
-        $associationType->setCode($code);
-        $associationType->setIsQuantified(true);
+        $factory = $this->get('pim_catalog.factory.association_type');
+        $updater = $this->get('pim_catalog.updater.association_type');
+        $saver = $this->get('pim_catalog.saver.association_type');
 
-        $this->get('pim_catalog.saver.association_type')->save($associationType);
+        $associationType = $factory->create();
+        $updater->update($associationType,  ['code' => $code, 'is_quantified' => true]);
+        $saver->save($associationType);
 
         return $associationType;
     }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductEndToEnd.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\QuantifiedAssociations;
+
+use Akeneo\Test\Integration\Configuration;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class AddQuantifiedAssociationsToProductEndToEnd extends AbstractProductTestCase
+{
+    use QuantifiedAssociationsTestCaseTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @test
+     */
+    public function it_add_quantified_associations_to_a_product(): void
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->createQuantifiedAssociationType('PRODUCTSET');
+        $this->createProduct('chair', []);
+        $this->createProduct('table', []);
+        $this->createProductModel([
+            'code' => 'umbrella',
+            'family_variant' => 'familyVariantA1',
+            'values' => [],
+        ]);
+        $identifier = 'garden_table_set';
+
+        $data = <<<JSON
+{
+    "identifier": "$identifier",
+    "quantified_associations": {
+        "PRODUCTSET": {
+            "products": [
+                {"identifier": "chair", "quantity": 4},
+                {"identifier": "table", "quantity": 1}
+            ],
+            "product_models": [
+                {"identifier": "umbrella", "quantity": 1}
+            ]
+        }
+    }
+}
+JSON;
+
+        $client->request('POST', '/api/rest/v1/products', [], [], [], $data);
+
+        $expectedProduct = [
+            'identifier' => $identifier,
+            'family' => null,
+            'parent' => null,
+            'groups' => [],
+            'categories' => [],
+            'enabled' => true,
+            'values' => [
+                'sku' => [
+                    ['locale' => null, 'scope' => null, 'data' => $identifier],
+                ],
+            ],
+            'created' => '2016-06-14T13:12:50+02:00',
+            'updated' => '2016-06-14T13:12:50+02:00',
+            'associations' => [],
+            'quantified_associations' => [
+                'PRODUCTSET' => [
+                    'products' => [
+                        ['identifier' => 'chair', 'quantity' => 4],
+                        ['identifier' => 'table', 'quantity' => 1],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'umbrella', 'quantity' => 1],
+                    ],
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSameProducts($expectedProduct, $identifier);
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromProductEndToEnd.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\QuantifiedAssociations;
+
+use Akeneo\Test\Integration\Configuration;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class DeleteQuantifiedAssociationsFromProductEndToEnd extends AbstractProductTestCase
+{
+    use QuantifiedAssociationsTestCaseTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @test
+     */
+    public function it_update_quantified_associations_in_a_product(): void
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->createQuantifiedAssociationType('PRODUCTSET');
+        $this->createProduct('table', []);
+        $this->createProductModel([
+            'code' => 'umbrella',
+            'family_variant' => 'familyVariantA1',
+            'values' => [],
+        ]);
+        $identifier = 'garden_table_set';
+
+        $data = <<<JSON
+{
+    "identifier": "$identifier",
+    "quantified_associations": {
+        "PRODUCTSET": {
+            "products": [
+                {"identifier": "table", "quantity": 1}
+            ],
+            "product_models": [
+                {"identifier": "umbrella", "quantity": 1}
+            ]
+        }
+    }
+}
+JSON;
+
+        $client->request('POST', '/api/rest/v1/products', [], [], [], $data);
+
+        $data = <<<JSON
+{
+    "identifier": "$identifier",
+    "quantified_associations": {
+        "PRODUCTSET": {
+            "products": [],
+            "product_models": []
+        }
+    }
+}
+JSON;
+
+        $client->request('PATCH', sprintf('/api/rest/v1/products/%s', $identifier), [], [], [], $data);
+
+        $expectedProduct = [
+            'identifier' => $identifier,
+            'family' => null,
+            'parent' => null,
+            'groups' => [],
+            'categories' => [],
+            'enabled' => true,
+            'values' => [
+                'sku' => [
+                    ['locale' => null, 'scope' => null, 'data' => $identifier],
+                ],
+            ],
+            'created' => '2016-06-14T13:12:50+02:00',
+            'updated' => '2016-06-14T13:12:50+02:00',
+            'associations' => [],
+            'quantified_associations' => [
+                'PRODUCTSET' => [
+                    'products' => [],
+                    'product_models' => [],
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSameProducts($expectedProduct, $identifier);
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInProductEndToEnd.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\QuantifiedAssociations;
+
+use Akeneo\Test\Integration\Configuration;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class UpdateQuantifiedAssociationsInProductEndToEnd extends AbstractProductTestCase
+{
+    use QuantifiedAssociationsTestCaseTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @test
+     */
+    public function it_update_quantified_associations_in_a_product(): void
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->createQuantifiedAssociationType('PRODUCTSET');
+        $this->createProduct('chair', []);
+        $this->createProduct('table', []);
+        $identifier = 'garden_table_set';
+
+        $data = <<<JSON
+{
+    "identifier": "$identifier",
+    "quantified_associations": {
+        "PRODUCTSET": {
+            "products": [
+                {"identifier": "chair", "quantity": 4},
+                {"identifier": "table", "quantity": 1}
+            ]
+        }
+    }
+}
+JSON;
+
+        $client->request('POST', '/api/rest/v1/products', [], [], [], $data);
+
+        $data = <<<JSON
+{
+    "identifier": "$identifier",
+    "quantified_associations": {
+        "PRODUCTSET": {
+            "products": [
+                {"identifier": "chair", "quantity": 6},
+                {"identifier": "table", "quantity": 1}
+            ]
+        }
+    }
+}
+JSON;
+
+        $client->request('PATCH', sprintf('/api/rest/v1/products/%s', $identifier), [], [], [], $data);
+
+        $expectedProduct = [
+            'identifier' => $identifier,
+            'family' => null,
+            'parent' => null,
+            'groups' => [],
+            'categories' => [],
+            'enabled' => true,
+            'values' => [
+                'sku' => [
+                    ['locale' => null, 'scope' => null, 'data' => $identifier],
+                ],
+            ],
+            'created' => '2016-06-14T13:12:50+02:00',
+            'updated' => '2016-06-14T13:12:50+02:00',
+            'associations' => [],
+            'quantified_associations' => [
+                'PRODUCTSET' => [
+                    'products' => [
+                        ['identifier' => 'chair', 'quantity' => 6],
+                        ['identifier' => 'table', 'quantity' => 1],
+                    ],
+                    'product_models' => [],
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSameProducts($expectedProduct, $identifier);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_partial_update_quantified_associations_in_a_product(): void
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->createQuantifiedAssociationType('PRODUCTSET_A');
+        $this->createQuantifiedAssociationType('PRODUCTSET_B');
+        $this->createProduct('chair', []);
+        $identifier = 'garden_table_set';
+
+        $data = <<<JSON
+{
+    "identifier": "$identifier",
+    "quantified_associations": {
+        "PRODUCTSET_A": {
+            "products": [
+                {"identifier": "chair", "quantity": 4}
+            ]
+        },
+        "PRODUCTSET_B": {
+            "products": [
+                {"identifier": "chair", "quantity": 4}
+            ]
+        }
+    }
+}
+JSON;
+
+        $client->request('POST', '/api/rest/v1/products', [], [], [], $data);
+
+        $data = <<<JSON
+{
+    "identifier": "$identifier",
+    "quantified_associations": {
+        "PRODUCTSET_A": {
+            "products": [
+                {"identifier": "chair", "quantity": 6}
+            ]
+        }
+    }
+}
+JSON;
+
+        $client->request('PATCH', sprintf('/api/rest/v1/products/%s', $identifier), [], [], [], $data);
+
+        $expectedProduct = [
+            'identifier' => $identifier,
+            'family' => null,
+            'parent' => null,
+            'groups' => [],
+            'categories' => [],
+            'enabled' => true,
+            'values' => [
+                'sku' => [
+                    ['locale' => null, 'scope' => null, 'data' => $identifier],
+                ],
+            ],
+            'created' => '2016-06-14T13:12:50+02:00',
+            'updated' => '2016-06-14T13:12:50+02:00',
+            'associations' => [],
+            'quantified_associations' => [
+                'PRODUCTSET_A' => [
+                    'products' => [
+                        ['identifier' => 'chair', 'quantity' => 6],
+                    ],
+                    'product_models' => [],
+                ],
+                'PRODUCTSET_B' => [
+                    'products' => [
+                        ['identifier' => 'chair', 'quantity' => 4],
+                    ],
+                    'product_models' => [],
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSameProducts($expectedProduct, $identifier);
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductEndToEnd.php
@@ -33,17 +33,50 @@ class ValidateQuantifiedAssociationsInProductEndToEnd extends AbstractProductTes
     public function it_returns_an_error_if_the_quantified_associations_format_is_invalid(): void
     {
         $client = $this->createAuthenticatedClient();
-        $this->createQuantifiedAssociationType('PRODUCTSET');
-        $this->createProduct('chair', []);
+        $identifier = 'garden_table_set';
+
+        $data = <<<JSON
+{
+    "identifier": "$identifier",
+    "quantified_associations": [
+        {"identifier": "chair", "quantity": 4}
+    ]
+}
+JSON;
+
+        $client->request('POST', '/api/rest/v1/products', [], [], [], $data);
+
+        $expectedContent = [
+            'code' => 422,
+            'message' => 'Property "quantified_associations" expects an array with valid data, association type code should be a string. Check the expected format on the API documentation.',
+            '_links' => [
+                'documentation' => [
+                    'href' => 'http://api.akeneo.com/api-reference.html#post_products'
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_if_the_quantified_associations_data_is_invalid(): void
+    {
+        $client = $this->createAuthenticatedClient();
         $identifier = 'garden_table_set';
 
         $data = <<<JSON
 {
     "identifier": "$identifier",
     "quantified_associations": {
-        "PRODUCTSET": [
-            {"identifier": "chair", "quantity": 4}
-        ]
+        "THIS_ASSOCIATION_TYPE_DOES_NOT_EXISTS": {
+            "products": []
+        }
     }
 }
 JSON;
@@ -51,11 +84,12 @@ JSON;
         $client->request('POST', '/api/rest/v1/products', [], [], [], $data);
 
         $expectedContent = [
-            'code'    => 422,
-            'message' => 'Property "quantified_associations" expects an array of arrays as data. Check the expected format on the API documentation.',
-            '_links'  => [
-                'documentation' => [
-                    'href' => 'http://api.akeneo.com/api-reference.html#post_products'
+            'code' => 422,
+            'message' => 'Validation failed.',
+            'errors' => [
+                [
+                    'property' => 'quantifiedAssociations.THIS_ASSOCIATION_TYPE_DOES_NOT_EXISTS',
+                    'message' => 'This association type doesn\'t exist. Please make sure it hasn\'t been deleted in the meantime.',
                 ],
             ],
         ];

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductEndToEnd.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\QuantifiedAssociations;
+
+use Akeneo\Test\Integration\Configuration;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class ValidateQuantifiedAssociationsInProductEndToEnd extends AbstractProductTestCase
+{
+    use QuantifiedAssociationsTestCaseTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_if_the_quantified_associations_format_is_invalid(): void
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->createQuantifiedAssociationType('PRODUCTSET');
+        $this->createProduct('chair', []);
+        $identifier = 'garden_table_set';
+
+        $data = <<<JSON
+{
+    "identifier": "$identifier",
+    "quantified_associations": {
+        "PRODUCTSET": [
+            {"identifier": "chair", "quantity": 4}
+        ]
+    }
+}
+JSON;
+
+        $client->request('POST', '/api/rest/v1/products', [], [], [], $data);
+
+        $expectedContent = [
+            'code'    => 422,
+            'message' => 'Property "quantified_associations" expects an array of arrays as data. Check the expected format on the API documentation.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => 'http://api.akeneo.com/api-reference.html#post_products'
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/RemoveQuantifiedAssociationsFromProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/RemoveQuantifiedAssociationsFromProductEndToEnd.php
@@ -2,7 +2,6 @@
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\InternalApi\QuantifiedAssociations;
 
-use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\InternalApi\QuantifiedAssociations\AbstractProductWithQuantifiedAssociationsTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
 class RemoveQuantifiedAssociationsFromProductEndToEnd extends AbstractProductWithQuantifiedAssociationsTestCase
@@ -12,17 +11,19 @@ class RemoveQuantifiedAssociationsFromProductEndToEnd extends AbstractProductWit
      */
     public function it_remove_quantified_associations_from_a_product(): void
     {
-        $product = $this->createProduct([
-            'values' => [
-                'sku' => [
-                    [
-                        'scope' => null,
-                        'locale' => null,
-                        'data' => 'yellow_chair',
+        $product = $this->createProduct(
+            [
+                'values' => [
+                    'sku' => [
+                        [
+                            'scope' => null,
+                            'locale' => null,
+                            'data' => 'yellow_chair',
+                        ],
                     ],
                 ],
-            ],
-        ]);
+            ]
+        );
         $normalizedProduct = $this->getProductFromInternalApi($product->getId());
 
         $quantifiedAssociations = [
@@ -54,14 +55,30 @@ class RemoveQuantifiedAssociationsFromProductEndToEnd extends AbstractProductWit
         $normalizedProductWithoutQuantifiedAssociations = $this->updateNormalizedProduct(
             $normalizedProduct,
             [
-                'quantified_associations' => [],
+                'quantified_associations' => [
+                    'PRODUCTSET' => [
+                        'products' => [],
+                        'product_models' => [],
+                    ],
+                ],
             ]
         );
 
-        $response = $this->updateProductWithInternalApi($product->getId(), $normalizedProductWithoutQuantifiedAssociations);
+        $response = $this->updateProductWithInternalApi(
+            $product->getId(),
+            $normalizedProductWithoutQuantifiedAssociations
+        );
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $body = json_decode($response->getContent(), true);
-        $this->assertSame($body['quantified_associations'], []);
+        $this->assertSame(
+            [
+                'PRODUCTSET' => [
+                    'products' => [],
+                    'product_models' => [],
+                ],
+            ],
+            $body['quantified_associations']
+        );
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/AbstractProductModelTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/AbstractProductModelTestCase.php
@@ -127,12 +127,12 @@ JSON;
     }
 
     /**
-     * @param array  $expectedProductModel normalized data of the product model that should be created
-     * @param string $identifier           identifier of the product that should be created
+     * @param array $expectedProductModel normalized data of the product model that should be created
+     * @param string $code code of the product model that should be created
      */
-    protected function assertSameProductModels(array $expectedProductModel, $identifier)
+    protected function assertSameProductModels(array $expectedProductModel, $code)
     {
-        $productModel = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier($identifier);
+        $productModel = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier($code);
         $standardizedProductModel = $this->get('pim_standard_format_serializer')->normalize($productModel, 'standard');
 
         NormalizedProductCleaner::clean($expectedProductModel);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/AbstractProductModelTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/AbstractProductModelTestCase.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi;
 
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 
 class AbstractProductModelTestCase extends AbstractProductTestCase
 {
@@ -123,6 +124,21 @@ JSON;
         }
 
         return $standardizedProductModels;
+    }
+
+    /**
+     * @param array  $expectedProductModel normalized data of the product model that should be created
+     * @param string $identifier           identifier of the product that should be created
+     */
+    protected function assertSameProductModels(array $expectedProductModel, $identifier)
+    {
+        $productModel = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier($identifier);
+        $standardizedProductModel = $this->get('pim_standard_format_serializer')->normalize($productModel, 'standard');
+
+        NormalizedProductCleaner::clean($expectedProductModel);
+        NormalizedProductCleaner::clean($standardizedProductModel);
+
+        $this->assertSame($expectedProductModel, $standardizedProductModel);
     }
 
     /**

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductModelEndToEnd.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\QuantifiedAssociations;
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi\QuantifiedAssociations;
 
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
-use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi\AbstractProductModelTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class DeleteQuantifiedAssociationsFromProductEndToEnd extends AbstractProductTestCase
+class AddQuantifiedAssociationsToProductModelEndToEnd extends AbstractProductModelTestCase
 {
     use QuantifiedAssociationsTestCaseTrait;
 
@@ -30,24 +30,27 @@ class DeleteQuantifiedAssociationsFromProductEndToEnd extends AbstractProductTes
     /**
      * @test
      */
-    public function it_delete_quantified_associations_from_a_product(): void
+    public function it_add_quantified_associations_to_a_product_model(): void
     {
         $client = $this->createAuthenticatedClient();
         $this->createQuantifiedAssociationType('PRODUCTSET');
+        $this->createProduct('chair', []);
         $this->createProduct('table', []);
         $this->createProductModel([
             'code' => 'umbrella',
             'family_variant' => 'familyVariantA1',
             'values' => [],
         ]);
-        $identifier = 'garden_table_set';
+        $code = 'garden_table_set';
 
         $data = <<<JSON
 {
-    "identifier": "$identifier",
+    "code": "$code",
+    "family_variant": "familyVariantA1",
     "quantified_associations": {
         "PRODUCTSET": {
             "products": [
+                {"identifier": "chair", "quantity": 4},
                 {"identifier": "table", "quantity": 1}
             ],
             "product_models": [
@@ -58,41 +61,26 @@ class DeleteQuantifiedAssociationsFromProductEndToEnd extends AbstractProductTes
 }
 JSON;
 
-        $client->request('POST', '/api/rest/v1/products', [], [], [], $data);
+        $client->request('POST', '/api/rest/v1/product-models', [], [], [], $data);
 
-        $data = <<<JSON
-{
-    "identifier": "$identifier",
-    "quantified_associations": {
-        "PRODUCTSET": {
-            "products": [],
-            "product_models": []
-        }
-    }
-}
-JSON;
-
-        $client->request('PATCH', sprintf('/api/rest/v1/products/%s', $identifier), [], [], [], $data);
-
-        $expectedProduct = [
-            'identifier' => $identifier,
-            'family' => null,
+        $expectedProductModel = [
+            'code' => $code,
+            'family_variant' => 'familyVariantA1',
             'parent' => null,
-            'groups' => [],
             'categories' => [],
-            'enabled' => true,
-            'values' => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => $identifier],
-                ],
-            ],
+            'values' => [],
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
             'quantified_associations' => [
                 'PRODUCTSET' => [
-                    'products' => [],
-                    'product_models' => [],
+                    'products' => [
+                        ['identifier' => 'chair', 'quantity' => 4],
+                        ['identifier' => 'table', 'quantity' => 1],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'umbrella', 'quantity' => 1],
+                    ],
                 ],
             ],
         ];
@@ -100,7 +88,7 @@ JSON;
         $response = $client->getResponse();
 
         $this->assertSame('', $response->getContent());
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertSameProducts($expectedProduct, $identifier);
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSameProductModels($expectedProductModel, $code);
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromProductEndToEnd.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\QuantifiedAssociations;
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi\QuantifiedAssociations;
 
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
-use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi\AbstractProductModelTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class DeleteQuantifiedAssociationsFromProductEndToEnd extends AbstractProductTestCase
+class DeleteQuantifiedAssociationsFromProductEndToEnd extends AbstractProductModelTestCase
 {
     use QuantifiedAssociationsTestCaseTrait;
 
@@ -30,7 +30,7 @@ class DeleteQuantifiedAssociationsFromProductEndToEnd extends AbstractProductTes
     /**
      * @test
      */
-    public function it_delete_quantified_associations_from_a_product(): void
+    public function it_delete_quantified_associations_from_a_product_model(): void
     {
         $client = $this->createAuthenticatedClient();
         $this->createQuantifiedAssociationType('PRODUCTSET');
@@ -40,11 +40,12 @@ class DeleteQuantifiedAssociationsFromProductEndToEnd extends AbstractProductTes
             'family_variant' => 'familyVariantA1',
             'values' => [],
         ]);
-        $identifier = 'garden_table_set';
+        $code = 'garden_table_set';
 
         $data = <<<JSON
 {
-    "identifier": "$identifier",
+    "code": "$code",
+    "family_variant": "familyVariantA1",
     "quantified_associations": {
         "PRODUCTSET": {
             "products": [
@@ -58,11 +59,11 @@ class DeleteQuantifiedAssociationsFromProductEndToEnd extends AbstractProductTes
 }
 JSON;
 
-        $client->request('POST', '/api/rest/v1/products', [], [], [], $data);
+        $client->request('POST', '/api/rest/v1/product-models', [], [], [], $data);
 
         $data = <<<JSON
 {
-    "identifier": "$identifier",
+    "code": "$code",
     "quantified_associations": {
         "PRODUCTSET": {
             "products": [],
@@ -72,20 +73,14 @@ JSON;
 }
 JSON;
 
-        $client->request('PATCH', sprintf('/api/rest/v1/products/%s', $identifier), [], [], [], $data);
+        $client->request('PATCH', sprintf('/api/rest/v1/product-models/%s', $code), [], [], [], $data);
 
-        $expectedProduct = [
-            'identifier' => $identifier,
-            'family' => null,
+        $expectedProductModel = [
+            'code' => $code,
+            'family_variant' => 'familyVariantA1',
             'parent' => null,
-            'groups' => [],
             'categories' => [],
-            'enabled' => true,
-            'values' => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => $identifier],
-                ],
-            ],
+            'values' => [],
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
@@ -100,7 +95,7 @@ JSON;
         $response = $client->getResponse();
 
         $this->assertSame('', $response->getContent());
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertSameProducts($expectedProduct, $identifier);
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSameProductModels($expectedProductModel, $code);
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromProductModelEndToEnd.php
@@ -7,7 +7,7 @@ use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi\AbstractProductModelTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class UpdateQuantifiedAssociationsInProductEndToEnd extends AbstractProductModelTestCase
+class DeleteQuantifiedAssociationsFromProductModelEndToEnd extends AbstractProductModelTestCase
 {
     use QuantifiedAssociationsTestCaseTrait;
 
@@ -30,12 +30,16 @@ class UpdateQuantifiedAssociationsInProductEndToEnd extends AbstractProductModel
     /**
      * @test
      */
-    public function it_can_partial_update_quantified_associations_in_a_product(): void
+    public function it_delete_quantified_associations_from_a_product_model(): void
     {
         $client = $this->createAuthenticatedClient();
-        $this->createQuantifiedAssociationType('PRODUCTSET_A');
-        $this->createQuantifiedAssociationType('PRODUCTSET_B');
-        $this->createProduct('chair', []);
+        $this->createQuantifiedAssociationType('PRODUCTSET');
+        $this->createProduct('table', []);
+        $this->createProductModel([
+            'code' => 'umbrella',
+            'family_variant' => 'familyVariantA1',
+            'values' => [],
+        ]);
         $code = 'garden_table_set';
 
         $data = <<<JSON
@@ -43,14 +47,12 @@ class UpdateQuantifiedAssociationsInProductEndToEnd extends AbstractProductModel
     "code": "$code",
     "family_variant": "familyVariantA1",
     "quantified_associations": {
-        "PRODUCTSET_A": {
+        "PRODUCTSET": {
             "products": [
-                {"identifier": "chair", "quantity": 4}
-            ]
-        },
-        "PRODUCTSET_B": {
-            "products": [
-                {"identifier": "chair", "quantity": 4}
+                {"identifier": "table", "quantity": 1}
+            ],
+            "product_models": [
+                {"identifier": "umbrella", "quantity": 1}
             ]
         }
     }
@@ -63,10 +65,9 @@ JSON;
 {
     "code": "$code",
     "quantified_associations": {
-        "PRODUCTSET_A": {
-            "products": [
-                {"identifier": "chair", "quantity": 6}
-            ]
+        "PRODUCTSET": {
+            "products": [],
+            "product_models": []
         }
     }
 }
@@ -84,16 +85,8 @@ JSON;
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
             'quantified_associations' => [
-                'PRODUCTSET_A' => [
-                    'products' => [
-                        ['identifier' => 'chair', 'quantity' => 6],
-                    ],
-                    'product_models' => [],
-                ],
-                'PRODUCTSET_B' => [
-                    'products' => [
-                        ['identifier' => 'chair', 'quantity' => 4],
-                    ],
+                'PRODUCTSET' => [
+                    'products' => [],
                     'product_models' => [],
                 ],
             ],
@@ -102,7 +95,7 @@ JSON;
         $response = $client->getResponse();
 
         $this->assertSame('', $response->getContent());
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
         $this->assertSameProductModels($expectedProductModel, $code);
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromProductModelEndToEnd.php
@@ -95,7 +95,7 @@ JSON;
         $response = $client->getResponse();
 
         $this->assertSame('', $response->getContent());
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertSameProductModels($expectedProductModel, $code);
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInProductEndToEnd.php
@@ -4,10 +4,10 @@ namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\Quantif
 
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
-use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi\AbstractProductModelTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class UpdateQuantifiedAssociationsInProductEndToEnd extends AbstractProductTestCase
+class UpdateQuantifiedAssociationsInProductEndToEnd extends AbstractProductModelTestCase
 {
     use QuantifiedAssociationsTestCaseTrait;
 
@@ -36,11 +36,12 @@ class UpdateQuantifiedAssociationsInProductEndToEnd extends AbstractProductTestC
         $this->createQuantifiedAssociationType('PRODUCTSET_A');
         $this->createQuantifiedAssociationType('PRODUCTSET_B');
         $this->createProduct('chair', []);
-        $identifier = 'garden_table_set';
+        $code = 'garden_table_set';
 
         $data = <<<JSON
 {
-    "identifier": "$identifier",
+    "code": "$code",
+    "family_variant": "familyVariantA1",
     "quantified_associations": {
         "PRODUCTSET_A": {
             "products": [
@@ -56,11 +57,11 @@ class UpdateQuantifiedAssociationsInProductEndToEnd extends AbstractProductTestC
 }
 JSON;
 
-        $client->request('POST', '/api/rest/v1/products', [], [], [], $data);
+        $client->request('POST', '/api/rest/v1/product-models', [], [], [], $data);
 
         $data = <<<JSON
 {
-    "identifier": "$identifier",
+    "code": "$code",
     "quantified_associations": {
         "PRODUCTSET_A": {
             "products": [
@@ -71,20 +72,14 @@ JSON;
 }
 JSON;
 
-        $client->request('PATCH', sprintf('/api/rest/v1/products/%s', $identifier), [], [], [], $data);
+        $client->request('PATCH', sprintf('/api/rest/v1/product-models/%s', $code), [], [], [], $data);
 
-        $expectedProduct = [
-            'identifier' => $identifier,
-            'family' => null,
+        $expectedProductModel = [
+            'code' => $code,
+            'family_variant' => 'familyVariantA1',
             'parent' => null,
-            'groups' => [],
             'categories' => [],
-            'enabled' => true,
-            'values' => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => $identifier],
-                ],
-            ],
+            'values' => [],
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
@@ -108,6 +103,6 @@ JSON;
 
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-        $this->assertSameProducts($expectedProduct, $identifier);
+        $this->assertSameProductModels($expectedProductModel, $code);
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInProductEndToEnd.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\QuantifiedAssociations;
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi\QuantifiedAssociations;
 
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductModelEndToEnd.php
@@ -33,18 +33,52 @@ class ValidateQuantifiedAssociationsInProductModelEndToEnd extends AbstractProdu
     public function it_returns_an_error_if_the_quantified_associations_format_is_invalid(): void
     {
         $client = $this->createAuthenticatedClient();
-        $this->createQuantifiedAssociationType('PRODUCTSET');
-        $this->createProduct('chair', []);
         $code = 'garden_table_set';
 
         $data = <<<JSON
 {
-    "identifier": "$code",
+    "code": "$code",
+    "family_variant": "familyVariantA1",
+    "quantified_associations": [
+        {"identifier": "chair", "quantity": 4}
+    ]
+}
+JSON;
+
+        $client->request('POST', '/api/rest/v1/product-models', [], [], [], $data);
+
+        $expectedContent = [
+            'code' => 422,
+            'message' => 'Property "quantified_associations" expects an array with valid data, association type code should be a string. Check the expected format on the API documentation.',
+            '_links' => [
+                'documentation' => [
+                    'href' => 'http://api.akeneo.com/api-reference.html#post_product_model'
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_if_the_quantified_associations_data_is_invalid(): void
+    {
+        $client = $this->createAuthenticatedClient();
+        $code = 'garden_table_set';
+
+        $data = <<<JSON
+{
+    "code": "$code",
     "family_variant": "familyVariantA1",
     "quantified_associations": {
-        "PRODUCTSET": [
-            {"identifier": "chair", "quantity": 4}
-        ]
+        "THIS_ASSOCIATION_TYPE_DOES_NOT_EXISTS": {
+            "products": []
+        }
     }
 }
 JSON;
@@ -53,10 +87,11 @@ JSON;
 
         $expectedContent = [
             'code' => 422,
-            'message' => 'Property "quantified_associations" expects an array of arrays as data. Check the expected format on the API documentation.',
-            '_links' => [
-                'documentation' => [
-                    'href' => 'http://api.akeneo.com/api-reference.html#post_product_model'
+            'message' => 'Validation failed.',
+            'errors' => [
+                [
+                    'property' => 'quantifiedAssociations.THIS_ASSOCIATION_TYPE_DOES_NOT_EXISTS',
+                    'message' => 'This association type doesn\'t exist. Please make sure it hasn\'t been deleted in the meantime.',
                 ],
             ],
         ];

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductModelEndToEnd.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi\QuantifiedAssociations;
+
+use Akeneo\Test\Integration\Configuration;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class ValidateQuantifiedAssociationsInProductModelEndToEnd extends AbstractProductTestCase
+{
+    use QuantifiedAssociationsTestCaseTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_error_if_the_quantified_associations_format_is_invalid(): void
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->createQuantifiedAssociationType('PRODUCTSET');
+        $this->createProduct('chair', []);
+        $code = 'garden_table_set';
+
+        $data = <<<JSON
+{
+    "identifier": "$code",
+    "family_variant": "familyVariantA1",
+    "quantified_associations": {
+        "PRODUCTSET": [
+            {"identifier": "chair", "quantity": 4}
+        ]
+    }
+}
+JSON;
+
+        $client->request('POST', '/api/rest/v1/product-models', [], [], [], $data);
+
+        $expectedContent = [
+            'code' => 422,
+            'message' => 'Property "quantified_associations" expects an array of arrays as data. Check the expected format on the API documentation.',
+            '_links' => [
+                'documentation' => [
+                    'href' => 'http://api.akeneo.com/api-reference.html#post_product_model'
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/InternalApi/QuantifiedAssociations/RemoveQuantifiedAssociationsFromProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/InternalApi/QuantifiedAssociations/RemoveQuantifiedAssociationsFromProductModelEndToEnd.php
@@ -11,10 +11,12 @@ class RemoveQuantifiedAssociationsFromProductModelEndToEnd extends AbstractProdu
      */
     public function it_remove_quantified_associations_from_a_product_model(): void
     {
-        $productModel = $this->createProductModel([
-            'code' => 'standard_chair',
-            'family_variant' => 'accessories_size',
-        ]);
+        $productModel = $this->createProductModel(
+            [
+                'code' => 'standard_chair',
+                'family_variant' => 'accessories_size',
+            ]
+        );
         $normalizedProductModel = $this->getProductModelFromInternalApi($productModel->getId());
 
         $quantifiedAssociations = [
@@ -49,7 +51,12 @@ class RemoveQuantifiedAssociationsFromProductModelEndToEnd extends AbstractProdu
         $normalizedProductModelWithoutQuantifiedAssociations = $this->updateNormalizedProductModel(
             $normalizedProductModel,
             [
-                'quantified_associations' => [],
+                'quantified_associations' => [
+                    'PRODUCTSET' => [
+                        'products' => [],
+                        'product_models' => [],
+                    ],
+                ],
             ]
         );
 
@@ -60,6 +67,14 @@ class RemoveQuantifiedAssociationsFromProductModelEndToEnd extends AbstractProdu
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $body = json_decode($response->getContent(), true);
-        $this->assertSame($body['quantified_associations'], []);
+        $this->assertSame(
+            [
+                'PRODUCTSET' => [
+                    'products' => [],
+                    'product_models' => [],
+                ],
+            ],
+            $body['quantified_associations']
+        );
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/ProductModelUpdaterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/ProductModelUpdaterSpec.php
@@ -3,6 +3,7 @@
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater;
 
 use Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation\QuantifiedAssociationsFromAncestorsFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Validator\QuantifiedAssociationsStructureValidatorInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\ImmutablePropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -26,7 +27,8 @@ class ProductModelUpdaterSpec extends ObjectBehavior
         IdentifiableObjectRepositoryInterface $familyVariantRepository,
         IdentifiableObjectRepositoryInterface $productModelRepository,
         ParentAssociationsFilter $parentAssociationsFilter,
-        QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter
+        QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter,
+        QuantifiedAssociationsStructureValidatorInterface $quantifiedAssociationsStructureValidator
     ) {
         $this->beConstructedWith(
             $propertySetter,
@@ -35,6 +37,7 @@ class ProductModelUpdaterSpec extends ObjectBehavior
             $productModelRepository,
             $parentAssociationsFilter,
             $quantifiedAssociationsFromAncestorsFilter,
+            $quantifiedAssociationsStructureValidator,
             ['categories'],
             ['code']
         );

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/ProductUpdaterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/ProductUpdaterSpec.php
@@ -7,6 +7,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Exception\UnknownAttributeException;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation\QuantifiedAssociationsFromAncestorsFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\ProductUpdater;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Validator\QuantifiedAssociationsStructureValidatorInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
@@ -20,13 +21,15 @@ class ProductUpdaterSpec extends ObjectBehavior
         PropertySetterInterface $propertySetter,
         ObjectUpdaterInterface $valuesUpdater,
         ParentAssociationsFilter $parentAssociationsFilter,
-        QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter
+        QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter,
+        QuantifiedAssociationsStructureValidatorInterface $quantifiedAssociationsStructureValidator
     ) {
         $this->beConstructedWith(
             $propertySetter,
             $valuesUpdater,
             $parentAssociationsFilter,
             $quantifiedAssociationsFromAncestorsFilter,
+            $quantifiedAssociationsStructureValidator,
             ['identifier', 'created', 'updated']
         );
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetterSpec.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Setter;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\QuantifiedAssociations;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\FieldSetterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\QuantifiedAssociationsFieldSetter;
+use PhpSpec\ObjectBehavior;
+
+class QuantifiedAssociationsFieldSetterSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(QuantifiedAssociationsFieldSetter::class);
+    }
+
+    public function it_is_a_field_setter()
+    {
+        $this->shouldImplement(FieldSetterInterface::class);
+    }
+
+    public function it_only_work_with_quantified_associations_field()
+    {
+        $this->supportsField('quantified_associations')->shouldReturn(true);
+        $this->supportsField('family')->shouldReturn(false);
+    }
+
+    public function it_set_the_quantified_associations_to_a_product(
+        ProductInterface $product
+    ) {
+        $submittedQuantifiedAssociations = [
+            'PRODUCTSET_A' => [
+                'products' => [
+                    ['identifier' => 'AKN_TS1_ALT', 'quantity' => 200],
+                ],
+            ],
+        ];
+
+        $existingQuantifiedAssociations = [
+            'PRODUCTSET_A' => [
+                'products' => [
+                    ['identifier' => 'AKN_TS1', 'quantity' => 2],
+                ],
+                'product_models' => [
+                    ['identifier' => 'MODEL_AKN_TS1', 'quantity' => 2],
+                ],
+            ],
+            'PRODUCTSET_B' => [
+                'products' => [
+                    ['identifier' => 'AKN_TSH2', 'quantity' => 2],
+                ],
+                'product_models' => [],
+            ],
+        ];
+
+        $expectedQuantifiedAssociations = [
+            'PRODUCTSET_A' => [
+                'products' => [
+                    ['identifier' => 'AKN_TS1_ALT', 'quantity' => 200],
+                ],
+                'product_models' => [
+                    ['identifier' => 'MODEL_AKN_TS1', 'quantity' => 2],
+                ],
+            ],
+            'PRODUCTSET_B' => [
+                'products' => [
+                    ['identifier' => 'AKN_TSH2', 'quantity' => 2],
+                ],
+                'product_models' => [],
+            ],
+        ];
+
+        $product->normalizeQuantifiedAssociations()->willReturn($existingQuantifiedAssociations);
+
+        $product->setQuantifiedAssociations(QuantifiedAssociations::createFromNormalized($expectedQuantifiedAssociations))
+            ->shouldBeCalled();
+
+        $this->setFieldData($product, 'quantified_associations', $submittedQuantifiedAssociations);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Validator/QuantifiedAssociationsStructureValidatorSpec.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Validator;
+
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Validator\QuantifiedAssociationsStructureValidator;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Validator\QuantifiedAssociationsStructureValidatorInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use PhpSpec\ObjectBehavior;
+
+class QuantifiedAssociationsStructureValidatorSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(QuantifiedAssociationsStructureValidator::class);
+    }
+
+    public function it_is_a_quantified_associations_structure_validator()
+    {
+        $this->shouldImplement(QuantifiedAssociationsStructureValidatorInterface::class);
+    }
+
+    public function it_throws_when_not_array()
+    {
+        $field = 'quantified_associations';
+        $data = null;
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::arrayExpected(
+                $field,
+                QuantifiedAssociationsStructureValidator::class,
+                $data
+            )
+        )->during(
+            'validate',
+            [$field, $data]
+        );
+    }
+
+    public function it_throws_when_association_type_code_not_a_scalar()
+    {
+        $field = 'quantified_associations';
+        $data = [
+            0 => [],
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                $field,
+                'association type code should be a string',
+                QuantifiedAssociationsStructureValidator::class,
+                $data
+            )
+        )->during(
+            'validate',
+            [$field, $data]
+        );
+    }
+
+    public function it_throws_when_association_type_values_is_not_an_array()
+    {
+        $field = 'quantified_associations';
+        $data = [
+            'PACK' => 'foo',
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                $field,
+                '"PACK" should contain an array',
+                QuantifiedAssociationsStructureValidator::class,
+                $data
+            )
+        )->during(
+            'validate',
+            [$field, $data]
+        );
+    }
+
+    public function it_throws_when_quantified_link_type_is_not_a_string()
+    {
+        $field = 'quantified_associations';
+        $data = [
+            'PACK' => [
+                0 => [],
+            ],
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                $field,
+                'entity type in "PACK" should be a string',
+                QuantifiedAssociationsStructureValidator::class,
+                $data
+            )
+        )->during(
+            'validate',
+            [$field, $data]
+        );
+    }
+
+    public function it_throws_when_quantified_links_is_not_an_array()
+    {
+        $field = 'quantified_associations';
+        $data = [
+            'PACK' => [
+                'products' => 'foo',
+            ],
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                $field,
+                '"PACK[products]" should contain an array',
+                QuantifiedAssociationsStructureValidator::class,
+                $data
+            )
+        )->during(
+            'validate',
+            [$field, $data]
+        );
+    }
+
+    public function it_throws_when_quantified_links_is_not_a_sequential_array()
+    {
+        $field = 'quantified_associations';
+        $data = [
+            'PACK' => [
+                'products' => [
+                    'foo' => [],
+                ],
+            ],
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                $field,
+                '"PACK[products]" should contain an array',
+                QuantifiedAssociationsStructureValidator::class,
+                $data
+            )
+        )->during(
+            'validate',
+            [$field, $data]
+        );
+    }
+
+    public function it_throws_when_quantified_link_has_no_identifier()
+    {
+        $field = 'quantified_associations';
+        $data = [
+            'PACK' => [
+                'products' => [
+                    ['quantity' => 3],
+                ],
+            ],
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                $field,
+                'a quantified association should contain the key "identifier"',
+                QuantifiedAssociationsStructureValidator::class,
+                $data
+            )
+        )->during(
+            'validate',
+            [$field, $data]
+        );
+    }
+
+    public function it_throws_when_quantified_link_has_no_quantity()
+    {
+        $field = 'quantified_associations';
+        $data = [
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'foo'],
+                ],
+            ],
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                $field,
+                'a quantified association should contain the key "quantity"',
+                QuantifiedAssociationsStructureValidator::class,
+                $data
+            )
+        )->during(
+            'validate',
+            [$field, $data]
+        );
+    }
+
+    public function it_throws_when_quantified_link_identifier_is_not_a_string()
+    {
+        $field = 'quantified_associations';
+        $data = [
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 1, 'quantity' => 3],
+                ],
+            ],
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                $field,
+                'a quantified association should contain a valid identifier',
+                QuantifiedAssociationsStructureValidator::class,
+                $data
+            )
+        )->during(
+            'validate',
+            [$field, $data]
+        );
+    }
+
+    public function it_throws_when_quantified_link_quantity_is_not_an_integer()
+    {
+        $field = 'quantified_associations';
+        $data = [
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'foo', 'quantity' => 'bar'],
+                ],
+            ],
+        ];
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::validArrayStructureExpected(
+                $field,
+                'a quantified association should contain a valid quantity',
+                QuantifiedAssociationsStructureValidator::class,
+                $data
+            )
+        )->during(
+            'validate',
+            [$field, $data]
+        );
+    }
+
+    public function it_does_no_throws_when_valid()
+    {
+        $field = 'quantified_associations';
+        $data = [
+            'PACK' => [
+                'products' => [
+                    ['identifier' => 'foo', 'quantity' => 3],
+                ],
+            ],
+        ];
+
+        $this->shouldNotThrow()->during(
+            'validate',
+            [$field, $data]
+        );
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- Add a structure validator on quantified associations using the same method as we already do for the associations
- Change QuantifiedAssociationsFieldSetter to merge by keys (expected behavior for partial updates)
- End2End tests on the create/update/delete of quantified associations. (including validation)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
