### PR TITLE
PIM-9267: Add a service for SSO IdP in docker-compose.yml (as mentioned in the documentation page)

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -5,6 +5,7 @@
 ## Improvement
 
 -PIM-9106: Improve error message when editing an attribute when it's due to a regular expression
+-PIM-9267: Add a service for SSO IdP in docker-compose.yml (as mentioned in the documentation page)
 
 ## Bug fixes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,19 @@ services:
     networks:
       - 'pim'
 
+  sso-idp-server:
+    image: 'kristophjunge/test-saml-idp'
+    ports:
+      - '${DOCKER_PORT_SSO_IDP:-8082}:8080'
+    volumes:
+      - './docker/sso_authsources.php:/var/www/simplesamlphp/config/authsources.php'
+    environment:
+      SIMPLESAMLPHP_SP_ENTITY_ID: '${AKENEO_PIM_URL:-http://localhost:8080/}/saml/metadata'
+      SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: '${AKENEO_PIM_URL:-http://localhost:8080/}/saml/acs'
+      SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE: '${AKENEO_PIM_URL:-http://localhost:8080/}/saml/logout'
+    networks:
+      - 'pim'
+
   object-storage:
     image: 'minio/minio'
     entrypoint: '/bin/sh -c "mkdir -p /data/asset /data/archive /data/catalog/ /data/jobs && minio server /data"'

--- a/docker/sso_authsources.php
+++ b/docker/sso_authsources.php
@@ -1,0 +1,34 @@
+<?php
+
+$config = array(
+
+    'admin' => array(
+        'core:AdminPassword',
+    ),
+
+    'example-userpass' => array(
+        'exampleauth:UserPass',
+        'admin:admin' => array(
+            'akeneo_uid' => array('admin'),
+        ),
+        'julia:julia' => array(
+            'akeneo_uid' => array('julia'),
+        ),
+        'peter:peter' => array(
+            'akeneo_uid' => array('peter'),
+        ),
+        'mary:mary' => array(
+            'akeneo_uid' => array('mary'),
+        ),
+        'sandra:sandra' => array(
+            'akeneo_uid' => array('sandra'),
+        ),
+        'pamela:pamela' => array(
+            'akeneo_uid' => array('pamela'),
+        ),
+        'julien:julien' => array(
+            'akeneo_uid' => array('julien'),
+        ),
+    ),
+
+);

--- a/std-build/install-required-files.sh
+++ b/std-build/install-required-files.sh
@@ -25,6 +25,7 @@ mkdir -p $STANDARD_DISTRIB_DIR/src \
 cp $DEV_DISTRIB_DIR/docker/wait_docker_up.sh $STANDARD_DISTRIB_DIR/docker/
 cp $DEV_DISTRIB_DIR/docker/httpd.conf $STANDARD_DISTRIB_DIR/docker/
 cp $DEV_DISTRIB_DIR/docker/akeneo.conf $STANDARD_DISTRIB_DIR/docker/
+cp $DEV_DISTRIB_DIR/docker/sso_authsources.php $STANDARD_DISTRIB_DIR/docker/
 
 # We use the same bootstrap.php to load .env file on standard as on CE-dev
 cp $DEV_DISTRIB_DIR/config/bootstrap.php $STANDARD_DISTRIB_DIR/config/


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In the documentation page 'Use SSO authentication locally', we can read:
"We provide an already configured IdP server image in the docker-compose.yml file, named sso-idp-server".

However, the docker-compose.yml in Akeneo 4 did'nt have a service for SSO IdP.
So I added it.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
