### PR TITLE
AOB-968: fix product label rendering, return false if values are undefined

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- AOB-968: Fix product label rendering on edit form
+
 # 4.0.31 (2020-06-01)
 
 ## Improvement

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-label.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-label.js
@@ -47,6 +47,10 @@ define(
 
                 var values = this.getFormData().values[attributeAsLabelIdentifier];
 
+                if (undefined === values) {
+                    return false;
+                }
+
                 return values.find(value => {
                     return (false === scopable || value.scope === scope)
                       && (false === localizable || value.locale === locale);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The `getLabelFromAttribute` method tries to find  the `attributeAsLabelIdentifier` value in form values, on Onboarder side this value is not sent to the front,
so it throws an exception when trying to apply to find method on something `undefined`, 
in that case, we return false to display the product identifier. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
