### PR TITLE
PIM-9273: Allow to save product after locale deletion

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9277: Fix product computing when moving an attribute in family variant
+- PIM-9273: Add a filter to remove the product values of deleted channels and not activated locales
 
 # 4.0.30 (2020-05-28)
 

--- a/src/Akeneo/Channel/Bundle/DependencyInjection/AkeneoChannelExtension.php
+++ b/src/Akeneo/Channel/Bundle/DependencyInjection/AkeneoChannelExtension.php
@@ -29,6 +29,7 @@ class AkeneoChannelExtension extends Extension
         $loader->load('jobs.yml');
         $loader->load('job_defaults.yml');
         $loader->load('job_constraints.yml');
+        $loader->load('queries.yml');
         $loader->load('services.yml');
         $loader->load('steps.yml');
         $loader->load('validators.yml');

--- a/src/Akeneo/Channel/Bundle/Query/Sql/SqlGetChannelCodeWithLocaleCodes.php
+++ b/src/Akeneo/Channel/Bundle/Query/Sql/SqlGetChannelCodeWithLocaleCodes.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Channel\Bundle\Query\Sql;
+
+use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class SqlGetChannelCodeWithLocaleCodes implements GetChannelCodeWithLocaleCodesInterface
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct($connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function findAll(): array
+    {
+        $sql = <<<SQL
+SELECT channel.code AS channelCode, JSON_ARRAYAGG(locale.code) AS localeCodes
+FROM pim_catalog_channel channel
+    LEFT JOIN pim_catalog_channel_locale channel_locale on channel.id = channel_locale.channel_id
+    LEFT JOIN pim_catalog_locale locale ON channel_locale.locale_id = locale.id
+GROUP BY channel.code;
+SQL;
+
+        $results = $this->connection->executeQuery($sql)->fetchAll();
+
+        return array_map([$this, 'hydrateLocaleCodes'], $results);
+    }
+
+    private function hydrateLocaleCodes(array $row): array
+    {
+        $row['localeCodes'] = array_filter(\json_decode($row['localeCodes'], true));
+
+        return $row;
+    }
+}

--- a/src/Akeneo/Channel/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/queries.yml
@@ -1,0 +1,10 @@
+services:
+    pim_channel.query.sql.get_channel_code_with_locale_codes:
+        class: 'Akeneo\Channel\Bundle\Query\Sql\SqlGetChannelCodeWithLocaleCodes'
+        arguments:
+            - '@database_connection'
+
+    pim_channel.query.cache.channel_exists_with_locale:
+        class: 'Akeneo\Channel\Component\Query\PublicApi\Cache\CachedChannelExistsWithLocale'
+        arguments:
+            - '@pim_channel.query.sql.get_channel_code_with_locale_codes'

--- a/src/Akeneo/Channel/Component/Query/GetChannelCodeWithLocaleCodesInterface.php
+++ b/src/Akeneo/Channel/Component/Query/GetChannelCodeWithLocaleCodesInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Channel\Component\Query;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetChannelCodeWithLocaleCodesInterface
+{
+    /**
+     * Returns a list of channel codes with bound locales codes using this format:
+     *
+     *  [
+     *      {
+     *          "channelCode": "ecommerce",
+     *          "localeCodes": ["en_US", "fr_FR"]
+     *      },
+     *      {
+     *          "channelCode": "mobile",
+     *          "localeCodes": ["en_US", "de_DE"]
+     *      }
+     *  ]
+     *
+     * @return array
+     */
+    public function findAll(): array;
+}

--- a/src/Akeneo/Channel/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
+++ b/src/Akeneo/Channel/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Channel\Component\Query\PublicApi\Cache;
+
+use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInterface
+{
+    /** @var GetChannelCodeWithLocaleCodesInterface */
+    private $getChannelCodeWithLocaleCodes;
+
+    /** @var null|array */
+    private $indexedChannelsWithLocales = null;
+
+    public function __construct(GetChannelCodeWithLocaleCodesInterface $getChannelCodeWithLocaleCodes)
+    {
+        $this->getChannelCodeWithLocaleCodes = $getChannelCodeWithLocaleCodes;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function doesChannelExist(string $channelCode): bool
+    {
+        $this->initializeCache();
+
+        return array_key_exists($channelCode, $this->indexedChannelsWithLocales);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isLocaleActive(string $localeCode): bool
+    {
+        $this->initializeCache();
+
+        foreach ($this->indexedChannelsWithLocales as $channelWithLocales) {
+            if (in_array($localeCode, $channelWithLocales['localeCodes'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isLocaleBoundToChannel(string $localeCode, string $channelCode): bool
+    {
+        $this->initializeCache();
+
+        return isset($this->indexedChannelsWithLocales[$channelCode])
+            ? in_array($localeCode, $this->indexedChannelsWithLocales[$channelCode]['localeCodes'])
+            : false
+            ;
+    }
+
+    private function initializeCache(): void
+    {
+        if (null == $this->indexedChannelsWithLocales) {
+            $channelsWithLocales = $this->getChannelCodeWithLocaleCodes->findAll();
+            foreach ($channelsWithLocales as $channelWithLocales) {
+                $this->indexedChannelsWithLocales[$channelWithLocales['channelCode']] = $channelWithLocales;
+            }
+        }
+    }
+}

--- a/src/Akeneo/Channel/Component/Query/PublicApi/ChannelExistsWithLocaleInterface.php
+++ b/src/Akeneo/Channel/Component/Query/PublicApi/ChannelExistsWithLocaleInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Channel\Component\Query\PublicApi;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ChannelExistsWithLocaleInterface
+{
+    public function doesChannelExist(string $channelCode): bool;
+
+    /**
+     * A locale is active when is bound to at least one channel.
+     * And not active when bound to none channel.
+     *
+     * @param string $localeCode
+     * @return bool
+     */
+    public function isLocaleActive(string $localeCode): bool;
+
+    public function isLocaleBoundToChannel(string $localeCode, string $channelCode): bool;
+}

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -122,6 +122,9 @@ $rules = [
         'Akeneo\Pim\Structure\Component\Query\PublicApi',
         'Psr\Log\LoggerInterface',
 
+        // Required for NonExistentValuesFilter on channels and locales
+        'Akeneo\Channel\Component\Query\PublicApi',
+
         // TIP-915: PIM/Enrichment should not be linked to AttributeOption
         // TIP-916: Do not check if entities exist in PQB filters or sorters
         'Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface',

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
@@ -116,6 +116,13 @@ services:
         tags:
             - { name: akeneo.pim.enrichment.factory.non_existent_values_filter }
 
+    akeneo.pim.enrichment.factory.non_existent_values_filter.channel_locale:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\NonExistentChannelLocaleValuesFilter'
+        arguments:
+            - '@pim_channel.query.cache.channel_exists_with_locale'
+        tags:
+            - { name: akeneo.pim.enrichment.factory.non_existent_values_filter }
+
     akeneo.pim.enrichment.factory.empty_values_cleaner:
         public: true
         class: 'Akeneo\Pim\Enrichment\Component\Product\Factory\EmptyValuesCleaner'

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
+
+use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class NonExistentChannelLocaleValuesFilter implements NonExistentValuesFilter
+{
+    /** @var ChannelExistsWithLocaleInterface */
+    private $channelsLocales;
+
+    public function __construct(ChannelExistsWithLocaleInterface $channelsLocales)
+    {
+        $this->channelsLocales = $channelsLocales;
+    }
+
+    public function filter(OnGoingFilteredRawValues $onGoingFilteredRawValues): OnGoingFilteredRawValues
+    {
+        $filteredRawValues = [];
+        foreach ($onGoingFilteredRawValues->nonFilteredRawValuesCollectionIndexedByType() as $type => $rawValuesIndexedByAttribute) {
+            $filteredRawValues[$type] = [];
+            foreach ($rawValuesIndexedByAttribute as $attributeCode => $rawValuesIndexedByProduct) {
+                foreach ($rawValuesIndexedByProduct as $productIndex => $productValues) {
+                    $productValues['values'] = $this->filterProductValues($productValues['values']);
+                    $filteredRawValues[$type][$attributeCode][$productIndex] = $productValues;
+                }
+            }
+        }
+
+        return $onGoingFilteredRawValues->addFilteredValuesIndexedByType($filteredRawValues);
+    }
+
+    private function filterProductValues(array $productValues): array
+    {
+        $filteredProductValues = [];
+        foreach ($productValues as $channel => $localeValues) {
+            if ($this->doesChannelExist($channel)) {
+                foreach ($localeValues as $locale => $value) {
+                    if ($this->isLocaleActivatedForChannel($locale, $channel)) {
+                        $filteredProductValues[$channel][$locale] = $value;
+                    }
+                }
+            }
+        }
+
+        return $filteredProductValues;
+    }
+
+    private function doesChannelExist(string $channel): bool
+    {
+        return $channel === '<all_channels>' || $this->channelsLocales->doesChannelExist($channel);
+    }
+
+    private function isLocaleActivatedForChannel(string $locale, string $channel): bool
+    {
+        return $locale === '<all_locales>'
+            || (
+                $channel === '<all_channels>'
+                    ? $this->channelsLocales->isLocaleActive($locale)
+                    : $this->channelsLocales->isLocaleBoundToChannel($locale, $channel)
+            );
+    }
+}

--- a/tests/back/Acceptance/Channel/InMemoryGetChannelCodeWithLocaleCodes.php
+++ b/tests/back/Acceptance/Channel/InMemoryGetChannelCodeWithLocaleCodes.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\Acceptance\Channel;
+
+use Akeneo\Channel\Component\Model\ChannelInterface;
+use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class InMemoryGetChannelCodeWithLocaleCodes implements GetChannelCodeWithLocaleCodesInterface
+{
+    /** @var InMemoryChannelRepository */
+    private $channelRepository;
+
+    public function __construct(InMemoryChannelRepository $channelRepository)
+    {
+        $this->channelRepository = $channelRepository;
+    }
+
+    public function findAll(): array
+    {
+        return array_map(function (ChannelInterface $channel): array {
+            return [
+                'channelCode' => $channel->getCode(),
+                'localeCodes' => $channel->getLocaleCodes(),
+            ];
+        }, $this->channelRepository->findAll());
+    }
+}

--- a/tests/back/Acceptance/Resources/config/pim/queries.yml
+++ b/tests/back/Acceptance/Resources/config/pim/queries.yml
@@ -4,7 +4,13 @@ services:
         class: 'Akeneo\Test\Acceptance\Attribute\InMemoryGetAttributes'
         arguments:
             - '@pim_catalog.repository.attribute'
+
     akeneo.pim.structure.query.get_existing_attribute_option_codes_from_option_codes:
         class: 'Akeneo\Test\Acceptance\AttributeOption\InMemoryGetExistingAttributeOptionCodes'
         arguments:
             - '@pim_catalog.repository.attribute_option'
+
+    pim_channel.query.sql.get_channel_code_with_locale_codes:
+        class: 'Akeneo\Test\Acceptance\Channel\InMemoryGetChannelCodeWithLocaleCodes'
+        arguments:
+            - '@pim_catalog.repository.channel'

--- a/tests/back/Acceptance/spec/Channel/InMemoryGetChannelCodeWithLocaleCodesSpec.php
+++ b/tests/back/Acceptance/spec/Channel/InMemoryGetChannelCodeWithLocaleCodesSpec.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Test\Acceptance\Channel;
+
+use Akeneo\Channel\Component\Model\Channel;
+use Akeneo\Channel\Component\Model\Locale;
+use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Akeneo\Test\Acceptance\Channel\InMemoryChannelRepository;
+use Akeneo\Test\Acceptance\Channel\InMemoryGetChannelCodeWithLocaleCodes;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class InMemoryGetChannelCodeWithLocaleCodesSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $frFRLocale = new Locale();
+        $frFRLocale->setCode('fr_FR');
+        $enUSLocale = new Locale();
+        $enUSLocale->setCode('en_US');
+        $deDELocale = new Locale();
+        $deDELocale->setCode('de_DE');
+
+        $ecommerceChannel = new Channel();
+        $ecommerceChannel->setCode('ecommerce');
+        $ecommerceChannel->addLocale($enUSLocale);
+        $ecommerceChannel->addLocale($frFRLocale);
+
+        $mobileChannel = new Channel();
+        $mobileChannel->setCode('mobile');
+        $mobileChannel->addLocale($enUSLocale);
+        $mobileChannel->addLocale($deDELocale);
+
+        $printChannel = new Channel();
+        $printChannel->setCode('print');
+
+        $this->beConstructedWith(new InMemoryChannelRepository([
+             $ecommerceChannel,
+             $mobileChannel,
+             $printChannel,
+         ]));
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(InMemoryGetChannelCodeWithLocaleCodes::class);
+        $this->shouldImplement(GetChannelCodeWithLocaleCodesInterface::class);
+    }
+
+    function it_returns_all_channel_codes_with_bound_locale_codes()
+    {
+        $this->findAll()->shouldBe([
+             [
+                 'channelCode' => 'ecommerce',
+                 'localeCodes' => ['en_US', 'fr_FR'],
+             ],
+             [
+                 'channelCode' => 'mobile',
+                 'localeCodes' => ['en_US', 'de_DE'],
+             ],
+             [
+                 'channelCode' => 'print',
+                 'localeCodes' => [],
+             ],
+         ]);
+    }
+}

--- a/tests/back/Channel/Integration/Channel/Query/Sql/SqlGetChannelCodeWithLocaleCodesIntegration.php
+++ b/tests/back/Channel/Integration/Channel/Query/Sql/SqlGetChannelCodeWithLocaleCodesIntegration.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Channel\Integration\Channel\Query\Sql;
+
+use Akeneo\Channel\Bundle\Query\Sql\SqlGetChannelCodeWithLocaleCodes;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class SqlGetChannelCodeWithLocaleCodesIntegration extends TestCase
+{
+    /** @var SqlGetChannelCodeWithLocaleCodes */
+    private $sqlGetChannelCodeWithLocaleCodes;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sqlGetChannelCodeWithLocaleCodes = $this->get(
+            'pim_channel.query.sql.get_channel_code_with_locale_codes'
+        );
+    }
+
+    public function test_it_returns_all_channels_with_bound_locales(): void
+    {
+        $results = $this->sqlGetChannelCodeWithLocaleCodes->findAll();
+
+        $this->assertIsArray($results);
+        $this->assertCount(3, $results);
+        $channelCodes = array_column($results, 'channelCode');
+        $this->assertCount(3, $channelCodes);
+        $this->assertContains('ecommerce', $channelCodes);
+        $this->assertContains('mobile', $channelCodes);
+        $this->assertContains('print', $channelCodes);
+
+        $mobileChannel = array_values(array_filter($results, function ($channel) {
+            return $channel['channelCode'] === 'mobile';
+        }))[0];
+        $localeCodesBoundToMobile = $mobileChannel['localeCodes'];
+        $this->assertCount(3, $localeCodesBoundToMobile);
+        $this->assertContains('en_US', $localeCodesBoundToMobile);
+        $this->assertContains('fr_FR', $localeCodesBoundToMobile);
+        $this->assertContains('de_DE', $localeCodesBoundToMobile);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+}

--- a/tests/back/Channel/Specification/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
+++ b/tests/back/Channel/Specification/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Channel\Component\Query\PublicApi\Cache;
+
+use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Akeneo\Channel\Component\Query\PublicApi\Cache\CachedChannelExistsWithLocale;
+use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use PhpSpec\ObjectBehavior;
+
+class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
+{
+    function let(GetChannelCodeWithLocaleCodesInterface $getChannelCodeWithLocaleCodes)
+    {
+        $getChannelCodeWithLocaleCodes->findAll()->willReturn([
+            [
+                'channelCode' => 'ecommerce',
+                'localeCodes' => ['en_US', 'fr_FR'],
+            ],
+            [
+                'channelCode' => 'mobile',
+                'localeCodes' => ['de_DE'],
+            ],
+            [
+                'channelCode' => 'print',
+                'localeCodes' => [],
+            ],
+        ]);
+        $this->beConstructedWith($getChannelCodeWithLocaleCodes);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CachedChannelExistsWithLocale::class);
+        $this->shouldImplement(ChannelExistsWithLocaleInterface::class);
+    }
+
+    function it_tests_the_channel_exist()
+    {
+        $this->doesChannelExist('ecommerce')->shouldReturn(true);
+        $this->doesChannelExist('mobile')->shouldReturn(true);
+        $this->doesChannelExist('print')->shouldReturn(true);
+        $this->doesChannelExist('other')->shouldReturn(false);
+    }
+
+    function it_tests_the_locale_is_active()
+    {
+        $this->isLocaleActive('fr_FR')->shouldReturn(true);
+        $this->isLocaleActive('en_US')->shouldReturn(true);
+        $this->isLocaleActive('de_DE')->shouldReturn(true);
+        $this->isLocaleActive('es_ES')->shouldReturn(false);
+    }
+
+    function it_tests_the_locale_is_bound_to_locale()
+    {
+        $this->isLocaleBoundToChannel('fr_FR', 'ecommerce')->shouldReturn(true);
+        $this->isLocaleBoundToChannel('en_US', 'ecommerce')->shouldReturn(true);
+        $this->isLocaleBoundToChannel('de_DE', 'ecommerce')->shouldReturn(false);
+
+        $this->isLocaleBoundToChannel('de_DE', 'mobile')->shouldReturn(true);
+        $this->isLocaleBoundToChannel('en_US', 'mobile')->shouldReturn(false);
+
+        $this->isLocaleBoundToChannel('en_US', 'print')->shouldReturn(false);
+
+        $this->isLocaleBoundToChannel('en_US', 'unknown')->shouldReturn(false);
+        $this->isLocaleBoundToChannel('unknown', 'unknown')->shouldReturn(false);
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/PQB/AbstractProductQueryBuilderTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/AbstractProductQueryBuilderTestCase.php
@@ -7,6 +7,7 @@ use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
+use PHPUnit\Framework\Assert;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -175,5 +176,18 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
         }
 
         $this->assertSame($products, $expected);
+    }
+
+    protected function activateLocaleForChannel(string $localeCode, string $channelCode): void
+    {
+        $channel = $this->get('pim_catalog.repository.channel')->findOneByIdentifier($channelCode);
+        Assert::assertNotNull($channel, sprintf('Channel "%s" not found', $channelCode));
+
+        $locale = $this->get('pim_catalog.repository.locale')->findOneByIdentifier($localeCode);
+        Assert::assertNotNull($locale, sprintf('Locale "%s" not found', $localeCode));
+
+        $channel->addLocale($locale);
+
+        $this->get('pim_catalog.saver.channel')->save($channel);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Boolean/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Boolean/LocalizableScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
     {
         parent::setUp();
 
+        $this->activateLocaleForChannel('fr_Fr', 'ecommerce');
+
         $this->createAttribute([
             'code'                => 'a_localizable_scopable_yes_no',
             'type'                => AttributeTypes::BOOLEAN,

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/LocalizableScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
     {
         parent::setUp();
 
+        $this->activateLocaleForChannel('fr_Fr', 'ecommerce');
+
         $this->createAttribute([
             'code'                => 'a_localizable_scopable_date',
             'type'                => AttributeTypes::DATE,

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableScopableFilterIntegration.php
@@ -20,6 +20,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
     {
         parent::setUp();
 
+        $this->activateLocaleForChannel('fr_Fr', 'ecommerce');
+
         $this->createFamily([
             'code' => 'a_family',
             'attributes' => ['sku', 'a_localizable_scopable_image']

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
     {
         parent::setUp();
 
+        $this->activateLocaleForChannel('fr_FR', 'ecommerce');
+
         $this->createAttribute([
             'code'                => 'a_scopable_localizable_metric',
             'type'                => AttributeTypes::METRIC,

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
     {
         parent::setUp();
 
+        $this->activateLocaleForChannel('fr_Fr', 'ecommerce');
+
         $this->createAttribute([
             'code'                => 'a_localizable_scopable_number',
             'type'                => AttributeTypes::NUMBER,

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
     {
         parent::setUp();
 
+        $this->activateLocaleForChannel('fr_Fr', 'ecommerce');
+
         $this->createAttribute([
             'code'                => 'a_localizable_scopable_simple_select',
             'type'                => AttributeTypes::OPTION_SIMPLE_SELECT,

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
     {
         parent::setUp();
 
+        $this->activateLocaleForChannel('fr_Fr', 'ecommerce');
+
         $this->createAttribute([
             'code'                => 'a_localizable_scopable_multi_select',
             'type'                => AttributeTypes::OPTION_MULTI_SELECT,

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
     {
         parent::setUp();
 
+        $this->activateLocaleForChannel('fr_Fr', 'ecommerce');
+
         $this->createAttribute([
             'code'             => 'a_scopable_localizable_price',
             'type'             => AttributeTypes::PRICE_COLLECTION,

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
     {
         parent::setUp();
 
+        $this->activateLocaleForChannel('fr_Fr', 'ecommerce');
+
         $this->createAttribute([
             'code'                => 'a_localizable_scopable_text',
             'type'                => AttributeTypes::TEXT,

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableScopableFilterIntegration.php
@@ -21,6 +21,8 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
     {
         parent::setUp();
 
+        $this->activateLocaleForChannel('fr_Fr', 'ecommerce');
+
         $this->createAttribute([
             'code'                => 'a_localizable_scopable_text_area',
             'type'                => AttributeTypes::TEXTAREA,

--- a/tests/back/Pim/Enrichment/Integration/PQB/ProductQueryBuilderIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/ProductQueryBuilderIntegration.php
@@ -101,6 +101,8 @@ class ProductQueryBuilderIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
+        $this->activateLocaleForChannel('fr_FR', 'ecommerce');
+
         $this->createProduct(
             'complex_product_1',
             [

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilterSpec.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
+
+use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\OnGoingFilteredRawValues;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class NonExistentChannelLocaleValuesFilterSpec extends ObjectBehavior
+{
+    public function let(ChannelExistsWithLocaleInterface $channelsLocales)
+    {
+        $this->beConstructedWith($channelsLocales);
+    }
+
+    public function it_filters_values_of_non_existing_channels($channelsLocales)
+    {
+        $ongoingFilteredRawValues = OnGoingFilteredRawValues::fromNonFilteredValuesCollectionIndexedByType([
+            AttributeTypes::OPTION_SIMPLE_SELECT => [
+                'a_select' => [
+                    [
+                        'identifier' => 'product_A',
+                        'values' => [
+                            '<all_channels>' => [
+                                '<all_locales>' => 'option_A'
+                            ],
+                        ]
+                    ],
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [
+                            'ecommerce' => [
+                                'en_US' => 'option_B'
+                            ],
+                            'foo' => [
+                                'en_US' => 'option_B'
+                            ],
+                        ]
+                    ]
+                ],
+                'another_select' => [
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [
+                            'foo' => [
+                                'en_US' => 'option_B'
+                            ],
+                        ]
+                    ]
+                ]
+            ],
+            AttributeTypes::TEXTAREA => [
+                'a_description' => [
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [
+                            'foo' => [
+                                '<all_locales>' => 'plop'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $channelsLocales->doesChannelExist('ecommerce')->willReturn(true);
+        $channelsLocales->doesChannelExist('foo')->willReturn(false);
+        $channelsLocales->isLocaleBoundToChannel('en_US', 'ecommerce')->willReturn(true);
+
+        $filteredRawValues = $this->filter($ongoingFilteredRawValues)->filteredRawValuesCollectionIndexedByType();
+        $filteredRawValues->shouldBeLike([
+            AttributeTypes::OPTION_SIMPLE_SELECT => [
+                'a_select' => [
+                    [
+                        'identifier' => 'product_A',
+                        'values' => [
+                            '<all_channels>' => [
+                                '<all_locales>' => 'option_A'
+                            ],
+                        ],
+                    ],
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [
+                            'ecommerce' => [
+                                'en_US' => 'option_B'
+                            ],
+                        ],
+                    ],
+                ],
+                'another_select' => [
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [],
+                    ],
+                ],
+            ],
+            AttributeTypes::TEXTAREA => [
+                'a_description' => [
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function it_filters_values_of_not_activated_locales($channelsLocales)
+    {
+        $ongoingFilteredRawValues = OnGoingFilteredRawValues::fromNonFilteredValuesCollectionIndexedByType([
+            AttributeTypes::OPTION_SIMPLE_SELECT => [
+                'a_select' => [
+                    [
+                        'identifier' => 'product_A',
+                        'values' => [
+                            'ecommerce' => [
+                                'en_US' => 'option_A',
+                                'en_CA' => 'option_A',
+                                'fr_FR' => 'option_A',
+                            ],
+                        ],
+                    ],
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [
+                            'ecommerce' => [
+                                'en_CA' => 'option_B'
+                            ],
+                        ],
+                    ],
+                ],
+                'another_select' => [
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [
+                            'ecommerce' => [
+                                '<all_locales>' => 'option_B'
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            AttributeTypes::TEXTAREA => [
+                'a_description' => [
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [
+                            '<all_channels>' => [
+                                'en_US' => 'plop',
+                                'fr_FR' => 'hop',
+                                'en_CA' => 'bar'
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $channelsLocales->doesChannelExist('ecommerce')->willReturn(true);
+        $channelsLocales->isLocaleBoundToChannel('en_US', 'ecommerce')->willReturn(true);
+        $channelsLocales->isLocaleBoundToChannel('en_CA', 'ecommerce')->willReturn(false);
+        $channelsLocales->isLocaleBoundToChannel('fr_FR', 'ecommerce')->willReturn(false);
+        $channelsLocales->isLocaleActive('en_US')->willReturn(true);
+        $channelsLocales->isLocaleActive('en_CA')->willReturn(false);
+        $channelsLocales->isLocaleActive('fr_FR')->willReturn(true);
+
+        $filteredRawValues = $this->filter($ongoingFilteredRawValues)->filteredRawValuesCollectionIndexedByType();
+        $filteredRawValues->shouldBeLike([
+            AttributeTypes::OPTION_SIMPLE_SELECT => [
+                'a_select' => [
+                    [
+                        'identifier' => 'product_A',
+                        'values' => [
+                            'ecommerce' => [
+                                'en_US' => 'option_A',
+                            ],
+                        ]
+                    ],
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [],
+                    ],
+                ],
+                'another_select' => [
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [
+                            'ecommerce' => [
+                                '<all_locales>' => 'option_B'
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            AttributeTypes::TEXTAREA => [
+                'a_description' => [
+                    [
+                        'identifier' => 'product_B',
+                        'values' => [
+                            '<all_channels>' => [
+                                'en_US' => 'plop',
+                                'fr_FR' => 'hop',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
Please focus your review on the second commit. The first commit has been backported from master

Since the 4.0, the validation of the product values is stricter. It's no more possible to update a value for a locale not activated for the given channel  (but activated for another channel). It's was possible in 3.2, but it was a mistake.

The side effect is that if a locale is deactivated for a channel, all the products that had a value on a scopable and localizable attribute for this locale cannot be updated anymore from the UI. It's because the values of the deactivated locale are still submitted and don't pass the validation.

The solution is to filter these values when they are fetched from the database, as it has been done for the other similar cases (e.g. deleted options or deleted reference data)