### PR TITLE
PIM-9282 : make calling attribute options via API case insensitive

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - AOB-968: Fix product label rendering on edit form
+- PIM-9282: Make calling attribute options via API case insensitive
 
 # 4.0.31 (2020-06-01)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
@@ -138,7 +138,7 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
             $attributeOptions
         );
 
-        $unexistingValues = array_diff($values, $optionCodes);
+        $unexistingValues = array_udiff($values, $optionCodes, 'strcasecmp');
         if (count($unexistingValues) > 0) {
             throw new ObjectNotFoundException(
                 sprintf(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

An inconsistency has been detected into the API : the creation of attribute options via API is not case sensitive, while calling attribute options via API is case sensitive.
So, I make calling attribute options case insensitive.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
