### PR TITLE
TIP-450 Fix breaking build when only one Behat is selected by CircleCi

### DIFF
--- a/.circleci/run_behat.sh
+++ b/.circleci/run_behat.sh
@@ -9,10 +9,10 @@ echo "TEST FILES ON THIS CONTAINER: $TEST_FILES"
 
 fail=0
 counter=1
-total=$(($(echo $TEST_FILES | grep -o ' ' | wc -l) + 1))
+total=$(echo $TEST_FILES | tr ' ' "\n" | wc -l)
 
 for TEST_FILE in $TEST_FILES; do
-    echo "\nLAUNCHING $TEST_FILE ($counter/$total):"
+    echo -e "\nLAUNCHING $TEST_FILE ($counter/$total):"
     output=$(basename $TEST_FILE)_$(uuidgen)
 
     set +e


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Pretty basic PR to fix a "random" problem on Behat execution when only one Behat scenario is selected by CircleCI to be run on a container.

With the previous code, if there was only one scenario, the `grep` command would fail, as there was no scenario separator (the space character).
This fix simplifies the code as well by removing the grep and the embedded command interpretation.

The -e added in the echo inside the loop was added in order for the "\n" to be interpreted...

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
