### PR TITLE
RAC-59: Add validation to fordib quantified association type in associations

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -195,6 +195,7 @@ acceptance:
                 - test.attribute_option.context
                 - test.locale.context
                 - test.channel.context
+                - test.user.context
             filters:
                 tags: '@acceptance-back'
         channel:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
@@ -26,6 +26,9 @@ Akeneo\Pim\Enrichment\Component\Product\Model\Product:
                 message: 'regex.comma_or_semicolon_or_surrounding_space.message'
             - Length:
                 max: 255
+        associations:
+            - Symfony\Component\Validator\Constraints\All:
+                - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\AssociationTypeIsNotQuantified: ~
         quantifiedAssociations:
             - Symfony\Component\Validator\Constraints\Valid: ~
     getters:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/productmodel.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/productmodel.yml
@@ -23,6 +23,9 @@ Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel:
         familyVariant:
             - NotBlank:
                 message: 'product_model.family_variant.not_blank.message'
+        associations:
+            - Symfony\Component\Validator\Constraints\All:
+                - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\AssociationTypeIsNotQuantified: ~
         quantifiedAssociations:
             - Symfony\Component\Validator\Constraints\Valid: ~
     getters:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
@@ -91,7 +91,8 @@ pim_catalog:
             products_do_not_exist: "The following products don't exist: {{ values }}. Please make sure the products haven't been deleted in the meantime."
             product_models_do_not_exist: "The following product models don't exist: {{ values }}. Please make sure the product models haven't been deleted in the meantime."
             association_type_does_not_exist: This association type doesn't exist. Please make sure it hasn't been deleted in the meantime.
-            association_type_is_not_quantified: This association type isn't used to write quantities. Please, choose a different one before trying again.
+            association_type_is_not_quantified: '"{{ association_type }}" can’t be used for associations with quantities. Please, choose a different association type with quantities or use the "associations" property.'
+            association_type_should_not_be_quantified: '"{{ association_type }}" can only be used for associations with quantities. Please, choose a different association type or use the "quantified_associations" property.'
 
 mass_edit:
     edit_common_attributes:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.fr_FR.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.fr_FR.yml
@@ -91,7 +91,7 @@ pim_catalog:
       product_models_do_not_exist: "Les modèles de produits suivants : {{ values }} n'existent pas. Merci de vérifier qu'ils n'ont pas été supprimés entre temps."
       association_type_does_not_exist: Ce type d'association n'existe pas. Merci de vérifier qu'il n'a pas été supprimé entre temps.
       association_type_is_not_quantified: '"{{ association_type }}" ne permet pas de renseigner des associations avec quantités. Merci d’utiliser un autre type d’association quantifiée ou d’utiliser la propriété "associations".'
-      association_type_should_not_be_quantified: '"{{ association_type }}" permet uniquement de renseigner uniquement des associations avec quantités. Merci d’utiliser un autre type d’association ou d’utiliser la propriété "quantified_associations".'
+      association_type_should_not_be_quantified: '"{{ association_type }}" permet uniquement de renseigner des associations avec quantités. Merci d’utiliser un autre type d’association ou d’utiliser la propriété "quantified_associations".'
 
 mass_edit:
   edit_common_attributes:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.fr_FR.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.fr_FR.yml
@@ -84,13 +84,15 @@ pim_catalog:
     pim_immutable_product_validator: Le même identifiant est déjà défini sur un autre produit
     pim_immutable_product_model_validator: Le même code est déjà défini sur un autre modèle de produit.
     quantified_associations:
-      unexpected_link_type: The link type "{{ value }}" doesn't exist. You can only associate products or product models.
-      max_associations: You've reached the limit of {{ limit }} associations. Please, delete some existing associations before adding new ones.
-      invalid_quantity: '"{{ value }}" is an invalid quantity. Please, write a value between {{ min }} and {{ max }}.'
-      products_do_not_exist: "The following products don't exist: {{ values }}. Please make sure the products haven't been deleted in the meantime."
-      product_models_do_not_exist: "The following product models don't exist: {{ values }}. Please make sure the product models haven't been deleted in the meantime."
-      association_type_does_not_exist: This association type doesn't exist. Please make sure it hasn't been deleted in the meantime.
-      association_type_is_not_quantified: This association type isn't used to write quantities. Please, choose a different one before trying again.
+      unexpected_link_type: Le type de lien "{{ value }}" n'existe pas. Seuls des produits ou des modèles de produits peuvent être associés entre eux.
+      max_associations: Vous avez atteint la limite de {{ limit }} associations. Merci de supprimer des associations existantes si vous souhaitez en rajouter de nouvelles.
+      invalid_quantity: La quantité "{{ value }}" est invalide. Merci d'entrer une valeur comprise entre {{ min }} et {{ max }} inclus.
+      products_do_not_exist: "Les produits suivants : {{ values }} n'existent pas. Merci de vérifier qu'ils n'ont pas été supprimés entre temps."
+      product_models_do_not_exist: "Les modèles de produits suivants : {{ values }} n'existent pas. Merci de vérifier qu'ils n'ont pas été supprimés entre temps."
+      association_type_does_not_exist: Ce type d'association n'existe pas. Merci de vérifier qu'il n'a pas été supprimé entre temps.
+      association_type_is_not_quantified: '"{{ association_type }}" ne permet pas de renseigner des associations avec quantités. Merci d’utiliser un autre type d’association quantifiée ou d’utiliser la propriété "associations".'
+      association_type_should_not_be_quantified: '"{{ association_type }}" permet uniquement de renseigner uniquement des associations avec quantités. Merci d’utiliser un autre type d’association ou d’utiliser la propriété "quantified_associations".'
+
 mass_edit:
   edit_common_attributes:
     invalid_values: Il y a des erreurs dans le formulaire d'attributs

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/AssociationTypeIsNotQuantified.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/AssociationTypeIsNotQuantified.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+class AssociationTypeIsNotQuantified extends Constraint
+{
+    public const ASSOCIATION_TYPE_SHOULD_NOT_BE_QUANTIFIED_MESSAGE = 'pim_catalog.constraint.quantified_associations.association_type_should_not_be_quantified';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/AssociationTypeIsNotQuantifiedValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/AssociationTypeIsNotQuantifiedValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\AssociationInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class AssociationTypeIsNotQuantifiedValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$value instanceof AssociationInterface) {
+            throw new UnexpectedTypeException($value, AssociationInterface::class);
+        }
+
+        if (!$constraint instanceof AssociationTypeIsNotQuantified) {
+            throw new UnexpectedTypeException($constraint, AssociationTypeIsNotQuantified::class);
+        }
+
+        if ($value->getAssociationType()->isQuantified()) {
+            $this->context
+                ->buildViolation(
+                    AssociationTypeIsNotQuantified::ASSOCIATION_TYPE_SHOULD_NOT_BE_QUANTIFIED_MESSAGE,
+                    [
+                        '{{ association_type }}' => $value->getAssociationType()->getCode(),
+                    ]
+                )
+                ->addViolation();
+        }
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/QuantifiedAssociationsValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/QuantifiedAssociationsValidator.php
@@ -104,7 +104,10 @@ class QuantifiedAssociationsValidator extends ConstraintValidator
 
         if (!$associationType->isQuantified()) {
             $this->context->buildViolation(
-                QuantifiedAssociationsConstraint::ASSOCIATION_TYPE_IS_NOT_QUANTIFIED_MESSAGE
+                QuantifiedAssociationsConstraint::ASSOCIATION_TYPE_IS_NOT_QUANTIFIED_MESSAGE,
+                [
+                    '{{ association_type }}' => $associationType->getCode(),
+                ]
             )
                 ->atPath($propertyPath)
                 ->addViolation();

--- a/tests/back/Acceptance/Product/InMemoryProductRepository.php
+++ b/tests/back/Acceptance/Product/InMemoryProductRepository.php
@@ -121,6 +121,12 @@ class InMemoryProductRepository implements
 
     public function getItemsFromIdentifiers(array $identifiers)
     {
-        throw new NotImplementedException(__METHOD__);
+        $items = [];
+
+        foreach($identifiers as $identifier){
+            $items[] = $this->findOneByIdentifier($identifier);
+        }
+
+        return $items;
     }
 }

--- a/tests/back/Acceptance/Product/InMemoryProductRepository.php
+++ b/tests/back/Acceptance/Product/InMemoryProductRepository.php
@@ -123,7 +123,7 @@ class InMemoryProductRepository implements
     {
         $items = [];
 
-        foreach($identifiers as $identifier){
+        foreach ($identifiers as $identifier) {
             $items[] = $this->findOneByIdentifier($identifier);
         }
 

--- a/tests/back/Acceptance/Resources/config/behat/services.yml
+++ b/tests/back/Acceptance/Resources/config/behat/services.yml
@@ -83,6 +83,13 @@ services:
             - '@test.channel.builder'
             - '@test.currency.builder'
 
+    test.user.context:
+        class: 'Akeneo\Test\Acceptance\User\UserContext'
+        arguments:
+            - '@pim_user.factory.user'
+            - '@security.token_storage'
+        public: true
+
     test.attribute.context:
         public: true
         class: 'Akeneo\Test\Acceptance\Attribute\AttributeContext'

--- a/tests/back/Acceptance/User/UserContext.php
+++ b/tests/back/Acceptance/User/UserContext.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\Acceptance\User;
+
+use Akeneo\UserManagement\Component\Factory\UserFactory;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use Behat\Behat\Context\Context;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+class UserContext implements Context
+{
+    /** @var UserFactory */
+    private $userFactory;
+
+    /** @var TokenStorageInterface */
+    private $tokenStorage;
+
+    public function __construct(
+        UserFactory $userFactory,
+        TokenStorageInterface $tokenStorage
+    ) {
+        $this->userFactory = $userFactory;
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * @Given /^an authentified administrator$/
+     */
+    public function anAuthenifiedAdministrator()
+    {
+        /** @var UserInterface $user */
+        $user = $this->userFactory->create();
+        $user->setUsername('admin');
+
+        $token = new UsernamePasswordToken($user, null, 'main', ['ROLE_ADMINISTRATOR']);
+        $this->tokenStorage->setToken($token);
+    }
+}

--- a/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
+++ b/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
@@ -120,4 +120,19 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
         $products['a-product']->shouldBe($product1);
         $products['a-second-product']->shouldBe($product2);
     }
+
+    function it_returns_products_from_identifiers()
+    {
+        foreach(['A', 'B', 'C'] as $identifier){
+            $product = new Product();
+            $product->setIdentifier($identifier);
+            $this->save($product);
+        }
+
+        $products = $this->getItemsFromIdentifiers(['A', 'B']);
+        $products->shouldBeArray();
+        $products->shouldHaveCount(2);
+        $products[0]->getIdentifier()->shouldBe('A');
+        $products[1]->getIdentifier()->shouldBe('B');
+    }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductEndToEnd.php
@@ -2,7 +2,6 @@
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\InternalApi\QuantifiedAssociations;
 
-use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\InternalApi\QuantifiedAssociations\AbstractProductWithQuantifiedAssociationsTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
 class AddQuantifiedAssociationsToProductEndToEnd extends AbstractProductWithQuantifiedAssociationsTestCase

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/InternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/InternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductModelEndToEnd.php
@@ -4,7 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\InternalApi\Qu
 
 use Symfony\Component\HttpFoundation\Response;
 
-class AddQuantifiedAssociationsToProductEndToEnd extends AbstractProductModelWithQuantifiedAssociationsTestCase
+class AddQuantifiedAssociationsToProductModelEndToEnd extends AbstractProductModelWithQuantifiedAssociationsTestCase
 {
     /**
      * @test

--- a/tests/features/pim/enrichment/entity-with-quantified-associations/validate_quantified_associations.feature
+++ b/tests/features/pim/enrichment/entity-with-quantified-associations/validate_quantified_associations.feature
@@ -81,3 +81,15 @@ Feature: Validate the quantified associations of a product
   Scenario: Cannot save a product model with an invalid quantified association
     When a product model is associated with an invalid quantified association
     Then there is at least a validation error on this product model
+
+  @acceptance-back
+  Scenario: Cannot save a product with a quantified association type used in a normal association
+    Given a product without associations
+    When I add an association without quantity to this product using a quantified association type
+    Then this product has a validation error about association type should not be quantified
+
+  @acceptance-back
+  Scenario: Cannot save a product model with a quantified association type used in a normal association
+    Given a product model without associations
+    When I add an association without quantity to this product model using a quantified association type
+    Then this product model has a validation error about association type should not be quantified

--- a/tests/features/pim/enrichment/entity-with-quantified-associations/validate_quantified_associations.feature
+++ b/tests/features/pim/enrichment/entity-with-quantified-associations/validate_quantified_associations.feature
@@ -5,6 +5,7 @@ Feature: Validate the quantified associations of a product
 
   Background:
     Given a catalog with the attribute "sku" as product identifier
+    And an authentified administrator
 
   @acceptance-back
   Scenario: Cannot save a product with a nonexistent quantified association type


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Add a validator to check that no quantified association type are used in `Product::associations`.
Also update the translations for `association_type_is_not_quantified` and `association_type_should_not_be_quantified` after feedback.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
