### PR TITLE
PIM-9282 : make calling attribute options via API case insensitive (PIM 3.0)

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -4,6 +4,7 @@
 
 ## Bug fixes
 
+- PIM-9282: Make calling attribute options via API case insensitive
 - GITHUB-APD-124: Update help menu link to redirect to the right version on the help center
 
 # 3.0.79 (2020-05-27)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
@@ -138,7 +138,7 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
             $attributeOptions
         );
 
-        $unexistingValues = array_diff($values, $optionCodes);
+        $unexistingValues = array_udiff($values, $optionCodes, 'strcasecmp');
         if (count($unexistingValues) > 0) {
             throw new ObjectNotFoundException(
                 sprintf(

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/product_mapping.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/product_mapping.yml
@@ -148,6 +148,7 @@ mappings:
                     path_match: 'values.*-option.*'
                     mapping:
                         type: 'keyword'
+                        normalizer: 'attribute_option_normalizer'
             -
                 options_scopable_localizable_structure:
                     path_match: 'values.*-options.*'
@@ -159,6 +160,7 @@ mappings:
                     path_match: 'values.*-options.*'
                     mapping:
                         type: 'keyword'
+                        normalizer: 'attribute_option_normalizer'
             -
                 reference_data_option_scopable_localizable_structure:
                     path_match: 'values.*-reference_data_option.*'
@@ -170,6 +172,7 @@ mappings:
                     path_match: 'values.*-reference_data_option.*'
                     mapping:
                         type: 'keyword'
+                        normalizer: 'attribute_option_normalizer'
             -
                 reference_data_options_scopable_localizable_structure:
                     path_match: 'values.*-reference_data_options.*'
@@ -181,6 +184,7 @@ mappings:
                     path_match: 'values.*-reference_data_options.*'
                     mapping:
                         type: 'keyword'
+                        normalizer: 'attribute_option_normalizer'
             -
                 prices_data_options_scopable_localizable_structure:
                     path_match: 'values.*-prices.*'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/settings.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/settings.yml
@@ -7,6 +7,8 @@ settings:
                 filter: ['lowercase']
             identifier_normalizer:
                 filter: ['lowercase']
+            attribute_option_normalizer:
+                filter: ['lowercase']
         char_filter:
             newline_pattern:
                 pattern: '\\n'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Same as https://github.com/akeneo/pim-community-dev/pull/12201 but for PIM 3.0.
For 3.0, it will be necessary to reset indices before re-indexing
