### PR TITLE
PIM-9290: Fix product categories loading

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -5,6 +5,7 @@
 - AOB-968: Fix product label rendering on edit form
 - CXP-306: Fix the collect of product events
 - PIM-9282: Make calling attribute options via API case insensitive
+- PIM-9290: Fix product categories loading
 
 # 4.0.31 (2020-06-01)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/categories.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/categories.js
@@ -117,7 +117,7 @@ define(
                     this.treeAssociate = new TreeAssociate('#trees', '#hidden-tree-input', {
                         list_categories: this.config.itemCategoryListRoute,
                         children:        'pim_enrich_categorytree_children'
-                    });
+                    }, 'POST');
 
                     this.delegateEvents();
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/tree-associate.jstree.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/tree-associate.jstree.js
@@ -3,7 +3,7 @@ define(
     function ($, _, Routing, mediator) {
         'use strict';
 
-        return function (elementId, hiddenCategoryId, routes) {
+        return function (elementId, hiddenCategoryId, routes, fetchingDataMethod = 'GET') {
             var $el = $(elementId);
             if (!$el || !$el.length || !_.isObject($el)) {
                 return;
@@ -42,13 +42,11 @@ define(
                 },
                 json_data: {
                     ajax: {
+                        method: fetchingDataMethod,
                         url: function (node) {
                             var treeHasItem = $('#tree-link-' + currentTree).hasClass('tree-has-item');
 
                             if ((!node || (node === -1)) && treeHasItem) {
-                                // First load of the tree: get the checked categories
-                                var selected = this.parseHiddenCategories();
-
                                 return Routing.generate(
                                     routes.list_categories,
                                     {
@@ -56,8 +54,7 @@ define(
                                         categoryId: currentTree,
                                         _format: 'json',
                                         dataLocale: dataLocale,
-                                        context: 'associate',
-                                        selected: selected
+                                        context: 'associate'
                                     }
                                 );
                             }
@@ -70,10 +67,15 @@ define(
                                     context: 'associate'
                                 }
                             );
-                        }.bind(this),
+                        },
                         data: function (node) {
                             var data           = {};
                             var treeHasItem = $('#tree-link-' + currentTree).hasClass('tree-has-item');
+
+                            // First load of the tree: get the checked categories
+                            if ((!node || (node === -1)) && treeHasItem) {
+                                data.selected = this.parseHiddenCategories();
+                            }
 
                             if (node && node !== -1 && node.attr) {
                                 data.id = node.attr('id').replace('node_', '');
@@ -85,7 +87,7 @@ define(
                             }
 
                             return data;
-                        },
+                        }.bind(this),
                         complete: function () {
                             // Disable the root checkbox
                             $('.jstree-root>input.jstree-real-checkbox').attr('disabled', 'disabled');


### PR DESCRIPTION
When a product has a lot of categories, the URI to load the categories tree of the PEF can be too long. All the categories of the product are added to the URI as "selected" categories.

I'm not totally comfortable with this solution, but it's the easiest. I added an optional parameter to "tree-associate" to be flexible on the HTTP method to use. I don't see another solution that would not need a big rework.

