### PR TITLE
PIM-9289: Display a correct error message when deleting a group or an association 

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,9 +1,0 @@
-# 5.0.x
-
-## Bug fixes
-
-- PIM-9274: Fix Yaml reader to display the number of lines read for incorrectly formatted files
-
-## Improvements
-
-- AOB-277: Add an acl to allow a role member to view all job executions in last job execution grids, job tracker and last operations widget.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-9274: Fix Yaml reader to display the number of lines read for incorrectly formatted files
 - TIP-1406: Add a tag to configure a DIC service based on a feature flag
 - PIM-9133: Fix product save when the user has no permission on some attribute groups
 - Fixes memory leak when indexing product models with a lot of product models in the same family

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PIM-9197: Make queries in InMemoryGetAttributes case insensitive
 - PIM-9213: Fix tooltip hover on Ellipsis for Family Name on creating product
 - PIM-9184: API - Fix dbal query group by part for saas instance
+- PIM-9289: Display a correct error message when deleting a group or an association
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -454,3 +454,8 @@ batch_jobs:
         quick_export.label: XLSX product quick export
         quick_export_product_model.label: XLSX product model quick export
         perform.label: XLSX product quick export
+
+error:
+    removing:
+        group: Impossible to remove group
+        attribute_type: Impossible to remove association type

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -458,4 +458,4 @@ batch_jobs:
 error:
     removing:
         group: Impossible to remove group
-        attribute type: Impossible to remove association type
+        association type: Impossible to remove association type

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -458,4 +458,4 @@ batch_jobs:
 error:
     removing:
         group: Impossible to remove group
-        attribute_type: Impossible to remove association type
+        attribute type: Impossible to remove association type


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When deleting an association or a group linked to a published product, an error pop in is displayed but the message was the translation keys.
So, I added the translation keys in a jsmessages.en_US.yml file and associated them an error message.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | OK
| Review and 2 GTM                  |
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
