### PR TITLE
DAPI-1038: Attribute options revamp - Remove an option

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/AttributeOptions.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/AttributeOptions.tsx
@@ -57,18 +57,26 @@ const AttributeOptions = () => {
 
     const saveAttributeOption = useCallback(async (attributeOption: AttributeOption) => {
         setIsSaving(true);
-        await attributeOptionSaver(attributeOption);
+        try {
+            await attributeOptionSaver(attributeOption);
+            dispatchAction(updateAttributeOptionAction(attributeOption));
+        } catch (error) {
+            notify(NotificationLevel.ERROR, error);
+        }
         setIsSaving(false);
-        dispatchAction(updateAttributeOptionAction(attributeOption));
     }, [dispatchAction, setIsSaving]);
 
     const createAttributeOption = useCallback(async (optionCode: string) => {
         setIsSaving(true);
-        const attributeOption = await attributeOptionCreate(optionCode);
+        try {
+            const attributeOption = await attributeOptionCreate(optionCode);
+            dispatchAction(createAttributeOptionAction(attributeOption));
+            setShowNewOptionForm(false);
+            setSelectedOption(attributeOption);
+        } catch (error) {
+            notify(NotificationLevel.ERROR, error);
+        }
         setIsSaving(false);
-        dispatchAction(createAttributeOptionAction(attributeOption));
-        setShowNewOptionForm(false);
-        setSelectedOption(attributeOption);
     }, [attributeOptionCreate, setIsSaving, dispatchAction, setShowNewOptionForm, setSelectedOption]);
 
     const deleteAttributeOption = useCallback(async (attributeOptionId: number) => {

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/AttributeOptions.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/AttributeOptions.tsx
@@ -25,14 +25,20 @@ const AttributeOptions = () => {
     const notify = useNotify();
 
     useEffect(() => {
-        if (attributeOptions !== null && attributeOptions.length > 0 && selectedOption === null) {
+        if (attributeOptions !== null && attributeOptions.length > 0 && (selectedOption === null || !selectedOptionExists())) {
             setSelectedOption(attributeOptions[0]);
+        } else if (attributeOptions === null || attributeOptions.length === 0) {
+            setSelectedOption(null);
         }
     }, [attributeOptions]);
 
     useEffect(() => {
         setSelectedOption(null);
     }, [attribute.attributeId]);
+
+    const selectedOptionExists = () => {
+        return attributeOptions && selectedOption && attributeOptions.filter((option: AttributeOption) => option.id === selectedOption.id).length === 1;
+    };
 
     const selectAttributeOption = useCallback(async (optionId: number | null) => {
         if (attributeOptions !== null) {

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/DeleteConfirmationModal.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/DeleteConfirmationModal.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {useTranslate} from '@akeneo-pim-community/legacy-bridge';
+
+interface deleteConfirmationModalProps {
+    attributeOptionCode: string;
+    confirmDelete: () => void;
+    cancelDelete: () => void;
+}
+
+const DeleteConfirmationModal = ({attributeOptionCode, confirmDelete, cancelDelete}: deleteConfirmationModalProps) => {
+    const translate = useTranslate();
+
+    return (
+        <div className="modal modal--fullPage in" role="attribute-option-delete-confirmation-modal">
+            <div className="AknFullPage">
+                <div className="AknFullPage-content AknFullPage-content--withIllustration">
+                    <div>
+                        <div className="AknFullPage-image AknFullPage-illustration AknFullPage-illustration--delete"/>
+                    </div>
+                    <div>
+                        <div className="AknFullPage-titleContainer">
+                            <div className="AknFullPage-title">
+                                {translate('pim_enrich.entity.fallback.module.delete.title', {'itemName': attributeOptionCode})}
+                            </div>
+                            <div className="AknFullPage-description">
+                                {translate('pim_enrich.entity.fallback.module.delete.item_placeholder', {'itemName': attributeOptionCode})}
+                            </div>
+                        </div>
+                        <div className="modal-body"/>
+                        <div className="AknButtonList">
+                            <div className="AknButton AknButton--grey AknButtonList-item cancel" onClick={cancelDelete} role="attribute-option-confirm-cancel-button">
+                                {translate('pim_common.cancel')}
+                            </div>
+                            <div title="Delete" className="AknButton AknButtonList-item AknButton--apply AknButton--important ok" onClick={confirmDelete} role="attribute-option-confirm-delete-button">
+                                {translate('pim_common.delete')}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div className="AknFullPage-cancel cancel" onClick={cancelDelete} role="attribute-option-confirm-cancel-button"/>
+        </div>
+    );
+};
+
+export default DeleteConfirmationModal;

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/Edit.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/Edit.tsx
@@ -11,10 +11,10 @@ interface EditProps {
 const Edit = ({option, saveAttributeOption}: EditProps) => {
     const translate = useTranslate();
     const locales = useLocalesContext();
-    const [updatedOption, setUpdatedOption] = useState<AttributeOption | null>(null);
+    const [updatedOption, setUpdatedOption] = useState<AttributeOption>(option);
 
     useEffect(() => {
-        setUpdatedOption(null);
+        setUpdatedOption(option);
     }, [option]);
 
     const onUpdateOptionLabel = (event: ChangeEvent<HTMLInputElement>, localeCode: string) => {
@@ -22,13 +22,6 @@ const Edit = ({option, saveAttributeOption}: EditProps) => {
         let updatedOption: AttributeOption = {...option};
         updatedOption.optionValues[localeCode].value = event.target.value;
         setUpdatedOption(updatedOption);
-    };
-
-    const saveOption = () => {
-        if (updatedOption !== null) {
-            saveAttributeOption(updatedOption);
-            setUpdatedOption(null);
-        }
     };
 
     return (
@@ -57,7 +50,7 @@ const Edit = ({option, saveAttributeOption}: EditProps) => {
                         </div>
                     );
                 })}
-                <button className="AknButton AknButton--apply save" role="save-options-translations" onClick={() => saveOption()}>
+                <button className="AknButton AknButton--apply save" role="save-options-translations" onClick={() => saveAttributeOption(updatedOption)}>
                     {translate('pim_common.done')}
                 </button>
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/List.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/List.tsx
@@ -10,9 +10,10 @@ interface ListProps {
     selectAttributeOption: (selectedOptionId: number | null) => void;
     showNewOptionForm: (isDisplayed: boolean) => void;
     selectedOptionId: number | null;
+    deleteAttributeOption: (attributeOptionId: number) => void;
 }
 
-const List = ({selectAttributeOption, selectedOptionId, showNewOptionForm}: ListProps) => {
+const List = ({selectAttributeOption, selectedOptionId, showNewOptionForm, deleteAttributeOption}: ListProps) => {
     const attributeOptions = useAttributeOptions();
     const translate = useTranslate();
     const [showNewOptionPlaceholder, setShowNewOptionPlaceholder] = useState<boolean>(false);
@@ -35,6 +36,14 @@ const List = ({selectAttributeOption, selectedOptionId, showNewOptionForm}: List
         showNewOptionForm(true);
     };
 
+    const cancelNewOption = () => {
+        showNewOptionForm(false);
+        setShowNewOptionPlaceholder(false);
+        if (attributeOptions !== null && attributeOptions.length > 0) {
+            selectAttributeOption(attributeOptions[0].id);
+        }
+    };
+
     return (
         <div className="AknSubsection AknAttributeOption-list">
             <div className="AknSubsection-title AknSubsection-title--glued tabsection-title">
@@ -55,10 +64,12 @@ const List = ({selectAttributeOption, selectedOptionId, showNewOptionForm}: List
                             data={attributeOption}
                             onSelectAttributeOption={onSelectItem}
                             isSelected={selectedOptionId === attributeOption.id}
+                            deleteAttributeOption={deleteAttributeOption}
                         />
                     );
                 })}
-                {showNewOptionPlaceholder === true && (<NewOptionPlaceholder/>)}
+
+                {showNewOptionPlaceholder === true && (<NewOptionPlaceholder cancelNewOption={cancelNewOption}/>)}
             </div>
         </div>
     );

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/List.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/List.tsx
@@ -62,7 +62,7 @@ const List = ({selectAttributeOption, selectedOptionId, showNewOptionForm, delet
                         <ListItem
                             key={attributeOption.code}
                             data={attributeOption}
-                            onSelectAttributeOption={onSelectItem}
+                            selectAttributeOption={onSelectItem}
                             isSelected={selectedOptionId === attributeOption.id}
                             deleteAttributeOption={deleteAttributeOption}
                         />

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/ListItem.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/ListItem.tsx
@@ -1,21 +1,42 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {AttributeOption} from '../model';
+import DeleteConfirmationModal from './DeleteConfirmationModal';
 
 interface AttributeOptionItemProps {
     data: AttributeOption;
-    onSelectAttributeOption: (selectedOptionId: number) => void;
+    selectAttributeOption: (selectedOptionId: number) => void;
     isSelected: boolean;
     deleteAttributeOption: (optionId: number) => void;
 }
 
-const ListItem = ({data, onSelectAttributeOption, isSelected, deleteAttributeOption}: AttributeOptionItemProps) => {
+const ListItem = ({data, selectAttributeOption, isSelected, deleteAttributeOption}: AttributeOptionItemProps) => {
+    const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] = useState<boolean>(false);
+
+    const deleteOption = () => {
+        setShowDeleteConfirmationModal(false);
+        deleteAttributeOption(data.id);
+    };
+
+    const cancelDelete = () => {
+        setShowDeleteConfirmationModal(false);
+    };
+
     return (
-        <div className={`AknAttributeOption-listItem ${isSelected ? 'AknAttributeOption-listItem--selected' : ''}`} role="attribute-option-item">
-            <span className="AknAttributeOption-itemCode" onClick={() => onSelectAttributeOption(data.id)} role="attribute-option-item-label">
-                {data.code}
-            </span>
-            <span className="AknAttributeOption-delete-option-icon" onClick={() => deleteAttributeOption(data.id)}/>
-        </div>
+        <>
+            <div className={`AknAttributeOption-listItem ${isSelected ? 'AknAttributeOption-listItem--selected' : ''}`} role="attribute-option-item">
+                <span className="AknAttributeOption-itemCode" onClick={() => selectAttributeOption(data.id)} role="attribute-option-item-label">
+                    {data.code}
+                </span>
+                <span className="AknAttributeOption-delete-option-icon" onClick={() => setShowDeleteConfirmationModal(true)} role="attribute-option-delete-button"/>
+            </div>
+            {showDeleteConfirmationModal && (
+                <DeleteConfirmationModal
+                    attributeOptionCode={data.code}
+                    confirmDelete={deleteOption}
+                    cancelDelete={cancelDelete}
+                />)
+            }
+        </>
     );
 };
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/ListItem.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/ListItem.tsx
@@ -5,14 +5,16 @@ interface AttributeOptionItemProps {
     data: AttributeOption;
     onSelectAttributeOption: (selectedOptionId: number) => void;
     isSelected: boolean;
+    deleteAttributeOption: (optionId: number) => void;
 }
 
-const ListItem = ({data, onSelectAttributeOption, isSelected}: AttributeOptionItemProps) => {
+const ListItem = ({data, onSelectAttributeOption, isSelected, deleteAttributeOption}: AttributeOptionItemProps) => {
     return (
         <div className={`AknAttributeOption-listItem ${isSelected ? 'AknAttributeOption-listItem--selected' : ''}`} role="attribute-option-item">
             <span className="AknAttributeOption-itemCode" onClick={() => onSelectAttributeOption(data.id)} role="attribute-option-item-label">
                 {data.code}
             </span>
+            <span className="AknAttributeOption-delete-option-icon" onClick={() => deleteAttributeOption(data.id)}/>
         </div>
     );
 };

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/NewOptionPlaceholder.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/NewOptionPlaceholder.tsx
@@ -13,7 +13,7 @@ const NewOptionPlaceholder = ({cancelNewOption}: newOptionPlaceholderProps) => {
             <span className="AknAttributeOption-itemCode">
                 {translate('pim_enrich.entity.attribute_option.module.edit.new_option_code')}
             </span>
-            <span className="AknAttributeOption-cancel-new-option-icon" onClick={() => cancelNewOption()}/>
+            <span className="AknAttributeOption-cancel-new-option-icon" onClick={() => cancelNewOption()} role="new-option-cancel"/>
         </div>
     );
 };

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/NewOptionPlaceholder.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/NewOptionPlaceholder.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import {useTranslate} from '@akeneo-pim-community/legacy-bridge';
 
-const NewOptionPlaceholder = () => {
+interface newOptionPlaceholderProps {
+  cancelNewOption: () => void;
+}
+
+const NewOptionPlaceholder = ({cancelNewOption}: newOptionPlaceholderProps) => {
     const translate = useTranslate();
 
     return (
@@ -9,6 +13,7 @@ const NewOptionPlaceholder = () => {
             <span className="AknAttributeOption-itemCode">
                 {translate('pim_enrich.entity.attribute_option.module.edit.new_option_code')}
             </span>
+            <span className="AknAttributeOption-cancel-new-option-icon" onClick={() => cancelNewOption()}/>
         </div>
     );
 };

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useCreateAttributeOption.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useCreateAttributeOption.ts
@@ -22,6 +22,12 @@ const useCreateAttributeOption = () => {
             }
         );
 
+        switch (response.status) {
+        case 400:
+            const responseContent = await response.json();
+            throw responseContent.code;
+        }
+
         return await response.json();
     };
 };

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useDeleteAttributeOption.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useDeleteAttributeOption.ts
@@ -22,7 +22,7 @@ const useDeleteAttributeOption = () => {
         switch (response.status) {
         case 400:
             const responseContent = await response.json();
-            throw Error(responseContent.message);
+            throw responseContent.message;
         }
     };
 };

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useDeleteAttributeOption.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useDeleteAttributeOption.ts
@@ -1,0 +1,30 @@
+import {useRouter} from '@akeneo-pim-community/legacy-bridge';
+import {useAttributeContext} from '../contexts';
+
+const useDeleteAttributeOption = () => {
+    const router = useRouter();
+    const attribute = useAttributeContext();
+
+    return async (attributeOptionId: number) => {
+        const response = await fetch(
+            router.generate('pim_enrich_attributeoption_delete', {
+                attributeId: attribute.attributeId,
+                attributeOptionId: attributeOptionId,
+            }),
+            {
+                method: 'DELETE',
+                headers: [
+                    ['Content-type', 'application/json'],
+                    ['X-Requested-With', 'XMLHttpRequest'],
+                ],
+            }
+        );
+        switch (response.status) {
+        case 400:
+            const responseContent = await response.json();
+            throw Error(responseContent.message);
+        }
+    };
+};
+
+export {useDeleteAttributeOption};

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useSaveAttributeOption.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useSaveAttributeOption.ts
@@ -7,7 +7,7 @@ const useSaveAttributeOption = () => {
     const attribute = useAttributeContext();
 
     return async (attributeOption: AttributeOption) => {
-        await fetch(
+        const response = await fetch(
             router.generate('pim_enrich_attributeoption_update', {
                 attributeId: attribute.attributeId,
                 attributeOptionId: attributeOption.id,
@@ -21,6 +21,16 @@ const useSaveAttributeOption = () => {
                 body: JSON.stringify(attributeOption),
             }
         );
+        switch (response.status) {
+        case 400:
+            const responseContent = await response.json();
+            if (responseContent.hasOwnProperty('code')) {
+                throw responseContent.code;
+            }
+            if (responseContent.hasOwnProperty('optionValues')) {
+                throw responseContent.optionValues;
+            }
+        }
     };
 };
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/reducers/attributeOptionsReducer.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/reducers/attributeOptionsReducer.ts
@@ -49,6 +49,22 @@ export const createAttributeOptionAction: ActionCreator<CreateAttributeOptionAct
     };
 };
 
+interface DeleteAttributeOptionAction extends Action {
+    payload: {
+        optionId: number;
+    };
+}
+
+const DELETE_ATTRIBUTE_OPTION = 'DELETE_ATTRIBUTE_OPTION';
+export const deleteAttributeOptionAction: ActionCreator<DeleteAttributeOptionAction> = (optionId: number) => {
+    return {
+        type: DELETE_ATTRIBUTE_OPTION,
+        payload: {
+            optionId: optionId,
+        }
+    };
+};
+
 const attributeOptionsReducer: Reducer<AttributeOption[] | null> = (previousState = null, {type, payload}) => {
     switch (type) {
     case INITIALIZE_ATTRIBUTE_OPTIONS: {
@@ -74,6 +90,17 @@ const attributeOptionsReducer: Reducer<AttributeOption[] | null> = (previousStat
         }
 
         return [...previousState, payload.option];
+    }
+    case DELETE_ATTRIBUTE_OPTION: {
+        if (previousState === null) {
+            return previousState;
+        }
+
+        const index = previousState.findIndex((attributeOption: AttributeOption) => attributeOption.id === payload.optionId);
+        let newState = [...previousState];
+        newState.splice(index, 1);
+
+        return newState;
     }
     default:
         return previousState;

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/reducers/index.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/reducers/index.ts
@@ -2,6 +2,7 @@ import attributeOptionsReducer, {
     initializeAttributeOptionsAction,
     updateAttributeOptionAction,
     createAttributeOptionAction,
+    deleteAttributeOptionAction,
 } from './attributeOptionsReducer';
 
 export {
@@ -9,4 +10,5 @@ export {
     updateAttributeOptionAction,
     createAttributeOptionAction,
     attributeOptionsReducer,
+    deleteAttributeOptionAction,
 };

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/less/attribute-option.less
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/less/attribute-option.less
@@ -11,6 +11,9 @@
   &-listItem {
     line-height: 54px;
     border-bottom: 1px @AknGrey60 solid;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 
     &--selected {
       background-color: @AknBlue20;
@@ -20,8 +23,14 @@
       margin-top: 20px;
     }
 
-    &:hover:not(&--selected) {
-      background-color: @AknLightGray;
+    &:hover {
+      :not(&--selected) {
+        background-color: @AknLightGray;
+      }
+
+      .AknAttributeOption-delete-option-icon {
+        display: block;
+      }
     }
 
     .AknAttributeOption-itemCode {
@@ -30,6 +39,18 @@
       text-transform: uppercase;
       color: @AknLightPurple;
       cursor: pointer;
+    }
+
+    .AknAttributeOption-cancel-new-option-icon, .AknAttributeOption-delete-option-icon {
+      margin-right: 20px;
+      background: url("/bundles/pimui/images/icon-delete-slategrey.svg") no-repeat center;
+      width: 16px;
+      height: 16px;
+      cursor: pointer;
+      display: none;
+    }
+    .AknAttributeOption-cancel-new-option-icon {
+      display: block;
     }
   }
 

--- a/tests/front/unit/structure/attribute-option/components/Edit.unit.tsx
+++ b/tests/front/unit/structure/attribute-option/components/Edit.unit.tsx
@@ -78,8 +78,6 @@ describe('Edit an attribute option', () => {
 
         const saveButton = getByRole(container, 'save-options-translations');
         expect(saveButton).toBeInTheDocument();
-        await fireEvent.click(saveButton);
-        expect(saveCallback).toHaveBeenCalledTimes(0);
 
         await fireEvent.change(translations[0], {target: {value: 'Black 2'}});
         await fireEvent.click(saveButton);

--- a/tests/front/unit/structure/attribute-option/components/List.unit.tsx
+++ b/tests/front/unit/structure/attribute-option/components/List.unit.tsx
@@ -90,6 +90,10 @@ describe('Attribute options list', () => {
 
         expect(newOptionPlaceholder).toBeInTheDocument();
         expect(showNewOptionFormCallback).toHaveBeenNthCalledWith(1, true);
+
+        const cancelNewOptionButton = getByRole(container, 'new-option-cancel');
+        fireEvent.click(cancelNewOptionButton);
+        expect(newOptionPlaceholder).not.toBeInTheDocument();
     });
 
     test('it allows option selection', async () => {
@@ -121,14 +125,19 @@ describe('Attribute options list', () => {
 async function renderComponent(selectOptionCallback, showNewOptionFormCallback, selectedOptionId = null) {
     await act(async () => {
         ReactDOM.render(
-          <DependenciesProvider>
-              <Provider store={createStoreWithInitialState({})}>
-                  <AttributeContextProvider attributeId={8}>
-                      <List selectAttributeOption={selectOptionCallback} showNewOptionForm={showNewOptionFormCallback} selectedOptionId={selectedOptionId}/>
-                  </AttributeContextProvider>
-              </Provider>
-          </DependenciesProvider>,
-          container
+            <DependenciesProvider>
+                <Provider store={createStoreWithInitialState({})}>
+                    <AttributeContextProvider attributeId={8}>
+                        <List
+                            selectAttributeOption={selectOptionCallback}
+                            showNewOptionForm={showNewOptionFormCallback}
+                            selectedOptionId={selectedOptionId}
+                            deleteAttributeOption={jest.fn()}
+                        />
+                    </AttributeContextProvider>
+                </Provider>
+            </DependenciesProvider>,
+            container
         );
     });
 }

--- a/tests/front/unit/structure/attribute-option/components/ListItem.unit.tsx
+++ b/tests/front/unit/structure/attribute-option/components/ListItem.unit.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import * as ReactDOM from 'react-dom';
 import '@testing-library/jest-dom/extend-expect';
-import {act, fireEvent, getByRole} from '@testing-library/react';
+import {act, fireEvent, getByRole, queryByRole, queryAllByRole} from '@testing-library/react';
 import ListItem from 'akeneopimstructure/js/attribute-option/components/ListItem';
 import {AttributeOption} from 'akeneopimstructure/js/attribute-option/model';
+import {DependenciesProvider} from '@akeneo-pim-community/legacy-bridge';
 
 let container: HTMLElement;
 
@@ -16,33 +17,28 @@ afterEach(() => {
     document.body.removeChild(container);
 });
 
+const option: AttributeOption = {
+    id: 80,
+    code: 'black',
+    optionValues: {
+        en_US: {
+            id: 1,
+            value: 'Black',
+            locale: 'en_US',
+        },
+        fr_FR: {
+            id: 2,
+            value: 'Noir',
+            locale: 'fr_FR',
+        },
+    },
+};
+
 describe('Attribute options list item', () => {
     test('it renders a list item', async () => {
-        const option: AttributeOption = {
-            id: 80,
-            code: 'black',
-            optionValues: {
-                en_US: {
-                    id: 1,
-                    value: 'Black',
-                    locale: 'en_US',
-                },
-                fr_FR: {
-                    id: 2,
-                    value: 'Noir',
-                    locale: 'fr_FR',
-                },
-            },
-        };
-
         const onSelectCallback = jest.fn();
 
-        await act(async () => {
-            ReactDOM.render(
-                <ListItem data={option} onSelectAttributeOption={onSelectCallback} isSelected={true} />,
-                container
-            );
-        });
+        await renderComponent(onSelectCallback, jest.fn());
 
         const attributeOption = getByRole(container, 'attribute-option-item');
         expect(attributeOption).toHaveClass('AknAttributeOption-listItem--selected');
@@ -51,4 +47,66 @@ describe('Attribute options list item', () => {
         await fireEvent.click(attributeOptionLabel);
         expect(onSelectCallback).toHaveBeenNthCalledWith(1, 80);
     });
+
+    test('it allows attribute option to be deleted', async () => {
+        const deleteAttributeOptionCallback = jest.fn();
+
+        await renderComponent(jest.fn(), deleteAttributeOptionCallback);
+
+        const deleteButton = getByRole(container, 'attribute-option-delete-button');
+        let deleteConfirmationModal = queryByRole(container, 'attribute-option-delete-confirmation-modal');
+        expect(deleteConfirmationModal).not.toBeInTheDocument();
+
+        await fireEvent.click(deleteButton);
+
+        deleteConfirmationModal = getByRole(container, 'attribute-option-delete-confirmation-modal');
+        const confirmDeleteButton = getByRole(container, 'attribute-option-confirm-delete-button');
+        const cancelButtons = queryAllByRole(container, 'attribute-option-confirm-cancel-button');
+
+        expect(deleteAttributeOptionCallback).not.toHaveBeenCalled();
+        expect(deleteConfirmationModal).toBeInTheDocument();
+        expect(cancelButtons).toHaveLength(2);
+
+        await fireEvent.click(confirmDeleteButton);
+        expect(deleteAttributeOptionCallback).toHaveBeenCalled();
+    });
+
+    test('the attribute option deletion can be cancelled with the 2 cancel buttons', async () => {
+        const deleteAttributeOptionCallback = jest.fn();
+
+        await renderComponent(jest.fn(), deleteAttributeOptionCallback);
+
+        const deleteButton = getByRole(container, 'attribute-option-delete-button');
+        await fireEvent.click(deleteButton);
+        const deleteConfirmationModal = getByRole(container, 'attribute-option-delete-confirmation-modal');
+        let cancelButtons = queryAllByRole(container, 'attribute-option-confirm-cancel-button');
+
+        expect(cancelButtons).toHaveLength(2);
+
+        await fireEvent.click(cancelButtons[0]);
+        expect(deleteAttributeOptionCallback).not.toHaveBeenCalled();
+        expect(deleteConfirmationModal).not.toBeInTheDocument();
+
+        await fireEvent.click(deleteButton);
+        cancelButtons = queryAllByRole(container, 'attribute-option-confirm-cancel-button');
+        await fireEvent.click(cancelButtons[1]);
+        expect(deleteAttributeOptionCallback).not.toHaveBeenCalled();
+        expect(deleteConfirmationModal).not.toBeInTheDocument();
+    });
 });
+
+async function renderComponent(selectAttributeOptionCallback, deleteAttributeOptionCallback) {
+    await act(async () => {
+        ReactDOM.render(
+            <DependenciesProvider>
+                <ListItem
+                    data={option}
+                    selectAttributeOption={selectAttributeOptionCallback}
+                    isSelected={true}
+                    deleteAttributeOption={deleteAttributeOptionCallback}
+                />
+            </DependenciesProvider>,
+            container
+        );
+    });
+}

--- a/tests/front/unit/structure/attribute-option/reducers/attributeOptionsReducer.unit.ts
+++ b/tests/front/unit/structure/attribute-option/reducers/attributeOptionsReducer.unit.ts
@@ -3,6 +3,7 @@ import {
     initializeAttributeOptionsAction,
     updateAttributeOptionAction,
     createAttributeOptionAction,
+    deleteAttributeOptionAction,
 } from 'akeneopimstructure/js/attribute-option/reducers';
 
 const blackAndBlueOptions = [
@@ -155,5 +156,56 @@ describe('Attribute options reducer', () => {
             })
           )
         ).toBeNull();
+    });
+
+    test('delete an attribute option', () => {
+        expect(
+          attributeOptionsReducer(
+            [
+                {
+                    "id": 85,
+                    "code": "black",
+                    "optionValues": {
+                        "en_US": {"id":252,"locale":"en_US","value":"Black"},
+                        "fr_FR":{"id":253,"locale":"fr_FR","value":"Noir"}
+                    }
+                },
+                {
+                    "id": 86,
+                    "code": "blue",
+                    "optionValues": {
+                        "en_US": {"id":255,"locale":"en_US","value":"Blue"},
+                        "fr_FR":{"id":256,"locale":"fr_FR","value":"Bleu"}
+                    }
+                },
+                {
+                    "id": 115,
+                    "code": "yellow",
+                    "optionValues": {
+                        "en_US": {"id":350,"locale":"en_US","value":"Yellow"},
+                        "fr_FR":{"id":351,"locale":"fr_FR","value":"Jaune"}
+                    }
+                }
+            ],
+            deleteAttributeOptionAction(115)
+          )
+        ).toMatchObject([
+            {
+                "id": 85,
+                "code": "black",
+                "optionValues": {
+                    "en_US": {"id":252,"locale":"en_US","value":"Black"},
+                    "fr_FR":{"id":253,"locale":"fr_FR","value":"Noir"}
+                }
+            },
+            {
+                "id": 86,
+                "code": "blue",
+                "optionValues": {
+                    "en_US": {"id":255,"locale":"en_US","value":"Blue"},
+                    "fr_FR":{"id":256,"locale":"fr_FR","value":"Bleu"}
+                }
+            },
+        ]);
     });
 });

--- a/tests/front/unit/structure/attribute-option/reducers/attributeOptionsReducer.unit.ts
+++ b/tests/front/unit/structure/attribute-option/reducers/attributeOptionsReducer.unit.ts
@@ -89,14 +89,7 @@ describe('Attribute options reducer', () => {
         expect(
           attributeOptionsReducer(
             null,
-            updateAttributeOptionAction({
-                "id": 86,
-                "code": "blue",
-                "optionValues": {
-                    "en_US": {"id":255,"locale":"en_US","value":"Blue 2"},
-                    "fr_FR":{"id":256,"locale":"fr_FR","value":"Bleu 2"}
-                }
-            })
+            updateAttributeOptionAction({})
           )
         ).toBeNull();
     });
@@ -146,14 +139,7 @@ describe('Attribute options reducer', () => {
         expect(
           attributeOptionsReducer(
             null,
-            createAttributeOptionAction({
-                "id": 86,
-                "code": "blue",
-                "optionValues": {
-                    "en_US": {"id":255,"locale":"en_US","value":"Blue 2"},
-                    "fr_FR":{"id":256,"locale":"fr_FR","value":"Bleu 2"}
-                }
-            })
+            createAttributeOptionAction({})
           )
         ).toBeNull();
     });
@@ -207,5 +193,14 @@ describe('Attribute options reducer', () => {
                 }
             },
         ]);
+    });
+
+    test('delete an attribute option with an empty state', () => {
+        expect(
+            attributeOptionsReducer(
+                null,
+                deleteAttributeOptionAction({})
+            )
+        ).toBeNull();
     });
 });


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
2 features in this PR: Attribute option deletion (with a confirmation modal) + new option cancellation.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
