### PR TITLE
PIM-9291: Fix product updated with a text value made of spaces only

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,6 +6,7 @@
 - CXP-306: Fix the collect of product events
 - PIM-9282: Make calling attribute options via API case insensitive
 - PIM-9290: Fix product categories loading
+- PIM-9291: Fix product updated with a text value made of spaces only
 
 # 4.0.31 (2020-06-01)
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Builder/EntityWithValuesBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Builder/EntityWithValuesBuilder.php
@@ -56,7 +56,7 @@ class EntityWithValuesBuilder implements EntityWithValuesBuilderInterface
 
         $formerValue = $entityWithValues->getValue($attribute->code(), $localeCode, $channelCode);
         $isFormerValueFilled = null !== $formerValue && '' !== $formerValue && [] !== $formerValue;
-        $isNewValueFilled = null !== $data && '' !== $data && [] !== $data;
+        $isNewValueFilled = null !== $data && !$this->isEmptyStringValue($data) && [] !== $data;
 
         if (!$isFormerValueFilled && $isNewValueFilled) {
             return $this->createValue($entityWithValues, $attribute, $localeCode, $channelCode, $data);
@@ -71,6 +71,11 @@ class EntityWithValuesBuilder implements EntityWithValuesBuilderInterface
         }
 
         return null;
+    }
+
+    private function isEmptyStringValue($value): bool
+    {
+        return is_string($value) && '' === trim($value);
     }
 
     private function createValue(

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Builder/EntityWithValuesBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Builder/EntityWithValuesBuilderSpec.php
@@ -62,6 +62,23 @@ class EntityWithValuesBuilderSpec extends ObjectBehavior
         $this->addOrReplaceValue($product, $color, 'en_US', 'ecommerce', null);
     }
 
+    function it_considers_a_value_made_of_spaces_only_as_empty(
+        $productValueFactory,
+        ProductInterface $product,
+        AttributeInterface $label,
+        ValueInterface $labelValue
+    ) {
+        $label->getCode()->willReturn('label');
+        $product->getValue('label', null, null)->willReturn($labelValue);
+
+        $product->removeValue($labelValue)->willReturn($product);
+
+        $productValueFactory->createByCheckingData(Argument::cetera())->shouldNotBeCalled();
+        $product->addValue(Argument::any())->shouldNotBecalled();
+
+        $this->addOrReplaceValue($product, $label, null, null, ' ');
+    }
+
     function it_adds_a_non_empty_product_value(
         $productValueFactory,
         ProductInterface $product,


### PR DESCRIPTION
Updating a product with a text value made of spaces only generates a server error. So the product cannot be updated, and the error message displayed is only "The product could not be updated."  The user cannot know what's the problem and what attribute causes this problem. (it occurs for UI, API, and imports)

The error comes from the service `TextValueFactory` https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/TextValueFactory.php that doesn't accept empty strings and considers legitimately a string made of spaces only as empty.

There's surely a more global problem about trailing spaces, but I think that as an SLA fix, it's better to only focus on this precise problem: to not consider a string made of spaces only as a non-empty value for a product attribute. If a "trim" is made too soon on the values it can generate side effects.

So I think that the best place to "trim" the value is in `src/Akeneo/Pim/Enrichment/Component/Product/Builder/EntityWithValuesBuilder.php`. The service `TextValueFactory` should not be called at all.