### PR TITLE
PIM-9282 : make calling attribute options via API case unsensitive

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9282: Make calling attribute options via API case insensitive
+
 # 3.2.58 (2020-06-01)
 
 # 3.2.57 (2020-05-28)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
@@ -138,7 +138,7 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
             $attributeOptions
         );
 
-        $unexistingValues = array_diff($values, $optionCodes);
+        $unexistingValues = array_udiff($values, $optionCodes, 'strcasecmp');
         if (count($unexistingValues) > 0) {
             throw new ObjectNotFoundException(
                 sprintf(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Same as https://github.com/akeneo/pim-community-dev/pull/12201 but for PIM 3.2.
**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
