### PR TITLE
RUL-276: ObjectNotFoundException extends \LogicException

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Exception/ObjectNotFoundException.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Exception/ObjectNotFoundException.php
@@ -9,7 +9,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Exception;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ObjectNotFoundException extends \Exception
+class ObjectNotFoundException extends \LogicException
 {
     /**
      * @param string     $message


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The phpDoc of [`ProductQueryBuilderInterface::addFilter()`](https://github.com/akeneo/pim-community-dev/blob/55841bceae131dbe475042f45fcf1d86ffb75745/src/Akeneo/Pim/Enrichment/Component/Product/Query/ProductQueryBuilderInterface.php#L30) states that it can only throw `\LogicException`, but some filters throw `ObjectNotFoundException`s, which directly extends the base `\Exception`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
