### PR TITLE
PIM-6978: Fix products load twice at first connection

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -29,6 +29,7 @@
 
 - PIM-9203: Box shadow appearing on category selector in product grid
 - PIM-9250: Display glitch - vertical grey lines appear when opening category tree
+- PIM-6978: Products grid loaded twice
 - AOB-968: Fix product label rendering on edit form
 - CXP-306: Fix the collect of product events
 - PIM-9282: Make calling attribute options via API case insensitive

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-selector.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-selector.ts
@@ -185,6 +185,12 @@ class FiltersSelector extends BaseView {
     const currentState: FilterState = this.datagridCollection.state.filters;
     const updatedState: FilterState = Object.assign(this.getState(), categoryFilter);
 
+    // currentState === [] means there is no defined filter during the user session (backend api), fallback on the default init one
+    if (Array.isArray(currentState)) {
+      this.datagridCollection.state.filters = updatedState;
+      return;
+    }
+
     const stateHasChanged = !_.isEqual(currentState, updatedState);
     const currentStateIsEmpty = _.isEmpty(currentState);
     const shouldReloadState = (stateHasChanged || currentStateIsEmpty) && false === this.silent;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
Fix : https://akeneo.atlassian.net/browse/PIM-6978
Here it's a front solution, a backend one may be better.
If we have from the backend a state.filters = [], we know that there is no current filter active on the page.
But when the grid is loaded, front activate a default filter.
```json
{"category":
   {"type": 1,
    "value" : {"treeId": 1, "categoryId": -2}
   },
    "scope": {"value": "ecommerce"} 
}
```
So we can avoid the fetch, deducing from the empty array value (becoming an object later on).
~~A better (and stronger solution) could be to have the default value set by the backend and just make a equality between the two values.
Question here is what do we want as an api contract for that.~~
Discussed with the maintenance team the fix seems ok for now but needs some intensive QA testing.

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
