### PR TITLE
GITHUB-APD-158: hardcode version name as master to allow correct analytics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,6 +400,8 @@ jobs:
         -   run:
                 name: Test missing database and index structure migrations
                 command: vendor/akeneo/pim-community-dev/.circleci/detect_structure_changes.sh ${CIRCLE_BRANCH}
+        - store_artifacts:
+              path: /tmp/structure_changes
 
   test_back_data_migrations:
       machine:

--- a/.circleci/detect_structure_changes.sh
+++ b/.circleci/detect_structure_changes.sh
@@ -30,6 +30,8 @@ else
     PR_BRANCH=$1
 fi
 
+mkdir /tmp/structure_changes
+
 ## STEP 1: install 4.0 database and index
 echo "##"
 echo "## STEP 1: install 4.0 database and index"
@@ -107,10 +109,10 @@ echo "Launch branch migrations..."
 docker-compose run -u www-data php bin/console doctrine:migrations:migrate --env=test --no-interaction
 
 echo "Dump 4.0 with migrations database..."
-docker-compose exec -T mysql mysqldump --no-data --skip-opt --skip-comments --password=$APP_DATABASE_PASSWORD --user=$APP_DATABASE_USER $APP_DATABASE_NAME | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > /tmp/dump_40_database_with_migrations.sql
+docker-compose exec -T mysql mysqldump --no-data --skip-opt --skip-comments --password=$APP_DATABASE_PASSWORD --user=$APP_DATABASE_USER $APP_DATABASE_NAME | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > /tmp/structure_changes/dump_40_database_with_migrations.sql
 
 echo "Dump 4.0 with migrations index..."
-docker-compose exec -T elasticsearch curl -XGET "$APP_INDEX_HOSTS/_all/_mapping"|json_pp --json_opt=canonical,pretty > /tmp/dump_40_index_with_migrations.json
+docker-compose exec -T elasticsearch curl -XGET "$APP_INDEX_HOSTS/_all/_mapping"|json_pp --json_opt=canonical,pretty > /tmp/structure_changes/dump_40_index_with_migrations.json
 
 
 ## STEP 3: install fresh branch database and indexes
@@ -122,10 +124,10 @@ echo "Install fresh branch database and indexes..."
 APP_ENV=test make database
 
 echo "Dump branch database..."
-docker-compose exec -T mysql mysqldump --no-data --skip-opt --skip-comments --password=$APP_DATABASE_PASSWORD --user=$APP_DATABASE_USER $APP_DATABASE_NAME | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > /tmp/dump_branch_database.sql
+docker-compose exec -T mysql mysqldump --no-data --skip-opt --skip-comments --password=$APP_DATABASE_PASSWORD --user=$APP_DATABASE_USER $APP_DATABASE_NAME | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > /tmp/structure_changes/dump_branch_database.sql
 
 echo "Dump branch index..."
-docker-compose exec -T elasticsearch curl -XGET "$APP_INDEX_HOSTS/_all/_mapping"|json_pp --json_opt=canonical,pretty > /tmp/dump_branch_index.json
+docker-compose exec -T elasticsearch curl -XGET "$APP_INDEX_HOSTS/_all/_mapping"|json_pp --json_opt=canonical,pretty > /tmp/structure_changes/dump_branch_index.json
 
 
 ## STEP 4: compare the results
@@ -134,9 +136,9 @@ echo "## STEP 4: compare the results"
 echo "##"
 
 echo "Compare database 40+PR migrations from database PR..."
-diff /tmp/dump_40_database_with_migrations.sql /tmp/dump_branch_database.sql --context=10
+diff /tmp/structure_changes/dump_40_database_with_migrations.sql /tmp/structure_changes/dump_branch_database.sql --context=10
 
 echo "Compare index 40+PR migrations from index PR..."
-sed -i -r 's/[0-9]+_[0-9]+_[0-9]+_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/version_uuid/g' /tmp/dump_40_index_with_migrations.json
-sed -i -r 's/[0-9]+_[0-9]+_[0-9]+_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/version_uuid/g' /tmp/dump_branch_index.json
-diff /tmp/dump_40_index_with_migrations.json /tmp/dump_branch_index.json --context=10
+sed -i -r 's/[0-9]+_[0-9]+_[0-9]+_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/version_uuid/g' /tmp/structure_changes/dump_40_index_with_migrations.json
+sed -i -r 's/[0-9]+_[0-9]+_[0-9]+_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/version_uuid/g' /tmp/structure_changes/dump_branch_index.json
+diff /tmp/structure_changes/dump_40_index_with_migrations.json /tmp/structure_changes/dump_branch_index.json --context=10

--- a/.circleci/detect_structure_changes.sh
+++ b/.circleci/detect_structure_changes.sh
@@ -139,6 +139,6 @@ echo "Compare database 40+PR migrations from database PR..."
 diff /tmp/structure_changes/dump_40_database_with_migrations.sql /tmp/structure_changes/dump_branch_database.sql --context=10
 
 echo "Compare index 40+PR migrations from index PR..."
-sed -i -r 's/[0-9]+_[0-9]+_[0-9]+_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/version_uuid/g' /tmp/structure_changes/dump_40_index_with_migrations.json
-sed -i -r 's/[0-9]+_[0-9]+_[0-9]+_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/version_uuid/g' /tmp/structure_changes/dump_branch_index.json
+sed -i -r 's/([0-9]+_[0-9]+_[0-9]+_)?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/version_uuid/g' /tmp/structure_changes/dump_40_index_with_migrations.json
+sed -i -r 's/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/version_uuid/g' /tmp/structure_changes/dump_branch_index.json
 diff /tmp/structure_changes/dump_40_index_with_migrations.json /tmp/structure_changes/dump_branch_index.json --context=10

--- a/src/Akeneo/Platform/CommunityVersion.php
+++ b/src/Akeneo/Platform/CommunityVersion.php
@@ -12,10 +12,10 @@ namespace Akeneo\Platform;
 class CommunityVersion
 {
     /** @staticvar string */
-    const VERSION = '4.0.35';
+    const VERSION = 'master';
 
     /** @staticvar string */
-    const VERSION_CODENAME = 'Hare Tonic';
+    const VERSION_CODENAME = 'Community master';
 
     /** @staticvar string */
     const EDITION = 'CE';

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
@@ -261,7 +261,7 @@ class Client
         $body['aliases'] = [$this->indexName => (object) []];
 
         $params = [
-            'index' => strtolower($this->indexName . '_' . str_replace('.', '_', CommunityVersion::VERSION) . '_' . Uuid::uuid4()),
+            'index' => strtolower($this->indexName . '_' . Uuid::uuid4()),
             'body' => $body,
         ];
 

--- a/tests/back/Platform/Specification/CommunityVersionSpec.php
+++ b/tests/back/Platform/Specification/CommunityVersionSpec.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Specification\Akeneo\Platform;
+
+use Akeneo\Platform\CommunityVersion;
+use PhpSpec\ObjectBehavior;
+use PHPUnit\Framework\Assert;
+
+class CommunityVersionSpec extends ObjectBehavior
+{
+    /**
+     * Do not change it during a pull up.
+     * It is useful to hardcode it as master, as it allows to follow who installed CE master thanks to the analytics.
+     *
+     * Test to remove when tagging a major version.
+     */
+    function it_is_master_version()
+    {
+        Assert::assertSame('master', CommunityVersion::VERSION);
+        Assert::assertSame('Community master', CommunityVersion::VERSION_CODENAME);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
https://github.com/akeneo/actionable-product-data/issues/158

It's currently not possible to know how many CE users installed master version.
Actually, it's mixed with 4.0.X, which is not good good for analytics.

So, the solution is to hardcode it. I added a test to avoid a mistake during a pull-up. 

*Note*: I changed the `detect_structure_changes.sh` script. Actually, changing the version name has an impact on this script, even if it's run only in EE.
It's because when we create an ES index, we prefix it with the version name from the CE. We were somehow "lucky" it worked.

It's totally useless to put the version name when creating an index. I did that when we switched from index to alias. It was to help at finding what was the previous index and the target index. But in serenity, we have index prefixed with `3_2` and it's confusing.

Now, when we create an index, it's not prefixed anymore. There is no impact on the installed database.

*Note 2*: I changed the regex in `detect_structure_changes.sh` script, both for 4.0 and current branch. In theory, it should not for the 4.0, but there is an index created during a migration 
 (so, without the version name prefix): `akeneo_connectivity_connection_error_e6026edc-2a98-4893-b7b4-7871d7327edf`


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
