### PR TITLE
PIM-9203: Fix box shadow category tree

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-9203: Box shadow appearing on category selector in product grid
 - AOB-968: Fix product label rendering on edit form
 - CXP-306: Fix the collect of product events
 - PIM-9282: Make calling attribute options via API case insensitive

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
@@ -9,6 +9,9 @@
 }
 
 .jstree {
+  .select2-container-active .select2-choice {
+    box-shadow: none;
+  }
   &.jstree-default {
     & > ul {
       max-height: ~"calc(100vh - 213px)";


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
Fix : https://akeneo.atlassian.net/browse/PIM-9203
Remove box shadow from active select 2 container
<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
