### PR TITLE
DAPI-1036: allows attribute options to be manually reordered

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/AttributeOptions.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/AttributeOptions.tsx
@@ -8,7 +8,13 @@ import {AttributeOption} from '../model';
 import {useSaveAttributeOption} from '../hooks/useSaveAttributeOption';
 import {useCreateAttributeOption} from '../hooks/useCreateAttributeOption';
 import {useDeleteAttributeOption} from '../hooks/useDeleteAttributeOption';
-import {createAttributeOptionAction, deleteAttributeOptionAction, updateAttributeOptionAction} from '../reducers';
+import {useManualSortAttributeOptions} from '../hooks/useManualSortAttributeOptions';
+import {
+    createAttributeOptionAction,
+    deleteAttributeOptionAction,
+    initializeAttributeOptionsAction,
+    updateAttributeOptionAction
+} from '../reducers';
 import {useAttributeContext} from '../contexts';
 import {NotificationLevel, useNotify} from '@akeneo-pim-community/legacy-bridge';
 
@@ -20,6 +26,7 @@ const AttributeOptions = () => {
     const attributeOptionSaver = useSaveAttributeOption();
     const attributeOptionCreate = useCreateAttributeOption();
     const attributeOptionDelete = useDeleteAttributeOption();
+    const attributeOptionManualSort = useManualSortAttributeOptions();
     const dispatchAction = useDispatch();
     const attributeContext = useAttributeContext();
     const notify = useNotify();
@@ -93,6 +100,13 @@ const AttributeOptions = () => {
         setIsSaving(false);
     }, [attributeOptionDelete, setIsSaving, dispatchAction, notify, setSelectedOption, attributeOptions, selectedOption]);
 
+    const manuallySortAttributeOptions = useCallback(async (sortedAttributeOptions: AttributeOption[]) => {
+        setIsSaving(true);
+        await attributeOptionManualSort(sortedAttributeOptions);
+        dispatchAction(initializeAttributeOptionsAction(sortedAttributeOptions));
+        setIsSaving(false);
+    }, [setIsSaving, attributeOptionManualSort, dispatchAction]);
+
     return (
         <div className="AknAttributeOption">
             {(attributeOptions === null || isSaving) && <div className="AknLoadingMask"/>}
@@ -102,6 +116,7 @@ const AttributeOptions = () => {
                 selectedOptionId={selectedOption ? selectedOption.id : null}
                 showNewOptionForm={setShowNewOptionForm}
                 deleteAttributeOption={deleteAttributeOption}
+                manuallySortAttributeOptions={manuallySortAttributeOptions}
             />
 
             {(selectedOption !== null && <Edit option={selectedOption} saveAttributeOption={saveAttributeOption}/>)}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/ListItem.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/ListItem.tsx
@@ -1,39 +1,125 @@
-import React, {useState} from 'react';
+import React, {useState, useRef} from 'react';
 import {AttributeOption} from '../model';
 import DeleteConfirmationModal from './DeleteConfirmationModal';
+import {useAttributeContext} from '../contexts';
+
+export type DragItem = {
+    code: string;
+    index: number;
+};
 
 interface AttributeOptionItemProps {
     data: AttributeOption;
     selectAttributeOption: (selectedOptionId: number) => void;
     isSelected: boolean;
     deleteAttributeOption: (optionId: number) => void;
+    moveAttributeOption: (sourceOptionCode: string, targetOptionCode: string) => void;
+    validateMoveAttributeOption: () => void;
+    dragItem: DragItem | null;
+    setDragItem: (dragitem: DragItem | null) => void;
+    index: number;
 }
 
-const ListItem = ({data, selectAttributeOption, isSelected, deleteAttributeOption}: AttributeOptionItemProps) => {
+const ListItem = ({data, selectAttributeOption, isSelected, deleteAttributeOption, moveAttributeOption, validateMoveAttributeOption, dragItem, setDragItem, index}: AttributeOptionItemProps) => {
     const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] = useState<boolean>(false);
+    const attributeContext = useAttributeContext();
+    const rowRef = useRef(null);
 
     const deleteOption = () => {
         setShowDeleteConfirmationModal(false);
         deleteAttributeOption(data.id);
     };
 
-    const cancelDelete = () => {
-        setShowDeleteConfirmationModal(false);
+    const onDragStart = (event: any) => {
+        event.stopPropagation();
+        event.persist();
+        event.dataTransfer.setData('optionCode', data.code);
+        event.dataTransfer.setDragImage(rowRef.current, 0, 0);
+        setDragItem({code: data.code, index});
     };
+
+    const onDragStartCapture = (event: any) => {
+        if (attributeContext.autoSortOptions || !event.target.classList.contains('AknAttributeOption-move-icon')) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    };
+
+    const onDragEndCapture = (event: any) => {
+        if (attributeContext.autoSortOptions || !event.target.classList.contains('AknAttributeOption-move-icon')) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    };
+
+    const onDragOver = (event: any) => {
+        event.stopPropagation();
+        event.preventDefault();
+        event.persist();
+
+        if (dragItem === null || dragItem.code === data.code) {
+            return;
+        }
+
+        const hoverBoundingRect = event.target.getBoundingClientRect();
+        const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+        const hoverClientY = (event.clientY || event.target.clientY) - hoverBoundingRect.top;
+
+        // Dragging downwards
+        if (dragItem.index < index && hoverClientY < hoverMiddleY) {
+            return;
+        }
+        // Dragging upwards
+        if (dragItem.index > index && hoverClientY > hoverMiddleY) {
+            return;
+        }
+
+        moveAttributeOption(dragItem.code, data.code);
+    };
+
+    const onDrop = (event: any) => {
+        event.stopPropagation();
+        event.preventDefault();
+        event.persist();
+        if (dragItem !== null) {
+            validateMoveAttributeOption();
+            setDragItem(null);
+        }
+    };
+
+    const className = `AknAttributeOption-listItem ${isSelected || (dragItem !== null && dragItem.code === data.code) ? 'AknAttributeOption-listItem--selected' : ''}`;
 
     return (
         <>
-            <div className={`AknAttributeOption-listItem ${isSelected ? 'AknAttributeOption-listItem--selected' : ''}`} role="attribute-option-item">
-                <span className="AknAttributeOption-itemCode" onClick={() => selectAttributeOption(data.id)} role="attribute-option-item-label">
+            <div
+                className={className}
+                role="attribute-option-item"
+                onClick={() => selectAttributeOption(data.id)}
+                draggable={true}
+                onDragStartCapture={onDragStartCapture}
+                onDragEndCapture={onDragEndCapture}
+                onDragStart={onDragStart}
+                onDragOver={(event: any) => onDragOver(event)}
+                onDrop={(event: any) => onDrop(event)}
+                style={dragItem !== null && dragItem.code === data.code ? {opacity: 0.4} : {}}
+                ref={rowRef}
+            >
+                <span className={`AknAttributeOption-move-icon ${attributeContext.autoSortOptions ? 'AknAttributeOption-move-icon--disabled' : ''}`} draggable={true} role={'attribute-option-move-handle'}/>
+                <span className="AknAttributeOption-itemCode" role="attribute-option-item-label">
                     {data.code}
                 </span>
-                <span className="AknAttributeOption-delete-option-icon" onClick={() => setShowDeleteConfirmationModal(true)} role="attribute-option-delete-button"/>
+                <span className="AknAttributeOption-delete-option-icon" onClick={(event: any) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    setShowDeleteConfirmationModal(true);
+                }} role="attribute-option-delete-button"/>
             </div>
+
             {showDeleteConfirmationModal && (
                 <DeleteConfirmationModal
                     attributeOptionCode={data.code}
                     confirmDelete={deleteOption}
-                    cancelDelete={cancelDelete}
+                    cancelDelete={() => setShowDeleteConfirmationModal(false)}
                 />)
             }
         </>

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/NewOptionPlaceholder.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/NewOptionPlaceholder.tsx
@@ -10,7 +10,7 @@ const NewOptionPlaceholder = ({cancelNewOption}: newOptionPlaceholderProps) => {
 
     return (
         <div className="AknAttributeOption-listItem AknAttributeOption-listItem--selected" role="new-option-placeholder">
-            <span className="AknAttributeOption-itemCode">
+            <span className="AknAttributeOption-itemCode AknAttributeOption-itemCode--new">
                 {translate('pim_enrich.entity.attribute_option.module.edit.new_option_code')}
             </span>
             <span className="AknAttributeOption-cancel-new-option-icon" onClick={() => cancelNewOption()} role="new-option-cancel"/>

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/contexts/LocalesContext.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/contexts/LocalesContext.tsx
@@ -1,5 +1,5 @@
 import React, {createContext, FC, useContext} from 'react';
-import {useLocales} from '../hooks';
+import useLocales from '../hooks/useLocales';
 import {Locale} from '../model';
 
 export const LocalesContext = createContext<Locale[]>([]);

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/index.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/index.ts
@@ -1,7 +1,15 @@
 import useAttributeOptions from './useAttributeOptions';
 import useLocales from './useLocales';
+import {useSaveAttributeOption} from './useSaveAttributeOption';
+import {useCreateAttributeOption} from './useCreateAttributeOption';
+import {useDeleteAttributeOption} from './useDeleteAttributeOption';
+import {useManualSortAttributeOptions} from './useManualSortAttributeOptions';
 
 export {
     useAttributeOptions,
+    useSaveAttributeOption,
+    useCreateAttributeOption,
+    useDeleteAttributeOption,
+    useManualSortAttributeOptions,
     useLocales,
 };

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useManualSortAttributeOptions.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useManualSortAttributeOptions.ts
@@ -1,0 +1,26 @@
+import {useRoute} from '@akeneo-pim-community/legacy-bridge';
+import {useAttributeContext} from '../contexts';
+import {AttributeOption} from '../model';
+
+const useManualSortAttributeOptions = () => {
+    const attribute = useAttributeContext();
+    const route = useRoute('pim_enrich_attributeoption_update_sorting', {
+        attributeId: attribute.attributeId.toString(),
+    });
+
+    return async (attributeOptions: AttributeOption[]) => {
+        await fetch(
+            route,
+            {
+                method: 'PUT',
+                headers: [
+                    ['Content-type', 'application/json'],
+                    ['X-Requested-With', 'XMLHttpRequest'],
+                ],
+                body: JSON.stringify(attributeOptions.map((option: AttributeOption) => option.id)),
+            }
+        );
+    };
+};
+
+export {useManualSortAttributeOptions};

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/less/attribute-option.less
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/less/attribute-option.less
@@ -12,15 +12,19 @@
     line-height: 54px;
     border-bottom: 1px @AknGrey60 solid;
     display: flex;
-    justify-content: space-between;
     align-items: center;
 
     &--selected {
-      background-color: @AknBlue20;
+      background-color: @AknBlue20 !important;
 
       .AknAttributeOption-delete-option-icon {
         display: block !important;
       }
+    }
+
+    &--move-target {
+      background-color: #ee5f5b !important;
+      pointer-events: none;
     }
 
     &:first-child {
@@ -28,9 +32,7 @@
     }
 
     &:hover {
-      :not(&--selected) {
-        background-color: @AknLightGray;
-      }
+      background-color: @AknLightGray;
 
       .AknAttributeOption-delete-option-icon {
         display: block;
@@ -43,6 +45,10 @@
       text-transform: uppercase;
       color: @AknLightPurple;
       cursor: pointer;
+
+      &--new {
+        margin-left: 44px;
+      }
     }
 
     .AknAttributeOption-cancel-new-option-icon, .AknAttributeOption-delete-option-icon {
@@ -52,9 +58,22 @@
       height: 16px;
       cursor: pointer;
       display: none;
+      margin-left: auto;
     }
     .AknAttributeOption-cancel-new-option-icon {
       display: block;
+    }
+
+    .AknAttributeOption-move-icon {
+      width: 20px;
+      height: 20px;
+      background: url("/bundles/pimui/images/icon-row-move.svg") no-repeat center;
+      margin: 0 12px 0 12px;
+      cursor: move;
+
+      &--disabled {
+        cursor: default;
+      }
     }
   }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/images/icon-row-move.svg
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/images/icon-row-move.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Icons / row</title>
+    <g id="Icons-/-row" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M22,21.5 L2,21.5 L22,21.5 Z M22,11.5 L2,11.5 L22,11.5 Z M22,2 L2,2 L22,2 Z" id="Combined-Shape" stroke="#A1A9B7"></path>
+    </g>
+</svg>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
