### PR TITLE
RUL-271: Allow relative dates for DateFilter and DateTimeFilter

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/DateTimeFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/DateTimeFilter.php
@@ -22,7 +22,7 @@ use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryIn
 class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
     const DATETIME_FORMAT = 'Y-m-d H:i:s';
-    const RELATIVE_DATETIME_FORMAT = '/^now|([+-])([0-9]+)\s?(second|minute|hour|day|week|month|year)s?$/';
+    const RELATIVE_DATETIME_FORMAT = '/^(now|[+-][0-9]+\s?(second|minute|hour|day|week|month|year)s?)$/';
 
     /** @var IdentifiableObjectRepositoryInterface */
     protected $jobInstanceRepository;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/DateTimeFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/DateTimeFilter.php
@@ -22,6 +22,7 @@ use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryIn
 class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
     const DATETIME_FORMAT = 'Y-m-d H:i:s';
+    const RELATIVE_DATETIME_FORMAT = '/^now|([+-])([0-9]+)\s?(second|minute|hour|day|week|month|year)s?$/';
 
     /** @var IdentifiableObjectRepositoryInterface */
     protected $jobInstanceRepository;
@@ -55,7 +56,9 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
         if (null === $this->searchQueryBuilder) {
             throw new \LogicException('The search query builder is not initialized in the filter.');
         }
-
+        // For now, we only allow relative dates for "simple" operators (excluding BETWEEN, NOT BETWEEN, and obviously
+        // SINCE LAST N DAYS and SINCE LAST JOB)
+        $value = $this->convertRelativeDate($value);
         $this->checkValue($operator, $field, $value);
 
         switch ($operator) {
@@ -285,5 +288,21 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
         $dateTime->setTimezone($utcTimeZone);
 
         return $dateTime->format('c');
+    }
+
+    /**
+     * Converts a "relative date" string ("now" | "+/- {amount} {unit}") to an actual DateTime object
+     */
+    protected function convertRelativeDate($value)
+    {
+        if (is_string($value) && 1 === preg_match(self::RELATIVE_DATETIME_FORMAT, trim($value))) {
+            try {
+                return new \DateTime(trim($value), new \DateTimeZone('UTC'));
+            } catch (\Exception $e) {
+                return $value;
+            }
+        }
+
+        return $value;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/DateTimeFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/DateTimeFilter.php
@@ -22,7 +22,7 @@ use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryIn
 class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
     const DATETIME_FORMAT = 'Y-m-d H:i:s';
-    const RELATIVE_DATETIME_FORMAT = '/^(now|[+-][0-9]+\s?(second|minute|hour|day|week|month|year)s?)$/';
+    const RELATIVE_DATETIME_FORMAT = '/^(now|[+-][0-9]+\s?(minute|hour|day|week|month|year)s?)$/';
 
     /** @var IdentifiableObjectRepositoryInterface */
     protected $jobInstanceRepository;
@@ -295,9 +295,9 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
      */
     protected function convertRelativeDate($value)
     {
-        if (is_string($value) && 1 === preg_match(self::RELATIVE_DATETIME_FORMAT, trim($value))) {
+        if (\is_string($value) && 1 === \preg_match(self::RELATIVE_DATETIME_FORMAT, \trim($value))) {
             try {
-                return new \DateTime(trim($value), new \DateTimeZone('UTC'));
+                return new \DateTime(\trim($value));
             } catch (\Exception $e) {
                 return $value;
             }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/DateTimeFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/DateTimeFilter.php
@@ -144,7 +144,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
                 return $this->addFieldFilter(
                     $field,
                     Operators::GREATER_THAN,
-                    new \DateTime(sprintf('%s days ago', $value), new \DateTimeZone('UTC')),
+                    new \DateTimeImmutable(sprintf('%s days ago', $value), new \DateTimeZone('UTC')),
                     $locale,
                     $channel,
                     $options
@@ -197,7 +197,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
     /**
      * @param string $operator
      * @param string $field
-     * @param string|array|\DateTime $value
+     * @param string|array|\DateTimeInterface $value
      */
     protected function checkValue($operator, $field, $value)
     {
@@ -272,8 +272,8 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
         $dateTime = $value;
         $utcTimeZone = new \DateTimeZone('UTC');
 
-        if (!$dateTime instanceof \DateTime) {
-            $dateTime = \DateTime::createFromFormat(static::DATETIME_FORMAT, $dateTime, $utcTimeZone);
+        if (!$dateTime instanceof \DateTimeInterface) {
+            $dateTime = \DateTimeImmutable::createFromFormat(static::DATETIME_FORMAT, $dateTime, $utcTimeZone);
 
             if (false === $dateTime || 0 < $dateTime->getLastErrors()['warning_count']) {
                 throw InvalidPropertyException::dateExpected(
@@ -285,7 +285,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
             }
         }
 
-        $dateTime->setTimezone($utcTimeZone);
+        $dateTime = $dateTime->setTimezone($utcTimeZone);
 
         return $dateTime->format('c');
     }
@@ -297,7 +297,7 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
     {
         if (\is_string($value) && 1 === \preg_match(self::RELATIVE_DATETIME_FORMAT, \trim($value))) {
             try {
-                return new \DateTime(\trim($value));
+                return new \DateTimeImmutable(\trim($value));
             } catch (\Exception $e) {
                 return $value;
             }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/presenters.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/presenters.yml
@@ -60,7 +60,7 @@ services:
         class: '%pim_catalog.localization.presenter.date.class%'
         arguments:
             - '@pim_catalog.localization.factory.datetime'
-            - ['created_at', 'updated_at']
+            - ['created', 'updated']
         tags:
             - { name: pim_catalog.localization.presenter, type: 'product_field' }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/Filter/FieldFilterHelper.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/Filter/FieldFilterHelper.php
@@ -86,7 +86,7 @@ class FieldFilterHelper
      */
     public static function checkDateTime($field, $value, $format, $dateMessageFormat, $className)
     {
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTimeInterface) {
             return;
         }
 
@@ -94,7 +94,7 @@ class FieldFilterHelper
             throw InvalidPropertyException::dateExpected($field, $format, $className, $value);
         }
 
-        $dateTime = \DateTime::createFromFormat($format, $value);
+        $dateTime = \DateTimeImmutable::createFromFormat($format, $value);
 
         if (false === $dateTime || 0 < $dateTime->getLastErrors()['warning_count']) {
             throw InvalidPropertyException::dateExpected(

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/Filter/FieldFilterHelper.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/Filter/FieldFilterHelper.php
@@ -78,7 +78,7 @@ class FieldFilterHelper
      * Check if value is a datetime corresponding to a format
      *
      * @param string $field
-     * @param string|\DateTime $value
+     * @param string|\DateTimeInterface $value
      * @param string $format
      * @param string $dateMessageFormat
      * @param string $className

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/DateTimeFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/DateTimeFilterIntegration.php
@@ -142,12 +142,6 @@ class DateTimeFilterIntegration extends AbstractProductQueryBuilderTestCase
         $result = $this->executeFilter([['updated', Operators::GREATER_THAN, 'now']]);
         $this->assert($result, []);
 
-        $result = $this->executeFilter([['updated', Operators::LOWER_THAN, '-30 seconds']]);
-        $this->assert($result, ['test', 'foo', 'bar', 'baz']);
-
-        $result = $this->executeFilter([['updated', Operators::GREATER_THAN, '-30 seconds']]);
-        $this->assert($result, []);
-
         $result = $this->executeFilter([['updated', Operators::LOWER_THAN, '-30 minutes']]);
         $this->assert($result, ['foo', 'bar', 'baz']);
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/DateTimeFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/DateTimeFilterSpec.php
@@ -314,7 +314,7 @@ class DateTimeFilterSpec extends ObjectBehavior
         $this->addFieldFilter('updated', '>', '-1 week');
     }
 
-    function it_thrwws_an_exception_for_relative_dates_on_unsupported_operators(SearchQueryBuilder $sqb)
+    function it_throws_an_exception_for_relative_dates_on_unsupported_operators(SearchQueryBuilder $sqb)
     {
         $this->setQueryBuilder($sqb);
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Allows to use a relative datetime format in the ES' DateFilter and DateTimeFilter. 
The format is stricter than PHP allows, it must be: `now` or `+/-$count $unit` (`$count` is an integer and `$unit` is one of "day", "week", "month" or "year", with an optional final "s"; the DateTimeFilter also accepts "minute" and "hour")

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
