### PR TITLE
PIM-9084: Block the export of attributes with specific locale wich isn't the used locale in the export profile

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
@@ -124,7 +124,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
 
         if (isset($filters['structure']['attributes'])
             && !empty($filters['structure']['attributes'])
-            && $this->hasItems === true) {
+            && $this->hasItems === true ) {
             $attributeCodes = $filters['structure']['attributes'];
         } elseif ($parameters->has('selected_properties')) {
             $attributeCodes = $parameters->get('selected_properties');
@@ -141,7 +141,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
 
         $headerStrings = [];
         foreach ($headers as $header) {
-            if ($withMedia || !$header->isMedia()) {
+            if (($localeCodes[1] === $header['specificToLocales'][1]) && ($withMedia || !$header->isMedia())) {
                 $headerStrings = array_merge(
                     $headerStrings,
                     $header->generateHeaderStrings()


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
