### PR TITLE
PIM-6148: * displayed for default view

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/view-selector-current.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/view-selector-current.js
@@ -68,17 +68,19 @@ define(
                     datagridState.columns = '';
                 }
 
+                const notNullDatagridStateFilters = !datagridState.filters ? '' : datagridState.filters;
+
                 var initialView = this.getRoot().initialView;
                 var initialViewExists = null !== initialView && 0 !== initialView.id;
 
-                var filtersModified = this.areFiltersModified(initialView.filters, datagridState.filters);
+                var filtersModified = this.areFiltersModified(initialView.filters, notNullDatagridStateFilters);
                 var columnsModified = !_.isEqual(initialView.columns, datagridState.columns.split(','));
 
                 if (initialViewExists) {
                     this.dirtyFilters = filtersModified;
                     this.dirtyColumns = columnsModified;
                 } else {
-                    var isDefaultFilters = ('' === datagridState.filters);
+                    var isDefaultFilters = ('' === notNullDatagridStateFilters);
                     var isDefaultColumns = _.isEqual(this.getRoot().defaultColumns, datagridState.columns.split(','));
 
                     this.dirtyFilters = !isDefaultFilters;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/grid/table.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/grid/table.js
@@ -251,7 +251,7 @@ define(
                 } else {
                     if (state.view) params = this.applyView(state.view, params);
                     if (state.filters) params = this.applyFilters(state.filters, params);
-                    params = this.applyColumns(state.columns || defaultColumns, params);
+                    params = this.applyColumns(state.columns || defaultColumns[0], params);
                 }
 
                 this.getRoot().trigger('datagrid:getParams', params);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
There is a * always displayed for the default view.
The problem has been fixed, but another appeared.
At first change in the filter menu, the default view doesn't get its *, it only works at the second modif. But works fine if you change the columns.
This problem stills a mystery

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
