### PR TITLE
PIM-9295: Check that target is a product when adding, setting or removing groups

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Adder/GroupFieldAdder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Adder/GroupFieldAdder.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Adder;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
@@ -37,6 +39,13 @@ class GroupFieldAdder extends AbstractFieldAdder
      */
     public function addFieldData($product, $field, $data, array $options = [])
     {
+        if (!$product instanceof ProductInterface) {
+            throw InvalidObjectException::objectExpected(
+                \is_object($product) ? \get_class($product) : \gettype($product),
+                ProductInterface::class
+            );
+        }
+
         $this->checkData($field, $data);
 
         $groups = [];

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/GroupFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/GroupFieldClearer.php
@@ -6,6 +6,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\ClearerInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Webmozart\Assert\Assert;
 
 /**
@@ -30,14 +31,18 @@ final class GroupFieldClearer implements ClearerInterface
      */
     public function clear($entity, string $property, array $options = []): void
     {
+        if (!$entity instanceof ProductInterface) {
+            throw InvalidObjectException::objectExpected(
+                \is_object($entity) ? \get_class($entity) : \gettype($entity),
+                ProductInterface::class
+            );
+        }
+
         Assert::true(
             $this->supportsProperty($property),
             sprintf('The clearer does not handle the "%s" property.', $property)
         );
 
-        // Groups are only available for products, not product models.
-        if ($entity instanceof ProductInterface) {
-            $entity->getGroups()->clear();
-        }
+        $entity->getGroups()->clear();
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Remover/GroupFieldRemover.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Remover/GroupFieldRemover.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Remover;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
@@ -37,6 +39,13 @@ class GroupFieldRemover extends AbstractFieldRemover
      */
     public function removeFieldData($product, $field, $data, array $options = [])
     {
+        if (!$product instanceof ProductInterface) {
+            throw InvalidObjectException::objectExpected(
+                \is_object($product) ? \get_class($product) : \gettype($product),
+                ProductInterface::class
+            );
+        }
+
         $this->checkData($field, $data);
 
         $groups = [];

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/EnabledFieldSetter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/EnabledFieldSetter.php
@@ -31,7 +31,10 @@ class EnabledFieldSetter extends AbstractFieldSetter
     public function setFieldData($product, $field, $data, array $options = [])
     {
         if (!$product instanceof ProductInterface) {
-            throw InvalidObjectException::objectExpected($product, ProductInterface::class);
+            throw InvalidObjectException::objectExpected(
+                \is_object($product) ? \get_class($product) : \gettype($product),
+                ProductInterface::class
+            );
         }
 
         if (0 === $data || '0' === $data) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/GroupFieldSetter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/GroupFieldSetter.php
@@ -40,7 +40,10 @@ class GroupFieldSetter extends AbstractFieldSetter
     public function setFieldData($product, $field, $data, array $options = [])
     {
         if (!$product instanceof ProductInterface) {
-            throw InvalidObjectException::objectExpected($product, ProductInterface::class);
+            throw InvalidObjectException::objectExpected(
+                \is_object($product) ? \get_class($product) : \gettype($product),
+                ProductInterface::class
+            );
         }
 
         $this->checkData($field, $data);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/GroupFieldClearerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/GroupFieldClearerSpec.php
@@ -6,7 +6,10 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\Group;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\ClearerInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Webmozart\Assert\Assert;
@@ -39,5 +42,15 @@ class GroupFieldClearerSpec extends ObjectBehavior
 
         $this->clear($product, 'groups');
         Assert::count($product->getGroups(), 0);
+    }
+
+    function it_throws_an_exception_if_the_subject_is_not_a_product()
+    {
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                ProductModel::class,
+                ProductInterface::class
+            )
+        )->during('clear', [new ProductModel(), 'groups']);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/EnabledFieldSetterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/EnabledFieldSetterSpec.php
@@ -2,11 +2,13 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Setter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\EnabledFieldSetter;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\FieldSetterInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\EnabledFieldSetter;
 use Prophecy\Argument;
 
 class EnabledFieldSetterSpec extends ObjectBehavior
@@ -56,5 +58,15 @@ class EnabledFieldSetterSpec extends ObjectBehavior
                 'foo'
             )
         )->during('setFieldData', [$product, 'enabled', 'foo']);
+    }
+
+    function it_throws_an_exception_if_the_subject_is_not_a_product()
+    {
+        $this->shouldThrow(
+            InvalidObjectException::objectExpected(
+                ProductModel::class,
+                ProductInterface::class
+            )
+        )->during('setFieldData', [new ProductModel(), 'enabled', true]);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When using `Akeneo\Pim\Enrichment\Component\Product\Updater` components for groups and status (enabled), we have to check that the target entity is a product

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
