### PR TITLE
DAPI: fix options list when then backend returns an empty object where there is no option

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/fetchers/baseFetcher.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/fetchers/baseFetcher.ts
@@ -1,5 +1,11 @@
 const baseFetcher = async (route: string) => {
-    const response = await fetch(route);
+    const response = await fetch(route, {
+        method: 'GET',
+        headers: [
+            ['Content-type', 'application/json'],
+            ['X-Requested-With', 'XMLHttpRequest'],
+        ],
+    });
 
     return await response.json();
 };

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/reducers/attributeOptionsReducer.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/reducers/attributeOptionsReducer.ts
@@ -68,6 +68,11 @@ export const deleteAttributeOptionAction: ActionCreator<DeleteAttributeOptionAct
 const attributeOptionsReducer: Reducer<AttributeOption[] | null> = (previousState = null, {type, payload}) => {
     switch (type) {
     case INITIALIZE_ATTRIBUTE_OPTIONS: {
+        //The backend can return an empty object ({}) when there is no option and an array otherwise
+        if (typeof payload.attributeOptions === 'object' && !Array.isArray(payload.attributeOptions)) {
+            return [];
+        }
+
         return [
             ...payload.attributeOptions
         ];

--- a/tests/front/unit/structure/attribute-option/reducers/attributeOptionsReducer.unit.ts
+++ b/tests/front/unit/structure/attribute-option/reducers/attributeOptionsReducer.unit.ts
@@ -36,6 +36,18 @@ describe('Attribute options reducer', () => {
         ).toMatchObject(blackAndBlueOptions);
     });
 
+    test('Initialize an empty list of attribute options with an array', () => {
+        expect(
+          attributeOptionsReducer([], initializeAttributeOptionsAction([]))
+        ).toMatchObject([]);
+    });
+
+    test('Initialize an empty list of attribute options with an object', () => {
+        expect(
+          attributeOptionsReducer([], initializeAttributeOptionsAction({}))
+        ).toMatchObject([]);
+    });
+
     test('Initialize attribute options action with an existing state', () => {
         expect(
           attributeOptionsReducer([


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
