### PR TITLE
DAPI-1076: ensure the redux store is resetted when unmounting the application

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/AttributeOptionsApp.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/AttributeOptionsApp.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {Provider} from 'react-redux';
 import attributeOptionsStore from './store/store';
 import AttributeOptions from './components/AttributeOptions';
 import {DependenciesProvider} from '@akeneo-pim-community/legacy-bridge';
 import {AttributeContextProvider, LocalesContextProvider} from './contexts';
 import OverridePimStyle from './components/OverridePimStyles';
+import {resetAttributeOptionsAction} from './reducers';
 
 interface IndexProps {
   attributeId: number;
@@ -12,6 +13,13 @@ interface IndexProps {
 }
 
 const AttributeOptionsApp = ({attributeId, autoSortOptions}: IndexProps) => {
+
+    useEffect(() => {
+        return () => {
+            attributeOptionsStore.dispatch(resetAttributeOptionsAction());
+        };
+    }, []);
+
     return (
         <DependenciesProvider>
             <Provider store={attributeOptionsStore}>

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useAttributeOptions.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/hooks/useAttributeOptions.ts
@@ -10,15 +10,18 @@ const useAttributeOptions = () => {
     const dispatchAction = useDispatch();
     const attribute = useAttributeContext();
     const route = useRoute('pim_enrich_attributeoption_index', {attributeId: attribute.attributeId.toString()});
+    let attributeOptions = useSelector((state: AttributeOptionsState) => state.attributeOptions);
 
     useEffect(() => {
         (async () => {
-            const attributeOptions = await baseFetcher(route);
-            dispatchAction(initializeAttributeOptionsAction(attributeOptions));
+            if (attributeOptions === null) {
+                attributeOptions = await baseFetcher(route);
+                dispatchAction(initializeAttributeOptionsAction(attributeOptions));
+            }
         })();
     }, []);
 
-    return useSelector((state: AttributeOptionsState) => state.attributeOptions);
+    return attributeOptions;
 };
 
 export default useAttributeOptions;

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/reducers/attributeOptionsReducer.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/reducers/attributeOptionsReducer.ts
@@ -17,6 +17,15 @@ export const initializeAttributeOptionsAction: ActionCreator<InitializeAttribute
     };
 };
 
+interface ResetAttributeOptionsAction extends Action {}
+
+const RESET_ATTRIBUTE_OPTIONS = 'RESET_ATTRIBUTE_OPTIONS';
+export const resetAttributeOptionsAction: ActionCreator<ResetAttributeOptionsAction> = () => {
+    return {
+        type: RESET_ATTRIBUTE_OPTIONS,
+    };
+};
+
 interface UpdateAttributeOptionAction extends Action {
     payload: {
         option: AttributeOption;
@@ -71,6 +80,9 @@ const attributeOptionsReducer: Reducer<AttributeOption[] | null> = (previousStat
         return [
             ...payload.attributeOptions
         ];
+    }
+    case RESET_ATTRIBUTE_OPTIONS: {
+        return null;
     }
     case UPDATE_ATTRIBUTE_OPTION: {
         if (previousState === null) {

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/reducers/index.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/reducers/index.ts
@@ -3,6 +3,7 @@ import attributeOptionsReducer, {
     updateAttributeOptionAction,
     createAttributeOptionAction,
     deleteAttributeOptionAction,
+    resetAttributeOptionsAction,
 } from './attributeOptionsReducer';
 
 export {
@@ -11,4 +12,5 @@ export {
     createAttributeOptionAction,
     attributeOptionsReducer,
     deleteAttributeOptionAction,
+    resetAttributeOptionsAction,
 };

--- a/tests/front/unit/structure/attribute-option/reducers/attributeOptionsReducer.unit.ts
+++ b/tests/front/unit/structure/attribute-option/reducers/attributeOptionsReducer.unit.ts
@@ -5,6 +5,7 @@ import {
     createAttributeOptionAction,
     deleteAttributeOptionAction,
 } from 'akeneopimstructure/js/attribute-option/reducers';
+import {resetAttributeOptionsAction} from "akeneopimstructure/js/attribute-option/reducers";
 
 const blackAndBlueOptions = [
     {
@@ -50,6 +51,22 @@ describe('Attribute options reducer', () => {
             ],
             initializeAttributeOptionsAction(blackAndBlueOptions))
         ).toMatchObject(blackAndBlueOptions);
+    });
+
+    test('Reset attribute options with an existing state', () => {
+        expect(
+          attributeOptionsReducer([
+                {
+                    "id": 1,
+                    "code": "red",
+                    "optionValues": {
+                        "en_US": {"id": 2,"locale":"en_US","value":"Red"},
+                        "fr_FR":{"id": 3,"locale":"fr_FR","value":"Rouge"}
+                    }
+                },
+            ],
+            resetAttributeOptionsAction())
+        ).toBeNull();
     });
 
     test('Update an attribute option', () => {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This PR adds a fix to avoid a weird blinking effect when we display the options for an attribute AFTER having visited another one before : the options of the previous attribute were displayed, until the new options are loaded. Somehow the redux store is not resetted when we leave the page, so we have to clean it manually.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
