### PR TITLE
Add psr/event-dispatcher dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ aliases:
 
   - &dockerCloudDeployer
       docker:
-        - image: eu.gcr.io/akeneo-cloud/cloud-deployer:2
+        - image: eu.gcr.io/akeneo-cloud/cloud-deployer:2.2
           auth:
             username: _json_key  # default username when using a JSON key file to authenticate
             password: $GCLOUD_SERVICE_KEY_DEV  # JSON service account you created, do not encode to base64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 ## Improvements
 
+- CLOUD-1959: Use cloud-deployer 2.2 and terraform 0.12.25
+
 # Technical Improvements
 
 ## Classes

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
         "monolog/monolog": "1.23.0",
         "ocramius/proxy-manager": "2.2.3",
         "oneup/flysystem-bundle": "3.1.0",
+        "psr/event-dispatcher": "^1.0.0",
         "ramsey/uuid": "^3.7",
         "sensio/framework-extra-bundle": "^5.4",
         "twig/extensions": "1.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81a607222b1ca85b460be16d4806b1a8",
+    "content-hash": "e0ca9320e8ee7dc57e5d8a9b76e05588",
     "packages": [
         {
             "name": "ass/xmlsecurity",
@@ -3116,6 +3116,52 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "time": "2019-01-08T18:20:26+00:00"
         },
         {
             "name": "psr/log",


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The Phpstan `0.12.29` version seems to have introduced an issue and do not handle correctly this kind of forward/backward compatibilty tricks: https://github.com/symfony/event-dispatcher-contracts/blob/v1.1.7/Event.php with the `inteface_exists` condition.

Some tests fail whereas they don't have to.

I've decided to add the `psr/event-dispatcher` dependency to solve the error.
The `psr/event-dispatcher` will be used in upcoming version of symfony event dispatcher component https://github.com/symfony/event-dispatcher-contracts/blob/v2.1.2/Event.php#L14

PS: includes @rybus fixes regarding the terraform version used.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
