### PR TITLE
PIM-9294: Fix the removal of a validation rule in attribute edit form

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9301: Fix extractUpdatedProductsByConnection query group by issue
+- PIM-9294: Fix removal of a validation rule in text attribute edit form
 
 # 4.0.33 (2020-06-11)
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/attribute.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/attribute.yml
@@ -292,13 +292,11 @@ Akeneo\Pim\Structure\Component\Model\Attribute:
                     - pim_reference_data_simpleselect
         validationRule:
             - Choice:
-                strict: true
-                choices: [null, url, email, regexp]
+                choices: [url, email, regexp]
                 groups:
                     - pim_catalog_text
             - Choice:
-                strict: true
-                choices: [null, regexp]
+                choices: [regexp]
                 groups:
                     - pim_catalog_identifier
             - IsNull:
@@ -472,5 +470,3 @@ Akeneo\Pim\Structure\Component\Model\AttributeOption:
             - Valid: ~
         optionValues:
             - Valid: ~
-
-

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/select.js
@@ -79,7 +79,7 @@ function (
          * {@inheritdoc}
          */
         getFieldValue: function (field) {
-            const value = $(field).val();
+            const value = '' === $(field).val() ? null : $(field).val();
 
             return this.config.isMultiple && null === value ? [] : value;
         }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fixes an issue where an empty string was sent to the back when clearing the `Validation rule` simple select field, and was then rejected by the validation.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
