### PR TITLE
PIM-9279: Fix missing required attributes in PEF when an attribute option was deleted

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -4,6 +4,7 @@
 
 - PIM-9301: Fix extractUpdatedProductsByConnection query group by issue
 - PIM-9294: Fix removal of a validation rule in text attribute edit form
+- PIM-9279: Fix missing required attributes display in PEF when an attribute option was deleted
 
 # 4.0.33 (2020-06-11)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -198,5 +198,6 @@ services:
             - '@pim_catalog.context.catalog'
             - '@pim_catalog.completeness.calculator'
             - '@pim_enrich.normalizer.missing_required_attributes'
+            - '@pim_catalog.completeness.missing_required_attributes_calculator'
         tags:
             - { name: pim_internal_api_serializer.normalizer, priority: 110 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/ProductNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/ProductNormalizerSpec.php
@@ -7,6 +7,7 @@ use Akeneo\Pim\Enrichment\Bundle\Context\CatalogContext;
 use Akeneo\Pim\Enrichment\Component\Category\Query\AscendantCategoriesInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Association\MissingAssociationAdder;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator;
+use Akeneo\Pim\Enrichment\Component\Product\Completeness\MissingRequiredAttributesCalculator;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletenessWithMissingAttributeCodesCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Converter\ConverterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\EntityWithFamilyVariantAttributesProvider;
@@ -20,7 +21,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\ImageNormaliz
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\MissingRequiredAttributesNormalizerInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\ProductCompletenessWithMissingAttributeCodesCollectionNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\VariantNavigationNormalizer;
-use Akeneo\Pim\Enrichment\Component\Product\ValuesFiller\FillMissingProductValues;
 use Akeneo\Pim\Enrichment\Component\Product\ValuesFiller\FillMissingValuesInterface;
 use Akeneo\Pim\Structure\Component\Model\AssociationTypeInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
@@ -31,7 +31,6 @@ use Akeneo\Tool\Bundle\VersioningBundle\Manager\VersionManager;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class ProductNormalizerSpec extends ObjectBehavior
@@ -56,7 +55,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         NormalizerInterface $parentAssociationsNormalizer,
         CatalogContext $catalogContext,
         CompletenessCalculator $completenessCalculator,
-        MissingRequiredAttributesNormalizerInterface $missingRequiredAttributesNormalizer
+        MissingRequiredAttributesNormalizerInterface $missingRequiredAttributesNormalizer,
+        MissingRequiredAttributesCalculator $missingRequiredAttributesCalculator
     ) {
         $this->beConstructedWith(
             $normalizer,
@@ -78,7 +78,8 @@ class ProductNormalizerSpec extends ObjectBehavior
             $parentAssociationsNormalizer,
             $catalogContext,
             $completenessCalculator,
-            $missingRequiredAttributesNormalizer
+            $missingRequiredAttributesNormalizer,
+            $missingRequiredAttributesCalculator
         );
     }
 
@@ -101,8 +102,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         UserContext $userContext,
         FillMissingValuesInterface $fillMissingProductValues,
         MissingAssociationAdder $missingAssociationAdder,
-        CompletenessCalculator $completenessCalculator,
         MissingRequiredAttributesNormalizerInterface $missingRequiredAttributesNormalizer,
+        MissingRequiredAttributesCalculator $missingRequiredAttributesCalculator,
         ProductInterface $mug,
         AssociationInterface $upsell,
         AssociationTypeInterface $groupType,
@@ -187,7 +188,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $group->getId()->willReturn(12);
 
         $productCompletenessWithMissingAttributeCodesCollection = new ProductCompletenessWithMissingAttributeCodesCollection(12, []);
-        $completenessCalculator->fromProductIdentifier('mug')->willReturn($productCompletenessWithMissingAttributeCodesCollection);
+        $missingRequiredAttributesCalculator->fromEntityWithFamily($mug)->willReturn($productCompletenessWithMissingAttributeCodesCollection);
         $completenessCollectionNormalizer->normalize($productCompletenessWithMissingAttributeCodesCollection)
                                          ->willReturn(['normalized_completenesses']);
         $missingRequiredAttributesNormalizer->normalize($productCompletenessWithMissingAttributeCodesCollection)
@@ -257,8 +258,8 @@ class ProductNormalizerSpec extends ObjectBehavior
         VariantNavigationNormalizer $navigationNormalizer,
         AscendantCategoriesInterface $ascendantCategories,
         MissingAssociationAdder $missingAssociationAdder,
-        CompletenessCalculator $completenessCalculator,
         MissingRequiredAttributesNormalizerInterface $missingRequiredAttributesNormalizer,
+        MissingRequiredAttributesCalculator $missingRequiredAttributesCalculator,
         ProductInterface $mug,
         AssociationInterface $upsell,
         AssociationTypeInterface $groupType,
@@ -350,7 +351,7 @@ class ProductNormalizerSpec extends ObjectBehavior
         $group->getId()->willReturn(12);
 
         $productCompletenessWithMissingAttributeCodesCollection = new ProductCompletenessWithMissingAttributeCodesCollection(12, []);
-        $completenessCalculator->fromProductIdentifier('mug')->willReturn($productCompletenessWithMissingAttributeCodesCollection);
+        $missingRequiredAttributesCalculator->fromEntityWithFamily($mug)->willReturn($productCompletenessWithMissingAttributeCodesCollection);
         $completenessCollectionNormalizer->normalize($productCompletenessWithMissingAttributeCodesCollection)->willReturn([]);
         $missingRequiredAttributesNormalizer->normalize($productCompletenessWithMissingAttributeCodesCollection)->willReturn([]);
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fixes the "Missing attribute values" in the PEF when an attribute option/entity record/asset was deleted. The solution is to calculate the completeness of a product from its ValueCollection (from which the removed options were filtered at load) instead of its DB raw values.
This method is way slower, but as it's only used for one product (PEF display) I guess it's OK

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
