### PR TITLE
Fix InstallStatusManager to expect column in the same case as requested

### DIFF
--- a/src/Akeneo/Platform/Bundle/InstallerBundle/InstallStatusManager/InstallStatusManager.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/InstallStatusManager/InstallStatusManager.php
@@ -47,7 +47,7 @@ class InstallStatusManager
      */
     public function getPimInstallDateTime() : ?\DateTime
     {
-        $sql = 'SELECT create_time FROM INFORMATION_SCHEMA.TABLES
+        $sql = 'SELECT ' . self::MYSQL_META_COLUMN_CREATE_TIME .  ' FROM INFORMATION_SCHEMA.TABLES
                 WHERE table_schema = :database_name
                 AND table_name = :install_table_name';
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
InstallStatusManager wrongly assumed that PIM is not installed because of the flawed way of validating it - it was doing an SQL query with lowercase column name but then checking results and expecting the column name in uppercase. While this might work with some specific versions of MySQL, but MariaDB (at least 10.3) is case-sensitive in the sense that it returns the result the same way as it was requested - i.e. lowercase in this case.

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

This change only makes the selection and verification to use the same constant value, so that case sensitivity become irrelevant and the solution can work equally well on MySQL and MariaDB


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
