### PR TITLE
PIM-9308: Fix infinite scroll in view selector when views are filtered

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -5,6 +5,7 @@
 - PIM-9301: Fix extractUpdatedProductsByConnection query group by issue
 - PIM-9294: Fix removal of a validation rule in text attribute edit form
 - PIM-9279: Fix missing required attributes display in PEF when an attribute option was deleted
+- PIM-9308: Fix infinite scroll in the view selector when some views are filtered
 
 # 4.0.33 (2020-06-11)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/view-selector.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/view-selector.js
@@ -180,9 +180,10 @@ define(
                     this.currentLoadingPage = page;
                     this.currentLoadingTerm = options.term;
 
-                    FetcherRegistry.getFetcher(fetcher).search(searchParameters).then(function (views) {
+                    FetcherRegistry.getFetcher(fetcher).search(searchParameters).then(function (response) {
+                        const views = response.results || response;
                         let choices = this.toSelect2Format(views);
-                        const more = choices.length === this.getResultsPerPage();
+                        const more = typeof response.more === 'undefined' ? (choices.length === this.getResultsPerPage()) : response.more;
 
                         if (page === 1 && !options.term) {
                             choices = this.ensureDefaultView(choices);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/view-selector.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/view-selector.js
@@ -183,7 +183,8 @@ define(
                     FetcherRegistry.getFetcher(fetcher).search(searchParameters).then(function (response) {
                         const views = response.results || response;
                         let choices = this.toSelect2Format(views);
-                        const more = typeof response.more === 'undefined' ? (choices.length === this.getResultsPerPage()) : response.more;
+                        const more = typeof response.more === 'undefined' ?
+                            (choices.length === this.getResultsPerPage()) : response.more;
 
                         if (page === 1 && !options.term) {
                             choices = this.ensureDefaultView(choices);

--- a/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/default-product-grid-view.ts
+++ b/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/default-product-grid-view.ts
@@ -57,12 +57,22 @@ class DefaultProductGridView extends BaseSelect {
         data: {options: {identifiers: [id]}},
         type: this.choiceVerb,
       }).then(response => {
-        const selected: InterfaceNormalizedDatagridView|undefined = _.findWhere(response, {id: parseInt(id)});
+        const selected: InterfaceNormalizedDatagridView|undefined = _.findWhere(response.results, {id: parseInt(id)});
         if (undefined !== selected) {
           callback(this.convertBackendItem(selected));
         }
       });
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  select2Results(response: any) {
+    return {
+      more: response.more,
+      results: response.results.map((item: any) => this.convertBackendItem(item)),
+    };
   }
 }
 

--- a/src/Oro/Bundle/PimDataGridBundle/Controller/Rest/DatagridViewController.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Controller/Rest/DatagridViewController.php
@@ -106,11 +106,15 @@ class DatagridViewController
         $term = $request->query->get('search', '');
 
         $views = $this->datagridViewRepo->findDatagridViewBySearch($user, $alias, $term, $options);
+        $moreResults = (count($views) === (int)$options['limit']);
         $views = $this->datagridViewFilter->filterCollection($views, 'pim.internal_api.datagrid_view.view');
 
         $normalizedViews = $this->normalizer->normalize($views, 'internal_api');
 
-        return new JsonResponse($normalizedViews);
+        return new JsonResponse([
+            'results' => $normalizedViews,
+            'more' => $moreResults,
+        ]);
     }
 
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When fetching views from the view selector, it can happen that some views are filtered after the SQL query (for instance because of permissions, or because a category used in the filter was deleted...).

When that's the case, the number of results returned by the backend is less than the limit specified in the request, and the view selector considers that there are no more results (whereas there can be more), and the infinite scroll stops.

In order to solve this, I let the backend decide whether there are more results.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
