### PR TITLE
GITHUB-APD-132: Fix coverage unit front

### DIFF
--- a/tests/front/unit/jest/unit.jest.js
+++ b/tests/front/unit/jest/unit.jest.js
@@ -19,6 +19,7 @@ const unitConfig = {
     'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/CreateMeasurementFamily.tsx',
     'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-unit/CreateUnit.tsx',
     'src/Akeneo/Platform/Bundle/CommunicationChannelBundle/Resources/workspaces/communication-channel/src/components/icons',
+    'src/Akeneo/Platform/Bundle/CommunicationChannelBundle/Resources/workspaces/communication-channel/src/components/panel/announcement/Image.tsx',
     'src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/view',
   ],
   moduleNameMapper: {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Quick fix on the coverage unit front to skip the Image.tsx file. I can't test the logic in the onLoad.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
