### PR TITLE
CXP-347: fix validation error icon size

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
@@ -132,6 +132,8 @@
     color: @AknRed;
     background: url("/bundles/pimui/images/icon-danger.svg") no-repeat left center;
     padding-left: 26px;
+    background-size: 20px;
+    background-position: top left;
   }
 
   &-validationWarning {
@@ -141,6 +143,8 @@
     color: @AknDarkBlue;
     background: url("/bundles/pimui/images/icon-danger-orange.svg") no-repeat left center;
     padding-left: 26px;
+    background-size: 20px;
+    background-position: top left;
   }
 
   &-validationWarningMessage {


### PR DESCRIPTION
Fix an issue on the icon size of multi-line validation error.

Before:
![3](https://user-images.githubusercontent.com/1671213/84995626-88dc6f00-b14c-11ea-8510-72b6f270fafb.png)

After:
![2](https://user-images.githubusercontent.com/1671213/84995616-837f2480-b14c-11ea-80d3-3353e8c8e74c.png)
![1](https://user-images.githubusercontent.com/1671213/84995621-8712ab80-b14c-11ea-81f7-f56d26c9ba4d.png)


