### PR TITLE
fix-nightly: fix missing nightly test

### DIFF
--- a/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
+++ b/src/Akeneo/Tool/Component/Api/tests/integration/Normalizer/ProductNormalizerIntegration.php
@@ -257,7 +257,16 @@ class ProductNormalizerIntegration extends TestCase
                 'X_SELL' => ['groups' => ['groupB'], 'products' => ['bar'], 'product_models' => []],
                 'SUBSTITUTION' => ['groups' => [], 'products' => [], 'product_models' => []],
             ],
-            'quantified_associations' => [],
+            'quantified_associations' => [
+                "PRODUCT_SET" => [
+                    "products" => [
+                        ["identifier" => 'bar', "quantity" => 3]
+                    ],
+                    "product_models" => [
+                        ["identifier" => 'baz', "quantity" => 2]
+                    ]
+                ],
+            ],
         ];
 
         $this->assertProduct('foo', $expected, []);
@@ -343,7 +352,16 @@ class ProductNormalizerIntegration extends TestCase
                 'X_SELL' => ['groups' => ['groupB'], 'products' => ['bar'], 'product_models' => []],
                 'SUBSTITUTION' => ['groups' => [], 'products' => [], 'product_models' => []],
             ],
-            'quantified_associations' => [],
+            'quantified_associations' => [
+                "PRODUCT_SET" => [
+                    "products" => [
+                        ["identifier" => 'bar', "quantity" => 3]
+                    ],
+                    "product_models" => [
+                        ["identifier" => 'baz', "quantity" => 2]
+                    ]
+                ],
+            ],
         ];
 
         $this->assertProduct('foo', $expected, ['attributes' => [


### PR DESCRIPTION

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Due to modification of technicalSql fixture those test does not pass.

This test was not launch in PR workflow (due to @group ce) only in nightly workflow

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
