### PR TITLE
CXP-365: add attribute validation documentation

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/ErrorManagement/DocumentationBuilder/AttributeValidation.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/ErrorManagement/DocumentationBuilder/AttributeValidation.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilder;
+
+use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Documentation\Documentation;
+use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Documentation\DocumentationCollection;
+use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Documentation\HrefMessageParameter;
+use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Documentation\RouteMessageParameter;
+use Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueValue;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class AttributeValidation implements DocumentationBuilderInterface
+{
+    public function support($object): bool
+    {
+        if ($object instanceof ConstraintViolationInterface) {
+            switch ($object->getCode()) {
+                case UniqueValue::UNIQUE_VALUE:
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ConstraintViolationInterface $constraintViolation
+     */
+    public function buildDocumentation($constraintViolation): DocumentationCollection
+    {
+        if (false === $this->support($constraintViolation)) {
+            throw new \InvalidArgumentException('Parameter $constraintViolation is not supported.');
+        }
+
+        return new DocumentationCollection([
+            new Documentation(
+                'More information about attributes and their validation: {manage_attributes} {manage_validation_parameters}',
+                [
+                    'manage_attributes' => new HrefMessageParameter(
+                        'Manage your attributes',
+                        'https://help.akeneo.com/pim/serenity/articles/manage-your-attributes.html'
+                    ),
+                    'manage_validation_parameters' => new HrefMessageParameter(
+                        'Manage your validation parameters',
+                        'https://help.akeneo.com/pim/serenity/articles/manage-your-attributes.html#add-attributes-validation-parameters'
+                    )
+                ],
+                Documentation::STYLE_INFORMATION
+            ),
+            new Documentation(
+                'Please check your {attribute_settings}.',
+                [
+                    'attribute_settings' => new RouteMessageParameter(
+                        'Attributes settings',
+                        'pim_enrich_attribute_index'
+                    )
+                ],
+                Documentation::STYLE_TEXT
+            )
+        ]);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/documentation.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/documentation.yml
@@ -7,6 +7,9 @@ services:
     Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilder\AttributeOptionDoesNotExist:
         tags: [akeneo_connectivity.connection.documentation_builder]
 
+    Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilder\AttributeValidation:
+        tags: [akeneo_connectivity.connection.documentation_builder]
+
     Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilder\UnknownAttribute:
         tags: [akeneo_connectivity.connection.documentation_builder]
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/UniqueValue.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/UniqueValue.php
@@ -13,6 +13,8 @@ use Symfony\Component\Validator\Constraint;
  */
 class UniqueValue extends Constraint
 {
+    const UNIQUE_VALUE = '4313666f-d637-4c7a-a515-0cf9693ca5ef';
+
     /** @var string */
     public $message = 'The {{ attribute_code }} attribute can not have the same value more than once. The {{ value }} value is already set on another product.';
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/UniqueValueValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/UniqueValueValidator.php
@@ -32,8 +32,8 @@ class UniqueValueValidator extends ConstraintValidator
     public function __construct(
         ProductUniqueDataRepositoryInterface $repository,
         UniqueValuesSet $uniqueValueSet,
-        IdentifiableObjectRepositoryInterface $attributeRepository)
-    {
+        IdentifiableObjectRepositoryInterface $attributeRepository
+    ) {
         $this->repository = $repository;
         $this->uniqueValuesSet = $uniqueValueSet;
         $this->attributeRepository = $attributeRepository;
@@ -88,7 +88,9 @@ class UniqueValueValidator extends ConstraintValidator
                     $this->context->buildViolation(
                         $constraint->message,
                         ['{{ value }}' => $valueData, '{{ attribute_code }}' => $attributeCode]
-                    )->addViolation();
+                    )
+                        ->setCode(UniqueValue::UNIQUE_VALUE)
+                        ->addViolation();
                 }
             }
         }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/UniqueValueValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/UniqueValueValidatorSpec.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 class UniqueValueValidatorSpec extends ObjectBehavior
 {
-    const PROPERTY_PATH='children[values].children[unique_attribute].children[text].data';
+    const PROPERTY_PATH = 'children[values].children[unique_attribute].children[text].data';
 
     function let(
         ProductUniqueDataRepositoryInterface $uniqueDataRepository,
@@ -67,6 +67,7 @@ class UniqueValueValidatorSpec extends ObjectBehavior
         $uniqueDataRepository->uniqueDataExistsInAnotherProduct($value, $product)->willReturn(true);
 
         $context->buildViolation(Argument::cetera())->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setCode(UniqueValue::UNIQUE_VALUE)->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($value, $constraint);
@@ -93,6 +94,7 @@ class UniqueValueValidatorSpec extends ObjectBehavior
         $uniqueValuesSet->addValue($value, $product)->willReturn(false);
 
         $context->buildViolation(Argument::cetera())->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setCode(UniqueValue::UNIQUE_VALUE)->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($value, $constraint);


### PR DESCRIPTION
Add default documentation for validation error on attributes
- enable it for UniqueValueValidator

![image](https://user-images.githubusercontent.com/1671213/85142237-5617a100-b248-11ea-8a91-5f82a71a20c3.png)
