### PR TITLE
RAC-93: fix: remove @todo already done in previous tickets

### DIFF
--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
@@ -67,7 +67,7 @@ abstract class AbstractProductTestCase extends ApiTestCase
 
         $this->get('pim_catalog.saver.product')->save($product);
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
-
+        $this->get('pim_catalog.validator.unique_value_set')->reset();
 
         return $product;
     }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
@@ -73,7 +73,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -113,7 +112,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -153,7 +151,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -227,7 +224,6 @@ JSON;
                     "product_models" => [],
                 ],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -607,7 +603,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -646,7 +641,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
@@ -65,7 +65,6 @@ JSON;
                 'created'       => '2016-06-14T13:12:50+02:00',
                 'updated'       => '2016-06-14T13:12:50+02:00',
                 'associations'  => [],
-                // @todo https://akeneo.atlassian.net/browse/MET-198
                 'quantified_associations' => [],
             ],
             'my_identifier'  => [
@@ -83,7 +82,6 @@ JSON;
                 'created'       => '2016-06-14T13:12:50+02:00',
                 'updated'       => '2016-06-14T13:12:50+02:00',
                 'associations'  => [],
-                // @todo https://akeneo.atlassian.net/browse/MET-198
                 'quantified_associations' => [],
             ],
         ];

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
@@ -95,7 +95,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -134,7 +133,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -299,7 +297,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -338,7 +335,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -382,7 +378,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -462,7 +457,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -502,7 +496,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -542,7 +535,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -583,7 +575,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -624,7 +615,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -665,7 +655,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -743,7 +732,6 @@ JSON;
                     'product_models' => [],
                 ],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -793,7 +781,6 @@ JSON;
                 'UPSELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
                 'X_SELL'       => ['groups'   => [], 'products' => ['product_categories'], 'product_models' => []],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -848,7 +835,6 @@ JSON;
                 'UPSELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
                 'X_SELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -889,7 +875,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -943,7 +928,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -996,7 +980,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -1046,7 +1029,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -1228,7 +1210,6 @@ JSON;
                 'UPSELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
                 'X_SELL'       => ['groups'   => ['groupA'], 'products' => ['product_categories'], 'product_models' => []],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -1268,7 +1249,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
@@ -71,7 +71,6 @@ JSON;
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -145,7 +144,6 @@ JSON;
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -322,7 +320,6 @@ JSON;
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
         $response = $client->getResponse();
@@ -665,7 +662,6 @@ JSON;
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -830,7 +826,6 @@ JSON;
                     "product_models" => [],
                 ],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
@@ -456,7 +456,6 @@ JSON;
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -507,7 +506,6 @@ JSON;
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -559,7 +557,6 @@ JSON;
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInProductModelEndToEnd.php
@@ -30,7 +30,7 @@ class UpdateQuantifiedAssociationsInProductModelEndToEnd extends AbstractProduct
     /**
      * @test
      */
-    public function it_can_partial_update_quantified_associations_in_a_product(): void
+    public function it_can_partial_update_quantified_associations_in_a_product_model(): void
     {
         $client = $this->createAuthenticatedClient();
         $this->createQuantifiedAssociationType('PRODUCTSET_A');

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
@@ -129,7 +129,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -214,7 +213,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -490,7 +488,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -576,7 +573,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -690,7 +686,6 @@ JSON;
                     "product_models" => [],
                 ],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -938,7 +933,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -1030,7 +1024,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateListVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateListVariantProductEndToEnd.php
@@ -138,7 +138,6 @@ JSON;
                 'created'       => '2016-06-14T13:12:50+02:00',
                 'updated'       => '2016-06-14T13:12:50+02:00',
                 'associations'  => [],
-                // @todo https://akeneo.atlassian.net/browse/MET-198
                 'quantified_associations' => [],
             ],
             'apollon_optionb_false' => [
@@ -192,7 +191,6 @@ JSON;
                 'created'       => '2016-06-14T13:12:50+02:00',
                 'updated'       => '2016-06-14T13:12:50+02:00',
                 'associations'  => [],
-                // @todo https://akeneo.atlassian.net/browse/MET-198
                 'quantified_associations' => [],
             ],
         ];

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateProductToVariantEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateProductToVariantEndToEnd.php
@@ -42,7 +42,6 @@ JSON;
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
             'associations' => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
@@ -151,7 +151,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -190,7 +189,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -469,7 +467,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -555,7 +552,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -642,7 +638,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -729,7 +724,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -846,7 +840,6 @@ JSON;
                     'product_models' => [],
                 ],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -943,7 +936,6 @@ JSON;
                 'UPSELL'       => ['groups' => [], 'products' => [], 'product_models' => []],
                 'X_SELL'       => ['groups' => [], 'products' => [], 'product_models' => []],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -1041,7 +1033,6 @@ JSON;
                 'UPSELL'       => ['groups' => [], 'products' => [], 'product_models' => []],
                 'X_SELL'       => ['groups' => [], 'products' => [], 'product_models' => []],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -1129,7 +1120,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -1267,7 +1257,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -1469,7 +1458,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -1654,7 +1642,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -1739,7 +1726,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -1870,7 +1856,6 @@ JSON;
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToVariantProductEndToEnd.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\VariantProduct\ExternalApi\QuantifiedAssociations;
+
+use Akeneo\Test\Integration\Configuration;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class AddQuantifiedAssociationsToVariantProductEndToEnd extends AbstractProductTestCase
+{
+    use QuantifiedAssociationsTestCaseTrait;
+
+    /**
+     * @test
+     */
+    public function it_add_quantified_associations_to_a_variant_product(): void
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->createQuantifiedAssociationType('PRODUCTSET');
+        $this->createProductModel([
+            'code' => 'garden_table_set',
+            'family_variant' => 'familyVariantA1',
+            'values' => [],
+        ]);
+
+        $this->createProductModel([
+            'code' => 'garden_table_set-black',
+            'parent' => 'garden_table_set',
+            'family_variant' => 'familyVariantA1',
+            'values' => [
+                'a_simple_select' => [['locale' => null, 'scope' => null, 'data' => 'optionB']],
+            ],
+        ]);
+
+        $this->createProductModel([
+            'code' => 'umbrella',
+            'family_variant' => 'familyVariantA1',
+            'values' => [],
+        ]);
+
+        $this->createProduct('chair');
+
+        $data = <<<JSON
+{
+    "identifier": "garden_table_set-black-gold",
+    "parent": "garden_table_set-black",
+    "values": {"a_yes_no": [{"locale": null, "scope": null, "data": true}]},
+    "quantified_associations": {
+        "PRODUCTSET": {
+            "products": [
+                {"identifier": "chair", "quantity": 8}
+            ],
+            "product_models": [
+                {"identifier": "umbrella", "quantity": 2}
+            ]
+        }
+    }
+}
+JSON;
+
+        $client->request('POST', '/api/rest/v1/products', [], [], [], $data);
+
+        $expectedProduct = [
+            'identifier' => 'garden_table_set-black-gold',
+            'family' => 'familyA',
+            'parent' => 'garden_table_set-black',
+            'groups' => [],
+            'categories' => [],
+            'enabled' => true,
+            'values' => [
+                "a_simple_select" => [
+                    ["data" => "optionB", "locale" => null, "scope" => null]
+                ],
+                "a_yes_no"=>[
+                    ["data" => true, "locale" => null, "scope" => null]
+                ],
+                "sku" => [
+                    ["data" => "garden_table_set-black-gold", "locale" => null, "scope" => null]
+                ]
+            ],
+            'created' => '2016-06-14T13:12:50+02:00',
+            'updated' => '2016-06-14T13:12:50+02:00',
+            'associations' => [],
+            'quantified_associations' => [
+                'PRODUCTSET' => [
+                    'products' => [
+                        ['identifier' => 'chair', 'quantity' => 8],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'umbrella', 'quantity' => 2],
+                    ],
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSameProducts($expectedProduct, 'garden_table_set-black-gold');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromVariantProductEndToEnd.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\VariantProduct\ExternalApi\QuantifiedAssociations;
+
+use Akeneo\Test\Integration\Configuration;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class DeleteQuantifiedAssociationsFromVariantProductEndToEnd extends AbstractProductTestCase
+{
+    use QuantifiedAssociationsTestCaseTrait;
+
+    /**
+     * @test
+     */
+    public function it_delete_quantified_associations_from_a_variant_product(): void
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->createQuantifiedAssociationType('PRODUCTSET');
+        $this->createProductModel([
+            'code' => 'garden_table_set',
+            'family_variant' => 'familyVariantA1',
+            'values' => [],
+        ]);
+
+        $this->createProductModel([
+            'code' => 'garden_table_set-black',
+            'parent' => 'garden_table_set',
+            'family_variant' => 'familyVariantA1',
+            'values' => [
+                'a_simple_select' => [['locale' => null, 'scope' => null, 'data' => 'optionB']],
+            ],
+        ]);
+
+        $this->createProductModel([
+            'code' => 'umbrella',
+            'family_variant' => 'familyVariantA1',
+            'values' => [],
+        ]);
+
+        $this->createProduct('chair');
+        $this->createVariantProduct('garden_table_set-black-gold', [
+            'parent' => 'garden_table_set-black',
+            'values' => [
+                'a_yes_no' => [['locale' => null, 'scope' => null, 'data' => true]],
+            ],
+            'quantified_associations' => [
+                "PRODUCTSET" => [
+                    "products" => [
+                        ["identifier" => "chair", "quantity" => 8]
+                    ],
+                    "product_models" => [
+                        ["identifier" => "umbrella", "quantity" => 2]
+                    ],
+                ],
+            ],
+        ]);
+
+        $data = <<<JSON
+{
+    "identifier": "garden_table_set-black-gold",
+    "quantified_associations": {
+        "PRODUCTSET": {
+            "products": [],
+            "product_models": []
+        }
+    }
+}
+JSON;
+
+        $client->request('PATCH', sprintf('/api/rest/v1/products/%s', 'garden_table_set-black-gold'), [], [], [], $data);
+
+        $expectedProduct = [
+            'identifier' => 'garden_table_set-black-gold',
+            'family' => 'familyA',
+            'parent' => 'garden_table_set-black',
+            'groups' => [],
+            'categories' => [],
+            'enabled' => true,
+            'values' => [
+                "a_simple_select" => [
+                    ["data" => "optionB", "locale" => null, "scope" => null]
+                ],
+                "a_yes_no"=>[
+                    ["data" => true, "locale" => null, "scope" => null]
+                ],
+                "sku" => [
+                    ["data" => "garden_table_set-black-gold", "locale" => null, "scope" => null]
+                ]
+            ],
+            'created' => '2016-06-14T13:12:50+02:00',
+            'updated' => '2016-06-14T13:12:50+02:00',
+            'associations' => [],
+            'quantified_associations' => [
+                'PRODUCTSET' => [
+                    'products' => [],
+                    'product_models' => [],
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSameProducts($expectedProduct, 'garden_table_set-black-gold');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInVariantProductEndToEnd.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\VariantProduct\ExternalApi\QuantifiedAssociations;
+
+use Akeneo\Test\Integration\Configuration;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class UpdateQuantifiedAssociationsInVariantProductEndToEnd extends AbstractProductTestCase
+{
+    use QuantifiedAssociationsTestCaseTrait;
+
+    /**
+     * @test
+     */
+    public function it_can_partial_update_quantified_associations_in_a_variant_product(): void
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->createQuantifiedAssociationType('PRODUCTSET');
+        $this->createProduct('chair');
+        $this->createProductModel([
+            'code' => 'garden_table_set',
+            'family_variant' => 'familyVariantA1',
+            'values' => [],
+        ]);
+
+        $this->createProductModel([
+            'code' => 'garden_table_set-black',
+            'parent' => 'garden_table_set',
+            'family_variant' => 'familyVariantA1',
+            'values' => [
+                'a_simple_select' => [['locale' => null, 'scope' => null, 'data' => 'optionB']],
+            ],
+        ]);
+
+        $this->createProductModel([
+            'code' => 'umbrella',
+            'family_variant' => 'familyVariantA1',
+            'values' => [],
+        ]);
+
+        $this->createVariantProduct('garden_table_set-black-gold', [
+            'parent' => 'garden_table_set-black',
+            'values' => [
+                'a_yes_no' => [['locale' => null, 'scope' => null, 'data' => true]],
+            ],
+            'quantified_associations' => [
+                "PRODUCTSET" => [
+                    "products" => [
+                        ["identifier" => "chair", "quantity" => 4]
+                    ],
+                    "product_models" => [
+                        ["identifier" => "umbrella", "quantity" => 4]
+                    ],
+                ],
+            ],
+        ]);
+
+        $data = <<<JSON
+{
+    "identifier": "garden_table_set-black-gold",
+    "quantified_associations": {
+        "PRODUCTSET": {
+            "products": [
+                {"identifier": "chair", "quantity": 6}
+            ]
+        }
+    }
+}
+JSON;
+
+        $client->request('PATCH', sprintf('/api/rest/v1/products/%s', 'garden_table_set-black-gold'), [], [], [], $data);
+
+        $expectedProduct = [
+            'identifier' => 'garden_table_set-black-gold',
+            'family' => 'familyA',
+            'parent' => 'garden_table_set-black',
+            'groups' => [],
+            'categories' => [],
+            'enabled' => true,
+            'values' => [
+                "a_simple_select" => [
+                    ["data" => "optionB", "locale" => null, "scope" => null]
+                ],
+                "a_yes_no"=>[
+                    ["data" => true, "locale" => null, "scope" => null]
+                ],
+                "sku" => [
+                    ["data" => "garden_table_set-black-gold", "locale" => null, "scope" => null]
+                ]
+            ],
+            'created' => '2016-06-14T13:12:50+02:00',
+            'updated' => '2016-06-14T13:12:50+02:00',
+            'associations' => [],
+            'quantified_associations' => [
+                'PRODUCTSET' => [
+                    'products' => [
+                        ['identifier' => 'chair', 'quantity' => 6],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'umbrella', 'quantity' => 4],
+                    ],
+                ],
+            ],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSameProducts($expectedProduct, 'garden_table_set-black-gold');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Normalizer/Standard/ProductStandardSortedCollectionIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Normalizer/Standard/ProductStandardSortedCollectionIntegration.php
@@ -75,7 +75,6 @@ class ProductStandardSortedCollectionIntegration extends TestCase
                     'product_models' => [],
                 ],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -133,7 +132,6 @@ class ProductStandardSortedCollectionIntegration extends TestCase
                     'product_models' => [],
                 ],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 
@@ -191,7 +189,6 @@ class ProductStandardSortedCollectionIntegration extends TestCase
                     'product_models' => [],
                 ],
             ],
-            // @todo https://akeneo.atlassian.net/browse/MET-198
             'quantified_associations' => [],
         ];
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This PR remove all @TODO MET-198 already done in https://github.com/akeneo/pim-community-dev/pull/12187 

This PR only add test on variant product

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | Done
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
