### PR TITLE
CXP-366: add number validation documentation

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/ErrorManagement/DocumentationBuilder/DefaultAttributeValidation.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/ErrorManagement/DocumentationBuilder/DefaultAttributeValidation.php
@@ -9,6 +9,8 @@ use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Docu
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Documentation\HrefMessageParameter;
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Documentation\RouteMessageParameter;
 use Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\IsNumeric;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Range;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueValue;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 
@@ -16,15 +18,24 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-final class AttributeValidation implements DocumentationBuilderInterface
+final class DefaultAttributeValidation implements DocumentationBuilderInterface
 {
+    const SUPPORTED_CONSTRAINTS_CODES = [
+        IsNumeric::IS_NUMERIC,
+        Range::INVALID_CHARACTERS_ERROR,
+        Range::NOT_IN_RANGE_ERROR,
+        Range::TOO_HIGH_ERROR,
+        Range::TOO_LOW_ERROR,
+        UniqueValue::UNIQUE_VALUE,
+    ];
+
     public function support($object): bool
     {
-        if ($object instanceof ConstraintViolationInterface) {
-            switch ($object->getCode()) {
-                case UniqueValue::UNIQUE_VALUE:
-                    return true;
-            }
+        if (
+            $object instanceof ConstraintViolationInterface
+            && in_array($object->getCode(), self::SUPPORTED_CONSTRAINTS_CODES)
+        ) {
+            return true;
         }
 
         return false;

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/documentation.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/documentation.yml
@@ -7,7 +7,7 @@ services:
     Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilder\AttributeOptionDoesNotExist:
         tags: [akeneo_connectivity.connection.documentation_builder]
 
-    Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilder\AttributeValidation:
+    Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilder\DefaultAttributeValidation:
         tags: [akeneo_connectivity.connection.documentation_builder]
 
     Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilder\UnknownAttribute:

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/ErrorManagement/DocumentationBuilder/DefaultAttributeValidationSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/ErrorManagement/DocumentationBuilder/DefaultAttributeValidationSpec.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilder;
+
+use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Documentation\DocumentationCollection;
+use Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilder\DefaultAttributeValidation;
+use Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\IsNumeric;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Range;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueValue;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class DefaultAttributeValidationSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->beAnInstanceOf(DefaultAttributeValidation::class);
+    }
+
+    function it_is_a_documentation_builder()
+    {
+        $this->beAnInstanceOf(DocumentationBuilderInterface::class);
+    }
+
+    function it_supports_some_attribute_validation_constraints(ConstraintViolationInterface $constraintViolation)
+    {
+        $constraintCodes = [
+            IsNumeric::IS_NUMERIC,
+            Range::INVALID_CHARACTERS_ERROR,
+            Range::TOO_HIGH_ERROR,
+            Range::TOO_LOW_ERROR,
+            UniqueValue::UNIQUE_VALUE
+        ];
+
+        foreach ($constraintCodes as $contraintCode) {
+            $constraintViolation->getCode()->willReturn($contraintCode);
+            $this->support($constraintViolation)->shouldReturn(true);
+        }
+    }
+
+    function it_does_not_support_other_types_of_error(ConstraintViolationInterface $constraintViolation)
+    {
+        $constraintViolation->getCode()->willReturn('other_error_code');
+
+        $this->support($constraintViolation)->shouldReturn(false);
+    }
+
+    function it_builds_the_documentation(ConstraintViolationInterface $constraintViolation)
+    {
+        $constraintViolation->getCode()->willReturn(UniqueValue::UNIQUE_VALUE);
+
+        $documentation = $this->buildDocumentation($constraintViolation);
+
+        $documentation->shouldHaveType(DocumentationCollection::class);
+        $documentation->normalize()->shouldReturn([
+            [
+                'message' => 'More information about attributes and their validation: {manage_attributes} {manage_validation_parameters}',
+                'parameters' => [
+                    'manage_attributes' => [
+                        'type' => 'href',
+                        'href' => 'https://help.akeneo.com/pim/serenity/articles/manage-your-attributes.html',
+                        'title' => 'Manage your attributes',
+                    ],
+                    'manage_validation_parameters' => [
+                        'type' => 'href',
+                        'href' => 'https://help.akeneo.com/pim/serenity/articles/manage-your-attributes.html#add-attributes-validation-parameters',
+                        'title' => 'Manage your validation parameters',
+                    ],
+                ],
+                'style' => 'information',
+            ],
+            [
+                'message' => 'Please check your {attribute_settings}.',
+                'parameters' => [
+                    'attribute_settings' => [
+                        'type' => 'route',
+                        'route' => 'pim_enrich_attribute_index',
+                        'routeParameters' => [],
+                        'title' => 'Attributes settings',
+                    ],
+                ],
+                'style' => 'text',
+            ]
+        ]);
+    }
+
+    function it_does_not_build_the_documentation_for_an_unsupported_error(
+        ConstraintViolationInterface $constraintViolation
+    ) {
+        $constraintViolation->getCode()->willReturn('other_error_code');
+
+        $this->shouldThrow(\InvalidArgumentException::class)
+            ->during('buildDocumentation', [$constraintViolation]);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/IsNumeric.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/IsNumeric.php
@@ -13,6 +13,8 @@ use Symfony\Component\Validator\Constraint;
  */
 class IsNumeric extends Constraint
 {
+    const IS_NUMERIC = "3ee14592-14a8-4314-836f-b6177aaf7c05";
+
     /** @var string */
     public $message = 'The {{ attribute }} attribute requires a number, and the submitted {{ value }} value is not.';
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/IsNumericValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/IsNumericValidator.php
@@ -41,7 +41,9 @@ class IsNumericValidator extends ConstraintValidator
                     '{{ value }}' => $value,
                 ]
 
-            );
+            )
+                ->setCode(IsNumeric::IS_NUMERIC);
+
             if (isset($propertyPath)) {
                 $violation->atPath($propertyPath);
             }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Range.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Range.php
@@ -20,8 +20,6 @@ class Range extends BaseRange
     public $maxDateMessage = 'The {{ attribute_code }} attribute requires a date that should be {{ limit }} or before.';
 
     /** @var string */
-    public $invalidDateMessage = 'This value is not a valid date.';
-
     public $invalidMessage = 'The {{ attribute }} attribute requires a number, and the submitted {{ value }} value is not.';
 
     /** @var string */

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/IsNumericValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/IsNumericValidatorSpec.php
@@ -107,7 +107,7 @@ class IsNumericValidatorSpec extends ObjectBehavior
 
     function it_adds_violation_when_validating_non_numeric_value(
         $context,
-        ConstraintViolationBuilderInterface $violation
+        ConstraintViolationBuilderInterface $violationBuilder
     ) {
         $numericConstraint = new IsNumeric();
         $numericConstraint->attributeCode = 'number';
@@ -120,8 +120,10 @@ class IsNumericValidatorSpec extends ObjectBehavior
                     '{{ value }}' => 'a',
                 ]
             )
-            ->shouldBeCalled()
-            ->willReturn($violation);
+            ->willReturn($violationBuilder);
+
+        $violationBuilder->setCode(IsNumeric::IS_NUMERIC)->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate('a', $numericConstraint);
     }
@@ -129,7 +131,7 @@ class IsNumericValidatorSpec extends ObjectBehavior
     function it_adds_violation_when_validating_non_numeric_metric_value(
         $context,
         MetricInterface $metric,
-        ConstraintViolationBuilderInterface $violation
+        ConstraintViolationBuilderInterface $violationBuilder
     ) {
         $numericConstraint = new IsNumeric();
         $numericConstraint->attributeCode = 'number';
@@ -144,7 +146,11 @@ class IsNumericValidatorSpec extends ObjectBehavior
                 ]
             )
             ->shouldBeCalled()
-            ->willReturn($violation);
+            ->willReturn($violationBuilder);
+
+        $violationBuilder->setCode(IsNumeric::IS_NUMERIC)->willReturn($violationBuilder);
+        $violationBuilder->atPath('data')->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($metric, $numericConstraint);
     }
@@ -152,7 +158,7 @@ class IsNumericValidatorSpec extends ObjectBehavior
     function it_adds_violation_when_validating_non_numeric_product_price_value(
         $context,
         ProductPriceInterface $productPrice,
-        ConstraintViolationBuilderInterface $violation
+        ConstraintViolationBuilderInterface $violationBuilder
     ) {
         $numericConstraint = new IsNumeric();
         $numericConstraint->attributeCode = 'number';
@@ -166,7 +172,11 @@ class IsNumericValidatorSpec extends ObjectBehavior
                 ]
             )
             ->shouldBeCalled()
-            ->willReturn($violation);
+            ->willReturn($violationBuilder);
+
+        $violationBuilder->setCode(IsNumeric::IS_NUMERIC)->willReturn($violationBuilder);
+        $violationBuilder->atPath('data')->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($productPrice, $numericConstraint);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/RangeSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/RangeSpec.php
@@ -36,12 +36,6 @@ class RangeSpec extends ObjectBehavior
         $this->invalidMessage->shouldBe('The {{ attribute }} attribute requires a number, and the submitted {{ value }} value is not.');
     }
 
-    function it_has_an_invalid_date_message()
-    {
-        $this->beConstructedWith(['min' => new \DateTime()]);
-        $this->invalidDateMessage->shouldBe('This value is not a valid date.');
-    }
-
     function it_has_an_attribute_code()
     {
         $this->beConstructedWith(['min' => new \DateTime(), 'attributeCode' => 'a_code']);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/RangeValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/RangeValidatorSpec.php
@@ -271,6 +271,7 @@ class RangeValidatorSpec extends ObjectBehavior
             )
             ->shouldBeCalled()
             ->willReturn($violation);
+        $violation->setCode(Range::TOO_LOW_ERROR)->willReturn($violation);
         $violation->addViolation()->shouldBeCalled();
 
         $this->validate(new \DateTime('2012-12-25'), $constraint);
@@ -295,6 +296,7 @@ class RangeValidatorSpec extends ObjectBehavior
             )
             ->shouldBeCalled()
             ->willReturn($violation);
+        $violation->setCode(Range::TOO_LOW_ERROR)->willReturn($violation);
         $violation->addViolation()->shouldBeCalled();
 
         $this->validate(new \DateTime('2012-12-25'), $constraint);
@@ -319,6 +321,7 @@ class RangeValidatorSpec extends ObjectBehavior
             )
             ->shouldBeCalled()
             ->willReturn($violation);
+        $violation->setCode(Range::TOO_HIGH_ERROR)->willReturn($violation);
         $violation->addViolation()->shouldBeCalled();
 
         $this->validate(new \DateTime('2015-12-25'), $constraint);
@@ -352,6 +355,7 @@ class RangeValidatorSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($violation);
         $violation->atPath('data')->shouldBeCalled()->willReturn($violation);
+        $violation->setCode(Range::TOO_HIGH_ERROR)->willReturn($violation);
         $violation->addViolation()->shouldBeCalled();
 
         $this->validate($productPrice, $constraint);
@@ -386,6 +390,7 @@ class RangeValidatorSpec extends ObjectBehavior
             ->willReturn($violation);
 
         $violation->atPath('data')->shouldBeCalled()->willReturn($violation);
+        $violation->setCode(Range::TOO_HIGH_ERROR)->willReturn($violation);
         $violation->addViolation()->shouldBeCalled();
 
         $this->validate($metric, $constraint);
@@ -397,14 +402,8 @@ class RangeValidatorSpec extends ObjectBehavior
         $constraint->max = 20;
 
         $context
-            ->buildViolation(
-                $constraint->invalidMessage,
-                [
-                    '{{ attribute }}' => $constraint->attributeCode,
-                    '{{ value }}' => null,
-                ]
-            )
-            ->shouldBeCalled();
+            ->buildViolation('myMessage', ['{{ value }}' => 21, '{{ limit }}' => 20])
+            ->shouldNotBeCalled();
 
         $this->validate(null, $constraint);
     }


### PR DESCRIPTION
Add default documentation to:

13.6
![image](https://user-images.githubusercontent.com/1671213/85283769-31ad0600-b48e-11ea-884f-031d1fd0432f.png)

13.11
![image](https://user-images.githubusercontent.com/1671213/85310383-2ff63900-b4b4-11ea-9fac-49c917b272d9.png)
13.12
![image](https://user-images.githubusercontent.com/1671213/85310868-d5a9a800-b4b4-11ea-92f3-8791420cd51c.png)

13.16.1
13.16.2
![image](https://user-images.githubusercontent.com/1671213/85310503-5caa5080-b4b4-11ea-8f47-73ab934b8d88.png)
