### PR TITLE
GITHUB-APD-172: I want to be able to track which announcements meet the most success in the communication panel 

### DIFF
--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Model/Read/AnnouncementItem.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Model/Read/AnnouncementItem.php
@@ -17,6 +17,9 @@ final class AnnouncementItem
     private const DATE_INTERVAL_FORMAT = 'P%sD';
 
     /** @var string */
+    private $id;
+
+    /** @var string */
     private $title;
 
     /** @var string */
@@ -40,9 +43,6 @@ final class AnnouncementItem
     /** @var string[] */
     private $tags;
 
-    /** @var string[] */
-    private $editions;
-
     /**
      * @param string $title
      * @param string $description
@@ -52,10 +52,10 @@ final class AnnouncementItem
      * @param DateTimeImmutable $startDate
      * @param int $notificationDuration
      * @param string[] $tags
-     * @param string[] $editions
      * @return void
      */
     public function __construct(
+        string $id,
         string $title,
         string $description,
         ?string $img,
@@ -63,9 +63,9 @@ final class AnnouncementItem
         string $link,
         \DateTimeImmutable $startDate,
         int $notificationDuration,
-        array $tags,
-        array $editions
+        array $tags
     ) {
+        $this->id = $id;
         $this->title = $title;
         $this->description = $description;
         $this->img = $img;
@@ -74,7 +74,6 @@ final class AnnouncementItem
         $this->startDate = $startDate;
         $this->notificationDuration = $notificationDuration;
         $this->tags = $tags;
-        $this->editions = $editions;
     }
 
     /**
@@ -85,6 +84,7 @@ final class AnnouncementItem
         $this->addNewTag();
 
         return [
+            'id' => $this->id,
             'title' => $this->title,
             'description' => $this->description,
             'img' => $this->img,

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/InMemory/InMemoryFindAnnouncementItems.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/InMemory/InMemoryFindAnnouncementItems.php
@@ -36,6 +36,7 @@ final class InMemoryFindAnnouncementItems implements FindAnnouncementItemsInterf
     private function getAnnouncementItem(array $announcement): AnnouncementItem
     {
         return new AnnouncementItem(
+            $announcement['id'],
             $announcement['title'],
             $announcement['description'],
             $announcement['img'] ?? null,
@@ -43,8 +44,7 @@ final class InMemoryFindAnnouncementItems implements FindAnnouncementItemsInterf
             $announcement['link'],
             new \DateTimeImmutable($announcement['startDate']),
             $announcement['notificationDuration'],
-            $announcement['tags'],
-            $announcement['editions']
+            $announcement['tags']
         );
     }
 }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/InMemory/serenity-updates.json
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/InMemory/serenity-updates.json
@@ -1,7 +1,7 @@
 {
     "data": [
         {
-            "id": "update-easily_monitor_errors_on_your_connections-2020-06-04",
+            "id": "update_1-easily-monitor-errors-on-your-connections_2020-06-04",
             "startDate": "2020/06/04",
             "notificationDuration": 14,
             "tags": [
@@ -14,7 +14,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-05.html#easily-monitor-errors-on-your-connections"
         },
         {
-            "id": "update-new_metrics_on_the_connection_dashboard-2020-06-04",
+            "id": "update_2-new-metric-on-the-connection-dashboard_2020-06-04",
             "startDate": "2020/06/04",
             "notificationDuration": 14,
             "tags": [
@@ -27,7 +27,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-05.html#new-metrics-on-the-connection-dashboard"
         },
         {
-            "id": "update-new_association_type_the_two_way_association-2020-06-04",
+            "id": "update_3-2-way-associations_2020-06-04",
             "startDate": "2020/06/04",
             "notificationDuration": 14,
             "tags": [
@@ -40,7 +40,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-05.html#new-association-type-the-two-way-association"
         },
         {
-            "id": "update-more_visibility_on_pim_jobs-2020-06-04",
+            "id": "update_4-visibility-on-jobs_2020-06-04",
             "startDate": "2020/06/04",
             "notificationDuration": 14,
             "tags": [
@@ -51,7 +51,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-05.html#more-visibility-on-pim-jobs"
         },
         {
-            "id": "update-rules_engine_improvements-2020-06-04",
+            "id": "update_5-rules-engine-new-improvements_2020-06-04",
             "startDate": "2020/06/04",
             "notificationDuration": 14,
             "tags": [
@@ -62,7 +62,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-05.html#rules-engine-improvements"
         },
         {
-            "id": "update-a_new_screen_to_add_your_own_measurement_units-2020-05-07",
+            "id": "update_1-new-screen-for-measurements-families_2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
@@ -75,7 +75,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#a-new-screen-to-add-your-own-measurement-units"
         },
         {
-            "id": "update-new_endpoints_to_manage_measurements-2020-05-07",
+            "id": "update_2-new-measurements-api-endpoints_2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
@@ -88,7 +88,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#new-endpoints-to-manage-measurements"
         },
         {
-            "id": "update-product_associations_update-2020-05-07",
+            "id": "update_3-associations-updates_2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
@@ -101,7 +101,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#product-associations-update"
         },
         {
-            "id": "update-track_your_destination_connections-2020-05-07",
+            "id": "update_4-destination-connections-tracking_2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
@@ -114,7 +114,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#track-your-destination-connections"
         },
         {
-            "id": "update-connection_dashboard_updates-2020-05-07",
+            "id": "update_5-connection-dashboard-updates_2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
@@ -125,7 +125,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#connection-dashboard-updates"
         },
         {
-            "id": "update-rules_engine_new_actions_and_improvements-2020-05-07",
+            "id": "update_6-rules-engine-new-actions-and-improvements_2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
@@ -136,7 +136,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#rules-engine-new-actions-and-improvements"
         },
         {
-            "id": "update-rules_engine_new_actions_and_improvements-2020-05-07",
+            "id": "update_7-data-quality-new-improvements_2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
@@ -147,7 +147,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#data-quality-insights-made-even-more-powerful"
         },
         {
-            "id": "update-data_quality_improvements-2020-04-02",
+            "id": "update_1-data-quality-new-improvements_2020-04-02",
             "startDate": "2020/04/02",
             "notificationDuration": 7,
             "tags": [
@@ -158,7 +158,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-03.html#data-quality-improvements"
         },
         {
-            "id": "update-new_measurement_units_and_families-2020-04-02",
+            "id": "update_2-product-modeling-improved-thanks-new-measurement-units_2020-04-02",
             "startDate": "2020/04/02",
             "notificationDuration": 7,
             "tags": [
@@ -169,7 +169,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-03.html#new-measurement-units-and-families"
         },
         {
-            "id": "update-rules_engine_extended_capabilities-2020-04-02",
+            "id": "update_3-rules-engine-extended-capabilities_2020-04-02",
             "startDate": "2020/04/02",
             "notificationDuration": 7,
             "tags": [
@@ -180,7 +180,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-03.html#rules-engine-extended-capabilities"
         },
         {
-            "id": "update-optimize_the_weight_of_your_assets-2020-03-05",
+            "id": "update_1-optimize-weight-assets_2020-03-05",
             "startDate": "2020/03/05",
             "notificationDuration": 7,
             "tags": [
@@ -193,7 +193,7 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-02.html#optimize-the-weight-of-your-assets"
         },
         {
-            "id": "update-new_warning_message_on_connection_usernames-2020-03-05",
+            "id": "update_2-new-warning-message-username-connection_2020-03-05",
             "startDate": "2020/03/05",
             "notificationDuration": 7,
             "tags": [

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/InMemory/serenity-updates.json
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/InMemory/serenity-updates.json
@@ -1,14 +1,11 @@
 {
     "data": [
         {
+            "id": "update-easily_monitor_errors_on_your_connections-2020-06-04",
             "startDate": "2020/06/04",
             "notificationDuration": 14,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "CE",
-                "EE"
             ],
             "title": "Easily monitor errors on your connections",
             "description": "For each of your connections, a new `Monitoring` page now lists the last integration errors that may have occurred.",
@@ -17,14 +14,11 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-05.html#easily-monitor-errors-on-your-connections"
         },
         {
+            "id": "update-new_metrics_on_the_connection_dashboard-2020-06-04",
             "startDate": "2020/06/04",
             "notificationDuration": 14,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "CE",
-                "EE"
             ],
             "title": "New metrics on the Connection dashboard",
             "description": "The Connection dashboard now displays additional information to ease error monitoring and allow you to see at a glance how your source connections are performing.",
@@ -33,14 +27,11 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-05.html#new-metrics-on-the-connection-dashboard"
         },
         {
+            "id": "update-new_association_type_the_two_way_association-2020-06-04",
             "startDate": "2020/06/04",
             "notificationDuration": 14,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "CE",
-                "EE"
             ],
             "title": "New association type: the two-way association",
             "description": "Easily handle products compatibility in your PIM thanks to our **brand new two-way association type**! This new association type is now available under `Settings`/`Association types`.",
@@ -49,41 +40,33 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-05.html#new-association-type-the-two-way-association"
         },
         {
+            "id": "update-more_visibility_on_pim_jobs-2020-06-04",
             "startDate": "2020/06/04",
             "notificationDuration": 14,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "CE",
-                "EE"
             ],
             "title": "More visibility on PIM jobs",
             "description": "To give you more visibility and control on all PIM jobs, we added a new permission: `View all jobs in the Process Tracker` to see all jobs of any status under the Process Tracker.",
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-05.html#more-visibility-on-pim-jobs"
         },
         {
+            "id": "update-rules_engine_improvements-2020-06-04",
             "startDate": "2020/06/04",
             "notificationDuration": 14,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "EE"
             ],
             "title": "Rules engine improvements",
             "description": "Small UI enhancements and a new parameter for your calculation action, check out the last improvements of the rules engine!",
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-05.html#rules-engine-improvements"
         },
         {
+            "id": "update-a_new_screen_to_add_your_own_measurement_units-2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "CE",
-                "EE"
             ],
             "title": "A new screen to add your own measurement units",
             "description": "In order to give you more flexibility, we have improved the way we manage metrics in the PIM. Discover our new Measurements feature now!",
@@ -92,14 +75,11 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#a-new-screen-to-add-your-own-measurement-units"
         },
         {
+            "id": "update-new_endpoints_to_manage_measurements-2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "CE",
-                "EE"
             ],
             "title": "New endpoints to manage measurements",
             "description": "We introduced two new API endpoints to create, update and list your measurement families.",
@@ -108,14 +88,11 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#new-endpoints-to-manage-measurements"
         },
         {
+            "id": "update-product_associations_update-2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "CE",
-                "EE"
             ],
             "title": "Product associations update",
             "description": "Starting now, enjoy some small improvements to make your life easier when you work with product associations.",
@@ -124,14 +101,11 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#product-associations-update"
         },
         {
+            "id": "update-track_your_destination_connections-2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "CE",
-                "EE"
             ],
             "title": "Track your destination connections",
             "description": "You can now easily track the number of products that are sent to your destinations in the Connection dashboard.",
@@ -140,93 +114,77 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#track-your-destination-connections"
         },
         {
+            "id": "update-connection_dashboard_updates-2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "CE",
-                "EE"
             ],
             "title": "Connection dashboard updates",
             "description": "The Connection dashboard has been improved with a new layout as well as the possibility to choose which connection you want to track.",
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#connection-dashboard-updates"
         },
         {
+            "id": "update-rules_engine_new_actions_and_improvements-2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "EE"
             ],
             "title": "Rules engine new actions and improvements",
             "description": "Discover the latest enhancements on the rules engine: we added two new actions, the possibility to name your rules and we also improved the rules format for associations.",
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#rules-engine-new-actions-and-improvements"
         },
         {
+            "id": "update-rules_engine_new_actions_and_improvements-2020-05-07",
             "startDate": "2020/05/07",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "EE"
             ],
             "title": "Data Quality Insights made even more powerful",
             "description": "Data Quality Insights recommendations and grades are now also available for product models to help you ensure that all your products have enriched and consistent content. Also, our spell-check feature now supports additional languages.",
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-04.html#data-quality-insights-made-even-more-powerful"
         },
         {
+            "id": "update-data_quality_improvements-2020-04-02",
             "startDate": "2020/04/02",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "EE"
             ],
             "title": "Data quality improvements",
             "description": "To help you craft the best product information ever, Data quality insights recommendations and grades are now available for variant products and our spell-check feature supports additional languages!",
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-03.html#data-quality-improvements"
         },
         {
+            "id": "update-new_measurement_units_and_families-2020-04-02",
             "startDate": "2020/04/02",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "CE",
-                "EE"
             ],
             "title": "New measurement units and families",
             "description": "We added four new measurement families: `Force`, `Angle`, `Capacitance` and `Volume Flow` to better fit your needs in terms of product modeling.",
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-03.html#new-measurement-units-and-families"
         },
         {
+            "id": "update-rules_engine_extended_capabilities-2020-04-02",
             "startDate": "2020/04/02",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "EE"
             ],
             "title": "Rules engine extended capabilities",
             "description": "A new action and enhancements made on the copy action: easily and automatically concatenate your attributes, and now copy values from an attribute type to another attribute type.",
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-03.html#rules-engine-extended-capabilities"
         },
         {
+            "id": "update-optimize_the_weight_of_your_assets-2020-03-05",
             "startDate": "2020/03/05",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "EE"
             ],
             "title": "Optimize the weight of your assets",
             "description": "If you need to reduce the size of your images, you can now use our new operation: `optimize_jpeg`. This transformation operation will compress your file to a jpeg.",
@@ -235,14 +193,11 @@
             "link": "https://help.akeneo.com/pim/serenity/updates/2020-02.html#optimize-the-weight-of-your-assets"
         },
         {
+            "id": "update-new_warning_message_on_connection_usernames-2020-03-05",
             "startDate": "2020/03/05",
             "notificationDuration": 7,
             "tags": [
                 "updates"
-            ],
-            "editions": [
-                "CE",
-                "EE"
             ],
             "title": "New warning message on connection usernames",
             "description": "Whenever one of your connectors is not using the dedicated connection username, we now display a warning message in the main Connections screen as well as in the Connection form.",

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Announcement/ListAnnouncementIntegration.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Announcement/ListAnnouncementIntegration.php
@@ -40,6 +40,7 @@ class ListAnnouncementIntegration extends WebTestCase
 
     private function assertItemKeys(array $item): void
     {
+        Assert::assertArrayHasKey('id', $item);
         Assert::assertArrayHasKey('title', $item);
         Assert::assertArrayHasKey('description', $item);
         Assert::assertArrayHasKey('img', $item);

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Application/Announcement/Query/ListAnnouncementsHandlerSpec.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Application/Announcement/Query/ListAnnouncementsHandlerSpec.php
@@ -29,36 +29,30 @@ class ListAnnouncementsHandlerSpec extends ObjectBehavior
     {
         $announcements = [
             [
-                'startDate' => '2020/06/04',
-                'endDate' => '2020/12/31',
-                'notificationDuration' => 14,
-                'tags' => [
-                    'updates'
-                ],
-                'editions' => [
-                    'CE',
-                    'EE'
-                ],
+                'id' => 'update-easily_monitor_errors_on_your_connections-2020-06-04',
                 'title' => 'Easily monitor errors on your connections',
                 'description' => 'For each of your connections, a new `Monitoring` page now lists the last integration errors that may have occurred.',
                 'img' => '/bundles/akeneocommunicationchannel/images/announcements/new-connection-monitoring-page.png',
                 'altImg' => 'Connection monitoring page',
-                'link' => 'https://help.akeneo.com/pim/serenity/updates/2020-05.html#easily-monitor-errors-on-your-connections'
-            ],
-            [
+                'link' => 'https://help.akeneo.com/pim/serenity/updates/2020-05.html#easily-monitor-errors-on-your-connections',
                 'startDate' => '2020/06/04',
                 'endDate' => '2020/12/31',
                 'notificationDuration' => 14,
                 'tags' => [
                     'updates'
-                ],
-                'editions' => [
-                    'CE',
-                    'EE'
-                ],
+                ]
+            ],
+            [
+                'id' => 'update-new_metrics_on_the_connection_dashboard-2020-06-04',
                 'title' => 'New metrics on the Connection dashboard',
                 'description' => 'The Connection dashboard now displays additional information to ease error monitoring and allow you to see at a glance how your source connections are performing.',
-                'link' => 'https://help.akeneo.com/pim/serenity/updates/2020-05.html#new-metrics-on-the-connection-dashboard'
+                'link' => 'https://help.akeneo.com/pim/serenity/updates/2020-05.html#new-metrics-on-the-connection-dashboard',
+                'startDate' => '2020/06/04',
+                'endDate' => '2020/12/31',
+                'notificationDuration' => 14,
+                'tags' => [
+                    'updates'
+                ]
             ],
         ];
         $announcementItems = $this->createAnnouncementItems($announcements);
@@ -76,6 +70,7 @@ class ListAnnouncementsHandlerSpec extends ObjectBehavior
     {
         return array_map(function ($announcement) {
             return new AnnouncementItem(
+                $announcement['id'],
                 $announcement['title'],
                 $announcement['description'],
                 $announcement['img'] ?? null,
@@ -84,7 +79,6 @@ class ListAnnouncementsHandlerSpec extends ObjectBehavior
                 new \DateTimeImmutable($announcement['startDate']),
                 $announcement['notificationDuration'],
                 $announcement['tags'],
-                $announcement['editions']
             );
         }, $announcements);
     }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Domain/Announcement/Model/Read/AnnouncementItemSpec.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Domain/Announcement/Model/Read/AnnouncementItemSpec.php
@@ -5,26 +5,29 @@ declare(strict_types=1);
 namespace spec\Akeneo\Platform\CommunicationChannel\Domain\Announcement\Model\Read;
 
 use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Model\Read\AnnouncementItem;
+use DateTimeImmutable;
 use PhpSpec\ObjectBehavior;
 
 class AnnouncementItemSpec extends ObjectBehavior
 {
+    /** @var DateTimeImmutable */
+    private $startDate;
+
     public function let(): void
     {
+        $this->startDate = new DateTimeImmutable();
+
         $this->beConstructedWith(
+            sprintf('update-title-%s', $this->startDate->format('YYYY-MM-dd')),
             'Title',
             'Description',
             '/images/announcements/new-connection-monitoring-page.png',
             'Connection monitoring page',
             'http://link.com#easily-monitor-errors-on-your-connections',
-            new \DateTimeImmutable(),
+            $this->startDate,
             14,
             [
                 'updates'
-            ],
-            [
-                'CE',
-                'EE'
             ]
         );
     }
@@ -35,15 +38,14 @@ class AnnouncementItemSpec extends ObjectBehavior
 
     public function it_normalizes_itself(): void
     {
-        $startDate = new \DateTimeImmutable();
-
         $this->toArray()->shouldReturn([
+            'id' => sprintf('update-title-%s', $this->startDate->format('YYYY-MM-dd')),
             'title' => 'Title',
             'description' => 'Description',
             'img' => '/images/announcements/new-connection-monitoring-page.png',
             'altImg' => 'Connection monitoring page',
             'link' => 'http://link.com#easily-monitor-errors-on-your-connections',
-            'startDate' => $startDate->format('F\, jS Y'),
+            'startDate' => $this->startDate->format('F\, jS Y'),
             'tags' => ['new', 'updates'],
         ]);
     }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Announcement.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Announcement.tsx
@@ -51,7 +51,12 @@ const AnnouncementComponent = ({announcement, campaign}: AnnouncementProps): JSX
       <Description tags={announcement.tags} description={announcement.description} />
       {null !== announcement.img && <Image src={announcement.img} alt={altImg} />}
       <LineContainer>
-        <LinkComponent baseUrl={announcement.link} title={announcement.title} campaign={campaign} />
+        <LinkComponent
+          baseUrl={announcement.link}
+          title={announcement.title}
+          campaign={campaign}
+          content={announcement.id}
+        />
       </LineContainer>
     </Container>
   );

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Link.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Link.tsx
@@ -19,12 +19,15 @@ type LinkProps = {
   baseUrl: string;
   title: string;
   campaign: string | null;
+  content: string;
 };
 
-const buildLinkAnnouncementUrl = (baseUrl: string, campaign: string | null): URL => {
+const buildLinkAnnouncementUrl = (baseUrl: string, campaign: string | null, content: string): URL => {
   const url = new URL(baseUrl);
   url.searchParams.append('utm_source', 'akeneo-app');
   url.searchParams.append('utm_medium', 'communication-panel');
+  url.searchParams.append('utm_content', content);
+
   if (null !== campaign) {
     url.searchParams.append('utm_campaign', campaign);
   }
@@ -32,9 +35,9 @@ const buildLinkAnnouncementUrl = (baseUrl: string, campaign: string | null): URL
   return url;
 };
 
-const LinkComponent = ({baseUrl, title, campaign}: LinkProps): JSX.Element => {
+const LinkComponent = ({baseUrl, title, campaign, content}: LinkProps): JSX.Element => {
   const __ = useTranslate();
-  const url = buildLinkAnnouncementUrl(baseUrl, campaign);
+  const url = buildLinkAnnouncementUrl(baseUrl, campaign, content);
 
   return (
     <Link href={url.href} title={title} target="_blank">

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/definitions/announcement.schema.json
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/definitions/announcement.schema.json
@@ -2,6 +2,7 @@
   "title": "Announcement",
   "type": "object",
   "properties": {
+    "id": {"type": "string"},
     "title": {"type": "string"},
     "description": {"type": "string"},
     "img": {"type": ["string", "null"]},
@@ -16,6 +17,7 @@
     "startDate": {"type": "string"}
   },
   "required": [
+    "id",
     "title",
     "description",
     "link",

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/__mocks__/dataProvider.ts
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/__mocks__/dataProvider.ts
@@ -1,6 +1,7 @@
 export const getExpectedAnnouncements = () => {
   return [
     {
+      id: 'update-title_announcement-20-04-2020',
       title: 'Title announcement',
       description: 'Description announcement',
       img: '/path/img/announcement.png',
@@ -10,6 +11,7 @@ export const getExpectedAnnouncements = () => {
       startDate: '20-04-2020',
     },
     {
+      id: 'update-title_announcement_2-20-04-2020',
       title: 'Title announcement 2',
       description: 'Description announcement 2',
       link: 'http://external-2.com',

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/Panel.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/Panel.unit.tsx
@@ -54,7 +54,7 @@ test('it can open the read more link in a new tab', async () => {
   await act(async () => renderWithProviders(<Panel />, container as HTMLElement));
 
   expect((container.querySelector(`a[title="${expectedAnnouncements[0].title}"]`) as HTMLLinkElement).href).toEqual(
-    `http://external.com/?utm_source=akeneo-app&utm_medium=communication-panel&utm_campaign=${campaign}`
+    `http://external.com/?utm_source=akeneo-app&utm_medium=communication-panel&utm_content=${expectedAnnouncements[0].id}&utm_campaign=${campaign}`
   );
   expect((container.querySelector(`a[title="${expectedAnnouncements[0].title}"]`) as HTMLLinkElement).target).toEqual(
     '_blank'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Ticket : https://github.com/akeneo/actionable-product-data/issues/172

It adds an id to know on which announcements users are clicking on (thanks to analytics). 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
