### PR TITLE
PIM-9304: Add MYSQL index on the updated field for product tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PIM-9213: Fix tooltip hover on Ellipsis for Family Name on creating product
 - PIM-9184: API - Fix dbal query group by part for saas instance
 - PIM-9289: Display a correct error message when deleting a group or an association
+- PIM-9304: Add indexes on the updated field of product and product model tables to fix slow queries
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/doctrine/Product/Product.orm.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/doctrine/Product/Product.orm.yml
@@ -3,6 +3,9 @@ Akeneo\Pim\Enrichment\Component\Product\Model\Product:
     table: pim_catalog_product
     changeTrackingPolicy: DEFERRED_EXPLICIT
     repositoryClass: Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Repository\ProductRepository
+    indexes:
+        idx_product_updated:
+            columns: [ updated ]
     fields:
         id:
             type: integer

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/doctrine/Product/ProductModel.orm.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/doctrine/Product/ProductModel.orm.yml
@@ -3,6 +3,9 @@ Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel:
     table: pim_catalog_product_model
     changeTrackingPolicy: DEFERRED_EXPLICIT
     repositoryClass: Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Repository\ProductModelRepository
+    indexes:
+        idx_product_model_updated:
+            columns: [ updated ]
     fields:
         id:
             type: integer

--- a/upgrades/schema/Version_5_0_20200623085649_add_indexes_on_product_updated.php
+++ b/upgrades/schema/Version_5_0_20200623085649_add_indexes_on_product_updated.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_5_0_20200623085649_add_indexes_on_product_updated extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->addSql(<<<SQL
+            ALTER TABLE pim_catalog_product_model 
+                ADD INDEX idx_product_model_updated (updated);
+            SQL
+        );
+        $this->addSql(<<<SQL
+            ALTER TABLE pim_catalog_product
+                ADD INDEX idx_product_updated (updated);
+            SQL
+        );
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/upgrades/test_schema/Version_5_0_20200623085649_add_indexes_on_product_updated_Integration.php
+++ b/upgrades/test_schema/Version_5_0_20200623085649_add_indexes_on_product_updated_Integration.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+class Version_5_0_20200623085649_add_indexes_on_product_updated_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_5_0_20200623085649_add_indexes_on_product_updated';
+
+    /** @test */
+    public function it_adds_indexes_on_product_update_date(): void
+    {
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $this->assertIndexExists('idx_product_updated', 'pim_catalog_product');
+        $this->assertIndexExists('idx_product_model_updated', 'pim_catalog_product_model');
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dropIndexIfExists('idx_product_updated', 'pim_catalog_product');
+        $this->dropIndexIfExists('idx_product_model_updated', 'pim_catalog_product_model');
+    }
+
+    private function findIndex($index, $table): ?array
+    {
+        $result = $this
+            ->get('database_connection')->executeQuery(<<<SQL
+               SHOW INDEX FROM $table WHERE KEY_NAME = '$index';
+            SQL
+            )
+            ->fetch(\PDO::FETCH_ASSOC)
+        ;
+
+        if ($result === false) {
+            return null;
+        }
+
+        return $result;
+    }
+
+    private function assertIndexExists($index, $table): void
+    {
+        $indexInformation = $this->findIndex($index, $table);
+        Assert::assertNotNull($indexInformation, sprintf('The index "%s" does not exists on table "%s"', $index, $table));
+    }
+
+    private function dropIndexIfExists($index, $table): void
+    {
+        $indexInformation = $this->findIndex($index, $table);
+
+        if ($indexInformation) {
+            $this->get('database_connection')->executeUpdate(<<<SQL
+                DROP INDEX $index ON $table;
+            SQL
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This pull requests aims to add indexes on the updated field of the tables pim_catalog_product and pim_catalog_product_model. It fixes slow queries when we attend to search product by updated date

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
