### PR TITLE
PIM-9314: Reset scroll position when switching attribute group in the PEF

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-9314: Reset scroll position when switching attribute group in the PEF
 - PIM-9084: Filter locale specific attributes in exports when the value's locale and the export profile's locale are different
 
 # 3.2.59 (2020-06-15)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes.js
@@ -515,7 +515,7 @@ define(
                                 return -1;
                             }
 
-                            if (a.sortOrder > b.sortOder) {
+                            if (a.sortOrder > b.sortOrder) {
                                 return 1;
                             }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/edit-form.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/edit-form.js
@@ -65,8 +65,13 @@ define(
                 this.listenTo(this.getRoot(), 'pim_enrich:form:extension:render:before', () => {
                     this.saveScroll();
                 });
+
                 this.listenTo(this.getRoot(), 'pim_enrich:form:extension:render:after', () => {
                     this.setScroll();
+                });
+
+                this.listenTo(this.getRoot(), 'group:change', () => {
+                    this.resetScroll();
                 });
 
                 this.onExtensions('save-buttons:register-button', function (button) {
@@ -117,6 +122,10 @@ define(
                 if (containerElement && null !== this.scrollPosition) {
                     containerElement.scrollTop = this.scrollPosition;
                 }
+            },
+
+            resetScroll: function () {
+                this.scrollPosition = 0;
             },
 
             /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/group-selector.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/group-selector.js
@@ -120,6 +120,7 @@ define(
 
                     if (!options.silent) {
                         this.trigger('group:change');
+                        this.getRoot().trigger('group:change');
                     }
 
                     this.render();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**Issue:** When using the attribute group filter option on a product page, scrolling its attributes, and changing the attribute group, the PIM didn't display the top of the list, but the bottom. 

**Solution:** I added a reset function to set the scroll position to the top of the attribute list when selecting a new attribute group.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | OK
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
