### PR TITLE
RAC-51: Disable the manage filters button from associations group grid

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/association_group.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/association_group.yml
@@ -7,6 +7,8 @@ datagrid:
             columnListener:
                 dataField: id
                 columnName: is_checked
+            filtersAsColumn: false
+            manageFilters: false
         source:
             type: pim_datasource_default
             entity: '%pim_catalog.entity.group.class%'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When displaying the associations with the mode `Display groups`, there was a `Filters` button floating.
Its only purpose was to open a panel with the same exact fitlers already visible: `label`, `is_associated`, `code`, `type`.
The solution suggested by our dear Stephane is to simply remove this button.

**before:**

![(PNG Image, 629 × 311 pixels)](https://user-images.githubusercontent.com/1421130/85839735-a25c6700-b79b-11ea-9b22-1b341e7ec436.png)

**after:**

![Screenshot_2020-06-26_10-55-54](https://user-images.githubusercontent.com/1421130/85839756-a9837500-b79b-11ea-9ef2-f26fd9fb6b8e.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
