### PR TITLE
PIM-9319: Fix date timezone for a correct display of the dates in the Connection Dashboard

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9319: Fix date timezone for a correct display of the dates in the Connection Dashboard
+
 # 4.0.35 (2020-06-22)
 
 ## Bug fixes

--- a/src/Akeneo/Connectivity/Connection/front/src/audit/components/EventChart.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/components/EventChart.tsx
@@ -58,17 +58,18 @@ export const EventChart: FC<Props> = ({title, eventType, theme}: Props) => {
                     weekday: 'long',
                     month: 'short',
                     day: 'numeric',
+                    timeZone: 'UTC',
                 }).format(new Date(date));
 
-                return {
-                    x: index,
-                    y: value,
-                    xLabel:
-                        index + 1 !== numberOfData
-                            ? xLabel
-                            : translate('akeneo_connectivity.connection.dashboard.charts.legend.today'),
-                    yLabel: 0 === index ? '' : formatNumber(value),
-                };
+                    return {
+                        x: index,
+                        y: value,
+                        xLabel:
+                            index + 1 !== numberOfData
+                                ? xLabel
+                                : translate('akeneo_connectivity.connection.dashboard.charts.legend.today'),
+                        yLabel: 0 === index ? '' : formatNumber(value),
+                    };
             }
         );
 

--- a/src/Akeneo/Connectivity/Connection/front/src/audit/components/EventChart.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/components/EventChart.tsx
@@ -61,15 +61,15 @@ export const EventChart: FC<Props> = ({title, eventType, theme}: Props) => {
                     timeZone: 'UTC',
                 }).format(new Date(date));
 
-                    return {
-                        x: index,
-                        y: value,
-                        xLabel:
-                            index + 1 !== numberOfData
-                                ? xLabel
-                                : translate('akeneo_connectivity.connection.dashboard.charts.legend.today'),
-                        yLabel: 0 === index ? '' : formatNumber(value),
-                    };
+                return {
+                    x: index,
+                    y: value,
+                    xLabel:
+                        index + 1 !== numberOfData
+                            ? xLabel
+                            : translate('akeneo_connectivity.connection.dashboard.charts.legend.today'),
+                    yLabel: 0 === index ? '' : formatNumber(value),
+                };
             }
         );
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**Issue** : In the Connection Dashboard, the dates were not correct for a user located in a timezone different than UTC.
_Example : 
In Boston, the dates displayed today (Friday, June 26) were the following:
Friday, Jun 19 / Saturday, Jun 20 / Sunday, Jun 21 / Monday, Jun 22 / Tuesday, Jun 23 / Wednesday, Jun 24 / Today_
The user timezone (set in the pim) was "crushed" by the browser timezone.

**Solution** : I added the timezone option 'UTC' to display correct dates.
_Now, today, with a browser's timezone set to 'EDT' (for example) the dates are:
Saturday, Jun 20 / Sunday, Jun 21 / Monday, Jun 22 / Tuesday, Jun 23 / Wednesday, Jun 24 / Thursday, Jun 24 / Today_

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | OK
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
