### PR TITLE
PIM-9328: Add "en_GB" code to display the corresponding locale in the UI

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9328: Add "en_GB" code to display the corresponding locale in the UI.
+
 # 4.0.35 (2020-06-22)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/locale_provider.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/locale_provider.yml
@@ -1,7 +1,7 @@
 parameters:
     pim_localization.provider.ui_locale.class:
     pim_localization.provider.ui_locale.min_percentage: 0.8
-    pim_localization.provider.ui_locale.locale_codes:   ['en_US', 'ca_ES', 'da_DK', 'de_DE', 'es_ES', 'fi_FI', 'fr_FR', 'hr_HR', 'it_IT', 'ja_JP', 'ko_KR', 'nl_NL', 'pl_PL', 'pt_BR', 'pt_PT', 'ru_RU', 'sv_SE', 'tl_PH', 'zh_CN', 'sv_SE', 'en_NZ']
+    pim_localization.provider.ui_locale.locale_codes:   ['ca_ES', 'da_DK', 'de_DE', 'en_GB','en_US', 'es_ES', 'fi_FI', 'fr_FR', 'hr_HR', 'it_IT', 'ja_JP', 'ko_KR', 'nl_NL', 'pl_PL', 'pt_BR', 'pt_PT', 'ru_RU', 'sv_SE', 'tl_PH', 'zh_CN', 'sv_SE', 'en_NZ']
 
 services:
     pim_localization.provider.ui_locale:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/locale_provider.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/locale_provider.yml
@@ -1,7 +1,7 @@
 parameters:
     pim_localization.provider.ui_locale.class:
     pim_localization.provider.ui_locale.min_percentage: 0.8
-    pim_localization.provider.ui_locale.locale_codes:   ['ca_ES', 'da_DK', 'de_DE', 'en_GB','en_US', 'es_ES', 'fi_FI', 'fr_FR', 'hr_HR', 'it_IT', 'ja_JP', 'ko_KR', 'nl_NL', 'pl_PL', 'pt_BR', 'pt_PT', 'ru_RU', 'sv_SE', 'tl_PH', 'zh_CN', 'sv_SE', 'en_NZ']
+    pim_localization.provider.ui_locale.locale_codes:   ['ca_ES', 'da_DK', 'de_DE', 'en_GB', 'en_US', 'es_ES', 'fi_FI', 'fr_FR', 'hr_HR', 'it_IT', 'ja_JP', 'ko_KR', 'nl_NL', 'pl_PL', 'pt_BR', 'pt_PT', 'ru_RU', 'sv_SE', 'tl_PH', 'zh_CN', 'sv_SE', 'en_NZ']
 
 services:
     pim_localization.provider.ui_locale:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**Issue** : 
The en_GB UI language was no longer available in the local UI settings.

**Solution** : 
An "en_GB" translations file was already in the pim so I added the corresponding code (en_GB) in the locale_provider.yml file.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | OK
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
