### PR TITLE
PIM-9327: fix: the label value was not search by scope and locale in pdf export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PIM-9213: Fix tooltip hover on Ellipsis for Family Name on creating product
 - PIM-9184: API - Fix dbal query group by part for saas instance
 - PIM-9289: Display a correct error message when deleting a group or an association
+- PIM-9327: PDF generation header miss the product name when the attribute used as label is localizable 
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/Product/renderPdf.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/Product/renderPdf.html.twig
@@ -84,7 +84,7 @@
     <body>
         <div class="header">
             {% block header %}
-                <h1>{{ product.label }} {{ product.identifier != product.label ? '(' ~ product.identifier ~ ')' : '' }}</h1>
+                <h1>{{ product.getLabel(locale, scope) }} {{ product.identifier != product.getLabel(locale, scope) ? '(' ~ product.identifier ~ ')' : '' }}</h1>
                 <span class="rendering-date">{{ renderingDate|date }}</span>
             {% endblock %}
         </div>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
The product label is not showed when product attribute as name is localizable or scopable

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
