### PR TITLE
DAPI-1085: Fix css bug when collapsed panel

### DIFF
--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/public/bridge/view/panel.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/public/bridge/view/panel.tsx
@@ -28,18 +28,23 @@ class PanelView extends ReactView {
 
   openPanel() {
     this.$el.removeClass('AknPanel--collapsed');
+    this.$el.removeClass('AknPanel--no-overflow');
     mediator.trigger('pim-app:overlay:show');
   }
 
   closePanel() {
     if (!this.isColapsed()) {
       this.$el.addClass('AknPanel--collapsed');
+      // Trick to keep the transition for collapsing the panel on the right (during 0.3s) and fix the bug with the overflow (cf: https://akeneo.atlassian.net/browse/DAPI-1085)
+      setTimeout(() => {
+        this.$el.addClass('AknPanel--no-overflow');
+      }, 300);
       mediator.trigger('pim-app:overlay:hide');
     }
   }
 
   isColapsed() {
-    return this.$el.hasClass('AknPanel--collapsed');
+    return this.$el.hasClass('AknPanel--collapsed') && this.$el.addClass('AknPanel--no-overflow');
   }
 }
 

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/public/less/components/Panel.less
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/public/less/components/Panel.less
@@ -9,7 +9,7 @@
   overflow-y: scroll;
   background: @AknWhite;
   border-left: 1px solid #ccd1d8;
-  transition: right @AknColumnTiming @AknColumnTransition;
+  transition: right 0.3s @AknColumnTransition;
   z-index: 999;
 
   &:empty {
@@ -18,5 +18,10 @@
 
   &--collapsed {
     right: -@AknPanelWidth;
+  }
+
+  &--no-overflow {
+    overflow: hidden;
+    height: 0px;
   }
 }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/Header.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/Header.tsx
@@ -12,7 +12,7 @@ const Container = styled.div`
   height: 44px;
   border-bottom: 1px solid ${({theme}: AkeneoThemedProps) => theme.color.purple100};
   display: flex;
-  position: fixed;
+  position: sticky;
   top: 0px;
   padding-bottom: 47px;
 `;

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/ListAnnouncement.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/ListAnnouncement.tsx
@@ -6,7 +6,7 @@ import {AnnouncementComponent, EmptyAnnouncementList} from './announcement';
 import {Announcement} from './../../models/announcement';
 
 const Container = styled.ul`
-  margin: 74px 30px 0 30px;
+  margin: 30px 30px 0 30px;
 `;
 
 type ListAnnouncementProps = {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Ticket : https://akeneo.atlassian.net/browse/DAPI-1085

Problem : It had a css bug triggered by Lucas when we opened a dropdown for the filter. It was displaying a part of the panel. Because of even when the panel was collapsed, it was considered as an element in the dom. It was just out of the screen.

Solution : Put a display none when the Panel is collapsed like that the element it's not considered as an element of the dom anymore.

![Kapture 2020-06-30 at 10 44 40](https://user-images.githubusercontent.com/10549767/86072228-4574ef80-bac0-11ea-8ee4-75c61d4192b0.gif)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
