### PR TITLE
GITHUB-APD-178: Add akeneo_communication_channel_announcements_viewed table

### DIFF
--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/DependencyInjection/AkeneoCommunicationChannelExtension.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/DependencyInjection/AkeneoCommunicationChannelExtension.php
@@ -20,5 +20,6 @@ class AkeneoCommunicationChannelExtension extends Extension
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('announcement_list.yml');
+        $loader->load('installer.yml');
     }
 }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Installer/InstallerSubscriber.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Installer/InstallerSubscriber.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\CommunicationChannel\Infrastructure\Framework\Symfony\Installer;
+
+use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvents;
+use Akeneo\Platform\CommunicationChannel\Infrastructure\Framework\Symfony\Installer\Query\CreateViewedAnnouncementsTableQuery;
+use Doctrine\DBAL\Driver\Connection as DbalConnection;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @author    Christophe Chausseray <chausseray.christophe@gmail.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InstallerSubscriber implements EventSubscriberInterface
+{
+    private $dbalConnection;
+
+    public function __construct(DbalConnection $dbalConnection)
+    {
+        $this->dbalConnection = $dbalConnection;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            InstallerEvents::POST_DB_CREATE => ['createCommunicationChannelTable'],
+        ];
+    }
+
+    public function createCommunicationChannelTable(): void
+    {
+        $this->dbalConnection->exec(CreateViewedAnnouncementsTableQuery::QUERY);
+    }
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Installer/Query/CreateViewedAnnouncementsTableQuery.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Installer/Query/CreateViewedAnnouncementsTableQuery.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\CommunicationChannel\Infrastructure\Framework\Symfony\Installer\Query;
+
+/**
+ * @author    Christophe Chausseray <chausseray.christophe@gmail.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class CreateViewedAnnouncementsTableQuery
+{
+    const QUERY = <<<SQL
+CREATE TABLE IF NOT EXISTS akeneo_communication_channel_viewed_announcements(
+    announcement_id VARCHAR(100) NOT NULL,
+    user_id INT NOT NULL,
+    PRIMARY KEY (announcement_id, user_id),
+    CONSTRAINT FK_COMMUNICATION_CHANNEL_VIEWED_ANNOUNCEMENTS_user_id FOREIGN KEY (user_id) REFERENCES oro_user (id) ON DELETE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB ROW_FORMAT = DYNAMIC
+SQL;
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/config/installer.yml
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/config/installer.yml
@@ -1,0 +1,7 @@
+services:
+    akeneo_communication_channel.installer.installer_subscriber:
+        class: Akeneo\Platform\CommunicationChannel\Infrastructure\Framework\Symfony\Installer\InstallerSubscriber
+        arguments:
+            - '@database_connection'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/.php_cd.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/.php_cd.php
@@ -23,6 +23,8 @@ $rules = [
             'Akeneo\Platform\CommunicationChannel\Application',
             'Akeneo\Platform\CommunicationChannel\Domain',
             'Symfony\Component',
+            'Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvents',
+            'Doctrine\DBAL\Driver\Connection'
         ]
     )->in('Akeneo\Platform\CommunicationChannel\Infrastructure'),
 ];

--- a/upgrades/schema/Version_5_0_20200630044018_create_communication_channel_viewed_announcements_table.php
+++ b/upgrades/schema/Version_5_0_20200630044018_create_communication_channel_viewed_announcements_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * @author    Christophe Chausseray <chausseray.christophe@gmail.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Version_5_0_20200630044018_create_communication_channel_viewed_announcements_table extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS akeneo_communication_channel_viewed_announcements(
+    announcement_id VARCHAR(100) NOT NULL,
+    user_id INT NOT NULL,
+    PRIMARY KEY (announcement_id, user_id),
+    CONSTRAINT FK_COMMUNICATION_CHANNEL_VIEWED_ANNOUNCEMENTS_user_id FOREIGN KEY (user_id) REFERENCES oro_user (id) ON DELETE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB ROW_FORMAT = DYNAMIC
+SQL;
+
+        $this->addSql($sql);
+
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Ticket : https://github.com/akeneo/actionable-product-data/issues/178

There will be notification if the user didn't see all announcements in the PIM. So, we need to track which announcements the user saw. It will be done in the created table.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
