### PR TITLE
TIP-1493: launch a "regular CE build" from the same PR workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -556,17 +556,17 @@ workflows:
                 name: test_back_phpunit_ce
                 requires:
                     - test_back_static_and_acceptance_ce
-                    - test_front_static_acceptance_and_integration
+                    - test_front_static_acceptance_and_integration_ce
           - test_back_missing_structure_migrations:
                 name: test_back_missing_structure_migrations_ce
                 requires:
                     - test_back_static_and_acceptance_ce
-                    - test_front_static_acceptance_and_integration
+                    - test_front_static_acceptance_and_integration_ce
           - test_back_data_migrations:
                 name: test_back_data_migrations_ce
                 requires:
                     - test_back_static_and_acceptance_ce
-                    - test_front_static_acceptance_and_integration
+                    - test_front_static_acceptance_and_integration_ce
           - test_back_behat_legacy:
                 name: test_back_behat_legacy_ce
                 requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,7 +538,7 @@ workflows:
                             - master
           - checkout_ce:
                 requires:
-                    - ready_to_build?
+                    - ready_to_build_only_ce?
           - build_dev:
                 name: build_dev_ce
                 requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
 
   build_dev:
     parameters:
-        is_pull_request:
+        is_ee_built:
             type: boolean
             default: true
     machine:
@@ -65,7 +65,7 @@ jobs:
           name: Copy docker-compose.override.yml.dist
           command: cp .circleci/docker-compose.override.yml.dist docker-compose.override.yml
       - when:
-            condition: << parameters.is_pull_request >>
+            condition: << parameters.is_ee_built >>
             steps:
               - run:
                   name: Build the latest EE Docker images
@@ -73,7 +73,7 @@ jobs:
                       make php-image-dev
                       docker save -o php-pim-image.tar akeneo/pim-dev/php:7.3
       - unless:
-            condition: << parameters.is_pull_request >>
+            condition: << parameters.is_ee_built >>
             steps:
               - run:
                   name: Save the CE image as a tar
@@ -297,7 +297,7 @@ jobs:
 
   build_prod:
       parameters:
-          is_pull_request:
+          is_ee_built:
               type: boolean
               default: true
       environment:
@@ -541,6 +541,7 @@ workflows:
                     - ready_to_build_only_ce?
           - build_dev:
                 name: build_dev_ce
+                is_ee_built: false
                 requires:
                     - checkout_ce
           - test_back_static_and_acceptance:
@@ -585,7 +586,7 @@ workflows:
       jobs:
           - checkout_ce
           - build_dev:
-                is_pull_request: false
+                is_ee_built: false
                 requires:
                     - checkout_ce
           - test_back_static_and_acceptance:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,11 +547,11 @@ workflows:
           - test_back_static_and_acceptance:
                 name: test_back_static_and_acceptance_ce
                 requires:
-                    - build_dev
+                    - build_dev_ce
           - test_front_static_acceptance_and_integration:
                 name: test_front_static_acceptance_and_integration_ce
                 requires:
-                    - build_dev
+                    - build_dev_ce
           - test_back_phpunit:
                 name: test_back_phpunit_ce
                 requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,6 +540,7 @@ workflows:
                 requires:
                     - ready_to_build?
           - build_dev:
+                name: build_dev_ce
                 requires:
                     - checkout_ce
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,6 +543,35 @@ workflows:
                 name: build_dev_ce
                 requires:
                     - checkout_ce
+          - test_back_static_and_acceptance:
+                name: test_back_static_and_acceptance_ce
+                requires:
+                    - build_dev
+          - test_front_static_acceptance_and_integration:
+                name: test_front_static_acceptance_and_integration_ce
+                requires:
+                    - build_dev
+          - test_back_phpunit:
+                name: test_back_phpunit_ce
+                requires:
+                    - test_back_static_and_acceptance_ce
+                    - test_front_static_acceptance_and_integration
+          - test_back_missing_structure_migrations:
+                name: test_back_missing_structure_migrations_ce
+                requires:
+                    - test_back_static_and_acceptance_ce
+                    - test_front_static_acceptance_and_integration
+          - test_back_data_migrations:
+                name: test_back_data_migrations_ce
+                requires:
+                    - test_back_static_and_acceptance_ce
+                    - test_front_static_acceptance_and_integration
+          - test_back_behat_legacy:
+                name: test_back_behat_legacy_ce
+                requires:
+                    - test_back_phpunit_ce
+                    - test_back_missing_structure_migrations_ce
+                    - test_back_data_migrations_ce
 
   nightly:
       triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,11 +557,6 @@ workflows:
                 requires:
                     - test_back_static_and_acceptance_ce
                     - test_front_static_acceptance_and_integration_ce
-          - test_back_missing_structure_migrations:
-                name: test_back_missing_structure_migrations_ce
-                requires:
-                    - test_back_static_and_acceptance_ce
-                    - test_front_static_acceptance_and_integration_ce
           - test_back_data_migrations:
                 name: test_back_data_migrations_ce
                 requires:
@@ -571,7 +566,6 @@ workflows:
                 name: test_back_behat_legacy_ce
                 requires:
                     - test_back_phpunit_ce
-                    - test_back_missing_structure_migrations_ce
                     - test_back_data_migrations_ce
 
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,6 +530,18 @@ workflows:
                 requires:
                     - test_back_behat_legacy
                     - test_back_performance
+          - ready_to_build_only_ce?:
+                type: approval
+                filters:
+                    branches:
+                        ignore:
+                            - master
+          - checkout_ce:
+                requires:
+                    - ready_to_build?
+          - build_dev:
+                requires:
+                    - checkout_ce
 
   nightly:
       triggers:


### PR DESCRIPTION
## What?

This PR comes from a discussion we had with Juju. Sometimes the squads need to launch a regular CE build from a CE PR, just to ensure they didn't break some weird stuff in the Community Edition (probably due to a "sensitive" CE/EE override problem).

Currently, as I hope you know, a CE build actually checkouts the EE master and the proper CE branch. All EE tests are launched. And normally, EE tests also contains CE tests. A build is considered green when all EE tests are green. Which is really good, as our goal is to not break the SaaS offer when we merge a CE PR.

With this PR, you have a new approval step `ready_to_build_only_ce?`. This branch of the workflow will checkout the CE branch and launch only CE tests. **A PR is still considered mergeable when `pull_request_success` is green. That means this branch of the workflow will have no effect on our merges.** This step is **not** required to merge. This is just an help for people who want to check sensitive CE/EE overrides' problems.

![ce_build](https://user-images.githubusercontent.com/3691804/86369265-7a2ea580-bc7e-11ea-8111-2bac9917b576.png)

## How?

Duplicating the jobs in the CircleCI config file was out of question. Instead, I used a very handy feature of CircleCI. You can reuse the same job several times in the same workflow as long as you explicitly give a specific name. For instance:

```
workflow:
    pull_request:
        jobs:
            test_backend: ~
            test_backend:
                 name: second_test_backend
 ```

This workflow would launch the job `test_backend` twice under the names `test_backend` and `second_test_backend`.

And that works perfectly for us as our CircleCI jobs do the same between CE and EE. Indeed, all the logic is done in our Makefiles.

