### PR TITLE
DAPI-1115 fix filter label color and subsection font weight

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Subsection.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Subsection.less
@@ -7,7 +7,7 @@
     font-size: @AknFontSizeBig;
     text-transform: uppercase;
     border-bottom: 1px solid @AknGrey140;
-    font-weight: bold;
+    font-weight: normal;
     line-height: 44px;
     height: 44px;
     display: flex;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/ActionButton.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/button/ActionButton.less
@@ -6,7 +6,7 @@
   line-height: @AknMicroButtonSize - 2;
   font-size: @AknDefaultFontSize;
   border: 1px solid @AknBorderColor;
-  color: @AknDefaultFontColor;
+  color: @AknDarkBlue;
   background-color: white;
   border-radius: 100px;
   font-weight: normal;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/FilterBox.less
@@ -125,7 +125,7 @@
 
   &-filterLabel {
     display: block;
-    color: @AknGrey;
+    color: @AknDarkBlue;
     text-transform: uppercase;
     font-size: @AknDefaultFontSize;
     white-space: nowrap;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix also DAPI-1114 (grid)

Before products:
![before-products-filters-label](https://user-images.githubusercontent.com/927944/86132792-b1b71980-bae7-11ea-8164-98db6c1943fb.png)
After products:
![product-filters-label+Channel+Locale+Subsection](https://user-images.githubusercontent.com/927944/86132812-b8de2780-bae7-11ea-8bba-beb3b1a7929f.png)
Before Grids:
![before-attributes-filter-labels](https://user-images.githubusercontent.com/927944/86132823-bd0a4500-bae7-11ea-9ede-2a7dd22d6c80.png)
After Grids:
![attributes-filters-label](https://user-images.githubusercontent.com/927944/86132835-c1366280-bae7-11ea-8631-5de0bf34acd1.png)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
