### PR TITLE
GITHUB-APD-179: Add announcements viewed endpoint

### DIFF
--- a/config/services/test/test_services.yml
+++ b/config/services/test/test_services.yml
@@ -10,6 +10,8 @@ parameters:
 imports:
     # Akeneo/Connectivity/Connection
     - { resource: ../../../src/Akeneo/Connectivity/Connection/back/tests/Integration/Resources/config/loaders.yml }
+    # Akeneo/Platform/CommunicationChannel
+    - { resource: ../../../src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Resources/config/in_memory.yml }
 
 services:
 

--- a/make-file/communication-channel.mk
+++ b/make-file/communication-channel.mk
@@ -56,9 +56,9 @@ _COMMUNICATION_CHANNEL_YARN_RUN = $(YARN_RUN) run --cwd=src/Akeneo/Platform/Bund
 
 # Tests Back
 
-communication-channel-static-analysis-back:
-	$(PHP_RUN) vendor/bin/phpstan analyse --configuration src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/phpstan.neon
-	$(PHP_RUN) vendor/bin/phpstan analyse --configuration src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/phpstan-infra.neon
+communication-channel-lint-back:
+	$(PHP_RUN) vendor/bin/phpstan analyse --level=8 src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain
+	$(PHP_RUN) vendor/bin/phpstan analyse --level=5 src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure
 
 communication-channel-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/.php_cd.php src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back
@@ -81,8 +81,10 @@ communication-channel-unit-front:
 # Developpement
 
 communication-channel-back:
+	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf var/cache/dev
+	APP_ENV=dev $(DOCKER_COMPOSE) run -e APP_DEBUG=1 -u www-data --rm php bin/console cache:warmup
 	${PHP_RUN} vendor/bin/php-cs-fixer fix --config=.php_cs.php src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back
-	$(MAKE) communication-channel-static-analysis-back
+	$(MAKE) communication-channel-lint-back
 	$(MAKE) communication-channel-coupling-back
 	$(MAKE) communication-channel-unit-back
 	$(MAKE) communication-channel-integration-back

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -25,7 +25,7 @@ lint-back:
 	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf var/cache/dev
 	${PHP_RUN} vendor/bin/php-cs-fixer fix --diff --dry-run --config=.php_cs.php
 	$(MAKE) connectivity-connection-lint-back
-	$(MAKE) communication-channel-static-analysis-back
+	$(MAKE) communication-channel-lint-back
 
 .PHONY: lint-front
 lint-front:

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Command/AddViewedAnnouncementsByUserCommand.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Command/AddViewedAnnouncementsByUserCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\CommunicationChannel\Application\Announcement\Command;
+
+/**
+ * @author Christophe Chausseray <chausseray.christophe@gmail.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class AddViewedAnnouncementsByUserCommand
+{
+    /** @var string[] */
+    private $viewedAnnouncementIds;
+
+    /** @var int */
+    private $userId;
+
+    /**
+     * @param string[] $viewedAnnouncementIds
+     * @param int $userId
+     */
+    public function __construct(array $viewedAnnouncementIds, int $userId)
+    {
+        $this->viewedAnnouncementIds = $viewedAnnouncementIds;
+        $this->userId = $userId;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function ViewedAnnouncementIds(): array
+    {
+        return $this->viewedAnnouncementIds;
+    }
+
+    public function userId(): int
+    {
+        return $this->userId;
+    }
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Command/AddViewedAnnouncementsByUserHandler.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Command/AddViewedAnnouncementsByUserHandler.php
@@ -24,13 +24,13 @@ final class AddViewedAnnouncementsByUserHandler
 
     public function execute(AddViewedAnnouncementsByUserCommand $command): void
     {
-        $viewAnnouncements = array_map(function ($viewedAnnouncementId) use ($command) {
+        $viewedAnnouncements = array_map(function ($viewedAnnouncementId) use ($command) {
             return ViewedAnnouncement::create(
                 $viewedAnnouncementId,
                 $command->userId()
             );
         }, $command->ViewedAnnouncementIds());
 
-        $this->viewedAnnouncementRepository->create($viewAnnouncements);
+        $this->viewedAnnouncementRepository->create($viewedAnnouncements);
     }
 }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Command/AddViewedAnnouncementsByUserHandler.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Command/AddViewedAnnouncementsByUserHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\CommunicationChannel\Application\Announcement\Command;
+
+use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Model\Write\ViewedAnnouncement;
+use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Repository\ViewedAnnouncementRepositoryInterface;
+
+/**
+ * @author Christophe Chausseray <chausseray.christophe@gmail.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class AddViewedAnnouncementsByUserHandler
+{
+    /** @var ViewedAnnouncementRepositoryInterface */
+    private $viewedAnnouncementRepository;
+
+    public function __construct(ViewedAnnouncementRepositoryInterface $viewedAnnouncementRepository)
+    {
+        $this->viewedAnnouncementRepository = $viewedAnnouncementRepository;
+    }
+
+    public function execute(AddViewedAnnouncementsByUserCommand $command): void
+    {
+        $viewAnnouncements = array_map(function ($viewedAnnouncementId) use ($command) {
+            return ViewedAnnouncement::create(
+                $viewedAnnouncementId,
+                $command->userId()
+            );
+        }, $command->ViewedAnnouncementIds());
+
+        $this->viewedAnnouncementRepository->create($viewAnnouncements);
+    }
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Query/ListAnnouncementsHandler.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Query/ListAnnouncementsHandler.php
@@ -9,7 +9,7 @@ use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Query\FindAnnouncem
 use Akeneo\Platform\VersionProviderInterface;
 
 /**
- * @author Christophe Chausseray <chaauseray.christophe@gmail.com>
+ * @author Christophe Chausseray <chausseray.christophe@gmail.com>
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Model/Read/AnnouncementItem.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Model/Read/AnnouncementItem.php
@@ -7,7 +7,7 @@ namespace Akeneo\Platform\CommunicationChannel\Domain\Announcement\Model\Read;
 use DateTimeImmutable;
 
 /**
- * @author Christophe Chausseray <chaauseray.christophe@gmail.com>
+ * @author Christophe Chausseray <chausseray.christophe@gmail.com>
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Model/Write/ViewedAnnouncement.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Model/Write/ViewedAnnouncement.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\CommunicationChannel\Domain\Announcement\Model\Write;
+
+/**
+ * @author Christophe Chausseray <chausseray.christophe@gmail.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class ViewedAnnouncement
+{
+    /** @var string */
+    private $announcementId;
+
+    /** @var int */
+    private $userId;
+
+    private function __construct(string $announcementId, int $userId)
+    {
+        $this->announcementId = $announcementId;
+        $this->userId = $userId;
+    }
+
+    public static function create(string $announcementId, int $userId): self
+    {
+        return new self($announcementId, $userId);
+    }
+
+    public function announcementId(): string
+    {
+        return $this->announcementId;
+    }
+
+    public function userId(): int
+    {
+        return $this->userId;
+    }
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Query/FindAnnouncementItemsInterface.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Query/FindAnnouncementItemsInterface.php
@@ -7,7 +7,7 @@ namespace Akeneo\Platform\CommunicationChannel\Domain\Announcement\Query;
 use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Model\Read\AnnouncementItem;
 
 /**
- * @author Christophe Chausseray <chaauseray.christophe@gmail.com>
+ * @author Christophe Chausseray <chausseray.christophe@gmail.com>
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Repository/ViewedAnnouncementRepositoryInterface.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Repository/ViewedAnnouncementRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\CommunicationChannel\Domain\Announcement\Repository;
+
+use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Model\Write\ViewedAnnouncement;
+
+interface ViewedAnnouncementRepositoryInterface
+{
+    /**
+     * @param ViewedAnnouncement[] $viewedAnnouncements
+     */
+    public function create(array $viewedAnnouncements): void;
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/InMemory/InMemoryFindAnnouncementItems.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/InMemory/InMemoryFindAnnouncementItems.php
@@ -8,7 +8,7 @@ use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Model\Read\Announce
 use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Query\FindAnnouncementItemsInterface;
 
 /**
- * @author Christophe Chausseray <chaauseray.christophe@gmail.com>
+ * @author Christophe Chausseray <chausseray.christophe@gmail.com>
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Delivery/InternalApi/Announcement/AddViewedAnnouncementsAction.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Delivery/InternalApi/Announcement/AddViewedAnnouncementsAction.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\CommunicationChannel\Infrastructure\Delivery\InternalApi\Announcement;
+
+use Akeneo\Platform\CommunicationChannel\Application\Announcement\Command\AddViewedAnnouncementsByUserCommand;
+use Akeneo\Platform\CommunicationChannel\Application\Announcement\Command\AddViewedAnnouncementsByUserHandler;
+use Akeneo\UserManagement\Bundle\Context\UserContext;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * @author Christophe Chausseray <chausseray.christophe@gmail.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class AddViewedAnnouncementsAction
+{
+    /** @var UserContext */
+    private $userContext;
+
+    /** @var AddViewedAnnouncementsByUserHandler */
+    private $addViewedAnnouncementsByUserHandler;
+
+    public function __construct(UserContext $userContext, AddViewedAnnouncementsByUserHandler $addViewedAnnouncementsByUserHandler)
+    {
+        $this->userContext = $userContext;
+        $this->addViewedAnnouncementsByUserHandler = $addViewedAnnouncementsByUserHandler;
+    }
+
+    public function __invoke(Request $request)
+    {
+        if (!$request->request->has('viewed_announcement_ids')) {
+            throw new UnprocessableEntityHttpException('You should give a "viewed_announcements_ids" key.');
+        }
+
+        if (null === $user = $this->userContext->getUser()) {
+            throw new NotFoundHttpException('Current user not found');
+        }
+
+        $command = new AddViewedAnnouncementsByUserCommand(
+            $request->request->get('viewed_announcement_ids'),
+            $user->getId()
+        );
+        $this->addViewedAnnouncementsByUserHandler->execute($command);
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Delivery/InternalApi/Announcement/ListAction.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Delivery/InternalApi/Announcement/ListAction.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 /**
- * @author Christophe Chausseray <chaauseray.christophe@gmail.com>
+ * @author Christophe Chausseray <chausseray.christophe@gmail.com>
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/DependencyInjection/AkeneoCommunicationChannelExtension.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/DependencyInjection/AkeneoCommunicationChannelExtension.php
@@ -19,6 +19,7 @@ class AkeneoCommunicationChannelExtension extends Extension
     public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('add_viewed_announcements.yml');
         $loader->load('announcement_list.yml');
         $loader->load('installer.yml');
     }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Installer/Query/CreateViewedAnnouncementsTableQuery.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Installer/Query/CreateViewedAnnouncementsTableQuery.php
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS akeneo_communication_channel_viewed_announcements(
     user_id INT NOT NULL,
     PRIMARY KEY (announcement_id, user_id),
     CONSTRAINT FK_COMMUNICATION_CHANNEL_VIEWED_ANNOUNCEMENTS_user_id FOREIGN KEY (user_id) REFERENCES oro_user (id) ON DELETE CASCADE,
-    INDEX IDX_VIEWED_ANNOUNCEMENTS_user_id_announcement_id (user_id, announcement_id)
+    UNIQUE INDEX IDX_VIEWED_ANNOUNCEMENTS_user_id_announcement_id (user_id, announcement_id)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB ROW_FORMAT = DYNAMIC
 SQL;
 }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Installer/Query/CreateViewedAnnouncementsTableQuery.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Installer/Query/CreateViewedAnnouncementsTableQuery.php
@@ -16,7 +16,8 @@ CREATE TABLE IF NOT EXISTS akeneo_communication_channel_viewed_announcements(
     announcement_id VARCHAR(100) NOT NULL,
     user_id INT NOT NULL,
     PRIMARY KEY (announcement_id, user_id),
-    CONSTRAINT FK_COMMUNICATION_CHANNEL_VIEWED_ANNOUNCEMENTS_user_id FOREIGN KEY (user_id) REFERENCES oro_user (id) ON DELETE CASCADE
+    CONSTRAINT FK_COMMUNICATION_CHANNEL_VIEWED_ANNOUNCEMENTS_user_id FOREIGN KEY (user_id) REFERENCES oro_user (id) ON DELETE CASCADE,
+    INDEX IDX_VIEWED_ANNOUNCEMENTS_user_id_announcement_id (user_id, announcement_id)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB ROW_FORMAT = DYNAMIC
 SQL;
 }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/config/add_viewed_announcements.yml
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/config/add_viewed_announcements.yml
@@ -1,0 +1,17 @@
+services:
+    akeneo_communication_channel.internal_api.announcement.add_viewed_announcements:
+        public: true
+        class: 'Akeneo\Platform\CommunicationChannel\Infrastructure\Delivery\InternalApi\Announcement\AddViewedAnnouncementsAction'
+        arguments:
+            - '@pim_user.context.user'
+            - '@akeneo_communication_channel.handler.command.add_viewed_announcements_by_user'
+
+    akeneo_communication_channel.handler.command.add_viewed_announcements_by_user:
+        class: 'Akeneo\Platform\CommunicationChannel\Application\Announcement\Command\AddViewedAnnouncementsByUserHandler'
+        arguments:
+            - '@akeneo_communication_channel.repository.dbal.viewed_announcement'
+
+    akeneo_communication_channel.repository.dbal.viewed_announcement:
+        class: 'Akeneo\Platform\CommunicationChannel\Infrastructure\Persistence\Dbal\Repository\DbalViewedAnnouncementRepository'
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/config/announcement_list.yml
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/config/announcement_list.yml
@@ -9,7 +9,7 @@ services:
         class: 'Akeneo\Platform\CommunicationChannel\Application\Announcement\Query\ListAnnouncementsHandler'
         arguments:
             - '@pim_catalog.version_provider'
-            - '@akeneo_communication_channel.query.find_announcement_items.in_memory'
+            - '@akeneo_communication_channel.query.in_memory.find_announcement_items'
 
-    akeneo_communication_channel.query.find_announcement_items.in_memory:
+    akeneo_communication_channel.query.in_memory.find_announcement_items:
         class: 'Akeneo\Platform\CommunicationChannel\Infrastructure\CommunicationChannel\InMemory\InMemoryFindAnnouncementItems'

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/config/routing.yml
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Resources/config/routing.yml
@@ -2,3 +2,8 @@ akeneo_communication_channel_announcement_list_rest:
     path: '/rest/announcements'
     defaults: { _controller: akeneo_communication_channel.internal_api.announcement.list }
     methods: [GET]
+
+akeneo_communication_channel_viewed_announcements_add_rest:
+    path: '/rest/viewed_announcements/add'
+    defaults: { _controller: akeneo_communication_channel.internal_api.announcement.add_viewed_announcements }
+    methods: [POST]

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Persistence/Dbal/Repository/DbalViewedAnnouncementRepository.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Persistence/Dbal/Repository/DbalViewedAnnouncementRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\CommunicationChannel\Infrastructure\Persistence\Dbal\Repository;
+
+use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Repository\ViewedAnnouncementRepositoryInterface;
+use Doctrine\DBAL\Connection as DbalConnection;
+
+/**
+ * @author    Christophe Chausseray <chausseray.christophe@gmail.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DbalViewedAnnouncementRepository implements ViewedAnnouncementRepositoryInterface
+{
+    /** @var DbalConnection */
+    private $dbalConnection;
+
+    public function __construct(DbalConnection $dbalConnection)
+    {
+        $this->dbalConnection = $dbalConnection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $viewedAnnouncements): void
+    {
+        $values = $parameters = [];
+        foreach ($viewedAnnouncements as $index => $viewedAnnouncement) {
+            $values[] = <<<SQL
+                (:announcement_id_$index, :user_id_$index)
+            SQL;
+            $parameters['announcement_id_' . $index] = $viewedAnnouncement->announcementId();
+            $parameters['user_id_' . $index] = $viewedAnnouncement->userId();
+        }
+
+        $valuesQuery = implode(',', $values);
+        $insertQuery = <<<SQL
+            INSERT INTO akeneo_communication_channel_viewed_announcements
+                (announcement_id, user_id)
+            VALUES $valuesQuery
+            ON DUPLICATE KEY UPDATE announcement_id=announcement_id;
+        SQL;
+
+
+        $this->dbalConnection->executeQuery(
+            $insertQuery,
+            $parameters
+        );
+    }
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Persistence/InMemory/Repository/InMemoryViewedAnnouncementRepository.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Persistence/InMemory/Repository/InMemoryViewedAnnouncementRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\CommunicationChannel\Infrastructure\Persistence\InMemory\Repository;
+
+use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Repository\ViewedAnnouncementRepositoryInterface;
+
+/**
+ * @author    Christophe Chausseray <chausseray.christophe@gmail.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InMemoryViewedAnnouncementRepository implements ViewedAnnouncementRepositoryInterface
+{
+    /** @var array */
+    public $dataRows = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $viewedAnnouncements): void
+    {
+        foreach ($viewedAnnouncements as $viewedAnnouncement) {
+            $this->dataRows[] = [
+                'announcement_id' => $viewedAnnouncement->announcementId(),
+                'user_id' => $viewedAnnouncement->userId(),
+            ];
+        }
+    }
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/.php_cd.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/.php_cd.php
@@ -22,9 +22,11 @@ $rules = [
         [
             'Akeneo\Platform\CommunicationChannel\Application',
             'Akeneo\Platform\CommunicationChannel\Domain',
-            'Symfony\Component',
             'Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvents',
-            'Doctrine\DBAL\Driver\Connection'
+            'Akeneo\UserManagement\Bundle\Context\UserContext',
+            'Symfony\Component',
+            'Doctrine\DBAL\Driver\Connection',
+            'Doctrine\DBAL\Connection'
         ]
     )->in('Akeneo\Platform\CommunicationChannel\Infrastructure'),
 ];

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Delivery/InternalApi/Announcement/AddViewedAnnouncementsActionIntegration.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Delivery/InternalApi/Announcement/AddViewedAnnouncementsActionIntegration.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\CommunicationChannel\Test\Integration\Delivery\InternalApi\Announcement;
+
+use Akeneo\Platform\CommunicationChannel\Test\Integration\WebTestCase;
+use Akeneo\Test\Integration\Configuration;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Response;
+
+class AddViewedAnnouncementsActionIntegration extends WebTestCase
+{
+    /** @var UserInterface */
+    private $user;
+
+    public function setUp(): void
+    {
+        parent::setup();
+
+        $this->user = $this->authenticateAsAdmin();
+    }
+
+    public function test_it_can_add_viewed_announcements()
+    {
+        $viewedAnnouncementIds = ['update_1-easily-monitor-errors-on-your-connections_2020-06-04', 'update_2-new-metric-on-the-connection-dashboard_2020-06-04'];
+        $this->client->request(
+            'POST',
+            '/rest/viewed_announcements/add',
+            [
+                'viewed_announcement_ids' => $viewedAnnouncementIds
+            ]
+        );
+
+        Assert::assertSame(Response::HTTP_NO_CONTENT, $this->client->getResponse()->getStatusCode());
+        $this->assertViewedAnnouncement($viewedAnnouncementIds);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function assertViewedAnnouncement(array $viewedAnnouncementIds): void
+    {
+        $viewedAnnouncementRepository = $this->get('akeneo_communication_channel.repository.in_memory.viewed_announcement');
+        $viewedAnnouncements = [];
+        foreach ($viewedAnnouncementIds as $announcementId) {
+            $viewedAnnouncements[] = [
+                'announcement_id' => $announcementId,
+                'user_id' => $this->user->getId()
+            ];
+        }
+
+        Assert::assertSame($viewedAnnouncements, $viewedAnnouncementRepository->dataRows);
+    }
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Delivery/InternalApi/Announcement/AddViewedAnnouncementsActionIntegration.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Delivery/InternalApi/Announcement/AddViewedAnnouncementsActionIntegration.php
@@ -36,6 +36,16 @@ class AddViewedAnnouncementsActionIntegration extends WebTestCase
         $this->assertViewedAnnouncement($viewedAnnouncementIds);
     }
 
+    public function test_it_throws_an_exception_when_it_does_not_have_a_view_announcement_ids()
+    {
+        $this->client->request(
+            'GET',
+            '/rest/announcements'
+        );
+
+        Assert::assertEquals(Response::HTTP_UNPROCESSABLE_ENTITY, $this->client->getResponse()->getStatusCode());
+    }
+
     protected function getConfiguration(): Configuration
     {
         return $this->catalog->useMinimalCatalog();

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Delivery/InternalApi/Announcement/ListAnnouncementIntegration.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Delivery/InternalApi/Announcement/ListAnnouncementIntegration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Platform\CommunicationChannel\Test\Integration\Announcement;
+namespace Akeneo\Platform\CommunicationChannel\Test\Integration\Delivery\InternalApi\Announcement;
 
 use Akeneo\Platform\CommunicationChannel\Test\Integration\WebTestCase;
 use Akeneo\Test\Integration\Configuration;
@@ -20,7 +20,7 @@ class ListAnnouncementIntegration extends WebTestCase
 
     public function test_it_can_list_first_paginated_announcements()
     {
-        $expectedAnnouncements = json_decode(file_get_contents(dirname(__FILE__) . '/../../../Infrastructure/CommunicationChannel/InMemory/serenity-updates.json'), true);
+        $expectedAnnouncements = json_decode(file_get_contents(dirname(__FILE__) . '/../../../../../Infrastructure/CommunicationChannel/InMemory/serenity-updates.json'), true);
         $limit = 5;
         $this->client->request(
             'GET',
@@ -40,7 +40,7 @@ class ListAnnouncementIntegration extends WebTestCase
 
     public function test_it_can_list_paginated_announcements_with_a_search_after_parameter()
     {
-        $expectedAnnouncements = json_decode(file_get_contents(dirname(__FILE__) . '/../../../Infrastructure/CommunicationChannel/InMemory/serenity-updates.json'), true);
+        $expectedAnnouncements = json_decode(file_get_contents(dirname(__FILE__) . '/../../../../../Infrastructure/CommunicationChannel/InMemory/serenity-updates.json'), true);
         $searchAfter = '2e04e7e4-6c55-4cdd-b151-dab34d6a31a4';
         $limit = 5;
         $this->client->request(

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Persistence/Dbal/Repository/DbalViewedAnnouncementRepositoryIntegration.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Persistence/Dbal/Repository/DbalViewedAnnouncementRepositoryIntegration.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\CommunicationChannel\Test\Integration\Persistence\Dbal\Repository;
+
+use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Model\Write\ViewedAnnouncement;
+use Akeneo\Platform\CommunicationChannel\Infrastructure\Persistence\Dbal\Repository\DbalViewedAnnouncementRepository;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection as DbalConnection;
+use PHPUnit\Framework\Assert;
+
+class DbalViewedAnnouncementRepositoryIntegration extends TestCase
+{
+    /** @var DbalConnection */
+    private $dbalConnection;
+
+    /** @var DbalViewedAnnouncementRepository */
+    private $repository;
+
+    /** @var array */
+    private $userFromDb;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dbalConnection = $this->get('database_connection');
+        $this->repository = $this->get('akeneo_communication_channel.repository.dbal.viewed_announcement');
+        $this->userFromDb = $this->selectUserFromDb();
+    }
+
+    public function test_it_creates_viewed_announcements_by_the_user()
+    {
+        $viewedAnnouncements = $this->createViewedAnnouncements(['announcement_id_1', 'announcement_id_2']);
+
+        $this->repository->create($viewedAnnouncements);
+
+        $viewedAnnouncementsFromDb = $this->selectViewedAnnouncementByUserFromDb((int) $this->userFromDb['id']);
+
+        Assert::assertSame('announcement_id_1', $viewedAnnouncementsFromDb[0]['announcement_id']);
+        Assert::assertSame($this->userFromDb['id'], $viewedAnnouncementsFromDb[0]['user_id']);
+        Assert::assertSame('announcement_id_2', $viewedAnnouncementsFromDb[1]['announcement_id']);
+        Assert::assertSame($this->userFromDb['id'], $viewedAnnouncementsFromDb[1]['user_id']);
+    }
+
+    public function test_it_updates_when_the_viewed_announcement_already_exists()
+    {
+        $viewedAnnouncements = $this->createViewedAnnouncements(['announcement_id_1', 'announcement_id_2']);
+
+        $this->repository->create($viewedAnnouncements);
+
+        $duplicateViewedAnnouncements = $this->createViewedAnnouncements(['announcement_id_1']);
+
+        $this->repository->create($duplicateViewedAnnouncements);
+
+        $viewedAnnouncementFromDb = $this->selectViewedAnnouncementByUserFromDb((int) $this->userFromDb['id']);
+
+        Assert::assertSame('announcement_id_1', $viewedAnnouncementFromDb[0]['announcement_id']);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function createViewedAnnouncements(array $viewAnnouncementIds)
+    {
+        return array_map(function ($viewAnnouncementId) {
+            return ViewedAnnouncement::create(
+                $viewAnnouncementId,
+                (int) $this->userFromDb['id']
+            );
+        }, $viewAnnouncementIds);
+    }
+
+    private function selectUserFromDb()
+    {
+        $query = <<<SQL
+        SELECT id
+        FROM oro_user
+        WHERE username = 'admin'
+SQL;
+        $statement = $this->dbalConnection->executeQuery($query);
+
+        return $statement->fetch();
+    }
+
+    private function selectViewedAnnouncementByUserFromDb(int $userId)
+    {
+        $query = <<<SQL
+    SELECT user_id, announcement_id
+    FROM akeneo_communication_channel_viewed_announcements
+    WHERE user_id = :userId
+SQL;
+        $statement = $this->dbalConnection->executeQuery($query, ['userId' => $userId]);
+
+        return $statement->fetchAll();
+    }
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Resources/config/in_memory.yml
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Resources/config/in_memory.yml
@@ -1,0 +1,8 @@
+services:
+    akeneo_communication_channel.handler.command.add_viewed_announcements_by_user:
+        class: 'Akeneo\Platform\CommunicationChannel\Application\Announcement\Command\AddViewedAnnouncementsByUserHandler'
+        arguments:
+            - '@akeneo_communication_channel.repository.in_memory.viewed_announcement'
+
+    akeneo_communication_channel.repository.in_memory.viewed_announcement:
+        class: 'Akeneo\Platform\CommunicationChannel\Infrastructure\Persistence\InMemory\Repository\InMemoryViewedAnnouncementRepository'

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Application/Announcement/Command/AddViewedAnnouncementsByUserHandlerSpec.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Application/Announcement/Command/AddViewedAnnouncementsByUserHandlerSpec.php
@@ -6,7 +6,6 @@ namespace spec\Akeneo\Platform\CommunicationChannel\Application\Announcement\Com
 
 use Akeneo\Platform\CommunicationChannel\Application\Announcement\Command\AddViewedAnnouncementsByUserCommand;
 use Akeneo\Platform\CommunicationChannel\Application\Announcement\Command\AddViewedAnnouncementsByUserHandler;
-use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Model\Write\ViewedAnnouncement;
 use Akeneo\Platform\CommunicationChannel\Infrastructure\Persistence\InMemory\Repository\InMemoryViewedAnnouncementRepository;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Application/Announcement/Command/AddViewedAnnouncementsByUserHandlerSpec.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Application/Announcement/Command/AddViewedAnnouncementsByUserHandlerSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Platform\CommunicationChannel\Application\Announcement\Command;
+
+use Akeneo\Platform\CommunicationChannel\Application\Announcement\Command\AddViewedAnnouncementsByUserCommand;
+use Akeneo\Platform\CommunicationChannel\Application\Announcement\Command\AddViewedAnnouncementsByUserHandler;
+use Akeneo\Platform\CommunicationChannel\Domain\Announcement\Model\Write\ViewedAnnouncement;
+use Akeneo\Platform\CommunicationChannel\Infrastructure\Persistence\InMemory\Repository\InMemoryViewedAnnouncementRepository;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class AddViewedAnnouncementsByUserHandlerSpec extends ObjectBehavior
+{
+    public function let(InMemoryViewedAnnouncementRepository $viewedAnnouncementRepository): void
+    {
+        $this->beConstructedWith($viewedAnnouncementRepository);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldBeAnInstanceOf(AddViewedAnnouncementsByUserHandler::class);
+    }
+
+    public function it_handles_the_add_viewed_announcements_by_user($viewedAnnouncementRepository): void
+    {
+        $command = new AddViewedAnnouncementsByUserCommand(
+            ['announcement_id_1', 'announcement_id_2'],
+            1
+        );
+        $this->execute($command);
+
+        $viewedAnnouncementRepository->create(Argument::type('array'))->shouldBeCalled();
+    }
+}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Domain/Announcement/Model/Read/AnnouncementItemSpec.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Domain/Announcement/Model/Read/AnnouncementItemSpec.php
@@ -31,6 +31,7 @@ class AnnouncementItemSpec extends ObjectBehavior
             ]
         );
     }
+
     public function it_is_initializable(): void
     {
         $this->shouldBeAnInstanceOf(AnnouncementItem::class);

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/phpstan-infra.neon
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/phpstan-infra.neon
@@ -1,4 +1,0 @@
-parameters:
-    level: 5
-    paths:
-        - %rootDir%/../../../src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/phpstan.neon
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/phpstan.neon
@@ -1,5 +1,0 @@
-parameters:
-    level: 8
-    paths:
-        - %rootDir%/../../../src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application
-        - %rootDir%/../../../src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain

--- a/upgrades/schema/Version_5_0_20200702232424_create_communication_channel_viewed_announcement_index.php
+++ b/upgrades/schema/Version_5_0_20200702232424_create_communication_channel_viewed_announcement_index.php
@@ -18,7 +18,7 @@ final class Version_5_0_20200702232424_create_communication_channel_viewed_annou
     {
         $sql = <<<SQL
             ALTER TABLE akeneo_communication_channel_viewed_announcements
-            ADD INDEX IDX_VIEWED_ANNOUNCEMENTS_user_id_announcement_id (user_id, announcement_id);
+            ADD UNIQUE INDEX IDX_VIEWED_ANNOUNCEMENTS_user_id_announcement_id (user_id, announcement_id);
         SQL;
 
         $this->addSql($sql);

--- a/upgrades/schema/Version_5_0_20200702232424_create_communication_channel_viewed_announcement_index.php
+++ b/upgrades/schema/Version_5_0_20200702232424_create_communication_channel_viewed_announcement_index.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * @author    Christophe Chausseray <chausseray.christophe@gmail.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Version_5_0_20200702232424_create_communication_channel_viewed_announcement_index extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $sql = <<<SQL
+            ALTER TABLE akeneo_communication_channel_viewed_announcements
+            ADD INDEX IDX_VIEWED_ANNOUNCEMENTS_user_id_announcement_id (user_id, announcement_id);
+        SQL;
+
+        $this->addSql($sql);
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Ticket : https://github.com/akeneo/actionable-product-data/issues/179

There will be notification if the user didn't view all announcements in the PIM. So, we need to track which announcements the user saw. The table creation to track is done in the first commit (which is the PR https://github.com/akeneo/pim-community-dev/pull/12380).

But to flag an announcement as viewed, we need to expose it in a controller. That's the role of this PR: expose an HTTP endpoint to mark all the articles as viewed.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
