### PR TITLE
CXP-358: change boolean validation error message

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/ErrorManagement/DocumentationBuilder/DefaultAttributeValidation.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/ErrorManagement/DocumentationBuilder/DefaultAttributeValidation.php
@@ -9,6 +9,7 @@ use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Docu
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Documentation\HrefMessageParameter;
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Documentation\RouteMessageParameter;
 use Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Boolean;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\IsNumeric;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\IsString;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Length;
@@ -17,6 +18,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\NotDecimal;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Range;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Regex;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueValue;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 
 /**
@@ -26,17 +28,18 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
 final class DefaultAttributeValidation implements DocumentationBuilderInterface
 {
     const SUPPORTED_CONSTRAINTS_CODES = [
+        Boolean::NOT_BOOLEAN_ERROR,
         IsNumeric::IS_NUMERIC,
+        IsString::IS_STRING,
+        Length::TOO_LONG_ERROR,
         NotBlank::IS_BLANK_ERROR,
+        NotDecimal::NOT_DECIMAL,
         Range::INVALID_CHARACTERS_ERROR,
         Range::NOT_IN_RANGE_ERROR,
         Range::TOO_HIGH_ERROR,
         Range::TOO_LOW_ERROR,
         Regex::REGEX_FAILED_ERROR,
         UniqueValue::UNIQUE_VALUE,
-        NotDecimal::NOT_DECIMAL,
-        IsString::IS_STRING,
-        Length::TOO_LONG_ERROR,
     ];
 
     public function support($object): bool

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/ErrorManagement/DocumentationBuilder/DefaultAttributeValidationSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/ErrorManagement/DocumentationBuilder/DefaultAttributeValidationSpec.php
@@ -7,7 +7,12 @@ namespace spec\Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\Doc
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\Documentation\DocumentationCollection;
 use Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilder\DefaultAttributeValidation;
 use Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\DocumentationBuilderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Boolean;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\IsNumeric;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\IsString;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Length;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\NotBlank;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\NotDecimal;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Range;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Regex;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueValue;
@@ -33,8 +38,14 @@ class DefaultAttributeValidationSpec extends ObjectBehavior
     function it_supports_some_attribute_validation_constraints(ConstraintViolationInterface $constraintViolation)
     {
         $constraintCodes = [
+            Boolean::NOT_BOOLEAN_ERROR,
             IsNumeric::IS_NUMERIC,
+            IsString::IS_STRING,
+            Length::TOO_LONG_ERROR,
+            NotBlank::IS_BLANK_ERROR,
+            NotDecimal::NOT_DECIMAL,
             Range::INVALID_CHARACTERS_ERROR,
+            Range::NOT_IN_RANGE_ERROR,
             Range::TOO_HIGH_ERROR,
             Range::TOO_LOW_ERROR,
             Regex::REGEX_FAILED_ERROR,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/BooleanValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/BooleanValueFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Factory\Value;
@@ -22,7 +23,7 @@ final class BooleanValueFactory extends ScalarValueFactory implements ValueFacto
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_bool($data)) {
+        if (!is_scalar($data) || (is_string($data) && '' === trim($data))) {
             throw InvalidPropertyTypeException::booleanExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Boolean.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Boolean.php
@@ -13,8 +13,10 @@ use Symfony\Component\Validator\Constraint;
  */
 class Boolean extends Constraint
 {
+    const NOT_BOOLEAN_ERROR = '541d44c2-0cec-4b43-87f7-5df101b2a951';
+
     /** @var string */
-    public $message = 'Property "%attribute%" expects a boolean as data, "%givenType%" given.';
+    public $message = 'The {{ attribute_code }} attribute requires a boolean value (true or false) as data, a {{ given_type }} was detected.';
 
     /**
      * {@inheritdoc}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/BooleanValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/BooleanValidator.php
@@ -41,19 +41,16 @@ class BooleanValidator extends ConstraintValidator
             return;
         }
 
-        if (!is_bool($checkedValue)
-            && '0' !== $checkedValue
-            && '1' !== $checkedValue
-            && 0 !== $checkedValue
-            && 1 !== $checkedValue
-        ) {
+        if (!is_bool($checkedValue)) {
             $this->context->buildViolation(
                 $constraint->message,
                 [
-                    '%attribute%' => $code,
-                    '%givenType%' => gettype($checkedValue),
+                    '{{ attribute_code }}' => $code,
+                    '{{ given_type }}' => gettype($checkedValue),
                 ]
-            )->addViolation();
+            )
+                ->setCode(Boolean::NOT_BOOLEAN_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/BooleanValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/BooleanValueFactorySpec.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Factory\Value;
@@ -86,7 +87,7 @@ final class BooleanValueFactorySpec extends ObjectBehavior
             $this->getAttribute(true, true),
             'ecommerce',
             'fr_FR',
-            'michel'
+            new \stdClass()
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/BooleanSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/BooleanSpec.php
@@ -4,6 +4,7 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Validator\Constr
 
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Boolean;
 use PhpSpec\ObjectBehavior;
+use Symfony\Component\Validator\Constraint;
 
 class BooleanSpec extends ObjectBehavior
 {
@@ -14,11 +15,12 @@ class BooleanSpec extends ObjectBehavior
 
     function it_has_message()
     {
-        $this->message->shouldBe('Property "%attribute%" expects a boolean as data, "%givenType%" given.');
+        $this->message
+            ->shouldBe('The {{ attribute_code }} attribute requires a boolean value (true or false) as data, a {{ given_type }} was detected.');
     }
 
     function it_is_a_validator_constraint()
     {
-        $this->shouldBeAnInstanceOf('Symfony\Component\Validator\Constraint');
+        $this->shouldBeAnInstanceOf(Constraint::class);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/BooleanValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/BooleanValidatorSpec.php
@@ -49,40 +49,34 @@ class BooleanValidatorSpec extends ObjectBehavior
         $this->validate(false, $constraint);
     }
 
-    function it_does_not_add_violation_when_validates_boolean_like_value($context, Boolean $constraint)
-    {
-        $context
-            ->buildViolation(Argument::cetera())
-            ->shouldNotBeCalled();
-
-        $this->validate(1, $constraint);
-        $this->validate(0, $constraint);
-        $this->validate('1', $constraint);
-        $this->validate('0', $constraint);
-    }
-
     function it_adds_violation_when_validating_non_boolean_value(
         $context,
         Boolean $constraint,
-        ConstraintViolationBuilderInterface $violation
+        ConstraintViolationBuilderInterface $violationBuilder
     ) {
         $context
             ->buildViolation(
                 $constraint->message,
-                ['%attribute%' => '', '%givenType%' => 'integer']
+                ['{{ attribute_code }}' => '', '{{ given_type }}' => 'integer']
             )
-            ->shouldBeCalled()
-            ->willReturn($violation);
+            ->willReturn($violationBuilder);
+        $violationBuilder->setCode(Boolean::NOT_BOOLEAN_ERROR)
+            ->willReturn($violationBuilder);
+        $violationBuilder->addViolation()
+            ->shouldBeCalled();
 
         $this->validate(666, $constraint);
 
         $context
             ->buildViolation(
                 $constraint->message,
-                ['%attribute%' => '', '%givenType%' => 'string']
+                ['{{ attribute_code }}' => '', '{{ given_type }}' => 'string']
             )
-            ->shouldBeCalled()
-            ->willReturn($violation);
+            ->willReturn($violationBuilder);
+        $violationBuilder->setCode(Boolean::NOT_BOOLEAN_ERROR)
+            ->willReturn($violationBuilder);
+        $violationBuilder->addViolation()
+            ->shouldBeCalled();
 
         $this->validate('foo', $constraint);
         $this->validate('true', $constraint);
@@ -90,10 +84,13 @@ class BooleanValidatorSpec extends ObjectBehavior
         $context
             ->buildViolation(
                 $constraint->message,
-                ['%attribute%' => '', '%givenType%' => 'array']
+                ['{{ attribute_code }}' => '', '{{ given_type }}' => 'array']
             )
-            ->shouldBeCalled()
-            ->willReturn($violation);
+            ->willReturn($violationBuilder);
+        $violationBuilder->setCode(Boolean::NOT_BOOLEAN_ERROR)
+            ->willReturn($violationBuilder);
+        $violationBuilder->addViolation()
+            ->shouldBeCalled();
 
         $this->validate(['foo'], $constraint);
         $this->validate([true], $constraint);
@@ -133,7 +130,7 @@ class BooleanValidatorSpec extends ObjectBehavior
         $context,
         Boolean $constraint,
         ValueInterface $value,
-        ConstraintViolationBuilderInterface $violation
+        ConstraintViolationBuilderInterface $violationBuilder
     ) {
         $value->getAttributeCode()->willReturn('foo');
         $value->getData()->willReturn(666);
@@ -141,10 +138,13 @@ class BooleanValidatorSpec extends ObjectBehavior
         $context
             ->buildViolation(
                 $constraint->message,
-                ['%attribute%' => 'foo', '%givenType%' => 'integer']
+                ['{{ attribute_code }}' => 'foo', '{{ given_type }}' => 'integer']
             )
-            ->shouldBeCalled()
-            ->willReturn($violation);
+            ->willReturn($violationBuilder);
+        $violationBuilder->setCode(Boolean::NOT_BOOLEAN_ERROR)
+            ->willReturn($violationBuilder);
+        $violationBuilder->addViolation()
+            ->shouldBeCalled();
 
         $this->validate($value, $constraint);
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- Change boolean validation error message and add it to the default documentation builder.

- Fix the `BooleanValueFactory.php` to only check that the attribute data is a scalar and let the validation stack check the boolean value
- and fixed the Boolean validator to do what the BooleanValueFactory was doing aka only check boolean value (and not 0|1)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
