### PR TITLE
PIM-9315: Improve the error message when you have no rights on a product

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Improvement
+
+-PIM-9315: Improve error message when when you have no rights on a product
+
 # 4.0.36 (2020-06-30)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -283,7 +283,7 @@ class ProductController
 
             $product = $this->getConnectorProducts->fromProductIdentifier($code, $user->getId());
         } catch (ObjectNotFoundException $e) {
-            throw new NotFoundHttpException(sprintf('Product "%s" does not exist.', $code));
+            throw new NotFoundHttpException(sprintf('Product "%s" does not exist or you do not have permission to access it.', $code));
         }
 
         $normalizedProduct = $this->connectorProductNormalizer->normalizeConnectorProduct($product);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
@@ -188,7 +188,7 @@ class ProductModelController
 
             $productModel = $this->getConnectorProductModels->fromProductModelCode($code, $user->getId());
         } catch (ObjectNotFoundException $e) {
-            throw new NotFoundHttpException(sprintf('Product model "%s" does not exist.', $code));
+            throw new NotFoundHttpException(sprintf('Product model "%s" does not exist or you do not have permission to access it.', $code));
         }
 
         return new JsonResponse(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
@@ -72,7 +72,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
         $content = json_decode($response->getContent(), true);
         $this->assertCount(2, $content, 'response contains 2 items');
         $this->assertSame(Response::HTTP_NOT_FOUND, $content['code']);
-        $this->assertSame('Product "not_found" does not exist.', $content['message']);
+        $this->assertSame('Product "not_found" does not exist or you do not have permission to access it.', $content['message']);
     }
 
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When trying (for example) to modify a product on which you do not have rights on, the PIM displayed  **"Product XXX does not exist."**, but the real problem here was that you didn't have permission to access the product XXX.

For security reasons, it was decided that this message should be improved as follows (for products and product models) :
**“Product XXX does not exist or you do not have permission to access it”.**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | OK
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
