### PR TITLE
DAPI-1118: Preserve the selection of the catalogLocale when we navigate from the product edit form

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/index.yml
@@ -57,6 +57,7 @@ extensions:
         position: 1000
         config:
             alias: attribute-grid
+            localeKey: dataLocale
 
     pim-attribute-index-create-button:
         module: pim/form/common/attributes/create-button

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes.js
@@ -156,7 +156,7 @@ define(
                 this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
                 this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', (localeEvent) => {
                     if ('base_product' === localeEvent.context) {
-                        this.setLocale(localeEvent.localeCode, {});
+                        this.setLocale(localeEvent.localeCode, {silent: true});
                     }
                 });
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes.js
@@ -156,7 +156,7 @@ define(
                 this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:pre_render', this.initLocale.bind(this));
                 this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', (localeEvent) => {
                     if ('base_product' === localeEvent.context) {
-                        this.setLocale(localeEvent.localeCode, {silent: true});
+                        this.setLocale(localeEvent.localeCode, {});
                     }
                 });
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When coming from the PEF, attribute labels should be in the locale selected in the PEF

To reproduce:
1. Set your locale in the product grid to FR
2. Go to attribute grid -> attribute labels are in French
3. Go to a product and click on the attribute labels with spelling mistakes linkExpected result: Attribute labels are in French - OK
4. Click on "back to products"
5. Change locale for EN
6. Click on the attribute labels with spelling mistakes link

Expected result: Attribute labels are in English - KO
Current result: Attribute labels are in French 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
