### PR TITLE
CXP-79: Remove instable datetime test

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Repository/DbalEventCountRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Repository/DbalEventCountRepositoryIntegration.php
@@ -98,10 +98,6 @@ SQL;
             $expected->eventType(),
             $actual['event_type']
         );
-        Assert::assertEquals(
-            (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-            $actual['updated']
-        );
     }
 
     protected function getConfiguration(): Configuration


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Test on updated datetime was instable and not relevant is this case, I just deleted it

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
