### PR TITLE
Test coverage blocking CI because not 100%

### DIFF
--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -47,6 +47,11 @@ unit-front:
 	$(YARN_RUN) unit
 	$(MAKE) connectivity-connection-unit-front
 
+.PHONY: unit-front-coverage
+unit-front-coverage:
+	$(YARN_RUN) unit-coverage || (exit 0)
+	$(MAKE) connectivity-connection-unit-front_coverage
+
 ### Acceptance tests
 .PHONY: acceptance-back
 acceptance-back:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint src/**/*.js --config .eslintrc --ignore-path .eslintignore --quiet",
     "lint-fix": "yarn run lint --fix",
     "unit": "jest --no-cache --config tests/front/unit/jest/unit.jest.js --runInBand",
+    "unit-coverage": "jest --no-cache --config tests/front/unit/jest/unit-coverage.jest.js --runInBand",
     "integration": "jest --no-cache --config ./tests/front/integration/jest/integration.jest.js",
     "acceptance": "cucumber-js --tags @acceptance-front -r ./frontend/test/acceptance/run-steps.js -r ./tests/front/acceptance/cucumber",
     "acceptance-html-report": "yarn acceptance ./tests/features/ -f json:public/test_dist/acceptance-js.json && node frontend/test/acceptance/generate-html-report.js",

--- a/tests/front/unit/jest/unit-coverage.jest.js
+++ b/tests/front/unit/jest/unit-coverage.jest.js
@@ -1,0 +1,36 @@
+const baseConfig = require(`${__dirname}/unit.jest.js`);
+
+const unitConfig = {
+  collectCoverage: true,
+  coveragePathIgnorePatterns: [
+    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge',
+    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/Button.tsx',
+    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/NoData.tsx',
+    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/icons',
+    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/illustrations',
+    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/tools',
+    'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/',
+    'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/icons/',
+    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/tests/front/unit/utils.tsx',
+    'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/illustrations/',
+    'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/CreateMeasurementFamily.tsx',
+    'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-unit/CreateUnit.tsx',
+    'src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/icons',
+    'src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Image.tsx',
+    'src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/view',
+    'src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/contexts',
+    'src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/fetchers',
+    'src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/store',
+  ],
+  coverageReporters: ['text-summary', 'html'],
+  coverageDirectory: '<rootDir>/coverage/',
+  coverageThreshold: {
+    global: {
+      statements: 100,
+      functions: 100,
+      lines: 100,
+    },
+  },
+};
+
+module.exports = Object.assign({}, baseConfig, unitConfig);

--- a/tests/front/unit/jest/unit.jest.js
+++ b/tests/front/unit/jest/unit.jest.js
@@ -6,26 +6,6 @@ const unitConfig = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  coveragePathIgnorePatterns: [
-    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge',
-    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/Button.tsx',
-    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/NoData.tsx',
-    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/icons',
-    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/illustrations',
-    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/tools',
-    'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/',
-    'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/icons/',
-    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/tests/front/unit/utils.tsx',
-    'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/illustrations/',
-    'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/CreateMeasurementFamily.tsx',
-    'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-unit/CreateUnit.tsx',
-    'src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/icons',
-    'src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Image.tsx',
-    'src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/view',
-    'src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/contexts',
-    'src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/fetchers',
-    'src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/store',
-  ],
   moduleNameMapper: {
     '^require-context$': `${__dirname}/../../../../frontend/webpack/require-context.js`,
     '^module-registry$': `${__dirname}/../../../../public/js/module-registry.js`,
@@ -45,15 +25,7 @@ const unitConfig = {
     },
     fos: {Router: {setData: () => {}}},
   },
-  coverageReporters: ['text-summary', 'html'],
-  coverageDirectory: '<rootDir>/coverage/',
-  coverageThreshold: {
-    global: {
-      statements: 100,
-      functions: 100,
-      lines: 100,
-    },
-  },
+  collectCoverage: false,
   setupFiles: [`${__dirname}/enzyme.js`, `${__dirname}/mocks.js`, `${__dirname}/fetchMock.ts`],
 };
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->


## Issue: Test coverage blocking CI because not 100%

- It can be hard to have 100%
- Octopus/Weasels fixed by having separate packages tested with custom jest config
- Not very convenient to have 100% test coverage and be smarter on how to tests, what should be tested
- Approach with workspace is cool, we should


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
