### PR TITLE
Test coverage blocking CI because not 100%

### DIFF
--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -44,8 +44,13 @@ endif
 
 .PHONY: unit-front
 unit-front:
+ifeq ($(CI),true)
 	$(YARN_RUN) unit
 	$(MAKE) connectivity-connection-unit-front
+else
+	$(YARN_RUN) unit --coverage || (exit 0)
+	$(MAKE) connectivity-connection-unit-front_coverage
+endif
 
 ### Acceptance tests
 .PHONY: acceptance-back

--- a/tests/front/unit/jest/unit.jest.js
+++ b/tests/front/unit/jest/unit.jest.js
@@ -6,6 +6,7 @@ const unitConfig = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  collectCoverage: false,
   coveragePathIgnorePatterns: [
     'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge',
     'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/Button.tsx',


### PR DESCRIPTION

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

## Issue: Test coverage blocking CI because not 100%

- It can be hard to have 100%
- Octopus/Weasels fixed by having separate packages tested with custom jest config
- Not very convenient to have 100% test coverage and be smarter on how to tests, what should be tested
- Approach with workspace is cool, we should


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
