### PR TITLE
Fix quantified associations tests only launched on nightly

### DIFF
--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductModelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductModelsIntegration.php
@@ -179,6 +179,10 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                         'products' => [['identifier' => 'a_simple_product', 'quantity' => 1]],
                         'product_models' => [['identifier' => 'simple_pm', 'quantity' => 9]],
                     ],
+                    'ANOTHER_PRODUCT_SET' => [
+                        'products' => [['identifier' => 'a_simple_product', 'quantity' => 4]],
+                        'product_models' => [],
+                    ],
                 ],
                 ['categoryA1', 'categoryA2'],
                 new ReadValueCollection(
@@ -354,6 +358,10 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                         'products' => [['identifier' => 'a_simple_product', 'quantity' => 1]],
                         'product_models' => [['identifier' => 'simple_pm', 'quantity' => 9]],
                     ],
+                    'ANOTHER_PRODUCT_SET' => [
+                        'products' => [['identifier' => 'a_simple_product', 'quantity' => 4]],
+                        'product_models' => [],
+                    ],
                 ],
                 ['categoryA1', 'categoryA2'],
                 new ReadValueCollection(
@@ -418,6 +426,10 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                 'PRODUCT_SET' => [
                     'products' => [['identifier' => 'a_simple_product', 'quantity' => 1]],
                     'product_models' => [['identifier' => 'simple_pm', 'quantity' => 9]],
+                ],
+                'ANOTHER_PRODUCT_SET' => [
+                    'products' => [['identifier' => 'a_simple_product', 'quantity' => 4]],
+                    'product_models' => [],
                 ],
             ],
             ['categoryA1', 'categoryA2'],


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Since quantified associations of product model and variant products inherit quantified associations of parents those tests no longer pass


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
