### PR TITLE
RAC-118: refactor: make QuantifiedAssociations immutable

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithQuantifiedAssociationsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithQuantifiedAssociationsInterface.php
@@ -93,4 +93,10 @@ interface EntityWithQuantifiedAssociationsInterface
      * @return array
      */
     public function normalizeQuantifiedAssociations(): array;
+
+    /**
+     * Update quantified associations by merging with another quantified associations
+     * @param QuantifiedAssociations $quantifiedAssociations
+     */
+    public function mergeQuantifiedAssociations(QuantifiedAssociations $quantifiedAssociations): void;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
@@ -37,6 +37,13 @@ trait EntityWithQuantifiedAssociationTrait
         return $this->quantifiedAssociations;
     }
 
+    public function mergeQuantifiedAssociations(QuantifiedAssociations $quantifiedAssociations): void
+    {
+        $quantifiedAssociationsMerged = $this->quantifiedAssociations->merge($quantifiedAssociations);
+
+        $this->setQuantifiedAssociations($quantifiedAssociationsMerged);
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
@@ -235,11 +235,11 @@ class QuantifiedAssociations
         $result = [];
         foreach ($quantifiedAssociationsNormalized as $associationType => $associationsNormalized) {
             foreach ($associationsNormalized as $quantifiedLinksType => $quantifiedLinksNormalized) {
-                $result[$associationType][$quantifiedLinksType] = array_column(
-                    $quantifiedLinksNormalized,
-                    null,
-                    'identifier'
-                );
+                foreach ($quantifiedLinksNormalized as $quantifiedLinkNormalized) {
+                    $identifier = $quantifiedLinkNormalized['identifier'];
+
+                    $result[$associationType][$quantifiedLinksType][$identifier] = $quantifiedLinkNormalized;
+                }
             }
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
@@ -131,8 +131,8 @@ class QuantifiedAssociations
 
     public function merge(QuantifiedAssociations $quantifiedAssociations): self
     {
-        $currentQuantifiedAssociationsNormalized = $this->normalizeIndexedByIdentifiers();
-        $quantifiedAssociationsToMergeNormalized = $quantifiedAssociations->normalizeIndexedByIdentifiers();
+        $currentQuantifiedAssociationsNormalized = $this->normalizeWithIndexedIdentifiers();
+        $quantifiedAssociationsToMergeNormalized = $quantifiedAssociations->normalizeWithIndexedIdentifiers();
 
         $mergedQuantifiedAssociationsNormalized = array_replace_recursive(
             $currentQuantifiedAssociationsNormalized,
@@ -228,7 +228,7 @@ class QuantifiedAssociations
         return new self($filteredQuantifiedAssociations);
     }
 
-    private function normalizeIndexedByIdentifiers()
+    private function normalizeWithIndexedIdentifiers()
     {
         $quantifiedAssociationsNormalized = $this->normalize();
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
@@ -235,6 +235,7 @@ class QuantifiedAssociations
         $result = [];
         foreach ($quantifiedAssociationsNormalized as $associationType => $associationsNormalized) {
             foreach ($associationsNormalized as $quantifiedLinksType => $quantifiedLinksNormalized) {
+                $result[$associationType][$quantifiedLinksType] = [];
                 foreach ($quantifiedLinksNormalized as $quantifiedLinkNormalized) {
                     $identifier = $quantifiedLinkNormalized['identifier'];
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
@@ -129,38 +129,17 @@ class QuantifiedAssociations
         return array_unique($result);
     }
 
-    public function merge(QuantifiedAssociations $quantifiedAssociations): void
+    public function merge(QuantifiedAssociations $quantifiedAssociations): self
     {
-        $normalizedQuantifiedAssociationsToMerge = $quantifiedAssociations->normalize();
+        $currentQuantifiedAssociationsNormalized = $this->normalizeIndexedByIdentifiers();
+        $quantifiedAssociationsToMergeNormalized = $quantifiedAssociations->normalizeIndexedByIdentifiers();
 
-        foreach ($normalizedQuantifiedAssociationsToMerge as $associationTypeCode => $association) {
-            foreach ($association as $associationEntityType => $quantifiedLinks) {
-                if (!isset($this->quantifiedAssociations[$associationTypeCode][$associationEntityType])) {
-                    $this->quantifiedAssociations[$associationTypeCode][$associationEntityType] = [];
-                }
+        $mergedQuantifiedAssociationsNormalized = array_replace_recursive(
+            $currentQuantifiedAssociationsNormalized,
+            $quantifiedAssociationsToMergeNormalized
+        );
 
-                foreach ($quantifiedLinks as $quantifiedLink) {
-                    $key = $this->searchKeyOfDuplicatedQuantifiedAssociation(
-                        $this->quantifiedAssociations,
-                        $associationTypeCode,
-                        $associationEntityType,
-                        $quantifiedLink
-                    );
-
-                    if (null !== $key) {
-                        $this->quantifiedAssociations[$associationTypeCode][$associationEntityType][$key] = new QuantifiedLink(
-                            $this->quantifiedAssociations[$associationTypeCode][$associationEntityType][$key]->identifier(),
-                            $quantifiedLink['quantity']
-                        );
-                    } else {
-                        $this->quantifiedAssociations[$associationTypeCode][$associationEntityType][] = new QuantifiedLink(
-                            $quantifiedLink['identifier'],
-                            $quantifiedLink['quantity']
-                        );
-                    }
-                }
-            }
-        }
+        return self::createFromNormalized($mergedQuantifiedAssociationsNormalized);
     }
 
     public function normalizeWithMapping(IdMapping $mappedProductIdentifiers, IdMapping $mappedProductModelIdentifiers)
@@ -249,39 +228,21 @@ class QuantifiedAssociations
         return new self($filteredQuantifiedAssociations);
     }
 
-    /**
-     * Since we are using an unindexed array for the quantified associations,
-     * we need to find if there is a row with the same identifier as the one we have.
-     * With its key, we will be able to overwrite the quantity.
-     *
-     * For context, this is the structure:
-     * [
-     *      'PACK' => [
-     *          'products' => [
-     *              ['identifier' => 'foo', 'quantity' => 2],
-     *              ['identifier' => 'bar', 'quantity' => 4],
-     *          ]
-     *      ]
-     * ]
-     *
-     */
-    private function searchKeyOfDuplicatedQuantifiedAssociation(
-        array $source,
-        string $associationTypeCode,
-        string $associationEntityType,
-        array $quantifiedLink
-    ): ?int {
-        $matchingSourceQuantifiedAssociations = array_filter(
-            $source[$associationTypeCode][$associationEntityType] ?? [],
-            function ($sourceQuantifiedAssociation) use ($quantifiedLink) {
-                return $sourceQuantifiedAssociation->identifier() === $quantifiedLink['identifier'];
-            }
-        );
+    private function normalizeIndexedByIdentifiers()
+    {
+        $quantifiedAssociationsNormalized = $this->normalize();
 
-        if (empty($matchingSourceQuantifiedAssociations)) {
-            return null;
+        $result = [];
+        foreach ($quantifiedAssociationsNormalized as $associationType => $associationsNormalized) {
+            foreach ($associationsNormalized as $quantifiedLinksType => $quantifiedLinksNormalized) {
+                $result[$associationType][$quantifiedLinksType] = array_column(
+                    $quantifiedLinksNormalized,
+                    null,
+                    'identifier'
+                );
+            }
         }
 
-        return array_keys($matchingSourceQuantifiedAssociations)[0];
+        return $result;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/QuantifiedAssociation/QuantifiedAssociationsMerger.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/QuantifiedAssociation/QuantifiedAssociationsMerger.php
@@ -21,21 +21,20 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\Quantifi
  */
 class QuantifiedAssociationsMerger
 {
-    public function normalizeAndMergeQuantifiedAssociationsFrom(
-        array $entitiesWithQuantifiedAssociations,
-        QuantifiedAssociations $quantifiedAssociationToMergeInto = null
-    ): array {
+    public function normalizeAndMergeQuantifiedAssociationsFrom(array $entitiesWithQuantifiedAssociations): array
+    {
         if (empty($entitiesWithQuantifiedAssociations)) {
             return [];
         }
 
-        $mergedQuantifiedAssociations = null === $quantifiedAssociationToMergeInto ? QuantifiedAssociations::createFromNormalized([]) : $quantifiedAssociationToMergeInto;
+        $firstEntityWithQuantifiedAssociations = array_shift($entitiesWithQuantifiedAssociations);
+        $mergedQuantifiedAssociations = $firstEntityWithQuantifiedAssociations->getQuantifiedAssociations();
         foreach ($entitiesWithQuantifiedAssociations as $entity) {
             if (!$entity instanceof EntityWithQuantifiedAssociationsInterface) {
                 continue;
             }
 
-            $mergedQuantifiedAssociations->merge($entity->getQuantifiedAssociations());
+            $mergedQuantifiedAssociations = $mergedQuantifiedAssociations->merge($entity->getQuantifiedAssociations());
         }
 
         return $mergedQuantifiedAssociations->normalize();

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Adder/QuantifiedAssociationFieldAdder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Adder/QuantifiedAssociationFieldAdder.php
@@ -41,11 +41,8 @@ class QuantifiedAssociationFieldAdder extends AbstractFieldAdder
      */
     public function addFieldData($product, $field, $data, array $options = [])
     {
-        $currentQuantifiedAssociations = $product->getQuantifiedAssociations();
         $quantifiedAssociationsToMerge = QuantifiedAssociations::createFromNormalized($data);
 
-        $mergedQuantifiedAssociations = $currentQuantifiedAssociations->merge($quantifiedAssociationsToMerge);
-
-        $product->setQuantifiedAssociations($mergedQuantifiedAssociations);
+        $product->mergeQuantifiedAssociations($quantifiedAssociationsToMerge);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Adder/QuantifiedAssociationFieldAdder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Adder/QuantifiedAssociationFieldAdder.php
@@ -8,7 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\Quantifi
  * Quantified association field adder
  *
  * @author    Julien Sanchez <julien@akeneo.com>
- * @copyright 2°2° Akeneo SAS (http://www.akeneo.com)
+ * @copyright Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class QuantifiedAssociationFieldAdder extends AbstractFieldAdder
@@ -41,6 +41,11 @@ class QuantifiedAssociationFieldAdder extends AbstractFieldAdder
      */
     public function addFieldData($product, $field, $data, array $options = [])
     {
-        $product->getQuantifiedAssociations()->merge(QuantifiedAssociations::createFromNormalized($data));
+        $currentQuantifiedAssociations = $product->getQuantifiedAssociations();
+        $quantifiedAssociationsToMerge = QuantifiedAssociations::createFromNormalized($data);
+
+        $mergedQuantifiedAssociations = $currentQuantifiedAssociations->merge($quantifiedAssociationsToMerge);
+
+        $product->setQuantifiedAssociations($mergedQuantifiedAssociations);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationsSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationsSpec.php
@@ -396,9 +396,7 @@ class QuantifiedAssociationsSpec extends ObjectBehavior
         ]);
     }
 
-    public function it_merge_quantified_associations_and_overwrite_quantities_from_duplicated_identifiers(
-        QuantifiedAssociations $quantifiedAssociationsToMerge
-    ) {
+    public function it_merge_quantified_associations_and_overwrite_quantities_from_duplicated_identifiers() {
         $this->beConstructedThrough(
             'createFromNormalized',
             [
@@ -414,7 +412,7 @@ class QuantifiedAssociationsSpec extends ObjectBehavior
             ]
         );
 
-        $quantifiedAssociationsToMerge->normalize()->willReturn([
+        $quantifiedAssociationsToMerge = QuantifiedAssociations::createFromNormalized([
             'PACK' => [
                 'products' => [
                     ['identifier' => 'B', 'quantity' => 3],
@@ -424,9 +422,7 @@ class QuantifiedAssociationsSpec extends ObjectBehavior
             ],
         ]);
 
-        $this->merge($quantifiedAssociationsToMerge);
-
-        $this->normalize()->shouldReturn([
+        $this->merge($quantifiedAssociationsToMerge)->shouldBeLike(QuantifiedAssociations::createFromNormalized([
             'PACK' => [
                 'products' => [
                     ['identifier' => 'A', 'quantity' => 2],
@@ -436,7 +432,7 @@ class QuantifiedAssociationsSpec extends ObjectBehavior
                 ],
                 'product_models' => []
             ],
-        ]);
+        ]));
     }
 
     private function anIdMapping(): IdMapping

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/QuantifiedAssociation/QuantifiedAssociationsMergerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/QuantifiedAssociation/QuantifiedAssociationsMergerSpec.php
@@ -9,32 +9,34 @@ use PhpSpec\ObjectBehavior;
 class QuantifiedAssociationsMergerSpec extends ObjectBehavior
 {
     public function it_merge_quantified_associations(
-        ProductInterface $product_1,
-        ProductInterface $product_2,
-        QuantifiedAssociations $quantifiedAsociations_1,
-        QuantifiedAssociations $quantifiedAsociations_2,
-        QuantifiedAssociations $emptyQuantifiedAssociation
+        ProductInterface $product1,
+        ProductInterface $product2,
+        QuantifiedAssociations $quantifiedAssociations1,
+        QuantifiedAssociations $quantifiedAssociations2,
+        QuantifiedAssociations $quantifiedAssociationsMerged
     ) {
-        $product_1->getQuantifiedAssociations()->willReturn($quantifiedAsociations_1);
-        $product_2->getQuantifiedAssociations()->willReturn($quantifiedAsociations_2);
+        $product1->getQuantifiedAssociations()->willReturn($quantifiedAssociations1);
+        $product2->getQuantifiedAssociations()->willReturn($quantifiedAssociations2);
 
-        $emptyQuantifiedAssociation->merge($quantifiedAsociations_1)->shouldBeCalled();
-        $emptyQuantifiedAssociation->merge($quantifiedAsociations_2)->shouldBeCalled();
-        $emptyQuantifiedAssociation->normalize()->willReturn([
-            'PACK' => [
-                'products' => [
-                    ['identifier' => 'A', 'quantity' => 2],
-                    ['identifier' => 'B', 'quantity' => 3],
-                    ['identifier' => 'C', 'quantity' => 42],
-                    ['identifier' => 'D', 'quantity' => 5],
+        $quantifiedAssociations1->merge($quantifiedAssociations2)->shouldBeCalled()->willReturn($quantifiedAssociationsMerged);
+        $quantifiedAssociationsMerged->normalize()->willReturn(
+            [
+                'PACK' => [
+                    'products' => [
+                        ['identifier' => 'A', 'quantity' => 2],
+                        ['identifier' => 'B', 'quantity' => 3],
+                        ['identifier' => 'C', 'quantity' => 42],
+                        ['identifier' => 'D', 'quantity' => 5],
+                    ],
+                    'product_models' => [],
                 ],
-            ],
-        ]);
+            ]
+        );
 
         $this->normalizeAndMergeQuantifiedAssociationsFrom([
-            $product_1,
-            $product_2,
-        ], $emptyQuantifiedAssociation)->shouldReturn([
+            $product1,
+            $product2,
+        ])->shouldReturn([
             'PACK' => [
                 'products' => [
                     ['identifier' => 'A', 'quantity' => 2],
@@ -42,6 +44,7 @@ class QuantifiedAssociationsMergerSpec extends ObjectBehavior
                     ['identifier' => 'C', 'quantity' => 42],
                     ['identifier' => 'D', 'quantity' => 5],
                 ],
+                'product_models' => [],
             ],
         ]);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Adder/QuantifiedAssociationFieldAdderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Adder/QuantifiedAssociationFieldAdderSpec.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Adder;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithQuantifiedAssociationsInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\QuantifiedAssociations;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Adder\AdderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Updater\Adder\FieldAdderInterface;
+use PhpSpec\ObjectBehavior;
+
+class QuantifiedAssociationFieldAdderSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(['quantified_associations']);
+    }
+
+    function it_is_an_adder()
+    {
+        $this->shouldImplement(AdderInterface::class);
+        $this->shouldImplement(FieldAdderInterface::class);
+    }
+
+    function it_supports_quantified_associations_field()
+    {
+        $this->supportsField('quantified_associations')->shouldReturn(true);
+        $this->supportsField('associations')->shouldReturn(false);
+    }
+
+    function it_merge_quantified_associations(
+        EntityWithQuantifiedAssociationsInterface $entityWithQuantifiedAssociations,
+        QuantifiedAssociations $currentQuantifiedAssociations,
+        QuantifiedAssociations $quantifiedAssociationsMerged
+    ) {
+        $dataToAdd = [
+            'PRODUCT_SET' => [
+                'products' => [
+                    ['identifier' => 'productA', 'quantity' => 8]
+                ],
+            ],
+            'ANOTHER_PRODUCT_SET' => [
+                'product_models' => [
+                    ['identifier' => 'productModelA', 'quantity' => 9],
+                ],
+            ],
+        ];
+
+        $quantifiedAssociationToAdd = QuantifiedAssociations::createFromNormalized([
+            'PRODUCT_SET' => [
+                'products' => [
+                    ['identifier' => 'productA', 'quantity' => 8]
+                ],
+            ],
+            'ANOTHER_PRODUCT_SET' => [
+                'product_models' => [
+                    ['identifier' => 'productModelA', 'quantity' => 9],
+                ],
+            ],
+        ]);
+
+        $entityWithQuantifiedAssociations->getQuantifiedAssociations()->willReturn($currentQuantifiedAssociations);
+        $entityWithQuantifiedAssociations->setQuantifiedAssociations($quantifiedAssociationsMerged)->shouldBeCalled();
+        $currentQuantifiedAssociations
+            ->merge($quantifiedAssociationToAdd)
+            ->shouldBeCalled()
+            ->willReturn($quantifiedAssociationsMerged);
+
+        $this->addFieldData($entityWithQuantifiedAssociations, 'quantified_associations', $dataToAdd);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Adder/QuantifiedAssociationFieldAdderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Adder/QuantifiedAssociationFieldAdderSpec.php
@@ -58,12 +58,7 @@ class QuantifiedAssociationFieldAdderSpec extends ObjectBehavior
             ],
         ]);
 
-        $entityWithQuantifiedAssociations->getQuantifiedAssociations()->willReturn($currentQuantifiedAssociations);
-        $entityWithQuantifiedAssociations->setQuantifiedAssociations($quantifiedAssociationsMerged)->shouldBeCalled();
-        $currentQuantifiedAssociations
-            ->merge($quantifiedAssociationToAdd)
-            ->shouldBeCalled()
-            ->willReturn($quantifiedAssociationsMerged);
+        $entityWithQuantifiedAssociations->mergeQuantifiedAssociations($quantifiedAssociationToAdd)->shouldBeCalled();
 
         $this->addFieldData($entityWithQuantifiedAssociations, 'quantified_associations', $dataToAdd);
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR contain refactor of function merge in QuantifiedAssociations class. 
This function is now immutable. 

This use array_replace_recursive instead of using several loops 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Done
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
