### PR TITLE
PIM-9348: Revert RAC-95

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/associationtype.yml
@@ -14,9 +14,6 @@ Akeneo\Pim\Structure\Component\Model\AssociationType:
             - Regex:
                 pattern: /^[a-zA-Z0-9_]+$/
                 message: Association type code may contain only letters, numbers and underscores
-            - Regex:
-                pattern: /[a-zA-Z]+/
-                message: Association type code must contain at least one letter
             - Length:
                 max: 100
         translations:

--- a/tests/back/Pim/Structure/Integration/AssociationType/Validation/AssociationTypeValidationIntegration.php
+++ b/tests/back/Pim/Structure/Integration/AssociationType/Validation/AssociationTypeValidationIntegration.php
@@ -80,27 +80,6 @@ class AssociationTypeValidationIntegration extends TestCase
         $this->assertSame('code', $violation->getPropertyPath());
     }
 
-    public function testAssociationTypeCodeIntegerRegex()
-    {
-        $associationType = $this->createAssociationType();
-        $this->getUpdater()->update(
-            $associationType,
-            [
-                'code' => '123456',
-            ]
-        );
-
-        $violations = $this->getValidator()->validate($associationType);
-        $violation = current($violations)[0];
-
-        $this->assertCount(1, $violations);
-        $this->assertSame(
-            'Association type code must contain at least one letter',
-            $violation->getMessage()
-        );
-        $this->assertSame('code', $violation->getPropertyPath());
-    }
-
     public function testAssociationTypeCodeLength()
     {
         $associationType = $this->createAssociationType();


### PR DESCRIPTION
This reverts commit 90bfe7bdb7be17ad768d6f2b2975a2c380a22d66.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

We introduced a new constraint in RAC-95 which broke a customer environment, we are reverting the change.
This change was trying to prevent a bug which didn't happen yet.
This bug should be prevented by the work currently happening in https://akeneo.atlassian.net/browse/RAC-103

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
