### PR TITLE
PIM-9344:  Correctly convert variable to string in pdf renderer

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9344: Fix pdf renderer when using pim_catalog_simpleselect
+
 # 4.0.38 (2020-07-07)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/Product/renderPdf.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/Product/renderPdf.html.twig
@@ -115,7 +115,7 @@
                                 {% endif %}
 
                                 {% if content != null and manualHeight == true %}
-                                    {% set manualHeight = attribute.label|length >(content.__toString()|length / 3) %}
+                                    {% set manualHeight = attribute.label|length > (content|trim|length / 3) %}
                                 {% endif %}
 
                                 <div class="attributes"{% if manualHeight %} style="height: {{ (attribute.label|length / 30)|round(0, 'ceil') * 18 + 10 }}px"{% endif %}>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The pdf renderer expect every attribute value to be an object with `__toString`.
In some cases, it does not work because the content is already a string (`pim_catalog_simpleselect` and `pim_catalog_multiselect` are already converted to string before that line).

A simple fix is to use `|trim` instead of `.__toString()` because the twig trim filter always cast the value to a string with `(string)$value` and it will work for both cases (objects implementing `__toString` and strings)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -