### PR TITLE
GITHUB-APD-188: Update to fetch announcements only when we open the panel

### DIFF
--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/AnnouncementList.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/AnnouncementList.tsx
@@ -14,10 +14,10 @@ const Container = styled.ul`
 
 type ListAnnouncementProps = {
   campaign: string;
-  panelIsClosed: boolean;
+  panelIsOpened: boolean;
 };
 
-const AnnouncementList = ({campaign, panelIsClosed}: ListAnnouncementProps) => {
+const AnnouncementList = ({campaign, panelIsOpened}: ListAnnouncementProps) => {
   const __ = useTranslate();
   const containerRef = useRef<HTMLUListElement | null>(null);
   const scrollableElement = null !== containerRef.current ? containerRef.current.parentElement : null;
@@ -25,6 +25,7 @@ const AnnouncementList = ({campaign, panelIsClosed}: ListAnnouncementProps) => {
   const [announcementResponse, handleFetchingResults] = useInfiniteScroll(
     fetchAnnouncements,
     scrollableElement,
+    false,
     limitNbElements
   );
   const handleHasNewAnnouncements = useHasNewAnnouncements();
@@ -39,15 +40,20 @@ const AnnouncementList = ({campaign, panelIsClosed}: ListAnnouncementProps) => {
     if (newAnnouncements.length > 0) {
       await handleAddViewedAnnouncements(newAnnouncements);
       await handleHasNewAnnouncements();
-      await handleFetchingResults(null, limitNbElements);
     }
   }, [announcementResponse.items]);
 
   useEffect(() => {
-    if (panelIsClosed) {
+    if (panelIsOpened) {
+      handleFetchingResults(null, limitNbElements);
+    } else {
       updateNewAnnouncements();
+      if (null !== scrollableElement) {
+        /* istanbul ignore next: can't simulate a scrollable element in the AnnouncementList.unit.tsx */
+        scrollableElement.scrollTop = 0;
+      }
     }
-  }, [panelIsClosed]);
+  }, [panelIsOpened]);
 
   if (announcementResponse.hasError) {
     return <EmptyAnnouncementList text={__('akeneo_communication_channel.panel.list.error')} />;

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/AnnouncementList.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/AnnouncementList.tsx
@@ -14,10 +14,10 @@ const Container = styled.ul`
 
 type ListAnnouncementProps = {
   campaign: string;
-  panelIsOpened: boolean;
+  panelIsClosed: boolean;
 };
 
-const AnnouncementList = ({campaign, panelIsOpened}: ListAnnouncementProps) => {
+const AnnouncementList = ({campaign, panelIsClosed}: ListAnnouncementProps) => {
   const __ = useTranslate();
   const containerRef = useRef<HTMLUListElement | null>(null);
   const scrollableElement = null !== containerRef.current ? containerRef.current.parentElement : null;
@@ -25,7 +25,6 @@ const AnnouncementList = ({campaign, panelIsOpened}: ListAnnouncementProps) => {
   const [announcementResponse, handleFetchingResults] = useInfiniteScroll(
     fetchAnnouncements,
     scrollableElement,
-    false,
     limitNbElements
   );
   const handleHasNewAnnouncements = useHasNewAnnouncements();
@@ -40,20 +39,19 @@ const AnnouncementList = ({campaign, panelIsOpened}: ListAnnouncementProps) => {
     if (newAnnouncements.length > 0) {
       await handleAddViewedAnnouncements(newAnnouncements);
       await handleHasNewAnnouncements();
+      await handleFetchingResults(null, limitNbElements);
     }
   }, [announcementResponse.items]);
 
   useEffect(() => {
-    if (panelIsOpened) {
-      handleFetchingResults(null, limitNbElements);
-    } else {
+    if (panelIsClosed) {
       updateNewAnnouncements();
       if (null !== scrollableElement) {
         /* istanbul ignore next: can't simulate a scrollable element in the AnnouncementList.unit.tsx */
         scrollableElement.scrollTop = 0;
       }
     }
-  }, [panelIsOpened]);
+  }, [panelIsClosed]);
 
   if (announcementResponse.hasError) {
     return <EmptyAnnouncementList text={__('akeneo_communication_channel.panel.list.error')} />;

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/Panel.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/Panel.tsx
@@ -21,9 +21,11 @@ const Panel = (): JSX.Element => {
 
   useEffect(() => {
     if (isSerenity) {
+      /* istanbul ignore next: can't test the callback function */
       mediator.on('communication-channel:panel:open', () => {
         setIsOpened(true);
       });
+      /* istanbul ignore next */
       mediator.on('communication-channel:panel:close', () => {
         setIsOpened(false);
       });
@@ -50,7 +52,7 @@ const Panel = (): JSX.Element => {
     <>
       <HeaderPanel title={__('akeneo_communication_channel.panel.title')} onClickCloseButton={onClosePanel} />
       {isSerenity ? (
-        <AnnouncementList campaign={campaign} panelIsClosed={!isOpened} />
+        <AnnouncementList campaign={campaign} panelIsOpened={isOpened} />
       ) : (
         <EmptyAnnouncementList text={__('akeneo_communication_channel.panel.list.empty')} />
       )}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/Panel.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/Panel.tsx
@@ -52,7 +52,7 @@ const Panel = (): JSX.Element => {
     <>
       <HeaderPanel title={__('akeneo_communication_channel.panel.title')} onClickCloseButton={onClosePanel} />
       {isSerenity ? (
-        <AnnouncementList campaign={campaign} panelIsOpened={isOpened} />
+        <AnnouncementList campaign={campaign} panelIsClosed={!isOpened} />
       ) : (
         <EmptyAnnouncementList text={__('akeneo_communication_channel.panel.list.empty')} />
       )}

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/hooks/useInfiniteScroll.ts
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/hooks/useInfiniteScroll.ts
@@ -18,6 +18,7 @@ type ResultsResponse = {
  *
  * @param fetch Function to fetch the paginated items. Those function needs to take in parameter the seard after id and the items limit. It returns a Promise of items.
  * @param scrollableElement HTML element where the scroll is done
+ * @param fetchFirstResults Flag to know if it has to fetch the first results
  * @param limit Limit numbers of items by qurey to fetch items (By default 10).
  * @param threshold Thereshold Maximum distance to bottom of the scroll to start the fetch of the items (By default 300).
  *
@@ -26,6 +27,7 @@ type ResultsResponse = {
 const useInfiniteScroll = (
   fetch: (searchAfter: string | null, limit: number) => Promise<any[]>,
   scrollableElement: HTMLElement | null,
+  fetchFirstResults: boolean = false,
   limit: number = 10,
   threshold: number = 300
 ): [ResultsResponse, (searchAfter: string | null, limit: number) => void] => {
@@ -64,7 +66,9 @@ const useInfiniteScroll = (
           handleFetchingResults(searchAfter, limit);
         }
       };
-    } else {
+    }
+
+    if (fetchFirstResults && null === scrollableElement) {
       handleFetchingResults(null, limit);
     }
   }, [scrollableElement, state]);

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/hooks/useInfiniteScroll.ts
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/hooks/useInfiniteScroll.ts
@@ -18,7 +18,6 @@ type ResultsResponse = {
  *
  * @param fetch Function to fetch the paginated items. Those function needs to take in parameter the seard after id and the items limit. It returns a Promise of items.
  * @param scrollableElement HTML element where the scroll is done
- * @param fetchFirstResults Flag to know if it has to fetch the first results
  * @param limit Limit numbers of items by qurey to fetch items (By default 10).
  * @param threshold Thereshold Maximum distance to bottom of the scroll to start the fetch of the items (By default 300).
  *
@@ -27,7 +26,6 @@ type ResultsResponse = {
 const useInfiniteScroll = (
   fetch: (searchAfter: string | null, limit: number) => Promise<any[]>,
   scrollableElement: HTMLElement | null,
-  fetchFirstResults: boolean = false,
   limit: number = 10,
   threshold: number = 300
 ): [ResultsResponse, (searchAfter: string | null, limit: number) => void] => {
@@ -66,9 +64,7 @@ const useInfiniteScroll = (
           handleFetchingResults(searchAfter, limit);
         }
       };
-    }
-
-    if (fetchFirstResults && null === scrollableElement) {
+    } else {
       handleFetchingResults(null, limit);
     }
   }, [scrollableElement, state]);

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/reducers/infiniteScrollReducer.ts
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/reducers/infiniteScrollReducer.ts
@@ -19,7 +19,7 @@ const reducer: Reducer<State, Actions> = (state, action) => {
     case INFINITE_SCROLL_FETCHING_RESULTS:
       return {...state, isFetching: true};
     case INFINITE_SCROLL_FIRST_RESULTS_FETCHED:
-      return {...state, items: action.payload.items, isFetching: false};
+      return {...state, items: action.payload.items, isFetching: false, lastAppend: false};
     case INFINITE_SCROLL_NEXT_RESULTS_FETCHED:
       return {
         ...state,

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/AnnouncementList.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/AnnouncementList.unit.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import {act, getByText, getAllByText} from '@testing-library/react';
+import {AnnouncementList} from '@akeneo-pim-community/communication-channel/src/components/panel/AnnouncementList';
+import {formatCampaign} from '@akeneo-pim-community/communication-channel/src/tools/formatCampaign';
+import {renderWithProviders} from '@akeneo-pim-community/shared/tests/front/unit/utils';
+import {getExpectedAnnouncements, getExpectedPimAnalyticsData} from '../../__mocks__/dataProvider';
+import {useHasNewAnnouncements} from '@akeneo-pim-community/communication-channel/src/hooks/useHasNewAnnouncements';
+import {useInfiniteScroll} from '@akeneo-pim-community/communication-channel/src/hooks/useInfiniteScroll';
+import {useAddViewedAnnouncements} from '@akeneo-pim-community/communication-channel/src/hooks/useAddViewedAnnouncements';
+
+jest.mock('@akeneo-pim-community/communication-channel/src/hooks/useHasNewAnnouncements');
+jest.mock('@akeneo-pim-community/communication-channel/src/hooks/useInfiniteScroll');
+jest.mock('@akeneo-pim-community/communication-channel/src/hooks/useAddViewedAnnouncements');
+
+const expectedAnnouncements = getExpectedAnnouncements();
+const expectedPimAnalyticsData = getExpectedPimAnalyticsData();
+
+let container: HTMLElement;
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+afterEach(() => {
+  document.body.removeChild(container);
+  container = null;
+});
+
+test('it check if it has new announcements when the component is mounted', async () => {
+  const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
+  const handleHasNewAnnouncements = jest.fn();
+  useHasNewAnnouncements.mockReturnValue(handleHasNewAnnouncements);
+  useInfiniteScroll.mockReturnValue([
+    {
+      items: [],
+      isFetching: false,
+      hasError: false,
+    },
+    jest.fn(),
+  ]);
+
+  await act(async () =>
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={false} />, container as HTMLElement)
+  );
+
+  expect(handleHasNewAnnouncements).toBeCalledTimes(1);
+});
+
+test('it shows the announcements when we open the panel', async () => {
+  const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
+  const handleFetchingResults = jest.fn();
+  useInfiniteScroll.mockReturnValue([
+    {
+      items: expectedAnnouncements,
+      isFetching: false,
+      hasError: false,
+    },
+    handleFetchingResults,
+  ]);
+
+  await act(async () =>
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={true} />, container as HTMLElement)
+  );
+
+  expect(container.querySelectorAll('ul li').length).toEqual(2);
+  expect(handleFetchingResults).toBeCalledTimes(1);
+});
+
+test('it can show for each announcement the information from the json', async () => {
+  const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
+  useInfiniteScroll.mockReturnValue([
+    {
+      items: expectedAnnouncements,
+      isFetching: false,
+      hasError: false,
+    },
+    jest.fn(),
+  ]);
+
+  await act(async () =>
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={true} />, container as HTMLElement)
+  );
+
+  expect(getByText(container, expectedAnnouncements[0].title)).toBeInTheDocument();
+  expect(getByText(container, expectedAnnouncements[0].description)).toBeInTheDocument();
+  expectedAnnouncements[0].tags.map(tag => {
+    expect(getByText(container, tag)).toBeInTheDocument();
+  });
+  expect(getAllByText(container, expectedAnnouncements[0].startDate).length).toEqual(2);
+  expect(container.querySelector(`img[alt="${expectedAnnouncements[0].altImg}"]`)).toBeInTheDocument();
+  expect(container.querySelector(`a[title="${expectedAnnouncements[0].title}"]`)).toBeInTheDocument();
+});
+
+test('it can open the read more link in a new tab', async () => {
+  const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
+  useInfiniteScroll.mockReturnValue([
+    {
+      items: expectedAnnouncements,
+      isFetching: false,
+      hasError: false,
+    },
+    jest.fn(),
+  ]);
+
+  await act(async () =>
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={true} />, container as HTMLElement)
+  );
+
+  expect((container.querySelector(`a[title="${expectedAnnouncements[0].title}"]`) as HTMLLinkElement).href).toEqual(
+    `http://external.com/?utm_source=akeneo-app&utm_medium=communication-panel&utm_content=${expectedAnnouncements[0].id}&utm_campaign=${campaign}`
+  );
+  expect((container.querySelector(`a[title="${expectedAnnouncements[0].title}"]`) as HTMLLinkElement).target).toEqual(
+    '_blank'
+  );
+});
+
+test('it can display a message when it has an error during the fetch', async () => {
+  const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
+  useInfiniteScroll.mockReturnValue([
+    {
+      items: [],
+      isFetching: false,
+      hasError: true,
+    },
+    jest.fn(),
+  ]);
+
+  await act(async () =>
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={true} />, container as HTMLElement)
+  );
+
+  expect(container.querySelectorAll('ul li').length).toEqual(0);
+  expect(getByText(container, 'akeneo_communication_channel.panel.list.error')).toBeInTheDocument();
+});
+
+test('it updates the new announcements when we close the panel', async () => {
+  const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
+  const handleHasNewAnnouncements = jest.fn();
+  useHasNewAnnouncements.mockReturnValue(handleHasNewAnnouncements);
+  useInfiniteScroll.mockReturnValue([
+    {
+      items: expectedAnnouncements,
+      isFetching: false,
+      hasError: false,
+    },
+    jest.fn(),
+  ]);
+  const handleAddViewedAnnouncements = jest.fn();
+  useAddViewedAnnouncements.mockReturnValue(handleAddViewedAnnouncements);
+
+  await act(async () =>
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={false} />, container as HTMLElement)
+  );
+
+  expect(handleAddViewedAnnouncements).toBeCalledWith([expectedAnnouncements[0]]);
+  expect(handleHasNewAnnouncements).toBeCalledTimes(2);
+});

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/AnnouncementList.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/AnnouncementList.unit.tsx
@@ -40,7 +40,7 @@ test('it check if it has new announcements when the component is mounted', async
   ]);
 
   await act(async () =>
-    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={false} />, container as HTMLElement)
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={true} />, container as HTMLElement)
   );
 
   expect(handleHasNewAnnouncements).toBeCalledTimes(1);
@@ -59,11 +59,10 @@ test('it shows the announcements when we open the panel', async () => {
   ]);
 
   await act(async () =>
-    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={true} />, container as HTMLElement)
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsClosed={false} />, container as HTMLElement)
   );
 
   expect(container.querySelectorAll('ul li').length).toEqual(2);
-  expect(handleFetchingResults).toBeCalledTimes(1);
 });
 
 test('it can show for each announcement the information from the json', async () => {
@@ -78,7 +77,7 @@ test('it can show for each announcement the information from the json', async ()
   ]);
 
   await act(async () =>
-    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={true} />, container as HTMLElement)
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsClosed={false} />, container as HTMLElement)
   );
 
   expect(getByText(container, expectedAnnouncements[0].title)).toBeInTheDocument();
@@ -103,7 +102,7 @@ test('it can open the read more link in a new tab', async () => {
   ]);
 
   await act(async () =>
-    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={true} />, container as HTMLElement)
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsClosed={false} />, container as HTMLElement)
   );
 
   expect((container.querySelector(`a[title="${expectedAnnouncements[0].title}"]`) as HTMLLinkElement).href).toEqual(
@@ -126,14 +125,14 @@ test('it can display a message when it has an error during the fetch', async () 
   ]);
 
   await act(async () =>
-    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={true} />, container as HTMLElement)
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsClosed={false} />, container as HTMLElement)
   );
 
   expect(container.querySelectorAll('ul li').length).toEqual(0);
   expect(getByText(container, 'akeneo_communication_channel.panel.list.error')).toBeInTheDocument();
 });
 
-test('it updates the new announcements when we close the panel', async () => {
+test('it updates the new announcements when closing the panel', async () => {
   const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
   const handleHasNewAnnouncements = jest.fn();
   useHasNewAnnouncements.mockReturnValue(handleHasNewAnnouncements);
@@ -149,7 +148,7 @@ test('it updates the new announcements when we close the panel', async () => {
   useAddViewedAnnouncements.mockReturnValue(handleAddViewedAnnouncements);
 
   await act(async () =>
-    renderWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={false} />, container as HTMLElement)
+    renderWithProviders(<AnnouncementList campaign={campaign} panelIsClosed={true} />, container as HTMLElement)
   );
 
   expect(handleAddViewedAnnouncements).toBeCalledWith([expectedAnnouncements[0]]);

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/Panel.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/Panel.unit.tsx
@@ -6,9 +6,11 @@ import {dependencies} from '@akeneo-pim-community/legacy-bridge';
 import {renderWithProviders} from '@akeneo-pim-community/shared/tests/front/unit/utils';
 import {usePimVersion} from '@akeneo-pim-community/communication-channel/src/hooks/usePimVersion';
 import {useHasNewAnnouncements} from '@akeneo-pim-community/communication-channel/src/hooks/useHasNewAnnouncements';
+import {useInfiniteScroll} from '@akeneo-pim-community/communication-channel/src/hooks/useInfiniteScroll';
 
 jest.mock('@akeneo-pim-community/communication-channel/src/hooks/usePimVersion');
 jest.mock('@akeneo-pim-community/communication-channel/src/hooks/useHasNewAnnouncements');
+jest.mock('@akeneo-pim-community/communication-channel/src/hooks/useInfiniteScroll');
 
 let container: HTMLElement;
 beforeEach(() => {
@@ -26,6 +28,14 @@ test('it displays a panel of announcements when it is a serenity version', async
     data: {edition: 'Serenity', version: '192939349'},
     hasError: false,
   });
+  useInfiniteScroll.mockReturnValue([
+    {
+      items: [],
+      isFetching: false,
+      hasError: false,
+    },
+    jest.fn(),
+  ]);
 
   await act(async () => renderWithProviders(<Panel />, container as HTMLElement));
 

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/reducers/infiniteScrollReducer.unit.ts
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/reducers/infiniteScrollReducer.unit.ts
@@ -50,6 +50,43 @@ it('handles INFINITE_SCROLL_FIRST_RESULTS_FETCHED action', () => {
   });
 });
 
+it('handles to set the last append to false when INFINITE_SCROLL_FIRST_RESULTS_FETCHED is dispatched', () => {
+  const initialState = {
+    items: [],
+    isFetching: false,
+    hasError: false,
+    lastAppend: true,
+  };
+  const action = infiniteScrollFirstResultsFetched([
+    {
+      title: 'item scrollable',
+      description: 'description item scrollable',
+    },
+    {
+      title: 'item scrollable 2',
+      description: 'description item scrollable 2',
+    },
+  ]);
+
+  const newState = reducer(initialState, action);
+
+  expect(newState).toStrictEqual({
+    items: [
+      {
+        title: 'item scrollable',
+        description: 'description item scrollable',
+      },
+      {
+        title: 'item scrollable 2',
+        description: 'description item scrollable 2',
+      },
+    ],
+    isFetching: false,
+    hasError: false,
+    lastAppend: false,
+  });
+});
+
 it('handles INFINITE_SCROLL_NEXT_RESULTS_FETCHED action', () => {
   const initialState = {
     items: [

--- a/tests/front/unit/jest/unit.jest.js
+++ b/tests/front/unit/jest/unit.jest.js
@@ -21,8 +21,6 @@ const unitConfig = {
     'src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-unit/CreateUnit.tsx',
     'src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/icons',
     'src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Image.tsx',
-    'src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/Panel.tsx',
-    'src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/AnnouncementList.tsx',
     'src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/view',
     'src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/contexts',
     'src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/fetchers',


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Ticket : https://github.com/akeneo/actionable-product-data/issues/188

- Optimise the fetch of the announcement list to do it when we open the panel instead of doing it when we mount the component. Moreover, we don't need to refresh the list when we close the panel anymore.
- Fix bug with the last append. In fact, I spotted a bug when we re-open the panel after we have already scrolled all the pages. We couldn't scroll the pages anymore.
- Update to scroll top when we close the panel. If we re-opened the panel after we have already scrolled some pages, the scroll would be at the end of the first page (because of the load of the first elements only). In order to have a better UX, we scroll top to the panel when we close it.
- Improve tests

*Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs/Unit                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
