### PR TITLE
PIM-9349: Fix record list alignment when images are loading indefinitely

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9349: Fix record list alignment when images are loading indefinitely
+
 # 4.0.38 (2020-07-07)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/grid/Grid.less
@@ -327,6 +327,7 @@
     margin-top: 3px;
     margin-bottom: -3px;
     object-fit: contain;
+    overflow: hidden;
 
     &--withLayer {
       margin-top: 4px;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In the record list, when the image is not loading, it's 1px taller than expected, breaking the alignement of the list.
A simple overflow hidden enforce the image size.

![Screenshot_2020-07-08_11-24-10](https://user-images.githubusercontent.com/1421130/86901938-919de080-c10d-11ea-90f6-499780fc1d10.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -