### PR TITLE
PIM-9330: Sort jobs and connectors by alphabetical order on associated menus on Imports and Exports pages.

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Improvement
+
+-PIM-9330: Sort jobs and connectors by alphabetical order on associated menus on Imports and Exports pages.
+
 # 4.0.38 (2020-07-07)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select-filter.js
@@ -147,6 +147,14 @@ function(_, __, AbstractFilter, MultiselectDecorator) {
             AbstractFilter.prototype.render.apply(this, arguments);
 
             var options =  this.choices.slice(0);
+            options = options.map((option) => {
+                option.__translation = _.__(option.label);
+                return option;
+            });
+            options.sort((a, b) => {
+                return a.__translation.localeCompare(b.__translation);
+            });
+
             this.$el.empty();
 
             if (this.populateDefault) {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
 
The job and connector labels were not sorted by alphabetical order on associated menus on Imports and Exports pages.

So, I added 2 functions :
1 - to translate the label keys
2 - and then to sort them by alphabetical order


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | OK
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
