### PR TITLE
RAC-119: move business logic into QuantifiedAssociations class to remove setQuantifiedAssociations

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithQuantifiedAssociationsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithQuantifiedAssociationsInterface.php
@@ -100,8 +100,8 @@ interface EntityWithQuantifiedAssociationsInterface
     public function mergeQuantifiedAssociations(QuantifiedAssociations $quantifiedAssociations): void;
 
     /**
-     * Update quantified associations by override with another quantified associations
+     * Update quantified associations by path
      * @param array $submittedQuantifiedAssociations
      */
-    public function overrideQuantifiedAssociations(array $submittedQuantifiedAssociations): void;
+    public function patchQuantifiedAssociations(array $submittedQuantifiedAssociations): void;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithQuantifiedAssociationsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithQuantifiedAssociationsInterface.php
@@ -17,11 +17,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\Quantifi
 interface EntityWithQuantifiedAssociationsInterface
 {
     /**
-     * Set the quantified associations
-     */
-    public function setQuantifiedAssociations(QuantifiedAssociations $quantifiedAssociations): void;
-
-    /**
      * Get the quantified associations
      */
     public function getQuantifiedAssociations(): QuantifiedAssociations;
@@ -103,4 +98,10 @@ interface EntityWithQuantifiedAssociationsInterface
      * @param QuantifiedAssociations $quantifiedAssociations
      */
     public function mergeQuantifiedAssociations(QuantifiedAssociations $quantifiedAssociations): void;
+
+    /**
+     * Update quantified associations by override with another quantified associations
+     * @param array $submittedQuantifiedAssociations
+     */
+    public function overrideQuantifiedAssociations(array $submittedQuantifiedAssociations): void;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithQuantifiedAssociationsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithQuantifiedAssociationsInterface.php
@@ -41,6 +41,19 @@ interface EntityWithQuantifiedAssociationsInterface
     public function getQuantifiedAssociationsProductModelIds(): array;
 
     /**
+     * Remove quantified association with product/product model not present in parameter
+     *
+     * @param array $productIdentifiersToKeep
+     * @param array $productModelCodesToKeep
+     */
+    public function filterQuantifiedAssociations(array $productIdentifiersToKeep, array $productModelCodesToKeep): void;
+
+    /**
+     * Remove all quantified associations
+     */
+    public function clearQuantifiedAssociations(): void;
+
+    /**
      * Hydrates quantified associations from raw quantified associations
      *
      * @param IdMapping $mappedProductIds

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
@@ -24,21 +24,11 @@ trait EntityWithQuantifiedAssociationTrait
     /**
      * @inheritDoc
      */
-    public function setQuantifiedAssociations(QuantifiedAssociations $quantifiedAssociations): void
-    {
-        $this->quantifiedAssociations = $quantifiedAssociations;
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function filterQuantifiedAssociations(array $productIdentifiersToKeep, array $productModelCodesToKeep): void
     {
-        $filteredQuantifiedAssociations = $this->quantifiedAssociations
+        $this->quantifiedAssociations = $this->quantifiedAssociations
             ->filterProductIdentifiers($productIdentifiersToKeep)
             ->filterProductModelCodes($productModelCodesToKeep);
-
-        $this->setQuantifiedAssociations($filteredQuantifiedAssociations);
     }
 
     /**
@@ -54,9 +44,17 @@ trait EntityWithQuantifiedAssociationTrait
      */
     public function mergeQuantifiedAssociations(QuantifiedAssociations $quantifiedAssociations): void
     {
-        $quantifiedAssociationsMerged = $this->quantifiedAssociations->merge($quantifiedAssociations);
+        $this->quantifiedAssociations = $this->quantifiedAssociations->merge($quantifiedAssociations);
+    }
 
-        $this->setQuantifiedAssociations($quantifiedAssociationsMerged);
+    /**
+     * @inheritDoc
+     */
+    public function overrideQuantifiedAssociations(array $submittedQuantifiedAssociations): void
+    {
+        $this->quantifiedAssociations = $this->quantifiedAssociations->overrideQuantifiedAssociations(
+            $submittedQuantifiedAssociations
+        );
     }
 
     /**
@@ -64,9 +62,7 @@ trait EntityWithQuantifiedAssociationTrait
      */
     public function clearQuantifiedAssociations(): void
     {
-        $quantifiedAssociationsCleared = $this->quantifiedAssociations->clearQuantifiedAssociations();
-
-        $this->setQuantifiedAssociations($quantifiedAssociationsCleared);
+        $this->quantifiedAssociations = $this->quantifiedAssociations->clearQuantifiedAssociations();
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
@@ -58,13 +58,13 @@ trait EntityWithQuantifiedAssociationTrait
     /**
      * @inheritDoc
      */
-    public function overrideQuantifiedAssociations(array $submittedQuantifiedAssociations): void
+    public function patchQuantifiedAssociations(array $submittedQuantifiedAssociations): void
     {
         if (null === $this->quantifiedAssociations) {
             return;
         }
 
-        $this->quantifiedAssociations = $this->quantifiedAssociations->overrideQuantifiedAssociations(
+        $this->quantifiedAssociations = $this->quantifiedAssociations->patchQuantifiedAssociations(
             $submittedQuantifiedAssociations
         );
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
@@ -26,6 +26,10 @@ trait EntityWithQuantifiedAssociationTrait
      */
     public function filterQuantifiedAssociations(array $productIdentifiersToKeep, array $productModelCodesToKeep): void
     {
+        if (null === $this->quantifiedAssociations) {
+            return;
+        }
+
         $this->quantifiedAssociations = $this->quantifiedAssociations
             ->filterProductIdentifiers($productIdentifiersToKeep)
             ->filterProductModelCodes($productModelCodesToKeep);
@@ -44,6 +48,10 @@ trait EntityWithQuantifiedAssociationTrait
      */
     public function mergeQuantifiedAssociations(QuantifiedAssociations $quantifiedAssociations): void
     {
+        if ($this->quantifiedAssociations === null) {
+            return;
+        }
+
         $this->quantifiedAssociations = $this->quantifiedAssociations->merge($quantifiedAssociations);
     }
 
@@ -52,6 +60,10 @@ trait EntityWithQuantifiedAssociationTrait
      */
     public function overrideQuantifiedAssociations(array $submittedQuantifiedAssociations): void
     {
+        if (null === $this->quantifiedAssociations) {
+            return;
+        }
+
         $this->quantifiedAssociations = $this->quantifiedAssociations->overrideQuantifiedAssociations(
             $submittedQuantifiedAssociations
         );
@@ -62,6 +74,10 @@ trait EntityWithQuantifiedAssociationTrait
      */
     public function clearQuantifiedAssociations(): void
     {
+        if (null === $this->quantifiedAssociations) {
+            return;
+        }
+
         $this->quantifiedAssociations = $this->quantifiedAssociations->clearQuantifiedAssociations();
     }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/EntityWithQuantifiedAssociationTrait.php
@@ -32,16 +32,41 @@ trait EntityWithQuantifiedAssociationTrait
     /**
      * @inheritDoc
      */
+    public function filterQuantifiedAssociations(array $productIdentifiersToKeep, array $productModelCodesToKeep): void
+    {
+        $filteredQuantifiedAssociations = $this->quantifiedAssociations
+            ->filterProductIdentifiers($productIdentifiersToKeep)
+            ->filterProductModelCodes($productModelCodesToKeep);
+
+        $this->setQuantifiedAssociations($filteredQuantifiedAssociations);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function getQuantifiedAssociations(): QuantifiedAssociations
     {
         return $this->quantifiedAssociations;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function mergeQuantifiedAssociations(QuantifiedAssociations $quantifiedAssociations): void
     {
         $quantifiedAssociationsMerged = $this->quantifiedAssociations->merge($quantifiedAssociations);
 
         $this->setQuantifiedAssociations($quantifiedAssociationsMerged);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clearQuantifiedAssociations(): void
+    {
+        $quantifiedAssociationsCleared = $this->quantifiedAssociations->clearQuantifiedAssociations();
+
+        $this->setQuantifiedAssociations($quantifiedAssociationsCleared);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
@@ -108,7 +108,7 @@ class QuantifiedAssociations
         return new self($mappedQuantifiedAssociations);
     }
 
-    public function overrideQuantifiedAssociations(array $submittedQuantifiedAssociations): self
+    public function patchQuantifiedAssociations(array $submittedQuantifiedAssociations): self
     {
         $currentQuantifiedAssociationNormalized = $this->normalize();
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
@@ -153,7 +153,7 @@ class QuantifiedAssociations
     {
         $quantifiedAssociationsCleared = array_fill_keys(
             $this->getAssociationTypeCodes(),
-            ['products' => [], 'products_models' => []]
+            ['products' => [], 'product_models' => []]
         );
 
         return self::createFromNormalized($quantifiedAssociationsCleared);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
@@ -134,6 +134,16 @@ class QuantifiedAssociations
         return array_unique($result);
     }
 
+    public function clearQuantifiedAssociations()
+    {
+        $quantifiedAssociationsCleared = array_fill_keys(
+            $this->getAssociationTypeCodes(),
+            ['products' => [], 'products_models' => []]
+        );
+
+        return self::createFromNormalized($quantifiedAssociationsCleared);
+    }
+
     public function merge(QuantifiedAssociations $quantifiedAssociations): self
     {
         $currentQuantifiedAssociationsNormalized = $this->normalizeWithIndexedIdentifiers();
@@ -201,15 +211,15 @@ class QuantifiedAssociations
         return $result;
     }
 
-    public function filterProductIdentifiers(array $grantedProductIdentifiers): QuantifiedAssociations
+    public function filterProductIdentifiers(array $productIdentifiersToKeep): QuantifiedAssociations
     {
         $filteredQuantifiedAssociations = [];
         foreach ($this->quantifiedAssociations as $associationTypeCode => $quantifiedAssociation) {
             $filteredQuantifiedAssociations[$associationTypeCode]['product_models'] = $quantifiedAssociation['product_models'];
             $filteredQuantifiedAssociations[$associationTypeCode]['products'] = array_filter(
                 $quantifiedAssociation['products'],
-                function (QuantifiedLink $quantifiedLink) use ($grantedProductIdentifiers) {
-                    return in_array($quantifiedLink->identifier(), $grantedProductIdentifiers);
+                function (QuantifiedLink $quantifiedLink) use ($productIdentifiersToKeep) {
+                    return in_array($quantifiedLink->identifier(), $productIdentifiersToKeep);
                 }
             );
         }
@@ -217,20 +227,25 @@ class QuantifiedAssociations
         return new self($filteredQuantifiedAssociations);
     }
 
-    public function filterProductModelCodes(array $grantedProductModelCodes): QuantifiedAssociations
+    public function filterProductModelCodes(array $productModelCodesToKeep): QuantifiedAssociations
     {
         $filteredQuantifiedAssociations = [];
         foreach ($this->quantifiedAssociations as $associationTypeCode => $quantifiedAssociation) {
             $filteredQuantifiedAssociations[$associationTypeCode]['products'] = $quantifiedAssociation['products'];
             $filteredQuantifiedAssociations[$associationTypeCode]['product_models'] = array_filter(
                 $quantifiedAssociation['product_models'],
-                function (QuantifiedLink $quantifiedLink) use ($grantedProductModelCodes) {
-                    return in_array($quantifiedLink->identifier(), $grantedProductModelCodes);
+                function (QuantifiedLink $quantifiedLink) use ($productModelCodesToKeep) {
+                    return in_array($quantifiedLink->identifier(), $productModelCodesToKeep);
                 }
             );
         }
 
         return new self($filteredQuantifiedAssociations);
+    }
+
+    private function getAssociationTypeCodes()
+    {
+        return array_keys($this->quantifiedAssociations);
     }
 
     private function normalizeWithIndexedIdentifiers()

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociations.php
@@ -108,6 +108,21 @@ class QuantifiedAssociations
         return new self($mappedQuantifiedAssociations);
     }
 
+    public function overrideQuantifiedAssociations(array $submittedQuantifiedAssociations): self
+    {
+        $currentQuantifiedAssociationNormalized = $this->normalize();
+
+        $result = $this->normalize();
+        foreach ($submittedQuantifiedAssociations as $submittedAssociationTypeCode => $submittedAssociations) {
+            $result[$submittedAssociationTypeCode] = array_merge(
+                $currentQuantifiedAssociationNormalized[$submittedAssociationTypeCode] ?? [],
+                $submittedAssociations
+            );
+        }
+
+        return self::createFromNormalized($result);
+    }
+
     public function getQuantifiedAssociationsProductIdentifiers(): array
     {
         $result = [];

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/QuantifiedAssociationFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/QuantifiedAssociationFieldClearer.php
@@ -37,10 +37,7 @@ final class QuantifiedAssociationFieldClearer implements ClearerInterface
         );
 
         if ($entity instanceof EntityWithQuantifiedAssociationsInterface) {
-            $clearedQuantifiedAssociation = array_map(function ($quantifiedAssociationNormalized) {
-                return [];
-            }, $entity->getQuantifiedAssociations()->normalize());
-            $entity->setQuantifiedAssociations(QuantifiedAssociations::createFromNormalized($clearedQuantifiedAssociation));
+            $entity->clearQuantifiedAssociations();
         }
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetter.php
@@ -32,76 +32,11 @@ class QuantifiedAssociationsFieldSetter extends AbstractFieldSetter
      */
     public function setFieldData($entity, $field, $data, array $options = [])
     {
-        $normalizedQuantifiedAssociations = $entity->normalizeQuantifiedAssociations();
-        $mergedQuantifiedAssociations = $this->mergeByKeys($normalizedQuantifiedAssociations, $data);
-
-        $entity->setQuantifiedAssociations(QuantifiedAssociations::createFromNormalized($mergedQuantifiedAssociations));
+        $entity->overrideQuantifiedAssociations($data);
     }
 
     public function supportsField($field)
     {
         return 'quantified_associations' === $field;
-    }
-
-    /**
-     * Merge 2 arrays of QuantifiedAssociations by keys, this is the expected behavior for PATCH partial updates.
-     *
-     * Given:
-     * {
-     *     "PRODUCTSET_A": {
-     *         "products": [
-     *              {"identifier": "AKN_TS1", "quantity": 2}
-     *         ],
-     *         "product_models": [
-     *              {"identifier": "MODEL_AKN_TS1", "quantity": 2}
-     *         ],
-     *     },
-     *     "PRODUCTSET_B": {
-     *         "products": [
-     *              {"identifier": "AKN_TS1", "quantity": 2}
-     *         ],
-     *         "product_models": [],
-     *     },
-     * }
-     * When merging:
-     * {
-     *     "PRODUCTSET_A": {
-     *         "products": [
-     *              {"identifier": "AKN_TS1_ALT", "quantity": 200}
-     *         ],
-     *     }
-     * }
-     * This will result in:
-     * {
-     *     "PRODUCTSET_A": {
-     *         "products": [
-     *              {"identifier": "AKN_TS1_ALT", "quantity": 200}
-     *         ],
-     *         "product_models": [
-     *              {"identifier": "MODEL_AKN_TS1", "quantity": 2}
-     *         ],
-     *     },
-     *     "PRODUCTSET_B": {
-     *         "products": [
-     *              {"identifier": "AKN_TS1", "quantity": 2}
-     *         ],
-     *         "product_models": [],
-     *     },
-     * }
-     */
-    private function mergeByKeys(array $quantifiedAssociations1, array $quantifiedAssociations2): array
-    {
-        foreach ($quantifiedAssociations2 as $associationTypeCode => $association) {
-            if (!isset($quantifiedAssociations1[$associationTypeCode])) {
-                $quantifiedAssociations1[$associationTypeCode] = $association;
-                continue;
-            }
-
-            foreach ($association as $quantifiedLinkType => $quantifiedLinks) {
-                $quantifiedAssociations1[$associationTypeCode][$quantifiedLinkType] = $quantifiedLinks;
-            }
-        }
-
-        return $quantifiedAssociations1;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetter.php
@@ -32,7 +32,7 @@ class QuantifiedAssociationsFieldSetter extends AbstractFieldSetter
      */
     public function setFieldData($entity, $field, $data, array $options = [])
     {
-        $entity->overrideQuantifiedAssociations($data);
+        $entity->patchQuantifiedAssociations($data);
     }
 
     public function supportsField($field)

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration.php
@@ -154,7 +154,7 @@ class GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration exten
         ]);
 
         $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, [
-            "quantified_associations" => [
+            'quantified_associations' => [
                 'PRODUCT_SET' => [
                     'product_models' => [
                         ['identifier' => 'productModelC', 'quantity' => 7],
@@ -164,7 +164,7 @@ class GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration exten
         ]);
 
         $subProductModel = $this->getEntityBuilder()->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, [
-            "quantified_associations" => [
+            'quantified_associations' => [
                 'PRODUCT_SET' => [
                     'product_models' => [
                         ['identifier' => 'productModelB', 'quantity' => 6],

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration.php
@@ -153,8 +153,26 @@ class GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration exten
             ],
         ]);
 
-        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, []);
-        $subProductModel = $this->getEntityBuilder()->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, []);
+        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, [
+            "quantified_associations" => [
+                'PRODUCT_SET' => [
+                    'product_models' => [
+                        ['identifier' => 'productModelC', 'quantity' => 7],
+                    ],
+                ],
+            ]
+        ]);
+
+        $subProductModel = $this->getEntityBuilder()->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, [
+            "quantified_associations" => [
+                'PRODUCT_SET' => [
+                    'product_models' => [
+                        ['identifier' => 'productModelB', 'quantity' => 6],
+                    ],
+                ],
+            ]
+        ]);
+
         $this->getEntityBuilder()->createVariantProduct('variant_product_1', 'aFamily', 'familyVariantWithTwoLevels', $subProductModel, [
             'quantified_associations' => [
                 'PRODUCT_SET' => [
@@ -164,31 +182,6 @@ class GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration exten
                 ],
             ],
         ]);
-        $subProductModel->setQuantifiedAssociations(
-            QuantifiedAssociations::createFromNormalized(
-                [
-                    'PRODUCT_SET' => [
-                        'product_models' => [
-                            ['identifier' => 'productModelB', 'quantity' => 6],
-                        ],
-                    ],
-                ]
-            )
-        );
-        $rootProductModel->setQuantifiedAssociations(
-            QuantifiedAssociations::createFromNormalized(
-                [
-                    'PRODUCT_SET' => [
-                        'product_models' => [
-                            ['identifier' => 'productModelC', 'quantity' => 7],
-                        ],
-                    ],
-                ]
-            )
-        );
-        $this->productModelSaver()->save($rootProductModel);
-        $this->productModelSaver()->save($subProductModel);
-
 
         $actual = $this->getQuery()->fromProductIdentifiers(['productC', 'productD', 'variant_product_1']);
         $expected = [
@@ -364,10 +357,5 @@ class GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration exten
     private function getQuery(): GetProductModelQuantifiedAssociationsByProductIdentifiers
     {
         return $this->get('akeneo.pim.enrichment.product.query.get_product_model_quantified_associations_by_product_identifiers');
-    }
-
-    private function productModelSaver(): SaverInterface
-    {
-        return $this->get('pim_catalog.saver.product_model');
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductIdentifiersIntegration.php
@@ -103,7 +103,7 @@ class GetProductQuantifiedAssociationsByProductIdentifiersIntegration extends Ab
             ],
         ]);
         $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, [
-            "quantified_associations" => [
+            'quantified_associations' => [
                 'PRODUCT_SET' => [
                     'products' => [
                         ['identifier' => 'productB', 'quantity' => 7],
@@ -112,7 +112,7 @@ class GetProductQuantifiedAssociationsByProductIdentifiersIntegration extends Ab
             ]
         ]);
         $subProductModel = $this->getEntityBuilder()->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, [
-            "quantified_associations" => [
+            'quantified_associations' => [
                 'PRODUCT_SET' => [
                     'products' => [
                         ['identifier' => 'productC', 'quantity' => 6],

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductIdentifiersIntegration.php
@@ -102,8 +102,24 @@ class GetProductQuantifiedAssociationsByProductIdentifiersIntegration extends Ab
                 ],
             ],
         ]);
-        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, []);
-        $subProductModel = $this->getEntityBuilder()->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, []);
+        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, [
+            "quantified_associations" => [
+                'PRODUCT_SET' => [
+                    'products' => [
+                        ['identifier' => 'productB', 'quantity' => 7],
+                    ],
+                ],
+            ]
+        ]);
+        $subProductModel = $this->getEntityBuilder()->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, [
+            "quantified_associations" => [
+                'PRODUCT_SET' => [
+                    'products' => [
+                        ['identifier' => 'productC', 'quantity' => 6],
+                    ],
+                ],
+            ]
+        ]);
         $this->getEntityBuilder()->createVariantProduct('variant_product_1', 'aFamily', 'familyVariantWithTwoLevels', $subProductModel, [
             'quantified_associations' => [
                 'PRODUCT_SET' => [
@@ -113,30 +129,6 @@ class GetProductQuantifiedAssociationsByProductIdentifiersIntegration extends Ab
                 ],
             ],
         ]);
-        $subProductModel->setQuantifiedAssociations(
-            QuantifiedAssociations::createFromNormalized(
-                [
-                    'PRODUCT_SET' => [
-                        'products' => [
-                            ['identifier' => 'productC', 'quantity' => 6],
-                        ],
-                    ],
-                ]
-            )
-        );
-        $rootProductModel->setQuantifiedAssociations(
-            QuantifiedAssociations::createFromNormalized(
-                [
-                    'PRODUCT_SET' => [
-                        'products' => [
-                            ['identifier' => 'productB', 'quantity' => 7],
-                        ],
-                    ],
-                ]
-            )
-        );
-        $this->productModelSaver()->save($rootProductModel);
-        $this->productModelSaver()->save($subProductModel);
 
         $actual = $this->getQuery()->fromProductIdentifiers(['productC', 'productD', 'variant_product_1']);
         $expected = [
@@ -361,10 +353,5 @@ class GetProductQuantifiedAssociationsByProductIdentifiersIntegration extends Ab
     protected function getConfiguration()
     {
         return $this->catalog->useMinimalCatalog();
-    }
-
-    private function productModelSaver(): SaverInterface
-    {
-        return $this->get('pim_catalog.saver.product_model');
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductModelCodesIntegration.php
@@ -81,7 +81,7 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
     {
         $this->getEntityBuilder()->createProductModel('productModelB', 'familyVariantWithTwoLevels', null, []);
         $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, [
-            "quantified_associations" => [
+            'quantified_associations' => [
                 'PRODUCT_SET' => [
                     'product_models' => [
                         ['identifier' => 'productModelB', 'quantity' => 2],
@@ -145,7 +145,7 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
     {
         $this->getEntityBuilder()->createProductModel('productModelA', 'familyVariantWithTwoLevels', null, []);
         $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, [
-            "quantified_associations" => [
+            'quantified_associations' => [
                 'PRODUCT_SET' => [
                     'product_models' => [
                         ['identifier' => 'productModelA', 'quantity' => 999],

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductModelCodesIntegration.php
@@ -79,7 +79,15 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
      */
     public function itReturnQuantifiedAssociationWithProductModelsOnMultipleProductModels()
     {
-        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, []);
+        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, [
+            "quantified_associations" => [
+                'PRODUCT_SET' => [
+                    'product_models' => [
+                        ['identifier' => 'productModelB', 'quantity' => 2],
+                    ],
+                ],
+            ]
+        ]);
         $this->getEntityBuilder()->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, []);
 
         $this->getEntityBuilder()->createProductModel('productModelA', 'familyVariantWithTwoLevels', null, []);
@@ -105,18 +113,6 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
                 ],
             ],
         ]);
-        $rootProductModel->setQuantifiedAssociations(
-            QuantifiedAssociations::createFromNormalized(
-                [
-                    'PRODUCT_SET' => [
-                        'product_models' => [
-                            ['identifier' => 'productModelB', 'quantity' => 2],
-                        ],
-                    ],
-                ]
-            )
-        );
-        $this->productModelSaver()->save($rootProductModel);
 
         $actual = $this->getQuery()->fromProductModelCodes(['productModelC', 'productModelD']);
         $expected = [
@@ -147,7 +143,15 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
      */
     public function itReturnsTheQuantifiedAssociationOfTheChildrenWhenDesynchronizedWithTheParent()
     {
-        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, []);
+        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, [
+            "quantified_associations" => [
+                'PRODUCT_SET' => [
+                    'product_models' => [
+                        ['identifier' => 'productModelA', 'quantity' => 999],
+                    ],
+                ],
+            ]
+        ]);
         $this->getEntityBuilder()->createProductModel('productModelA', 'familyVariantWithTwoLevels', null, []);
         $this->getEntityBuilder()->createProductModel('productModelB', 'familyVariantWithTwoLevels', $rootProductModel, [
             'quantified_associations' => [
@@ -158,18 +162,6 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
                 ],
             ],
         ]);
-        $rootProductModel->setQuantifiedAssociations(
-            QuantifiedAssociations::createFromNormalized(
-                [
-                    'PRODUCT_SET' => [
-                        'product_models' => [
-                            ['identifier' => 'productModelA', 'quantity' => 999],
-                        ],
-                    ],
-                ]
-            )
-        );
-        $this->productModelSaver()->save($rootProductModel);
 
         $actual = $this->getQuery()->fromProductModelCodes(['productModelB']);
         $expected = [
@@ -330,10 +322,5 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
     private function getQuery(): GetProductModelQuantifiedAssociationsByProductModelCodes
     {
         return $this->get('akeneo.pim.enrichment.product_model.query.get_product_model_quantified_associations_by_product_model_codes');
-    }
-
-    private function productModelSaver(): SaverInterface
-    {
-        return $this->get('pim_catalog.saver.product_model');
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductModelCodesIntegration.php
@@ -79,6 +79,7 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
      */
     public function itReturnQuantifiedAssociationWithProductModelsOnMultipleProductModels()
     {
+        $this->getEntityBuilder()->createProductModel('productModelB', 'familyVariantWithTwoLevels', null, []);
         $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, [
             "quantified_associations" => [
                 'PRODUCT_SET' => [
@@ -91,7 +92,6 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
         $this->getEntityBuilder()->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, []);
 
         $this->getEntityBuilder()->createProductModel('productModelA', 'familyVariantWithTwoLevels', null, []);
-        $this->getEntityBuilder()->createProductModel('productModelB', 'familyVariantWithTwoLevels', null, []);
         $this->getEntityBuilder()->createProductModel('productModelC', 'familyVariantWithTwoLevels', null, [
             'quantified_associations' => [
                 'PRODUCT_SET' => [
@@ -143,6 +143,7 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
      */
     public function itReturnsTheQuantifiedAssociationOfTheChildrenWhenDesynchronizedWithTheParent()
     {
+        $this->getEntityBuilder()->createProductModel('productModelA', 'familyVariantWithTwoLevels', null, []);
         $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, [
             "quantified_associations" => [
                 'PRODUCT_SET' => [
@@ -152,7 +153,6 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
                 ],
             ]
         ]);
-        $this->getEntityBuilder()->createProductModel('productModelA', 'familyVariantWithTwoLevels', null, []);
         $this->getEntityBuilder()->createProductModel('productModelB', 'familyVariantWithTwoLevels', $rootProductModel, [
             'quantified_associations' => [
                 'PRODUCT_SET' => [

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductModelCodesIntegration.php
@@ -129,7 +129,15 @@ class GetProductQuantifiedAssociationsByProductModelCodesIntegration extends Abs
     public function itReturnsTheQuantifiedAssociationOfTheChildrenWhenDesynchronizedWithTheParent()
     {
         $this->getEntityBuilder()->createProduct('productA', 'aFamily', []);
-        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, []);
+        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, [
+            'quantified_associations' => [
+                'PRODUCT_SET' => [
+                    'products' => [
+                        ['identifier' => 'productA', 'quantity' => 999],
+                    ],
+                ],
+            ]
+        ]);
         $this->getEntityBuilder()->createProductModel('productModelB', 'familyVariantWithTwoLevels', $rootProductModel, [
             'quantified_associations' => [
                 'PRODUCT_SET' => [
@@ -139,18 +147,6 @@ class GetProductQuantifiedAssociationsByProductModelCodesIntegration extends Abs
                 ],
             ],
         ]);
-        $rootProductModel->setQuantifiedAssociations(
-            QuantifiedAssociations::createFromNormalized(
-                [
-                    'PRODUCT_SET' => [
-                        'products' => [
-                            ['identifier' => 'productA', 'quantity' => 999],
-                        ],
-                    ],
-                ]
-            )
-        );
-        $this->productModelSaver()->save($rootProductModel);
 
         $actual = $this->getQuery()->fromProductModelCodes(['productModelB']);
         $expected = [
@@ -308,10 +304,5 @@ class GetProductQuantifiedAssociationsByProductModelCodesIntegration extends Abs
     private function getQuery(): GetProductQuantifiedAssociationsByProductModelCodes
     {
         return $this->get('akeneo.pim.enrichment.product_model.query.get_product_quantified_associations_by_product_model_codes');
-    }
-
-    private function productModelSaver(): SaverInterface
-    {
-        return $this->get('pim_catalog.saver.product_model');
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductModelSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductModelSpec.php
@@ -455,35 +455,6 @@ class ProductModelSpec extends ObjectBehavior
         ]);
     }
 
-    function it_updates_the_raw_quantified_associations()
-    {
-        $idMapping = $this->idMapping();
-        $this->rawQuantifiedAssociations = [];
-        $this->setQuantifiedAssociations(QuantifiedAssociations::createWithAssociationsAndMapping(
-            [
-                'PACK' => [
-                    'products'       => [
-                        ['id' => 1, 'quantity' => 1],
-                        ['id' => 2, 'quantity' => 2]
-                    ],
-                    'product_models' => [
-                        ['id' => 1, 'quantity' => 1],
-                        ['id' => 2, 'quantity' => 2]
-                    ],
-                ]
-            ],
-            $idMapping,
-            $idMapping,
-            ['PACK']
-        ));
-        $this->getQuantifiedAssociationsProductIds()->shouldReturn([]);
-        $this->getQuantifiedAssociationsProductModelIds()->shouldReturn([]);
-
-        $this->updateRawQuantifiedAssociations($idMapping, $idMapping);
-        $this->getQuantifiedAssociationsProductIds()->shouldReturn([1, 2]);
-        $this->getQuantifiedAssociationsProductModelIds()->shouldReturn([1, 2]);
-    }
-
     function it_filter_quantified_associations_during_hydration()
     {
         $idMapping = $this->idMapping();

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationsSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationsSpec.php
@@ -458,7 +458,7 @@ class QuantifiedAssociationsSpec extends ObjectBehavior
     public function it_override_empty_quantified_associations()
     {
         $this->beConstructedThrough('createFromNormalized', [[]]);
-        $this->overrideQuantifiedAssociations([
+        $this->patchQuantifiedAssociations([
             'PRODUCTSET_A' => [
                 'products' => [
                     ['identifier' => 'AKN_TS1', 'quantity' => 2],
@@ -495,7 +495,7 @@ class QuantifiedAssociationsSpec extends ObjectBehavior
             ],
         ]);
 
-        $this->overrideQuantifiedAssociations([
+        $this->patchQuantifiedAssociations([
             'PRODUCTSET_A' => [
                 'products' => [
                     ['identifier' => 'AKN_TS1_ALT', 'quantity' => 200],

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationsSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationsSpec.php
@@ -415,6 +415,121 @@ class QuantifiedAssociationsSpec extends ObjectBehavior
         ]);
     }
 
+    public function it_clear_quantified_associations_already_empty()
+    {
+        $this->beConstructedThrough('createFromNormalized', [[]]);
+
+        $this->clearQuantifiedAssociations()->normalize()->shouldReturn([]);
+    }
+
+    public function it_clear_all_quantified_associations_already_empty()
+    {
+        $this->beConstructedThrough('createFromNormalized', [
+            [
+                'PRODUCTSET_A' => [
+                    'products' => [
+                        ['identifier' => 'AKN_TS1', 'quantity' => 2],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'MODEL_AKN_TS1', 'quantity' => 2],
+                    ],
+                ],
+                'PRODUCTSET_B' => [
+                    'products' => [
+                        ['identifier' => 'AKN_TSH2', 'quantity' => 2],
+                    ],
+                    'product_models' => [],
+                ],
+            ],
+        ]);
+
+        $this->clearQuantifiedAssociations()->normalize()->shouldReturn([
+            'PRODUCTSET_A' => [
+                'products' => [],
+                'product_models' => [],
+            ],
+            'PRODUCTSET_B' => [
+                'products' => [],
+                'product_models' => [],
+            ],
+        ]);
+    }
+
+    public function it_override_empty_quantified_associations()
+    {
+        $this->beConstructedThrough('createFromNormalized', [[]]);
+        $this->overrideQuantifiedAssociations([
+            'PRODUCTSET_A' => [
+                'products' => [
+                    ['identifier' => 'AKN_TS1', 'quantity' => 2],
+                ],
+            ]
+        ])->normalize()->shouldReturn([
+            'PRODUCTSET_A' => [
+                'products' => [
+                    ['identifier' => 'AKN_TS1', 'quantity' => 2],
+                ],
+                'product_models' => [],
+            ],
+        ]);
+    }
+
+    public function it_override_existing_quantified_associations()
+    {
+        $this->beConstructedThrough('createFromNormalized', [
+            [
+                'PRODUCTSET_A' => [
+                    'products' => [
+                        ['identifier' => 'AKN_TS1', 'quantity' => 2],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'MODEL_AKN_TS1', 'quantity' => 2],
+                    ],
+                ],
+                'PRODUCTSET_B' => [
+                    'products' => [
+                        ['identifier' => 'AKN_TSH2', 'quantity' => 2],
+                    ],
+                    'product_models' => [],
+                ],
+            ],
+        ]);
+
+        $this->overrideQuantifiedAssociations([
+            'PRODUCTSET_A' => [
+                'products' => [
+                    ['identifier' => 'AKN_TS1_ALT', 'quantity' => 200],
+                ],
+            ],
+            'PRODUCTSET_C' => [
+                'products' => [
+                    ['identifier' => 'AKN_TS1_ALT', 'quantity' => 200],
+                ],
+            ]
+        ])->normalize()->shouldReturn([
+            'PRODUCTSET_A' => [
+                'products' => [
+                    ['identifier' => 'AKN_TS1_ALT', 'quantity' => 200],
+                ],
+                'product_models' => [
+                    ['identifier' => 'MODEL_AKN_TS1', 'quantity' => 2],
+                ],
+            ],
+            'PRODUCTSET_B' => [
+                'products' => [
+                    ['identifier' => 'AKN_TSH2', 'quantity' => 2],
+                ],
+                'product_models' => [],
+            ],
+            'PRODUCTSET_C' => [
+                'products' => [
+                    ['identifier' => 'AKN_TS1_ALT', 'quantity' => 200],
+                ],
+                'product_models' => [],
+            ]
+        ]);
+    }
+
     public function it_merge_quantified_associations_and_overwrite_quantities_from_duplicated_identifiers() {
         $this->beConstructedThrough(
             'createFromNormalized',

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetterSpec.php
@@ -26,7 +26,7 @@ class QuantifiedAssociationsFieldSetterSpec extends ObjectBehavior
         $this->supportsField('family')->shouldReturn(false);
     }
 
-    public function it_set_the_quantified_associations_to_a_product(
+    public function it_override_quantified_associations_to_a_product(
         ProductInterface $product
     ) {
         $submittedQuantifiedAssociations = [
@@ -37,44 +37,7 @@ class QuantifiedAssociationsFieldSetterSpec extends ObjectBehavior
             ],
         ];
 
-        $existingQuantifiedAssociations = [
-            'PRODUCTSET_A' => [
-                'products' => [
-                    ['identifier' => 'AKN_TS1', 'quantity' => 2],
-                ],
-                'product_models' => [
-                    ['identifier' => 'MODEL_AKN_TS1', 'quantity' => 2],
-                ],
-            ],
-            'PRODUCTSET_B' => [
-                'products' => [
-                    ['identifier' => 'AKN_TSH2', 'quantity' => 2],
-                ],
-                'product_models' => [],
-            ],
-        ];
-
-        $expectedQuantifiedAssociations = [
-            'PRODUCTSET_A' => [
-                'products' => [
-                    ['identifier' => 'AKN_TS1_ALT', 'quantity' => 200],
-                ],
-                'product_models' => [
-                    ['identifier' => 'MODEL_AKN_TS1', 'quantity' => 2],
-                ],
-            ],
-            'PRODUCTSET_B' => [
-                'products' => [
-                    ['identifier' => 'AKN_TSH2', 'quantity' => 2],
-                ],
-                'product_models' => [],
-            ],
-        ];
-
-        $product->normalizeQuantifiedAssociations()->willReturn($existingQuantifiedAssociations);
-
-        $product->setQuantifiedAssociations(QuantifiedAssociations::createFromNormalized($expectedQuantifiedAssociations))
-            ->shouldBeCalled();
+        $product->overrideQuantifiedAssociations($submittedQuantifiedAssociations)->shouldBeCalled();
 
         $this->setFieldData($product, 'quantified_associations', $submittedQuantifiedAssociations);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/QuantifiedAssociationsFieldSetterSpec.php
@@ -37,7 +37,7 @@ class QuantifiedAssociationsFieldSetterSpec extends ObjectBehavior
             ],
         ];
 
-        $product->overrideQuantifiedAssociations($submittedQuantifiedAssociations)->shouldBeCalled();
+        $product->patchQuantifiedAssociations($submittedQuantifiedAssociations)->shouldBeCalled();
 
         $this->setFieldData($product, 'quantified_associations', $submittedQuantifiedAssociations);
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Goals of this PR : 
- Remove all logic into EntityWithQuantifiedAssociationTrait this class should only be a "passe plat"
- Remove setQuantifiedAssociations from EntityWithQuantifiedAssociationTrait => business logic should be into domain not in services

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
