### PR TITLE
PIM-9356: Fix external api endpoint for products with invalid quantified associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PIM-9289: Display a correct error message when deleting a group or an association
 - PIM-9327: PDF generation header miss the product name when the attribute used as label is localizable 
 - PIM-9324: Fix product grid not loading when asset used as main picture is deleted
+- PIM-9356: Fix external api endpoint for products with invalid quantified associations
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductIdentifiers.php
@@ -98,6 +98,9 @@ SQL;
     {
         $productIds = [];
         foreach ($allQuantifiedAssociationsWithProductId as $quantifiedAssociationWithId) {
+            if (empty($quantifiedAssociationWithId)) {
+                continue;
+            }
             $productIds = array_merge($productIds, $this->productIds($quantifiedAssociationWithId));
         }
 
@@ -105,6 +108,9 @@ SQL;
 
         $result = [];
         foreach ($allQuantifiedAssociationsWithProductId as $associationTypeCode => $associationWithIds) {
+            if (empty($associationWithIds) || !is_string($associationTypeCode)) {
+                continue;
+            }
             if (!$this->associationTypeExists($associationTypeCode)) {
                 continue;
             }
@@ -134,7 +140,7 @@ SQL;
             function (array $quantifiedAssociations) {
                 return $quantifiedAssociations['id'];
             },
-            $quantifiedAssociationWithProductId['product_models']
+            $quantifiedAssociationWithProductId['product_models'] ?? []
         );
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductIdentifiers.php
@@ -97,6 +97,9 @@ SQL;
     {
         $productIds = [];
         foreach ($allQuantifiedAssociationsWithProductId as $quantifiedAssociationWithId) {
+            if (empty($quantifiedAssociationWithId)) {
+                continue;
+            }
             $productIds = array_merge($productIds, $this->productIds($quantifiedAssociationWithId));
         }
 
@@ -104,6 +107,9 @@ SQL;
 
         $result = [];
         foreach ($allQuantifiedAssociationsWithProductId as $associationTypeCode => $associationWithIds) {
+            if (empty($associationWithIds) || !is_string($associationTypeCode)) {
+                continue;
+            }
             if (!$this->associationTypeExists($associationTypeCode)) {
                 continue;
             }
@@ -116,7 +122,7 @@ SQL;
                 }
                 $uniqueQuantifiedAssociations[$identifier] = [
                     'identifier' => $identifier,
-                    'quantity'   => (int) $associationWithProductId['quantity']
+                    'quantity' => (int)$associationWithProductId['quantity']
                 ];
             }
             if (!empty($uniqueQuantifiedAssociations)) {
@@ -133,7 +139,7 @@ SQL;
             function (array $quantifiedAssociations) {
                 return $quantifiedAssociations['id'];
             },
-            $quantifiedAssociationWithProductId['products']
+            $quantifiedAssociationWithProductId['products'] ?? []
         );
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductModelCodes.php
@@ -99,6 +99,9 @@ SQL;
 
         $result = [];
         foreach ($allQuantifiedAssociationsWithProductModelIds as $associationTypeCode => $associationWithIds) {
+            if (empty($associationWithIds) || !is_string($associationTypeCode)) {
+                continue;
+            }
             if (!$this->associationTypeExists($associationTypeCode)) {
                 continue;
             }
@@ -128,7 +131,7 @@ SQL;
             function (array $quantifiedAssociations) {
                 return $quantifiedAssociations['id'];
             },
-            $quantifiedAssociationWithProductModelId['product_models']
+            $quantifiedAssociationWithProductModelId['product_models'] ?? []
         );
     }
 
@@ -141,6 +144,9 @@ SQL;
     ): IdMapping {
         $productModelIds = [];
         foreach ($allQuantifiedAssociationsWithProductModelIds as $quantifiedAssociationWithId) {
+            if (empty($quantifiedAssociationWithId)) {
+                continue;
+            }
             $productModelIds = array_merge($productModelIds, $this->productModelIds($quantifiedAssociationWithId));
         }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductModelCodes.php
@@ -99,6 +99,9 @@ SQL;
 
         $result = [];
         foreach ($allQuantifiedAssociationsWithProductIds as $associationTypeCode => $associationWithIds) {
+            if (empty($associationWithIds) || !is_string($associationTypeCode)) {
+                continue;
+            }
             if (!$this->associationTypeExists($associationTypeCode)) {
                 continue;
             }
@@ -128,7 +131,7 @@ SQL;
             function (array $quantifiedAssociations) {
                 return $quantifiedAssociations['id'];
             },
-            $quantifiedAssociationWithProductModelId['products']
+            $quantifiedAssociationWithProductModelId['products'] ?? []
         );
     }
 
@@ -141,6 +144,9 @@ SQL;
     {
         $productModelCodes = [];
         foreach ($allQuantifiedAssociationsWithProductModelIds as $quantifiedAssociationWithId) {
+            if (empty($quantifiedAssociationWithId)) {
+                continue;
+            }
             $productModelCodes = array_merge(
                 $productModelCodes,
                 $this->productModelCodes($quantifiedAssociationWithId)

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration.php
@@ -9,7 +9,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\Quantifi
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
 use AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\AbstractQuantifiedAssociationIntegration;
-use Doctrine\DBAL\Connection;
 
 class GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration extends AbstractQuantifiedAssociationIntegration
 {
@@ -354,28 +353,6 @@ class GetProductModelQuantifiedAssociationsByProductIdentifiersIntegration exten
         $this->getAssociationTypeRemover()->remove($associationType);
         $actual = $this->getQuery()->fromProductIdentifiers(['productB']);
 
-        $this->assertSame([], $actual);
-    }
-
-    /**
-     * @test
-     */
-    public function itDoesNotFailOnInvalidQuantifiedAssociations()
-    {
-        $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, []);
-
-        /** @var Connection $connexion */
-        $connexion = $this->get('doctrine.dbal.default_connection');
-
-        $query = <<<SQL
-        UPDATE pim_catalog_product_model
-        SET quantified_associations = '[]'
-        WHERE code = 'root_product_model'
-SQL;
-
-        $connexion->executeUpdate($query);
-
-        $actual = $this->getQuery()->fromProductIdentifiers(['root_product_model']);
         $this->assertSame([], $actual);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductIdentifiersIntegration.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\Quantifi
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
 use AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\AbstractQuantifiedAssociationIntegration;
+use Doctrine\DBAL\Connection;
 
 class GetProductQuantifiedAssociationsByProductIdentifiersIntegration extends AbstractQuantifiedAssociationIntegration
 {
@@ -350,6 +351,30 @@ class GetProductQuantifiedAssociationsByProductIdentifiersIntegration extends Ab
         $this->getAssociationTypeRemover()->remove($associationType);
         $actual = $this->getQuery()->fromProductIdentifiers(['productB']);
 
+        $this->assertSame([], $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function itDoesNotFailOnInvalidQuantifiedAssociations()
+    {
+        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, []);
+        $subProductModel = $this->getEntityBuilder()->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, []);
+        $this->getEntityBuilder()->createVariantProduct('variant_product_1', 'aFamily', 'familyVariantWithTwoLevels', $subProductModel, []);
+
+        /** @var Connection $connexion */
+        $connexion = $this->get('doctrine.dbal.default_connection');
+
+        $query = <<<SQL
+        UPDATE pim_catalog_product_model
+        SET quantified_associations = '[]'
+        WHERE code = 'root_product_model'
+SQL;
+
+        $connexion->executeUpdate($query);
+
+        $actual = $this->getQuery()->fromProductIdentifiers(['variant_product_1']);
         $this->assertSame([], $actual);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductIdentifiersIntegration.php
@@ -356,6 +356,8 @@ class GetProductQuantifiedAssociationsByProductIdentifiersIntegration extends Ab
 
     /**
      * @test
+     *
+     * https://akeneo.atlassian.net/browse/PIM-9356
      */
     public function itDoesNotFailOnInvalidQuantifiedAssociations()
     {
@@ -363,8 +365,8 @@ class GetProductQuantifiedAssociationsByProductIdentifiersIntegration extends Ab
         $subProductModel = $this->getEntityBuilder()->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, []);
         $this->getEntityBuilder()->createVariantProduct('variant_product_1', 'aFamily', 'familyVariantWithTwoLevels', $subProductModel, []);
 
-        /** @var Connection $connexion */
-        $connexion = $this->get('doctrine.dbal.default_connection');
+        /** @var Connection $connection */
+        $connection = $this->get('doctrine.dbal.default_connection');
 
         $query = <<<SQL
         UPDATE pim_catalog_product_model
@@ -372,7 +374,7 @@ class GetProductQuantifiedAssociationsByProductIdentifiersIntegration extends Ab
         WHERE code = 'root_product_model'
 SQL;
 
-        $connexion->executeUpdate($query);
+        $connection->executeUpdate($query);
 
         $actual = $this->getQuery()->fromProductIdentifiers(['variant_product_1']);
         $this->assertSame([], $actual);

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductModelQuantifiedAssociationsByProductModelCodesIntegration.php
@@ -323,30 +323,6 @@ class GetProductModelQuantifiedAssociationsByProductModelCodesIntegration extend
         $this->assertSame([], $actual);
     }
 
-    /**
-     * @test
-     *
-     * https://akeneo.atlassian.net/browse/PIM-9356
-     */
-    public function itDoesNotFailOnInvalidQuantifiedAssociations()
-    {
-        $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, []);
-
-        /** @var Connection $connection */
-        $connection = $this->get('doctrine.dbal.default_connection');
-
-        $query = <<<SQL
-        UPDATE pim_catalog_product_model
-        SET quantified_associations = '[]'
-        WHERE code = 'root_product_model'
-SQL;
-
-        $connection->executeUpdate($query);
-
-        $actual = $this->getQuery()->fromProductIdentifiers(['root_product_model']);
-        $this->assertSame([], $actual);
-    }
-
     protected function getConfiguration()
     {
         return $this->catalog->useMinimalCatalog();

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/QuantifiedAssociation/GetProductQuantifiedAssociationsByProductModelCodesIntegration.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\Quantifi
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
 use AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\AbstractQuantifiedAssociationIntegration;
+use Doctrine\DBAL\Connection;
 
 class GetProductQuantifiedAssociationsByProductModelCodesIntegration extends AbstractQuantifiedAssociationIntegration
 {
@@ -297,6 +298,32 @@ class GetProductQuantifiedAssociationsByProductModelCodesIntegration extends Abs
         $this->getAssociationTypeRemover()->remove($associationType);
         $actual = $this->getQuery()->fromProductModelCodes(['productModelA']);
 
+        $this->assertSame([], $actual);
+    }
+
+    /**
+     * @test
+     *
+     * https://akeneo.atlassian.net/browse/PIM-9356
+     */
+    public function itDoesNotFailOnInvalidQuantifiedAssociations()
+    {
+        $rootProductModel = $this->getEntityBuilder()->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, []);
+        $subProductModel = $this->getEntityBuilder()->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, []);
+        $this->getEntityBuilder()->createVariantProduct('variant_product_1', 'aFamily', 'familyVariantWithTwoLevels', $subProductModel, []);
+
+        /** @var Connection $connection */
+        $connection = $this->get('doctrine.dbal.default_connection');
+
+        $query = <<<SQL
+        UPDATE pim_catalog_product_model
+        SET quantified_associations = '[]'
+        WHERE code = 'root_product_model'
+SQL;
+
+        $connection->executeUpdate($query);
+
+        $actual = $this->getQuery()->fromProductModelCodes(['variant_product_1']);
         $this->assertSame([], $actual);
     }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**Context:** the upcoming feature about quantified associations has been merged regularly on master during the development, with a feature flag disabling the UI.

Apparently, there was an earlier version saving `[]` in the json column instead of `NULL` when there was no quantified associations.
This is not happening anymore, we have a lot of validation before saving the quantified associations now.

Since the last release (2 days ago), the quantified associations are exposed in the external api endpoint for GET products (it's not documented yet). 

The query for returning the quantified associations:
```
SELECT
    p.identifier,
    JSON_MERGE_PRESERVE(COALESCE(pm2.quantified_associations, '{}'), COALESCE(pm1.quantified_associations, '{}'), COALESCE(p.quantified_associations, '{}')) AS all_quantified_associations
FROM pim_catalog_product p
LEFT JOIN pim_catalog_product_model pm1 ON p.product_model_id = pm1.id
LEFT JOIN pim_catalog_product_model pm2 ON pm1.parent_id = pm2.id
WHERE p.identifier IN (:productIdentifiers)
```
has an unexpected behavior when one this column is `[]` and the code hydrating this raw data fail.

I've added integration tests to cover this invalid data.
And the code simply skip data with unexpected structure.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -