### PR TITLE
PIM-9359: Fix ES configuration override for dynamic templates

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9359: Fix ES configuration override for dynamic templates
+
 # 4.0.40 (2020-07-13)
 
 ## Improvement

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
@@ -72,34 +72,32 @@ class Loader
      */
     private function mergeMappings(array $originalMappings, array $additionalMappings): array
     {
-        foreach ($additionalMappings as $indexName => $definitions) {
-            if (isset($definitions['properties'])) {
-                $originalProperties = isset($originalMappings[$indexName]['properties']) ?
-                    $originalMappings[$indexName]['properties'] : [];
+        if (isset($additionalMappings['properties'])) {
+            $originalProperties = isset($originalMappings['properties']) ?
+                $originalMappings['properties'] : [];
 
-                $originalMappings[$indexName]['properties'] = array_replace_recursive(
-                    $originalProperties,
-                    $definitions['properties']
-                );
-            }
-            if (isset($definitions['dynamic_templates'])) {
-                $originalTemplates = isset($originalMappings[$indexName]['dynamic_templates']) ?
-                    $originalMappings[$indexName]['dynamic_templates'] : [];
-
-                $originalMappings[$indexName]['dynamic_templates'] = array_merge_recursive(
-                    $originalTemplates,
-                    $definitions['dynamic_templates']
-                );
-            }
-            // hacky stuff to merge all other mappings
-            $otherMappings = $definitions;
-            unset($otherMappings['properties']);
-            unset($otherMappings['dynamic_templates']);
-            $originalMappings[$indexName] = array_replace_recursive(
-                $originalMappings[$indexName] ?? [],
-                $otherMappings
+            $originalMappings['properties'] = array_replace_recursive(
+                $originalProperties,
+                $additionalMappings['properties']
             );
         }
+        if (isset($additionalMappings['dynamic_templates'])) {
+            $originalTemplates = isset($originalMappings['dynamic_templates']) ?
+                $originalMappings['dynamic_templates'] : [];
+
+            $originalMappings['dynamic_templates'] = array_merge_recursive(
+                $originalTemplates,
+                $additionalMappings['dynamic_templates']
+            );
+        }
+        // hacky stuff to merge all other mappings
+        $otherMappings = $additionalMappings;
+        unset($otherMappings['properties']);
+        unset($otherMappings['dynamic_templates']);
+        $originalMappings = array_replace_recursive(
+            $originalMappings,
+            $otherMappings
+        );
 
         return $originalMappings;
     }

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
@@ -73,8 +73,7 @@ class Loader
     private function mergeMappings(array $originalMappings, array $additionalMappings): array
     {
         if (isset($additionalMappings['properties'])) {
-            $originalProperties = isset($originalMappings['properties']) ?
-                $originalMappings['properties'] : [];
+            $originalProperties = $originalMappings['properties'] ?? [];
 
             $originalMappings['properties'] = array_replace_recursive(
                 $originalProperties,

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
@@ -81,8 +81,7 @@ class Loader
             );
         }
         if (isset($additionalMappings['dynamic_templates'])) {
-            $originalTemplates = isset($originalMappings['dynamic_templates']) ?
-                $originalMappings['dynamic_templates'] : [];
+            $originalTemplates = $originalMappings['dynamic_templates'] ?? [];
 
             $originalMappings['dynamic_templates'] = array_merge_recursive(
                 $originalTemplates,

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/LoaderSpec.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/LoaderSpec.php
@@ -26,40 +26,38 @@ class LoaderSpec extends ObjectBehavior
         );
         $indexConfiguration->getMappings()->shouldReturn(
             [
-                'an_index_type1' => [
-                    'properties' => [
-                        'name' => [
-                            'properties' => [
-                                'last' => [
-                                    'type' => 'text',
-                                ],
+                'properties' => [
+                    'name' => [
+                        'properties' => [
+                            'last' => [
+                                'type' => 'text',
                             ],
-                        ],
-                        'user_id' => [
-                            'type' => 'keyword',
-                            'ignore_above' => 100,
                         ],
                     ],
-                    'dynamic_templates' => [
-                        [
-                            'my_dynamic_template_1' => [
-                                'path_match' => '*foo*',
-                                'match_mapping_type' => 'object',
-                                'mapping' =>
-                                    [
-                                        'type' => 'object',
-                                    ],
-                            ],
+                    'user_id' => [
+                        'type' => 'keyword',
+                        'ignore_above' => 100,
+                    ],
+                ],
+                'dynamic_templates' => [
+                    [
+                        'my_dynamic_template_1' => [
+                            'path_match' => '*foo*',
+                            'match_mapping_type' => 'object',
+                            'mapping' =>
+                                [
+                                    'type' => 'object',
+                                ],
                         ],
-                        [
-                            'my_dynamic_template_2' => [
-                                'path_match' => '*bar*',
-                                'mapping' =>
-                                    [
-                                        'type' => 'keyword',
-                                        'index' => 'not_analyzed',
-                                    ],
-                            ],
+                    ],
+                    [
+                        'my_dynamic_template_2' => [
+                            'path_match' => '*bar*',
+                            'mapping' =>
+                                [
+                                    'type' => 'keyword',
+                                    'index' => 'not_analyzed',
+                                ],
                         ],
                     ],
                 ],
@@ -98,58 +96,50 @@ class LoaderSpec extends ObjectBehavior
         );
         $indexConfiguration->getMappings()->shouldReturn(
             [
-                'an_index_type1' => [
-                    'properties' => [
-                        'name' => [
-                            'properties' => [
-                                'last' => [
-                                    'type' => 'text',
-                                ],
-                            ],
-                        ],
-                        'user_id' => [
-                            'type' => 'keyword',
-                            'ignore_above' => 100,
-                        ],
-                        'just_another_property' => null,
-                    ],
-                    'dynamic_templates' => [
-                        [
-                            'my_dynamic_template_1' => [
-                                'path_match' => '*foo*',
-                                'match_mapping_type' => 'object',
-                                'mapping' => [
-                                    'type' => 'object',
-                                ],
-                            ],
-                        ],
-                        [
-                            'my_dynamic_template_2' => [
-                                'path_match' => '*bar*',
-                                'mapping' => [
-                                    'type' => 'keyword',
-                                    'index' => 'not_analyzed',
-                                ],
-                            ],
-                        ],
-                        [
-                            'my_dynamic_template_3' => [
-                                'path_match' => '*foo3*',
-                                'match_mapping_type' => 'object',
-                                'mapping' => [
-                                    'type' => 'object',
-                                ],
+                'properties' => [
+                    'name' => [
+                        'properties' => [
+                            'last' => [
+                                'type' => 'text',
                             ],
                         ],
                     ],
-                    'just_another_mapping' => null,
+                    'user_id' => [
+                        'type' => 'keyword',
+                        'ignore_above' => 100,
+                    ],
+                    'just_another_property' => null,
                 ],
-                'an_index_type2' => [
-                    'just_a_mapping' => null,
+                'dynamic_templates' => [
+                    [
+                        'my_dynamic_template_1' => [
+                            'path_match' => '*foo*',
+                            'match_mapping_type' => 'object',
+                            'mapping' => [
+                                'type' => 'object',
+                            ],
+                        ],
+                    ],
+                    [
+                        'my_dynamic_template_2' => [
+                            'path_match' => '*bar*',
+                            'mapping' => [
+                                'type' => 'keyword',
+                                'index' => 'not_analyzed',
+                            ],
+                        ],
+                    ],
+                    [
+                        'my_dynamic_template_3' => [
+                            'path_match' => '*foo3*',
+                            'match_mapping_type' => 'object',
+                            'mapping' => [
+                                'type' => 'object',
+                            ],
+                        ],
+                    ],
                 ],
-                'an_index_type3' => [
-                    'just_a_mapping' => null,
-                ],
+                'just_another_mapping' => null,
             ]
         );
         $indexConfiguration->getAliases()->shouldReturn(
@@ -197,60 +187,52 @@ class LoaderSpec extends ObjectBehavior
                 ],
             'mappings' =>
                 [
-                    'an_index_type1' => [
-                        'properties' => [
-                            'name' => [
-                                'properties' => [
-                                    'last' => [
-                                        'type' => 'text',
-                                    ],
+                    'properties' => [
+                        'name' => [
+                            'properties' => [
+                                'last' => [
+                                    'type' => 'text',
                                 ],
                             ],
-                            'user_id' => [
-                                'type' => 'keyword',
-                                'ignore_above' => 100,
-                            ],
-                            'just_another_property' => null,
                         ],
-                        'dynamic_templates' => [
-                            [
-                                'my_dynamic_template_1' => [
-                                    'path_match' => '*foo*',
-                                    'match_mapping_type' => 'object',
-                                    'mapping' =>
-                                        [
-                                            'type' => 'object',
-                                        ],
-                                ],
-                            ],
-                            [
-                                'my_dynamic_template_2' => [
-                                    'path_match' => '*bar*',
-                                    'mapping' =>
-                                        [
-                                            'type' => 'keyword',
-                                            'index' => 'not_analyzed',
-                                        ],
-                                ],
-                            ],
-                            [
-                                'my_dynamic_template_3' => [
-                                    'path_match' => '*foo3*',
-                                    'match_mapping_type' => 'object',
-                                    'mapping' => [
+                        'user_id' => [
+                            'type' => 'keyword',
+                            'ignore_above' => 100,
+                        ],
+                        'just_another_property' => null,
+                    ],
+                    'dynamic_templates' => [
+                        [
+                            'my_dynamic_template_1' => [
+                                'path_match' => '*foo*',
+                                'match_mapping_type' => 'object',
+                                'mapping' =>
+                                    [
                                         'type' => 'object',
                                     ],
+                            ],
+                        ],
+                        [
+                            'my_dynamic_template_2' => [
+                                'path_match' => '*bar*',
+                                'mapping' =>
+                                    [
+                                        'type' => 'keyword',
+                                        'index' => 'not_analyzed',
+                                    ],
+                            ],
+                        ],
+                        [
+                            'my_dynamic_template_3' => [
+                                'path_match' => '*foo3*',
+                                'match_mapping_type' => 'object',
+                                'mapping' => [
+                                    'type' => 'object',
                                 ],
                             ],
                         ],
-                        'just_another_mapping' => null,
                     ],
-                    'an_index_type2' => [
-                        'just_a_mapping' => null,
-                    ],
-                    'an_index_type3' => [
-                        'just_a_mapping' => null,
-                    ],
+                    'just_another_mapping' => null,
                 ],
             'aliases' =>
                 [

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf1.yml
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf1.yml
@@ -7,25 +7,24 @@ settings:
                 replacement: ""
 
 mappings:
-    an_index_type1:
-        properties:
-            name:
-                properties:
-                    last:
-                        type: text
-            user_id:
-                type: keyword
-                ignore_above: 100
-        dynamic_templates:
-            -
-                my_dynamic_template_1:
-                    path_match: '*foo*'
-                    match_mapping_type: 'object'
-                    mapping:
-                        type: 'object'
-            -
-                my_dynamic_template_2:
-                    path_match: '*bar*'
-                    mapping:
-                        type: 'keyword'
-                        index: 'not_analyzed'
+    properties:
+        name:
+            properties:
+                last:
+                    type: text
+        user_id:
+            type: keyword
+            ignore_above: 100
+    dynamic_templates:
+        -
+            my_dynamic_template_1:
+                path_match: '*foo*'
+                match_mapping_type: 'object'
+                mapping:
+                    type: 'object'
+        -
+            my_dynamic_template_2:
+                path_match: '*bar*'
+                mapping:
+                    type: 'keyword'
+                    index: 'not_analyzed'

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf2.yml
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf2.yml
@@ -4,14 +4,13 @@ settings:
         number_of_replicas: 2
 
 mappings:
-    an_index_type1:
-        properties:
-            just_another_property: ~
-        dynamic_templates:
-            -
-                my_dynamic_template_3:
-                    path_match: '*foo3*'
-                    match_mapping_type: 'object'
-                    mapping:
-                        type: 'object'
-        just_another_mapping: ~
+    properties:
+        just_another_property: ~
+    dynamic_templates:
+        -
+            my_dynamic_template_3:
+                path_match: '*foo3*'
+                match_mapping_type: 'object'
+                mapping:
+                    type: 'object'
+    just_another_mapping: ~

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf3.yml
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf3.yml
@@ -1,9 +1,3 @@
-mappings:
-    an_index_type2:
-        just_a_mapping: ~
-    an_index_type3:
-        just_a_mapping: ~
-
 aliases:
     alias_1: {}
     alias_2:


### PR DESCRIPTION
Since 4.0 the ES configuration files doesn't include the index name anymore. However, the ES config loader has not been updated accordingly to that.